### PR TITLE
Broken admin panel on missing portlet

### DIFF
--- a/dotCMS/html/common/nav_main_inc.jsp
+++ b/dotCMS/html/common/nav_main_inc.jsp
@@ -32,9 +32,14 @@ var portletTabMap = {}; // this holds a Map of portletId, tabId, used when refre
 
                 Portlet portlet = (Portlet) APILocator.getPortletAPI().findPortlet(portletIDs.get(0));
                 Object object = Class.forName(portlet.getPortletClass()).newInstance();
-                if(object instanceof BaseRestPortlet){
-                    tabHREF =  "javascript:dotAjaxNav.show('/api/portlet/"+ portletIDs.get(0) + "/', '" + l + "');";
-            	}
+                try {
+                        Object object = Class.forName(portlet.getPortletClass()).newInstance();
+                        if(object instanceof BaseRestPortlet){
+                            tabHREF = "javascript:dotAjaxNav.show('/api/portlet/"+ portletIDs.get(0) + "/', '" + l + "');";
+                        }
+                } catch(Exception e) {
+                        com.dotmarketing.util.Logger.error(this.getClass(), "Exception on portlet: " + (portlet == null ? "[null]" : portlet.getPortletClass()), e);
+                }
 
                 %>
 


### PR DESCRIPTION
If you add portlet from OSGI plugin and then remove OSGI plugin without first removing portlet tab then admin panel completely breaks. This change fixes issue.
