### PR TITLE
Fixes #8978 - Remove unnecesary validations and always set cond.delet…

### DIFF
--- a/src/com/dotmarketing/viewtools/BrowserAPI.java
+++ b/src/com/dotmarketing/viewtools/BrowserAPI.java
@@ -372,15 +372,15 @@ public class BrowserAPI {
 
 			} else {
 		        ChildrenCondition cond = new ChildrenCondition();
+		        
 		        if(showWorking)
 		        	cond.working = true;
 		        else
 		        	cond.live = true;
-				files.addAll(folderAPI.getFiles(parent,	userAPI.getSystemUser(), false, cond));
-				if (showArchived) {
-					cond.deleted = showArchived;
-					files.addAll(folderAPI.getFiles(parent, userAPI.getSystemUser(), false, cond));
-				}
+				
+		        cond.deleted = showArchived;
+					
+				files.addAll(folderAPI.getFiles(parent, userAPI.getSystemUser(), false, cond));
 				files.addAll(APILocator.getFileAssetAPI().findFileAssetsByFolder(parent, "", !showWorking, showWorking, user, false));
 			}
 


### PR DESCRIPTION
Fix for #8978 

Removed unnecessary validations and added proper ones. For Legacy files, cond.delete value was sent as null, so Archived assets validation on the FolderFactoryImpl.getChildrenClass methods was never hit for legacy files, therefore it always shows the Archived Assets. 

Tested on backported fix to 3.3, running MSSQL 2012 and Java 8. Working as expected. No other assets displaying is affected by this fix. 
