### PR TITLE
#469 updated language with new error messages and configured…

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -3722,7 +3722,9 @@ publisher_Endpoint_type_https=Dynamic dotCMS HTTPS
 publisher_Endpoint_type_awss3=Static AWS S3
 publisher_Endpoint_awss3_authKey_format_invalid=Invalid format for AWS S3 properties
 publisher_Endpoint_awss3_authKey_missing_properties=Some properties are missing for Static AWS S3 publisher
+publisher_Endpoint_awss3_authKey_missing_bucket_id=Bucket ID property missing for Static AWS S3 publisher
 publisher_Endpoint_awss3_authKey_properties_invalid=Cannot connect to AWS S3 with the provided properties
+publisher_Endpoint_DefaultAWSCredentialsProviderChain_invalid=Cannot connect to AWS S3 with DefaultAWSCredentialsProviderChain
 publisher_Endpoint_type_awss3_requires_platform_license=Static AWS S3 publisher requires a Platform Level License
 
 publisher_Endpoints_Sending_Server_Short=Send To


### PR DESCRIPTION
…PublishingEndpointAjaxAction to use the aws default credential provider chain if one or both of the token or secret are missing from the endpoint configuration