### PR TITLE
BinaryCleanupJob Fixes

### DIFF
--- a/src/com/dotmarketing/init/DotInitScheduler.java
+++ b/src/com/dotmarketing/init/DotInitScheduler.java
@@ -376,7 +376,7 @@ public class DotInitScheduler {
 					if (isNew)
 						sched.scheduleJob(trigger);
 					else
-						sched.rescheduleJob("trigger11", "group8", trigger);
+						sched.rescheduleJob("trigger11", "group11", trigger);
 				} catch (Exception e) {
 					Logger.error(DotInitScheduler.class, e.getMessage(),e);
 				}

--- a/src/com/dotmarketing/quartz/job/BinaryCleanupJob.java
+++ b/src/com/dotmarketing/quartz/job/BinaryCleanupJob.java
@@ -67,7 +67,7 @@ public class BinaryCleanupJob implements Job {
 				try {
 					List<File> rFiles = FileUtil.listFilesRecursively(tempDir);
 					for (File rFile : rFiles) {
-						if(FileUtils.isFileNewer(rFile, dDate)){
+						if(FileUtils.isFileOlder(rFile, dDate)){
 							deleteFolder = false;
 							break;
 						}
@@ -80,7 +80,7 @@ public class BinaryCleanupJob implements Job {
 					continue;
 				}
 			}else{
-				if(FileUtils.isFileNewer(file, dDate)){
+				if(FileUtils.isFileOlder(file, dDate)){
 					file.delete();
 				}
 			}


### PR DESCRIPTION
I ran into a couple of small issues with the BinaryCleanupJob that I fixed via a plugin. This pull request encompasses what I needed to change.
- Now using the correct group when rescheduleJob is called for the BinaryCleanupJob. Prior to this change, it was impossible to reschedule the BinaryCleanupJob via property configuration.
- Changed FileUtils.isFileNewer calls to FileUtils.isFileOlder in the BinaryCleanupJob. Prior to this change, files that were newer than the configured BINARY_CLEANUP_FILE_LIFE_HOURS were deleted instead of files that were older than BINARY_CLEANUP_FILE_LIFE_HOURS.
