### PR TITLE
Card 387 translations

### DIFF
--- a/dotCMS/WEB-INF/messages/Language_de.properties
+++ b/dotCMS/WEB-INF/messages/Language_de.properties
@@ -1892,7 +1892,7 @@ This-utility-will-do-a-find-and-replace=Dieses Utility führt ein Suchen und Ers
 Please-specify-the-following-parameters-and-click-replace=Bitte geben Sie die folgenden Parameter an und klicken Sie auf Ersetzen:
 String-to-find=Zu suchender String
 Replace-with=Ersetzen durch
-Fix-Assets-Inconsistencies=Unstimmigkeiten in Einheiten reparieren
+Fix-Assets-Inconsistencies=Unstimmigkeiten in Einheiten Reparieren
 Drop-Old-Assets-Versions=Alte Einheitsversionen fallen lassen
 This-utility-will-remove-old-versions-of-contentlets=Dieses Utility wird alle alten Versionen von Contentlets, Containern, Vorlagen, Links und Einheiten löschen, die älter sind, als das angegebene Datum. Es wird keine Veränderungen an Live- oder Arbeitsversionen der Einheiten vornehmen. Dieser Vorgang sucht nach Unstimmigkeiten in den Einheiten, bevor die alten Versionen gelöscht werden. Es wird empfohlen eine Reindexierung Ihres Contents durchzuführen, nachdem der Vorgang abgeschlossen wurde.
 Remove-assets-older-than=Einheiten entfernen, die älter sind als
@@ -3890,7 +3890,7 @@ publisher_dialog_push=Senden
 push_publish_integrity_content_file_assets_conflicts=Dateiressourcen-Inode-Konflikte
 # Integrity Checker Tab
 integritychecker.file-assets=Dateiressourcen
-notification.reindexing.error.processrecord=Konnte den Eintrag nicht erneut mit der Kennung "{0}" versehen. Er ist in einem schlechten Zustand oder mit verwaisten Einträgen verbunden. Sie können versuchen, das Tool {0} zu starten, und die erneute Indizierung noch einmal durchführen.
+notification.reindexing.error.processrecord=Konnte den Eintrag nicht erneut mit der Kennung "{0}" versehen. Er ist in einem schlechten Zustand oder mit verwaisten Einträgen verbunden. Sie können versuchen, das Tool Unstimmigkeiten in Einheiten Reparieren zu starten, und die erneute Indizierung noch einmal durchführen.
 Stop-Reindexation-And-Make-Active=Erneute Indizierung stoppen und Index aktivieren
 Switching-To-New-Index=Wechsel zum neuen Index...
 Download-Failed-Records-As-CSV=Fehlgeschlagene Einträge als CSV-Datei herunterladen

--- a/dotCMS/WEB-INF/messages/Language_de.properties
+++ b/dotCMS/WEB-INF/messages/Language_de.properties
@@ -3890,3 +3890,7 @@ publisher_dialog_push=Senden
 push_publish_integrity_content_file_assets_conflicts=Dateiressourcen-Inode-Konflikte
 # Integrity Checker Tab
 integritychecker.file-assets=Dateiressourcen
+notification.reindexing.error.processrecord=Konnte den Eintrag nicht erneut mit der Kennung "{0}" versehen. Er ist in einem schlechten Zustand oder mit verwaisten Einträgen verbunden. Sie können versuchen, das Tool {0} zu starten, und die erneute Indizierung noch einmal durchführen.
+Stop-Reindexation-And-Make-Active=Erneute Indizierung stoppen und Index aktivieren
+Switching-To-New-Index=Wechsel zum neuen Index...
+Download-Failed-Records-As-CSV=Fehlgeschlagene Einträge als CSV-Datei herunterladen

--- a/dotCMS/WEB-INF/messages/Language_es.properties
+++ b/dotCMS/WEB-INF/messages/Language_es.properties
@@ -4038,3 +4038,7 @@ publisher_dialog_push=Enviar
 push_publish_integrity_content_file_assets_conflicts=Conflictos de inodo en archivos de activos
 # Integrity Checker Tab
 integritychecker.file-assets=Archivos de activos
+notification.reindexing.error.processrecord=No se ha podido reindexar el registro con el Identificador "{0}". Su estado es malo o está asociado a registros huérfanos. Puede intentar ejecutar la herramienta {0} y reiniciar la reindexación.
+Stop-Reindexation-And-Make-Active=Detener Reindexación y Activar este índice
+Switching-To-New-Index=Cambiando al índice nuevo...
+Download-Failed-Records-As-CSV=Descargar registros con fallas como archivo CSV

