### PR TITLE
Issue 962 error pages allow customization for default error pages

### DIFF
--- a/dotCMS/WEB-INF/messages/Language.properties
+++ b/dotCMS/WEB-INF/messages/Language.properties
@@ -4906,6 +4906,7 @@ alert-metadata-container=Create a metadata container means that in the container
 503-body1=(we were this..close to putting an under construction icon here)
 503-body2=The site you were looking is stopped or is undergoing maintenance.<br/>Please make sure that you have typed the correct URL.<br/> If not, please try back again later.  Thanks!
 503-copywright=DM Web, Corp.
+
  
 ## BEGIN PLUGINS
 ## END PLUGINS

--- a/dotCMS/WEB-INF/messages/Language.properties
+++ b/dotCMS/WEB-INF/messages/Language.properties
@@ -4857,11 +4857,55 @@ modes.Add-Content-Metadata=Add Metadata Content
 alert-metadata-container=Create a metadata container means that in the container code field may be present only meta HTML tags like, for example, \"<meta name=\"keywords\" content=\"my keywords\"/>\".\nAre you sure?
 ## END GRAZIANO issue-12-dnd-template
 
+## error pages messages
+400-image-title=dotCMS content management system
+400-page-title=dotCMS: 400 Bad Request
+400-title=Bad Request (400 error)
+400-body1=The request could not be understood by the server due to malformed syntax.
+400-body2=If the problem persists, you can always return to the <a href="/">home page</a>.
+400-copywright=DM Web, Corp.
 
+401-image-title=dotCMS content management system
+401-page-title=dotCMS: 401 Not Authorized
+401-title=Not Authorized (401 error)
+401-body1=The page or file you were looking for requires authorization.<BR/>Please make sure that you have the proper roles required to view this asset. 
+401-body2=If the problem persists, you can always return to the <a href="/">home page</a>.
+401-copywright=DM Web, Corp.
 
+402-image-title=dotCMS content management system
+402-page-title=dotCMS: 402 Payment Required
+402-title=Payment Required (402 error)
+402-body1=The page or file you were looking require payment.
+402-body2=If the problem persists, you can always return to the <a href="/">home page</a>.
+402-copywright=DM Web, Corp.
 
+403-image-title=dotCMS content management system
+403-page-title=dotCMS: 403 Forbidden
+403-title=Forbidden (403 error)
+403-body1=The page or file you were looking is forbidden to you<br>(logged in or not).
+403-body2=If the problem persists, you can always return to the <a href="/">home page</a>.
+403-copywright=DM Web, Corp.
 
+404-image-title=dotCMS content management system
+404-page-title=dotCMS: Page not found (404 error)
+404-title=Page not found (404 error)
+404-body1=The page or file you were looking for was not found. <BR/>Please make sure that you have typed the correct URL. 
+404-body2=If the problem persists, you can always return to the <a href="/">home page</a>.
+404-copywright=DM Web, Corp.
 
+500-image-title=dotCMS content management system
+500-page-title=dotCMS: 500 error
+500-title=Server Error (500 error)
+500-body1=The page or file you were looking for caused a little tiny <a href="javascript:showError()">error</a>. <BR/>Please make sure that you have typed the correct URL. 
+500-body2=If the problem persists, you can always return to the <a href="/">home page</a>.
+500-copywright=DM Web, Corp.
 
+503-image-title=dotCMS content management system
+503-page-title=dotCMS: 503 Undergoing Maintenance
+503-title=Site Undergoing Maintenance
+503-body1=(we were this..close to putting an under construction icon here)
+503-body2=The site you were looking is stopped or is undergoing maintenance.<br/>Please make sure that you have typed the correct URL.<br/> If not, please try back again later.  Thanks!
+503-copywright=DM Web, Corp.
+ 
 ## BEGIN PLUGINS
 ## END PLUGINS

--- a/dotCMS/portal/400.jsp
+++ b/dotCMS/portal/400.jsp
@@ -12,6 +12,7 @@
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <%@page import="com.liferay.portal.model.Company"%>
 <%@page import="com.dotmarketing.util.CompanyUtils"%>
