### PR TITLE
#2567

### DIFF
--- a/dotCMS/html/js/dotcms/dijit/form/FileAjaxUploader.js
+++ b/dotCMS/html/js/dotcms/dijit/form/FileAjaxUploader.js
@@ -246,7 +246,6 @@ dojo.declare("dotcms.dijit.form.FileAjaxUploader", [dijit._Widget, dijit._Templa
 		dojo.style(this.fileUploadForm, { display: 'none' });
 		dojo.style(this.fileUploadStatus, { display: 'none' });
 		dojo.style(this.fileUploadRemoveButton, { display: '' });
-		dojo.style(this.fileUploadInfoButton, { display: '' });
 		FileAjax.clearFileUploadStatus(this.name, function () {});
 		this.onUploadFinish(this.fileName, this);
 


### PR DESCRIPTION
Image uploaded through binary field is saved to the system only after the content is saved.

File Link is based on the content's inode and populated only after saving the content.

As the File Name is already displayed beside the Remove button, 

hiding the info button after new image upload.
