### PR TITLE
#10243 Nullable tag, allow inode when creating the content type

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/type/ContentType.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/type/ContentType.java
@@ -56,6 +56,7 @@ public abstract class ContentType implements Serializable, Permissionable, Conte
   public abstract String id();
 
 
+  @Nullable
   @Value.Lazy
   public String inode() {
     return id();


### PR DESCRIPTION
If is the inode is not allowed to be null before the creation an NPE is thrown.