+
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
 	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);

--- a/dotCMS/portal/400.jsp
+++ b/dotCMS/portal/400.jsp
@@ -7,8 +7,18 @@
 <%@ page import="com.dotmarketing.business.CacheLocator"%>
 <%@ page import="com.dotmarketing.util.Logger"%>
 <%@ page import="com.dotmarketing.db.DbConnectionFactory"%>
+<%@ page import="com.liferay.portal.util.ImageKey" %>
+<%@ page import="com.liferay.portal.util.WebKeys" %>
+<%@page import="com.liferay.portal.language.LanguageUtil"%>
+<%@page import="com.liferay.portal.model.Company"%>
+<%@page import="com.dotmarketing.util.CompanyUtils"%>
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
+	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);
+	Company company = CompanyUtils.getDefaultCompany();
+	String portalUrl =  company.getPortalURL();
+	String IMAGE_PATH = (String) application.getAttribute(WebKeys.IMAGE_PATH);
+	String defaultImage =  IMAGE_PATH+"/company_logo?img_id="+company.getCompanyId()+"&key="+ImageKey.get(company.getCompanyId());
 			
 	String ep_originatingHost = host.getHostname();
 	String ep_errorCode = "400";
@@ -91,8 +101,8 @@
 
 <html>
 <head>
-	<link rel="shortcut icon" href="//www.dotcms.com/global/favicon.ico" type="image/x-icon">
-	<title>dotCMS: 400 Bad Request</title>
+	<link rel="shortcut icon" href="http://<%=defaultHost.getHostname()%>/home/favicon.ico"" type="image/x-icon">
+	<title><%= LanguageUtil.get(pageContext,"400-page-title") %></title>
 
 	<style type="text/css">
 		body{
@@ -130,19 +140,19 @@
 </head>
 <body>
 <div id="main">
-			<div id="logo">
-		<a href="http://dotcms.com"><img src="/html/images/skin/logo.gif" width="140"  hspace="10" border="0" alt="dotCMS content management system" title="dotCMS content management system"  /></a>
-			</div>
+	<div id="logo">
+		<a href="http://<%=portalUrl%>/"><img src="<%=defaultImage%>" width="140"  hspace="10" border="0" alt="<%=LanguageUtil.get(pageContext,"400-image-title")%>" title="<%=LanguageUtil.get(pageContext,"400-image-title")%>"  /></a>
+	</div>
 	<div id="text">
 	
-		<h1>Bad Request (400 error)</h1>
+		<h1><%= LanguageUtil.get(pageContext,"400-title") %></h1>
 		
-		<p>The request could not be understood by the server due to malformed syntax.</p>
-		<p>If the problem persists, you can always return to the <a href="/">home page</a>.</p>
+		<p><%= LanguageUtil.get(pageContext,"400-body1") %></p>
+		<p><%= LanguageUtil.get(pageContext,"400-body2") %></p>
 	</div>
 </div>
 <br clear="all"/>&nbsp;<br clear="all"/>
-<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://dotcms.com">DM Web, Corp.</a></div>
+<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://<%=portalUrl%>"><%= LanguageUtil.get(pageContext,"400-copywright") %></a></div>
 </body>
 </html>
 

--- a/dotCMS/portal/401.jsp
+++ b/dotCMS/portal/401.jsp
@@ -7,9 +7,21 @@
 <%@ page import="com.dotmarketing.business.CacheLocator"%>
 <%@ page import="com.dotmarketing.util.Logger"%>
 <%@ page import="com.dotmarketing.db.DbConnectionFactory"%>
+<%@ page import="com.liferay.portal.util.ImageKey" %>
+<%@ page import="com.liferay.portal.util.WebKeys" %>
+<%@page import="com.liferay.portal.language.LanguageUtil"%>
+<%@page import="com.liferay.portal.model.Company"%>
+<%@page import="com.dotmarketing.util.CompanyUtils"%>
+
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
-		
+	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);
+	Company company = CompanyUtils.getDefaultCompany();
+	String portalUrl =  company.getPortalURL();
+	String IMAGE_PATH = (String) application.getAttribute(WebKeys.IMAGE_PATH);
+	String defaultImage =  IMAGE_PATH+"/company_logo?img_id="+company.getCompanyId()+"&key="+ImageKey.get(company.getCompanyId());
+	
+	
 	String ep_originatingHost = host.getHostname();
 	String ep_errorCode = "401";
 	
