### PR TITLE
fixes #7486

### DIFF
--- a/src/com/dotmarketing/velocity/VelocityServlet.java
+++ b/src/com/dotmarketing/velocity/VelocityServlet.java
@@ -150,16 +150,16 @@ public abstract class VelocityServlet extends HttpServlet {
         request.setRequestUri(uri);
 		
 		if (DbConnectionFactory.isMsSql() && LicenseUtil.getLevel() < 299) {
-			request.getRequestDispatcher("/portal/no_license.jsp").forward(request, response);
+			request.getRequestDispatcher("/portal/no_license.jsp").forward(req, response);
 			return;
 		}
 
 		if (DbConnectionFactory.isOracle() && LicenseUtil.getLevel() < 399) {
-			request.getRequestDispatcher("/portal/no_license.jsp").forward(request, response);
+			request.getRequestDispatcher("/portal/no_license.jsp").forward(req, response);
 			return;
 		}
 		if (!LicenseUtil.isASAllowed()) {
-			request.getRequestDispatcher("/portal/no_license.jsp").forward(request, response);
+			request.getRequestDispatcher("/portal/no_license.jsp").forward(req, response);
 			return;
 
 		}


### PR DESCRIPTION
Committed tested code in 3.1 + Weblogic 10.3.6. If a license is not applied, it redirects to /portal/no_license.jsp. If an Enterprise license is applied, all Frontend pages are displayed as expected.
