### PR TITLE
#11762 folder name set to lowercase

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/folder/business/FolderAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/folder/business/FolderAPITest.java
@@ -75,7 +75,7 @@ public class FolderAPITest {
 		// make sure the rename is properly propagated on children (that's done in a db trigger)
 		Identifier ident=APILocator.getIdentifierAPI().find(ftest),ident1=APILocator.getIdentifierAPI().find(ftest1),
 				ident2=APILocator.getIdentifierAPI().find(ftest2),ident3=APILocator.getIdentifierAPI().find(ftest3);
-		Assert.assertTrue(ident.getAssetName().startsWith("folderTestXX"));
+		Assert.assertTrue(ident.getAssetName().startsWith("foldertestxx"));//After 4.1 the asset_name is saved lowercase
 		Assert.assertEquals(ident.getPath(),ident1.getParentPath());
 		Assert.assertEquals(ident1.getPath(),ident2.getParentPath());
 		Assert.assertEquals(ident2.getPath(),ident3.getParentPath());

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -568,6 +568,7 @@ public class FolderAPIImpl implements FolderAPI  {
 
 		boolean isNew = folder.getInode() == null;
 		folder.setModDate(new Date());
+		folder.setName(folder.getName().toLowerCase());
 		ffac.save(folder, existingId);
 
 		SystemEventType systemEventType = isNew ? SystemEventType.SAVE_FOLDER : SystemEventType.UPDATE_FOLDER;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -849,7 +849,7 @@ public class FolderFactoryImpl extends FolderFactory {
 		});
 
         Folder ff=(Folder) HibernateUtil.load(Folder.class, folder.getInode());
-		ff.setName(newName);
+		ff.setName(newName.toLowerCase());
 		ff.setTitle(newName);
 		ff.setModDate(new Date());
 


### PR DESCRIPTION
https://github.com/dotCMS/core/blob/master/dotCMS/src/main/resources/postgres.sql#L2093 

When you update a folder the trigger above is triggered, it set the asset_name the name of the folder without matter the case it has. According to the upgrade task https://github.com/dotCMS/core/blob/master/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04115LowercaseIdentifierUrls.java almost everything under the columns parent_path and asset_name in the identifier table must be lowercase.