### PR TITLE
fixes #3049 on master25 Role names cut-off in Roles page

### DIFF
--- a/dotCMS/html/portlet/ext/useradmin/view_users_js_inc.jsp
+++ b/dotCMS/html/portlet/ext/useradmin/view_users_js_inc.jsp
@@ -508,6 +508,7 @@ function builtUserRolesMutiSelect(roles) {
             var nodeName = getDBFQNLabel(roles[i].DBFQN);
             c.innerHTML = nodeName;
             c.value = roles[i].id;
+            c.title = nodeName;
             sel.appendChild(c);
 
             var alreadyAdded = false;
@@ -848,6 +849,7 @@ function addUserRoles() {
                 var c = win.doc.createElement('option');
                 c.innerHTML = dbfqnLabel;
                 c.value = id;
+                c.title = dbfqnLabel;
                 select.appendChild(c);
 
 


### PR DESCRIPTION
when we hover the text we can see the full path, and committed on master-2.5 please check it.