@@ -110,8 +122,8 @@
 
 <html>
 <head>
-		<link rel="shortcut icon" href="//www.dotcms.com/global/favicon.ico" type="image/x-icon">
-	<title>dotCMS: 401 Not Authorized</title>
+		<link rel="shortcut icon" href="http://<%=defaultHost.getHostname()%>/home/favicon.ico"" type="image/x-icon">
+	<title><%= LanguageUtil.get(pageContext,"401-page-title") %></title>
 
 	<style type="text/css">
 		body{
@@ -149,20 +161,19 @@
 </head>
 <body>
 <div id="main">
-			<div id="logo">
-		<a href="http://dotcms.com"><img src="/html/images/skin/logo.gif" width="140"  hspace="10" border="0" alt="dotCMS content management system" title="dotCMS content management system"  /></a>
-			</div>
+	<div id="logo">
+		<a href="http://<%=portalUrl%>/"><img src="<%=defaultImage%>" width="140"  hspace="10" border="0" alt="<%=LanguageUtil.get(pageContext,"401-image-title")%>" title="<%=LanguageUtil.get(pageContext,"401-image-title")%>"  /></a>
+	</div>
 	<div id="text">
 	
-		<h1>Not Authorized (401 error)</h1>
+		<h1><%= LanguageUtil.get(pageContext,"401-title") %></h1>
 		
-		<p>The page or file you were looking for requires authorization. 
-		<BR/>Please make sure that you have the proper roles required to view this asset. </p>
-		<p>If the problem persists, you can always return to the <a href="/">home page</a>.</p>
+		<p><%= LanguageUtil.get(pageContext,"401-body1") %></p>
+		<p><%= LanguageUtil.get(pageContext,"401-body2") %></p>
 	</div>
 </div>
 <br clear="all"/>&nbsp;<br clear="all"/>
-<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://dotcms.com">DM Web, Corp.</a></div>
+<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://<%=portalUrl%>"><%= LanguageUtil.get(pageContext,"401-copywright") %></a></div>
 
 
 </body>

--- a/dotCMS/portal/401.jsp
+++ b/dotCMS/portal/401.jsp
@@ -12,7 +12,6 @@
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <%@page import="com.liferay.portal.model.Company"%>
 <%@page import="com.dotmarketing.util.CompanyUtils"%>
-
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
 	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);

--- a/dotCMS/portal/402.jsp
+++ b/dotCMS/portal/402.jsp
@@ -12,7 +12,6 @@
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <%@page import="com.liferay.portal.model.Company"%>
 <%@page import="com.dotmarketing.util.CompanyUtils"%>
-
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
 	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);

--- a/dotCMS/portal/402.jsp
+++ b/dotCMS/portal/402.jsp
@@ -7,9 +7,20 @@
 <%@ page import="com.dotmarketing.business.CacheLocator"%>
 <%@ page import="com.dotmarketing.util.Logger"%>
 <%@ page import="com.dotmarketing.db.DbConnectionFactory"%>
+<%@ page import="com.liferay.portal.util.ImageKey" %>
+<%@ page import="com.liferay.portal.util.WebKeys" %>
+<%@page import="com.liferay.portal.language.LanguageUtil"%>
+<%@page import="com.liferay.portal.model.Company"%>
+<%@page import="com.dotmarketing.util.CompanyUtils"%>
+
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
-		
+	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);
+	Company company = CompanyUtils.getDefaultCompany();
+	String portalUrl =  company.getPortalURL();
+	String IMAGE_PATH = (String) application.getAttribute(WebKeys.IMAGE_PATH);
+	String defaultImage =  IMAGE_PATH+"/company_logo?img_id="+company.getCompanyId()+"&key="+ImageKey.get(company.getCompanyId());
+	
 	String ep_originatingHost = host.getHostname();
 	String ep_errorCode = "402";
 	
