### PR TITLE
#1058

### DIFF
--- a/dotCMS/WEB-INF/messages/Language.properties
+++ b/dotCMS/WEB-INF/messages/Language.properties
@@ -4369,6 +4369,7 @@ field-variable-saved=Field variable saved
 message.delete.fieldvariable=Are you sure you want to delete this Field Variable?
 Add-new-Field-Variable=Add new Field Variable
 No-Field-Variables-Found=No Field Variables Found
+No-Field-No-Field-Variable=You will need to save the field before being able to add variables
 
 Build=Build
 Unopened=Unopened

--- a/dotCMS/html/portlet/ext/structure/edit_field.jsp
+++ b/dotCMS/html/portlet/ext/structure/edit_field.jsp
@@ -465,7 +465,9 @@ s2 += " class=\"form-text\" id=\"textAreaValues\">" + textArea + "</textarea>";
 		var fieldId='<%=request.getParameter("inode")%>';
 	    if(fieldId!="null"){
 	    	fieldVariablesAdmin.showFieldVariables(fieldId,false);
-	    }		
+	    } else {
+	    	fieldVariablesAdmin.showInitFieldVariables();
+	    }	
 	}
 </script>
 

--- a/dotCMS/html/portlet/ext/structure/view_field_variables_inc.jsp
+++ b/dotCMS/html/portlet/ext/structure/view_field_variables_inc.jsp
@@ -43,8 +43,7 @@
 			FieldVariableAjax.getFieldVariablesForField(fieldId, dojo.hitch(this, fieldVariablesAdmin.showFieldVariablesCallback));
 			this.fieldId = fieldId;
 		},
-
-	 	showFieldVariablesCallback: function (variables) {
+		showFieldVariablesCallback: function (variables) {
 
 			if(this.isDialog)
 				dojo.html.set(dojo.byId('fieldVariablesDialogTable'), '');
@@ -77,7 +76,10 @@
 				dojo.style(dojo.byId('viewFieldVariablesTab'), 'visibility', 'visible');
 			}
 		},
-
+		showInitFieldVariables: function (){
+			dojo.style(dojo.byId('viewFieldVariablesInitTab'), 'height', '100px');
+			dojo.style(dojo.byId('viewFieldVariablesInitTab'), 'visibility', 'visible');
+		},
 		insertVariable: function (variable) {
 
 			if (this.currentIndex % 2 == 0){
@@ -217,7 +219,7 @@
     }));
 
 </script>
-
+	
 <div id="viewFieldVariablesTab">
 	<div class="yui-u" style="text-align:right;margin:5px 20px 10px 0;">
 	    <button dojoType="dijit.form.Button" onClick="fieldVariablesAdmin.addNewVariable(); return false;" iconClass="plusIcon">
@@ -288,7 +290,7 @@
 	        </tr>
     	</thead>
 		<tbody id="fieldVariablesDialogTable">
-		
+		  
 		</tbody>
 		<tbody id="noFieldVariablesDialogTable" style="visibility:hidden;">
 			<tr>
@@ -321,7 +323,11 @@
 		</button>
 	</div>
 </div> 
-
+<div id="viewFieldVariablesInitTab" style="visibility:hidden;">
+	<div class="yui-u" style="text-align:left;width:800px;">
+		<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "No-Field-No-Field-Variable")) %>
+	</div>
+</div>
 
 <script type="text/javascript">
 


### PR DESCRIPTION
removed the scroll and added message when someone is adding a new field to a structure to indicate in the "Field Variables" tab that no variables can be added until the field has been saved. 

Files Updated
- /dotCMS/WEB-INF/messages/Language.properties
- /dotCMS/html/portlets/ext/structure/edit_field.jsp
- /dotCMS/html/portlets/ext/structure/view_field_variables_inc.jsp
