### PR TITLE
fixes #4943 the filtering select was searching by id instead of the disp...

### DIFF
--- a/dotCMS/html/portlet/ext/structure/edit_field.jsp
+++ b/dotCMS/html/portlet/ext/structure/edit_field.jsp
@@ -469,7 +469,7 @@ s2 += " class=\"form-text\" id=\"textAreaValues\">" + textArea + "</textarea>";
 					 value: '',
 					 required: true,
 					 store: myStore,
-					 searchAttr: "id",
+					 searchAttr: "displayName",
 					 labelAttr: "label",
 					 labelType: "html",
 					 onChange: elementTypeChange,


### PR DESCRIPTION
the filtering select was searching by id instead of the displayName. the ids uses _ instead of blank spaces, causing the error message. 
