### PR TITLE
fixes #8443

### DIFF
--- a/src/com/dotmarketing/portlets/user/ajax/UserAjax.java
+++ b/src/com/dotmarketing/portlets/user/ajax/UserAjax.java
@@ -370,7 +370,7 @@ public class UserAjax {
 
 	public Map<String, Boolean> getUserRolesValues (String userId, String hostIdentifier) throws Exception {
 		//auth
-		User modUser = getAdminUser();
+		User modUser = getLoggedInUser();
 
 		Map<String, Boolean> userPerms = new HashMap<String,Boolean>();
 		if(UtilMethods.isSet(userId)){


### PR DESCRIPTION
Updated getUserRolesValues() method in UserAjax.java class.

When a limited user logs in to the backend and open the Website Browser, it gets a DotSecurityException because when its roles are checked, it asks if the user is Admin. Since it's a limited user, it throws an Exception and stops the remaining JS code execution. 

This method is supposed to check the user in session, for auth purposes. Switching it to getLoggedInUser() does the trick for both admin and limited users, so they can navigate the Website Browser according to their roles. 
