### PR TITLE
#1036

### DIFF
--- a/dotCMS/WEB-INF/messages/Language.properties
+++ b/dotCMS/WEB-INF/messages/Language.properties
@@ -3766,6 +3766,7 @@ modes.CMS-Task=CMS Task
 modes.Create-a-Task=Create a Task
 modes.Edit-Widget=Edit Widget
 modes.Edit-Content=Edit Content
+modes.Form=Form
 modes.Move-Content-Up=Move Content Up
 modes.Move-Content-Down=Move Content Down
 modes.Remove-Content=Remove Content

--- a/dotCMS/WEB-INF/velocity/static/preview_mode/content_controls.vtl
+++ b/dotCMS/WEB-INF/velocity/static/preview_mode/content_controls.vtl
@@ -28,7 +28,7 @@
 	<div id="edit-$CONTENT_INODE" class="dotContentletEdit">	
 		#if($_widget == true)
 				#if($_isFormWidget)
-				
+					<span class="dotEditContentDisabled">${langbackendwebapi.get("modes.Form")}: ${structures.findStructure($ContentletTitle).name}</span>
 				#elseif($EDIT_CONTENT_PERMISSION && $CONTAINER_NUM_CONTENTLETS > 0)
 					<a class="dotEditWidget" href="javascript:parent.editContentlet('$CONTAINER_INODE', '$CONTENT_INODE');">$langbackendwebapi.get("modes.Edit-Widget")</a>
 				#else


### PR DESCRIPTION
The form structures added to a page are now identified in the edit mode with an identification span that show the form name.

Files Updated
- /dotCMS/WEB-INF/messages/Language.properties
- /dotCMS/WEB-INF/velocity/static/preview_mode/content_controls.vtl
