### PR TITLE
#858

### DIFF
--- a/test/com/dotmarketing/portlets/contentlet/business/ContentletFactoryTest.java
+++ b/test/com/dotmarketing/portlets/contentlet/business/ContentletFactoryTest.java
@@ -62,7 +62,7 @@ public class ContentletFactoryTest extends ContentletBaseTest {
         assertEquals( contentlets.size(), 5 );
 
         //Validate the integrity of the array
-        Contentlet contentlet = contentletFactory.find( contentlets.iterator().next().getInode() );
+        Contentlet contentlet = contentletFactory.find( contentlets.get( 0 ).getInode() );
 
         //Validations
         assertTrue( contentlet != null && ( contentlet.getInode() != null && !contentlet.getInode().isEmpty() ) );


### PR DESCRIPTION
Actually locally I could never reproduce the issue, I'm aware of it but was impossible to me to make it fail..., this is the old code:

``` java
@Test
    public void findAllCurrentOffsetLimit () throws DotDataException, DotSecurityException {

        //Getting all contentlets live/working contentlets
        List<Contentlet> contentlets = contentletFactory.findAllCurrent( 0, 5 );

        //Validations
        assertTrue( contentlets != null && !contentlets.isEmpty() );
        assertEquals( contentlets.size(), 5 );

        //Validate the integrity of the array
        Contentlet contentlet = contentletFactory.find( contentlets.iterator().next().getInode() );

        //Validations
        assertTrue( contentlet != null && ( contentlet.getInode() != null && !contentlet.getInode().isEmpty() ) );
    }
```

Hudson shows a null pointer exception on this line:

``` java
//Validate the integrity of the array
Contentlet contentlet = contentletFactory.find( contentlets.iterator().next().getInode() );
```

Where the contentlets array must have data as it passed already two asserts and the contentletFactory object was already used to retrieve the collection.
