### PR TITLE
dotCMS/core#10825 fix adding environments for Oracle DBS

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publisher/util/PublisherUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/PublisherUtil.java
@@ -61,8 +61,12 @@ public class PublisherUtil {
 			pep.setGroupId(row.get("group_id").toString());
 		}
 		pep.setAddress(row.get("address").toString());
-		pep.setPort(row.get("port").toString());
-		pep.setProtocol(row.get("protocol").toString());
+		if(row.get("port") != null) {
+		    pep.setPort(row.get("port").toString());
+		}
+		if(row.get("protocol") != null) {
+		    pep.setProtocol(row.get("protocol").toString());
+		}
 		pep.setServerName(new StringBuilder(row.get("server_name").toString()));
 		pep.setAuthKey(new StringBuilder(row.get("auth_key").toString()));
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsconfig/remotePublishing.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsconfig/remotePublishing.jsp
@@ -944,7 +944,7 @@ function deleteEnvPushHistory(envId) {
                         <div>
                             <%=("https".equals(endpoint.getProtocol())) ? "<span class='encryptIcon'></span>": "<span class='shimIcon'></span>" %>
                             <%if (!"awss3".equalsIgnoreCase(endpoint.getProtocol())){%>
-                            	<i style="color:#888;"><%=endpoint.getProtocol()%>://<%=endpoint.getAddress()%>:<%=endpoint.getPort()%></i>
+                            	<i style="color:#888;"><%=endpoint.getProtocol()!=null?endpoint.getProtocol():""%>://<%=endpoint.getAddress()%>:<%=endpoint.getPort()!=null?endpoint.getPort():""%></i>
 	                        <%} else {
 	                        	String endpointString = "aws-s3";
 								try {


### PR DESCRIPTION
Tested as a backported fix for dotCMS 3.7.1, running on Oracle 11G databases.

Tested:

1. Adding/updating/deleting environments.
2. Integrity Checker.
3. Push Publishing between environments.

Works OK.