### PR TITLE
fixes #8618

### DIFF
--- a/src/com/dotmarketing/servlets/BinaryExporterServlet.java
+++ b/src/com/dotmarketing/servlets/BinaryExporterServlet.java
@@ -452,7 +452,7 @@ public class BinaryExporterServlet extends HttpServlet {
 				mimeType = "application/octet-stream";
 			}
 			resp.setContentType(mimeType);
-			resp.setHeader("Content-Disposition", "inline; filename=" + UtilMethods.encodeURL(downloadName));
+			resp.setHeader("Content-Disposition", "inline; filename=\"" + UtilMethods.encodeURL(downloadName) + "\"" );
 
 			if (req.getParameter("dotcms_force_download") != null || req.getParameter("force_download") != null) {
 
@@ -462,7 +462,7 @@ public class BinaryExporterServlet extends HttpServlet {
 				if(!x.equals(y)){
 					downloadName = downloadName.replaceAll("\\." + x, "\\." + y);
 				}
-				resp.setHeader("Content-Disposition", "attachment; filename=" + UtilMethods.encodeURL(downloadName));
+				resp.setHeader("Content-Disposition", "attachment; filename=\"" + UtilMethods.encodeURL(downloadName) + "\"");
 				resp.setHeader("Content-Type", "application/force-download");
 			} else {
 

--- a/src/com/dotmarketing/servlets/HTMLPDFServlet.java
+++ b/src/com/dotmarketing/servlets/HTMLPDFServlet.java
@@ -137,7 +137,7 @@ public class HTMLPDFServlet extends VelocityServlet {
 
 
 
-		resp.setHeader("Content-Disposition", "attachment; filename=" + fName);
+		resp.setHeader("Content-Disposition", "attachment; filename=\"" + fName + "\"");
 		HttpSession session = req.getSession();
 		String reqURI = req.getRequestURI();
 

--- a/src/com/dotmarketing/servlets/ImportExportXMLServlet.java
+++ b/src/com/dotmarketing/servlets/ImportExportXMLServlet.java
@@ -125,7 +125,7 @@ public class ImportExportXMLServlet extends HttpServlet {
 				File zipFile = new File(FileUtil.getRealPath(backupFilePath + "/backup_" + x + "_.zip"));
 
 				response.setHeader("Content-type", "");
-				response.setHeader("Content-Disposition", "attachment; filename=" + zipFile.getName());
+				response.setHeader("Content-Disposition", "attachment; filename=\"" + zipFile.getName() + "\"");
 
 				createXMLFiles();
 


### PR DESCRIPTION
Tested with Chrome, Firefox and Safari (for Mac). Filename with commas can be downloaded without issues.
