### PR TITLE
#3669

### DIFF
--- a/dotCMS/WEB-INF/jsp/lucene/lucene_search.jsp
+++ b/dotCMS/WEB-INF/jsp/lucene/lucene_search.jsp
@@ -132,6 +132,20 @@ String referer = new URLEncoder().encode("/c/portal/layout?p_l_id=" + layout.get
 				
 				<dt></dt><dd><button type="submit" id="submitButton" dojoType="dijit.form.Button" value="Submit"><%= LanguageUtil.get(pageContext, "Submit") %></button></dd>
 			</dl>
+            <script language="Javascript">
+				/**
+					focus on search box
+				**/
+				require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+					dojo.require('dojox.timing');
+					t = new dojox.timing.Timer(500);
+					t.onTick = function(){
+					  focusUtil.focus(dom.byId("query"));
+					  t.stop();
+					}
+					t.start();
+				});
+			</script>
 		</form>
 	</div>
 	<hr>

--- a/dotCMS/WEB-INF/jsp/tag_manager/tag_manager.jsp
+++ b/dotCMS/WEB-INF/jsp/tag_manager/tag_manager.jsp
@@ -435,7 +435,7 @@ td {font-size: 100%;}
 	<div class="yui-g nameHeader">
 		<div class="yu-u first" id="filters">
 	        <input type="hidden" name="host_id" id="host_id" value="<%=(String)session.getAttribute(com.dotmarketing.util.WebKeys.CMS_SELECTED_HOST_ID)%>">
-			<input type="text" name="filterBox" value="" dojoType="dijit.form.TextBox" placeHolder="Filter" trim="true" id="filterBox" intermediateChanges="true" onChange="searchTagByName();" onblur="alterFocus(document.activeElement, this);" >
+			<input type="text" name="filterBox" value="" dojoType="dijit.form.TextBox" placeHolder="Filter" trim="true" id="filterBox" intermediateChanges="true" onChange="searchTagByName();" onBlur="alterFocus(document.activeElement, this);" >
 		       <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Search")) %>
 		    </button>
 			<button dojoType="dijit.form.Button" iconclass="resetIcon" id="resetButton" onClick="resetSearch()">
@@ -448,16 +448,16 @@ td {font-size: 100%;}
 
 		<div class="yui-u" style="text-align:right;">
 		<form name="export_form" id="export_form" method="get">
-			<button dojoType="dijit.form.Button" onclick="addNewTag()" type="button" iconClass="plusIcon">
+			<button dojoType="dijit.form.Button" onClick="addNewTag()" type="button" iconClass="plusIcon">
 				<%= LanguageUtil.get(pageContext, "add-tag") %>
 			</button>
-			<button dojoType="dijit.form.Button" type="button" iconClass="uploadIcon" onclick="openImportTagsDialog()">
+			<button dojoType="dijit.form.Button" type="button" iconClass="uploadIcon" onClick="openImportTagsDialog()">
 				<%= LanguageUtil.get(pageContext, "import-tags") %>
 			</button>
-			<button dojoType="dijit.form.Button" type="button" iconClass="downloadIcon" onclick="exportTags()">
+			<button dojoType="dijit.form.Button" type="button" iconClass="downloadIcon" onClick="exportTags()">
 				<%= LanguageUtil.get(pageContext, "export-tags") %>
 			</button>
-			<button dojoType="dijit.form.Button" type="button" onclick="deleteTagsBatch()" iconClass="deleteIcon">
+			<button dojoType="dijit.form.Button" type="button" onClick="deleteTagsBatch()" iconClass="deleteIcon">
 			<%= LanguageUtil.get(pageContext, "delete-tags") %>
 			</button>
 			<input type="hidden" id="cmd" value="none">
@@ -470,7 +470,20 @@ td {font-size: 100%;}
 		<div id="tagsGrid"></div>
 	</div>
 </div>
