### PR TITLE
#10557 fix getTopAssets method for Pages

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/dashboard/business/DashboardFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/dashboard/business/DashboardFactory.java
@@ -156,7 +156,7 @@ public abstract class DashboardFactory {
 		// This query counts legacy html pages
 		StringBuilder sbCountLegacyHtmlPages = new StringBuilder("(SELECT COUNT(*) ")
 		.append("FROM htmlpage_version_info pageinfo JOIN identifier ON (identifier.id = pageinfo.identifier) ") 
-		.append("WHERE identifier.host_inode = ? AND pageinfo.live_inode IS NOT NULL GROUP BY identifier.host_inode)");
+		.append("WHERE identifier.host_inode = ? AND pageinfo.live_inode IS NOT NULL)");
 		
 		// This query counts html pages by combine 'html page contentlets' and 'legacy html pages'
 		StringBuilder sbCountAllHtmlPages = new StringBuilder("SELECT identifier.host_inode AS host_inode, ")


### PR DESCRIPTION
Tested as a backported fix on 3.6.x releases. Query was tested on SQL Server, MySQL and Postgres DB. In all tests, the total amount of pages were retrieved, whether Legacy Pages exist under the site or not.