### PR TITLE
#10370: Path bug fixed. Based on previous comments and research, the …

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/osgi/OSGIUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/osgi/OSGIUtilTest.java
@@ -1,0 +1,113 @@
+package com.dotcms.osgi;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.OSGIUtil;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.mockito.Mockito;
+
+import javax.servlet.ServletContextEvent;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * OSGIUtilTest
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class OSGIUtilTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+        // Initialize OSGI
+        initializeOSGIFramework();
+    }
+
+    /**
+     * Initialize Mock OSGI Framework
+     */
+    private static void initializeOSGIFramework() {
+        try {
+            Mockito.when(Config.CONTEXT.getRealPath("/WEB-INF/felix"))
+                .thenReturn(Config.getStringProperty("context.path.felix", "/WEB-INF/felix"));
+            ServletContextEvent context = new ServletContextEvent(Config.CONTEXT);
+            OSGIUtil.getInstance().initializeFramework(context);
+        } catch (Exception ex) {
+            throw new RuntimeException("Unable to initialize OSGI Framework", ex);
+        }
+    }
+
+    /**
+     * Restart the OSGI Framework
+     */
+    private void restartOSGI() {
+        //First we need to stop the framework
+        OSGIUtil.getInstance().stopFramework();
+
+        //Now we need to initialize it
+        initializeOSGIFramework();
+    }
+
+    /**
+     * Test the felix deploy path is the default path
+     */
+    @Test
+    public void test01DefaultFelixDeployPath() throws Exception {
+        String deployPath = OSGIUtil.getInstance().getFelixDeployPath();
+
+        Assert.assertNotNull(deployPath);
+        assertThat("Path ends with /WEB-INF/felix/load", deployPath.endsWith("/WEB-INF/felix/load"));
+    }
+
+    /**
+     * Test the felix undeploy path is the default path
+     */
+    @Test
+    public void test02DefaultFelixUndeployPath() throws Exception {
+        String undeployPath = OSGIUtil.getInstance().getFelixUndeployPath();
+
+        Assert.assertNotNull(undeployPath);
+        assertThat("Path ends with /WEB-INF/felix/undeployed", undeployPath.endsWith("/WEB-INF/felix/undeployed"));
+    }
+
+    /**
+     * Test the felix deploy path is a custom path
+     */
+    @Test
+    public void test03CustomFelixDeployPath() throws Exception {
+        String deployPath = Config.getStringProperty("context.path.felix", "/WEB-INF/felix");
+        deployPath = deployPath.replace("/WEB-INF/felix", "/WEB-INF/customfelix/load");
+        Config.setProperty("felix.felix.fileinstall.dir", deployPath);
+
+        restartOSGI();
+
+        deployPath = OSGIUtil.getInstance().getFelixDeployPath();
+
+        Assert.assertNotNull(deployPath);
+        assertThat("Path ends with /WEB-INF/customfelix/load", deployPath.endsWith("/WEB-INF/customfelix/load"));
+    }
+
+    /**
+     * Test the felix undeploy path is a custom path
+     */
+    @Test
+    public void test04CustomFelixUndeployPath() throws Exception {
+        String undeployPath = Config.getStringProperty("context.path.felix", "/WEB-INF/felix");
+        undeployPath = undeployPath.replace("/WEB-INF/felix", "/WEB-INF/customfelix/undeployed");
+        Config.setProperty("felix.felix.undeployed.dir", undeployPath);
+
+        restartOSGI();
+
+        undeployPath = OSGIUtil.getInstance().getFelixUndeployPath();
+
+        Assert.assertNotNull(undeployPath);
+        assertThat("Path ends with /WEB-INF/customfelix/undeployed",
+            undeployPath.endsWith("/WEB-INF/customfelix/undeployed"));
+    }
+
+}

--- a/dotCMS/src/integration-test/java/com/dotcms/osgi/OSGIUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/osgi/OSGIUtilTest.java
@@ -4,12 +4,15 @@ import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.OSGIUtil;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.mockito.Mockito;
+
+import java.io.File;
 
 import javax.servlet.ServletContextEvent;
 
