### PR TITLE
 #9619 Avoid overriding of content's map values.

### DIFF
--- a/dotCMS/WEB-INF/jsp/es_search_portlet/render.jsp
+++ b/dotCMS/WEB-INF/jsp/es_search_portlet/render.jsp
@@ -319,7 +319,7 @@ if(query == null){
 				<% for (Object x : cons){%>
 					<%
 						Contentlet c =(Contentlet) x;
-						c = ContentletUtil.setSpecialFieldValues(user, c);
+						String mapStr = ContentletUtil.getContentPrintableMap(user, c).toString();
 					%>
 
 						<tr>
@@ -347,7 +347,7 @@ if(query == null){
 						<tr >
 							<td>&nbsp;</td>
 							<td colspan=2>
-								<div style="padding:20px;"><%= UtilMethods.makeHtmlSafe(c.getMap().toString()) %></div>
+								<div style="padding:20px;"><%= UtilMethods.makeHtmlSafe(mapStr) %></div>
 							</td>
 						</tr>
 						<%	counter++;%>

--- a/src/com/dotcms/rest/ContentResource.java
+++ b/src/com/dotcms/rest/ContentResource.java
@@ -490,10 +490,9 @@ public class ContentResource {
 
 		for(Contentlet c : cons){
 			Map<String, Object> m = new HashMap<>();
-			m.putAll(c.getMap());
 			Structure s = c.getStructure();
 
-			c = ContentletUtil.setSpecialFieldValues(user, c);
+			m.putAll(ContentletUtil.getContentPrintableMap(user, c));
 
 			if(s.getStructureType() == Structure.STRUCTURE_TYPE_WIDGET && "true".equals(render)) {
 				m.put("parsedCode",  WidgetResource.parseWidget(request, response, c));
@@ -540,7 +539,7 @@ public class ContentResource {
 		return json.toString();
 	}
 
-	private String getJSON(List<Contentlet> cons, HttpServletRequest request, HttpServletResponse response, String render, User user) throws IOException{
+	private String getJSON(List<Contentlet> cons, HttpServletRequest request, HttpServletResponse response, String render, User user) throws IOException, DotDataException{
 		JSONObject json = new JSONObject();
 		JSONArray jsonCons = new JSONArray();
 
@@ -571,14 +570,10 @@ public class ContentResource {
 		return jsonFields;
 	}
 
-	public static JSONObject contentletToJSON(Contentlet con, HttpServletRequest request, HttpServletResponse response, String render, User user)
-			throws DotDataException, JSONException, IOException{
-
+	public static JSONObject contentletToJSON(Contentlet con, HttpServletRequest request, HttpServletResponse response, String render, User user) throws JSONException, IOException, DotDataException{
 		JSONObject jo = new JSONObject();
 		Structure s = con.getStructure();
-		con = ContentletUtil.setSpecialFieldValues(user, con);
-
-		Map<String,Object> map = con.getMap();
+		Map<String,Object> map = ContentletUtil.getContentPrintableMap(user, con);
 
 		Set<String> jsonFields=getJSONFields(s);
 


### PR DESCRIPTION
- ContentletUtil.java: setSpecialFields was removed and replace by a new method since it was messing with some values in the contentlet
  that resulted in images and files lost. New method 'getContentPrintableMap' was created to obtain a map
  with content's original map as well as tags, binaries and categories. This is now call in places when we need to print the content including
  binaries, categories and tags (e.g. Content endpoint, ES Portlet)
- ContentResource.java: modifications to make use of the ContentletUtil.getContentPrintableMap
- render.jsp: modifications to make use of the ContentletUtil.getContentPrintableMap
