### PR TITLE
#12128 fix - send ContentType variable instead of name

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/cms/content/submit/util/SubmitContentUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/cms/content/submit/util/SubmitContentUtil.java
@@ -292,9 +292,9 @@ public class SubmitContentUtil {
 	 * @return Contentlet
 	 * @throws DotDataException
 	 */
-	private static Contentlet setAllFields(String structureName, List<String> parametersName, List<String[]> values) throws DotDataException{
+	private static Contentlet setAllFields(String structureVelVarName, List<String> parametersName, List<String[]> values) throws DotDataException{
 		LanguageAPI lAPI = APILocator.getLanguageAPI();
-		Structure st = CacheLocator.getContentTypeCache().getStructureByVelocityVarName(structureName);
+		Structure st = CacheLocator.getContentTypeCache().getStructureByVelocityVarName(structureVelVarName);
 		String contentletInode = null;
 		long contentLanguageId = 1;
 		Field fileField = new Field(),imageField=new Field(),binaryField=new Field();
@@ -454,7 +454,7 @@ public class SubmitContentUtil {
 		/**
 		 * Set the content values
 		 */
-		contentlet = SubmitContentUtil.setAllFields(st.getName(), parametersName, values);
+		contentlet = SubmitContentUtil.setAllFields(st.getVelocityVarName(), parametersName, values);
 
 
 		/**


### PR DESCRIPTION
Tested on master and backported fix to 4.1.1, along with fix from #12123. Forms can be submitted without issues.