### PR TITLE
improvements for #8738

### DIFF
--- a/src/com/dotmarketing/viewtools/SQLResultsViewTool.java
+++ b/src/com/dotmarketing/viewtools/SQLResultsViewTool.java
@@ -225,7 +225,15 @@ public class SQLResultsViewTool implements ViewTool {
                 Contentlet con = APILocator.getContentletAPI().find(inode, APILocator.getUserAPI().getSystemUser(), true);
                 userId = con.getModUser();
             } else if (fieldResourceName.indexOf(".vtl") > -1) {
-                String[] segments = fieldResourceName.split("/");
+                String separator = "";
+                //We check if the VTL File is loaded from a Unix/Linux instance or Windows.
+                if((fieldResourceName.indexOf("/") > -1)){
+                    separator = "/";
+                }
+                else{
+                    separator = "\\\\";
+                }
+                String[] segments = fieldResourceName.split(separator);
                 inode = segments[segments.length-3];
                 Contentlet con = APILocator.getContentletAPI().find(inode, APILocator.getUserAPI().getSystemUser(), true);
                 userId = con.getModUser();


### PR DESCRIPTION
Tested in 3.3 + Postgres 9.4.

Added the following code:

```
        #set($query = "SELECT parent_path||asset_name AS uri FROM identifier WHERE asset_type = 'contentlet'")
        #set($results = $sql.getSQLResults("default",$query,0,0))
        #foreach($id in $results)
        URI: $id.uri
        <br>
        #end
```

To Templates, Containers, Web Page Contents, Simple Widgets and a VTL file. All tests returned the query results list. 
