### PR TITLE
dotCMS/core#10828 fix push empty templates in Oracle

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/templates/business/TemplateAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/templates/business/TemplateAPIImpl.java
@@ -28,23 +28,18 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotHibernateException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.factories.InodeFactory;
 import com.dotmarketing.portlets.containers.business.ContainerAPI;
 import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI.TemplateContainersReMap.ContainerRemapTuple;
-import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
-import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
 import com.dotmarketing.portlets.templates.model.Template;
-import com.dotmarketing.services.PageServices;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
-import com.liferay.portal.PortalException;
-import com.liferay.portal.SystemException;
 import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
 import com.liferay.util.StringUtil;
 
 public class TemplateAPIImpl extends BaseWebAssetAPI implements TemplateAPI {
@@ -369,24 +364,28 @@ public class TemplateAPIImpl extends BaseWebAssetAPI implements TemplateAPI {
 	}
 
 	public void updateParseContainerSyntax(Template template) {
-		String tb = template.getBody();
-		Perl5Matcher matcher = (Perl5Matcher) localP5Matcher.get();
-		String oldParse;
-		String newParse;
-    	while(matcher.contains(tb, parseContainerPattern)){
-     		MatchResult match = matcher.getMatch();
-    		int groups = match.groups();
-     		for(int g=0;g<groups;g++){
-     			oldParse = match.group(g);
-     			if(matcher.contains(oldParse, oldContainerPattern)){
-     				MatchResult matchOld = matcher.getMatch();
-     				newParse = matchOld.group(0).trim();
-     				newParse = containerTag + newParse + "')";
-     				tb = StringUtil.replace(tb,oldParse,newParse);
-     			}
-     		}
-     		template.setBody(tb);
-    	}
+	    String tb = template.getBody();
+	    if(!UtilMethods.isSet(tb)){
+	        template.setBody(StringPool.BLANK); 
+	    }else{
+	        Perl5Matcher matcher = (Perl5Matcher) localP5Matcher.get();
+	        String oldParse;
+	        String newParse;
+	        while(matcher.contains(tb, parseContainerPattern)){
+	            MatchResult match = matcher.getMatch();
+	            int groups = match.groups();
+	            for(int g=0;g<groups;g++){
+	                oldParse = match.group(g);
+	                if(matcher.contains(oldParse, oldContainerPattern)){
+	                    MatchResult matchOld = matcher.getMatch();
+	                    newParse = matchOld.group(0).trim();
+	                    newParse = containerTag + newParse + "')";
+	                    tb = StringUtil.replace(tb,oldParse,newParse);
+	                }
+	            }
+	            template.setBody(tb);
+	        }
+	    }
 	}
 
 	@SuppressWarnings("unchecked")

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/templates/business/TemplateFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/templates/business/TemplateFactoryImpl.java
@@ -32,8 +32,6 @@ import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.folders.model.Folder;
-import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
-import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
 import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.portlets.templates.model.TemplateVersionInfo;
 import com.dotmarketing.portlets.workflows.business.DotWorkflowException;
@@ -349,10 +347,14 @@ public class TemplateFactoryImpl implements TemplateFactory {
 	}
 	
 	private List<String> getContainerIds(String templateBody) {
+	    List<String> ids = new LinkedList<String>();
+	    if(!UtilMethods.isSet(templateBody)){
+	        return ids;
+	    }
 		Pattern oldContainerReferencesRegex = Pattern.compile("#parse\\s*\\(\\s*\\$container([^\\s)]+)\\s*\\)");
 		Pattern newContainerReferencesRegex = Pattern.compile("#parseContainer\\s*\\(\\s*['\"]*([^'\")]+)['\"]*\\s*\\)");
 		Matcher matcher = oldContainerReferencesRegex.matcher(templateBody);
-		List<String> ids = new LinkedList<String>();
+		
 		while(matcher.find()) {
 			String containerId = matcher.group(1).trim();
 			if(!ids.contains(containerId))


### PR DESCRIPTION
Tested as a backported fix in dotCMS 3.7.1 + Oracle 11G Databases. 

Works OK.