### PR TITLE
dotCMS/core#8683 fix force push status for created bundles

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publisher/ajax/RemotePublishAjaxAction.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/ajax/RemotePublishAjaxAction.java
@@ -44,6 +44,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.elasticsearch.common.base.Strings;
+
 import java.io.*;
 import java.lang.reflect.Method;
 import java.text.ParseException;
@@ -864,6 +866,13 @@ public class RemotePublishAjaxAction extends AjaxAction {
             String _contentPushExpireTime = request.getParameter( "remotePublishExpireTime" );
             String _iWantTo = request.getParameter( "iWantTo" );
             String whoToSendTmp = request.getParameter( "whoToSend" );
+            String forcePushTmp = request.getParameter( "forcePush" );
+            
+            Boolean forcePush = false;
+            if(!Strings.isNullOrEmpty(forcePushTmp)){
+                forcePush = Boolean.valueOf(forcePushTmp);
+            }
+            
             List<String> whereToSend = Arrays.asList(whoToSendTmp.split(","));
             List<Environment> envsToSendTo = new ArrayList<Environment>();
 
@@ -889,6 +898,7 @@ public class RemotePublishAjaxAction extends AjaxAction {
             SimpleDateFormat dateFormat = new SimpleDateFormat( "yyyy-MM-dd-H-m" );
             Date publishDate = dateFormat.parse( _contentPushPublishDate + "-" + _contentPushPublishTime );
             Bundle bundle = APILocator.getBundleAPI().getBundleById(bundleId);
+            bundle.setForcePush(forcePush);
             APILocator.getBundleAPI().saveBundleEnvironments(bundle, envsToSendTo);
 
             if ( _iWantTo.equals( RemotePublishAjaxAction.DIALOG_ACTION_PUBLISH )) {

--- a/dotCMS/src/main/java/com/dotcms/publisher/bundle/business/BundleFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/bundle/business/BundleFactory.java
@@ -23,7 +23,7 @@ public abstract class BundleFactory {
 
     protected static String DELETE_BUNDLE = "DELETE FROM publishing_bundle where id = ?";
 
-    protected static String UPDATE_BUNDLE = "UPDATE publishing_bundle SET name = ?, publish_date = ?, expire_date = ? where id = ?";
+    protected static String UPDATE_BUNDLE = "UPDATE publishing_bundle SET name = ?, publish_date = ?, expire_date = ?, force_push = ? where id = ?";
 
     protected static final String UPDATE_BUNDLE_OWNER_REFERENCES = "UPDATE publishing_bundle SET owner = ? where owner = ?";
 

--- a/dotCMS/src/main/java/com/dotcms/publisher/bundle/business/BundleFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/bundle/business/BundleFactoryImpl.java
@@ -162,6 +162,7 @@ public class BundleFactoryImpl extends BundleFactory {
 		dc.addParam(bundle.getName());
 		dc.addParam(bundle.getPublishDate());
 		dc.addParam(bundle.getExpireDate());
+		dc.addParam(bundle.isForcePush());
 		dc.addParam(bundle.getId());
 
 		dc.loadResult();


### PR DESCRIPTION
Tested on backported fix, on dotCMS 3.7.1 + Postgres DB. 

Force Push attrib us updated and all contents included in bundle are force-pushed, along with dependencies. 