### PR TITLE
#11188 Call ContentTypeAPI

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/ajax/PermissionAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/ajax/PermissionAjax.java
@@ -381,6 +381,10 @@ public class PermissionAjax {
 				perm = InodeFactory.getInode(inode, InodeUtils.getClassByDBType(type));
 			}
 		}
+		
+		if(perm == null){
+			perm = APILocator.getContentTypeAPI(user).find(assetId);
+		}
 
 		if(perm == null || !UtilMethods.isSet(perm.getPermissionId())) {
 			perm = InodeFactory.getInode(assetId, Inode.class);


### PR DESCRIPTION
We need to search first if is the assetId is a Content Type, if not search it through the InodeFactory. This is because the InodeFactory makes the search via Hibernate and the ContentType Mapping was deleted in the hibernate files.