### PR TITLE
fixes #2777 Unable to edit categories sort order in ie9

### DIFF
--- a/dotCMS/html/portlet/ext/categories/view_categories.jsp
+++ b/dotCMS/html/portlet/ext/categories/view_categories.jsp
@@ -102,13 +102,8 @@ td {font-size: 100%;}
 	};
 
 	var sortSelectable = function() {
-		dojo.forEach(
-			      dojo.query('[unselectable]'),
-			      function(selectTag){
-			        selectTag.unselectable = 'off';
-			      }
-			    );
-			 
+		var toSel = document.activeElement;
+		document.getElementById(toSel.id).setAttribute("unselectable", "off");			 
 	};
 
 	


### PR DESCRIPTION
Fixed the issue, tested with all browsers, and committed the code for review, please check it.
