### PR TITLE
#9073 disable display of anonymous user on user admin screen and delete

### DIFF
--- a/src/com/dotmarketing/business/UserAPI.java
+++ b/src/com/dotmarketing/business/UserAPI.java
@@ -140,7 +140,7 @@ public interface UserAPI {
     
     /**
 	 * This Method return the number of user that have a firstname, lastname or email like the filter string.
-	 * For example all amount of user with lastName "Andrews"
+	 * For example all amount of user with lastName "Andrews", includes anonymous
 	 * This method will ALWAYS hit DB
 	 * @param filter Compare string
 	 * @return long
@@ -149,6 +149,15 @@ public interface UserAPI {
 	 */
     public long getCountUsersByNameOrEmailOrUserID(String filter) throws DotDataException;
 
+    /**
+	 * This Method return the number of user that have a firstname, lastname or email like the filter string.
+	 * For example all amount of user with lastName "Andrews", this might exclude anonymous
+	 * This method will ALWAYS hit DB
+	 * @param filter Compare string
+	 * @return long
+	 * @throws DotDataException
+	 */
+    public long getCountUsersByNameOrEmailOrUserID(String filter, boolean includeAnonymous) throws DotDataException;
 
     /**
      * This method return a a paginated list of user that have a firstname, lastname or email like
@@ -176,7 +185,7 @@ public interface UserAPI {
 
     /**
      * This method return a a paginated list of user that have a firstname, lastname or email like
-     * the compare string passed
+     * the compare string passed, includes anonymous
 	 * This method will ALWAYS hit DB
      * @param filter compare string
      * @param page page to display
@@ -185,6 +194,17 @@ public interface UserAPI {
      * @version 1.9
      */
     public List<User> getUsersByNameOrEmailOrUserID(String filter,int page,int pageSize) throws DotDataException;
+
+    /**
+     * This method return a a paginated list of user that have a firstname, lastname or email like
+     * the compare string passed, this might exclude the anonymous user
+	 * This method will ALWAYS hit DB
+     * @param filter compare string
+     * @param page page to display
+     * @param pageSize number of element to show in the page
+     * @return List<User>
+     */
+    public List<User> getUsersByNameOrEmailOrUserID(String filter,int page,int pageSize, boolean includeAnonymous) throws DotDataException;
 
     /**
      * This method return a list of users and roles which name are like the compared string passed

--- a/src/com/dotmarketing/business/UserAPIImpl.java
+++ b/src/com/dotmarketing/business/UserAPIImpl.java
@@ -202,8 +202,16 @@ public class UserAPIImpl implements UserAPI {
 		return uf.getCountUsersByNameOrEmailOrUserID(filter);
 	}
 
+	public long getCountUsersByNameOrEmailOrUserID(String filter, boolean includeAnonymous) throws DotDataException {
+		return uf.getCountUsersByNameOrEmailOrUserID(filter, includeAnonymous);
+	}
+
 	public List<User> getUsersByNameOrEmailOrUserID(String filter, int page, int pageSize) throws DotDataException {
 		return uf.getUsersByNameOrEmailOrUserID(filter, page, pageSize);
+	}
+
+	public List<User> getUsersByNameOrEmailOrUserID(String filter, int page, int pageSize, boolean includeAnonymous) throws DotDataException {
+		return uf.getUsersByNameOrEmailOrUserID(filter, page, pageSize, includeAnonymous);
 	}
 
 	@SuppressWarnings("deprecation")
@@ -298,6 +306,9 @@ public class UserAPIImpl implements UserAPI {
 		}
 		if (userToDelete.getUserId() == replacementUser.getUserId()) {
 			throw new DotDataException("Can't delete a user without a replacement userId");
+		}
+		if (getAnonymousUser().getUserId() == userToDelete.getUserId()){
+			throw new DotDataException("Anonymous user can not be deleted.");
 		}
 		if(!perAPI.doesUserHavePermission(upAPI.getUserProxy(userToDelete,APILocator.getUserAPI().getSystemUser(), false), PermissionAPI.PERMISSION_EDIT, user, respectFrontEndRoles)){
 			throw new DotSecurityException("User doesn't have permission to userToDelete the user which is trying to be saved");

--- a/src/com/dotmarketing/business/UserFactory.java
+++ b/src/com/dotmarketing/business/UserFactory.java
@@ -187,7 +187,7 @@ public abstract class UserFactory {
 	
 	/**
 	 * This Method return the number of user that have a firstname, lastname or email like the filter string.
-	 * For example all amount of user with lastName "Andrews"
+	 * For example all amount of user with lastName "Andrews", includes anonymous user
 	 * @param filter Compare string
 	 * @return long
 	 * @version 1.9
@@ -195,9 +195,20 @@ public abstract class UserFactory {
 	 */
 	protected abstract long getCountUsersByNameOrEmailOrUserID(String filter)
 			throws DotDataException;
+
+	/**
+	 * This Method return the number of user that have a firstname, lastname or email like the filter string.
+	 * For example all amount of user with lastName "Andrews", this might exclude anonymous
+	 * @param filter Compare string
+	 * @return long
+	 * @throws DotDataException
+	 */
+	protected abstract long getCountUsersByNameOrEmailOrUserID(String filter, boolean includeAnonymous)
+			throws DotDataException;
+
 	/**
      * This method return a a paginated list of user that have a firstname, lastname or email like
-     * the compare string passed
+     * the compare string passed, includes anonymous user
 	 * This method will ALWAYS hit DB
      * @param filter compare string
      * @param page page to display
@@ -207,8 +218,18 @@ public abstract class UserFactory {
      */
 	protected abstract List<User> getUsersByNameOrEmailOrUserID(String filter, int page,
 			int pageSize) throws DotDataException;
-	
-	
-	
-    
+
+	/**
+     * This method return a a paginated list of user that have a firstname, lastname or email like
+     * the compare string passed, this might exclude anonymous from the list
+	 * This method will ALWAYS hit DB
+     * @param filter compare string
+     * @param page page to display
+     * @param pageSize number of element to show in the page
+     * @return List<User>
+     */
+	protected abstract List<User> getUsersByNameOrEmailOrUserID(String filter, int page,
+			int pageSize, boolean includeAnonymous) throws DotDataException;
+
+
 }