@@ -90,8 +101,8 @@
 
 <html>
 <head>
-	<link rel="shortcut icon" href="//www.dotcms.com/global/favicon.ico" type="image/x-icon">
-	<title>dotCMS: 402 Payment Required</title>
+	<link rel="shortcut icon" href="http://<%=defaultHost.getHostname()%>/home/favicon.ico"" type="image/x-icon">
+	<title><%= LanguageUtil.get(pageContext,"402-page-title") %></title>
 
 	<style type="text/css">
 		body{
@@ -129,19 +140,19 @@
 </head>
 <body>
 <div id="main">
-			<div id="logo">
-		<a href="http://dotcms.com"><img src="/html/images/skin/logo.gif" width="140"  hspace="10" border="0" alt="dotCMS content management system" title="dotCMS content management system"  /></a>
-			</div>
+	<div id="logo">
+		<a href="http://<%=portalUrl%>/"><img src="<%=defaultImage%>" width="140"  hspace="10" border="0" alt="<%=LanguageUtil.get(pageContext,"402-image-title")%>" title="<%=LanguageUtil.get(pageContext,"402-image-title")%>"  /></a>
+	</div>
 	<div id="text">
 	
-		<h1>Payment Required (402 error)</h1>
+		<h1><%= LanguageUtil.get(pageContext,"402-title") %></h1>
 		
-		<p>The page or file you were looking require payment.</p>
-		<p>If the problem persists, you can always return to the <a href="/">home page</a>.</p>
+		<p><%= LanguageUtil.get(pageContext,"402-body1") %></p>
+		<p><%= LanguageUtil.get(pageContext,"402-body2") %></p>
 	</div>
 </div>
 <br clear="all"/>&nbsp;<br clear="all"/>
-<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://dotcms.com">DM Web, Corp.</a></div>
+<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://<%=portalUrl%>"><%= LanguageUtil.get(pageContext,"402-copywright") %></a></div>
 </body>
 </html>
 <%} catch( Exception e){

--- a/dotCMS/portal/403.jsp
+++ b/dotCMS/portal/403.jsp
@@ -7,11 +7,22 @@
 <%@ page import="com.dotmarketing.business.CacheLocator"%>
 <%@ page import="com.dotmarketing.util.Logger"%>
 <%@ page import="com.dotmarketing.db.DbConnectionFactory"%>
+<%@ page import="com.liferay.portal.util.ImageKey" %>
+<%@ page import="com.liferay.portal.util.WebKeys" %>
+<%@page import="com.liferay.portal.language.LanguageUtil"%>
+<%@page import="com.liferay.portal.model.Company"%>
+<%@page import="com.dotmarketing.util.CompanyUtils"%>
+
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
-		
+	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);
+	Company company = CompanyUtils.getDefaultCompany();
+	String portalUrl =  company.getPortalURL();
+	String IMAGE_PATH = (String) application.getAttribute(WebKeys.IMAGE_PATH);
+	String defaultImage =  IMAGE_PATH+"/company_logo?img_id="+company.getCompanyId()+"&key="+ImageKey.get(company.getCompanyId());
+	
 	String ep_originatingHost = host.getHostname();
-	String ep_errorCode = "403";
+	String ep_errorCode = "403"; 
 	
 	// Get 403 from virtual link
 	String pointer = (String) com.dotmarketing.cache.VirtualLinksCache.getPathFromCache(host.getHostname() + ":/cms403Page");
@@ -90,8 +101,8 @@
 
 <html>
 <head>