--- a/dotCMS/WEB-INF/messages/Language_es.properties
+++ b/dotCMS/WEB-INF/messages/Language_es.properties
@@ -4038,7 +4038,7 @@ publisher_dialog_push=Enviar
 push_publish_integrity_content_file_assets_conflicts=Conflictos de inodo en archivos de activos
 # Integrity Checker Tab
 integritychecker.file-assets=Archivos de activos
-notification.reindexing.error.processrecord=No se ha podido reindexar el registro con el Identificador "{0}". Su estado es malo o está asociado a registros huérfanos. Puede intentar ejecutar la herramienta {0} y reiniciar la reindexación.
+notification.reindexing.error.processrecord=No se ha podido reindexar el registro con el Identificador "{0}". Su estado es malo o está asociado a registros huérfanos. Puede intentar ejecutar la herramienta Arreglar Inconsistencias de Objetos y reiniciar la reindexación.
 Stop-Reindexation-And-Make-Active=Detener Reindexación y Activar este índice
 Switching-To-New-Index=Cambiando al índice nuevo...
 Download-Failed-Records-As-CSV=Descargar registros con fallas como archivo CSV

--- a/dotCMS/WEB-INF/messages/Language_fr.properties
+++ b/dotCMS/WEB-INF/messages/Language_fr.properties
@@ -3903,5 +3903,5 @@ push_publish_integrity_content_file_assets_conflicts=Conflits de nœuds d'index 
 integritychecker.file-assets=Banques de fichiers
 notification.reindexing.error.processrecord=Impossible d’indexer l’enregistrement avec l’identifiant"{0}". Il se peut qu’il soit en mauvais état ou associé à des enregistrements orphelins. Vous pouvez essayer d’exécuter l’outil Réparer les Incohérences des Assets et redémarrer re-index.
 Stop-Reindexation-And-Make-Active=Arrêter l’indexation et Activer
-Switching-To-New-Index=Passer à Nouvel index
+Switching-To-New-Index=Passer à Nouvel index...
 Download-Failed-Records-As-CSV=Télécharger les enregistrements ratés comme fichier CSV

--- a/dotCMS/WEB-INF/messages/Language_fr.properties
+++ b/dotCMS/WEB-INF/messages/Language_fr.properties
@@ -1900,7 +1900,7 @@ This-utility-will-do-a-find-and-replace=Cet utilitaire effectuera une recherche 
 Please-specify-the-following-parameters-and-click-replace=Veuillez spécifier les paramètres suivants et cliquer sur Replace :
 String-to-find=Chaîne à trouver
 Replace-with=Remplacer par
-Fix-Assets-Inconsistencies=Réparer les incohérences des assets
+Fix-Assets-Inconsistencies=Réparer les Incohérences des Assets
 Drop-Old-Assets-Versions=Suspendre les versions des anciens assets
 This-utility-will-remove-old-versions-of-contentlets=Cet utilitaire supprimera les anciennes versions de contentlets, de conteneurs, de templates, de liens et des asets, qui sont plus anciennes que la date spécifiée. Il n&#39affectera aucunement les versions actives et de travail des assets. Ce processus vérifiera les incohérences des assets, avant de de supprimer l&#39ancienne version. Il est fortement suggéré de faire une réindexation de votre contenu une fois le processus de redimensionnement terminé.
 Remove-assets-older-than=Supprimer les assets plus anciens que
@@ -3901,3 +3901,7 @@ publisher_dialog_push=Transfert
 push_publish_integrity_content_file_assets_conflicts=Conflits de nœuds d'index des banques de fichiers
 # Integrity Checker Tab
 integritychecker.file-assets=Banques de fichiers
+notification.reindexing.error.processrecord=Impossible d’indexer l’enregistrement avec l’identifiant"{0}". Il se peut qu’il soit en mauvais état ou associé à des enregistrements orphelins. Vous pouvez essayer d’exécuter l’outil Réparer les Incohérences des Assets et redémarrer re-index.
+Stop-Reindexation-And-Make-Active=Arrêter l’indexation et Activer
+Switching-To-New-Index=Passer à Nouvel index
+Download-Failed-Records-As-CSV=Télécharger les enregistrements ratés comme fichier CSV

--- a/dotCMS/WEB-INF/messages/Language_it.properties
+++ b/dotCMS/WEB-INF/messages/Language_it.properties
@@ -1940,7 +1940,7 @@ This-utility-will-do-a-find-and-replace=Questa uility effettuer\u00E0 una sostit
 Please-specify-the-following-parameters-and-click-replace=Specificare i seguenti parametri e cliccare su \u0022Sostituisci\u0022
 String-to-find=String da ricercare
 Replace-with=Sostituisci con
