### PR TITLE
Fix deleting site with multilang page and content

### DIFF
--- a/src/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/src/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1228,21 +1228,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             // Find all multi-language working contentlets
             List<Contentlet> otherLanguageCons = conFac.getContentletsByIdentifier(con.getIdentifier());
 
-            if (isDeletingAHost) {
-                // When we are deleting a host, we need to delete
-                // live, working or archived contentlets
-                for (Contentlet contentlet : otherLanguageCons) {
-                    if (contentlet.getInode() != con.getInode()
-                            && contentlet.getLanguageId() != con.getLanguageId()) {
-                        if (perCons.contains(contentlet)) {
-                            indexAPI.removeContentFromIndex(contentlet);
-                        } else {
-                            cannotDelete = true;
-                            break;
-                        }
-                    }
-                }
-            } else {
+            if(!isDeletingAHost) {
                 // When we are NOT deleting a host and at least one multi-language
                 // contentlet is NOT archived we cannot delete.
                 for (Contentlet contentlet : otherLanguageCons) {
@@ -1281,7 +1267,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             contentletsVersion.addAll(findAllVersions(APILocator.getIdentifierAPI().find(con.getIdentifier()), user, respectFrontendRoles));
-            APILocator.getVersionableAPI().deleteContentletVersionInfo(con.getIdentifier(), con.getLanguageId());
 
             List<MultiTree> mts = MultiTreeFactory.getMultiTreeByChild(con.getIdentifier());
             for (MultiTree mt : mts) {


### PR DESCRIPTION
1. Clean logic for the case of a call of deleteContents from site deletion.
   We only need to do the check for unarchived content in other langs to prevent the
   deletion  in cases different than site deletion.
2. Remove call to indexAPI.removeContentFromIndex in the old confusing logic for the
   case of site deletion since it is called for every content later in the method
3. Remove deletion of ContentVersionInfo inside the loop that deals with multitrees.
   This is because if a parent page and child content were in the list being iterated
   and the parent page was first in that list, it would remove its version info, thus
   when getting content child's multitree, it would be impossible to find the parent by
   identifier since its version info was removed in the previous iteration. The deletion of
   all content's version info's ocurrs later in the method