--- a/src/com/dotmarketing/business/UserFactoryLiferayImpl.java
+++ b/src/com/dotmarketing/business/UserFactoryLiferayImpl.java
@@ -336,12 +336,17 @@ public class UserFactoryLiferayImpl extends UserFactory {
 	
 	@Override
 	public long getCountUsersByNameOrEmailOrUserID(String filter) throws DotDataException {
+		return getCountUsersByNameOrEmailOrUserID(filter, true);
+	}
+
+	@Override
+	public long getCountUsersByNameOrEmailOrUserID(String filter, boolean includeAnonymous) throws DotDataException {
 		filter = (UtilMethods.isSet(filter) ? filter.toLowerCase() : "");
 		filter = SQLUtil.sanitizeParameter(filter);    	
 		String sql = "select count(*) as count from user_ where " +
 				"lower(userid) like '%" + filter + "%' or lower(firstName) like '%" + filter + "%' or lower(lastName) like '%" + filter +"%' or " +
-				"lower(emailAddress) like '%" + filter + "%' or " + 
-				DotConnect.concat(new String[] { "lower(firstName)", "' '", "lower(lastName)" }) + " like '%" + filter +"%'";
+				"lower(emailAddress) like '%" + filter + "%' or " +
+				DotConnect.concat(new String[] { "lower(firstName)", "' '", "lower(lastName)" }) + " like '%" + filter +"%'" + ((!includeAnonymous)?"AND userid <> 'anonymous'":"");
 		DotConnect dotConnect = new DotConnect();
 		dotConnect.setSQL(sql);
 		return dotConnect.getInt("count");
@@ -349,6 +354,11 @@ public class UserFactoryLiferayImpl extends UserFactory {
 	
 	@Override
 	public List<User> getUsersByNameOrEmailOrUserID(String filter, int page, int pageSize) throws DotDataException {
+		return getUsersByNameOrEmailOrUserID(filter, page, pageSize, true);
+	}
+
+	@Override
+	public List<User> getUsersByNameOrEmailOrUserID(String filter, int page, int pageSize, boolean includeAnonymous) throws DotDataException {
 		List users = new ArrayList(pageSize);
 		if(page==0){
 			page = 1;
@@ -358,7 +368,7 @@ public class UserFactoryLiferayImpl extends UserFactory {
 		filter = (UtilMethods.isSet(filter) ? filter.toLowerCase() : "");
 		filter = SQLUtil.sanitizeParameter(filter);    		
 		String sql = "select userid from user_ where (lower(userid) like '%" + filter + "%' or lower(firstName) like '%" + filter + "%' or lower(lastName) like '%" + filter +"%' or lower(emailAddress) like '%" + filter + "%' " +
-				" or " + DotConnect.concat(new String[] { "lower(firstName)", "' '", "lower(lastName)" }) + " like '%" + filter +"%') AND userid <> 'system' " +
+				" or " + DotConnect.concat(new String[] { "lower(firstName)", "' '", "lower(lastName)" }) + " like '%" + filter +"%') AND userid <> 'system' " + ((!includeAnonymous)?"AND userid <> 'anonymous'":"") +
 				"order by firstName asc,lastname asc";
 		DotConnect dotConnect = new DotConnect();
 		dotConnect.setSQL(sql);

--- a/src/com/dotmarketing/portlets/user/ajax/UserAjax.java
+++ b/src/com/dotmarketing/portlets/user/ajax/UserAjax.java
@@ -1165,7 +1165,7 @@ private Map<String, Object> processRoleList(String query, int start, int limit, 
 				@Override
 				public int getUserCount() {
 					try {
-						return new Long(userAPI.getCountUsersByNameOrEmailOrUserID(filter)).intValue();
+						return new Long(userAPI.getCountUsersByNameOrEmailOrUserID(filter,false)).intValue();
 					} catch (DotDataException e) {
 						Logger.error(this, e.getMessage(), e);
 						return 0;
@@ -1177,7 +1177,7 @@ private Map<String, Object> processRoleList(String query, int start, int limit, 
 					try {
 						int page = (start/limit)+1;
 						int pageSize = limit;
-						return userAPI.getUsersByNameOrEmailOrUserID(filter, page, pageSize);
+						return userAPI.getUsersByNameOrEmailOrUserID(filter, page, pageSize,false);
 					} catch (DotDataException e) {
 						Logger.error(this, e.getMessage(), e);
 						return new ArrayList<User>();
@@ -1706,8 +1706,13 @@ private Map<String, Object> processRoleList(String query, int start, int limit, 
         }
         return loggedInUser;
 	}
-	
-	
-	
-	
+
+	/** UserAPI getAnonymousUser() wrapper use to validate anonymous on the UI
+	 * @return Anonymous user
+	 * @throws DotDataException
+	 */
+	public String getAnonymousUserId() throws DotDataException{
+		return APILocator.getUserAPI().getAnonymousUser().getUserId();
+	}
+
 }

--- a/test/com/dotmarketing/business/UserAPITest.java
+++ b/test/com/dotmarketing/business/UserAPITest.java
@@ -538,5 +538,24 @@ public class UserAPITest extends TestBase{
 		dwrAuthentication.shutdownWebContext();
 	}
 
+	/**
+	 * Validates rule to forbid anonymous user delete
+	 * as in other restrictions an exception is returned
+	 * @throws DotDataException
+	 */
+	@Test(expected=DotDataException.class)
+	public void deleteAnonymous() throws DotDataException{
 
+		UserAPI userAPI = APILocator.getUserAPI();
+		User systemUser = null;
+		User anonymousUser = null;
+
+		try{
+			systemUser = userAPI.getSystemUser();
+			anonymousUser = userAPI.getAnonymousUser();
+			userAPI.delete(anonymousUser, systemUser, false);
+		}catch(DotSecurityException e){
+			// no need to validate this, only used to get the user objects
+		}
+	}
 }


### PR DESCRIPTION
Removes from the API the possibility to delete the anonymous user
and adds a test for it.  Also updates the methods used to get the list
into the user admin screen, keeping anonymous from the list.  The old
method still works as before referencing the new one with the default
value of includeAnonymous = true.
