### PR TITLE
fixes #23 - created a wrapper for the cache administrator

### DIFF
--- a/src/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
+++ b/src/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
@@ -1242,8 +1242,6 @@ public class ContentletAjax {
                     
                     Contentlet contentlet = (Contentlet) contentletFormData.get(WebKeys.CONTENTLET_EDIT);
                     if(contentlet!=null) {
-                        CacheLocator.getContentletCache().remove(contentlet.getInode());
-                        CacheLocator.getIdentifierCache().removeFromCacheByVersionable(contentlet);
                         callbackData.remove("contentletIdentifier");
                         callbackData.remove("contentletInode");
                         callbackData.remove("contentletLocked");


### PR DESCRIPTION
Not every cache 'put' will be deferred to the commit. That will prevent rolledback data to be cached
