### PR TITLE
#10049 add improvements for UTF-8 file encoding

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/servlets/ImportExportXMLServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/ImportExportXMLServlet.java
@@ -2,6 +2,7 @@ package com.dotmarketing.servlets;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -10,6 +11,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
@@ -31,9 +33,7 @@ import javax.servlet.http.HttpSession;
 
 import com.dotcms.repackage.net.sf.hibernate.HibernateException;
 import com.dotcms.repackage.net.sf.hibernate.metadata.ClassMetadata;
-
 import com.dotcms.repackage.org.apache.commons.beanutils.BeanUtils;
-
 import com.dotmarketing.beans.Clickstream;
 import com.dotmarketing.beans.ClickstreamRequest;
 import com.dotmarketing.beans.Inode;
@@ -63,6 +63,8 @@ public class ImportExportXMLServlet extends HttpServlet {
 	 * The path where backup files are stored
 	 */
 	String backupFilePath = "../backup";
+	
+	private static final String CHARSET = UtilMethods.getCharsetConfiguration();
 
 	/**
 	 * The path where tmp files are stored. This gets wiped alot
@@ -332,7 +334,7 @@ public class ImportExportXMLServlet extends HttpServlet {
 			HibernateUtil _dh = null;
 			List _list = null;
 			File _writing = null;
-			BufferedOutputStream _bout = null;
+			BufferedWriter _bout = null;
 
 			for (Class clazz : _tablesToDump) {
 				_xstream = new XStream(new DomDriver());
@@ -344,7 +346,7 @@ public class ImportExportXMLServlet extends HttpServlet {
 				 */
 
 				_writing = new File(FileUtil.getRealPath(backupTempFilePath + "/" + clazz.getName() + ".xml"));
-				_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+				_bout = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(_writing), CHARSET));
 				_dh = new HibernateUtil(clazz);
 				_dh.setQuery("from " + clazz.getName());
 
@@ -364,7 +366,7 @@ public class ImportExportXMLServlet extends HttpServlet {
 			_list = PublicCompanyFactory.getCompanies();
 			_xstream = new XStream(new DomDriver());
 			_writing = new File(FileUtil.getRealPath(backupTempFilePath + "/" + Company.class.getName() + ".xml"));
-			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_bout = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(_writing), CHARSET));
 			_xstream.toXML(_list, _bout);
 			_bout.close();
 			_list = null;
