### PR TITLE
#9119: Using bind address improved logic

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 //noinspection GroovyAssignabilityCheck
 dependencies {
 
-    compile group: 'com.dotcms.enterprise', name: 'ee', version: 'ge8bb10e-SNAPSHOT'
+    compile group: 'com.dotcms.enterprise', name: 'ee', version: 'g1358b33-SNAPSHOT'
     compile group: 'com.dotcms.enterprise', name: 'eelic', version: 'gaeb6cd0'
 
     compile group: 'com.dotcms', name: 'ant-tooling', version: '1.2'

--- a/src/com/dotmarketing/business/ChainableCacheAdministratorImpl.java
+++ b/src/com/dotmarketing/business/ChainableCacheAdministratorImpl.java
@@ -112,8 +112,8 @@ public class ChainableCacheAdministratorImpl implements DotCacheAdministrator {
 			    
 			    String storedBindAddr = (UtilMethods.isSet(localServer.getHost()) && !localServer.getHost().equals("localhost"))
 	                    ?localServer.getHost():localServer.getIpAddress();
-	            bindAddr = UtilMethods.isSet(cacheProperties.get("BIND_ADDRESS"))?cacheProperties.get("BIND_ADDRESS")
-	                    :Config.getStringProperty("CACHE_BINDADDRESS", storedBindAddr );
+
+	            bindAddr = UtilMethods.isSet(localServer.getIpAddress()) ? localServer.getIpAddress() : storedBindAddr;
 
 				if(UtilMethods.isSet(cacheProperties.get("CACHE_BINDPORT"))){
 					bindPort = cacheProperties.get("CACHE_BINDPORT");
@@ -127,7 +127,7 @@ public class ChainableCacheAdministratorImpl implements DotCacheAdministrator {
 	                    
                 localServer.setCachePort(Integer.parseInt(bindPort));
 
-                localServer.setHost(Config.getStringProperty("CACHE_BINDADDRESS", null));                
+                localServer.setHost(bindAddr);
 
                 List<String> myself = new ArrayList<String>();
                 myself.add(localServer.getServerId());


### PR DESCRIPTION
dependencies.gradle: Updating to the new ee jar.
ChainableCacheAdministratorImpl.java: Use IP from the server, now that is validated by the new logic for cache bind address that we use in Cluster Factory.
