### PR TITLE
proposed fix #8238

### DIFF
--- a/dotCMS/html/common/bottom_portal_inc.jsp
+++ b/dotCMS/html/common/bottom_portal_inc.jsp
@@ -49,7 +49,6 @@
 		myId.src ="/html/common/keep_alive.jsp?r=<%=System.currentTimeMillis()%>";
 	}
 	function killSession(){
-		alert("Session Expired !!");
 		window.location = "/c/portal/logout?referer=/c";
 	}
 	<% if(Config.getStringProperty("KEEP_SESSION_ALIVE").equalsIgnoreCase("true")) {%>

--- a/dotCMS/html/common/bottom_portal_inc.jsp
+++ b/dotCMS/html/common/bottom_portal_inc.jsp
@@ -49,14 +49,14 @@
 		myId.src ="/html/common/keep_alive.jsp?r=<%=System.currentTimeMillis()%>";
 	}
 	function killSession(){
-		  alert("Session Expired !!");
-		  window.location = "/html/portal/login.jsp?r="+<%=System.currentTimeMillis()%>;
+		alert("Session Expired !!");
+		window.location = "/c/portal/logout?referer=/c";
 	}
 	<% if(Config.getStringProperty("KEEP_SESSION_ALIVE").equalsIgnoreCase("true")) {%>
-	// 15 minutes
+		// 15 minutes
 		setTimeout("setKeepAlive()", 60000 * 15);
 	<%}else{%>
-	// 30 minutes
+		// 30 minutes
 		setTimeout("killSession()", 60000 * 30);
 	<%} %>
 </script>


### PR DESCRIPTION
An explicit call to login.jsp file in IE does not necessarily invalidate the current session, even if the KEEP_SESSION_ALIVE property is set to false. 

Inspecting the code, I noticed that the Logout function across all backend is a call to "/c/portal/logout?referrer=/c", and this call invalidates session, clear backend cookies and redirect to Backend login page. I think this call should replace the login.jsp from bottom_portal_inc.jsp. See the parent ticket (#8238) and check how session cookies change after implementing this fix on 3.2.3. 

Tested on 3.2.3/Postgres 9.3/Java 8 and with IE 11 and Chrome 46. 
