### PR TITLE
avoid OOM exception #9451

### DIFF
--- a/src/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
+++ b/src/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
@@ -1,5 +1,7 @@
 package com.dotmarketing.portlets.fileassets.business;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -506,20 +508,59 @@ public class FileAssetAPIImpl implements FileAssetAPI {
 
     @Override
     public String getContentMetadataAsString(File metadataFile) throws Exception {
+        Logger.debug(this.getClass(), "DEBUG --> Parsing Metadata from file: " + metadataFile.getPath() );
+
+        //Check if Metadata Max Size is set (in Bytes)
+        int metadataLimitInBytes = Config.getIntProperty("META_DATA_MAX_SIZE", 5) * 1024 * 1024;
+
+        //If Max Size limit is greater than what Java allows for Int values
+        if(metadataLimitInBytes > Integer.MAX_VALUE){
+            metadataLimitInBytes = Integer.MAX_VALUE;
+        }
+
+        //Subtracting 1024 Bytes (buffer size)
+        metadataLimitInBytes = metadataLimitInBytes - 1024;
+
         String type=new Tika().detect(metadataFile);
-        
+
         InputStream input=new FileInputStream(metadataFile);
-        
+
         if(type.equals("application/x-gzip")) {
-            // gzip compression were used
+            // gzip compression was used
             input = new GZIPInputStream(input);
         }
         else if(type.equals("application/x-bzip2")) {
-            // bzip2 compression were used
+            // bzip2 compression was used
             input = new BZip2CompressorInputStream(input);
         }
-        
-        return IOUtils.toString(input);
+
+        //Depending on the max limit of the metadata file size, 
+        //we'll get as many bytes as we can so we can parse it
+        //and then they'll be added to the ContentMap
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        byte[] buf = new byte[1024];
+        int bytesRead = 0;
+        int copied = 0;
+
+        while (bytesRead < metadataLimitInBytes && (copied = input.read(buf,0,buf.length)) > -1 ) {
+            baos.write(buf,0,copied);
+            bytesRead = bytesRead + copied;
+            
+        }
+
+        InputStream limitedInput = new ByteArrayInputStream(baos.toByteArray());
+
+        //let's close the original input since it's no longer necessary to keep it open
+        if (input != null) {
+            try {
+                input.close();
+            } catch (IOException e) {
+                 Logger.error(this.getClass(), "There was a problem with parsing a file Metadata: " + e.getMessage(), e);
+            }
+       }
+
+        return IOUtils.toString(limitedInput);
     }
 
     /**


### PR DESCRIPTION
Tested with same failing files provided by client, on AWS Instance:
- dotCMS 3.3.2
- Java 8
- SQL Server 2016 DB.

File was indexed.