@@ -374,7 +376,7 @@ public class ImportExportXMLServlet extends HttpServlet {
 			_list = APILocator.getUserAPI().findAllUsers();
 			_xstream = new XStream(new DomDriver());
 			_writing = new File(FileUtil.getRealPath(backupTempFilePath + "/" + User.class.getName() + ".xml"));
-			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_bout = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(_writing), CHARSET));
 			_xstream.toXML(_list, _bout);
 			_bout.close();
 			_list = null;

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/ImportExportXMLServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/ImportExportXMLServlet.java
@@ -240,7 +240,7 @@ public class ImportExportXMLServlet extends HttpServlet {
 				HibernateUtil _dh = null;
 
 				_className = f.getName().substring(0, f.getName().lastIndexOf("."));
-				_xstream = new XStream(new DomDriver());
+				_xstream = new XStream(new DomDriver(CHARSET));
 				_importClass = Class.forName(_className);
 				out.println("Importing:\t" + _className);
 				if (_importClass.equals(User.class)) {
@@ -337,7 +337,7 @@ public class ImportExportXMLServlet extends HttpServlet {
 			BufferedWriter _bout = null;
 
 			for (Class clazz : _tablesToDump) {
-				_xstream = new XStream(new DomDriver());
+				_xstream = new XStream(new DomDriver(CHARSET));
 
 				/*
 				 * String _shortClassName =
@@ -364,7 +364,7 @@ public class ImportExportXMLServlet extends HttpServlet {
 			/* Run Liferay's Tables */
 			/* Companies */
 			_list = PublicCompanyFactory.getCompanies();
-			_xstream = new XStream(new DomDriver());
+			_xstream = new XStream(new DomDriver(CHARSET));
 			_writing = new File(FileUtil.getRealPath(backupTempFilePath + "/" + Company.class.getName() + ".xml"));
 			_bout = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(_writing), CHARSET));
 			_xstream.toXML(_list, _bout);
@@ -374,7 +374,7 @@ public class ImportExportXMLServlet extends HttpServlet {
 
 			/* Users */
 			_list = APILocator.getUserAPI().findAllUsers();
-			_xstream = new XStream(new DomDriver());
+			_xstream = new XStream(new DomDriver(CHARSET));
 			_writing = new File(FileUtil.getRealPath(backupTempFilePath + "/" + User.class.getName() + ".xml"));
 			_bout = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(_writing), CHARSET));
 			_xstream.toXML(_list, _bout);

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportExportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportExportUtil.java
@@ -32,9 +32,7 @@ import java.util.zip.ZipFile;
 
 import com.dotcms.repackage.net.sf.hibernate.HibernateException;
 import com.dotcms.repackage.net.sf.hibernate.persister.AbstractEntityPersister;
-
 import com.dotcms.repackage.org.apache.commons.beanutils.BeanUtils;
-
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.beans.Tree;
 import com.dotmarketing.business.APILocator;
@@ -61,6 +59,7 @@ import com.liferay.portal.model.PortletPreferences;
 import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import com.dotcms.repackage.com.thoughtworks.xstream.XStream;
+import com.dotcms.repackage.com.thoughtworks.xstream.io.xml.DomDriver;
 
 
 /**
@@ -116,6 +115,8 @@ public class ImportExportUtil {
     private List<File> tagFiles = new ArrayList<File>();
     private File workflowSchemaFile = null;
     private File ruleFile = null;
+    
+    private static final String CHARSET = UtilMethods.getCharsetConfiguration();
 
     public ImportExportUtil() {
         MaintenanceUtil.flushCache();
@@ -356,10 +357,10 @@ public class ImportExportUtil {
                 return;
             }
 
-            _xstream = new XStream();
+            _xstream = new XStream(new DomDriver());
 
             try{
-                charStream = new InputStreamReader(new FileInputStream(file), "UTF-8");
+                charStream = new InputStreamReader(new FileInputStream(file), CHARSET);
             }catch (UnsupportedEncodingException uet) {
                 Logger.error(this, "Reader doesn't not recoginize Encoding type: ", uet);
             }
@@ -455,7 +456,7 @@ public class ImportExportUtil {
              */
 
             final List<Identifier> folderIdents=new ArrayList<Identifier>();
-            final XStream xstream = new XStream();
+            final XStream xstream = new XStream(new DomDriver());
 
             // collecting all folder identifiers
             for(File ff : identifiersXML) {
@@ -1145,12 +1146,12 @@ public class ImportExportUtil {
                     return;
                 }
             }
-            _xstream = new XStream();
+            _xstream = new XStream(new DomDriver());
             out.println("Importing:\t" + _className);
             Logger.info(this, "Importing:\t" + _className);
 
             try{
-                charStream = new InputStreamReader(new FileInputStream(f), "UTF-8");
+                charStream = new InputStreamReader(new FileInputStream(f), CHARSET);
             }catch (UnsupportedEncodingException uet) {
                 Logger.error(this, "Reader doesn't not recoginize Encoding type: ", uet);
             }

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportExportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportExportUtil.java
@@ -357,7 +357,7 @@ public class ImportExportUtil {
                 return;
             }
 
-            _xstream = new XStream(new DomDriver());
+            _xstream = new XStream(new DomDriver(CHARSET));
 
             try{
                 charStream = new InputStreamReader(new FileInputStream(file), CHARSET);
@@ -456,7 +456,7 @@ public class ImportExportUtil {
              */
 
             final List<Identifier> folderIdents=new ArrayList<Identifier>();
-            final XStream xstream = new XStream(new DomDriver());
+            final XStream xstream = new XStream(new DomDriver(CHARSET));
 
             // collecting all folder identifiers
             for(File ff : identifiersXML) {
@@ -1146,7 +1146,7 @@ public class ImportExportUtil {
                     return;
                 }
             }
-            _xstream = new XStream(new DomDriver());
+            _xstream = new XStream(new DomDriver(CHARSET));
             out.println("Importing:\t" + _className);
             Logger.info(this, "Importing:\t" + _className);
 


### PR DESCRIPTION
Tested on backported fix to 3.6.0 on Postgres and MySQL:

1. Tested clean install. Works OK.
2. Tested backing up data/assets from Maintenance portlet. Works OK.
3. Tested with backed up data as clean install (renamed backup to starter.zip). Works OK.