### PR TITLE
fixes #7929

### DIFF
--- a/src/com/dotmarketing/portlets/htmlpages/business/HTMLPageFactoryImpl.java
+++ b/src/com/dotmarketing/portlets/htmlpages/business/HTMLPageFactoryImpl.java
@@ -466,7 +466,11 @@ public class HTMLPageFactoryImpl implements HTMLPageFactory {
 			// gets identifier for this webasset and changes the uri and
 			// persists it
 			identifier.setHostId(APILocator.getHostAPI().findParentHost(newFolder, APILocator.getUserAPI().getSystemUser(), false).getIdentifier());
-			identifier.setURI(page.getURI(newFolder));
+			//identifier.setURI(page.getURI(newFolder));
+			String newURI = page.getURI(newFolder);
+			identifier.setParentPath(newURI.substring(0, newURI.lastIndexOf("/")+1));
+			identifier.setAssetName(newURI.substring(newURI.lastIndexOf("/")+1));
+			identifier.setAssetType("htmlpage");
 			APILocator.getIdentifierAPI().save(identifier);
 		}
 

--- a/src/com/dotmarketing/portlets/htmlpages/factories/HTMLPageFactory.java
+++ b/src/com/dotmarketing/portlets/htmlpages/factories/HTMLPageFactory.java
@@ -293,11 +293,17 @@ public class HTMLPageFactory {
             }
 
             identifier.setHostId( newHost.getIdentifier() );
-            identifier.setURI( workingWebAsset.getURI( parent ) );
+            //identifier.setURI( workingWebAsset.getURI( parent ) );
+			String newURI = workingWebAsset.getURI( parent );
+			identifier.setParentPath(newURI.substring(0, newURI.lastIndexOf("/")+1));
+			identifier.setAssetName(newURI.substring(newURI.lastIndexOf("/")+1));
         } else {//Directly under the host
             identifier.setHostId( host.getIdentifier() );
-            identifier.setURI( '/' + currentHTMLPage.getPageUrl() );
+            identifier.setParentPath("/");
+            identifier.setAssetName(currentHTMLPage.getPageUrl());
+            
         }
+        identifier.setAssetType("htmlpage");
 
         //HibernateUtil.saveOrUpdate(identifier);
         APILocator.getIdentifierAPI().save( identifier );
@@ -532,9 +538,11 @@ public class HTMLPageFactory {
    		WorkingCache.removeAssetFromCache(workingVersion);
    		CacheLocator.getIdentifierCache().removeFromCacheByVersionable(workingVersion);
    		
-
-   		
-    	ident.setURI(page.getURI(folder));
+    	//ident.setURI(page.getURI(folder));
+		String newURI = page.getURI( folder );
+		ident.setParentPath(newURI.substring(0, newURI.lastIndexOf("/")+1));
+		ident.setAssetName(newURI.substring(newURI.lastIndexOf("/")+1));
+		ident.setAssetType("htmlpage");
     	//HibernateUtil.saveOrUpdate(ident);
     	APILocator.getIdentifierAPI().save(ident);
     	


### PR DESCRIPTION
PR: 

Avoid using setURI() method from Identifier.java since it cannot check if the URI belongs to a Legacy Page without considering the VELOCITY_PAGE_EXTENSION property, which is no longer used in 3.2.x.
