### PR TITLE
add specific exception to avoid zeroing files #8552

### DIFF
--- a/dotCMS/src/main/java/com/liferay/util/FileUtil.java
+++ b/dotCMS/src/main/java/com/liferay/util/FileUtil.java
@@ -202,20 +202,17 @@ public class FileUtil {
                     sb.append(", destination: " + destination.getAbsolutePath());
                     Logger.warn(FileUtil.class, sb.toString());
                 }
-            }  catch (Exception e1) {
-                if (e1 instanceof FileAlreadyExistsException){
-                    StringBuilder sb = new StringBuilder();
-                    sb.append("Source File: " + source.getAbsolutePath());
-                    sb.append("already exists on the destination: " + destination.getAbsolutePath());
-                    Logger.debug(FileUtil.class, sb.toString());
-                }
-                if (e1 instanceof IOException ){
-                    hardLinks = false; // setting to false will execute the fallback
-                    StringBuilder sb = new StringBuilder();
-                    sb.append("Could not created the hard link, will try copy for source: " + source);
-                    sb.append(", destination: " + destination + ". Error message: " + e1.getMessage());
-                    Logger.debug(FileUtil.class, sb.toString());
-                }
+            }  catch (FileAlreadyExistsException e1) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("Source File: " + source.getAbsolutePath());
+                sb.append("already exists on the destination: " + destination.getAbsolutePath());
+                Logger.debug(FileUtil.class, sb.toString());
+            } catch (IOException e2 ){
+                hardLinks = false; // setting to false will execute the fallback
+                StringBuilder sb = new StringBuilder();
+                sb.append("Could not created the hard link, will try copy for source: " + source);
+                sb.append(", destination: " + destination + ". Error message: " + e2.getMessage());
+                Logger.debug(FileUtil.class, sb.toString());
             } 
         }
 

--- a/dotCMS/src/main/java/com/liferay/util/FileUtil.java
+++ b/dotCMS/src/main/java/com/liferay/util/FileUtil.java
@@ -47,6 +47,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -199,12 +200,15 @@ public class FileUtil {
                     Logger.warn(FileUtil.class, "Can't create hardLink. source: " + source.getAbsolutePath()
                             + ", destination: " + destination.getAbsolutePath());
                 }
-            } catch (IOException e) {
-
+            }  catch (FileAlreadyExistsException e1) {
+                Logger.debug(FileUtil.class,
+                        "Could not created the hard link, will try copy for source: " + source +
+                        ", destination: " + destination + ". Error message: " + e1.getMessage());
+            } catch (Exception e2) {
                 hardLinks = false; // setting to false will execute the fallback
                 Logger.debug(FileUtil.class,
                         "Could not created the hard link, will try copy for source: " + source +
-                        ", destination: " + destination + ". Error message: " + e.getMessage());
+                        ", destination: " + destination + ". Error message: " + e2.getMessage());
             }
         }
 

--- a/dotCMS/src/main/java/com/liferay/util/FileUtil.java
+++ b/dotCMS/src/main/java/com/liferay/util/FileUtil.java
@@ -197,19 +197,26 @@ public class FileUtil {
                 // setting this means we will try again if we cannot hard link
                 if (!destination.exists() || destination.length() == 0) {
                     hardLinks = false;
-                    Logger.warn(FileUtil.class, "Can't create hardLink. source: " + source.getAbsolutePath()
-                            + ", destination: " + destination.getAbsolutePath());
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("Can't create hardLink. source: " + source.getAbsolutePath());
+                    sb.append(", destination: " + destination.getAbsolutePath());
+                    Logger.warn(FileUtil.class, sb.toString());
                 }
-            }  catch (FileAlreadyExistsException e1) {
-                Logger.debug(FileUtil.class,
-                        "Could not created the hard link, will try copy for source: " + source +
-                        ", destination: " + destination + ". Error message: " + e1.getMessage());
-            } catch (Exception e2) {
-                hardLinks = false; // setting to false will execute the fallback
-                Logger.debug(FileUtil.class,
-                        "Could not created the hard link, will try copy for source: " + source +
-                        ", destination: " + destination + ". Error message: " + e2.getMessage());
-            }
+            }  catch (Exception e1) {
+                if (e1 instanceof FileAlreadyExistsException){
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("Source File: " + source.getAbsolutePath());
+                    sb.append("already exists on the destination: " + destination.getAbsolutePath());
+                    Logger.debug(FileUtil.class, sb.toString());
+                }
+                if (e1 instanceof IOException ){
+                    hardLinks = false; // setting to false will execute the fallback
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("Could not created the hard link, will try copy for source: " + source);
+                    sb.append(", destination: " + destination + ". Error message: " + e1.getMessage());
+                    Logger.debug(FileUtil.class, sb.toString());
+                }
+            } 
         }
 
         if (!hardLinks) {


### PR DESCRIPTION
#8552 

Tested on backported fix to 4.1.1. Files remain untouched once two site search jobs were run under the same cron expression