### PR TITLE
Issue 10336 fix upgrade tasks mssql v370

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03710AddFKForIntegrityCheckerTables.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03710AddFKForIntegrityCheckerTables.java
@@ -18,15 +18,11 @@ public class Task03710AddFKForIntegrityCheckerTables implements StartupTask {
             dc.executeStatement("truncate table schemes_ir;");
             dc.executeStatement("truncate table htmlpages_ir;");
             dc.executeStatement("truncate table fileassets_ir;");
-            //fix datatype for htmlpages_ir table
-            //dc.executeStatement("ALTER TABLE htmlpages_ir ALTER COLUMN language_id bigint;");
-            //dc.executeStatement("ALTER TABLE fileassets_ir ALTER COLUMN language_id bigint;");
-          //drop tables and recreate them
+            //drop tables and recreate them (We need this because language_id is a PK so you can not change the type since a constraint its created by default)
             dc.executeStatement("drop table htmlpages_ir;");
+            dc.executeStatement("drop table fileassets_ir;");
             dc.executeStatement("create table htmlpages_ir(html_page varchar(255), local_working_inode varchar(36), local_live_inode varchar(36), remote_working_inode varchar(36), remote_live_inode varchar(36),local_identifier varchar(36), "
             		+ "remote_identifier varchar(36), endpoint_id varchar(36), language_id bigint, PRIMARY KEY (local_working_inode, language_id, endpoint_id));");
-            
-            dc.executeStatement("drop table fileassets_ir;");
             dc.executeStatement("create table fileassets_ir(file_name varchar(255), local_working_inode varchar(36), local_live_inode varchar(36), remote_working_inode varchar(36), remote_live_inode varchar(36),local_identifier varchar(36), "
             		+ "remote_identifier varchar(36), endpoint_id varchar(36), language_id bigint, PRIMARY KEY (local_working_inode, language_id, endpoint_id));");
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03710AddFKForIntegrityCheckerTables.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03710AddFKForIntegrityCheckerTables.java
@@ -19,8 +19,17 @@ public class Task03710AddFKForIntegrityCheckerTables implements StartupTask {
             dc.executeStatement("truncate table htmlpages_ir;");
             dc.executeStatement("truncate table fileassets_ir;");
             //fix datatype for htmlpages_ir table
-            dc.executeStatement("ALTER TABLE htmlpages_ir ALTER COLUMN language_id bigint;");
-            dc.executeStatement("ALTER TABLE fileassets_ir ALTER COLUMN language_id bigint;");
+            //dc.executeStatement("ALTER TABLE htmlpages_ir ALTER COLUMN language_id bigint;");
+            //dc.executeStatement("ALTER TABLE fileassets_ir ALTER COLUMN language_id bigint;");
+          //drop tables and recreate them
+            dc.executeStatement("drop table htmlpages_ir;");
+            dc.executeStatement("create table htmlpages_ir(html_page varchar(255), local_working_inode varchar(36), local_live_inode varchar(36), remote_working_inode varchar(36), remote_live_inode varchar(36),local_identifier varchar(36), "
+            		+ "remote_identifier varchar(36), endpoint_id varchar(36), language_id bigint, PRIMARY KEY (local_working_inode, language_id, endpoint_id));");
+            
+            dc.executeStatement("drop table fileassets_ir;");
+            dc.executeStatement("create table fileassets_ir(file_name varchar(255), local_working_inode varchar(36), local_live_inode varchar(36), remote_working_inode varchar(36), remote_live_inode varchar(36),local_identifier varchar(36), "
+            		+ "remote_identifier varchar(36), endpoint_id varchar(36), language_id bigint, PRIMARY KEY (local_working_inode, language_id, endpoint_id));");
+
             //add FKS
             dc.executeStatement("alter table folders_ir add constraint FK_folder_ir_ep foreign key (endpoint_id) references publishing_end_point(id);");
             dc.executeStatement("alter table structures_ir add constraint FK_structure_ir_ep foreign key (endpoint_id) references publishing_end_point(id);");

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03725NewNotificationTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03725NewNotificationTable.java
@@ -85,8 +85,8 @@ public class Task03725NewNotificationTable extends AbstractJDBCStartupTask {
                 "    time_sent          DATETIME      NOT NULL,\n" +
                 "    was_read           TINYINT\n" +
                 "  );\n" +
-                "ALTER TABLE system_event ADD CONSTRAINT pk_notification PRIMARY KEY (group_id, user_id);\n" +
-                "ALTER TABLE system_event ADD CONSTRAINT df_notification_was_read DEFAULT ((0)) FOR was_read;\n" +
+                "ALTER TABLE notification ADD CONSTRAINT pk_notification PRIMARY KEY (group_id, user_id);\n" +
+                "ALTER TABLE notification ADD CONSTRAINT df_notification_was_read DEFAULT ((0)) FOR was_read;\n" +
                 "CREATE INDEX idx_not_read ON notification (was_read);";
     }
 


### PR DESCRIPTION
Task03710AddFKForIntegrityCheckerTables.java = Drop tables and recreate them, we need this because language_id is a PK so you can not change the type since a constraint its created by default (the name is autogenerated by mssql).

Task03725NewNotificationTable.java = Fix the wrong table when creating the constraint (Talked about this with @jcastro-dotcms )