### PR TITLE
fixes #12317

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/velocity/directive/DotParse.java
+++ b/dotCMS/src/main/java/com/dotmarketing/velocity/directive/DotParse.java
@@ -93,10 +93,8 @@ public class DotParse extends DotDirective {
         String errorMessage = String.format("Not found %s version of [%s]", (live) ? "Live" : "Working", templatePath);
         throw new ResourceNotFoundException(errorMessage);
       }
-
-      
       boolean respectFrontEndRolesForVTL = (!params.live) ? Config.getBooleanProperty("RESPECT_FRONTEND_ROLES_FOR_DOTPARSE", true) : params.live;
-      
+
       Contentlet c = APILocator.getContentletAPI().find(inode, params.user, respectFrontEndRolesForVTL);
       FileAsset asset = APILocator.getFileAssetAPI().fromContentlet(c);
       
@@ -113,19 +111,27 @@ public class DotParse extends DotDirective {
 
 
       return asset.getFileAsset().getAbsolutePath();
-    } catch (Exception e) {
-      Logger.warn(this.getClass(), " - unable to resolve " + templatePath + " getting this: "+ e.getMessage() );
-      if(e.getStackTrace().length>0)
-        Logger.warn(this.getClass(), " - at " + e.getStackTrace()[0]);
-      
-      //If we didn't find the resource don't change the exception type
-      if( e instanceof ResourceNotFoundException ) {
-        throw (ResourceNotFoundException) e;
-      }
-      else if(e instanceof DotSecurityException){
-          throw new ResourceNotFoundException(e) ;
-      }
-      throw new DotStateException(e);
+    } 
+    catch (ResourceNotFoundException e) {
+        Logger.warn(this.getClass(), " - unable to resolve " + templatePath + " getting this: "+ e.getMessage() );
+        if(e.getStackTrace().length>0){
+          Logger.warn(this.getClass(), " - at " + e.getStackTrace()[0]);
+        }
+        throw e;
+    }
+    catch (DotSecurityException  e) {
+        Logger.warn(this.getClass(), " - unable to resolve " + templatePath + " getting this: "+ e.getMessage() );
+        if(e.getStackTrace().length>0){
+            Logger.warn(this.getClass(), " - at " + e.getStackTrace()[0]);
+        }
+        throw new ResourceNotFoundException(e);
+    }
+    catch (Exception e) {
+        Logger.warn(this.getClass(), " - unable to resolve " + templatePath + " getting this: "+ e.getMessage() );
+        if(e.getStackTrace().length>0){
+            Logger.warn(this.getClass(), " - at " + e.getStackTrace()[0]);
+        }
+        throw new DotStateException(e);
     }
   }
 

--- a/dotCMS/src/main/java/com/dotmarketing/velocity/directive/DotParse.java
+++ b/dotCMS/src/main/java/com/dotmarketing/velocity/directive/DotParse.java
@@ -5,10 +5,12 @@ import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.filters.Constants;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.portlets.fileassets.business.FileAsset;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
@@ -92,7 +94,10 @@ public class DotParse extends DotDirective {
         throw new ResourceNotFoundException(errorMessage);
       }
 
-      Contentlet c = APILocator.getContentletAPI().find(inode, params.user, params.live);
+      
+      boolean respectFrontEndRolesForVTL = (!params.live) ? Config.getBooleanProperty("RESPECT_FRONTEND_ROLES_FOR_DOTPARSE", true) : params.live;
+      
+      Contentlet c = APILocator.getContentletAPI().find(inode, params.user, respectFrontEndRolesForVTL);
       FileAsset asset = APILocator.getFileAssetAPI().fromContentlet(c);
       
       
@@ -117,7 +122,9 @@ public class DotParse extends DotDirective {
       if( e instanceof ResourceNotFoundException ) {
         throw (ResourceNotFoundException) e;
       }
-      
+      else if(e instanceof DotSecurityException){
+          throw new ResourceNotFoundException(e) ;
+      }
       throw new DotStateException(e);
     }
   }


### PR DESCRIPTION
This will allow dotParse to render .vtls that have CMS_ANON read on them.