### PR TITLE
 #9711

### DIFF
--- a/dotCMS/html/portlet/ext/containers/edit_container_js_inc.jsp
+++ b/dotCMS/html/portlet/ext/containers/edit_container_js_inc.jsp
@@ -178,13 +178,13 @@
 
 
 	function addBinaryResize(velocityVarName) {
-		var insert = "#if ($UtilMethods.isSet($" + "{" + velocityVarName+"BinaryFileURI})) \n   <img src=\"/contentAsset/resize-image/${ContentIdentifier}/" + velocityVarName + "?w=150&h=100\" />\n#end \n";
+		var insert = "#if ($UtilMethods.isSet($" + "{" + velocityVarName+"BinaryFileURI})) \n   <img src=\"/contentAsset/resize-image/${ContentIdentifier}/" + velocityVarName + "?w=150&h=100&language_id=${language}\" />\n#end \n";
 		insertAtCursor(insert, "codeMaskMulti");
 		dijit.byId('variablesDialog').hide();
 	}
 
 	function addBinaryThumbnail(velocityVarName) {
-		var insert = "#if ($UtilMethods.isSet($" + "{" + velocityVarName+"BinaryFileURI})) \n   <img src=\"/contentAsset/image-thumbnail/${ContentIdentifier}/" + velocityVarName + "?w=150&h=150\" />\n#end \n";
+		var insert = "#if ($UtilMethods.isSet($" + "{" + velocityVarName+"BinaryFileURI})) \n   <img src=\"/contentAsset/image-thumbnail/${ContentIdentifier}/" + velocityVarName + "?w=150&h=150&language_id=${language}\" />\n#end \n";
 		insertAtCursor(insert, "codeMaskMulti");
 		dijit.byId('variablesDialog').hide();
 	}

--- a/dotCMS/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -553,11 +553,9 @@
 						  	}
 						  	resourceLinkUri = identifier.getParentPath()+contentlet.getStringProperty(FileAssetAPI.FILE_NAME_FIELD);
 						  	resourceLink.append(UtilMethods.encodeURIComponent(resourceLinkUri));
-						  	if(defaultLang != contentlet.getLanguageId()){
-						  		//resourceLinkUri.concat("?language_id="+contentlet.getLanguageId());
-						  		resourceLinkUri+="?language_id="+contentlet.getLanguageId();
-						  		resourceLink.append("?language_id="+contentlet.getLanguageId());
-						  	}
+                            //resourceLinkUri.concat("?language_id="+contentlet.getLanguageId());
+                            resourceLinkUri+="?language_id="+contentlet.getLanguageId();
+                            resourceLink.append("?language_id="+contentlet.getLanguageId());
 						  }
 
 						  com.dotmarketing.portlets.fileassets.business.FileAsset fa = APILocator.getFileAssetAPI().fromContentlet(contentlet);


### PR DESCRIPTION
- edit_container_js_inc.jsp: include the language_id in the code spitted by the variables 'resized' and 'thumbnailed' of FileAsset content type
  when included in container code
-  edit_field.jsp : always include the language_id to avoid getting the wrong file because of browser cache
