### PR TITLE
card811 fix exists comparator

### DIFF
--- a/src/com/dotmarketing/portlets/rules/conditionlet/SessionAttributeConditionlet.java
+++ b/src/com/dotmarketing/portlets/rules/conditionlet/SessionAttributeConditionlet.java
@@ -39,7 +39,7 @@ public class SessionAttributeConditionlet extends Conditionlet<SessionAttributeC
         1, SESSION_KEY,new TextInput<>(new TextType().minLength(1)));
 
     private static final ParameterDefinition<TextType> sessionValue = new ParameterDefinition<>(
-        2, SESSION_VALUE, new TextInput<>(new TextType().minLength(1))
+        2, SESSION_VALUE, new TextInput<>(new TextType())
     );
 
     public SessionAttributeConditionlet() {


### PR DESCRIPTION
The length can't min 1 because when the Exists Comparator is selected, there is no field of the value.
