### PR TITLE
Prevent trying to parse empty values

### DIFF
--- a/src/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/src/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -3478,6 +3478,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
         if(!InodeUtils.isSet(stInode)){
             throw new DotContentletValidationException("The contentlet's structureInode must be set");
         }
+
+        if(!UtilMethods.isSet(value.toString())) {
+            contentlet.setProperty(field.getVelocityVarName(), null);
+            return;
+        }
+
         if(field.getFieldType().equals(Field.FieldType.CATEGORY.toString()) || field.getFieldType().equals(Field.FieldType.CATEGORIES_TAB.toString())){
 
         }else if(fAPI.isElementConstant(field)){

--- a/src/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/src/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -3479,7 +3479,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             throw new DotContentletValidationException("The contentlet's structureInode must be set");
         }
 
-        if(!UtilMethods.isSet(value.toString())) {
+        if(value==null || !UtilMethods.isSet(value.toString())) {
             contentlet.setProperty(field.getVelocityVarName(), null);
             return;
         }


### PR DESCRIPTION
When an emtpy value is passed to the setContentletProperty method
we set the value to null and let the further call to validateContent
do its work. This prevents throwing errors like trying to parse an
empty string to a numeric value.

issue #8949
