### PR TITLE
#10678: Restored logic for download data/assets on 4.1

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/cmsmaintenance/action/ViewCMSMaintenanceAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/cmsmaintenance/action/ViewCMSMaintenanceAction.java
@@ -275,6 +275,58 @@ public class ViewCMSMaintenanceAction extends DotPortletAction {
 			deleteTempFiles();
 			boolean dataOnly = Parameter.getBooleanFromString(req.getParameter("dataOnly"), true);
 
+			if(cmd.equals("createZip")) {
+				if(!dataOnly){
+					moveAssetsToBackupDir();
+				}
+				message = "Creating XML Files. ";
+				createXMLFiles();
+				String x = UtilMethods.dateToJDBC(new Date()).replace(':', '-').replace(' ', '_');
+				File zipFile = new File(backupFilePath + "/backup_" + x + "_.zip");
+				message +="Zipping up to file:" + zipFile.getAbsolutePath();
+				BufferedOutputStream bout = new BufferedOutputStream(new FileOutputStream(zipFile));
+
+				zipTempDirectoryToStream(bout);
+				message +=". Done.";
+
+//			}else if(cmd.equals("wipeOutDotCMSDatabase")) {
+//
+//				message = "Deleted dotCMS Database";
+//				deleteDotCMS();
+
+			}else if(cmd.equals("downloadZip")) {
+
+				message ="File Downloaded";
+				String x = UtilMethods.dateToJDBC(new Date()).replace(':', '-').replace(' ', '_');
+				File zipFile = new File(backupFilePath + "/backup_" + x + "_.zip");
+
+				ActionResponseImpl responseImpl = (ActionResponseImpl) res;
+				HttpServletResponse httpResponse = responseImpl.getHttpServletResponse();
+				httpResponse.setHeader("Content-type", "");
+				httpResponse.setHeader("Content-Disposition", "attachment; filename=" + zipFile.getName());
+
+				if(!dataOnly){
+					moveAssetsToBackupDir();
+				}
+
+				createXMLFiles();
+
+				zipTempDirectoryToStream(httpResponse.getOutputStream());
+
+			}else if(cmd.equals("upload")) {
+ 
+ 
+				UploadPortletRequest uploadReq = PortalUtil.getUploadPortletRequest(req);
+				ActionResponseImpl responseImpl = (ActionResponseImpl) res;
+				HttpServletResponse httpResponse = responseImpl.getHttpServletResponse();
+
+				ActionRequestImpl requestImpl = (ActionRequestImpl) req;
+				HttpServletRequest httpRequest = requestImpl.getHttpServletRequest();
+
+				//message ="file upload Done.";
+
+				doUpload(httpRequest, httpResponse, uploadReq);
+			}
 		}
 
 		if(UtilMethods.isSet(message)){
@@ -493,6 +545,317 @@ public class ViewCMSMaintenanceAction extends DotPortletAction {
 		FileUtil.deltree(d);
 	}
 
+
+	/**
+	 * This method will pull a list of all tables /classed being managed by
+	 * hibernate and export them, one class per file to the backupTempFilePath
+	 * as valid XML. It uses XStream to write the xml out to the files.
+	 *
+	 * @throws ServletException
+	 * @throws IOException
+	 * @author Will
+	 * @throws DotDataException
+	 */
+	private void createXMLFiles() throws ServletException, IOException, DotDataException {
+
+//		deleteTempFiles();
+
+		Logger.info(this, "Starting createXMLFiles()");
+
+		Set<Class> _tablesToDump = new HashSet<Class>();
+		try {
+
+			/* get a list of all our tables */
+			Map map = HibernateUtil.getSession().getSessionFactory().getAllClassMetadata();
+			Iterator it = map.entrySet().iterator();
+			while (it.hasNext()) {
+				Map.Entry pairs = (Map.Entry) it.next();
+				Class x = (Class) pairs.getKey();
+				if (!x.equals(Inode.class) && !x.equals(Clickstream.class) && !x.equals(ClickstreamRequest.class) && !x.equals(Clickstream404.class))
+					_tablesToDump.add(x);
+
+			}
+			XStream _xstream = null;
+			HibernateUtil _dh = null;
+			List _list = null;
+			File _writing = null;
+			BufferedOutputStream _bout = null;
+
+			for (Class clazz : _tablesToDump) {
+				//http://jira.dotmarketing.net/browse/DOTCMS-5031
+                if(PermissionReference.class.equals(clazz)){
+                	continue;
+                }
+
+				_xstream = new XStream(new DomDriver());
+
+				//http://jira.dotmarketing.net/browse/DOTCMS-6059
+				if(clazz.equals(DashboardSummary404.class) || clazz.equals(DashboardUserPreferences.class)){
+					_xstream.addDefaultImplementation(com.dotcms.repackage.net.sf.hibernate.collection.Set.class, java.util.Set.class);
+					_xstream.addDefaultImplementation(com.dotcms.repackage.net.sf.hibernate.collection.List.class, java.util.List.class);
+					_xstream.addDefaultImplementation(com.dotcms.repackage.net.sf.hibernate.collection.Map.class, java.util.Map.class);
+					Mapper mapper = _xstream.getMapper();
+					_xstream.registerConverter(new HibernateCollectionConverter(mapper));
+					_xstream.registerConverter(new HibernateMapConverter(mapper));
+				}
+
+				/*
+				 * String _shortClassName =
+				 * clazz.getName().substring(clazz.getName().lastIndexOf("."),clazz.getName().length());
+				 * xstream.alias(_shortClassName, clazz);
+				 */
+				int i= 0;
+				int step = 1000;
+				int total =0;
+				java.text.NumberFormat formatter = new java.text.DecimalFormat("0000000000");
+				/* we will only export 10,000,000 items of any given type */
+				for(i=0;i < 10000000;i=i+step){
+
+                    _dh = new HibernateUtil(clazz);
+                    _dh.setFirstResult(i);
+                    _dh.setMaxResults(step);
+
+                    //This line was previously like;
+                    //_dh.setQuery("from " + clazz.getName() + " order by 1,2");
+                    //This caused a problem when the database is Oracle because Oracle causes problems when the results are ordered
+                    //by an NCLOB field. In the case of dot_containers table, the second field, CODE, is an NCLOB field. Because of this,
+                    //ordering is done only on the first field for the tables, which is INODE
+                    if(com.dotmarketing.beans.Tree.class.equals(clazz)){
+                    	_dh.setQuery("from " + clazz.getName() + " order by parent, child, relation_type");
+                    }
+                    else if(MultiTree.class.equals(clazz)){
+                    	_dh.setQuery("from " + clazz.getName() + " order by parent1, parent2, child, relation_type");
+                    }
+                    else if(TagInode.class.equals(clazz)){
+                    	_dh.setQuery("from " + clazz.getName() + " order by inode, tag_id");
+                    }
+                    else if(Tag.class.equals(clazz)){
+                    	_dh.setQuery("from " + clazz.getName() + " order by tag_id, tagname");
+                    }
+                    else if(CalendarReminder.class.equals(clazz)){
+                    	_dh.setQuery("from " + clazz.getName() + " order by user_id, event_id, send_date");
+                    } 
+                    else if(Identifier.class.equals(clazz)){
+                    	_dh.setQuery("from " + clazz.getName() + " order by parent_path, id");
+                    } else {
+                    	_dh.setQuery("from " + clazz.getName() + " order by 1");
+                    }
+
+                    _list = _dh.list();
+                    if(_list.size() ==0){
+                        try {
+                        _bout.close();
+                        }
+                        catch( java.lang.NullPointerException npe){}
+                        _list = null;
+                        _dh = null;
+                        _bout = null;
+
+                        break;
+                    }
+
+                    if(_list != null && _list.size() > 0 && _list.get(0) instanceof Comparable){
+                    	java.util.Collections.sort(_list);
+                    }
+
+    				_writing = new File(backupTempFilePath + "/" + clazz.getName() + "_" + formatter.format(i) + ".xml");
+    				_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+
+    				total = total + _list.size();
+
+    				try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException e) {
+                    	Logger.warn(this, "An error ocurred trying to create XML files");
+                        Logger.error(this,e.getMessage(),e);
+                    }
+
+    				_xstream.toXML(_list, _bout);
+
+    				_bout.close();
+    				_list = null;
+    				_dh = null;
+    				_bout = null;
+
+				}
+				Logger.info(this, "writing : " + total + " records for " + clazz.getName());
+			}
+ 
+ 
+			/* Run Liferay's Tables */
+			/* Companies */
+			_list = PublicCompanyFactory.getCompanies();
+			List<Company> companies = new ArrayList<Company>(_list);
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/" + Company.class.getName() + ".xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+
+			/* Users */
+			_list = APILocator.getUserAPI().findAllUsers();
+			_list.add(APILocator.getUserAPI().getDefaultUser());
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/" + User.class.getName() + ".xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+
+
+			/* users_roles */
+			DotConnect dc = new DotConnect();
+
+			/* counter */
+			dc.setSQL("select * from counter");
+			_list = dc.getResults();
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/Counter.xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+
+			/* counter */
+			dc.setSQL("select * from address");
+			_list = dc.getResults();
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/Address.xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+
+			/* pollschoice */
+			dc.setSQL("select * from pollschoice");
+			_list = dc.getResults();
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/Pollschoice.xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+
+			/* pollsdisplay */
+			dc.setSQL("select * from pollsdisplay");
+			_list = dc.getResults();
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/Pollsdisplay.xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+
+			/* pollsquestion */
+			dc.setSQL("select * from pollsquestion");
+			_list = dc.getResults();
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/Pollsquestion.xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+
+			/* pollsvote */
+			dc.setSQL("select * from pollsvote");
+			_list = dc.getResults();
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/Pollsvote.xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+
+			/* image */
+			_list = ImageLocalManagerUtil.getImages();
+
+			/*
+			 * The changes in this part were made for Oracle databases. Oracle has problems when
+			 * getString() method is called on a LONG field on an Oracle database. Because of this,
+			 * the object is loaded from liferay and DotConnect is not used
+			 * http://jira.dotmarketing.net/browse/DOTCMS-1911
+			 */
+
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/Image.xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+
+			/* portlet */
+
+			/*
+			 * The changes in this part were made for Oracle databases. Oracle has problems when
+			 * getString() method is called on a LONG field on an Oracle database. Because of this,
+			 * the object is loaded from liferay and DotConnect is not used
+			 * http://jira.dotmarketing.net/browse/DOTCMS-1911
+			 */
+			dc.setSQL("select * from portlet");
+			_list = dc.getResults();
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/Portlet.xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+
+			/* portlet_preferences */
+
+			try{
+				_list = PortletPreferencesLocalManagerUtil.getPreferences();
+			}catch(Exception e){
+				Logger.error(this,"Error in retrieveing all portlet preferences");
+			}
+			_xstream = new XStream(new DomDriver());
+			_writing = new File(backupTempFilePath + "/Portletpreferences.xml");
+			_bout = new BufferedOutputStream(new FileOutputStream(_writing));
+			_xstream.toXML(_list, _bout);
+			_bout.close();
+			_list = null;
+			_bout = null;
+			
+			
+			
+			File file = new File(backupTempFilePath + "/WorkflowSchemeImportExportObject.json");
+			WorkflowImportExportUtil.getInstance().exportWorkflows(file);
+
+			file = new File(backupTempFilePath + "/RuleImportExportObject.json");
+			RulesImportExportUtil.getInstance().export(file);
+			
+			IndiciesInfo info=APILocator.getIndiciesAPI().loadIndicies();
+
+			file = new File(backupTempFilePath + "/index_working.json");
+			new ESIndexAPI().backupIndex(info.working, file);
+			 
+			
+			file = new File(backupTempFilePath + "/index_live.json");
+			new ESIndexAPI().backupIndex(info.live, file);
+
+
+			
+			
+			
+			
+			
+		} catch (HibernateException e) {
+			Logger.error(this,e.getMessage(),e);
+		} catch (SystemException e) {
+			Logger.error(this,e.getMessage(),e);
+		}
+
+	}
 
 
 	/**


### PR DESCRIPTION
This logic is present in master-4.0 and was apparently removed (and not restored back) in master-4.1. No functional changes have been added to it.