### PR TITLE
#8932 handle support of Multilingual File Assets on Frontend Pulls

### DIFF
--- a/src-conf/dotmarketing-config.properties
+++ b/src-conf/dotmarketing-config.properties
@@ -21,6 +21,9 @@ DEFAULT_WIDGET_TO_DEFAULT_LANGUAGE=true
 ## it is similar to DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE but only applies for Pages
 DEFAULT_PAGE_TO_DEFAULT_LANGUAGE=true
 
+## it is similar to DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE but only applies for Files
+DEFAULT_FILE_TO_DEFAULT_LANGUAGE=false
+
 PER_PAGE = 40
 
 ##	in minutes

--- a/src/com/dotmarketing/filters/CMSFilter.java
+++ b/src/com/dotmarketing/filters/CMSFilter.java
@@ -19,7 +19,9 @@ import javax.servlet.http.HttpSession;
 import com.dotcms.visitor.business.VisitorAPI;
 import com.dotcms.visitor.domain.Visitor;
 import com.dotmarketing.util.*;
+
 import org.apache.commons.logging.LogFactory;
+
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
@@ -196,14 +198,26 @@ public class CMSFilter implements Filter {
 		if (iAm == IAm.FILE) {
 			Identifier ident = null;
 			try {
+	             //Serving the file through the /dotAsset servlet
+                StringWriter forward = new StringWriter();
+                forward.append("/dotAsset/");
+                
 				ident = APILocator.getIdentifierAPI().find(host, rewrite);
 				request.setAttribute(CMS_FILTER_IDENTITY, ident);
+				
 				RulesEngine.fireRules(request, response, Rule.FireOn.EVERY_REQUEST);
 				if(response.isCommitted()) {
                 /* Some form of redirect, error, or the request has already been fulfilled in some fashion by one or more of the actionlets. */
 					return;
 				}
-				request.getRequestDispatcher("/dotAsset/").forward(request, response);
+				
+                //If language is in session, set as query string
+                if(UtilMethods.isSet(languageId)){
+                    forward.append('?');
+                    forward.append(WebKeys.HTMLPAGE_LANGUAGE + "=" + languageId);
+                }
+                
+                request.getRequestDispatcher(forward.toString()).forward(request, response);
 			} catch (DotDataException e) {
 				Logger.error(CMSFilter.class, e.getMessage(), e);
 				throw new IOException(e.getMessage());

--- a/src/com/dotmarketing/filters/CmsUrlUtil.java
+++ b/src/com/dotmarketing/filters/CmsUrlUtil.java
@@ -123,7 +123,7 @@ public class CmsUrlUtil {
 		}
 		if ("contentlet".equals(id.getAssetType())) {
 			try {
-				ContentletVersionInfo cinfo = APILocator.getVersionableAPI().getContentletVersionInfo(id.getId(), APILocator.getLanguageAPI().getDefaultLanguage().getId());
+				ContentletVersionInfo cinfo = APILocator.getVersionableAPI().getContentletVersionInfo(id.getId(), languageId);
 				Contentlet c = APILocator.getContentletAPI().find(cinfo.getWorkingInode(), APILocator.getUserAPI().getSystemUser(), false);
 				return (c.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_FILEASSET);
 			} catch (Exception e) {

--- a/src/com/dotmarketing/servlets/SpeedyAssetServlet.java
+++ b/src/com/dotmarketing/servlets/SpeedyAssetServlet.java
@@ -175,12 +175,19 @@ public class SpeedyAssetServlet extends HttpServlet {
 					}
 				}
 				
-				
+                //If language is in session, let's load it. Otherwise, set langId with default Language Id
+                long langId = 0;
+                
+                if(UtilMethods.isSet(request.getSession().getAttribute(com.dotmarketing.util.WebKeys.HTMLPAGE_LANGUAGE))){
+                    langId = Long.parseLong((String)request.getSession().getAttribute(com.dotmarketing.util.WebKeys.HTMLPAGE_LANGUAGE));
+                } else {
+                    langId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+                }
 				
 				if(ident != null && ident.getURI() != null && !ident.getURI().equals("")){
 
 					if(serveWorkingVersion){
-						uri = WorkingCache.getPathFromCache(ident.getURI(), ident.getHostId());
+						uri = WorkingCache.getPathFromCache(ident.getURI(), ident.getHostId(), langId);
 						if(!UtilMethods.isSet(realPath)){
 							f = new File(FileUtil.getRealPath(assetPath + uri));
 						}else{
@@ -204,7 +211,7 @@ public class SpeedyAssetServlet extends HttpServlet {
 
 					}else {
 						try{
-							uri = LiveCache.getPathFromCache(ident.getURI(), ident.getHostId());
+							uri = LiveCache.getPathFromCache(ident.getURI(), ident.getHostId(), langId);
 						}catch (Exception e) {
 							if(isLoggedToBackend){
 								response.setHeader( "Pragma", "no-cache" );


### PR DESCRIPTION
Tested as a Backported Fix for 3.3.1 version + Postgres DB. 

Adding a Multilingual Document, e.g. http://localhost:8080/resources/documents/resource.txt and adding **language_id=1** or any other valid language as Query String, It will pull the right file.

Not setting a Language in the URI will fallback to the Default Language.
