### PR TITLE
11196 tries to fix issue with Existing Database on AWS by adding branch into name

### DIFF
--- a/dotCMS/build-aws-tests.gradle
+++ b/dotCMS/build-aws-tests.gradle
@@ -222,6 +222,10 @@ task createDBInstance(type: AmazonRDSCreateDBInstanceTask) {
 	doFirst {
 		dbInstanceIdentifier = getDatabasePropertyIdentifier( properties, project.database, project.branch )
 
+		if ( ! "MSSQL".equalsIgnoreCase( project.database ) ) {
+			dbName = getDatabasePropertyName( properties, project.database, project.branch )
+		}
+
 		engine = getDatabaseProperty( properties, "engine", project.database )
 		dbInstanceClass = getDatabaseProperty( properties, "instance.class", project.database )
 
@@ -230,10 +234,6 @@ task createDBInstance(type: AmazonRDSCreateDBInstanceTask) {
 		licenseModel = getDatabaseProperty( properties, "license", project.database )
 		publiclyAccessible = getDatabaseProperty( properties, "public", project.database ).toBoolean()
 		allocatedStorage = getDatabaseProperty( properties, "storage", project.database ).toInteger()
-
-		if ( ! "MSSQL".equalsIgnoreCase( project.database ) ) {
-			dbName = getDatabaseProperty( properties, "name", project.database )
-		}
 
 		masterUsername = getDatabaseProperty( properties, "user.master.username", project.database )
 		masterUserPassword = getDatabaseProperty( properties, "user.master.password", project.database )
@@ -280,8 +280,9 @@ task describeDBInstance {
 	doLast {
 		String dbInstanceEndpoint = getDBInstanceEndpoint( getDatabasePropertyIdentifier( properties, project.database, project.branch ) )
 
+		String dbInstanceName = getDatabasePropertyName( properties, project.database, project.branch )
+
 		String dbDriverClassName = getDatabaseProperty( properties, "driver", project.database )
-		String dbInstanceName = getDatabaseProperty( properties, "name", project.database )
 		String dbInstancePort = getDatabaseProperty( properties, "port", project.database )
 		String dbInstanceUsername = getDatabaseProperty( properties, "user.master.username", project.database )
 		String dbInstancePassword = getDatabaseProperty( properties, "user.master.password", project.database )
@@ -491,6 +492,10 @@ task executeScript(dependsOn: [describeInstance, describeDBInstance]) {
 
 String getDatabasePropertyIdentifier(Properties properties, String database, String branch) {
 	return properties.getProperty( "db.instance.identifier.prefix" ) +"-"+ branch.toLowerCase().replace(".", "") +"-"+ database.toLowerCase()
+}
+
+String getDatabasePropertyName(Properties properties, String database, String branch) {
+	return getDatabaseProperty(properties, "name", database) + branch.toLowerCase().replace(".", "").replace("-", "")
 }
 
 String getDatabaseProperty(Properties properties, String propertyName, String database) {


### PR DESCRIPTION
+ ./gradlew -b build-aws-tests.gradle waitDBInstanceCreated setupDBInstance -PdbInstanceId= -Pdatabase=MSSQL -Pbranch=release-4.1 -Pcommit=795ce67d0c26dc23689428f85a5fcb370ec5552a -PkeyFile=/var/lib/jenkins/dotcms-dev-test-deploy-2017-02-0x5513.pem --no-daemon
To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/3.5/userguide/gradle_daemon.html.
Daemon will be stopped at the end of the build stopping after processing
:waitDBInstanceCreated
:describeDBInstance
Described DB Instance = dotcms-release-41-mssql.co9h1fjtxrge.us-west-2.rds.amazonaws.com
:setupDBInstance
Failed to execute: CREATE DATABASE dotcms because: Database 'dotcms' already exists. Choose a different database name.
:setupDBInstance FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/var/lib/jenkins/jobs/Git_Releases_Int_Funct_Test_Runner_MSSQL/workspace/release-4.1/dotCMS/build-aws-tests.gradle' line: 364

* What went wrong:
Execution failed for task ':setupDBInstance'.
> java.sql.SQLException: Database 'dotcms' already exists. Choose a different database name.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED