### PR TITLE
#10026 removes options from dropdown

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
@@ -374,6 +374,9 @@ public class ESIndexResource {
     }
 
 
+    /**
+     * @deprecated  As of 2016-10-12, replaced by {@link #snapshotIndex(request, inputFile, inputFileDetail ,params)} and {@link #snapshotIndex(request, inputFile, inputFileDetail ,params)}
+     */
     @PUT
     @Path("/create/{params:.*}")
     @Produces("text/plain")

--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/index_stats.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/index_stats.jsp
@@ -96,7 +96,10 @@ Map<String,ClusterIndexHealth> map = esapi.getClusterHealth();
 
 		<div class="buttonRow" style="text-align: right;padding:20px;">
 
-			<div dojoType="dijit.form.DropDownButton">
+			<button dojoType="dijit.form.Button"  onClick="showRestoreSnapshotDialog();" iconClass="uploadIcon">
+               <%= LanguageUtil.get(pageContext,"Restore-Index-Snapshot") %>
+            </button>
+			<!-- div dojoType="dijit.form.DropDownButton">
 				<span><%= LanguageUtil.get(pageContext,"Add-Index") %></span>
 					<div dojoType="dijit.Menu">
 					
@@ -112,7 +115,7 @@ Map<String,ClusterIndexHealth> map = esapi.getClusterHealth();
                       <%= LanguageUtil.get(pageContext,"Restore-Index-Snapshot") %>
                     </div>
 		           </div>
-			</div>
+			</div -->
 		    <button dojoType="dijit.form.Button"  onClick="refreshIndexStats()" iconClass="resetIcon">
                <%= LanguageUtil.get(pageContext,"Refresh") %>
             </button>


### PR DESCRIPTION
- The dropdown is replaced by a button to restore snapshots
- The create index method on the REST endpoint is deprecated in favor
of using the snapshot functionality.