### PR TITLE
Bug Fixed

### DIFF
--- a/src/com/dotcms/publisher/receiver/handler/StructureHandler.java
+++ b/src/com/dotcms/publisher/receiver/handler/StructureHandler.java
@@ -65,6 +65,16 @@ public class StructureHandler implements IHandler {
 	        	    
 	        	    if(!localExists) {
 	        	        StructureFactory.saveStructure(structure, structure.getInode());
+	        	        
+	        	        /*************************************************************/
+	        	        /* GITHUB ISSUE: https://github.com/dotCMS/dotCMS/issues/2210
+	        	         * 
+	        	         * We need to fill this property because, even if it was created, later into the code we use 
+	        	         * this one for retrieve a Field List.
+	        	         * 
+	        	         */
+	        	        /*************************************************************/
+	        	        localSt = StructureCache.getStructureByInode(structure.getInode());
 	        	    }
 	        	    else {
 	        	        // lets update the attributes


### PR DESCRIPTION
#2210 Even if it creates the new structure, we need to fill the old property because it's used later into the code, for example for retrieve the Field List.
