### PR TITLE
fixes #4555 dotCMS uses redirect 301 instead of 302

### DIFF
--- a/src/com/dotmarketing/util/ServletResponseCharacterEncoding.java
+++ b/src/com/dotmarketing/util/ServletResponseCharacterEncoding.java
@@ -72,9 +72,10 @@ public class ServletResponseCharacterEncoding extends HttpServletResponseWrapper
 	throws IOException {
 		// Generate a temporary redirect to the specified location
 		try {
-			setStatus(301); 
 			setHeader( "Location", location ); 
 			setHeader( "Connection", "close" ); 
+			super.resetBuffer();
+			super.sendRedirect(location);
 		} catch (IllegalArgumentException e) {
 			setStatus(SC_NOT_FOUND);
 		}


### PR DESCRIPTION
Fixed the issue and pushed the code for review, please check it.
