### PR TITLE
#9064 Remove replicas management from UI and API when handle by dotCMS

### DIFF
--- a/dotCMS/html/portlet/ext/cmsmaintenance/index_stats.jsp
+++ b/dotCMS/html/portlet/ext/cmsmaintenance/index_stats.jsp
@@ -18,6 +18,7 @@
 <%@page import="java.util.Map"%>
 <%@ include file="/html/common/init.jsp"%>
 <%@page import="java.util.List"%>
+<%@page import="com.dotmarketing.util.Config"%>
 <%
 
 List<Structure> structs = StructureFactory.getStructures();
@@ -211,13 +212,13 @@ Map<String,ClusterIndexHealth> map = esapi.getClusterHealth();
 			<%ClusterIndexHealth health = map.get(x); %>
 			<div dojoType="dijit.Menu" contextMenuForWindow="false" style="display:none;" 
 			     targetNodeIds="<%=x%>Row" onOpen="dohighlight('<%=x%>Row')" onClose="undohighlight('<%=x%>Row')">
-                 
-                <div dojoType="dijit.MenuItem" onClick="updateReplicas('<%=x %>',<%=health.getNumberOfReplicas()%>);" class="showPointer">
-                    <span class="fixIcon"></span>
-                    <%= LanguageUtil.get(pageContext,"Update-Replicas-Index") %>
-                </div>
-                
-                
+        <%if(!Config.getBooleanProperty("CLUSTER_AUTOWIRE",true) || !Config.getBooleanProperty("AUTOWIRE_MANAGE_ES_REPLICAS",false)){ %>
+            <div dojoType="dijit.MenuItem" onClick="updateReplicas('<%=x %>',<%=health.getNumberOfReplicas()%>);" class="showPointer">
+                <span class="fixIcon"></span>
+                <%= LanguageUtil.get(pageContext,"Update-Replicas-Index") %>
+            </div>
+        <%} %>
+
 			 	<div dojoType="dijit.MenuItem" onClick="showRestoreIndexDialog('<%=x %>');" class="showPointer">
 			 		<span class="uploadIcon"></span>
 			 		<%= LanguageUtil.get(pageContext,"Restore-Index") %>

--- a/src/com/dotcms/content/elasticsearch/business/ESIndexAPI.java
+++ b/src/com/dotcms/content/elasticsearch/business/ESIndexAPI.java
@@ -512,7 +512,7 @@ public class ESIndexAPI {
 		 If CLUSTER_AUTOWIRE AND auto_expand_replicas are false we will specify the number of replicas to use
 		 */
 		if ( !Config.getBooleanProperty("CLUSTER_AUTOWIRE", true) &&
-				!Config.getBooleanProperty("AUTOWIRE_MANAGE_ES_RESPLICAS", false) &&
+				!Config.getBooleanProperty("AUTOWIRE_MANAGE_ES_REPLICAS", false) &&
 				!Config.getBooleanProperty("es.index.auto_expand_replicas", false) ) {
 
 			//Getting the number of replicas
@@ -634,6 +634,12 @@ public class ESIndexAPI {
 	 * @throws DotDataException
 	 */
     public  synchronized void updateReplicas (String indexName, int replicas) throws DotDataException {
+
+    	if ( Config.getBooleanProperty("CLUSTER_AUTOWIRE", true) &&
+				Config.getBooleanProperty("AUTOWIRE_MANAGE_ES_REPLICAS", false)){
+    		AdminLogger.log(this.getClass(),"updateReplicas", "Error on updateReplica. Replicas are configured to be handled by dotCMS.");
+    		throw new DotDataException("Error on updateReplica. Replicas are configured to be handled by dotCMS.");
+    	}
 
     	AdminLogger.log(this.getClass(), "updateReplicas", "Trying to update replicas to index: " + indexName);
 

--- a/src/com/dotcms/rest/ESIndexResource.java
+++ b/src/com/dotcms/rest/ESIndexResource.java
@@ -331,6 +331,9 @@ public class ESIndexResource {
         } catch (DotSecurityException sec) {
             SecurityLogger.logInfo(this.getClass(), "Access denied on updateReplica from "+request.getRemoteAddr());
             return Response.status(Status.UNAUTHORIZED).build();
+        }catch(DotDataException dt){
+        	Logger.error(this, dt.getMessage());
+        	return Response.status(Status.BAD_REQUEST).build();
         } catch (Exception de) {
             Logger.error(this, "Error on updateReplica. URI: "+request.getRequestURI(),de);
             return Response.serverError().build();


### PR DESCRIPTION
On the index management portlet the option to "update replicas" is
removed when CLUSTER_AUTOWIRE and AUTOWIRE_MANAGE_ES_REPLICAS are true.
The elasticearch REST API responds with BAD_REQUEST (error 400) in the
same case.  The ESIndexAPI returns a DotDataExpception wich is handle
by ESIndexResoure.
