### PR TITLE
Make the copy libs tasks part of the normal gradle build flow. Also m…

### DIFF
--- a/build-pre3_5-ant.gradle
+++ b/build-pre3_5-ant.gradle
@@ -18,43 +18,35 @@ apply from: "$rootDir/dependencies.gradle"
 
 configurations.compile.extendsFrom(configurations.felix)
 
-task copyToFelix {
-    copy {
+task copyToFelix(type: Copy) {
         from configurations.felix
         into felixFolder
         include '**/dot.org.apache.felix.bundlerepository*.jar'
         include '**/dot.org.apache.felix.fileinstall*.jar'
         include '**/dot.org.apache.felix.gogo.*.jar'
         include '**/dot.org.apache.felix.http.bundle*.jar'
-    }
 }
 
-task copyToLibDir() {
-    copy {
+task copyToLibDir(type: Sync) {
         from configurations.compile + configurations.provided + configurations.tomcatLibs
         into libsFolder
         exclude '**/dot.org.apache.felix.bundlerepository*.jar'
         exclude '**/dot.org.apache.felix.fileinstall*.jar'
         exclude '**/dot.org.apache.felix.gogo.*.jar'
         exclude '**/*.zip'
-    }
 }
 
 
-task copyStarterProject() {
-    copy {
+task copyStarterProject(type: Copy) {
         from configurations.starterContent
         into dotCmsFolder
         include '**/starter*.zip'
         rename(/starter(.+)\.zip/, "starter.zip")
-    }
 }
 
-task copyCoreWebContent() {
-    copy {
+task copyCoreWebContent(type: Copy) {
         from(zipTree(configurations.coreWeb.files[0]))
         into "${dotCmsFolder}/html/js/_rulesengine"
-    }
 }
 
 task copyToLib(dependsOn: [copyToFelix, copyToLibDir, copyStarterProject, copyCoreWebContent]) {
@@ -117,10 +109,9 @@ configurations.antLibs.each { File f ->
     antClassLoader.addURL(f.toURI().toURL())
 }
 
-copyToLib.execute()
 
 ant.importBuild 'build.xml'
-
-
+compile.dependsOn(copyToLib)
+project.'undeploy-plugins'.dependsOn(copyToLib)
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ task cleanPre3_5_Files(type: Delete) {
             "${project.projectDir}/dotCMS/html/js/_rulesengine"
 }
 
+task 'clean-tinymce-gz'(type: Delete){
+    description = "Removes all generated .gz pre-compressed files by tinymce_gzip.jsp"
+    delete fileTree("${project.projectDir}/dotCMS/html/js/tinymce/js/tinymce/").include("**/*.gz")
+}
+
 task listProperties() {
     description = 'Write out all the project properties at info log level.'
     doLast {
@@ -45,6 +50,7 @@ def usePre3_5Build(){
     logger.info("Building with pre3.5 Ant build system.")
     //Import and apply the dependencies from the dependencies scripts
     apply from: "$rootDir/build-pre3_5-ant.gradle"
+    clean.dependsOn cleanPre3_5_Files
 }
 
 def usePureGradleBuild(){
@@ -57,6 +63,7 @@ if(useNewHotness){
     usePureGradleBuild()
 } else {
     usePre3_5Build()
+    clean.dependsOn('clean-tinymce-gz')
 }
 
 defaultTasks 'help', 'tasks'

--- a/build.xml
+++ b/build.xml
@@ -148,12 +148,6 @@
 
     </target>
 
-    <target name="clean-tinymce-gz" description="Removes all generated .gz pre-compressed files by tinymce_gzip.jsp">
-        <delete>
-            <fileset dir="dotCMS/html/js/tinymce/js/tinymce/" includes="*.gz"/>
-        </delete>
-    </target>
-
     <target name="clean-core" description="Removes all compiled classes, jar." depends="check-src-build">
         <replaceregexp flags="s" match="&lt;!-- BEGIN JSPS --&gt;(.*)&lt;!-- END JSPS --&gt;"
                        replace="&lt;!-- BEGIN JSPS --&gt; &lt;!-- END JSPS --&gt;">
@@ -565,7 +559,7 @@
 
     <target name="deploy-tests" depends="uncomment-test-servlet, build, deploy-core-with-tests, deploy-plugins" description="builds and deploys core, plugins and unit tests" />
 
-    <target name="clean" depends="clean-plugins,undeploy-plugins,clean-core,clean-tinymce-gz" description="Cleans plugins and core code and also undeploys plugins" />
+    <target name="clean" depends="clean-plugins,undeploy-plugins,clean-core" description="Cleans plugins and core code and also undeploys plugins" />
 
     <macrodef name="iterate">
         <attribute name="target"/>


### PR DESCRIPTION
…oves the clean-tinymc-gz task into gradle, as the ant delete would fail if the directory was missing.
