### PR TITLE
Allow action parameters to hold null values.

### DIFF
--- a/src/com/dotcms/rest/api/v1/sites/ruleengine/RestRuleActionParameter.java
+++ b/src/com/dotcms/rest/api/v1/sites/ruleengine/RestRuleActionParameter.java
@@ -4,9 +4,7 @@ import com.dotcms.repackage.com.fasterxml.jackson.annotation.JsonProperty;
 import com.dotcms.repackage.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.dotcms.repackage.javax.validation.constraints.NotNull;
 import com.dotcms.rest.api.Validated;
-import com.dotcms.rest.exception.BadRequestException;
 
-import static com.dotcms.rest.validation.Preconditions.checkNotNull;
 
 @JsonDeserialize(builder = RestRuleActionParameter.Builder.class)
 public class RestRuleActionParameter extends Validated {
@@ -16,7 +14,6 @@ public class RestRuleActionParameter extends Validated {
     @NotNull
     public final String key;
 
-    @NotNull
     public final String value;
 
     private RestRuleActionParameter(Builder builder) {

--- a/src/com/dotmarketing/exception/DotDataException.java
+++ b/src/com/dotmarketing/exception/DotDataException.java
@@ -1,5 +1,8 @@
 package com.dotmarketing.exception;
 
+/**
+ * @todo remove the setMessage method, replace uses with 'throw new WhateverException(message, oldException)'
+ */
 public class DotDataException extends Exception {
 
 	/**
@@ -13,8 +16,8 @@ public class DotDataException extends Exception {
 		this.message = message;
 	}
 	public DotDataException(String message, Exception e) {
+        super(message, e);
 		this.message = message;
-		super.initCause(e);
 	}
 	/**
 	 * @return the message

--- a/src/com/dotmarketing/portlets/rules/business/RulesFactoryImpl.java
+++ b/src/com/dotmarketing/portlets/rules/business/RulesFactoryImpl.java
@@ -113,15 +113,13 @@ public class RulesFactoryImpl implements RulesFactory {
     }
 
     @Override
-    public List<RuleAction> getRuleActionsByRule(String ruleId)
-            throws DotDataException {
+    public List<RuleAction> getRuleActionsByRule(String ruleId) throws DotDataException {
         List<RuleAction> actionList = cache.getActions(ruleId);
-        if (actionList == null) {
+        if(actionList == null) {
             final DotConnect db = new DotConnect();
             db.setSQL(sql.SELECT_RULE_ACTIONS_BY_RULE);
             db.addParam(ruleId);
-            actionList = convertListToObjects(db.loadObjectResults(),
-                    RuleAction.class);
+            actionList = convertListToObjects(db.loadObjectResults(), RuleAction.class);
 
             getRuleActionParametersFromDB(actionList, db);
 
@@ -708,8 +706,7 @@ public class RulesFactoryImpl implements RulesFactory {
                 ret.add(this.convertMaptoObject(map, clazz));
             }
         } catch (final Exception e) {
-            throw new DotDataException("cannot convert object to " + clazz
-                    + " " + e.getMessage());
+            throw new DotDataException("cannot convert object to " + clazz + " " + e.getMessage(), e);
 
         }
         return ret;
@@ -723,8 +720,7 @@ public class RulesFactoryImpl implements RulesFactory {
                 ret.add(this.convertMaptoObject(map, clazz));
             }
         } catch (final Exception e) {
-            throw new DotDataException("cannot convert object to " + clazz
-                    + " " + e.getMessage());
+            throw new DotDataException("cannot convert object to " + clazz + " " + e.getMessage(), e);
 
         }
         return ret;
@@ -735,17 +731,17 @@ public class RulesFactoryImpl implements RulesFactory {
             InvocationTargetException {
 
         if (clazz.getName().equals(Rule.class.getName())) {
-            return this.convertRule(map);
+            return convertRule(map);
         } else if (clazz.getName().equals(RuleAction.class.getName())) {
-            return this.convertRuleAction(map);
+            return convertRuleAction(map);
         } else if (clazz.getName().equals(Condition.class.getName())) {
-            return this.convertCondition(map);
+            return convertCondition(map);
         } else if (clazz.getName().equals(ConditionGroup.class.getName())) {
-            return this.convertConditionGroup(map);
+            return convertConditionGroup(map);
         } else if (clazz.getName().equals(RuleActionParameter.class.getName())) {
-            return this.convertRuleActionParam(map);
+            return convertRuleActionParam(map);
         } else if (clazz.getName().equals(ConditionValue.class.getName())) {
-            return this.convertConditionValue(map);
+            return convertConditionValue(map);
         } else {
             return this.convert(clazz.newInstance(), map);
         }
@@ -812,7 +808,8 @@ public class RulesFactoryImpl implements RulesFactory {
         r.setId(row.get("id").toString());
         r.setRuleActionId(row.get("rule_action_id").toString());
         r.setKey(row.get("paramkey").toString());
-        r.setValue(row.get("value").toString());
+        Object value = row.get("value");
+        r.setValue(value == null ? null : String.valueOf(value));
         return r;
     }
 


### PR DESCRIPTION
Changed DotDataException constructor because initCause has a synchronization block and does nothing fancy. Shouldn't matter, but meh. Fix it when ya see it, or it'll never get fixed.
