### PR TITLE
Issue 9717 hide default user portlet

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -1087,7 +1087,7 @@ public class ImportUtil {
                     }
 
                     for(Category cat : nonHeaderParentCats){
-                        categoriesToRetain.addAll(catAPI.getChildren(cat,false, user, false));
+                        categoriesToRetain.addAll(catAPI.getAllChildren(cat, user, false));
                     }
 
                     /*

--- a/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
@@ -140,7 +140,7 @@
 		dojo.query("#usersGrid").addClass('view-users__users-list');
 
         //Loading the grid for first time
-        UserAjax.getUsersList(null, null, { start: 0, limit: 50 }, dojo.hitch(this, getUsersListCallback));
+        UserAjax.getUsersList(null, null, { start: 0, limit: 50, includeDefault: false }, dojo.hitch(this, getUsersListCallback));
     });
 
 	//Gethering the data from server and setting the grid to display it
@@ -202,7 +202,7 @@
 		dojo.byId('loadingUsers').style.display = '';
 		dojo.byId('usersGrid').style.display = 'none';
 		var value = dijit.byId('usersFilter').attr('value');
-		UserAjax.getUsersList(null, null, { start: 0, limit: 50, query: value }, dojo.hitch(this, getUsersListCallback));
+		UserAjax.getUsersList(null, null, { start: 0, limit: 50, query: value, includeDefault: false }, dojo.hitch(this, getUsersListCallback));
 	}
 
 	//Event handler for clearing the users filter
@@ -210,7 +210,7 @@
 		dojo.byId('loadingUsers').style.display = '';
 		dojo.byId('usersGrid').style.display = 'none';
 		dijit.byId('usersFilter').attr('value', '');
-		UserAjax.getUsersList(null, null, { start: 0, limit: 50, query: '' }, dojo.hitch(this, getUsersListCallback));
+		UserAjax.getUsersList(null, null, { start: 0, limit: 50, query: '', includeDefault: false }, dojo.hitch(this, getUsersListCallback));
 	}
 
 	//CRUD operations over users


### PR DESCRIPTION
#9717 

Tested on master-4.0 + Postgres 9.4.1. Default user is hidden from the Users List on the Users Portlet.