### PR TITLE
Fixes #6651 : dotContent Pull with Random sort fails.

### DIFF
--- a/src-conf/dotcms-config-cluster.properties
+++ b/src-conf/dotcms-config-cluster.properties
@@ -134,7 +134,7 @@ es.http.port=9200
 
 ## true: all dynamic scripting is disabled, scripts must be placed in the config/scripts directory.
 ## false: all dynamic scripting is enabled, scripts may be sent as strings in requests.
-es.script.disable_dynamic=true
+es.script.disable_dynamic=false
 
 ##  Slow Log ---------------------------------
 


### PR DESCRIPTION
The randomization of results is performed by dynamic scripting. Setting the es.script.disable_dynamic property to "false" will allow the execution of the script.
