### PR TITLE
Issue 9496 respect custom query string edit preview mode

### DIFF
--- a/dotCMS/WEB-INF/velocity/preview_left_menu_page_as_content.vtl
+++ b/dotCMS/WEB-INF/velocity/preview_left_menu_page_as_content.vtl
@@ -143,31 +143,48 @@
     
 
     var _lastUrl;
+    
+//changeUrl Function updates the mainFrame iframe depending on the selected view and session-related attributes
     function changeUrl(){
-    	
-    	var newUrl=""; 
-    	newUrl+="${VTLSERVLET_URI}?mainFrame=1&host_id=${host.identifier}";
-    	newUrl+="&com.dotmarketing.htmlpage.language="+language ;
-    	newUrl+="&com.dotmarketing.persona.id="+personaId ;
+        
+        var newUrl=""; 
 
-    	if(state == "live"){
-    		newUrl+="&livePage=1"
-    	}
-    	else if(state=="editing"){
-    		newUrl+="&previewPage=1"
-    	}
-    	else if(state=="preview"){
-    		newUrl+="&previewPage=2"
-    	}
-    	if(_lastUrl!=newUrl){
-	    	//console.log("changing url:" + newUrl);
-	    	_lastUrl=newUrl;
-	    	window.top.frameMain.location  = newUrl;
-   	 	}
+        //mainFrame indicates we're updating the main iframe only
+        newUrl+="${VTLSERVLET_URI}?mainFrame=1";
+
+        //We check what view mode is selected (Live, Edit or Preview)
+        if(state == "live"){
+            newUrl+="&livePage=1"
+        }
+        else if(state=="editing"){
+            newUrl+="&previewPage=1"
+        }
+        else if(state=="preview"){
+            newUrl+="&previewPage=2"
+        }
+
+        //Since it's a page as content, we add LanguageId, HostId AND PersonaId to the Query String
+        newUrl+="&com.dotmarketing.htmlpage.language="+language ;
+        newUrl+="&host_id=${host.identifier}";
+        newUrl+="&com.dotmarketing.persona.id="+personaId ;
+        
+        //Check other Query String Params
+        var queryStringFromContext = "${queryString}".split("&");
+        
+        //Let's check for duplicated ones and those that cannot be added to the QueryString params at the same time
+        for (i=0; i< queryStringFromContext.length; i++){
+            if(newUrl.indexOf(queryStringFromContext[i]) < 0 && queryStringFromContext[i].indexOf("leftMenu") < 0
+                && queryStringFromContext[i].indexOf("livePage") < 0 && queryStringFromContext[i].indexOf("previewPage") < 0){
+                newUrl += "&"+queryStringFromContext[i];
+            }
+        }
+        
+        if(_lastUrl!=newUrl){
+            //console.log("changing url:" + newUrl);
+            _lastUrl=newUrl;
+            window.top.frameMain.location  = newUrl;
+        }
     }
-    
-    
-
 
     function previewPage(){
 		//console.log("previewPage");

--- a/dotCMS/WEB-INF/velocity/preview_mode.vl
+++ b/dotCMS/WEB-INF/velocity/preview_mode.vl
@@ -80,7 +80,7 @@
 		<table style="border:0;padding:0;width:100%;overflow:hidden;" width="100%" cellspacing="0" cellpadding="0" border="0">
 			<tr>
 				<td>
-					<iframe id="frameMenu" name="frameMenu" style="width:220px;border:0;margin:0;" width="220" marginheight="0" marginwidth="0" frameborder="0" scrolling="no" src="${_baseURI}?leftMenu=true&livePage=$livePage&com.dotmarketing.htmlpage.language=$language&language=$language&host_id=${host.identifier}"></iframe>
+					<iframe id="frameMenu" name="frameMenu" style="width:220px;border:0;margin:0;" width="220" marginheight="0" marginwidth="0" frameborder="0" scrolling="no" src="${_baseURI}?leftMenu=true&livePage=$livePage&com.dotmarketing.htmlpage.language=$language&language=$language&host_id=${host.identifier}&$!{queryString}"></iframe>
 				</td>
 				<td>
 					<iframe id="frameMain" name="frameMain" style="border:0;margin:0;" marginheight="0" marginwidth="0" scrolling="auto" frameborder="0" src="${_baseURI}?mainFrame=true&livePage=$livePage&com.dotmarketing.htmlpage.language=$language&language=$language&host_id=${host.identifier}&$!{queryString}"></iframe>

--- a/dotCMS/WEB-INF/velocity/preview_mode.vl
+++ b/dotCMS/WEB-INF/velocity/preview_mode.vl
@@ -80,10 +80,10 @@
 		<table style="border:0;padding:0;width:100%;overflow:hidden;" width="100%" cellspacing="0" cellpadding="0" border="0">
 			<tr>
 				<td>
-					<iframe id="frameMenu" name="frameMenu" style="width:220px;border:0;margin:0;" width="220" marginheight="0" marginwidth="0" frameborder="0" scrolling="no" src="${_baseURI}?leftMenu=true&livePage=$livePage&com.dotmarketing.htmlpage.language=$language&language=$language&host_id=${host.identifier}&$!{queryString}"></iframe>
+					<iframe id="frameMenu" name="frameMenu" style="width:220px;border:0;margin:0;" width="220" marginheight="0" marginwidth="0" frameborder="0" scrolling="no" src="${_baseURI}?leftMenu=1&livePage=$livePage&com.dotmarketing.htmlpage.language=$language&language=$language&host_id=${host.identifier}&$!{queryString}"></iframe>
 				</td>
 				<td>
-					<iframe id="frameMain" name="frameMain" style="border:0;margin:0;" marginheight="0" marginwidth="0" scrolling="auto" frameborder="0" src="${_baseURI}?mainFrame=true&livePage=$livePage&com.dotmarketing.htmlpage.language=$language&language=$language&host_id=${host.identifier}&$!{queryString}"></iframe>
+					<iframe id="frameMain" name="frameMain" style="border:0;margin:0;" marginheight="0" marginwidth="0" scrolling="auto" frameborder="0" src="${_baseURI}?mainFrame=1&livePage=$livePage&com.dotmarketing.htmlpage.language=$language&language=$language&host_id=${host.identifier}&$!{queryString}"></iframe>
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
Tested on Master-3.5 + Java 8 + Postgres DB 

Custom queryString params are now included in the iframes' requests and respected on the Velocity Context. 

Velocity code to test with 

```
#set($pq = $request.getParameter('pq'))
Getting pq value from query string, via request.getParameter call: $pq
<br><br>
#set($pq = $request.getAttribute('pq'))
Getting pq value from query string, via request.getAttribute call: $pq
<br></br>
default request.getQueryString call: $request.getQueryString()
<br></br>
queryString var added to Velocity Context: $queryString
```

By changing the page language/persona in Edit/Preview mode, custom query params are respected without affecting system-related params, like Languages or selected Site in session.
