### PR TITLE
fixes #7849

### DIFF
--- a/src/com/dotmarketing/portlets/folders/model/Folder.java
+++ b/src/com/dotmarketing/portlets/folders/model/Folder.java
@@ -308,7 +308,8 @@ public class Folder extends Inode implements Serializable, Permissionable, Treea
 				return false;
 			if(!this.title.equals(((FolderForm) o).getTitle()))
 				return false;
-			if(!this.filesMasks.equals(((FolderForm) o).getFilesMasks()))
+			if((this.filesMasks == null && ((FolderForm) o).getFilesMasks() != null && ((FolderForm)o).getFilesMasks() != "")
+	                    || (this.filesMasks != null && !this.filesMasks.equals(((FolderForm) o).getFilesMasks())))	
 				return false;				
 			if(!this.showOnMenu == ((FolderForm) o).isShowOnMenu())
 				return false;


### PR DESCRIPTION
Tested in Ubuntu 14.04 + Oracle 11G Express + Java 7.

Folders with/without files masks can be edited. This field's value can be deleted and folder is now saved. 
