### PR TITLE
fixes #7499

### DIFF
--- a/src-conf/es-content-mapping.json
+++ b/src-conf/es-content-mapping.json
@@ -18,7 +18,8 @@
                     "match": "*_dotraw",
                     "mapping": {
                         "type": "string",
-                        "index": "not_analyzed"
+                        "index": "not_analyzed",
+			"ignore_above": 32766 
                     }
                 }
             },


### PR DESCRIPTION
Tested in 3.1. WARN message is gone from logfiles and all contents with big metadata fields are indexed.
