### PR TITLE
changed tested URL to match new definition of every request

### DIFF
--- a/test/com/dotmarketing/portlets/rules/actionlet/SetSessionAttributeActionletTest.java
+++ b/test/com/dotmarketing/portlets/rules/actionlet/SetSessionAttributeActionletTest.java
@@ -53,7 +53,7 @@ public class SetSessionAttributeActionletTest extends TestBase {
         createRule(Rule.FireOn.EVERY_REQUEST, firstTime);
 
         makeRequest(
-                "http://" + serverName + ":" + serverPort + "/html/images/star_on.gif?t=" + System.currentTimeMillis(),
+                "http://" + serverName + ":" + serverPort + "/robots.txt?t=" + System.currentTimeMillis(),
                 "JSESSIONID=" + request.getSession().getId());
 
         String firstTimeRequest = (String)request.getSession().getAttribute("time");
@@ -63,7 +63,7 @@ public class SetSessionAttributeActionletTest extends TestBase {
         updateRuleActionParam(secondTime);
 
         makeRequest(
-                "http://" + serverName + ":" + serverPort + "/html/images/star_on.gif?t=" + System.currentTimeMillis(),
+                "http://" + serverName + ":" + serverPort + "/robots.txt?t=" + System.currentTimeMillis(),
                 "JSESSIONID=" + request.getSession().getId());
 
         String secondTimeRequest = (String)request.getSession().getAttribute("time");

--- a/test/com/dotmarketing/portlets/rules/business/RulesAPITest.java
+++ b/test/com/dotmarketing/portlets/rules/business/RulesAPITest.java
@@ -53,11 +53,11 @@ public class RulesAPITest extends TestBase {
 		createRule(Rule.FireOn.EVERY_REQUEST);
 
 		makeRequest(
-				"http://" + serverName + ":" + serverPort + "/html/images/star_on.gif?t=" + System.currentTimeMillis());
+				"http://" + serverName + ":" + serverPort + "/robots.txt?t=" + System.currentTimeMillis());
 		Integer count = (Integer) request.getServletContext().getAttribute(Rule.FireOn.EVERY_REQUEST.name());
 
 		makeRequest(
-				"http://" + serverName + ":" + serverPort + "/html/images/star_on.gif?t=" + System.currentTimeMillis());
+				"http://" + serverName + ":" + serverPort + "/robots.txt?t=" + System.currentTimeMillis());
 		Integer newCount = (Integer) request.getServletContext().getAttribute(Rule.FireOn.EVERY_REQUEST.name());
 
 		assertTrue(newCount > count);


### PR DESCRIPTION
Had to change requested URL because of change to functional definition of "Every Request" - now only applies to file assets and pages (folders handled after redirect to default page)
