### PR TITLE
dotCMS/core#10833 fix findAll categories for import process

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -1087,7 +1087,7 @@ public class ImportUtil {
                     }
 
                     for(Category cat : nonHeaderParentCats){
-                        categoriesToRetain.addAll(catAPI.getChildren(cat,false, user, false));
+                        categoriesToRetain.addAll(catAPI.getAllChildren(cat, user, false));
                     }
 
                     /*


### PR DESCRIPTION
#10833 

Tested as backported fix on 3.6.1, as per client's instructions on ticket: https://my.dotcms.com/tickets/detail.dot?id=86dfc85c-c592-4612-b38e-8f6d9d90a015 

Works as expected once the categories field is removed from the CSV header file. Categories assigned to existing contents are preserved, regardless of the category level.