### PR TITLE
fixes #38 - ignoring other build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,12 @@ bin/*.sh
 .settings/*
 .project
 tomcat/work
+tomcat/logs
 
 # Instance Files     #
 ######################
 dotCMS/dotSecure
+dotCMS/dotsecure
 dotCMS/assets
 sql/cms
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Thumbs.db
 ######################
 dotCMS/WEB-INF/classes/
 build/
+dotCMS/WEB-INF/generated_web.xml
+dotCMS/WEB-INF/lib/dotcms_?.*.jar
+dotCMS/WEB-INF/lib/plugin-*.jar


### PR DESCRIPTION
still we have local changes after ant deploy and even more if ant deploy then ant clean

I found we can ignore local changes on versioned files -->  http://juststuffreally.blogspot.com/2008/10/if-you-have-file-that-lives-in-git.html

git update-index --assume-unchanged path-to-versioned-file-we-want-to-ignore-local-changes

To anyone interested.
