### PR TITLE
#8703 The build directory of each static plugin is cleaned before exe…

### DIFF
--- a/plugins/common.xml
+++ b/plugins/common.xml
@@ -48,7 +48,7 @@
 		<pathelement path="../../build/classes" />
 	</path>
 
-	<target name="build" depends="compile,jar" />
+	<target name="build" depends="clean,compile,jar" />
 	<target name="compile">
 
 		<echo>Building at: ${plugin.name} at ${basedir}</echo>


### PR DESCRIPTION
A cleaning task call was added to remove build directory before building each static plugin.
