### PR TITLE
Issue #3627: MailerTool docstring typo

### DIFF
--- a/src/com/dotmarketing/viewtools/MailerTool.java
+++ b/src/com/dotmarketing/viewtools/MailerTool.java
@@ -29,7 +29,7 @@ public class MailerTool implements ViewTool {
 	/**
 	 * Sends an email
 	 * 
-	 * Example:  #set($error = $mailer.sendMail(
+	 * Example:  #set($error = $mailer.sendEmail(
 	 *                   'them@theirdomain.com',
 	 *                   'you@yourdomain.com',
 	 *                   'The Subject',


### PR DESCRIPTION
This is a quick fix for a typo in the docstring of the MailerTool.
