### PR TITLE
Fix #9744 add tags values to CSV file when Content Type is exported

### DIFF
--- a/src/com/dotmarketing/portlets/contentlet/action/EditContentletAction.java
+++ b/src/com/dotmarketing/portlets/contentlet/action/EditContentletAction.java
@@ -74,6 +74,8 @@ import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.portlets.workflows.business.DotWorkflowException;
+import com.dotmarketing.tag.business.TagAPI;
+import com.dotmarketing.tag.model.Tag;
 import com.dotmarketing.util.ActivityLogger;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.HostUtil;
@@ -93,6 +95,7 @@ import com.liferay.portal.util.Constants;
 import com.liferay.portlet.ActionRequestImpl;
 import com.liferay.portlet.ActionResponseImpl;
 import com.liferay.util.FileUtil;
+import com.liferay.util.StringPool;
 import com.liferay.util.servlet.SessionMessages;
 
 /**
@@ -111,6 +114,7 @@ public class EditContentletAction extends DotPortletAction implements DotPortlet
 	private ContentletAPI conAPI;
 	private FieldAPI fAPI;
 	private HostWebAPI hostWebAPI;
+	private TagAPI tagAPI;
 
 	private String currentHost;
 
@@ -123,6 +127,7 @@ public class EditContentletAction extends DotPortletAction implements DotPortlet
 		conAPI = APILocator.getContentletAPI();
 		fAPI = APILocator.getFieldAPI();
 		hostWebAPI = WebAPILocator.getHostWebAPI();
+		tagAPI = APILocator.getTagAPI();
 	}
 
 	private Contentlet contentletToEdit;
@@ -1859,8 +1864,19 @@ public class EditContentletAction extends DotPortletAction implements DotPortlet
 								if(UtilMethods.isSet(text)){
 									text=text.substring(1);
 								}
-							}else{
-
+							} else if(f.getFieldType().equals(Field.FieldType.TAG.toString())){
+							    
+							    //Get Content Tags per field's Velocity Var Name
+							    List<Tag> tags = tagAPI.getTagsByInodeAndFieldVarName(content.getInode(), f.getVelocityVarName());
+							    if(tags!= null){
+							        for(Tag t:tags){
+							            if(text.equals(StringPool.BLANK))
+							                text = t.getTagName();
+							            else
+							                text = text + "," + t.getTagName();
+							        }
+							    }
+							} else{
 								if (value instanceof Date || value instanceof Timestamp) {
 									if(f.getFieldType().equals(Field.FieldType.DATE.toString())) {
 										SimpleDateFormat formatter = new SimpleDateFormat (WebKeys.DateFormats.EXP_IMP_DATE);
@@ -1878,7 +1894,6 @@ public class EditContentletAction extends DotPortletAction implements DotPortlet
 										text = text.substring (0, text.length()-1);
 									}
 								}
-
 							}
 							//Windows carriage return conversion
 							text = text.replaceAll("\r","");


### PR DESCRIPTION
Tested on Backported Fix to 3.5.1 + Java 8 + Postgres DB. 

CSV File is exported and includes tags values.

Attempted to insert again the CSV file and Tags values are respected. Contents are populated properly after generated CSV file is imported.
