### PR TITLE
Issue 1579 content versions tab on exe22

### DIFF
--- a/dotCMS/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
+++ b/dotCMS/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
@@ -120,32 +120,10 @@ catch(Exception e){
 
 <%--Start workflow tasks --%>
 <%for(WorkflowAction a : wfActions){ %>
-
-	<% List<WorkflowActionClass> actionlets = APILocator.getWorkflowAPI().findActionClasses(a); %>
-	<% boolean hasPushPublishActionlet = false; %>
-	<% for(WorkflowActionClass actionlet : actionlets){ %>
-		<% if(actionlet.getActionlet().getClass().getCanonicalName().equals(PushPublishActionlet.class.getCanonicalName())){ %>
-			<% hasPushPublishActionlet = true; %>
-		<% } %>
-	<% } %>
-	
-	<%if(a.requiresCheckout() && ! contentEditable) {%>
-		<a onclick="contentAdmin.executeWfAction('<%=a.getId()%>', <%= hasPushPublishActionlet || a.isAssignable() || a.isCommentable() || UtilMethods.isSet(a.getCondition()) %>)">
+  	<a onclick="contentAdmin.executeWfAction('<%=a.getId()%>', <%=a.isAssignable()%>, <%=a.isCommentable() || UtilMethods.isSet(a.getCondition()) %>)">
 		<span class="<%=a.getIcon()%>"></span>
-			<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, a.getName())) %>
-		</a>
-	<%} else if(!a.requiresCheckout() && ! contentEditable && InodeUtils.isSet(contentlet.getInode())) {%>
-		<a onclick="contentAdmin.executeWfAction('<%=a.getId()%>', <%= hasPushPublishActionlet || a.isAssignable() || a.isCommentable() || UtilMethods.isSet(a.getCondition()) %>)">
-		<span class="<%=a.getIcon()%>"></span>
-			<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, a.getName())) %>
-		</a>
-	<%} else if(a.requiresCheckout() &&  contentEditable ) {%>
-		<a onclick="contentAdmin.executeWfAction('<%=a.getId()%>', <%= hasPushPublishActionlet || a.isAssignable() || a.isCommentable() || UtilMethods.isSet(a.getCondition()) %>)">
-		<span class="<%=a.getIcon()%>"></span>
-			<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, a.getName())) %>
-		</a>
-	<%} %>
-
+		<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, a.getName())) %>
+	</a>
 <%} %>
 
 

--- a/src/com/dotmarketing/util/jasper/DotJasperTask.java
+++ b/src/com/dotmarketing/util/jasper/DotJasperTask.java
@@ -22,6 +22,32 @@ public class DotJasperTask extends JspC {
 				
 		}
 	}
-	
+
+    private static Set<String> includeList=null;
+    private static final Integer mutex=new Integer(0);
+    private static void buildIncludeList() {
+        synchronized(mutex) {
+         if(includeList!=null) return;
+         
+         Set<String> set=new HashSet<String>();
+         
+         //Load some defaults
+         set.add("contentlet_versions_inc.jsp");
+
+         includeList=set;
+        }
+    }
+
+    public static boolean includeJSP(String jsp) {
+        
+        if(includeList==null) buildIncludeList();
+        
+        for(String str : includeList){
+        	if(jsp.endsWith(str))
+        		return true;
+        }
+        
+    	return false;
+   }
 
 }

--- a/src/com/dotmarketing/util/jasper/DotJasperTask.java
+++ b/src/com/dotmarketing/util/jasper/DotJasperTask.java
@@ -1,5 +1,8 @@
 package com.dotmarketing.util.jasper;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.jasper.JasperException;
 import org.apache.jasper.JspC;
 import org.apache.log4j.ConsoleAppender;


### PR DESCRIPTION
1. contentlet_actions_inc.jsp some how got the 2.5 code, cleared it to match 2.2 code.
   
   This contentlet_actions_inc.jsp should not be merged with master(2.5).
2. As we are not packing JSPs in the exe, 
   
   added code to DotJasperTask.java so that contentlet_version_inc.jsp's URL will be in web.xml
   
   This DotJasperTask.java code can be merged to master(2.5).

Tested and committed.

Please check.
