### PR TITLE
Changed replaceAll() to replace(). Added support for Windows line break ...

### DIFF
--- a/dotCMS/html/portlet/ext/contentlet/edit_contentlet_relationships.jsp
+++ b/dotCMS/html/portlet/ext/contentlet/edit_contentlet_relationships.jsp
@@ -685,6 +685,7 @@
 							(new tinymce.Editor(formEle[i].id, tinyMCEProps)).render();
 						}
 						formEle[i].value = formEle[i].value.replace(/^\s+|\s+$/g, '');
+						formEle[i].value = formEle[i].value.replace(/\r\n/g, '');
 						formEle[i].value = formEle[i].value.replace(/\n/g, '');
 						<%
 						Iterator it = con.entrySet().iterator();
@@ -693,9 +694,10 @@
 							String v = "";
 							if(pairs.getValue()!=null){
 								v = pairs.getValue().toString();
-								v = v.replaceAll("\'","\\\\'");
-								v = v.replaceAll("\"","\\\\\"");
-								v = v.replaceAll("\n","");
+								v = v.replace("\'","\\\\'");
+								v = v.replace("\"","\\\\\"");
+								v = v.replace("\r\n","");
+								v = v.replace("\n","");
 								if(v.matches("(.*)-(.*)-(.*):(.*):(.*)")){
 									int index = v.lastIndexOf( ':' );
 									v = v.substring(0,index);

--- a/dotCMS/html/portlet/ext/contentlet/edit_contentlet_relationships.jsp
+++ b/dotCMS/html/portlet/ext/contentlet/edit_contentlet_relationships.jsp
@@ -687,6 +687,7 @@
 						formEle[i].value = formEle[i].value.replace(/^\s+|\s+$/g, '');
 						formEle[i].value = formEle[i].value.replace(/\r\n/g, '');
 						formEle[i].value = formEle[i].value.replace(/\n/g, '');
+						formEle[i].value = formEle[i].value.replace(/\r/g, '');
 						<%
 						Iterator it = con.entrySet().iterator();
 						while (it.hasNext()) {
@@ -698,6 +699,7 @@
 								v = v.replace("\"","\\\\\"");
 								v = v.replace("\r\n","");
 								v = v.replace("\n","");
+								v = v.replace("\r","");
 								if(v.matches("(.*)-(.*)-(.*):(.*):(.*)")){
 									int index = v.lastIndexOf( ':' );
 									v = v.substring(0,index);


### PR DESCRIPTION
Changed replaceAll() to replace(). Added support for Windows line break replacement in edit_contentlet_relationships.jsp 

This resolves an issue with Windows line breaks breaking the JavaScript in the JSP, which prevented related content from being displayed.

Please merge. =-)

Thanks,

Nathan Keiter
