### PR TITLE
#9935 restore reorder feature for KV fields

### DIFF
--- a/dotCMS/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -1003,6 +1003,15 @@
     <a class="goEnterpriseLink" href="<%=licenseURL%>"><span class="keyIcon"></span><%=licenseMessage%></a>
    <%} %>
    </div>
+   <%if(!field.isReadOnly()){ %>
+      <script>
+      var source<%=field.getFieldContentlet()%> = new dojo.dnd.Source(dojo.byId('<%=field.getFieldContentlet()%>_kvtable'));
+      dojo.connect(source<%=field.getFieldContentlet()%>, "insertNodes", function(){
+         setKVValue('<%=field.getFieldContentlet()%>', '<%=field.getVelocityVarName()%>');
+         recolorTable('<%=field.getFieldContentlet()%>');
+      });
+      </script>
+  <%}%>
 
 <%}%>
 


### PR DESCRIPTION
Tested on backported fix for 3.3.1. Reordering is enabled and order persists even after saving the content.
