### PR TITLE
fix: check before use date object

### DIFF
--- a/src/com/dotmarketing/portlets/report/action/RunReportAction.java
+++ b/src/com/dotmarketing/portlets/report/action/RunReportAction.java
@@ -214,7 +214,7 @@ public class RunReportAction extends DotPortletAction {
 		int day = c.get(Calendar.DATE);
 		int year = c.get(Calendar.YEAR);
 		String date = request.getParameter(par.getName() + "date");
-		if(date.matches(com.dotmarketing.util.Constants.REG_EX_VALIDATION_DATE_WITH_FORWARDSLASH) && date != null){
+		if(date != null && date.matches(com.dotmarketing.util.Constants.REG_EX_VALIDATION_DATE_WITH_FORWARDSLASH)){
 		    String[] splitDate = date.split("/");
 		    month = Integer.valueOf(splitDate[0]) - 1;
 		    day = Integer.valueOf(splitDate[1]);


### PR DESCRIPTION
Strangely that variable date  was used before it was checked

This possible defect found by AppChecker (http://www.npo-echelon.ru/en/solutions/appchecker.php)
