### PR TITLE
Issue #8966 Fixed mockito-core version

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -247,7 +247,7 @@ dependencies {
      */
     compile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
     compile 'junit:junit:4.12'
-    compile "org.mockito:mockito-core:1.+"
+    compile "org.mockito:mockito-core:1.10.19"
 
     /**
      * Order matters here: OSGI-Core must come after felix.


### PR DESCRIPTION
In dependencies.gradle specified the mockito-core version.

From "1.+" to "1.10.19"