-	<link rel="shortcut icon" href="//www.dotcms.com/global/favicon.ico" type="image/x-icon">
-	<title>dotCMS: 403 Forbidden</title>
+	<link rel="shortcut icon" href="http://<%=defaultHost.getHostname()%>/home/favicon.ico"" type="image/x-icon">
+	<title><%= LanguageUtil.get(pageContext,"403-page-title") %></title>
 
 	<style type="text/css">
 		body{
@@ -129,19 +140,19 @@
 </head>
 <body>
 <div id="main">
-			<div id="logo">
-		<a href="http://dotcms.com"><img src="/html/images/skin/logo.gif" width="140"  hspace="10" border="0" alt="dotCMS content management system" title="dotCMS content management system"  /></a>
-			</div>
+	<div id="logo">
+		<a href="http://<%=portalUrl%>/"><img src="<%=defaultImage%>" width="140"  hspace="10" border="0" alt="<%=LanguageUtil.get(pageContext,"403-image-title")%>" title="<%=LanguageUtil.get(pageContext,"403-image-title")%>"  /></a>
+	</div>
 	<div id="text">
 	
-		<h1>Forbidden (403 error)</h1>
+		<h1><%= LanguageUtil.get(pageContext,"403-title") %></h1>
 		
-		<p>The page or file you were looking is forbidden to you<br>(logged in or not).</p>
-		<p>If the problem persists, you can always return to the <a href="/">home page</a>.</p>
+		<p><%= LanguageUtil.get(pageContext,"403-body1") %></p>
+		<p><%= LanguageUtil.get(pageContext,"403-body2") %></p>
 	</div>
 </div>
 <br clear="all"/>&nbsp;<br clear="all"/>
-<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://dotcms.com">DM Web, Corp.</a></div>
+<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://<%=portalUrl%>"><%= LanguageUtil.get(pageContext,"403-copywright") %></a></div>
 </body>
 </html>
 <%} catch( Exception e){

--- a/dotCMS/portal/403.jsp
+++ b/dotCMS/portal/403.jsp
@@ -12,7 +12,6 @@
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <%@page import="com.liferay.portal.model.Company"%>
 <%@page import="com.dotmarketing.util.CompanyUtils"%>
-
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
 	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);

--- a/dotCMS/portal/404.jsp
+++ b/dotCMS/portal/404.jsp
@@ -13,6 +13,7 @@
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <%@page import="com.liferay.portal.model.Company"%>
 <%@page import="com.dotmarketing.util.CompanyUtils"%> 
+
 <%try{		
 
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);

--- a/dotCMS/portal/404.jsp
+++ b/dotCMS/portal/404.jsp
@@ -8,9 +8,19 @@
 <%@ page import="com.dotmarketing.util.Logger"%>
 <%@ page import="com.dotmarketing.db.DbConnectionFactory"%>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils"%>
+<%@ page import="com.liferay.portal.util.ImageKey" %>
+<%@ page import="com.liferay.portal.util.WebKeys" %>
+<%@page import="com.liferay.portal.language.LanguageUtil"%>
+<%@page import="com.liferay.portal.model.Company"%>
+<%@page import="com.dotmarketing.util.CompanyUtils"%> 
 <%try{		
 
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
+	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);
+	Company company = CompanyUtils.getDefaultCompany();
+	String portalUrl =  company.getPortalURL();
+	String IMAGE_PATH = (String) application.getAttribute(WebKeys.IMAGE_PATH);
+	String defaultImage =  IMAGE_PATH+"/company_logo?img_id="+company.getCompanyId()+"&key="+ImageKey.get(company.getCompanyId());
 	
 	// Save 404 request
 	com.dotmarketing.factories.ClickstreamFactory.add404Request(request,response,host);
@@ -19,6 +29,7 @@
 	
 	String ep_originatingHost = host.getHostname();
 	String ep_errorCode = "404";
+	String ep_error_uri = (String)request.getAttribute("javax.servlet.forward.request_uri");
 	
 	// Get 404 from virtual link
 	String pointer = (String) com.dotmarketing.cache.VirtualLinksCache.getPathFromCache(host.getHostname() + ":/cms404Page");