-
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("filterBox"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script>
  <%-- Add Tag Dialog --%>
 
 <div id="addTagDialog" title="<%= LanguageUtil.get(pageContext, "edit-tag") %>" dojoType="dijit.Dialog" style="display: none;width:500px">
@@ -490,7 +503,7 @@ td {font-size: 100%;}
 			<input id="tagId" type="hidden" value=" " />
 			<input id="userId" type="hidden" value=" " />
 			<input id="tagStorage" type="hidden" value=" "/>
-			<select id="tagStorage_dropDown" name="tagStorage_dropDown" dojoType="dijit.form.FilteringSelect" autocomplete="true" invalidMessage="Required." onchange="verifyHiddenFields()">
+			<select id="tagStorage_dropDown" name="tagStorage_dropDown" dojoType="dijit.form.FilteringSelect" autocomplete="true" invalidMessage="Required." onChange="verifyHiddenFields()">
 			<option value="SYSTEM_HOST"><%=LanguageUtil.get(pageContext, "tag-all-hosts") %></option>
 			<%for(Host h: allHosts){
 				if(!h.getIdentifier().equals(Host.SYSTEM_HOST) && h.isLive())
@@ -544,7 +557,7 @@ td {font-size: 100%;}
 		<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "upload-csv-with-tags")) %>
 		<br><br>
 		<div style="text-align:center">
-		<a onclick="downloadCSVSampleFile()" href="#"><%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "download-sample-csv-file")) %></a>
+		<a onClick="downloadCSVSampleFile()" href="#"><%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "download-sample-csv-file")) %></a>
 		</div>
 		<br>
 		<div class="buttonRow">

--- a/dotCMS/html/portlet/ext/calendar/view_calendar_main_inc.jsp
+++ b/dotCMS/html/portlet/ext/calendar/view_calendar_main_inc.jsp
@@ -217,3 +217,17 @@
 	resizeBrowser();
 </script>
 
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("keywordBox"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script> 

--- a/dotCMS/html/portlet/ext/campaigns/view_campaigns.jsp
+++ b/dotCMS/html/portlet/ext/campaigns/view_campaigns.jsp
@@ -136,7 +136,7 @@ value='<%=(com.dotmarketing.util.UtilMethods.isSet(request.getParameter("orderby
 <div class="yui-g portlet-toolbar">
 	<div class="yui-u first">
 		<input type="text" dojoType="dijit.form.TextBox" name="query" value="<%= com.dotmarketing.util.UtilMethods.isSet(query) ? query : "" %>" style="vertical-align:middle;" />
-		<button dojoType="dijit.form.Button" onClick="submitfm();" iconClass="searchIcon" style="vertical-align:middle;"><%=LanguageUtil.get(pageContext, "Search")%></button>
+		<button dojoType="dijit.form.Button" type="submit" onClick="submitfm();" iconClass="searchIcon" style="vertical-align:middle;"><%=LanguageUtil.get(pageContext, "Search")%></button>
 		<button dojoType="dijit.form.Button" onClick="resetSearch();" iconClass="resetIcon" style="vertical-align:middle;"><%=LanguageUtil.get(pageContext, "Reset")%></button>
 	</div>
 	
@@ -171,7 +171,20 @@ value='<%=(com.dotmarketing.util.UtilMethods.isSet(request.getParameter("orderby
 	}
 %>
 </div>
