### PR TITLE
Issue 9541 imageio plugins for extended image support

### DIFF
--- a/src/com/dotmarketing/image/filter/ImageFilter.java
+++ b/src/com/dotmarketing/image/filter/ImageFilter.java
@@ -40,8 +40,8 @@ public abstract class ImageFilter implements ImageFilterIf {
 			List<String> acceptFilter = new ArrayList<String>();
 			String thisFilter="";
 			if(parameters.get("filter")!=null && parameters.get("filter").length>0){
-				String[] filters = parameters.get("filter")[0].split(",");
-				
+				String[] filters = parameters.get("filter");
+	
 				
 				for(int i=0;i<filters.length;i++){
 					String x = filters[i];

--- a/src/com/dotmarketing/image/filter/ResizeImageFilter.java
+++ b/src/com/dotmarketing/image/filter/ResizeImageFilter.java
@@ -1,18 +1,23 @@
 package com.dotmarketing.image.filter;
 
 import java.awt.image.BufferedImage;
+import java.awt.image.BufferedImageOp;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Map;
 
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
 
 import com.dotcms.repackage.com.dotmarketing.jhlabs.image.ScaleFilter;
 import com.dotmarketing.util.ImageResizeUtils;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
+import com.twelvemonkeys.image.ResampleOp;
 
 public class ResizeImageFilter extends ImageFilter {
 	public String[] getAcceptedParameters(){
@@ -50,13 +55,10 @@ public class ResizeImageFilter extends ImageFilter {
 			int width    =      (int) w;    
 			int hieght     =     (int) h;
 
-			ScaleFilter filter = new ScaleFilter(width,hieght);
 
-			BufferedImage dst = new BufferedImage(width,hieght,
-					BufferedImage.TYPE_INT_ARGB);
-
-			 dst = filter.filter(src, dst);
-			ImageIO.write(dst, "png", resultFile);
+			BufferedImageOp resampler = new ResampleOp(width, hieght, ResampleOp.FILTER_LANCZOS); // A good default filter, see class documentation for more info
+			BufferedImage output = resampler.filter(ImageIO.read(file), null);
+			ImageIO.write(output, "png", resultFile);
 			return resultFile;
 			
 			//fos = new FileOutputStream(resultFile);

--- a/src/com/dotmarketing/image/filter/ThumbnailImageFilter.java
+++ b/src/com/dotmarketing/image/filter/ThumbnailImageFilter.java
@@ -1,6 +1,15 @@
 package com.dotmarketing.image.filter;
 
 import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.MediaTracker;
+import java.awt.RenderingHints;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
+import java.awt.image.BufferedImageOp;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -8,8 +17,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Map;
 
+import javax.imageio.ImageIO;
+
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.ImageResizeUtils;
 import com.dotmarketing.util.Logger;
+import com.twelvemonkeys.image.ResampleOp;
 
 public class ThumbnailImageFilter extends ImageFilter {
 	public String[] getAcceptedParameters() {
@@ -18,6 +31,9 @@ public class ThumbnailImageFilter extends ImageFilter {
 
 		};
 	}
+    public static final int DEFAULT_HEIGHT = Config.getIntProperty("DEFAULT_HEIGHT",100);
+    public static final int DEFAULT_WIDTH = Config.getIntProperty("DEFAULT_WIDTH",100);
+    public static final Color DEFAULT_BG_COLOR = new Color(Config.getIntProperty("DEFAULT_BG_R_COLOR"), Config.getIntProperty("DEFAULT_BG_G_COLOR"), Config.getIntProperty("DEFAULT_BG_B_COLOR"));
 
 	public File runFilter(File file,  Map<String, String[]> parameters) {
 
@@ -38,13 +54,78 @@ public class ThumbnailImageFilter extends ImageFilter {
 		FileOutputStream fos = null;
 		try {
 			resultFile.delete();
-			fos = new FileOutputStream(resultFile);
-			ImageResizeUtils.generateThumbnail(new FileInputStream(file), fos, FILE_EXT, width, height, color);
+	        if (height <= 0 && width <= 0) {
+	            height = DEFAULT_HEIGHT;
+	            width = DEFAULT_WIDTH;
+	        }
+
+	        if (color == null){
+	            color = DEFAULT_BG_COLOR;
+	        }
+	        
+
+	        Image image = ImageIO.read(file);
+
+
+
+	        // determine thumbnail size from WIDTH and HEIGHT
+	        int imageWidth = image.getWidth(null);
+	        int imageHeight = image.getHeight(null);
+	        double imageRatio = (double) imageWidth / (double) imageHeight;
+
+	        int thumbWidth = width;
+	        int thumbHeight = height;
+	        if (thumbWidth <= 0)
+	            thumbWidth = (int) (thumbHeight * imageRatio);
+	        if (thumbHeight <= 0)
+	            thumbHeight = (int) (thumbWidth / imageRatio);
+	        double thumbRatio = (double) thumbWidth / (double) thumbHeight;
+
+	        if (thumbRatio < imageRatio) {
+	            thumbHeight = (int) Math.ceil((thumbWidth / imageRatio));
+	        } else {
+	            thumbWidth = (int) Math.ceil((thumbHeight * imageRatio));
+	        }
+
+	        if (thumbWidth == 0)
+	            thumbWidth = 1;
+	        if (thumbHeight == 0)
+	            thumbHeight = 1;
+
+	        if (width <= 0)
+	            width = (int) Math.ceil(height * imageRatio);
+	        if (height <= 0)
+	            height = (int) Math.ceil(width / imageRatio);
+
+	        // draw original image to thumbnail image object and
+	        // scale it to the new size on-the-fly
+	        BufferedImage bgImage = new BufferedImage(width, height, java.awt.image.BufferedImage.TYPE_INT_RGB);
+	        Graphics2D resultGraphics = bgImage.createGraphics();
+	        resultGraphics.setColor(color);
+	        resultGraphics.fillRect(0, 0, width, height);
+
+	        
+	        
+	        BufferedImageOp resampler = new ResampleOp(thumbWidth, thumbHeight, ResampleOp.FILTER_LANCZOS); // A good default filter, see class documentation for more info
+	        BufferedImage thumbImage = resampler.filter(ImageIO.read(file), null);
+
+
+	        // compute offsets to center image in its space
+	        int offsetX = (width - thumbImage.getWidth()) / 2;
+	        int offsetY = (height - thumbImage.getHeight()) / 2;
+
+	        resultGraphics.drawImage(thumbImage, null, offsetX, offsetY);
+	        resultGraphics.dispose();
+
+	        // save thumbnail image to OUTFILE
+	        BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(resultFile));
+	        ImageIO.write(bgImage, "png", out);
+	        out.close();
+
+	        Logger.debug(ImageResizeUtils.class, "Done.");
 		} catch (FileNotFoundException e) {
 			Logger.error(this.getClass(), e.getMessage());
 		} catch (IOException e) {
-			Logger.error(this.getClass(), e.getMessage());
-		} catch (InterruptedException e) {
 			Logger.error(this.getClass(), e.getMessage());
 		} finally {
 			if (fos != null) {

--- a/src/com/dotmarketing/image/reader/SVGImageReaderSpi.java
+++ b/src/com/dotmarketing/image/reader/SVGImageReaderSpi.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2008, Harald Kuhr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name "TwelveMonkeys" nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.dotmarketing.image.reader;
+
+import com.twelvemonkeys.imageio.spi.ImageReaderSpiBase;
+import com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfo;
+import com.twelvemonkeys.imageio.util.IIOUtil;
+import com.twelvemonkeys.lang.SystemUtil;
+
+import javax.imageio.ImageReader;
+import javax.imageio.spi.ServiceRegistry;
+import javax.imageio.stream.ImageInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.Locale;
+
+
+/**
+ * SVGImageReaderSpi
+ * <p/>
+ *
+ * @author <a href="mailto:harald.kuhr@gmail.com">Harald Kuhr</a>
+ * @version $Id: SVGImageReaderSpi.java,v 1.1 2003/12/02 16:45:00 haku Exp $
+ */
+
+
+
+
+public final class SVGImageReaderSpi extends ImageReaderSpiBase {
+
+
+    /**
+     * Creates an {@code SVGImageReaderSpi}.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public SVGImageReaderSpi() {
+        super(new SVGProviderInfo());
+    }
+
+    public boolean canDecodeInput(final Object pSource) throws IOException {
+        return pSource instanceof ImageInputStream &&  canDecode((ImageInputStream) pSource);
+    }
+
+    @SuppressWarnings("StatementWithEmptyBody")
+    private static boolean canDecode(final ImageInputStream pInput) throws IOException {
+        // NOTE: This test is quite quick as it does not involve any parsing,
+        // however it may not recognize all kinds of SVG documents.
+        try {
+            pInput.mark();
+
+            // TODO: This is not ok for UTF-16 and other wide encodings
+            // TODO: Use an XML (encoding) aware Reader instance instead
+            // Need to figure out pretty fast if this is XML or not
+            int b;
+            while (Character.isWhitespace((char) (b = pInput.read()))) {
+                // Skip over leading WS
+            }
+
+            // If it's not a tag, this can't be valid XML
+            if (b != '<') {
+                return false;
+            }
+
+            // Algorithm for detecting SVG:
+            //  - Skip until begin tag '<' and read 4 bytes
+            //  - if next is "?" skip until "?>" and start over
+            //  - else if next is "!--" skip until  "-->" and start over
+            //  - else if next is  "!DOCTYPE " skip any whitespace
+            //      - compare next 3 bytes against "svg", return result
+            //  - else
+            //      - compare next 3 bytes against "svg", return result
+
+            byte[] buffer = new byte[4];
+            while (true) {
+                pInput.readFully(buffer);
+
+                if (buffer[0] == '?') {
+                    // This is the XML declaration or a processing instruction
+                    while (!((pInput.readByte() & 0xFF) == '?' && pInput.read() == '>')) {
+                        // Skip until end of XML declaration or processing instruction or EOF
+                    }
+                }
+                else if (buffer[0] == '!') {
+                    if (buffer[1] == '-' && buffer[2] == '-') {
+                        // This is a comment
+                        while (!((pInput.readByte() & 0xFF) == '-' && pInput.read() == '-' && pInput.read() == '>')) {
+                            // Skip until end of comment or EOF
+                        }
+                    }
+                    else if (buffer[1] == 'D' && buffer[2] == 'O' && buffer[3] == 'C'
+                            && pInput.read() == 'T' && pInput.read() == 'Y'
+                            && pInput.read() == 'P' && pInput.read() == 'E') {
+                        // This is the DOCTYPE declaration
+                        while (Character.isWhitespace((char) (b = pInput.read()))) {
+                            // Skip over WS
+                        }
+
+                        if (b == 's' && pInput.read() == 'v' && pInput.read() == 'g') {
+                            // It's SVG, identified by DOCTYPE
+                            return true;
+                        }
+
+                        // DOCTYPE found, but not SVG
+                        return false;
+                    }
+
+                    // Something else, we'll skip
+                }
+                else {
+                    // This is a normal tag
+                    if (buffer[0] == 's' && buffer[1] == 'v' && buffer[2] == 'g'
+                            && (Character.isWhitespace((char) buffer[3]) || buffer[3] == ':')) {
+                        // It's SVG, identified by root tag
+                        // TODO: Support svg with prefix + recognize namespace (http://www.w3.org/2000/svg)!
+                        return true;
+                    }
+
+                    // If the tag is not "svg", this isn't SVG
+                    return false;
+                }
+
+                while ((pInput.readByte() & 0xFF) != '<') {
+                    // Skip over, until next begin tag or EOF
+                }
+            }
+        }
+        catch (EOFException ignore) {
+            // Possible for small files...
+            return false;
+        }
+        finally {
+            //noinspection ThrowFromFinallyBlock
+            pInput.reset();
+        }
+    }
+
+    public ImageReader createReaderInstance(final Object extension) throws IOException {
+        return new SVGImageReader(this);
+    }
+
+    public String getDescription(final Locale locale) {
+        return "Scalable Vector Graphics (SVG) format image reader";
+    }
+
+    @SuppressWarnings({"deprecation"})
+    @Override
+    public void onRegistration(final ServiceRegistry registry, final Class<?> category) {
+        if (!true) {
+            try {
+                // NOTE: This will break, but it gives us some useful debug info
+                new SVGImageReader(this);
+            }
+            catch (Throwable t) {
+                System.err.println("Could not instantiate SVGImageReader (missing support classes).");
+                t.printStackTrace();
+            }
+
+            IIOUtil.deregisterProvider(registry, this, category);
+        }
+    }
+}

--- a/src/com/dotmarketing/image/reader/SVGProviderInfo.java
+++ b/src/com/dotmarketing/image/reader/SVGProviderInfo.java
@@ -1,0 +1,23 @@
+package com.dotmarketing.image.reader;
+
+import com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfo;
+import com.twelvemonkeys.lang.SystemUtil;
+
+final class SVGProviderInfo extends ReaderWriterProviderInfo {
+    final static boolean SVG_READER_AVAILABLE = SystemUtil.isClassAvailable("com.dotmarketing.image.reader.SVGImageReader");
+
+    protected SVGProviderInfo() {
+        super(
+                SVGProviderInfo.class,
+                SVG_READER_AVAILABLE ? new String[]{"svg", "SVG"} : new String[]{""}, // Names
+                SVG_READER_AVAILABLE ? new String[]{"svg"} : null, // Suffixes
+                SVG_READER_AVAILABLE ? new String[]{"image/svg", "image/x-svg", "image/svg+xml", "image/svg-xml"} : null, // Mime-types
+                "com.dotmarketing.image.reader.SVGImageReader", // Reader class name
+                new String[] {"com.dotmarketing.image.reader.SVGImageReaderSpi"},
+                null,
+                null,
+                false, null, null, null, null,
+                true, null, null, null, null
+        );
+    }
+}

--- a/src/com/dotmarketing/servlets/BinaryExporterServlet.java
+++ b/src/com/dotmarketing/servlets/BinaryExporterServlet.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
+import javax.imageio.ImageIO;
+import javax.imageio.spi.IIORegistry;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServlet;
@@ -47,6 +49,7 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotHibernateException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.image.reader.SVGImageReaderSpi;
 import com.dotmarketing.portlets.contentlet.business.BinaryContentExporter;
 import com.dotmarketing.portlets.contentlet.business.BinaryContentExporterException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
@@ -136,6 +139,13 @@ public class BinaryExporterServlet extends HttpServlet {
 				}
 			}
 		}
+		ImageIO.scanForPlugins();
+        final IIORegistry registry = IIORegistry.getDefaultInstance();
+        registry.deregisterServiceProvider(registry.getServiceProviderByClass(com.twelvemonkeys.imageio.plugins.svg.SVGImageReaderSpi.class));
+        registry.registerServiceProvider(new SVGImageReaderSpi());
+        
+		
+		
 	}
 
 	private static final long serialVersionUID = 1L;


### PR DESCRIPTION
SVG support was broken when twelvemonkeys was used with batik 1.8 - it is fixed in their master branch but not released yet.  This backports it.
