### PR TITLE
Backend HTTPS auto-login fix

### DIFF
--- a/dotCMS/html/portal/login.jsp
+++ b/dotCMS/html/portal/login.jsp
@@ -331,10 +331,7 @@ function showLanguageSelector(){
 			<dd>
 				<c:if test="<%= company.isAutoLogin()%>">
 					<input id="rememberMe" tabindex="3" <%= rememberMe ? "checked" : "" %> type="checkbox"  dojoType="dijit.form.CheckBox"
-					onclick="
-					<c:if test="<%= company.isAutoLogin() && !request.isSecure() %>">
-						if (this.checked) {document.fm.my_account_r_m.value = 'on';}else {document.fm.my_account_r_m.value = 'off';}
-					</c:if>">
+					onclick="if (this.checked) {document.fm.my_account_r_m.value = 'on';}else {document.fm.my_account_r_m.value = 'off';}">
 				</c:if>
 			</dd>
 		</dl>


### PR DESCRIPTION
- Removed the conditional around populating the onclick event of the "rememberMe" checkbox. First, there was a duplicate check that the company was configured to use auto-login followed by only allowing auto-login over HTTP. Now both HTTP and HTTPS are supported for auto-login.