@@ -80,16 +83,19 @@ public class OSGIUtilTest {
      */
     @Test
     public void test03CustomFelixDeployPath() throws Exception {
-        String deployPath = Config.getStringProperty("context.path.felix", "/WEB-INF/felix");
-        deployPath = deployPath.replace("/WEB-INF/felix", "/WEB-INF/customfelix/load");
-        Config.setProperty("felix.felix.fileinstall.dir", deployPath);
+        String felixPath = Config.getStringProperty("context.path.felix", "/WEB-INF/felix");
+        felixPath = felixPath.replace("/WEB-INF/felix", "/WEB-INF/customfelix");
+        Config.setProperty("felix.felix.base.dir", felixPath);
 
         restartOSGI();
 
-        deployPath = OSGIUtil.getInstance().getFelixDeployPath();
+        String deployFelixPath = OSGIUtil.getInstance().getFelixDeployPath();
 
-        Assert.assertNotNull(deployPath);
-        assertThat("Path ends with /WEB-INF/customfelix/load", deployPath.endsWith("/WEB-INF/customfelix/load"));
+        Assert.assertNotNull(deployFelixPath);
+        assertThat("Path ends with /WEB-INF/customfelix/load",
+            deployFelixPath.endsWith("/WEB-INF/customfelix/load"));
+
+        removeFolder(deployFelixPath);
     }
 
     /**
@@ -97,17 +103,32 @@ public class OSGIUtilTest {
      */
     @Test
     public void test04CustomFelixUndeployPath() throws Exception {
-        String undeployPath = Config.getStringProperty("context.path.felix", "/WEB-INF/felix");
-        undeployPath = undeployPath.replace("/WEB-INF/felix", "/WEB-INF/customfelix/undeployed");
-        Config.setProperty("felix.felix.undeployed.dir", undeployPath);
+        String felixPath = Config.getStringProperty("context.path.felix", "/WEB-INF/felix");
+        felixPath = felixPath.replace("/WEB-INF/felix", "/WEB-INF/customfelix");
+        Config.setProperty("felix.felix.base.dir", felixPath);
 
         restartOSGI();
 
-        undeployPath = OSGIUtil.getInstance().getFelixUndeployPath();
+        String undeployFelixPath = OSGIUtil.getInstance().getFelixUndeployPath();
 
-        Assert.assertNotNull(undeployPath);
+        Assert.assertNotNull(undeployFelixPath);
         assertThat("Path ends with /WEB-INF/customfelix/undeployed",
-            undeployPath.endsWith("/WEB-INF/customfelix/undeployed"));
+            undeployFelixPath.endsWith("/WEB-INF/customfelix/undeployed"));
+
+        removeFolder(felixPath);
     }
 
+    /**
+     * Remove created path
+     *
+     * @param path The path to remove
+     */
+    private void removeFolder(String path) {
+        try {
+            File directory = new File(path);
+            FileUtils.deleteDirectory(directory);
+        } catch (Exception ex) {
+            return;
+        }
+    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/osgi/AJAX/OSGIAJAX.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/osgi/AJAX/OSGIAJAX.java
@@ -139,14 +139,10 @@ public class OSGIAJAX extends OSGIBaseAJAX {
                         break;
                     }
 
+                    String felixDeployFolder = OSGIUtil.getInstance().getFelixDeployPath();
 
-                    String felixBaseFolder = OSGIUtil.getInstance().getFelixBasePath();
-
-                    File felixFolder  = (felixBaseFolder.startsWith("/WEB-INF")) ?
-                        new File(Config.CONTEXT.getRealPath(felixBaseFolder)) :
-                        new File(com.dotmarketing.util.FileUtil.getAbsolutlePath(felixBaseFolder));
-                    File osgiJar = new File(felixBaseFolder + "/load/" + fname);
-
+                    File felixFolder = new File(felixDeployFolder);
+                    File osgiJar = new File(felixDeployFolder + File.separator + fname);
 
                     if ( !felixFolder.exists() 
                             ||   !osgiJar.getCanonicalPath().startsWith(felixFolder.getCanonicalPath())) {


### PR DESCRIPTION
…load and undeploy folders are now fetched by properties (felix.felix.fileinstall.dir and felix.felix.undeployed.dir). These properties can be handled inside the dotmarketing.properties file as either full path or an external environment variable. All default felix files are still loaded on the default base folder (/WEB-INF/felix). If no properties are set they will be defaulted to the WEB-INF/felix base folder.