### PR TITLE
numberOfPuts was set to the most optimal size

### DIFF
--- a/dotCMS/src/test/java/com/dotmarketing/business/cache/provider/h22/H22CacheTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/business/cache/provider/h22/H22CacheTest.java
@@ -32,7 +32,7 @@ public class H22CacheTest {
 					+ "C"
 					+ "ASDSADFDDSFasfddsadasdsadsadasdq3r4efwqrrqwerqewrqewrqreqwreqwrqewrqwerqewrqewrqwerqwerqwerqewr43545324542354235243524354325423qwerewds fds fds gf eqgq ewg qeg qe wg egw	ww	eeR ASdsadsadadsadsadsadaqrewq43223t14@#$#@^%$%&%#$sfwf	erqwfewfqewfgqewdsfqewtr243fq43f4q444fa4ferfrearge");;
 	final String CANT_CACHE_KEYNAME = "CantCacheMe";
-	final int numberOfPuts = 10000;
+	final int numberOfPuts = 5000;
 	final int numberOfThreads = 40;
 	final int numberOfGroups = 100;
 	final int maxCharOfObjects = 100;


### PR DESCRIPTION
The goal was to set the numberOfPuts to 1000. However, it couldn't be accomplished because a minimum amount of time is needed by the test to save the cache groups, which wasn't being reached with 1000 puts and the test assertions failed. After some attempts, I figured out the most optimal size (5000 puts)