### PR TITLE
fixes #9106

### DIFF
--- a/src/com/dotmarketing/fixtask/tasks/FixTask00004CheckFileAssetsInconsistencies.java
+++ b/src/com/dotmarketing/fixtask/tasks/FixTask00004CheckFileAssetsInconsistencies.java
@@ -55,7 +55,7 @@ public class FixTask00004CheckFileAssetsInconsistencies  implements FixTask {
 						+ "inode i, " + "file_asset c "
 						+ "where ident.id = c.identifier and "
 						+ "ident.id not in (select ident.id "
-						+ "from identifier id, " + "inode i, "
+						+ "from identifier ident, " + "inode i, "
 						+ "file_asset c, " + "fileasset_version_info fvi "
 						+ "where c.identifier = ident.id and "
 						+ "i.inode = c.inode and " + "fvi.working_inode = c.inode) and "


### PR DESCRIPTION
Minor change to modify the alias used in one of the queries of the fix task. Tested in 3.5 during the upgrade of a client's DB.
