### PR TITLE
fixes card275 : Unable to start dotcms_3.3 in Jboss

### DIFF
--- a/dotCMS/WEB-INF/jboss-deployment-structure.xml
+++ b/dotCMS/WEB-INF/jboss-deployment-structure.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>  
-<jboss-deployment-structure>  
-    <deployment>  
-         <dependencies>  
-              <module name="com.dotcms.h2" />  
-        </dependencies>  
-    </deployment>  
-</jboss-deployment-structure>  
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.apache.log4j" />
+            <module name="org.slf4j" />
+            <module name="org.slf4j.ext" />
+            <module name="org.slf4j.impl" />
+            <module name="org.slf4j.jcl-over-slf4j" />
+            <module name="org.apache.commons.logging" />
+            <module name="org.jboss.logging"/>
+            <module name="org.jboss.logging.jul-to-slf4j-stub"/>
+            <module name="org.jboss.logmanager"/>
+            <module name="org.jboss.log4j.logmanager"/>
+        </exclusions>
+        <dependencies>
+            <module name="com.dotcms.h2" />
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
- Fix issue with log4j2 on JBOSS EAP 6.4.0

Signed-off-by: Rogelio Blanco rogelio.blanco@dotcms.com
