### PR TITLE
fixes #3296

### DIFF
--- a/dotCMS/WEB-INF/velocity/VM_global_library.vm
+++ b/dotCMS/WEB-INF/velocity/VM_global_library.vm
@@ -467,7 +467,7 @@
 			#end
 			
 			#foreach ($identifier in $results)
-				#getContentMapDetailByIdentifier($identifier.identifier)
+				#set($content = $dotcontent.find($identifier.identifier))
 				$!list.add(${math.sub($velocityCount,1)}, $content)
 			#end
 			


### PR DESCRIPTION
We actually need to redo these macros entirely - all logic should be in Java and they should be in viewtools.  That is for a later time, though.
