### PR TITLE
#9833 Fix integration tests problems

### DIFF
--- a/src/com/dotcms/mock/request/MockSessionRequest.java
+++ b/src/com/dotcms/mock/request/MockSessionRequest.java
@@ -1,7 +1,10 @@
 package com.dotcms.mock.request;
 
+import com.dotmarketing.util.Config;
+
 import java.util.UUID;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpSession;
@@ -24,6 +27,11 @@ public class MockSessionRequest extends HttpServletRequestWrapper implements Moc
 
 	public HttpServletRequest request() {
 		return this;
+	}
+
+	@Override
+	public ServletContext getServletContext() {
+		return Config.CONTEXT;
 	}
 
 	@Override

--- a/test/com/AllTestsSuite.java
+++ b/test/com/AllTestsSuite.java
@@ -87,7 +87,6 @@ import org.junit.runners.Suite;
     CategoryAPITest.class,
     MenuLinkAPITest.class,
     ContentletFactoryTest.class,
-    ContentletAPITest.class,
     ContainerAPITest.class,
     FieldFactoryTest.class,
     StructureFactoryTest.class,

--- a/test/com/dotcms/TestBase.java
+++ b/test/com/dotcms/TestBase.java
@@ -3,6 +3,8 @@ package com.dotcms;
 import com.dotmarketing.db.HibernateUtil;
 import com.dotmarketing.exception.DotHibernateException;
 import com.dotcms.repackage.net.sf.hibernate.HibernateException;
+import com.dotmarketing.util.BaseMessageResources;
+
 import org.junit.After;
 
 import java.sql.SQLException;
@@ -17,7 +19,7 @@ import java.sql.SQLException;
  * {@link org.junit.After @After}, {@link org.junit.Ignore @Ignore}
  * <br>For managing the assertions use the static class {@link org.junit.Assert Assert}
  */
