### PR TITLE
Fixes #8839 change value on response location header

### DIFF
--- a/src/com/dotmarketing/filters/CMSFilter.java
+++ b/src/com/dotmarketing/filters/CMSFilter.java
@@ -51,9 +51,9 @@ public class CMSFilter implements Filter {
 		VANITY_URL,
 		NOTHING_IN_THE_CMS
 	}
-	
-	
-	
+
+
+
 	public static final String CMS_INDEX_PAGE = Config.getStringProperty("CMS_INDEX_PAGE", "index");
 	public static final String CMS_FILTER_IDENTITY = "CMS_FILTER_IDENTITY";
 	public static final String CMS_FILTER_URI_OVERRIDE = "CMS_FILTER_URLMAP_OVERRIDE";
@@ -75,13 +75,13 @@ public class CMSFilter implements Filter {
 		}
 
 
-		
-		IAm iAm = IAm.NOTHING_IN_THE_CMS;
-		
-		LogFactory.getLog(this.getClass()).debug("CMS Filter URI = " + uri);
-		
 
-		
+		IAm iAm = IAm.NOTHING_IN_THE_CMS;
+
+		LogFactory.getLog(this.getClass()).debug("CMS Filter URI = " + uri);
+
+
+
 
 		/*
 		 * Getting host object form the session
@@ -125,7 +125,7 @@ public class CMSFilter implements Filter {
 		String queryString = request.getQueryString();
 		// if a vanity URL
 		if (iAm == IAm.VANITY_URL) {
-			
+
 			rewrite = VirtualLinksCache.getPathFromCache(host.getHostname() + ":" + ("/".equals(uri) ? "/cmsHomePage" : uri.endsWith("/")?uri.substring(0, uri.length() - 1):uri));
 
 			if (!UtilMethods.isSet(rewrite)) {
@@ -133,7 +133,7 @@ public class CMSFilter implements Filter {
 			}
 			if (UtilMethods.isSet(rewrite) && rewrite.contains("//")) {
 				response.sendRedirect(rewrite);
-				
+
 				closeDbSilently();
 				return;
 			}
@@ -157,12 +157,16 @@ public class CMSFilter implements Filter {
 
 		if (iAm == IAm.FOLDER) {
 			if (!uri.endsWith("/")) {
+				// If the value comes from the uri override attribute, used it, if not use the same uri as the
+				// current request, no decoding needed.
+				String undecodeUri = (request.getAttribute(CMS_FILTER_URI_OVERRIDE) != null) ? (String) request.getAttribute(CMS_FILTER_URI_OVERRIDE)
+						: request.getRequestURI();
 				if(UtilMethods.isSet(queryString)){
-					response.setHeader("Location", uri + "/?" + queryString );
+					response.setHeader("Location", undecodeUri + "/?" + queryString );
 				}
 				else{
-					response.setHeader("Location", uri +"/" );
-					
+					response.setHeader("Location", undecodeUri +"/" );
+
 				}
 				response.setStatus(301);
 				closeDbSilently();
@@ -288,18 +292,18 @@ public class CMSFilter implements Filter {
 	@Deprecated
 	private static final Integer mutex = new Integer(0);
 
-	
+
 	@Deprecated
 	private static void buildExcludeList() {
 		// not needed anymore
 	}
-	
+
 	@Deprecated
 	public static void addExclude(String URLPattern) {
 
 		// not needed anymore
 	}
-	
+
 	@Deprecated
 	public static void removeExclude(String URLPattern) {
 		// not needed anymore
@@ -317,7 +321,7 @@ public class CMSFilter implements Filter {
 
 		} finally {
 			try {
-				
+
 				DbConnectionFactory.closeConnection();
 			} catch (Exception e) {
 
@@ -326,7 +330,7 @@ public class CMSFilter implements Filter {
 	}
 
 	private String xssCheck(String uri, String queryString) throws ServletException{
-		
+
 		String rewrite=null;
 		if (Xss.URIHasXSS(uri)) {
 			Logger.warn(this, "XSS Found in request URI: " +uri );
@@ -344,10 +348,10 @@ public class CMSFilter implements Filter {
 				rewrite=uri;
 			}
 		}
-		
+
 		return rewrite;
 	}
-	
-	
+
+
 
 }


### PR DESCRIPTION
The string does NOT need to be decoded to set it on the location header,
the header is going to be used as a value for a redirect and passed
again through the filters.  If the value comes from the uri override
attribute, used it, if not use the same uri as the current request.