@@ -77,11 +88,11 @@
 	}
 	
 	// if we have virtual link and page exists, redirect or forward
-	String ep_error_uri = (String)request.getAttribute("javax.servlet.forward.request_uri");
 	if(UtilMethods.isSet(pointer) ){
 		if (pointer.startsWith("/")) {
 			Logger.debug(this, "cms404Page forwarding to relative path: " + pointer);			
 			request.getRequestDispatcher(pointer+ "?ep_originatingHost="+ep_originatingHost+"&ep_errorCode="+ep_errorCode+"&ep_error_uri="+ep_error_uri).forward(request, response);
+			
 		} else {
 			pointer = pointer + "?ep_originatingHost="+ep_originatingHost+"&ep_errorCode="+ep_errorCode+"&ep_error_uri="+ep_error_uri;
 			Logger.debug(this, "cms404Page redirecting to absolute path: " + pointer);
@@ -96,7 +107,7 @@
 	<%@page import="com.dotmarketing.cache.LiveCache"%>
 	<html>
 		<head>
-			<link rel="shortcut icon" href="//www.dotcms.com/global/favicon.ico" type="image/x-icon">
+			<link rel="shortcut icon" href="http://<%=defaultHost.getHostname()%>/home/favicon.ico"" type="image/x-icon">
 		    <script>
 		        function showError(){
 		            var ele = document.getElementById("error");
@@ -111,7 +122,7 @@
 		        
 		        
 		    </script>
-			<title>dotCMS: 404 page not found</title>
+			<title><%= LanguageUtil.get(pageContext,"404-page-title") %></title>
 		
 	<style type="text/css">
 		body{
@@ -148,19 +159,18 @@
 		<body>
 		<div id="main">
 			<div id="logo">
-				<a href="http://dotcms.com"><img src="/html/images/skin/logo.gif" width="140"  hspace="10" border="0" alt="dotCMS content management system" title="dotCMS content management system"  /></a>
+			    <a href="http://<%=portalUrl%>/"><img src="<%=defaultImage%>" width="140"  hspace="10" border="0" alt="<%=LanguageUtil.get(pageContext,"404-image-title")%>" title="<%=LanguageUtil.get(pageContext,"404-image-title")%>"  /></a>
 			</div>
 			<div id="text">
 			
-				<h1>Page not found (404 error)</h1>
+				<h1><%= LanguageUtil.get(pageContext,"404-title") %></h1>
 				
-				<p>The page or file you were looking for was not found. 
-				<BR/>Please make sure that you have typed the correct URL</a>. </p>
-				<p>If the problem persists, you can always return to the <a href="/">home page</a>.</p>
+				<p><%= LanguageUtil.get(pageContext,"404-body1") %></p>
+				<p><%= LanguageUtil.get(pageContext,"404-body2") %></p>
 			</div>
 		</div>
 		<br clear="all"/>&nbsp;<br clear="all"/>
-		<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://dotcms.com">DM Web, Corp.</a></div>
+		<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://<%=portalUrl%>"><%= LanguageUtil.get(pageContext,"404-copywright") %></a></div>
 		<br clear="all"/>&nbsp;<br clear="all"/>
 		
 

--- a/dotCMS/portal/500.jsp
+++ b/dotCMS/portal/500.jsp
@@ -8,8 +8,19 @@
 <%@ page import="com.dotmarketing.util.Logger"%>
 <%@ page import="com.dotmarketing.db.DbConnectionFactory"%>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils"%>
+<%@ page import="com.liferay.portal.util.ImageKey" %>
+<%@ page import="com.liferay.portal.util.WebKeys" %>
+<%@page import="com.liferay.portal.language.LanguageUtil"%>
+<%@page import="com.liferay.portal.model.Company"%>
+<%@page import="com.dotmarketing.util.CompanyUtils"%> 
+
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
+	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);
+	Company company = CompanyUtils.getDefaultCompany();
+	String portalUrl =  company.getPortalURL();
+	String IMAGE_PATH = (String) application.getAttribute(WebKeys.IMAGE_PATH);
+	String defaultImage =  IMAGE_PATH+"/company_logo?img_id="+company.getCompanyId()+"&key="+ImageKey.get(company.getCompanyId());
 		
 	String ep_originatingHost = host.getHostname();
 	String ep_errorCode = "500";
@@ -91,7 +102,7 @@
 
 <html>
     <head>
-
+    <link rel="shortcut icon" href="http://<%=defaultHost.getHostname()%>/home/favicon.ico"" type="image/x-icon">
     <script>
         function showError(){
             var ele = document.getElementById("error");
@@ -107,7 +118,7 @@
         
     </script>
     
-        <title>dotCMS: 500 error</title>
+        <title><%= LanguageUtil.get(pageContext,"500-page-title") %></title>
 
 	<style type="text/css">
 		body{
@@ -150,20 +161,19 @@
     <body>
         <div id="main">
 			<div id="logo">
-		<a href="http://dotcms.com"><img src="/html/images/skin/logo.gif" width="140"  hspace="10" border="0" alt="dotCMS content management system" title="dotCMS content management system"  /></a>
+				<a href="http://<%=portalUrl%>/"><img src="<%=defaultImage%>" width="140"  hspace="10" border="0" alt="<%=LanguageUtil.get(pageContext,"500-image-title")%>" title="<%=LanguageUtil.get(pageContext,"500-image-title")%>"  /></a>
 			</div>
             <div id="text">
 	
-                <h1>Server Error (500 error)</h1>
+                <h1><%= LanguageUtil.get(pageContext,"500-title") %></h1>
 		
-                <p>The page or file you were looking for caused a little tiny <a href="javascript:showError()">error</a>. 
-                <BR/>Please make sure that you have typed the correct URL. </p>
-                <p>If the problem persists, you can always return to the <a href="/">home page</a>.</p>
+                <p><%= LanguageUtil.get(pageContext,"500-body1") %></p>
+                <p><%= LanguageUtil.get(pageContext,"500-body2") %></p>
                 
             </div>
         </div>
         <br clear="all"/>&nbsp;<br clear="all"/>
-<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://dotcms.com">DM Web, Corp.</a></div>
+<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://<%=portalUrl%>"><%= LanguageUtil.get(pageContext,"500-copywright") %></a></div>
         <br clear="all"/>&nbsp;<br clear="all"/>
 		<div id="error" style="display: none;border: 1px #cccccc solid; padding:10px; margin:10px;width:80%">
 		        <% Exception x = (Exception) request.getAttribute("javax.servlet.error.exception");%>

--- a/dotCMS/portal/500.jsp
+++ b/dotCMS/portal/500.jsp
@@ -13,7 +13,6 @@
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <%@page import="com.liferay.portal.model.Company"%>
 <%@page import="com.dotmarketing.util.CompanyUtils"%> 
-
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
 	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);

--- a/dotCMS/portal/503.jsp
+++ b/dotCMS/portal/503.jsp
@@ -11,8 +11,7 @@
 <%@ page import="com.liferay.portal.util.WebKeys" %>
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <%@page import="com.liferay.portal.model.Company"%>
-<%@page import="com.dotmarketing.util.CompanyUtils"%>
- 
+<%@page import="com.dotmarketing.util.CompanyUtils"%> 
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
 	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);

--- a/dotCMS/portal/503.jsp
+++ b/dotCMS/portal/503.jsp
@@ -7,8 +7,19 @@
 <%@ page import="com.dotmarketing.business.CacheLocator"%>
 <%@ page import="com.dotmarketing.util.Logger"%>
 <%@ page import="com.dotmarketing.db.DbConnectionFactory"%>
+<%@ page import="com.liferay.portal.util.ImageKey" %>
+<%@ page import="com.liferay.portal.util.WebKeys" %>
+<%@page import="com.liferay.portal.language.LanguageUtil"%>
+<%@page import="com.liferay.portal.model.Company"%>
+<%@page import="com.dotmarketing.util.CompanyUtils"%>
+ 
 <%try{		
 	Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
+	Host defaultHost = WebAPILocator.getHostWebAPI().findDefaultHost(WebAPILocator.getUserWebAPI().getSystemUser(),false);
+	Company company = CompanyUtils.getDefaultCompany();
+	String portalUrl =  company.getPortalURL();
+	String IMAGE_PATH = (String) application.getAttribute(WebKeys.IMAGE_PATH);
+	String defaultImage =  IMAGE_PATH+"/company_logo?img_id="+company.getCompanyId()+"&key="+ImageKey.get(company.getCompanyId());
 		
 	String ep_originatingHost = host.getHostname();
 	String ep_errorCode = "503";
@@ -93,7 +104,7 @@
 
 <html>
 <head>
-	<link rel="shortcut icon" href="//www.dotcms.com/global/favicon.ico" type="image/x-icon">
+	<link rel="shortcut icon" href="http://<%=defaultHost.getHostname()%>/home/favicon.ico"" type="image/x-icon">
     <script>
         function showError(){
             var ele = document.getElementById("error");
@@ -108,7 +119,7 @@
         
         
     </script>
-	<title>dotCMS: 503 Undergoing Maintenance</title>
+	<title><%= LanguageUtil.get(pageContext,"503-page-title") %></title>
 
 	<style type="text/css">
 		body{
@@ -144,21 +155,18 @@
 </head>
 <body>
 <div id="main">
-			<div id="logo">
-		<a href="http://dotcms.com"><img src="/html/images/skin/logo.gif" width="140"  hspace="10" border="0" alt="dotCMS content management system" title="dotCMS content management system"  /></a>
-			</div>
-	<div id="text">
-	
-		<h1>Site Undergoing Maintenance</h1>
-		(we were this..close to putting an under construction icon here)
+	<div id="logo">
+		<a href="http://<%=portalUrl%>/"><img src="<%=defaultImage%>" width="140"  hspace="10" border="0" alt="<%=LanguageUtil.get(pageContext,"503-image-title")%>" title="<%=LanguageUtil.get(pageContext,"503-image-title")%>"  /></a>
+	</div>
+	<div id="text">	
+		<h1><%= LanguageUtil.get(pageContext,"503-title") %></h1>
+		<%= LanguageUtil.get(pageContext,"503-body1") %>
 		<br clear="all"/>&nbsp;<br clear="all"/>
-		<p>The site you were looking is stopped or is undergoing maintenance.
-		Please make sure that you have typed the correct URL. 
-		If not, please try back again later.  Thanks!</p>
+		<p><%= LanguageUtil.get(pageContext,"503-body2") %></p>
 	</div>
 
 <br clear="all"/>&nbsp;<br clear="all"/>
-<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://dotcms.com">DM Web, Corp.</a></div>
+<div id="footer">&copy; <script>var d = new Date();document.write(d.getFullYear());</script>, <a href="http://<%=portalUrl%>"><%= LanguageUtil.get(pageContext,"503-copywright") %></a></div>
 </body>
 </html>
 <%} catch( Exception e){


### PR DESCRIPTION
Changes done:
- Page's icon is now local instead of referring to dotmcs.com; instead of http://www.dotcms.com/global/favicon.ico, favicon's URL is now http:///home/favicon.ico (this file needs to be added to the starter - it will be reported in a separate task)
- Logo on error pages is now the logo configured in the Company Portlet
- Copyright URL is now the Portal URL configured in the Company Portlet
- Page Title, Page H1, Page Body, and copy right URL title are now taken from the dictionary terms allowing the user to assign their own text to the error pages in multiple languages.
- These language variables have been included in the default language file and are the ones that need to be defined by the user in case they want to customize the text in the default error pages:
  [error code]-image-title
  [error code]-page-title
  [error code]-title
  [error code]-body1
  [error code]-body2
  [error code]-copywright

error code = 400, 401, 402, 403, 404, 500, 503

Please see http://jira.dotmarketing.net/secure/attachment/5826733/screenshot-1.jpg .
