### PR TITLE
fixes #3708 Allow Cache-Control to be set on SpeedyAssetServlet

### DIFF
--- a/src-conf/dotmarketing-config.properties
+++ b/src-conf/dotmarketing-config.properties
@@ -556,6 +556,7 @@ ES_URL_ENDPOINT=http://localhost:9200/
 
 
 ## Default Caching Settings
+cache.maxage.days=30
 cache.default.size=1000
 cache.default.disk=false
 cache.default.ttl=5

--- a/src-conf/dotmarketing-config.properties
+++ b/src-conf/dotmarketing-config.properties
@@ -547,7 +547,8 @@ ES_URL_ENDPOINT=http://localhost:9200/
 ##  ContentMap object.  If false, the $URLMapContent will be a ContentMap java object.
 #ENABLE_LEGACY_URLMAP_CONTENT=true
 
-
+#Setting for the Cache-Control on files served to the browser. Controls the header setting
+asset.cache.control.max.days=30
 
 ##################### dotCMS Cache Configuration #####################
 #  Use the old cache (why?)
@@ -556,7 +557,6 @@ ES_URL_ENDPOINT=http://localhost:9200/
 
 
 ## Default Caching Settings
-cache.maxage.days=30
 cache.default.size=1000
 cache.default.disk=false
 cache.default.ttl=5

--- a/src/com/dotmarketing/servlets/SpeedyAssetServlet.java
+++ b/src/com/dotmarketing/servlets/SpeedyAssetServlet.java
@@ -310,7 +310,7 @@ public class SpeedyAssetServlet extends HttpServlet {
 			    // Set the expiration time
 				if (!_adminMode) {
 
-				    int _daysCache = 30;
+				    int _daysCache = Config.getIntProperty("cache.maxage.days");
 				    GregorianCalendar expiration = new GregorianCalendar();
 					expiration.add(java.util.Calendar.DAY_OF_MONTH, _daysCache);
 					int seconds = (_daysCache * 24 * 60 * 60);

--- a/src/com/dotmarketing/servlets/SpeedyAssetServlet.java
+++ b/src/com/dotmarketing/servlets/SpeedyAssetServlet.java
@@ -310,7 +310,7 @@ public class SpeedyAssetServlet extends HttpServlet {
 			    // Set the expiration time
 				if (!_adminMode) {
 
-				    int _daysCache = Config.getIntProperty("cache.maxage.days");
+				    int _daysCache = Config.getIntProperty("asset.cache.control.max.days");
 				    GregorianCalendar expiration = new GregorianCalendar();
 					expiration.add(java.util.Calendar.DAY_OF_MONTH, _daysCache);
 					int seconds = (_daysCache * 24 * 60 * 60);

--- a/src/com/dotmarketing/servlets/SpeedyAssetServlet.java
+++ b/src/com/dotmarketing/servlets/SpeedyAssetServlet.java
@@ -310,7 +310,7 @@ public class SpeedyAssetServlet extends HttpServlet {
 			    // Set the expiration time
 				if (!_adminMode) {
 
-				    int _daysCache = Config.getIntProperty("asset.cache.control.max.days");
+				    int _daysCache = Config.getIntProperty("asset.cache.control.max.days", 30);
 				    GregorianCalendar expiration = new GregorianCalendar();
 					expiration.add(java.util.Calendar.DAY_OF_MONTH, _daysCache);
 					int seconds = (_daysCache * 24 * 60 * 60);


### PR DESCRIPTION
Now _daysCache can be set through dotmarketing-config.properties, please check it.
