### PR TITLE
#12471 fixes in JSP

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/calendar/edit_event.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/calendar/edit_event.jsp
@@ -186,7 +186,7 @@ var editButtonRow="editEventButtonRow";
     			tabDividerOpen = true;%>
 					</div>
 				</div>
-				<div id="<%=f.getFieldContentlet()%>" dojoType="dijit.layout.ContentPane" title="<%=f.getFieldName()%>">
+				<div id="<%=f.getVelocityVarName()%>" dojoType="dijit.layout.ContentPane" title="<%=f.getFieldName()%>">
 					<div class="wrapperRight" style="height:100%;">
 						<div style="height:20px;"></div>
 			<% } else if(f.getFieldType().equals(Field.FieldType.CATEGORIES_TAB.toString())) {


### PR DESCRIPTION
Tested in current Master + H2 DB. 

Tested with Event Content Type, being this one the only Content Type affected because it uses its own JSP files.

Also tested with Site Content Type.

Note to QA:

In order to test this, the Content Type must have 2 or more Tab Dividers and group existing fields on each tab created.