### PR TITLE
#10327 fix Move/Delete methods for WebDAV

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/webdav/DotWebdavHelper.java
+++ b/dotCMS/src/main/java/com/dotmarketing/webdav/DotWebdavHelper.java
@@ -1134,6 +1134,7 @@ public class DotWebdavHelper {
 	}
 
 	public void move(String fromPath, String toPath, User user,boolean autoPublish)throws IOException, DotDataException {
+	    String resourceFromPath = fromPath;
 		fromPath = stripMapping(fromPath);
 		toPath = stripMapping(toPath);
 		PermissionAPI perAPI = APILocator.getPermissionAPI();
@@ -1153,7 +1154,7 @@ public class DotWebdavHelper {
 			Logger.error(DotWebdavHelper.class, e.getMessage(), e);
 			throw new IOException(e.getMessage());
 		}
-		if (isResource(fromPath,user)) {
+		if (isResource(resourceFromPath,user)) {
 			try {
 				if (!perAPI.doesUserHavePermission(toParentFolder,
 						PermissionAPI.PERMISSION_READ, user, false)) {
@@ -1333,6 +1334,7 @@ public class DotWebdavHelper {
 	}
 
 	public void removeObject(String uri, User user) throws IOException, DotDataException, DotSecurityException {
+	    String resourceUri = uri;
 		uri = stripMapping(uri);
 		Logger.debug(this.getClass(), "In the removeObject Method");
 		String hostName = getHostname(uri);
@@ -1350,7 +1352,7 @@ public class DotWebdavHelper {
 			throw new IOException(e.getMessage());
 		}
 		Folder folder = folderAPI.findFolderByPath(folderName, host,user,false);
-		if (isResource(uri,user)) {
+		if (isResource(resourceUri,user)) {
 			Identifier identifier  = APILocator.getIdentifierAPI().find(host, path);
 
 			Long timeOfPublishing = fileResourceCache.get(uri + "|" + user.getUserId());
@@ -1400,7 +1402,7 @@ public class DotWebdavHelper {
 			    LiveCache.removeAssetFromCache(webAsset);
 			}
 
-		} else if (isFolder(uri,user)) {
+		} else if (isFolder(resourceUri,user)) {
 			if(!path.endsWith("/"))
 				path += "/";
 			folder = folderAPI.findFolderByPath(path, host,user,false);


### PR DESCRIPTION
isResource and isFolder methods require that the URI in question is the original one, before the stripMapping method is called and URI value is replaced. So, the original resource URI needs to be sent in order to verify if the URI belongs to a file/folder and if the Site exists. 

Tested on 3.6.0 as a backported fix. Tests included:

- Added a new folder/file.
- Copied a folder/file to a new location.
- Moved a folder/file to a new location.
- Deleted a file/folder. 

All tests were successful. 