### PR TITLE
Fixing NullPointerException in WorkflowFactoryImpl

### DIFF
--- a/src/com/dotmarketing/portlets/workflows/business/WorkflowFactoryImpl.java
+++ b/src/com/dotmarketing/portlets/workflows/business/WorkflowFactoryImpl.java
@@ -1153,23 +1153,27 @@ public class WorkflowFactoryImpl implements WorkFlowFactory {
 
 		for (Map<String, Object> row : results) {
 			WorkflowTask wt = new WorkflowTask();
-			wt.setId(row.get("id").toString());
+			wt.setId(getStringValue(row, "id"));
 			wt.setCreationDate((Date)row.get("creation_date"));
 			wt.setModDate((Date)row.get("mod_date"));
 			wt.setDueDate((Date)row.get("due_date"));
-			wt.setCreatedBy(row.get("created_by").toString());
-			wt.setAssignedTo(row.get("assigned_to").toString());
-			wt.setBelongsTo(row.get("belongs_to")!=null?row.get("belongs_to").toString():"");
-			wt.setTitle(row.get("title").toString());
-			wt.setDescription(row.get("description")!=null?row.get("description").toString():"");
-			wt.setStatus(row.get("status").toString());
-			wt.setWebasset(row.get("webasset").toString());
+			wt.setCreatedBy(getStringValue(row, "created_by"));
+			wt.setAssignedTo(getStringValue(row, "assigned_to"));
+			wt.setBelongsTo(getStringValue(row, "belongs_to"));
+			wt.setTitle(getStringValue(row, "title"));
+			wt.setDescription(getStringValue(row, "description"));
+			wt.setStatus(getStringValue(row, "status"));
+			wt.setWebasset(getStringValue(row, "webasset"));
 			wfTasks.add(wt);
 		}
 
 		return wfTasks;
 	}
 
+	private String getStringValue(Map<String, Object> row, String key) {
+		Object value = row.get(key);
+		return (value == null) ? "" : value.toString();
+	}
 	// christian escalation
 	public List<WorkflowTask> searchAllTasks(WorkflowSearcher searcher) throws DotDataException {
 


### PR DESCRIPTION
An exception is thrown when the user changes from the "Me" workflow tasks to "All" workflow tasks on the "Workflow Tasks" admin panel page.  There must be a workflow item with a null in the "assigned_to" field.  There were a few fields that handled nulls in the searchTasks methos, so I introduced a helper method and changed all of the String fields to use that (since calling toString on any row.get("xxx") result could throw a NullPointerException).

Here is the stack trace:

01-Sep-2015 11:59:10.119 SEVERE [http-nio-8080-exec-1] org.apache.catalina.core.StandardWrapperValve.invoke Servlet.service() for servlet [jsp] in context with path [] threw exception [java.lang.NullPointerException] with root cause
 java.lang.NullPointerException
        at com.dotmarketing.portlets.workflows.business.WorkflowFactoryImpl.searchTasks(WorkflowFactoryImpl.java:1160)
        at com.dotmarketing.portlets.workflows.business.WorkflowAPIImpl.searchTasks(WorkflowAPIImpl.java:130)
        at com.dotmarketing.portlets.workflows.model.WorkflowSearcher.findTasks(WorkflowSearcher.java:144)
        at org.apache.jsp.html.portlet.ext.workflows.view_005ftasks_005flist_jsp._jspService(view_005ftasks_005flist_jsp.java:518)
        at org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:70)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:725)
        at org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:431)
        at org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:396)
        at org.apache.jasper.servlet.JspServlet.service(JspServlet.java:340)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:725)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:291)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at com.dotmarketing.filters.CMSFilter.doFilter(CMSFilter.java:208)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at com.dotmarketing.filters.AutoLoginFilter.doFilter(AutoLoginFilter.java:61)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at com.dotmarketing.cms.urlmap.filters.URLMapFilter.doFilter(URLMapFilter.java:299)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at com.dotmarketing.filters.TimeMachineFilter.doFilter(TimeMachineFilter.java:174)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at com.leonteq.dotcms.filter.languages.LanguageFilter.doFilter(LanguageFilter.java:61)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at com.leonteq.dotcms.filter.security.CORSFilter.doFilter(CORSFilter.java:59)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at com.dotcms.repackage.org.tuckey.web.filters.urlrewrite.UrlRewriteFilter.doFilter(UrlRewriteFilter.java:404)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at com.dotmarketing.filters.ThreadNameFilter.doFilter(ThreadNameFilter.java:90)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at com.dotmarketing.filters.CookiesFilter.doFilter(CookiesFilter.java:33)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at com.dotmarketing.filters.CharsetEncodingFilter.doFilter(CharsetEncodingFilter.java:146)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:219)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:106)
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:501)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:142)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:79)
        at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:610)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:88)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:516)
        at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1086)
        at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:659)
        at org.apache.coyote.http11.Http11NioProtocol$Http11ConnectionHandler.process(Http11NioProtocol.java:223)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1558)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1515)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.lang.Thread.run(Thread.java:745)