-public abstract class TestBase {
+public abstract class TestBase extends BaseMessageResources {
 
     @After
     public void after () throws SQLException, DotHibernateException, HibernateException {

--- a/test/com/dotmarketing/portlets/ContentletBaseTest.java
+++ b/test/com/dotmarketing/portlets/ContentletBaseTest.java
@@ -54,7 +54,6 @@ import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 
 import org.junit.BeforeClass;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -71,7 +70,6 @@ import java.util.Random;
  * Date: 3/19/12
  * Time: 11:36 AM
  */
-@PowerMockIgnore("javax.management.*")
 public class ContentletBaseTest extends TestBase {
 
     protected static ContentletAPI contentletAPI;

--- a/test/com/dotmarketing/portlets/ContentletBaseTest.java
+++ b/test/com/dotmarketing/portlets/ContentletBaseTest.java
@@ -45,6 +45,7 @@ import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.portlets.templates.business.TemplateAPI;
 import com.dotmarketing.portlets.templates.model.Template;
+import com.dotmarketing.servlets.test.ServletTestRunner;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.ConfigTestHelper;
 import com.dotmarketing.util.TestingJndiDatasource;
@@ -52,7 +53,6 @@ import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
@@ -109,8 +109,12 @@ public class ContentletBaseTest extends TestBase {
 
     @BeforeClass
     public static void prepare () throws Exception {
-        TestingJndiDatasource.init();
-        ConfigTestHelper._setupFakeTestingContext();
+
+        if (System.getProperty("TEST-RUNNER") == null || !System.getProperty("TEST-RUNNER")
+            .equals(ServletTestRunner.class.getCanonicalName())) {
+            TestingJndiDatasource.init();
+            ConfigTestHelper._setupFakeTestingContext();
+        }
 
         //Setting the test user
         user = APILocator.getUserAPI().getSystemUser();
@@ -201,7 +205,7 @@ public class ContentletBaseTest extends TestBase {
         contentlets.add( newContentlet );
     }
 
-    @AfterClass
+    //@AfterClass
     public static void afterClass () throws Exception {
 
         //Delete html pages

--- a/test/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/test/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -13,8 +13,9 @@ import com.dotcms.mock.request.MockInternalRequest;
 import com.dotcms.mock.response.BaseResponse;
 import com.dotcms.repackage.org.apache.commons.io.FileUtils;
 import com.dotcms.repackage.org.apache.commons.lang.time.FastDateFormat;
-import com.dotcms.repackage.org.apache.struts.util.MessageResources;
-
+import com.dotcms.repackage.org.apache.struts.Globals;
+import com.dotcms.repackage.org.apache.struts.config.ModuleConfig;
+import com.dotcms.repackage.org.apache.struts.config.ModuleConfigFactory;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.beans.MultiTree;
@@ -63,14 +64,9 @@ import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.context.Context;
 import org.apache.velocity.context.InternalContextAdapterImpl;
 import org.apache.velocity.runtime.parser.node.SimpleNode;
-import org.apache.velocity.tools.struts.StrutsUtils;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -90,15 +86,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * Created by Jonathan Gamba.
  * Date: 3/20/12
  * Time: 12:12 PM
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({StrutsUtils.class})
 public class ContentletAPITest extends ContentletBaseTest {
 
     /**
@@ -2052,14 +2045,17 @@ public class ContentletAPITest extends ContentletBaseTest {
     public void widgetInvalidateAllLang() throws Exception {
 
         String toolboxManagerPath = Config.getStringProperty("TOOLBOX_MANAGER_PATH");
-        MessageResources messageResources = mock(MessageResources.class);
         HttpServletRequest requestProxy = new MockInternalRequest().request();
         HttpServletResponse responseProxy = new BaseResponse().response();
 
-        Mockito.when(Config.CONTEXT.getResourceAsStream(toolboxManagerPath)).thenReturn(new FileInputStream(toolboxManagerPath));
-        PowerMockito.mockStatic(StrutsUtils.class);
+        ModuleConfigFactory factoryObject = ModuleConfigFactory.createFactory();
+        ModuleConfig config = factoryObject.createModuleConfig("");
 
-        PowerMockito.when(StrutsUtils.getMessageResources(Mockito.any(), Mockito.any())).thenReturn(messageResources);
+        Mockito.when(Config.CONTEXT.getResourceAsStream(toolboxManagerPath)).thenReturn(new FileInputStream(toolboxManagerPath));
+
+        Mockito.when(Config.CONTEXT.getAttribute(Globals.MODULE_KEY)).thenReturn(config);
+
+        initMessages();
 
         Structure sw=CacheLocator.getContentTypeCache().getStructureByVelocityVarName("SimpleWidget");
         Language def=APILocator.getLanguageAPI().getDefaultLanguage();

--- a/test/com/dotmarketing/servlets/test/ServletTestRunner.java
+++ b/test/com/dotmarketing/servlets/test/ServletTestRunner.java
@@ -67,6 +67,8 @@ public class ServletTestRunner extends HttpServlet {
 
         Logger.info( "Running unit tests....." );
 
+        System.setProperty("TEST-RUNNER", ServletTestRunner.class.getCanonicalName());
+
         //If nothing is present the default is to create an xml report
         if ( resultType == null || resultType.isEmpty() ) {
             xmlReport( response, className, methodName );

--- a/test/com/dotmarketing/util/ConfigTestHelper.java
+++ b/test/com/dotmarketing/util/ConfigTestHelper.java
@@ -38,8 +38,8 @@ public class ConfigTestHelper extends Config {
                 }
             });
             Config.CONTEXT = context;
-        }
 
+        }
         dotmarketingPropertiesUrl = new File("test-resources/it-dotmarketing-config.properties").toURI().toURL();
         clusterPropertiesUrl = new File("test-resources/it-dotcms-config-cluster.properties").toURI().toURL();
     }

--- a/test/com/dotmarketing/util/TestingJndiDatasource.java
+++ b/test/com/dotmarketing/util/TestingJndiDatasource.java
@@ -28,10 +28,14 @@ public class TestingJndiDatasource {
     private static InitialContextFactoryBuilder builder;
 
     static {
-        builder = new TestInitialContextFactory();
+        if (Config.CONTEXT == null) {
+            builder = new TestInitialContextFactory();
+        }
     }
 
     public static void init() throws Exception {
-        NamingManager.setInitialContextFactoryBuilder(builder);
+        if (builder != null && !NamingManager.hasInitialContextFactoryBuilder()) {
+            NamingManager.setInitialContextFactoryBuilder(builder);
+        }
     }
 }


### PR DESCRIPTION
- Avoid the creation of an InitialContextFactoryBuilder for each testing class. Now, it is created just once and reused.
- Avoid calling TestingJndiDatasource.init() and ConfigTestHelper._setupFakeTestingContext when running tests with the server up.
- ContentletAPITest was removed from AllTestsSuite. Now, this testing class will run with right-click from any IDE instead of Tomcat environment.