-
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("dijit_form_TextBox_0"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script> 
 <table border="0" cellpadding="0" cellspacing="0" width="100%" class="listingTable" >	
 	<tr>
 		<th width="30" style="text-align:center;"><input type="checkbox" dojoType="dijit.form.CheckBox" name="checkAll" id="checkAll" onclick="checkUncheckAll()"></th>

--- a/dotCMS/html/portlet/ext/categories/view_categories.jsp
+++ b/dotCMS/html/portlet/ext/categories/view_categories.jsp
@@ -844,7 +844,20 @@ td {font-size: 100%;}
 			<!-- END Permission Tab -->
 			</div>
 		</div>
-
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("catFilter"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script>
 
 
 </liferay:box>

--- a/dotCMS/html/portlet/ext/communications/view_communications.jsp
+++ b/dotCMS/html/portlet/ext/communications/view_communications.jsp
@@ -125,7 +125,7 @@ function deleteCommunication(inode) {
 			<input type="text" dojoType="dijit.form.TextBox" name="query2" value="<%= com.dotmarketing.util.UtilMethods.isSet(query2) ? query2 : "" %>">
 		</div>
 		
-		<button dojoType="dijit.form.Button" onClick="submitfm()" iconClass="searchIcon">
+		<button dojoType="dijit.form.Button" onClick="submitfm()" type="submit" iconClass="searchIcon">
 			<%=LanguageUtil.get(pageContext, "Search")%>
 		</button>
 
@@ -230,4 +230,20 @@ function deleteCommunication(inode) {
 
 
 </liferay:box>
+
+
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("dijit_form_TextBox_0"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script> 
 </form>

--- a/dotCMS/html/portlet/ext/containers/view_containers.jsp
+++ b/dotCMS/html/portlet/ext/containers/view_containers.jsp
@@ -207,7 +207,7 @@ function processDelete(inode, referer) {
 				} %>
 		</select>
 		<input type="text" name="query" dojoType="dijit.form.TextBox" style="width:175px;" value="<%= com.dotmarketing.util.UtilMethods.isSet(query) ? query : "" %>">
-	    <button dojoType="dijit.form.Button" onClick="submitfm()" iconClass="searchIcon">
+	    <button dojoType="dijit.form.Button" type="submit" onClick="submitfm()" iconClass="searchIcon">
 	        <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Search")) %>
 	    </button>
 		<button dojoType="dijit.form.Button" onClick="resetSearch()" iconClass="resetIcon">
@@ -225,6 +225,20 @@ function processDelete(inode, referer) {
 		<% } %>
 	</div>
 </div>
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("dijit_form_TextBox_0"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script> 
 </form>
 
 

--- a/dotCMS/html/portlet/ext/dashboard/view_dashboard.jsp
+++ b/dotCMS/html/portlet/ext/dashboard/view_dashboard.jsp
@@ -429,7 +429,20 @@ int periodData = dAPI.checkPeriodData(0,0);
 				</select>
 	    	</td>
 		    	
-		    	
+		    <script language="Javascript">
+				/**
+					focus on search box
+				**/
+				require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+					dojo.require('dojox.timing');
+					t = new dojox.timing.Timer(500);
+					t.onTick = function(){
+					  focusUtil.focus(dom.byId("dahboardHostSelector"));
+					  t.stop();
+					}
+					t.start();
+				});
+			</script>	
 		    	
 			<% int count = 2;
 			   int numTd = 8;
@@ -758,7 +771,7 @@ int periodData = dAPI.checkPeriodData(0,0);
 
 				
 	<div class="buttonRow">
-		<button dojoType="dijit.form.Button" onClick="submitfm();" iconClass="searchIcon">
+		<button dojoType="dijit.form.Button" type="submit" onClick="submitfm();" iconClass="searchIcon">
 			<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Search")) %>
 		</button>
 		<button dojoType="dijit.form.Button" id="clearButtonHost" onClick="clearHostSearch();" iconClass="resetIcon">

--- a/dotCMS/html/portlet/ext/formhandler/view_form.jsp
+++ b/dotCMS/html/portlet/ext/formhandler/view_form.jsp
@@ -120,7 +120,7 @@ function downloadToExcel(structureInode){
 			
 			<input type="text" dojoType="dijit.form.TextBox" name="query" value="<%= com.dotmarketing.util.UtilMethods.isSet(query) ? query : "" %>">
 			
-			<button dojoType="dijit.form.Button" onClick="submitfm()" iconClass="searchIcon">
+			<button dojoType="dijit.form.Button" type="submit" onClick="submitfm()" iconClass="searchIcon">
 				<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Search")) %>
 			</button>
 
@@ -140,7 +140,22 @@ function downloadToExcel(structureInode){
 	           <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Add-New-Form" )) %>
 	        </button>
 		</div>
-	</div>            
+	</div> 
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("dijit_form_TextBox_0"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script>
+               
 </form>
 	
 

--- a/dotCMS/html/portlet/ext/hostadmin/view_hosts.jsp
+++ b/dotCMS/html/portlet/ext/hostadmin/view_hosts.jsp
@@ -29,6 +29,20 @@
             <%=LanguageUtil.get(pageContext, "Reset")%>
         </button>
     </div>
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("filter"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script> 
     <div class="yui-u" style="text-align: right;">
 		<input dojoType="dijit.form.CheckBox" type="checkbox" name="showDeleted" id="showDeleted" onClick="hostAdmin.filterHosts();" <%=(showDeleted!=null) && (showDeleted.equals("true")) ? "checked" : ""%> value="true" />
 		<label for="showDeleted" style="font-size:85%;"><%=LanguageUtil.get(pageContext, "Show-Archived")%></label>

--- a/dotCMS/html/portlet/ext/htmlpages/view_htmlpages.jsp
+++ b/dotCMS/html/portlet/ext/htmlpages/view_htmlpages.jsp
@@ -9,7 +9,8 @@
 <%@page import="com.dotmarketing.business.APILocator"%>
 
 <%
-Boolean hostChanged = (Boolean) request.getAttribute(com.dotmarketing.util.WebKeys.HTMLPAGE_HOST_CHANGED);int pageNumber = 1;
+Boolean hostChanged = (Boolean) request.getAttribute(com.dotmarketing.util.WebKeys.HTMLPAGE_HOST_CHANGED);
+int pageNumber = 1;
 if (!hostChanged && (request.getParameter("pageNumber") != null) && (request.getParameter("resetQuery") == null)) {
 	pageNumber = Integer.parseInt(request.getParameter("pageNumber")); 
 }
@@ -156,7 +157,7 @@ hostId = request.getParameter("host_id");
 		<input type="hidden" name="host_id" id="host_id" value="<%=(String)session.getAttribute(com.dotmarketing.util.WebKeys.CMS_SELECTED_HOST_ID)%>">
 		<input type="text" dojoType="dijit.form.TextBox" name="query" value="<%= com.dotmarketing.util.UtilMethods.webifyString(query)  %>">
 	   
-	    <button dojoType="dijit.form.Button" onClick="submitfm()" iconClass="searchIcon">
+	    <button dojoType="dijit.form.Button" type="submit" onClick="submitfm()" iconClass="searchIcon">
 	        <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Search")) %>
 	    </button>
 	    
@@ -175,10 +176,26 @@ hostId = request.getParameter("host_id");
 	    </button>
 	</div>
 </div>
+<script language="Javascript">
+/**
+    focus on search box
+**/
+require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+    dojo.require('dojox.timing');
+    t = new dojox.timing.Timer(500);
+    t.onTick = function(){
+      focusUtil.focus(dom.byId("dijit_form_TextBox_0"));
+      t.stop();
+    }
+    t.start();
+});
+</script>
+
 </form>
 
 <form id="fm_publish" method="post">
 <input type="hidden" name="referer" value="<%=referer%>"><input type="hidden" name="cmd" value="prepublish">
+
 
 <table class="listingTable">
 	<tr>

--- a/dotCMS/html/portlet/ext/languagesmanager/edit_language_keys.jsp
+++ b/dotCMS/html/portlet/ext/languagesmanager/edit_language_keys.jsp
@@ -471,6 +471,20 @@
 		<button dojoType="dijit.form.Button" onClick="clearFilter();" iconClass="closeIcon">
 			<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Clear")) %>
 		</button>
+        <script language="Javascript">
+			/**
+				focus on search box
+			**/
+			require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+				dojo.require('dojox.timing');
+				t = new dojox.timing.Timer(500);
+				t.onTick = function(){
+				  focusUtil.focus(dom.byId("filter"));
+				  t.stop();
+				}
+				t.start();
+			});
+		</script> 
 	</div>
 </div>
 

--- a/dotCMS/html/portlet/ext/links/view_links.jsp
+++ b/dotCMS/html/portlet/ext/links/view_links.jsp
@@ -148,7 +148,7 @@ function togglePublish(){
 			<input type="hidden" name="resetQuery" value="">
             <input type="hidden" name="host_id" id="host_id" value="<%=(String)session.getAttribute(com.dotmarketing.util.WebKeys.CMS_SELECTED_HOST_ID)%>"> 
 			<input type="text"  dojoType="dijit.form.TextBox" style="width:175px;" name="query" value="<%= com.dotmarketing.util.UtilMethods.isSet(query) ? query : "" %>">
-            <button dojoType="dijit.form.Button" onClick="submitfm()" iconClass="searchIcon">
+            <button dojoType="dijit.form.Button" type="submit" onClick="submitfm()" iconClass="searchIcon">
                <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Search")) %>
             </button>
             <button dojoType="dijit.form.Button" onClick="resetSearch()" iconClass="resetIcon">
@@ -164,6 +164,20 @@ function togglePublish(){
 	</button>
 		</div>
 	</div>
+	<script language="Javascript">
+    /**
+        focus on search box
+    **/
+    require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+        dojo.require('dojox.timing');
+        t = new dojox.timing.Timer(500);
+        t.onTick = function(){
+          focusUtil.focus(dom.byId("dijit_form_TextBox_0"));
+          t.stop();
+        }
+        t.start();
+    });
+    </script>
 </form>
 <!-- END Toolbar -->
 

--- a/dotCMS/html/portlet/ext/mailinglists/view_mailinglists.jsp
+++ b/dotCMS/html/portlet/ext/mailinglists/view_mailinglists.jsp
@@ -119,7 +119,7 @@
 		<span style="vertical-align:middle;"><%=LanguageUtil.get(pageContext, "Mailing-List-Title")%>:</span>
 		<span style="vertical-align:middle;"><input type="text" dojoType="dijit.form.TextBox" name="query" id="query" value="<%=com.dotmarketing.util.UtilMethods.isSet(query) ? query : ""%>"></span>
 		<span style="vertical-align:middle;">
-			<button dojoType="dijit.form.Button" onClick="submitSearch()" iconClass="searchIcon">
+			<button dojoType="dijit.form.Button" type="submit" onClick="submitSearch()" iconClass="searchIcon">
 				<%=LanguageUtil.get(pageContext, "Search")%>
 			</button>
 		</span>
@@ -145,7 +145,20 @@
 %>
 </div>
 
-
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("query"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script>
 <input type="hidden" name="<portlet:namespace />cmd" value="">
 <input type="hidden" name="<portlet:namespace />redirect" value="">
 <input type="hidden" name="inode" value="">

--- a/dotCMS/html/portlet/ext/osgi/bundles.jsp
+++ b/dotCMS/html/portlet/ext/osgi/bundles.jsp
@@ -47,9 +47,23 @@ states.put(Bundle.STOP_TRANSIENT, LanguageUtil.get(pageContext, "OSGI-Bundles-St
 <div class="buttonBoxLeft">
 	<div dojoType="dojo.data.ItemFileReadStore" jsId="test" url="/html/portlet/ext/osgi/available_bundles_json.jsp"></div>
 	<%= LanguageUtil.get(pageContext,"OSGI-AVAIL-BUNDLES") %> : <input dojoType="dijit.form.ComboBox" store="test" searchAttr="label" name="availBundlesCombo" id="availBundlesCombo">
-	<button dojoType="dijit.form.Button" onclick="javascript:bundles.deploy()"><%=LanguageUtil.get(pageContext, "OSGI-Load-Bundle")%></button>
+	<button dojoType="dijit.form.Button" type="submit" onclick="javascript:bundles.deploy()"><%=LanguageUtil.get(pageContext, "OSGI-Load-Bundle")%></button>
 
 </div>
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("availBundlesCombo"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script> 
 <div class="buttonBoxRight">
 	<button dojoType="dijit.form.Button" onClick="javascript:dijit.byId('uploadOSGIDialog').show()" iconClass="plusIcon" type="button"><%=LanguageUtil.get(pageContext, "OSGI-Upload-Bundle")%></button>
 	<button dojoType="dijit.form.Button" onClick="bundles.reboot(true);" iconClass="resetIcon" type="button"><%=LanguageUtil.get(pageContext, "OSGI-restart-framework")%></button>

--- a/dotCMS/html/portlet/ext/roleadmin/view_roles.jsp
+++ b/dotCMS/html/portlet/ext/roleadmin/view_roles.jsp
@@ -105,7 +105,20 @@
 	<input dojoType="dijit.form.TextBox" onkeyup="filterRoles()" trim="true" id="rolesFilter" >
 	<button dojoType="dijit.form.Button" onclick="clearRolesFilter()" iconClass="resetIcon" type="button"><%= LanguageUtil.get(pageContext, "Clear") %></button>
 </div>
-
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("rolesFilter"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script>
 
 <div class="buttonBoxRight">
 	<span id="editRoleButtonWrapper" style="display:none;">

--- a/dotCMS/html/portlet/ext/structure/view_structure.jsp
+++ b/dotCMS/html/portlet/ext/structure/view_structure.jsp
@@ -274,7 +274,7 @@ var deleteLabel = "";
 
 		<input type="text" name="query" dojoType="dijit.form.TextBox" style="width:175px;" value="<%= com.dotmarketing.util.UtilMethods.isSet(query) ? query : "" %>">
 
-		<button dojoType="dijit.form.Button" onClick="submitfm()" iconClass="searchIcon">
+		<button dojoType="dijit.form.Button" type="submit" onClick="submitfm()" iconClass="searchIcon">
 		   <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Search")) %>
 		</button>
 
@@ -425,6 +425,21 @@ var deleteLabel = "";
 		</div>
 	</div>
 <!-- END Pagination -->
+
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("dijit_form_TextBox_0"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script> 
 
 </form>
 <form id="remotePublishForm">

--- a/dotCMS/html/portlet/ext/templates/view_templates.jsp
+++ b/dotCMS/html/portlet/ext/templates/view_templates.jsp
@@ -168,7 +168,7 @@ function processDelete(inode, referer) {
 			<input type="hidden" name="resetQuery" value="">
 			<input type="hidden" name="host_id" id="host_id" value="<%=(String)session.getAttribute(com.dotmarketing.util.WebKeys.CMS_SELECTED_HOST_ID)%>">
 			<input type="text" dojoType="dijit.form.TextBox" style="width:175px;" name="query" value="<%= com.dotmarketing.util.UtilMethods.isSet(query) ? query : "" %>">
-		    <button dojoType="dijit.form.Button"  onClick="submitfm()" iconClass="searchIcon">
+		    <button dojoType="dijit.form.Button" type="submit" onClick="submitfm()" iconClass="searchIcon">
 		       <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Search" )) %>
 		    </button>
 		
@@ -211,6 +211,21 @@ function processDelete(inode, referer) {
 	<div class="yui-u" style="text-align:right; white-space:nowrap" >
 
 	</div>
+	<script language="Javascript">
+		/**
+			focus on search box
+		**/
+		require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+			dojo.require('dojox.timing');
+			t = new dojox.timing.Timer(500);
+			t.onTick = function(){
+			  focusUtil.focus(dom.byId("dijit_form_TextBox_0"));
+			  t.stop();
+			}
+			t.start();
+		});
+    </script>    
+    
 </form>
 
 <form id="fm_publish" method="post">

--- a/dotCMS/html/portlet/ext/timemachine/timemachine_select.jsp
+++ b/dotCMS/html/portlet/ext/timemachine/timemachine_select.jsp
@@ -310,6 +310,20 @@ function futureChange() {
 	                       </td>
                        </tr>
                    </table>
+                   <script language="Javascript">
+						/**
+							focus on search box
+						**/
+						require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+							dojo.require('dojox.timing');
+							t = new dojox.timing.Timer(500);
+							t.onTick = function(){
+							  focusUtil.focus(dom.byId("timesel"));
+							  t.stop();
+							}
+							t.start();
+						});
+					</script>
                     <%if(APILocator.getRoleAPI().doesUserHaveRole(user, APILocator.getRoleAPI().loadCMSAdminRole())){ %>
                        <span id="settings" style="float:right">
                            <button id="settingsBtn" dojoType="dijit.form.Button" onClick="showSettings()">

--- a/dotCMS/html/portlet/ext/useradmin/view_users.jsp
+++ b/dotCMS/html/portlet/ext/useradmin/view_users.jsp
@@ -41,6 +41,21 @@
 	<button dojoType="dijit.form.Button" onclick="clearUserFilter()" type="button" iconClass="resetIcon"><%= LanguageUtil.get(pageContext, "Clear") %></button>
 </div>
 
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("usersFilter"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script> 
+
 <div class="buttonBoxRight">
 	<button dojoType="dijit.form.Button" type="button" onclick="addUser()" iconClass="plusIcon"><%= LanguageUtil.get(pageContext, "Add-User") %></button>
 

--- a/dotCMS/html/portlet/ext/virtuallinks/view_virtuallinks.jsp
+++ b/dotCMS/html/portlet/ext/virtuallinks/view_virtuallinks.jsp
@@ -83,7 +83,7 @@ window.location="<portlet:renderURL windowState='<%= WindowState.MAXIMIZED.toStr
 
 
 
-                <button dojoType="dijit.form.Button" iconClass="searchIcon" onClick="submitfm()"><%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "search")) %></button>
+                <button dojoType="dijit.form.Button" iconClass="searchIcon" type="submit" onClick="submitfm()"><%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "search")) %></button>
                 <button dojoType="dijit.form.Button" iconClass="resetIcon" onClick="resetSearch()"><%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Reset")) %></button>
            </div>
 
@@ -170,5 +170,18 @@ window.location="<portlet:renderURL windowState='<%= WindowState.MAXIMIZED.toStr
 	<%} %>
 
 </liferay:box>
-
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("query"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script> 
 </form>

--- a/dotCMS/html/portlet/ext/workflows/view_workflow_tasks.jsp
+++ b/dotCMS/html/portlet/ext/workflows/view_workflow_tasks.jsp
@@ -506,7 +506,7 @@ bottom="/html/common/box_bottom.jsp">
 					</dd>
 				</dl>
 				<div class="buttonRow">
-					<button dojoType="dijit.form.Button" iconClass="searchIcon" name="filterButton" onclick="doFilter()"> <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Search")) %></button>
+					<button dojoType="dijit.form.Button" iconClass="searchIcon" name="filterButton" type="submit" onclick="doFilter()"> <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Search")) %></button>
 					<button dojoType="dijit.form.Button" name="resetButton"  iconClass="resetIcon" onclick="resetFilters()"><%=LanguageUtil.get(pageContext, "reset")%></button>    
 				</div>
 			</div>
@@ -536,3 +536,17 @@ bottom="/html/common/box_bottom.jsp">
 dojo.ready(resizeBrowser);
 </script>
 
+<script language="Javascript">
+	/**
+		focus on search box
+	**/
+	require([ "dijit/focus", "dojo/dom", "dojo/domReady!" ], function(focusUtil, dom){
+		dojo.require('dojox.timing');
+		t = new dojox.timing.Timer(500);
+		t.onTick = function(){
+		  focusUtil.focus(dom.byId("keywords"));
+		  t.stop();
+		}
+		t.start();
+	});
+</script> 


### PR DESCRIPTION
Fixed issue-3669-focus-enter-key-for-searches

Added dojo focus and Enter key to submit a form from focused input field on following pages:

/dotCMS/html/portlet/ext/htmlpages/view_htmlpages.jsp
/dotCMS/html/portlet/ext/links/view_links.jsp
/dotCMS/html/portlet/ext/templates/view_templates.jsp
/dotCMS/html/portlet/ext/containers/view_containers.jsp
/dotCMS/html/portlet/ext/virtuallinks/view_virtuallinks.jsp
/dotCMS/html/portlet/ext/workflows/view_workflow_tasks.jsp
/dotCMS/html/portlet/ext/mailinglists/view_mailinglists.jsp
/dotCMS/html/portlet/ext/calendar/view_calendar_main_inc.jsp
/dotCMS/html/portlet/ext/formhandler/view_form.jsp
/dotCMS/html/portlet/ext/communications/view_communications.jsp
/dotCMS/html/portlet/ext/campaigns/view_campaigns.jsp
/dotCMS/html/portlet/ext/structure/view_structure.jsp
/dotCMS/html/portlet/ext/categories/view_categories.jsp
/dotCMS/html/portlet/ext/roleadmin/view_roles.jsp
/dotCMS/html/portlet/ext/useradmin/view_users.jsp
/dotCMS/html/portlet/ext/hostadmin/view_hosts.jsp
/dotCMS/html/portlet/ext/languagesmanager/edit_language_keys.jsp
/dotCMS/html/portlet/ext/osgi/bundles.jsp
/dotCMS/WEB-INF/jsp/tag_manager/tag_manager.jsp
/dotCMS/WEB-INF/jsp/lucene/lucene_search.jsp
/dotCMS/html/portlet/ext/dashboard/view_dashboard.jsp
/dotCMS/html/portlet/ext/timemachine/timemachine_select.jsp
