### PR TITLE
fixes #3252 Data too long for column notes

### DIFF
--- a/dotCMS/html/portlet/ext/containers/edit_container.jsp
+++ b/dotCMS/html/portlet/ext/containers/edit_container.jsp
@@ -313,7 +313,7 @@
 			<div id="notesDiv">
 				<dl>
 					<dt><%= LanguageUtil.get(pageContext, "Notes") %>:</dt>
-					<dd><textarea dojoType="dijit.form.Textarea" style="width:450px; min-height:150px" name="notes" id="notes"><%= UtilMethods.isSet(form.getNotes()) ? form.getNotes() : "" %></textarea></dd>
+					<dd><textarea dojoType="dijit.form.Textarea" style="width:450px; min-height:150px" maxlength="255" name="notes" id="notes"><%= UtilMethods.isSet(form.getNotes()) ? form.getNotes() : "" %></textarea></dd>
 				</dl>
 				<script type="text/javascript">
 					dojo.connect(dijit.byId('notes'), 'onkeydown', function(e) {if(dijit.byId('notes').focused) return catchTab(document.getElementById('notes'), e) });


### PR DESCRIPTION
prevented this on the client side using HTML's "maxlength" attribute for input field. Pushed the code please check it.
