### PR TITLE
Improve how Jobs are acquired and locked for MSSQL Clients #8987

### DIFF
--- a/src/com/dotmarketing/quartz/DotJobStore.java
+++ b/src/com/dotmarketing/quartz/DotJobStore.java
@@ -121,6 +121,8 @@ public class DotJobStore extends JobStoreCMT {
 			try {
 				setDriverDelegateClass("org.quartz.impl.jdbcjobstore.DotMSSQLDelegate");
 				setLockHandler(sem);
+				setAcquireTriggersWithinLock(true);  
+				setSelectWithLockSQL("SELECT * FROM {0}LOCKS WHERE LOCK_NAME = ? FOR UPDATE");
 			} catch (Exception e) {
 				Logger.info(this, e.getMessage());
 			}


### PR DESCRIPTION
Tested on 3.2.4 and 3.3 running MSSQL 2014 Databases. All jobs worked as expected and error messages are not displayed on logfiles anymore.
