### PR TITLE
Card 597  work on accrued tags

### DIFF
--- a/src/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/src/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -1227,7 +1227,10 @@ public class ESContentFactoryImpl extends ContentletFactory {
      */
     private SearchRequestBuilder createRequest(Client client, String query, String sortBy) {
     	
-        if(Config.getBooleanProperty("ELASTICSEARCH_USE_FILTERS_FOR_SEARCHING",false) && !"score".equalsIgnoreCase(sortBy)) {
+    	
+    	
+    	
+        if(Config.getBooleanProperty("ELASTICSEARCH_USE_FILTERS_FOR_SEARCHING",false) && sortBy!=null && ! sortBy.toLowerCase().startsWith("score")) {
 
             if("random".equals(sortBy)){
                 return client.prepareSearch()
@@ -1277,7 +1280,8 @@ public class ESContentFactoryImpl extends ContentletFactory {
             if(offset>0)
                 srb.setFrom(offset);
 
-            if(UtilMethods.isSet(sortBy) && !"score".equalsIgnoreCase(sortBy)) {
+            if(UtilMethods.isSet(sortBy) ) {
+            	sortBy = sortBy.toLowerCase();
             	if(sortBy.endsWith("-order")) {
             	    // related content ordering
             	    int ind0=sortBy.indexOf('-'); // relationships tipicaly have a format stname1-stname2
@@ -1296,6 +1300,24 @@ public class ESContentFactoryImpl extends ContentletFactory {
             	        }
             	    }
             	}
+            	else if(sortBy.startsWith("score")){
+            		String[] test = sortBy.split("\\s+");
+            		String defualtSecondarySort = "moddate";
+            		SortOrder defaultSecondardOrder = SortOrder.DESC;
+            		
+            		if(test.length>2){
+            			if(test[2].equalsIgnoreCase("desc"))
+            				defaultSecondardOrder = SortOrder.DESC;
+            			else
+            				defaultSecondardOrder = SortOrder.ASC;
+            		}
+            		if(test.length>1){
+            			defualtSecondarySort= test[1];
+            		}
+
+            		srb.addSort("_score", SortOrder.DESC);
+            		srb.addSort(defualtSecondarySort, defaultSecondardOrder);
+            	}
             	else if(!sortBy.startsWith("undefined") && !sortBy.startsWith("undefined_dotraw") && !sortBy.equals("random")) {
             		String[] sortbyArr=sortBy.split(",");
 	            	for (String sort : sortbyArr) {
@@ -1306,6 +1328,7 @@ public class ESContentFactoryImpl extends ContentletFactory {
 					}
             	}
             }
+            
             
             
             try{

--- a/src/com/dotcms/visitor/domain/Visitor.java
+++ b/src/com/dotcms/visitor/domain/Visitor.java
@@ -1,18 +1,27 @@
 package com.dotcms.visitor.domain;
 
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.dotcms.repackage.com.google.common.collect.HashMultiset;
+import com.dotcms.repackage.com.google.common.collect.Multiset;
+import com.dotcms.repackage.com.google.common.collect.Multisets;
 import com.dotcms.repackage.eu.bitwalker.useragentutils.DeviceType;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.personas.model.IPersona;
 
 import eu.bitwalker.useragentutils.UserAgent;
-
-import javax.servlet.http.HttpServletRequest;
-
-import java.io.Serializable;
-import java.net.InetAddress;
-import java.net.URI;
-import java.time.LocalDateTime;
-import java.util.*;
 
 public class Visitor implements Serializable {
 
@@ -26,8 +35,10 @@ public class Visitor implements Serializable {
 
     private IPersona persona;
 
-    private Set<String> accruedTags = new HashSet<>();
-
+    private Multiset<String> _accruedTags = HashMultiset.create();
+    		
+    		
+    		
     private UserAgent userAgent;
 
     private UUID dmid;
@@ -78,14 +89,70 @@ public class Visitor implements Serializable {
         this.persona = persona;
     }
 
-    public Set<String> getAccruedTags() {
-        return accruedTags;
+    
+   public class AccruedTag implements Serializable {
+
+	   private static final long serialVersionUID = 1L;
+	   final String tag;
+	   final int count;
+	   public AccruedTag ( String tag,  int count){
+		   	this.tag = tag;
+	   		this.count=count;
+	   }
+	   public String getTag() {
+		   return tag;
+	   }
+	   public int getCount() {
+		   return count;
+	   }
+		@Override
+		public boolean equals(Object obj) {
+			if(obj instanceof AccruedTag){
+				AccruedTag tag2=(AccruedTag)obj;
+				if(tag2.getTag().equals(this.tag) && this.count== tag2.count){
+					return true;
+				}
+			}
+			return false;
+		}
+		@Override
+		public String toString() {
+			return "{\"tag\":\"" + tag + "\", \"count\":" + count + "}";
+			
+		}
+		
+    }
+   
+    public List<AccruedTag> getAccruedTags() {
+    	List<AccruedTag> tags = new ArrayList<>();
+		for (String key : Multisets.copyHighestCountFirst(_accruedTags).elementSet()) {
+			AccruedTag tag = new AccruedTag(key,_accruedTags.count(key) );
+		    tags.add(tag);
+		}
+		return tags;
     }
 
-    public void setAccruedTags(Set<String> accruedTags) {
-        this.accruedTags = accruedTags;
+    public void addAccruedTags(Set<String> tags){
+    	for(String tag : tags){
+    		addTag(tag);
+    	}
+    	//_accruedTags.addAll(tags);
+    }
+    public void addTag(String tag){
+    	if(tag==null) return;
+    	_accruedTags.add(tag);
+    }
+    
+    public void addTag(String tag, int count){
+    	if(tag==null) return;
+    	_accruedTags.add(tag, count);
+    }
+    public void removeTag(String tag){
+    	_accruedTags.remove(tag);
     }
 
+
+    
     public UserAgent getUserAgent() {
         return userAgent;
     }
@@ -168,7 +235,7 @@ public class Visitor implements Serializable {
                 ", selectedLanguage=" + selectedLanguage +
                 ", locale=" + locale +
                 ", persona=" + persona +
-                ", accruedTags=" + accruedTags +
+                ", accruedTags=" + _accruedTags +
                 ", userAgent=" + userAgent +
                 ", device=" + getDevice() +
                 ", dmid=" + dmid +

--- a/src/com/dotmarketing/util/PaginatedArrayList.java
+++ b/src/com/dotmarketing/util/PaginatedArrayList.java
@@ -18,7 +18,7 @@ public class PaginatedArrayList<E> extends ArrayList<E>{
 	 */
 	private static final long serialVersionUID = -7345046002562313843L;
 	private long totalResults;
-	
+	private String query;
 	/**
 	 * @return the totalResults
 	 */
@@ -30,6 +30,12 @@ public class PaginatedArrayList<E> extends ArrayList<E>{
 	 */
 	public void setTotalResults(long totalResults) {
 		this.totalResults = totalResults;
+	}
+	public String getQuery() {
+		return query;
+	}
+	public void setQuery(String query) {
+		this.query = query;
 	}
 
 }

--- a/src/com/dotmarketing/viewtools/content/util/ContentUtils.java
+++ b/src/com/dotmarketing/viewtools/content/util/ContentUtils.java
@@ -163,6 +163,7 @@ public class ContentUtils {
 		
 		public static PaginatedArrayList<Contentlet> pull(String query, int offset,int limit, String sort, User user, String tmDate){
 		    PaginatedArrayList<Contentlet> ret = new PaginatedArrayList<Contentlet>();
+		    
 			try {
 				//need to send the query with the defaults --- 
 			    List<Contentlet> contentlets=null;
@@ -181,7 +182,7 @@ public class ContentUtils {
 		            
 		            PaginatedArrayList<Contentlet> wc=(PaginatedArrayList<Contentlet>)conAPI.search(wquery, limit, offset, sort, user, true);
 		            PaginatedArrayList<Contentlet> lc=(PaginatedArrayList<Contentlet>)conAPI.search(lquery, limit, offset, sort, user, true);
-		            
+		            ret.setQuery(lquery);
 		            // merging both results avoiding repeated inodes
 		            Set<String> inodes=new HashSet<String>();
 		            contentlets=new ArrayList<Contentlet>();
@@ -230,6 +231,7 @@ public class ContentUtils {
 			        // normal query
 			        PaginatedArrayList<Contentlet> conts=(PaginatedArrayList<Contentlet>)conAPI.search(query, limit, offset, sort, user, true);
 			        ret.setTotalResults(conts.getTotalResults());
+			        ret.setQuery(query);
 			        contentlets=conts;
 			    }
 				for(Contentlet c : contentlets)


### PR DESCRIPTION
This gets us 1/2 there on card 597.  This pull request added the pullPersonalized method to the ContentTool, well, more than one but they are just overloaded.  It allows allows for a secondary sort to be passed in when using scoring.

The pullPersonalized method takes the visitors persona and their accrued tags into account when pulling results for personalized content.

Work remaining.  
1. When we set a persona on the visitor object, we need to add all the persona tags to the visitor's accrued tags.
2. When a visitor visits a urlmapped page, we need to see if the associated content has tags and add them to the visitor's accrued tags (should this be automatic or should we leave this up to each implementation?).  By that I mean, you can, in velocity do something like:

```
#foreach($tag in $URLMapContent.tags)
$visitor.addTag($tag)
#end
```

and it all works.
