### PR TITLE
Card 427 store list of fired rules

### DIFF
--- a/src/com/dotmarketing/portlets/rules/business/RulesEngine.java
+++ b/src/com/dotmarketing/portlets/rules/business/RulesEngine.java
@@ -3,34 +3,102 @@ package com.dotmarketing.portlets.rules.business;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.Ruleable;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.portlets.rules.exception.RuleEngineException;
 import com.dotmarketing.portlets.rules.model.Rule;
+import com.dotmarketing.portlets.rules.model.Rule.FireOn;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
+import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ * Provides the entry point to trigger the execution of user-specified Rules for
+ * a given parent (such as, a Site or Host). Rules can be kicked off under the
+ * following conditions:
+ * <ul>
+ * <li>Every time a page is visited.</li>
+ * <li>Every request.</li>
+ * <li>Once per visitor.</li>
+ * <li>Once per visit to a site.</li>
+ * </ul>
+ * 
+ * @author Daniel Silva
+ * @version 1.0
+ * @since Apr 24, 2015
+ *
+ */
 public final class RulesEngine {
+	
 	private static int SLOW_RULE_LOG_MIN=Config.getIntProperty("SLOW_RULE_LOG_MIN", 100);
+	
+	private static final String SKIP_RULES_EXECUTION = "skip"; 
 
-    public static void fireRules(HttpServletRequest req, HttpServletResponse res, Rule.FireOn fireOn) {
+	/**
+	 * Triggers a specific category of Rules associated to the site (Host) based
+	 * on the requested resource.
+	 * 
+	 * @param req
+	 *            - The {@link HttpServletRequest} object.
+	 * @param res
+	 *            - The {@link HttpServletResponse} object.
+	 * @param fireOn
+	 *            - The category of the rules that will be fired: Every page,
+	 *            every request, etc.
+	 */
+	public static void fireRules(HttpServletRequest req, HttpServletResponse res, Rule.FireOn fireOn) {
+		Host host;
+		try {
+			host = WebAPILocator.getHostWebAPI().getCurrentHost(req);
+		} catch (Exception e) {
+			Logger.error(RulesEngine.class, "Unable to retrieve current request host for URI: " + req.getRequestURL(), e);
+			return;
+		}
+		fireRules(req, res, host, fireOn);
+	}
+	
+	/**
+	 * Triggers a specific category of Rules associated to the specified parent
+	 * object based on the requested resource.
+	 * 
+	 * @param req
+	 *            - The {@link HttpServletRequest} object.
+	 * @param res
+	 *            - The {@link HttpServletResponse} object.
+	 * @param parent
+	 *            - The object whose associated rules will be fired. For
+	 *            example, the {@link Host} object.
+	 * @param fireOn
+	 *            - The category of the rules that will be fired: Every page,
+	 *            every request, etc.
+	 */
+	public static void fireRules(HttpServletRequest req, HttpServletResponse res, Ruleable parent, Rule.FireOn fireOn) {
 
         //Check for the proper license level, the rules engine is an enterprise feature only
         if ( LicenseUtil.getLevel() < 200 ) {
             return;
         }
-
-        Host host;
-
-        try {
-            host =  WebAPILocator.getHostWebAPI().getCurrentHost(req);
-        } catch (Exception e) {
-            Logger.error(RulesEngine.class, "Unable to retrieve current request host for URI ", e);
-            return;
+        if (!UtilMethods.isSet(req)) {
+        	throw new DotRuntimeException("ERROR: HttpServletRequest is null");
+        }
+		if (SKIP_RULES_EXECUTION.equalsIgnoreCase(req.getParameter(WebKeys.RULES_ENGINE_PARAM))
+				|| SKIP_RULES_EXECUTION.equalsIgnoreCase(String.valueOf(req.getParameter(WebKeys.RULES_ENGINE_PARAM)))) {
+			return;
+		}
+        if (!UtilMethods.isSet(parent)) {
+        	return;
         }
 
         User systemUser;
@@ -44,24 +112,91 @@ public final class RulesEngine {
 
         try {
 
-            Set<Rule> rules = APILocator.getRulesAPI().getRulesByParentFireOn(host.getIdentifier(), systemUser, false, fireOn);
-
+			Set<Rule> rules = APILocator.getRulesAPI().getRulesByParentFireOn(parent.getIdentifier(), systemUser, false,
+					fireOn);
             for (Rule rule : rules) {
                 try {
                 	long before = System.currentTimeMillis();
                     rule.checkValid(); // @todo ggranum: this should actually be done on writing to the DB, or at worst reading from.
-                    rule.evaluate(req, res);
+                    boolean evaled = rule.evaluate(req, res);
+					if (evaled) {
+						Rule rCopy = new Rule();
+						rCopy.setId(rule.getId());
+						rCopy.setName(rule.getName());
+						rCopy.setParent(rule.getParent());
+						rCopy.setFireOn(rule.getFireOn());
+						rCopy.setEnabled(rule.isEnabled());
+						rCopy.setFolder(rule.getFolder());
+						rCopy.setShortCircuit(rule.isShortCircuit());
+						rCopy.setModDate(rule.getModDate());
+						trackFiredRule(rCopy, fireOn, req);
+					}
                     long after = System.currentTimeMillis();
         			if((after - before) > SLOW_RULE_LOG_MIN) {
-        				Logger.warn(RulesEngine.class, "Rule ID:"+rule.getId()+" is running too slow. The rule is fired on: "+ rule.getFireOn().name());
+						Logger.warn(RulesEngine.class, "Rule ID: " + rule.getId()
+								+ " is running too slow. The rule is fired on: " + rule.getFireOn().name());
         			}
                 } catch (RuleEngineException e) {
-                    Logger.error(RulesEngine.class, "Rule could not be evaluated. Rule Id: " + rule.getId(), e);
+                    Logger.error(RulesEngine.class, "Rule could not be evaluated. Rule ID: " + rule.getId(), e);
                 }
             }
 
         } catch(Exception e) {
-            Logger.error(RulesEngine.class, "Unable process rules." + e.getMessage(), e);
+            Logger.error(RulesEngine.class, "Unable process rules: " + e.getMessage(), e);
         }
     }
+
+	/**
+	 * Keeps track of the rules that have been fired for a given HTTP request.
+	 * This will allow Web developers to access the list of rules that were
+	 * triggered after a issuing a request. Depending on the rules category,
+	 * developers can examine the list of triggered rules either in the HTTP
+	 * Request or the HTTP Session:
+	 * 
+	 * <pre>
+	 * <table border='1'>
+	 * 	<th>HTTP Request</th>
+	 * 	<th>HTTP Session</th>
+	 * 	<tr>
+	 * 		<td>Per Page</td>
+	 * 		<td>Per Visitor</td>
+	 * 	</tr>
+	 *  <tr>
+	 * 		<td>Per Request</td>
+	 * 		<td></td>
+	 * 	</tr>
+	 *  <tr>
+	 * 		<td>Per Visit</td>
+	 * 		<td></td>
+	 * 	</tr>
+	 * </table>
+	 * </pre>
+	 * 
+	 * @param firedRule
+	 *            - The {@link Rule} that has been fired.
+	 * @param fireOn
+	 *            - The category of the {@link Rule} that determines whether the
+	 *            object must be added to the session or the request.
+	 * @param req
+	 *            - The {@link HttpServletRequest} object.
+	 */
+	@SuppressWarnings("unchecked")
+	private static void trackFiredRule(Rule firedRule, FireOn fireOn, HttpServletRequest req) {
+		Set<Rule> firedRules = null;
+		if (fireOn.equals(Rule.FireOn.ONCE_PER_VISITOR)) {
+			firedRules = (Set<Rule>) req.getSession(true).getAttribute(WebKeys.RULES_ENGINE_FIRE_LIST);
+		} else {
+			firedRules = (Set<Rule>) req.getAttribute(WebKeys.RULES_ENGINE_FIRE_LIST);
+		}
+		if (!UtilMethods.isSet(firedRules)) {
+			firedRules = new HashSet<Rule>();
+			if (fireOn.equals(Rule.FireOn.ONCE_PER_VISITOR)) {
+				req.getSession(true).setAttribute(WebKeys.RULES_ENGINE_FIRE_LIST, firedRules);
+			} else {
+				req.setAttribute(WebKeys.RULES_ENGINE_FIRE_LIST, firedRules);
+			}
+		}
+		firedRules.add(firedRule);
+	}
+
 }

--- a/src/com/dotmarketing/portlets/rules/model/Rule.java
+++ b/src/com/dotmarketing/portlets/rules/model/Rule.java
@@ -20,6 +20,17 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ * A Rule is composed of a list of conditions that get checked against when a 
+ * visitor requests a page. If the conditions in a rule are met, then one or 
+ * more actions are fired. Rules can be configured from their specific portlet 
+ * in the back-end and via RESTful services as well.
+ * 
+ * @author Daniel Silva
+ * @version 1.0
+ * @since Mar 10, 2015
+ *
+ */
 public class Rule implements Permissionable, Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -230,10 +241,25 @@ public class Rule implements Permissionable, Serializable {
         }
     }
 
-    public void evaluate(HttpServletRequest req, HttpServletResponse res) {
+	/**
+	 * Evaluates the set of conditions that make up this rule based on the
+	 * issued HTTP request. If the final result of such an evaluation is true,
+	 * then a set of one or more actions is executed.
+	 * 
+	 * @param req
+	 *            - The {@link HttpServletRequest} object that is triggering the
+	 *            rules evaluation/execution.
+	 * @param res
+	 *            - The {@link HttpServletResponse} object.
+	 * @return If the given conditions satisfy the rule, returns
+	 *         <code>true</code>. Otherwise, returns <code>false</code>.
+	 */
+    public boolean evaluate(HttpServletRequest req, HttpServletResponse res) {
         if(this.evaluateConditions(req, res, getGroups())) {
             this.evaluateActions(req, res, getRuleActions());
+            return true;
         }
+        return false;
     }
 
     private void evaluateActions(HttpServletRequest req, HttpServletResponse res, List<RuleAction> actions) {

--- a/src/com/dotmarketing/util/WebKeys.java
+++ b/src/com/dotmarketing/util/WebKeys.java
@@ -358,6 +358,8 @@ public final class WebKeys {
     public static final String RULES_CONDITIONLET_CLASSES = "RULES_CONDITIONLET_CLASSES";
     public static final String RULES_ACTIONLET_CLASSES = "RULES_ACTIONLET_CLASSES";
     public static final String RULES_CONDITIONLET_VISITEDURLS = "RULES_CONDITIONLET_VISITEDURLS";
+    public static final String RULES_ENGINE_PARAM = "dotRules";
+    public static final String RULES_ENGINE_FIRE_LIST = "dotRulesFired";
 
 	//ADMIN CONTROL
     public static final String ADMIN_CONTROL_TOP = "com.dotmarketing.admin.control.top";


### PR DESCRIPTION
The following code can be added to a widget in a page to test that the HTTP Request object has the “Per Page”, “Per Request”, and “Per Visit” rules, and the HTTP Session object has the “Per Visitor” rule: 

```
<h1>List of executed Rules</h1>
<h3>From request:</h3>
#foreach($rule in $request.getAttribute("dotRulesFired"))
-> $rule.name<br/>
#end
<h3>From session:</h3>
#foreach($rule in $session.getAttribute("dotRulesFired"))
-> $rule.name<br/>
#end
```
