### PR TITLE
Issue 2791 parent folder caches are not being flushed

### DIFF
--- a/src/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
+++ b/src/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
@@ -519,7 +519,7 @@ public class BrowserAjax {
                 }
                 
                 refreshIndex(null, parentFolder, user, null, folder );
-                APILocator.getPermissionAPI().resetAllPermissionReferences();
+                APILocator.getPermissionAPI().resetPermissionReferences(folder);
             }
         } catch ( Exception e ) {
             HibernateUtil.rollbackTransaction();

--- a/src/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
+++ b/src/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
@@ -519,6 +519,7 @@ public class BrowserAjax {
                 }
                 
                 refreshIndex(null, parentFolder, user, null, folder );
+                APILocator.getPermissionAPI().resetAllPermissionReferences();
             }
         } catch ( Exception e ) {
             HibernateUtil.rollbackTransaction();


### PR DESCRIPTION
Limited the scope to clear Permission References every time we move a folder.
