### PR TITLE
fixes #8429

### DIFF
--- a/src/com/dotmarketing/portlets/htmlpageasset/business/HTMLPageAssetAPIImpl.java
+++ b/src/com/dotmarketing/portlets/htmlpageasset/business/HTMLPageAssetAPIImpl.java
@@ -390,6 +390,7 @@ public class HTMLPageAssetAPIImpl implements HTMLPageAssetAPI {
         newpage.setShowOnMenu(legacyPage.isShowOnMenu());
         newpage.setModUser(legacyPage.getModUser());
         newpage.setModDate(legacyPage.getModDate());
+        newpage.setRedirect(legacyPage.getRedirect());
         return newpage;
     }
     


### PR DESCRIPTION
Tested in 3.3 + Java 8 + Postgres DB (upgraded from version 2.5.6). Redirect URL value is no longer dropped after pages are migrated.