-Fix-Assets-Inconsistencies=Ripara incoerenze negli asset
+Fix-Assets-Inconsistencies=Ripara Incoerenze Negli Asset
 Drop-Old-Assets-Versions=Elimina le vecchie versioni degli asset
 This-utility-will-remove-old-versions-of-contentlets=Questa utility rimuover\u00E0 tutte le versioni di contenuti, contenitori, template, link e asset che sono pi\u00F9 vecchie della data specificata. Non effettuer\u00E0 alcuna operazione sulle versioni operative o funzionanti degli asset. Questo processo verificher\u00E0 prima la presenza di incoerenze negli asset. \u00E8 suggerito di effettuare una re-indicizzazione dei contenuti dopo il termine del task.
 Remove-assets-older-than=Rimuovere asset pi\u00F9 vecchi di
@@ -3935,3 +3935,7 @@ publisher_dialog_push=Invia
 push_publish_integrity_content_file_assets_conflicts=Conflitti nell Inode delle Risorse File
 # Integrity Checker Tab
 integritychecker.file-assets=Risorse File
+notification.reindexing.error.processrecord=Impossibile reindicizzare il registro con l'identificatore "{0}". È un cattivo stato oppure è associato a dei registri orfani. Puoi provare ad avviare lo strumento Ripara Incoerenze Negli Asset e riavviare la reindicizzazione.
+Stop-Reindexation-And-Make-Active=Ferma la reindicizzazione e rendi attivo
+Switching-To-New-Index=Passaggio al nuovo indice...
+Download-Failed-Records-As-CSV=Scarica registri falliti come file CSV

--- a/dotCMS/WEB-INF/messages/Language_nl.properties
+++ b/dotCMS/WEB-INF/messages/Language_nl.properties
@@ -573,7 +573,7 @@ Filtered-by=Gefilterd op
 Finish=Voltooien
 Fire-Date=Uitvoeringsdatum
 First-Name=Voornaam
-Fix-Assets-Inconsistencies=Herstel Asset inconsistenties
+Fix-Assets-Inconsistencies=Herstel Asset Inconsistenties
 Flush-All-Caches=Wis Alle Caches
 Folder=Map
 Folder-Related-Assets=Map Gerelateerde Assets
@@ -3614,3 +3614,7 @@ publisher_dialog_push=Duwen
 push_publish_integrity_content_file_assets_conflicts=Bestandsbezit inode conflicten
 # Integrity Checker Tab
 integritychecker.file-assets=Bestandsbezit
+notification.reindexing.error.processrecord=Kon verslag niet herindexeren met de Identifier "{0}". Het is in een slechte staat of wordt geassocieerd met verweesde verslagen. U kunt proberen om de Herstel Asset Inconsistenties tool te gebruiken en het herindexeren te herstarten.
+Stop-Reindexation-And-Make-Active=Stop herindexeren en maak actief
+Switching-To-New-Index=Overschakelen naar nieuwe Index...
+Download-Failed-Records-As-CSV=Download mislukte verslagen als CSV-bestand

--- a/dotCMS/WEB-INF/messages/Language_ru.properties
+++ b/dotCMS/WEB-INF/messages/Language_ru.properties
@@ -4113,3 +4113,7 @@ publisher_dialog_push=Отправить
 push_publish_integrity_content_file_assets_conflicts=Конфликты индексных дескрипторов файловых ресурсов
 # Integrity Checker Tab
 integritychecker.file-assets=Файловые ресурсы
+notification.reindexing.error.processrecord=Невозможно переиндексировать запис с идентификатором "{0}". Она в плохом состоянии или связана с потерянными записями. Вы можете попробовать запустить инструмент Исправить несовместимость ресурсов и перезапустить переиндексирование.
+Stop-Reindexation-And-Make-Active=Остановить переиндексирование и сделать активным
+Switching-To-New-Index=Переключение на новый индекс...
+Download-Failed-Records-As-CSV=Загрузка неудачных записей в качестве CSV-файла

--- a/dotCMS/WEB-INF/messages/Language_zh_CN.properties
+++ b/dotCMS/WEB-INF/messages/Language_zh_CN.properties
@@ -3934,3 +3934,7 @@ publisher_dialog_push=推送
 push_publish_integrity_content_file_assets_conflicts=文件资产索引节点冲突
 # Integrity Checker Tab
 integritychecker.file-assets=文件资产
+notification.reindexing.error.processrecord=无法用标识符"{0}" 来重新检索记录。记录处于错误状态或者与孤立记录相关。你可以尝试运行修复 Assets 不一致工具，并重启重新检索。
+Stop-Reindexation-And-Make-Active=停止重新检索并激活当前索引
+Switching-To-New-Index=切换到新的索引……
+Download-Failed-Records-As-CSV=以CSV文件格式下载失败的数据库记录。 


### PR DESCRIPTION
1. Added translations for new keys.
2. Capitalized the text for the Fix-Assets-Inconsistencies button for translations where it wasn't capitalized, to make it easier to identify within a notification message.
