### PR TITLE
Fixed unrecognized quote characters in Javadocs

### DIFF
--- a/src/com/dotmarketing/portlets/rules/conditionlet/VisitorsCurrentUrlConditionlet.java
+++ b/src/com/dotmarketing/portlets/rules/conditionlet/VisitorsCurrentUrlConditionlet.java
@@ -82,7 +82,7 @@ public class VisitorsCurrentUrlConditionlet extends Conditionlet<VisitorsCurrent
 	/**
 	 * Process the baseUrl to comply with:
 	 * <ul><li>Does not include query params</li>
-	 * <li>If a person enters a string that .endsWith(“/”) , e.g. is a folder, we need to
+	 * <li>If a person enters a string that .endsWith("/") , e.g. is a folder, we need to
 	 * evaluate against the path + the Config variable for CMS_INDEX_PAGE, whatever that is,
 	 * e.g. /news-events/news/ checks against /news-events/news/index, this happens on IS,
 	 * IS_NOT and ENDS_WITH to ensure that the user can use STARTS_WITH or REGEXP without


### PR DESCRIPTION
Basically cosmetic, but with the wrong quote characters the javadocs fail to build.
