### PR TITLE
Increase time for blur event in the tags fields

### DIFF
--- a/dotCMS/html/js/tag.js
+++ b/dotCMS/html/js/tag.js
@@ -189,7 +189,7 @@ function closeSuggetionBox(e) {
 			e.target.value = "";
 			e.target.blur();
 		}
-	}, 100)
+	}, 500)
 }
 
 function removeAllTags() {


### PR DESCRIPTION
After a week of trying different ways to bind events to clicks, turns out the issue was that the onBlur event was triggering before the the click.
