### PR TITLE
#8898: Checkins hasLiveVersion() before archive

### DIFF
--- a/src/com/dotmarketing/portlets/contentlet/action/EditContentletAction.java
+++ b/src/com/dotmarketing/portlets/contentlet/action/EditContentletAction.java
@@ -2263,7 +2263,7 @@ public class EditContentletAction extends DotPortletAction implements DotPortlet
 						}
 
 						if (perAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT, user))
-							if (!contentlet.isLive())
+							if (!contentlet.hasLiveVersion())
 								contentlets.add(contentlet);
 							else {
 							    someContentIsLive=true;

--- a/src/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/src/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -770,4 +770,8 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 			 return super.put(key, value);
 		 }
 	}
+
+	public boolean hasLiveVersion() throws DotStateException, DotDataException {
+		return APILocator.getVersionableAPI().hasLiveVersion(this);
+	}
 }


### PR DESCRIPTION
- Added hasLiveVersion() method to contentlet class. This method will use the VersionableAPI to check is the identifier has a live version. In that case, the user will need to unpublish before archive.
