### PR TITLE
#12536 : As per Will's advice, marking all CMIS classes as deprecated…

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/cmis/CMISBaseTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/cmis/CMISBaseTest.java
@@ -33,6 +33,10 @@ import java.util.Map;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+/**
+ * @deprecated CMIS is deprecated and slated for removal.
+ */
+@Deprecated
 public class CMISBaseTest extends IntegrationTestBase {
 
 	protected static User user;

--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitAPIImpl.java
@@ -1,11 +1,26 @@
 package com.dotmarketing.business;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
 import com.dotcms.api.system.event.Payload;
 import com.dotcms.api.system.event.SystemEventType;
 import com.dotcms.api.system.event.SystemEventsAPI;
 import com.dotcms.api.system.event.Visibility;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Inode;
@@ -34,17 +49,6 @@ import com.google.common.collect.Sets;
 import com.liferay.portal.NoSuchRoleException;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.PortalUtil;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 /**
  * PermissionAPI is an API intended to be a helper class for class to get Permissions.  Classes within the dotCMS
@@ -165,11 +169,12 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return false;
 	}
 
-
+	@Override
 	public boolean doesRoleHavePermission(Permissionable permissionable, int permissionType, Role role, boolean respectFrontendRoles) throws DotDataException {
 		return doesRoleHavePermission(permissionable, permissionType, role);
 	}
 
+	@Override
 	public boolean doesRoleHavePermission(Permissionable permissionable, int permissionType, Role role) throws DotDataException {
 
 		// if we have bad data
@@ -220,8 +225,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return false;
 	}
 
-
-
+	@Override
 	public List<Permission> getInheritablePermissionsRecurse(Permissionable permissionable) throws DotDataException {
 		List<Permission> fPerms = getInheritablePermissions(permissionable, false);
 		Permissionable parent = permissionable.getParentPermissionable();
@@ -233,7 +237,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return fPerms;
 	}
 
-
+	@Override
 	public boolean doesUserHaveInheriablePermissions(Permissionable parentPermissionable, String type, int requiredPermissions, User user) throws DotDataException {
 
 		if(parentPermissionable == null){
@@ -273,9 +277,6 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return false;
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#doesUserHavePermission(com.dotmarketing.beans.Inode, int, com.liferay.portal.model.User)
-	 */
 	@Override
 	public void  checkPermission(Permissionable permissionable, PermissionLevel level, User user) throws DotSecurityException{
 		try{
@@ -288,20 +289,14 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		}
 	}
 
-
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#doesUserHavePermission(com.dotmarketing.beans.Inode, int, com.liferay.portal.model.User)
-	 */
+	@Override
 	public boolean doesUserHavePermission(Permissionable permissionable, int permissionType, User user) throws DotDataException {
 		return doesUserHavePermission(permissionable, permissionType, user, true);
 	}
 
-
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#doesUserHavePermission(com.dotmarketing.beans.Inode, int, com.liferay.portal.model.User, boolean)
-	 */
 	@CloseDBIfOpened
-	public boolean doesUserHavePermission(Permissionable permissionable, int permissionType, User user, boolean respectFrontendRoles) throws DotDataException {
+	@Override
+	public boolean doesUserHavePermission(final Permissionable permissionable, int permissionType, final User user, final boolean respectFrontendRoles) throws DotDataException {
 
 		// if we have bad data
 		if ((permissionable == null) || (!InodeUtils.isSet(permissionable.getPermissionId()))) {
@@ -325,12 +320,16 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 			permissionType=PERMISSION_EDIT;
 		}
 		
-		// http://jira.dotmarketing.net/browse/DOTCMS-6943
-		// everybody should be able to use file structures
-        if (permissionable instanceof Structure
-                && (permissionType==PERMISSION_WRITE || permissionType==PERMISSION_PUBLISH)
-                && ((Structure)permissionable).getStructureType()==Structure.STRUCTURE_TYPE_FILEASSET)
-            return true;
+        // everybody should be able to use file content types
+        if (permissionable instanceof Structure || permissionable instanceof ContentType) {
+            final Structure contentType = (permissionable instanceof ContentType)
+                            ? new StructureTransformer(ContentType.class.cast(permissionable)).asStructure()
+                            : Structure.class.cast(permissionable);
+            if ((PERMISSION_WRITE == permissionType || PERMISSION_PUBLISH == permissionType)
+                            && BaseContentType.FILEASSET.getType() == contentType.getStructureType()) {
+                return Boolean.TRUE;
+            }
+        }
 
 		Role adminRole;
 		Role anonRole;
@@ -424,10 +423,8 @@ public class PermissionBitAPIImpl implements PermissionAPI {
                 pAPI = APILocator.getPermissionAPI();
                 List<Role> role = pAPI.getRoles(inode, PermissionAPI.PERMISSION_READ + PermissionAPI.PERMISSION_EDIT + PermissionAPI.PERMISSION_PUBLISH, "", 0, 10, true);
                 if(role.size() > 0){
-                        int i = 0;
                         for (Role r : role) {
                                 ids.add(r.getId());
-                                i++;
                         }
                 }
         }
@@ -458,10 +455,8 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return doRolesHavePermission(userRoleIds,getPermissions(permissionable, true),permissionType);
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#removePermissionsOnInode(com.dotmarketing.beans.Inode)
-	 */
 	@WrapInTransaction
+	@Override
 	public void removePermissions(Permissionable permissionable) throws DotDataException {
 
 		permissionFactory.removePermissions(permissionable);
@@ -475,6 +470,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 
 	//This method can be used later
 	@WrapInTransaction
+	@Override
 	public void setDefaultCMSAnonymousPermissions(Permissionable permissionable) throws DotDataException{
 		Role cmsAnonymousRole;
 		try {
@@ -521,11 +517,8 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		}
 	}
 
-
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#setDefaultCMSAdminPermissions(com.dotmarketing.beans.Inode)
-	 */
 	@WrapInTransaction
+	@Override
 	public void setDefaultCMSAdminPermissions (Permissionable permissionable) throws DotDataException {
 		Role cmsAdminRole;
 		try {
@@ -550,10 +543,8 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#copyPermissions(com.dotmarketing.beans.Inode, com.dotmarketing.beans.Inode)
-	 */
 	@WrapInTransaction
+	@Override
 	public void copyPermissions(Permissionable from, Permissionable to) throws DotDataException {
 
 		permissionFactory.removePermissions(to);
@@ -584,32 +575,38 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	}
 
 	@CloseDBIfOpened
+	@Override
 	public List<Permission> getPermissions(Permissionable permissionable) throws DotDataException {
 		return permissionFactory.getPermissions(permissionable, false);
 	}
 
 	@CloseDBIfOpened
+	@Override
 	public List<Permission> getPermissions(Permissionable permissionable, boolean bitPermissions) throws DotDataException {
 		return permissionFactory.getPermissions(permissionable, bitPermissions);
 	}
 
 	@CloseDBIfOpened
+	@Override
 	public List<Permission> getPermissions(Permissionable permissionable,
 			boolean bitPermissions, boolean onlyIndividualPermissions) throws DotDataException {
 		return permissionFactory.getPermissions(permissionable, bitPermissions, onlyIndividualPermissions);
 	}
 
 	@CloseDBIfOpened
+	@Override
 	public List<Permission> getPermissions(Permissionable permissionable,
 			boolean bitPermissions, boolean onlyIndividualPermissions, boolean forceLoadFromDB) throws DotDataException {
 		return permissionFactory.getPermissions(permissionable, bitPermissions, onlyIndividualPermissions, forceLoadFromDB);
 	}
 
 	@CloseDBIfOpened
+	@Override
     public void addPermissionsToCache ( Permissionable permissionable ) throws DotDataException {
         permissionFactory.addPermissionsToCache( permissionable );
     }
 
+	@Override
     // todo: should be this a transaction (all of nothing on save several permissions)???
     public void save(Collection<Permission> permissions, Permissionable permissionable, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
         
@@ -630,7 +627,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	 * @throws DotDataException
 	 * @throws DotSecurityException
 	 */
-
+    @Override
 	public void save(Permission permission, Permissionable permissionable, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
 		save(permission, permissionable, user, respectFrontendRoles, true);
 	}
@@ -755,6 +752,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		AdminLogger.log(PermissionBitAPIImpl.class, "assign Permissions Action", "Assigning permissions to :"+permissionable.getPermissionId(),user);
 	}
 
+	@Override
 	public Set<User> getReadUsers(Permissionable permissionable) throws DotDataException {
 		Set<Role> roles = getReadRoles(permissionable);
 		Set<User> users = new HashSet<User>();
@@ -772,9 +770,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return users;
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#getReadRoles(com.dotmarketing.beans.Inode)
-	 */
+	@Override
 	public Set<Role> getReadRoles(Permissionable permissionable) throws DotDataException {
 		Set<Role> readPermissions = new HashSet<Role>();
 		List<Permission> permissions = getPermissions(permissionable);
@@ -788,9 +784,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return readPermissions;
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#getPublishRoles(com.dotmarketing.beans.Inode)
-	 */
+	@Override
 	public Set<Role> getPublishRoles(Permissionable permissionable) throws DotDataException {
 		Set<Role> publishPermissions = new HashSet<Role>();
 		List<Permission> permissions = getPermissions(permissionable);
@@ -804,6 +798,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return publishPermissions;
 	}
 
+	@Override
 	public Set<User> getWriteUsers(Permissionable permissionable) throws DotDataException {
 		Set<Role> roles = getWriteRoles(permissionable);
 		Set<User> users = new HashSet<User>();
@@ -823,9 +818,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return users;
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#getWriteRoles(com.dotmarketing.beans.Inode)
-	 */
+	@Override
 	public Set<Role> getWriteRoles(Permissionable permissionable) throws DotDataException {
 		Set<Role> writePermissions = new HashSet<Role>();
 		List<Permission> permissions = getPermissions(permissionable);
@@ -840,6 +833,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	}
 
 	@CloseDBIfOpened
+	@Override
 	public Set<Role> getRolesWithPermission(Permissionable permissionable, int permission) throws DotDataException {
 
 		Set<Role> roles = new HashSet<Role>();
@@ -853,6 +847,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 
 	}
 
+	@Override
 	public Set<User> getUsersWithPermission(Permissionable permissionable, int permission) throws DotDataException {
 		Set<Role> roles = getRolesWithPermission(permissionable, permission);
 		Set<User> users = new HashSet<User>();
@@ -870,11 +865,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return users;
 	}
 
-
-
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#doesUserOwn(com.dotmarketing.beans.Inode, com.liferay.portal.model.User)
-	 */
+	@Override
 	public boolean doesUserOwn(Inode inode, User user) throws DotDataException{
 		if(user == null || inode == null){
 			return false;
@@ -885,10 +876,8 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#mapAllPermissions()
-	 */
 	// PERMISSION MAP METHODS!!!
+	@Override
 	public void mapAllPermissions() throws DotDataException {
 
 		Logger.debug(PermissionBitAPIImpl.class, "\n\nGoing to map all Permissions!!!!");
@@ -900,10 +889,8 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		Logger.debug(PermissionBitAPIImpl.class, "\n\nFinished mapping all Permissions!!!!");
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#getPermissionIdsFromRoles()
-	 */
 	@CloseDBIfOpened
+	@Override
 	public List<Integer> getPermissionIdsFromRoles(final Permissionable permissionable, final Role[] roles,
 												   final User user) throws DotDataException {
 		Set<Integer> permissions = new TreeSet<Integer>();
@@ -975,6 +962,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return new ArrayList<Integer>(permissions);
 	}
 
+	@Override
 	public List<Integer> getPermissionIdsFromUser(Permissionable permissionable, User user) throws DotDataException {
 
 		RoleAPI roleAPI = APILocator.getRoleAPI();
@@ -984,9 +972,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#getRoles(long, int, java.lang.String, int, int)
-	 */
+	@Override
 	public List<Role> getRoles(String inode, int permissionType, String filter, int start, int limit) {
 
 		Inode inodeObj = null;
@@ -1025,7 +1011,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return roleList;
 	}
 
-
+	@Override
 	public List<Role> getRoles(String inode, int permissionType,
 			String filter, int start, int limit, boolean hideSystemRoles) {
 		List<Role> roleList = getRoles(inode, permissionType, filter, start, limit);
@@ -1039,10 +1025,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return roleList;
 	}
 
-
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#getRoleCount(long, int, java.lang.String)
-	 */
+	@Override
 	public int getRoleCount(String inode, int permissionType, String filter) {
 
 		Inode inodeObj = null;
@@ -1067,7 +1050,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return count;
 	}
 
-
+	@Override
 	public int getRoleCount(String inode, int permissionType,
 			String filter, boolean hideSystemRoles) {
 		Inode inodeObj = null;
@@ -1098,11 +1081,8 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return count;
 	}
 
-
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#getUsers(long, int, java.lang.String, int, int)
-	 */
 	@CloseDBIfOpened
+	@Override
 	public List<User> getUsers(String inode, int permissionType, String filter, int start, int limit) {
 
 		Inode inodeObj = null;
@@ -1128,10 +1108,8 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#getUserCount(long, int, java.lang.String)
-	 */
 	@CloseDBIfOpened
+	@Override
 	public int getUserCount(String inode, int permissionType, String filter) {
 
 		Inode inodeObj = null;
@@ -1151,15 +1129,18 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return count;
 	}
 
+	@Override
 	public void clearCache() {
 		CacheLocator.getPermissionCache().clearCache();
 	}
 
+	@Override
     public void removePermissionableFromCache(String permissionableId) {
         CacheLocator.getPermissionCache().remove(permissionableId);
     }
 
     @CloseDBIfOpened
+    @Override
 	public <P extends Permissionable> List<P> filterCollection(final List<P> inputList,
 															   final int requiredTypePermission,
 															   final boolean respectFrontendRoles, User user) throws DotDataException, DotSecurityException {
@@ -1190,6 +1171,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	}
 
 	@CloseDBIfOpened
+	@Override
 	public <P extends Permissionable> List<P> filterCollectionByDBPermissionReference(List<P> inputList, int requiredTypePermission,boolean respectFrontendRoles, User user) throws DotDataException, DotSecurityException {
 
 		RoleAPI roleAPI = APILocator.getRoleAPI();
@@ -1206,6 +1188,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	}
 
 	@WrapInTransaction
+	@Override
 	public void removePermissionsByRole(String roleId) {
 		try {
 			permissionFactory.removePermissionsByRole(roleId);
@@ -1215,31 +1198,37 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	}
 
 	@CloseDBIfOpened
+	@Override
 	public Map<String, Integer> getPermissionTypes() {
 		return permissionFactory.getPermissionTypes();
 	}
 
 	@WrapInTransaction
+	@Override
 	public void updateOwner(Permissionable asset, String ownerId) throws DotDataException {
 		permissionFactory.updateOwner(asset, ownerId);
 	}
 
+	@Override
 	public int maskOfAllPermissions () {
 		return permissionFactory.maskOfAllPermissions();
 	}
 
+	@Override
 	public List<Permission> getPermissionsByRole(Role role, boolean onlyFoldersAndHosts)
 			throws DotDataException {
 		return getPermissionsByRole(role, onlyFoldersAndHosts, false);
 	}
 
 	@CloseDBIfOpened
+	@Override
 	public List<Permission> getPermissionsByRole(Role role, boolean onlyFoldersAndHosts, boolean bitPermissions)
 		throws DotDataException {
 		return permissionFactory.getPermissionsByRole(role, onlyFoldersAndHosts, bitPermissions);
 	}
 
 	@WrapInTransaction
+	@Override
 	public void resetPermissionsUnder(Permissionable parent) throws DotDataException {
 		if(!parent.isParentPermissionable())
 			return;
@@ -1248,6 +1237,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	}
 
 	@CloseDBIfOpened
+	@Override
 	public List<Permission> getInheritablePermissions(Permissionable permissionable) throws DotDataException {
 		if(!permissionable.isParentPermissionable())
 			return null;
@@ -1255,6 +1245,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	}
 
 	@CloseDBIfOpened
+	@Override
 	public List<Permission> getInheritablePermissions(Permissionable permissionable, boolean bitPermissions) throws DotDataException {
 		if(!permissionable.isParentPermissionable())
 			return null;
@@ -1262,38 +1253,38 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	}
 
 	@WrapInTransaction
+	@Override
 	public void cascadePermissionUnder(Permissionable permissionable, Role role) throws DotDataException {
 		permissionFactory.cascadePermissionUnder(permissionable, role);
 	}
 
 	@WrapInTransaction
+	@Override
 	public void resetPermissionReferences(Permissionable perm) throws DotDataException {
 		permissionFactory.resetPermissionReferences(perm);
 
 	}
 
 	@WrapInTransaction
+	@Override
 	public void resetChildrenPermissionReferences(Structure structure) throws DotDataException {
 		permissionFactory.resetChildrenPermissionReferences(structure);
 	}
 
 	@WrapInTransaction
+	@Override
 	public void resetAllPermissionReferences() throws DotDataException {
 		permissionFactory.resetAllPermissionReferences();
 
 	}
 
-    /* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#doesUserHavePermissions(com.dotmarketing.beans.Inode, String, com.liferay.portal.model.User)
-	 */
+	@Override
 	public boolean doesUserHavePermissions(Permissionable permissionable, String requiredPermissions, User user) throws DotDataException{
 		return doesUserHavePermissions(permissionable, requiredPermissions, user, true);
 	}
 
-	/* (non-Javadoc)
-	 * @see com.dotmarketing.business.PermissionAPI#doesUserHavePermissions(com.dotmarketing.beans.Inode, String, com.liferay.portal.model.User, boolean)
-	 */
 	@CloseDBIfOpened
+	@Override
     public boolean doesUserHavePermissions(Permissionable permissionable, String requiredPermissions, User user, boolean respectFrontendRoles) throws DotDataException{
 
 		// if we have bad data
@@ -1468,6 +1459,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 		return false;
 	}
 
+	@Override
     public boolean doesUserHavePermissions(PermissionableType permType, int permissionType, User user) throws DotDataException {
     	if(user==null) return false;
 
@@ -1642,19 +1634,21 @@ public class PermissionBitAPIImpl implements PermissionAPI {
     }
 
     @CloseDBIfOpened
-    public Permissionable findParentPermissionable(Permissionable permissionable) throws DotDataException, DotSecurityException {
+    @Override
+    public Permissionable findParentPermissionable(final Permissionable permissionable) throws DotDataException, DotSecurityException {
 		Permissionable parentPermissionable=permissionable.getParentPermissionable();
 		if(parentPermissionable!=null) {
-			List<Permission> assetPermissions = getPermissions(permissionable, true);
-			Map<String, Inode> inodeCache = new HashMap<String, Inode>();
+			final List<Permission> assetPermissions = getPermissions(permissionable, true);
+			final Map<String, Inode> inodeCache = new HashMap<String, Inode>();
     		for(Permission p : assetPermissions) {
     			if(!p.getInode().equals(permissionable.getPermissionId())) {
-    				String assetInode = p.getInode();
-					Inode inode = inodeCache.get(p.getInode());
-					if(inode == null) {
-						inode = InodeFactory.getInode(assetInode, Inode.class);
-						inodeCache.put(inode.getInode(), inode);
-					}
+    				final String assetInode = p.getInode();
+                    Inode inode = inodeCache.get(p.getInode());
+                    if (null == inode) {
+                        // Both Structure and ContentType classes are handled properly here
+                        inode = InodeUtils.getInode(assetInode);
+                        inodeCache.put(inode.getInode(), inode);
+                    }
 					if(inode instanceof Folder) {
 						parentPermissionable = (Folder)inode;
 					} else if (inode instanceof Structure) {
@@ -1679,4 +1673,3 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	}
 
 }
-

--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
@@ -89,8 +89,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 1. The permisionable id
 	 * 2. The permisionable id
 	 */
-
-	private static final String loadPermissionSQL =
+	private static final String LOAD_PERMISSION_SQL =
 		" select {permission.*} from permission where inode_id = ? "+
         " union all "+
         " select {permission.*} from permission join permission_reference "+
@@ -102,7 +101,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * Parameters
 	 * 1. The reference id the references are pointing to
 	 */
-	private static final String loadPermissionReferencesByReferenceIdHSQL = "from " + PermissionReference.class.getCanonicalName() +
+	private static final String LOAD_PERMISSION_REFERENCES_BY_REFERENCEID_HSQL = "from " + PermissionReference.class.getCanonicalName() +
 		" permission_reference where reference_id = ?";
 
 	/*
@@ -113,7 +112,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 3. Type
 	 */
 
-	private static final String insertPermissionReferenceSQL =
+	private static final String INSERT_PERMISSION_REFERENCE_SQL =
 		DbConnectionFactory.isMySql() || DbConnectionFactory.isMsSql() || DbConnectionFactory.isH2() ?
 		"insert into permission_reference (asset_id, reference_id, permission_type) " +
 		"	values (?, ?, ?)":
@@ -130,7 +129,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 2. Permission type
 	 * 3. Reference id to be updated
 	 */
-	private static final String updatePermissionReferenceByReferenceIdSQL = "update permission_reference set reference_id = ? where permission_type = ? and reference_id = ?";
+	private static final String UPDATE_PERMISSION_REFERENCE_BY_REFERENCEID_SQL = "update permission_reference set reference_id = ? where permission_type = ? and reference_id = ?";
 
 	/*
 	 * To update a permission reference by the owner asset
@@ -139,7 +138,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 2. Permission type
 	 * 3. asset id
 	 */
-	private static final String updatePermissionReferenceByAssetIdSQL = "update permission_reference set reference_id = ? where permission_type = ? and asset_id = ?";
+	private static final String UPDATE_PERMISSION_REFERENCE_BY_ASSETID_SQL = "update permission_reference set reference_id = ? where permission_type = ? and asset_id = ?";
 
 	/*
 	 * Select permission references based on how are referencing the type of reference
@@ -147,33 +146,32 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 1. Reference id
 	 * 2. Permission type
 	 */
-	private static final String selectPermissionReferenceSQL = "select asset_id from permission_reference where reference_id = ? and permission_type = ?";
+	private static final String SELECT_PERMISSION_REFERENCE_SQL = "select asset_id from permission_reference where reference_id = ? and permission_type = ?";
 
 	/*
 	 * To remove a permission reference of an specific asset or referencing an asset
 	 *
 	 */
-	private static final String deletePermissionReferenceSQL = "delete from permission_reference where asset_id = ? or reference_id = ?";
+	private static final String DELETE_PERMISSION_REFERENCE_SQL = "delete from permission_reference where asset_id = ? or reference_id = ?";
 
 	/*
 	 * To remove all permission references
 	 *
 	 */
-	private static final String deleteAllPermissionReferencesSQL = "delete from permission_reference";
-
+	private static final String DELETE_ALL_PERMISSION_REFERENCES_SQL = "delete from permission_reference";
 
 	/*
 	 * To remove a permission reference of an specific asset
 	 *
 	 */
-	private static final String deletePermissionableReferenceSQL = "delete from permission_reference where asset_id = ?";
+	private static final String DELETE_PERMISSIONABLE_REFERENCE_SQL = "delete from permission_reference where asset_id = ?";
 
 	/*
 	 * To load template identifiers that are children of a host
 	 * Parameters
 	 * 1. The id of the host
 	 */
-	private static final String selectChildrenTemplateSQL =
+	private static final String SELECT_CHILD_TEMPLATE_SQL =
 		"select id from identifier where identifier.host_inode = ? and asset_type='template' ";
 
 	/*
@@ -181,7 +179,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * Parameters
 	 * 1. The id of the host
 	 */
-	private static final String selectChildrenTemplateWithIndividualPermissionsSQL =
+	private static final String SELECT_CHILD_TEMPLATE_WITH_INDIVIDUAL_PERMISSIONS_SQL =
         "select distinct identifier.id from identifier join permission on (inode_id = identifier.id) " +
         "where asset_type='template' and permission_type='" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "' " +
         "and host_inode = ? ";
@@ -193,7 +191,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteTemplatePermissionsSQL =
 		"delete from permission where inode_id in " +
-		"	(" + selectChildrenTemplateSQL + ")";
+		"	(" + SELECT_CHILD_TEMPLATE_SQL + ")";
 
 	/*
 	 * To remove all permission references of templates attached to an specific host
@@ -202,7 +200,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteTemplateReferencesSQL =
 		"delete from permission_reference where asset_id in " +
-		"	(" + selectChildrenTemplateSQL + ")";
+		"	(" + SELECT_CHILD_TEMPLATE_SQL + ")";
 
     /*
      * To insert permission references to all templates attached to a host, it only inserts the references if the template does not have
@@ -219,7 +217,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * Parameters
 	 * 1. The host id
 	 */
-	private static final String selectChildrenContainerSQL =
+    private static final String SELECT_CHILD_CONTAINER_SQL =
 		"select distinct identifier.id from identifier where " +
 		"identifier.host_inode = ? and asset_type='containers' ";
 
@@ -228,7 +226,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * Parameters
 	 * 1. The host id
 	 */
-	private final static String selectChildrenContainerWithIndividualPermissionsSQL =
+	private final static String SELECT_CHILD_CONTAINER_WITH_INDIVIDUAL_PERMISSIONS_SQL =
         "select distinct identifier.id from identifier join permission on (inode_id = identifier.id) " +
         "where asset_type='containers' and permission_type='" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "' " +
         "and host_inode = ? ";
@@ -240,7 +238,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteContainerPermissionsSQL =
 		"delete from permission where inode_id in " +
-		"	(" + selectChildrenContainerSQL + ")";
+		"	(" + SELECT_CHILD_CONTAINER_SQL + ")";
 
 	/*
 	 * To remove all permission references of containers attached to an specific host
@@ -249,7 +247,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteContainerReferencesSQL =
 		"delete from permission_reference where asset_id in " +
-		"	(" + selectChildrenContainerSQL + ")";
+		"	(" + SELECT_CHILD_CONTAINER_SQL + ")";
     /*
      * To insert permission references to all containers attached to a host, it only inserts the reference if the container does not have
      * a reference already and does not have individual permissions
@@ -263,7 +261,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	/**
 	 * Function name to get the folder path. MSSql need owner prefix dbo
 	 */
-	private static final String dotFolderPath=(DbConnectionFactory.isMsSql() ? "dbo.":"")+"dotFolderPath";
+	private static final String DOT_FOLDER_PATH=(DbConnectionFactory.isMsSql() ? "dbo.":"")+"dotFolderPath";
 
 	/*
 	 * To load folder inodes that are in the same tree/hierarchy of a parent host/folder
@@ -272,9 +270,9 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 2. Parent folder like path E.G. '/about/%' pass '%' if you want all from the host
 	 * 3. Parent folder exact path E.G. '/about/' pass '' if you want all from the host
 	 */
-	private static final String selectChildrenFolderSQL =
+	private static final String SELECT_CHILD_FOLDER_SQL =
 		"select distinct folder.inode from folder join identifier on (folder.identifier = identifier.id) where " +
-		"identifier.host_inode = ? and "+dotFolderPath+"(parent_path,asset_name) like ? and "+dotFolderPath+"(parent_path,asset_name) <> ? ";
+		"identifier.host_inode = ? and "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? and "+DOT_FOLDER_PATH+"(parent_path,asset_name) <> ? ";
 
 	/*
 	 * To load folder identifiers that are children of a host and have either individual and/or inheritable permissions
@@ -283,9 +281,9 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 2. Parent folder like path E.G. '/about/%' pass '%' if you want all from the host
 	 * 3. Parent folder exact path E.G. '/about/' pass '' if you want all from the host
 	 */
-	private static final String selectChildrenFolderWithDirectPermissionsSQL =
+	private static final String SELECT_CHILD_FOLDER_WITH_DIRECT_PERMISSIONS_SQL =
 	     "select distinct folder.inode from folder join identifier on (folder.identifier = identifier.id) join permission on (inode_id=folder.inode) where " +
-	     "identifier.host_inode = ? and "+dotFolderPath+"(parent_path,asset_name) like ? and "+dotFolderPath+"(parent_path,asset_name) <> ?";
+	     "identifier.host_inode = ? and "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? and "+DOT_FOLDER_PATH+"(parent_path,asset_name) <> ?";
 
 	/*
 	 * To remove all permissions of sub-folders of a given parent folder
@@ -296,7 +294,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteSubfolderPermissionsSQL =
 		"delete from permission where inode_id in " +
-		"	(" + selectChildrenFolderSQL + ")";
+		"	(" + SELECT_CHILD_FOLDER_SQL + ")";
 
 	/*
 	 * To delete all permission references on sub-folders of a given parent folder
@@ -310,19 +308,19 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteSubfolderReferencesSQL =
 			"delete from permission_reference where exists (" +
-			" " + selectChildrenFolderSQL + " and " +
+			" " + SELECT_CHILD_FOLDER_SQL + " and " +
 			"	permission_type = '" + Folder.class.getCanonicalName() + "' and asset_id = folder.inode)";
 
 	private final String deleteSubfolderReferencesSQLOnAdd =
 		"delete from permission_reference where exists(" +
-		" " + selectChildrenFolderSQL + " and " +
+		" " + SELECT_CHILD_FOLDER_SQL + " and " +
 		"	permission_type = '" + Folder.class.getCanonicalName() + "' and asset_id = folder.inode) " +
 		"and (reference_id in ( " +
 			"select distinct folder.inode " +
 			"from folder join identifier on (folder.identifier = identifier.id) " +
 			"where " +
 			"	identifier.host_inode = ? " +
-			"	and ("+dotFolderPath+"(parent_path,asset_name) not like ? OR "+dotFolderPath+"(parent_path,asset_name) = ?) " +
+			"	and ("+DOT_FOLDER_PATH+"(parent_path,asset_name) not like ? OR "+DOT_FOLDER_PATH+"(parent_path,asset_name) = ?) " +
 			"	and permission_type = 'com.dotmarketing.portlets.folders.model.Folder' " +
 			"	and reference_id = folder.inode" +
 			")" +
@@ -353,10 +351,10 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				"select nextval('permission_reference_seq'), ") +
 		" folder.inode, ?, '" + Folder.class.getCanonicalName() + "'" +
 		"	from folder where folder.inode in (" +
-		"		" + selectChildrenFolderSQL + " and " +
+		"		" + SELECT_CHILD_FOLDER_SQL + " and " +
 		"		folder.inode not in (" +
 		"			select asset_id from permission_reference join folder ref_folder on (reference_id = ref_folder.inode) where " +
-		"			"+dotFolderPath+"(parent_path,asset_name) like ? and permission_type = '" + Folder.class.getCanonicalName() + "'" +
+		"			"+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? and permission_type = '" + Folder.class.getCanonicalName() + "'" +
 		"		) and " +
 		"		folder.inode not in (" +
 		"			select inode_id from permission where " +
@@ -371,7 +369,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 1. The host id
 	 * 2. Parent folder like path E.G. '/about/%' pass '%' if you want all from the host
 	 */
-    private static final String selectChildrenHTMLPageSQL =
+	private static final String SELECT_CHILD_HTMLPAGE_SQL =
             "select distinct li.id from identifier li where" +
                 " li.asset_type='htmlpage' and li.host_inode = ? and li.parent_path like ?" +
             " UNION ALL" +
@@ -379,7 +377,8 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
                     " INNER JOIN contentlet lc ON (lc.identifier = li.id and li.asset_type = 'contentlet')" +
                     " INNER JOIN structure ls ON (lc.structure_inode = ls.inode and ls.structuretype = " + BaseContentType.HTMLPAGE.getType() + ")" +
                     " AND li.host_inode = ? and li.parent_path like ?";
-    private static final String selectChildrenHTMLPageOnPermissionsSQL =
+
+	private static final String SELECT_CHILD_HTMLPAGE_ON_PERMISSIONS_SQL =
             "select distinct li.id from identifier li" +
                     " JOIN permission_reference ON permission_type = '" + IHTMLPage.class.getCanonicalName() + "' and asset_id = li.id" +
                     " AND li.asset_type='htmlpage' and li.host_inode = ? and li.parent_path like ?" +
@@ -396,7 +395,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 1. The host id
 	 * 2. Parent folder like path E.G. '/about/%' pass '%' if you want all from the host
 	 */
-    private static final String selectChildrenHTMLPageWithIndividualPermissionsSQL =
+    private static final String SELECT_CHILD_HTMLPAGE_WITH_INDIVIDUAL_PERMISSIONS_SQL =
             "select distinct li.id from identifier li join permission on (inode_id = li.id) where " +
                     " li.asset_type='htmlpage' and li.host_inode = ? and li.parent_path like ? " +
                     " and permission_type = '" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "'" +
@@ -416,7 +415,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteHTMLPagePermissionsSQL =
 		"delete from permission where inode_id in " +
-		"	(" + selectChildrenHTMLPageSQL + ")";
+		"	(" + SELECT_CHILD_HTMLPAGE_SQL + ")";
 
 
 	/*
@@ -430,18 +429,18 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
     private final String deleteHTMLPageReferencesSQL =
 			(DbConnectionFactory.isMySql() ?
-					"delete from permission_reference where exists ( select id FROM (" + selectChildrenHTMLPageOnPermissionsSQL + ") AS C )" :
-					"delete from permission_reference where exists (" + selectChildrenHTMLPageOnPermissionsSQL + ")");
+					"delete from permission_reference where exists ( select id FROM (" + SELECT_CHILD_HTMLPAGE_ON_PERMISSIONS_SQL + ") AS C )" :
+					"delete from permission_reference where exists (" + SELECT_CHILD_HTMLPAGE_ON_PERMISSIONS_SQL + ")");
 
 	private final String deleteHTMLPageReferencesOnAddSQL =
 		(DbConnectionFactory.isMySql() ?
-				"delete from permission_reference where exists ( select id FROM (" + selectChildrenHTMLPageOnPermissionsSQL + ") AS C ) " :
-				"delete from permission_reference where exists (" + selectChildrenHTMLPageOnPermissionsSQL + ") ") +
+				"delete from permission_reference where exists ( select id FROM (" + SELECT_CHILD_HTMLPAGE_ON_PERMISSIONS_SQL + ") AS C ) " :
+				"delete from permission_reference where exists (" + SELECT_CHILD_HTMLPAGE_ON_PERMISSIONS_SQL + ") ") +
 		"and (reference_id in (" +
 			"select distinct folder.inode " +
 			" from folder join identifier on (folder.identifier = identifier.id) " +
 			" where identifier.host_inode = ? " +
-			" and ("+dotFolderPath+"(parent_path,asset_name) not like ? OR "+dotFolderPath+"(parent_path,asset_name) = ?) " +
+			" and ("+DOT_FOLDER_PATH+"(parent_path,asset_name) not like ? OR "+DOT_FOLDER_PATH+"(parent_path,asset_name) = ?) " +
 			" and reference_id = folder.inode" +
 			") " +
 			" OR EXISTS(SELECT c.inode " +
@@ -468,7 +467,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 1. The host id
 	 * 2. Parent folder like path E.G. '/about/%' pass '%' if you want all from the host
 	 */
-	private static final String selectChildrenLinkSQL =
+    private static final String SELECT_CHILD_LINK_SQL =
 		"select distinct identifier.id from identifier where " +
 		"asset_type='links' and identifier.host_inode = ? and identifier.parent_path like ?";
 
@@ -478,7 +477,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 1. The host id
 	 * 2. Parent folder like path E.G. '/about/%' pass '%' if you want all from the host
 	 */
-	private static final String selectChildrenLinkWithIndividualPermissionsSQL =
+	private static final String SELECT_CHILD_LINK_WITH_INDIVIDUAL_PERMISSIONS_SQL =
         "select distinct identifier.id from identifier join permission on (inode_id = identifier.id) where " +
         "asset_type='links' and identifier.host_inode = ? and identifier.parent_path like ? " +
         "and permission_type = '" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "'";
@@ -491,7 +490,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteLinkPermissionsSQL =
 		"delete from permission where inode_id in " +
-		"	(" + selectChildrenLinkSQL + ")";
+		"	(" + SELECT_CHILD_LINK_SQL + ")";
 
 	/*
 	 * To delete all permission references on menu links under a given folder hierarchy
@@ -504,19 +503,19 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteLinkReferencesSQL =
 			"delete from permission_reference where exists (" +
-			"	" + selectChildrenLinkSQL + " and" +
+			"	" + SELECT_CHILD_LINK_SQL + " and" +
 			"	permission_type = '" + Link.class.getCanonicalName() + "' and asset_id = identifier.id)";
 
 	private final String deleteLinkReferencesOnAddSQL =
 		"delete from permission_reference where exists (" +
-		"	" + selectChildrenLinkSQL + " and" +
+		"	" + SELECT_CHILD_LINK_SQL + " and" +
 		"	permission_type = '" + Link.class.getCanonicalName() + "' and asset_id = identifier.id) " +
 		"and (reference_id in (" +
 		"select distinct folder.inode " +
 		"from folder join identifier on (folder.identifier = identifier.id) " +
 		"where " +
 		" identifier.host_inode = ? " +
-		" and ("+dotFolderPath+"(parent_path,asset_name) not like ? OR "+dotFolderPath+"(parent_path,asset_name) = ?) " +
+		" and ("+DOT_FOLDER_PATH+"(parent_path,asset_name) not like ? OR "+DOT_FOLDER_PATH+"(parent_path,asset_name) = ?) " +
 		" and permission_type = 'com.dotmarketing.portlets.folders.model.Folder' " +
 		" and reference_id = folder.inode" +
 		") " +
@@ -544,7 +543,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 1. The host id
 	 * 2. Parent folder like path E.G. '/about/%' pass '%' if you want all from the host
 	 */
-	private static final String selectChildrenContentByPathSQL =
+    private static final String SELECT_CHILD_CONTENT_BY_PATH_SQL =
         "select distinct identifier.id from identifier where asset_type='contentlet' " +
         " and identifier.id <> identifier.host_inode and identifier.host_inode = ? " +
         " and identifier.parent_path like ?";
@@ -555,7 +554,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * 1. The host id
 	 * 2. Parent folder like path E.G. '/about/%' pass '%' if you want all from the host
 	 */
-    private static final String selectChildrenContentWithIndividualPermissionsByPathSQL =
+    private static final String SELECT_CHILD_CONTENT_WITH_INDIVIDUAL_PERMISSIONS_BY_PATH_SQL =
             "select distinct li.id from identifier li" +
                 " join permission lp on (lp.inode_id = li.id) " +
                 " INNER JOIN contentlet lc ON (lc.identifier = li.id and li.asset_type = 'contentlet')" +
@@ -569,9 +568,9 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * To load content identifiers that are of the type of a structure
 	 *
 	 * Parameters
-	 * 1. The structure inode
+	 * 1. The content type inode
 	 */
-	private static final String selectChildrenContentByStructureSQL =
+	private static final String SELECT_CHILD_CONTENT_BY_CONTENTTYPE_SQL =
 			" select distinct contentlet.identifier as id from contentlet " +
 			" where contentlet.structure_inode = ?";
 
@@ -583,7 +582,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteContentPermissionsByPathSQL =
 		"delete from permission where inode_id in " +
-		"	(" + selectChildrenContentByPathSQL + ")";
+		"	(" + SELECT_CHILD_CONTENT_BY_PATH_SQL + ")";
 
 	/*
 	 * To delete all permission references on content under a given host/folder hierarchy
@@ -596,18 +595,18 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 */
 	private final String deleteContentReferencesByPathSQL =
 			"delete from permission_reference where exists (" +
-			"	" + selectChildrenContentByPathSQL + " and " +
+			"	" + SELECT_CHILD_CONTENT_BY_PATH_SQL + " and " +
 			"permission_type = '" + Contentlet.class.getCanonicalName() + "' and asset_id = identifier.id)";
 
 	private final String deleteContentReferencesByPathOnAddSQL =
 		"delete from permission_reference where exists (" +
-		"	" + selectChildrenContentByPathSQL + " and " +
+		"	" + SELECT_CHILD_CONTENT_BY_PATH_SQL + " and " +
 		"permission_type = '" + Contentlet.class.getCanonicalName() + "' and asset_id = identifier.id) " +
 		"and (reference_id in (" +
 		"select distinct folder.inode " +
 		"from folder join identifier on (folder.identifier = identifier.id) " +
 		"where identifier.host_inode = ? " +
-		"and ("+dotFolderPath+"(parent_path,asset_name) not like ? OR "+dotFolderPath+"(parent_path,asset_name) = ?) " +
+		"and ("+DOT_FOLDER_PATH+"(parent_path,asset_name) not like ? OR "+DOT_FOLDER_PATH+"(parent_path,asset_name) = ?) " +
 		"and permission_type = '"+Contentlet.class.getCanonicalName()+"' " +
 		"and reference_id = folder.inode" +
 		") " +
@@ -618,19 +617,19 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	/*
 	 * To remove all permissions of content under a given parent folder
 	 * Parameters
-	 * 1. structure inode
+	 * 1. content type inode
 	 */
 	private final String deleteContentPermissionsByStructureSQL =
 		"delete from permission where inode_id in " +
-		"	(" + selectChildrenContentByStructureSQL + ")";
+		"	(" + SELECT_CHILD_CONTENT_BY_CONTENTTYPE_SQL + ")";
 
 	/*
-	 * To delete all permission references on content under a given structure
+	 * To delete all permission references on content under a given content type
 	 *
 	 * Parameters
-	 * 1. structure inode
+	 * 1. content type inode
 	 */
-	private static final String deleteContentReferencesByStructureSQL =
+	private static final String DELETE_CONTENT_REFERENCES_BY_CONTENTTYPE_SQL =
 		"delete from permission_reference where exists (" +
 		" select contentlet.identifier from contentlet " +
 		" where contentlet.structure_inode = ? " +
@@ -657,7 +656,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 * does not already have a reference or individual permissions assigned
 	 *
 	 * Parameters
-	 * 1. structure id
+	 * 1. content type id
 	 */
 	private final String insertContentReferencesByStructureSQL =
 		(DbConnectionFactory.isMySql() || DbConnectionFactory.isMsSql() || DbConnectionFactory.isH2() ?
@@ -670,7 +669,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				"select nextval('permission_reference_seq'), ") +
 		"	identifier.id, ?, '" + Contentlet.class.getCanonicalName() + "' " +
 		"	from identifier where identifier.id in (" +
-		"		" + selectChildrenContentByStructureSQL + " and " +
+		"		" + SELECT_CHILD_CONTENT_BY_CONTENTTYPE_SQL + " and " +
 		"		identifier.id not in (" +
 		"			select asset_id from permission_reference " +
 		"		) and " +
@@ -684,85 +683,85 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 
 	/*
-	 * To load structure identifiers that are in the same tree/hierarchy of a parent host/folder
+	 * To load content type identifiers that are in the same tree/hierarchy of a parent host/folder
 	 *
 	 * Parameters
-	 * 1. path like to the folder hierarchy the structure lives under E.G /about/% (files under /about/)
+	 * 1. path like to the folder hierarchy the content type lives under E.G /about/% (files under /about/)
 	 * 2. The host id
 	 * 3. The host id
 	 */
-	private static final String selectChildrenStructureByPathSQL =
+	private static final String SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL =
 		"select distinct structure.inode from structure where ( " +
 		"(structure.folder <> 'SYSTEM_FOLDER' AND exists(" +
 		"         select folder.inode from folder join identifier on (identifier.id=folder.identifier) " +
-		"         where structure.folder = folder.inode and "+dotFolderPath+"(parent_path,asset_name) like ?)) OR " +
+		"         where structure.folder = folder.inode and "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ?)) OR " +
 		"(structure.host <> 'SYSTEM_HOST' AND structure.host = ?) OR " +
 		"(structure.host = 'SYSTEM_HOST' AND exists (select inode from contentlet where title = 'System Host' AND inode = ?)))";
 
 
 	/*
-	 * To load structure identifiers that are in the same tree/hierarchy of a parent host/folder
+	 * To load content type identifiers that are in the same tree/hierarchy of a parent host/folder
 	 *
 	 * Parameters
-	 * 1. path like to the folder hierarchy the structure lives under E.G /about/% (files under /about/)
+	 * 1. path like to the folder hierarchy the content type lives under E.G /about/% (files under /about/)
 	 * 2. The host id
 	 * 3. The host id
 	 */
-	private static final String selectChildrenStructureByPathSQLFolder =
+	private static final String SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL_FOLDER =
 		"select distinct structure.inode from structure where ( " +
 		"(structure.folder <> 'SYSTEM_FOLDER' AND exists(" +
 		"            select folder.inode from folder join identifier on(identifier.id=folder.identifier) " +
-		"            where structure.folder = folder.inode and "+dotFolderPath+"(parent_path,asset_name) like ?)) OR " +
+		"            where structure.folder = folder.inode and "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ?)) OR " +
 		"(structure.host = 'SYSTEM_HOST' AND exists (select inode from contentlet where title = 'System Host' AND inode = ?)))";
 
 	/*
-	 * To delete all permission references on a structure under a given host/folder hierarchy
+	 * To delete all permission references on a content type under a given host/folder hierarchy
 	 *
 	 * Parameters
-	 * 1. path like to the folder hierarchy the structure lives under E.G /about/% (files under /about/)
-	 * 2. host the structure belongs to
-	 * 3. host the structure belongs to
-	 * 4. host the structure belongs to
+	 * 1. path like to the folder hierarchy the content type lives under E.G /about/% (files under /about/)
+	 * 2. host the content type belongs to
+	 * 3. host the content type belongs to
+	 * 4. host the content type belongs to
 	 * 5. same as 1
 	 */
-	private static final String deleteStructureReferencesByPathSQL =
+	private static final String DELETE_CONTENTTYPE_REFERENCES_BY_PATH_SQL =
 			"delete from permission_reference where exists (" +
-			"	" + selectChildrenStructureByPathSQL + " and asset_id = structure.inode and " +
+			"	" + SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL + " and asset_id = structure.inode and " +
 			"permission_type = '" + Structure.class.getCanonicalName() + "' and reference_id not in (" +
 			"select ref_folder.inode from folder ref_folder join identifier ref_ident on (ref_folder.identifier = ref_ident.id) where " +
-			"ref_ident.host_inode = ? and "+dotFolderPath+"(ref_ident.parent_path,ref_ident.asset_name) like ?))";
+			"ref_ident.host_inode = ? and "+DOT_FOLDER_PATH+"(ref_ident.parent_path,ref_ident.asset_name) like ?))";
 
 
 	/*
-	 * To delete all permission references on a structure under a given host/folder hierarchy
+	 * To delete all permission references on a content type under a given host/folder hierarchy
 	 *
 	 * Parameters
-	 * 1. path like to the folder hierarchy the structure lives under E.G /about/% (files under /about/)
-	 * 2. host the structure belongs to
-	 * 3. host the structure belongs to
-	 * 4. host the structure belongs to
+	 * 1. path like to the folder hierarchy the content type lives under E.G /about/% (files under /about/)
+	 * 2. host the content type belongs to
+	 * 3. host the content type belongs to
+	 * 4. host the content type belongs to
 	 * 5. same as 1
 	 */
 	private final String deleteStructureReferencesByPathSQLFolder =
 			"delete from permission_reference where exists (" +
-			"	" + selectChildrenStructureByPathSQLFolder + " and asset_id = structure.inode and " +
+			"	" + SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL_FOLDER + " and asset_id = structure.inode and " +
 			"permission_type = '" + Structure.class.getCanonicalName() + "' and reference_id not in (" +
 			"select ref_folder.inode from folder ref_folder join identifier ref_ident on (ref_folder.identifier = ref_ident.id) where " +
-			"ref_ident.host_inode = ? and "+dotFolderPath+"(ref_ident.parent_path,ref_ident.asset_name) like ?))";
+			"ref_ident.host_inode = ? and "+DOT_FOLDER_PATH+"(ref_ident.parent_path,ref_ident.asset_name) like ?))";
 
 
-	private static final String deleteStructureReferencesByPathOnAddSQL =
+	private static final String DELETE_CONTENTTYPE_REFERENCES_BY_PATH_ON_ADD_SQL =
 		"delete from permission_reference where exists(" +
-		"	" + selectChildrenStructureByPathSQL + " and asset_id = structure.inode and " +
+		"	" + SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL + " and asset_id = structure.inode and " +
 		"permission_type = '" + Structure.class.getCanonicalName() + "' and reference_id not in (" +
 		"select ref_folder.inode from folder ref_folder join identifier ref_ident on (ref_folder.identifier = ref_ident.id) where " +
-		"ref_ident.host_inode = ? and "+dotFolderPath+"(ref_ident.parent_path,ref_ident.asset_name) like ?)) " +
+		"ref_ident.host_inode = ? and "+DOT_FOLDER_PATH+"(ref_ident.parent_path,ref_ident.asset_name) like ?)) " +
 		"and (reference_id in (" +
 		"select distinct folder.inode " +
 		"from folder join identifier on(folder.identifier = identifier.id) " +
 		"where " +
 		"identifier.host_inode = ? " +
-		"and ("+dotFolderPath+"(parent_path,asset_name) not like ? OR "+dotFolderPath+"(parent_path,asset_name) = ?) " +
+		"and ("+DOT_FOLDER_PATH+"(parent_path,asset_name) not like ? OR "+DOT_FOLDER_PATH+"(parent_path,asset_name) = ?) " +
 		"and permission_type = 'com.dotmarketing.portlets.folders.model.Folder' " +
 		"and reference_id = folder.inode" +
 		") " +
@@ -774,16 +773,16 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 	private final String deleteStructureReferencesByPathOnAddSQLFolder =
 			"delete from permission_reference where exists(" +
-			"	" + selectChildrenStructureByPathSQLFolder + " and asset_id = structure.inode and " +
+			"	" + SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL_FOLDER + " and asset_id = structure.inode and " +
 			"permission_type = '" + Structure.class.getCanonicalName() + "' and reference_id not in (" +
 			"select ref_folder.inode from folder ref_folder join identifier ref_ident on(ref_folder.identifier = ref_ident.id) where  " +
-			"ref_ident.host_inode = ? and "+dotFolderPath+"(ref_ident.parent_path,ref_ident.asset_name) like ?)) " +
+			"ref_ident.host_inode = ? and "+DOT_FOLDER_PATH+"(ref_ident.parent_path,ref_ident.asset_name) like ?)) " +
 			"and (reference_id in (" +
 			"select distinct folder.inode " +
 			"from folder join identifier on (folder.identifier = identifier.id) " +
 			"where " +
 			"identifier.host_inode = ? " +
-			"and ("+dotFolderPath+"(parent_path,asset_name) not like ? OR "+dotFolderPath+"(parent_path,asset_name) = ?) " +
+			"and ("+DOT_FOLDER_PATH+"(parent_path,asset_name) not like ? OR "+DOT_FOLDER_PATH+"(parent_path,asset_name) = ?) " +
 			"and permission_type = 'com.dotmarketing.portlets.folders.model.Folder' " +
 			"and reference_id = folder.inode" +
 			") " +
@@ -794,17 +793,17 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 
 	/*
-	 * To insert permission references for structure under a parent folder hierarchy, it only inserts the references if the structure
+	 * To insert permission references for content type under a parent folder hierarchy, it only inserts the references if the structure
 	 * does not already have a reference or individual permissions assigned
 	 *
 	 * Parameters
 	 * 1. folder/host id the new references are going to point to
-	 * 2. path like to the folder hierarchy the structure lives under E.G /about/% (files under /about/)
-	 * 3. host the structure belongs to
-	 * 4. host the structure belongs to
+	 * 2. path like to the folder hierarchy the content type lives under E.G /about/% (files under /about/)
+	 * 3. host the content type belongs to
+	 * 4. host the content type belongs to
 	 * 5. same as 2
 	 */
-	private static final String insertStructureReferencesByPathSQL =
+	private static final String INSERT_CONTENTTYPE_REFERENCES_BY_PATH_SQL =
 		(DbConnectionFactory.isMySql() || DbConnectionFactory.isMsSql() || DbConnectionFactory.isH2() ?
 				"insert into permission_reference (asset_id, reference_id, permission_type) " +
 				"select ":
@@ -815,11 +814,11 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				"select nextval('permission_reference_seq'), ") +
 		"	structure.inode, ?, '" + Structure.class.getCanonicalName() + "' " +
 		"	from structure where structure.inode in (" +
-		"		" + selectChildrenStructureByPathSQL + " and" +
+		"		" + SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL + " and" +
 		"		structure.inode not in (" +
 		"			select asset_id from permission_reference join folder ref_folder on(reference_id = ref_folder.inode) " +
 		"                                join identifier on (ref_folder.identifier=identifier.id) where " +
-		"			"+dotFolderPath+"(parent_path,asset_name) like ? and permission_type = '" + Structure.class.getCanonicalName() + "'" +
+		"			"+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? and permission_type = '" + Structure.class.getCanonicalName() + "'" +
 		"		) and " +
 		"		structure.inode not in (" +
 		"			select inode_id from permission where " +
@@ -830,14 +829,14 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 
 	/*
-	 * To insert permission references for structure under a parent folder hierarchy, it only inserts the references if the structure
+	 * To insert permission references for content type under a parent folder hierarchy, it only inserts the references if the structure
 	 * does not already have a reference or individual permissions assigned
 	 *
 	 * Parameters
 	 * 1. folder/host id the new references are going to point to
-	 * 2. path like to the folder hierarchy the structure lives under E.G /about/% (files under /about/)
-	 * 3. host the structure belongs to
-	 * 4. host the structure belongs to
+	 * 2. path like to the folder hierarchy the content type lives under E.G /about/% (files under /about/)
+	 * 3. host the content type belongs to
+	 * 4. host the content type belongs to
 	 * 5. same as 2
 	 */
 	private final String insertStructureReferencesByPathSQLFolder =
@@ -851,11 +850,11 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				"select nextval('permission_reference_seq'), ") +
 		"	structure.inode, ?, '" + Structure.class.getCanonicalName() + "' " +
 		"	from structure where structure.inode in (" +
-		"		" + selectChildrenStructureByPathSQLFolder + " and" +
+		"		" + SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL_FOLDER + " and" +
 		"		structure.inode not in (" +
 		"			select asset_id from permission_reference join folder ref_folder on (reference_id = ref_folder.inode) " +
 		"                               join identifier on (ref_folder.identifier=identifier.id) where " +
-		"			"+dotFolderPath+"(parent_path,asset_name) like ? and permission_type = '" + Structure.class.getCanonicalName() + "'" +
+		"			"+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? and permission_type = '" + Structure.class.getCanonicalName() + "'" +
 		"		) and " +
 		"		structure.inode not in (" +
 		"			select inode_id from permission where " +
@@ -867,38 +866,38 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	/*
 	 * To remove all permissions of structures under a given parent folder
 	 * Parameters
-	 * 1. path like to the folder hierarchy the structure lives under E.G /about/% (files under /about/)
+	 * 1. path like to the folder hierarchy the content type lives under E.G /about/% (files under /about/)
 	 * 2. The host id
 	 * 3. The host id
 	 */
-	private static final String deleteStructurePermissionsByPathSQL =
+	private static final String DELETE_CONTENTTYPE_PERMISSIONS_BY_PATH_SQL =
 		"delete from permission where inode_id in " +
-		"	(" + selectChildrenStructureByPathSQL + ")";
+		"	(" + SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL + ")";
 
 
 	/*
 	 * To remove all permissions of structures under a given parent folder
 	 * Parameters
-	 * 1. path like to the folder hierarchy the structure lives under E.G /about/% (files under /about/)
+	 * 1. path like to the folder hierarchy the content type lives under E.G /about/% (files under /about/)
 	 * 2. The host id
 	 * 3. The host id
 	 */
 	private final String deleteStructurePermissionsByPathSQLFolder =
 		"delete from permission where inode_id in " +
-		"	(" + selectChildrenStructureByPathSQLFolder + ")";
+		"	(" + SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL_FOLDER + ")";
 
 	/*
-	 * To load structure identifiers that are children of a host and have inheritable permissions
+	 * To load content type identifiers that are children of a host and have inheritable permissions
 	 * Parameters
-	 * 1. path like to the folder hierarchy the structure lives under E.G /about/% (files under /about/)
+	 * 1. path like to the folder hierarchy the content type lives under E.G /about/% (files under /about/)
 	 * 2. The host id
 	 * 3. The host id
 	 */
-	private static final String selectChildrenStructureWithIndividualPermissionsByPathSQL =
-		selectChildrenStructureByPathSQL + " and exists (select * from permission where inode_id = structure.inode and " +
+	private static final String SELECT_CHILD_CONTENTTYPE_WITH_INDIVIDUAL_PERMISSIONS_BY_PATH_SQL =
+		SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL + " and exists (select * from permission where inode_id = structure.inode and " +
 		"permission_type = '" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "')";
 
-	private static final Map<PermissionType, String> selectChildrenWithIndividualPermissionsSQLs = new HashMap<>();
+	private static final Map<PermissionType, String> SELECT_CHILDREN_WITH_INDIVIDUAL_PERMISSIONS_SQLS = new HashMap<>();
 
 	static {
 		String[] listOfMasks = PermissionAPI.PERMISSION_TYPES;
@@ -916,13 +915,13 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 		}
 
-		selectChildrenWithIndividualPermissionsSQLs.put(PermissionType.TEMPLATE, selectChildrenTemplateWithIndividualPermissionsSQL);
-		selectChildrenWithIndividualPermissionsSQLs.put(PermissionType.CONTAINER, selectChildrenContainerWithIndividualPermissionsSQL);
-		selectChildrenWithIndividualPermissionsSQLs.put(PermissionType.FOLDER, selectChildrenFolderWithDirectPermissionsSQL);
-		selectChildrenWithIndividualPermissionsSQLs.put(PermissionType.IHTMLPAGE, selectChildrenHTMLPageWithIndividualPermissionsSQL);
-		selectChildrenWithIndividualPermissionsSQLs.put(PermissionType.LINK, selectChildrenLinkWithIndividualPermissionsSQL);
-		selectChildrenWithIndividualPermissionsSQLs.put(PermissionType.CONTENTLET, selectChildrenContentWithIndividualPermissionsByPathSQL);
-		selectChildrenWithIndividualPermissionsSQLs.put(PermissionType.STRUCTURE, selectChildrenStructureWithIndividualPermissionsByPathSQL);
+		SELECT_CHILDREN_WITH_INDIVIDUAL_PERMISSIONS_SQLS.put(PermissionType.TEMPLATE, SELECT_CHILD_TEMPLATE_WITH_INDIVIDUAL_PERMISSIONS_SQL);
+		SELECT_CHILDREN_WITH_INDIVIDUAL_PERMISSIONS_SQLS.put(PermissionType.CONTAINER, SELECT_CHILD_CONTAINER_WITH_INDIVIDUAL_PERMISSIONS_SQL);
+		SELECT_CHILDREN_WITH_INDIVIDUAL_PERMISSIONS_SQLS.put(PermissionType.FOLDER, SELECT_CHILD_FOLDER_WITH_DIRECT_PERMISSIONS_SQL);
+		SELECT_CHILDREN_WITH_INDIVIDUAL_PERMISSIONS_SQLS.put(PermissionType.IHTMLPAGE, SELECT_CHILD_HTMLPAGE_WITH_INDIVIDUAL_PERMISSIONS_SQL);
+		SELECT_CHILDREN_WITH_INDIVIDUAL_PERMISSIONS_SQLS.put(PermissionType.LINK, SELECT_CHILD_LINK_WITH_INDIVIDUAL_PERMISSIONS_SQL);
+		SELECT_CHILDREN_WITH_INDIVIDUAL_PERMISSIONS_SQLS.put(PermissionType.CONTENTLET, SELECT_CHILD_CONTENT_WITH_INDIVIDUAL_PERMISSIONS_BY_PATH_SQL);
+		SELECT_CHILDREN_WITH_INDIVIDUAL_PERMISSIONS_SQLS.put(PermissionType.STRUCTURE, SELECT_CHILD_CONTENTTYPE_WITH_INDIVIDUAL_PERMISSIONS_BY_PATH_SQL);
 	}
 
 	/**
@@ -1101,15 +1100,15 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	 *
 	 */
 	@SuppressWarnings("unchecked")
-	private void updatePermissionReferencesOnAdd(Permissionable permissionable) throws DotDataException {
+	private void updatePermissionReferencesOnAdd(final Permissionable permissionable) throws DotDataException {
 
 		String parentPermissionableId = permissionable.getPermissionId();
 
-		boolean isHost = permissionable instanceof Host ||
+		final boolean isHost = permissionable instanceof Host ||
 		(permissionable instanceof Contentlet && ((Contentlet)permissionable).getStructure().getVelocityVarName().equals("Host"));
-		boolean isFolder = permissionable instanceof Folder;
-		boolean isCategory = permissionable instanceof Category;
-		boolean isContentType = permissionable instanceof Structure || permissionable instanceof ContentType;
+		final boolean isFolder = permissionable instanceof Folder;
+		final boolean isCategory = permissionable instanceof Category;
+		final boolean isContentType = permissionable instanceof Structure || permissionable instanceof ContentType;
 
 		if(!isHost && !isFolder && !isCategory && !isContentType) {
 			return;
@@ -1162,7 +1161,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 						// Retrieving the list of templates changed to clear
 						// their caches
-						dc.setSQL(selectChildrenTemplateSQL);
+						dc.setSQL(SELECT_CHILD_TEMPLATE_SQL);
 						dc.addParam(permissionable.getPermissionId());
 						idsToClear.addAll(dc.loadResults());
 
@@ -1186,7 +1185,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 						// Retrieving the list of container changed to clear
 						// their caches
-						dc.setSQL(selectChildrenContainerSQL);
+						dc.setSQL(SELECT_CHILD_CONTAINER_SQL);
 						dc.addParam(permissionable.getPermissionId());
 						idsToClear.addAll(dc.loadResults());
 
@@ -1217,7 +1216,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 						// Retrieving the list of container changed to clear
 						// their caches
-						dc.setSQL(selectChildrenFolderSQL);
+						dc.setSQL(SELECT_CHILD_FOLDER_SQL);
 						dc.addParam(parentHost.getPermissionId());
 						dc.addParam(path + "%");
 						dc.addParam(isHost ? " " : path);
@@ -1258,7 +1257,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 						// Retrieving the list of pages changed to clear their
 						// caches
-						dc.setSQL(selectChildrenHTMLPageSQL);
+						dc.setSQL(SELECT_CHILD_HTMLPAGE_SQL);
 						dc.addParam(parentHost.getPermissionId());
 						dc.addParam(path + "%");
 						dc.addParam(parentHost.getPermissionId());
@@ -1295,7 +1294,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 						// Retrieving the list of links changed to clear their
 						// caches
-						dc.setSQL(selectChildrenLinkSQL);
+						dc.setSQL(SELECT_CHILD_LINK_SQL);
 						dc.addParam(parentHost.getPermissionId());
 						dc.addParam(path + "%");
 						idsToClear.addAll(dc.loadResults());
@@ -1331,7 +1330,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 						// Retrieving the list of links changed to clear their
 						// caches
-						dc.setSQL(selectChildrenContentByPathSQL);
+						dc.setSQL(SELECT_CHILD_CONTENT_BY_PATH_SQL);
 						dc.addParam(parentHost.getPermissionId());
 						dc.addParam(path + "%");
 						idsToClear.addAll(dc.loadResults());
@@ -1341,7 +1340,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 					} else if (p.getType().equals(Structure.class.getCanonicalName()) && !ran08) {
 
 						if(isHost){
-							dc.setSQL(deleteStructureReferencesByPathOnAddSQL);
+							dc.setSQL(DELETE_CONTENTTYPE_REFERENCES_BY_PATH_ON_ADD_SQL);
 							dc.addParam(path + "%");
 							dc.addParam(parentHost.getPermissionId());
 							dc.addParam(parentHost.getPermissionId());
@@ -1355,7 +1354,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 							if (shouldInsertPermissionReferencesEagerly()) {
 								// Adding new references to the new host
 								// Insert new references pointing to the host
-								dc.setSQL(insertStructureReferencesByPathSQL);
+								dc.setSQL(INSERT_CONTENTTYPE_REFERENCES_BY_PATH_SQL);
 								dc.addParam(permissionable.getPermissionId());
 								dc.addParam(path + "%");
 								dc.addParam(parentHost.getPermissionId());
@@ -1367,7 +1366,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 							// Retrieving the list of structures changed to clear
 							// their caches
 
-							dc.setSQL(selectChildrenStructureByPathSQL);
+							dc.setSQL(SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL);
 							dc.addParam(path + "%");
 							dc.addParam(parentHost.getPermissionId());
 							dc.addParam(parentHost.getPermissionId());
@@ -1397,7 +1396,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 							// Retrieving the list of structures changed to clear
 							// their caches
-							dc.setSQL(selectChildrenStructureByPathSQLFolder);
+							dc.setSQL(SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL_FOLDER);
 							dc.addParam(path + "%");
 							dc.addParam(parentHost.getPermissionId());
 							List<Map<String,Object>> sts=dc.loadResults();
@@ -1405,7 +1404,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 							Iterator<Map<String,Object>> it = sts.iterator();
 							while(it.hasNext()) {
-							    dc.setSQL(selectChildrenContentByStructureSQL);
+							    dc.setSQL(SELECT_CHILD_CONTENT_BY_CONTENTTYPE_SQL);
 							    dc.addParam(it.next().get("inode"));
 							    idsToClear.addAll(dc.loadResults());
 							}
@@ -1415,7 +1414,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				} else {
 					// If the system host we need to force all references of the
 					// type of the permissionable
-				    dc.setSQL(selectPermissionReferenceSQL);
+				    dc.setSQL(SELECT_PERMISSION_REFERENCE_SQL);
 				    dc.addParam(permissionable.getPermissionId());
 				    dc.addParam(p.getType());
 				    idsToClear.addAll(dc.loadResults());
@@ -1428,7 +1427,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
     				try {
     					List<Category> children = catAPI.getCategoryTreeDown(cat, cat, systemUser, false);
     					for(Category child : children) {
-    						dc.setSQL(updatePermissionReferenceByAssetIdSQL);
+    						dc.setSQL(UPDATE_PERMISSION_REFERENCE_BY_ASSETID_SQL);
     						dc.addParam(cat.getInode());
     						dc.addParam(Category.class.getCanonicalName());
     						dc.addParam(child.getInode());
@@ -1444,12 +1443,12 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 			} else if (isContentType) {
 			    if(!ran10) {
     				// Removing all references to the system host
-    				dc.setSQL(deleteContentReferencesByStructureSQL);
+    				dc.setSQL(DELETE_CONTENT_REFERENCES_BY_CONTENTTYPE_SQL);
     				// All the content that belongs to the host
     				dc.addParam(permissionable.getPermissionId());
     				dc.loadResult();
 
-    				dc.setSQL(selectChildrenContentByStructureSQL);
+    				dc.setSQL(SELECT_CHILD_CONTENT_BY_CONTENTTYPE_SQL);
     				dc.addParam(permissionable.getPermissionId());
     				idsToClear.addAll(dc.loadResults());
         				
@@ -1481,7 +1480,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	private void updatePermissionReferencesOnRemove(Permissionable permissionable) throws DotDataException {
 
 		DotConnect dc = new DotConnect();
-		String query = loadPermissionReferencesByReferenceIdHSQL;
+		String query = LOAD_PERMISSION_REFERENCES_BY_REFERENCEID_HSQL;
 		HibernateUtil hu = new HibernateUtil(PermissionReference.class);
 		hu.setQuery(query);
 		hu.setParam(permissionable.getPermissionId());
@@ -1521,7 +1520,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		for(String type: referenceReplacement.keySet()) {
 
 
-		    dc.setSQL(selectPermissionReferenceSQL);
+		    dc.setSQL(SELECT_PERMISSION_REFERENCE_SQL);
 		    dc.addParam(permissionable.getPermissionId());
 		    dc.addParam(type);
 		    toClear.addAll(dc.loadResults());
@@ -1529,7 +1528,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 			String replacement = referenceReplacement.get(type);
 			if(!replacement.equals(permissionable.getPermissionId())) {
 
-				dc.setSQL(updatePermissionReferenceByReferenceIdSQL);
+				dc.setSQL(UPDATE_PERMISSION_REFERENCE_BY_REFERENCEID_SQL);
 				dc.addParam(replacement);
 				dc.addParam(type);
 				dc.addParam(permissionable.getPermissionId());
@@ -1552,7 +1551,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	@SuppressWarnings("unchecked")
 	private void clearReferencesCache(Permissionable permissionable) throws DotDataException {
 
-		String query = loadPermissionReferencesByReferenceIdHSQL;
+		String query = LOAD_PERMISSION_REFERENCES_BY_REFERENCEID_HSQL;
 		HibernateUtil hu = new HibernateUtil(PermissionReference.class);
 		hu.setQuery(query);
 		hu.setParam(permissionable.getPermissionId());
@@ -1612,7 +1611,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 	private void removePermissionsReference(Permissionable permissionable) throws DotDataException {
 		DotConnect dc = new DotConnect();
-		dc.setSQL(deletePermissionReferenceSQL);
+		dc.setSQL(DELETE_PERMISSION_REFERENCE_SQL);
 		dc.addParam(permissionable.getPermissionId());
 		dc.addParam(permissionable.getPermissionId());
 		dc.loadResult();
@@ -1620,7 +1619,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 	private void removePermissionableReference(Permissionable permissionable) throws DotDataException {
 		DotConnect dc = new DotConnect();
-		dc.setSQL(deletePermissionableReferenceSQL);
+		dc.setSQL(DELETE_PERMISSIONABLE_REFERENCE_SQL);
 		dc.addParam(permissionable.getPermissionId());
 		dc.loadResult();
 	}
@@ -2183,7 +2182,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		Thread.currentThread().setName(threadName + " loadPermission:" + permissionable.getPermissionId());
 
 		HibernateUtil persistenceService = new HibernateUtil(Permission.class);
-		persistenceService.setSQLQuery(loadPermissionSQL);
+		persistenceService.setSQLQuery(LOAD_PERMISSION_SQL);
 		persistenceService.setParam(permissionable.getPermissionId());
 		persistenceService.setParam(permissionable.getPermissionId());
 		List<Permission> bitPermissionsList = (List<Permission>) persistenceService.list();
@@ -2277,10 +2276,10 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
                     List<Map<String, Object>> l2 = dc2.loadObjectResults();
 
 					if((l != null && l.size()>0) || (l2!=null && l2.size()>0)){
-						dc1.setSQL(deletePermissionableReferenceSQL);
+						dc1.setSQL(DELETE_PERMISSIONABLE_REFERENCE_SQL);
 						dc1.addParam(permissionable.getPermissionId());
 						dc1.loadResult();
-						dc1.setSQL(insertPermissionReferenceSQL);
+						dc1.setSQL(INSERT_PERMISSION_REFERENCE_SQL);
 						dc1.addParam(permissionable.getPermissionId());
 						dc1.addParam(newReference.getPermissionId());
 						dc1.addParam(type);
@@ -2401,16 +2400,16 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	void resetPermissionsUnder(Permissionable permissionable) throws DotDataException {
+	void resetPermissionsUnder(final Permissionable permissionable) throws DotDataException {
 
 		if(!permissionable.isParentPermissionable())
 			return;
 
-		boolean isHost = permissionable instanceof Host ||
+		final boolean isHost = permissionable instanceof Host ||
 			(permissionable instanceof Contentlet && ((Contentlet)permissionable).getStructure().getVelocityVarName().equals("Host"));
-		boolean isFolder = permissionable instanceof Folder;
-		boolean isContentType = permissionable instanceof Structure || permissionable instanceof ContentType;
-		boolean isCategory = permissionable instanceof Category;
+		final boolean isFolder = permissionable instanceof Folder;
+		final boolean isContentType = permissionable instanceof Structure || permissionable instanceof ContentType;
+		final boolean isCategory = permissionable instanceof Category;
 
 		DotConnect dc = new DotConnect();
 		HostAPI hostAPI = APILocator.getHostAPI();
@@ -2446,7 +2445,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 					dc.loadResult();
 				}
 				//Retrieving the list of templates to clear their caches later
-				dc.setSQL(selectChildrenTemplateSQL);
+				dc.setSQL(SELECT_CHILD_TEMPLATE_SQL);
 				dc.addParam(host.getPermissionId());
 				idsToClear.addAll(dc.loadResults());
 
@@ -2465,7 +2464,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 					dc.loadResult();
 				}
 				//Retrieving the list of containers to clear their caches later
-				dc.setSQL(selectChildrenContainerSQL);
+				dc.setSQL(SELECT_CHILD_CONTAINER_SQL);
 				dc.addParam(host.getPermissionId());
 				idsToClear.addAll(dc.loadResults());
 
@@ -2496,7 +2495,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				dc.loadResult();
 			}
 			//Retrieving the list of sub folders changed to clear their caches
-			dc.setSQL(selectChildrenFolderSQL);
+			dc.setSQL(SELECT_CHILD_FOLDER_SQL);
 			dc.addParam(host.getPermissionId());
 			dc.addParam(isHost?"%":folderPath+"%");
 			dc.addParam(isHost?" ":folderPath+"");
@@ -2527,7 +2526,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				dc.loadResult();
 			}
 			//Retrieving the list of htmlpages changed to clear their caches
-			dc.setSQL(selectChildrenHTMLPageSQL);
+			dc.setSQL(SELECT_CHILD_HTMLPAGE_SQL);
 			dc.addParam(host.getPermissionId());
 			dc.addParam(isHost?"%":folderPath+"%");
 			dc.addParam(host.getPermissionId());
@@ -2553,7 +2552,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				dc.loadResult();
 			}
 			//Retrieving the list of links changed to clear their caches
-			dc.setSQL(selectChildrenLinkSQL);
+			dc.setSQL(SELECT_CHILD_LINK_SQL);
 			dc.addParam(host.getPermissionId());
 			dc.addParam(isHost?"%":folderPath+"%");
 			idsToClear.addAll(dc.loadResults());
@@ -2577,7 +2576,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				dc.loadResult();
 			}
 			//Retrieving the list of content changed to clear their caches
-			dc.setSQL(selectChildrenContentByPathSQL);
+			dc.setSQL(SELECT_CHILD_CONTENT_BY_PATH_SQL);
 			dc.addParam(host.getPermissionId());
 			dc.addParam(isHost?"%":folderPath+"%");
 			idsToClear.addAll(dc.loadResults());
@@ -2585,21 +2584,21 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 			if(isHost){
 				//Removing permissions and permission references for all children structures
-				dc.setSQL(deleteStructureReferencesByPathSQL);
+				dc.setSQL(DELETE_CONTENTTYPE_REFERENCES_BY_PATH_SQL);
 				dc.addParam(isHost?"%":folderPath+"%");
 				dc.addParam(host.getPermissionId());
 				dc.addParam(host.getPermissionId());
 				dc.addParam(host.getPermissionId());
 				dc.addParam(isHost?"%":folderPath+"%");
 				dc.loadResult();
-				dc.setSQL(deleteStructurePermissionsByPathSQL);
+				dc.setSQL(DELETE_CONTENTTYPE_PERMISSIONS_BY_PATH_SQL);
 				dc.addParam(isHost?"%":folderPath+"%");
 				dc.addParam(host.getPermissionId());
 				dc.addParam(host.getPermissionId());
 				dc.loadResult();
 				if (shouldInsertPermissionReferencesEagerly()) {
 					//Pointing the children structures to reference the current host
-					dc.setSQL(insertStructureReferencesByPathSQL);
+					dc.setSQL(INSERT_CONTENTTYPE_REFERENCES_BY_PATH_SQL);
 					dc.addParam(permissionable.getPermissionId());
 					dc.addParam(isHost?"%":folderPath+"%");
 					dc.addParam(host.getPermissionId());
@@ -2609,7 +2608,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				}
 				// Retrieving the list of structures changed to clear their caches
 
-				dc.setSQL(selectChildrenStructureByPathSQL);
+				dc.setSQL(SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL);
 				dc.addParam(isHost?"%":folderPath+"%");
 				dc.addParam(host.getPermissionId());
 				dc.addParam(host.getPermissionId());
@@ -2637,7 +2636,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 					dc.loadResult();
 				}
 				// Retrieving the list of structures changed to clear their caches
-				dc.setSQL(selectChildrenStructureByPathSQLFolder);
+				dc.setSQL(SELECT_CHILD_CONTENTTYPE_BY_PATH_SQL_FOLDER);
 				dc.addParam(isHost?"%":folderPath+"%");
 				dc.addParam(host.getPermissionId());
 				idsToClear.addAll(dc.loadResults());
@@ -2648,7 +2647,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		} else if(isContentType) {
 
 			//Removing permissions and permission references for all children containers
-			dc.setSQL(deleteContentReferencesByStructureSQL);
+			dc.setSQL(DELETE_CONTENT_REFERENCES_BY_CONTENTTYPE_SQL);
 			dc.addParam(permissionable.getPermissionId());
 			dc.loadResult();
 			dc.setSQL(deleteContentPermissionsByStructureSQL);
@@ -2662,7 +2661,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				dc.loadResult();
 			}
 			//Retrieving the list of content changed to clear their caches
-			dc.setSQL(selectChildrenContentByStructureSQL);
+			dc.setSQL(SELECT_CHILD_CONTENT_BY_CONTENTTYPE_SQL);
 			dc.addParam(permissionable.getPermissionId());
 			idsToClear.addAll(dc.loadResults());
 
@@ -2910,7 +2909,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		}
 		Folder folder = isFolder ? (Folder) permissionable : null;
 		String folderPath = folder != null ? APILocator.getIdentifierAPI().find(folder).getPath() : "";
-		String query = selectChildrenWithIndividualPermissionsSQLs.get(permissionType);
+		String query = SELECT_CHILDREN_WITH_INDIVIDUAL_PERMISSIONS_SQLS.get(permissionType);
 
 		List<String> result = new ArrayList<String>();
 
@@ -2979,7 +2978,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	    ContentletIndexAPI indexAPI=new ESContentletIndexAPI();
 
 	    DotConnect dc = new DotConnect();
-		dc.setSQL(deleteContentReferencesByStructureSQL);
+		dc.setSQL(DELETE_CONTENT_REFERENCES_BY_CONTENTTYPE_SQL);
 		dc.addParam(structure.getPermissionId());
 		dc.loadResult();
 
@@ -3009,7 +3008,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	@Override
 	void resetPermissionReferences(Permissionable permissionable) throws DotDataException {
 		DotConnect dc = new DotConnect();
-		dc.setSQL(this.deletePermissionReferenceSQL);
+		dc.setSQL(this.DELETE_PERMISSION_REFERENCE_SQL);
 		dc.addParam(permissionable.getPermissionId());
 		dc.addParam(permissionable.getPermissionId());
 		dc.loadResult();
@@ -3020,7 +3019,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	@Override
 	void resetAllPermissionReferences() throws DotDataException {
 		DotConnect dc = new DotConnect();
-		dc.setSQL(this.deleteAllPermissionReferencesSQL);
+		dc.setSQL(this.DELETE_ALL_PERMISSION_REFERENCES_SQL);
 		dc.loadResult();
 		permissionCache.clearCache();
 
@@ -3196,7 +3195,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select ident.id, ?, '" + Container.class.getCanonicalName() + "'" +
 		            "	from identifier ident, " +
-		            "		(" + selectChildrenContainerSQL +
+		            "		(" + SELECT_CHILD_CONTAINER_SQL +
 		            "			and identifier.id not in (" + 
 		            "				select inode_id from permission " +
 		            "					where permission_type = '" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "') " + 
@@ -3214,11 +3213,11 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select identifier.id, ?, '" + Contentlet.class.getCanonicalName() + "' " +
 		            "	from identifier where identifier.id in (" +
-		            "		" + selectChildrenContentByPathSQL + " and" +
+		            "		" + SELECT_CHILD_CONTENT_BY_PATH_SQL + " and" +
 		            "		identifier.id not in (" +
 		            "			select asset_id from permission_reference join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "                                join identifier on (identifier.id=ref_folder.identifier) " +
-		            "			where "+dotFolderPath+"(parent_path,asset_name) like ? and permission_type = '" + Contentlet.class.getCanonicalName() + "'" +
+		            "			where "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? and permission_type = '" + Contentlet.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		identifier.id not in (" +
 		            "			select inode_id from permission where " +
@@ -3237,13 +3236,13 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select identifier.id, ?, '" + IHTMLPage.class.getCanonicalName() + "' " +
 		            "	from identifier, " +
-		            "		(" + selectChildrenHTMLPageSQL + " and" +
+		            "		(" + SELECT_CHILD_HTMLPAGE_SQL + " and" +
 		            "		li.id not in (" +
 		            "			select asset_id from " + 
 		            "				permission_reference " +
 		            "				join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "               join identifier on (ref_folder.identifier=identifier.id) " +
-		            "				where "+dotFolderPath+"(parent_path,asset_name) like ? " + 
+		            "				where "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? " + 
 		            "				and permission_type = '" + IHTMLPage.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		li.id not in (" +
@@ -3265,11 +3264,11 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select identifier.id, ?, '" + Link.class.getCanonicalName() + "' " +
 		            "	from identifier where identifier.id in (" +
-		            "		" + selectChildrenLinkSQL + " and" +
+		            "		" + SELECT_CHILD_LINK_SQL + " and" +
 		            "		identifier.id not in (" +
 		            "			select asset_id from permission_reference join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "            join identifier ii on (ii.id=ref_folder.identifier) where " +
-		            "			"+dotFolderPath+"(ii.parent_path,ii.asset_name) like ? and permission_type = '" + Link.class.getCanonicalName() + "'" +
+		            "			"+DOT_FOLDER_PATH+"(ii.parent_path,ii.asset_name) like ? and permission_type = '" + Link.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		identifier.id not in (" +
 		            "			select inode_id from permission where " +
@@ -3286,7 +3285,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				    "insert into permission_reference (asset_id, reference_id, permission_type) " +
 				    "select ident.id, ?, '" + Template.class.getCanonicalName() + "'" +
 				    "	from identifier ident, " + 
-				    "		(" + selectChildrenTemplateSQL + 
+				    "		(" + SELECT_CHILD_TEMPLATE_SQL + 
 				    "		and identifier.id not in (" + 
 				    "			select inode_id " + 
 				    "				from permission " +
@@ -3308,7 +3307,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select ident.id, ?, '" + Container.class.getCanonicalName() + "'" +
 		            "	from identifier ident, " +
-		            "		(" + selectChildrenContainerSQL +
+		            "		(" + SELECT_CHILD_CONTAINER_SQL +
 		            "			and identifier.id not in (" + 
 		            "				select inode_id from permission " +
 		            "					where permission_type = '" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "') " + 
@@ -3326,11 +3325,11 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select identifier.id, ?, '" + Contentlet.class.getCanonicalName() + "' " +
 		            "	from identifier, (" +
-		            "		" + selectChildrenContentByPathSQL + " and" +
+		            "		" + SELECT_CHILD_CONTENT_BY_PATH_SQL + " and" +
 		            "		identifier.id not in (" +
 		            "			select asset_id from permission_reference join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "                                join identifier on (identifier.id=ref_folder.identifier) " +
-		            "			where "+dotFolderPath+"(parent_path,asset_name) like ? and permission_type = '" + Contentlet.class.getCanonicalName() + "'" +
+		            "			where "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? and permission_type = '" + Contentlet.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		identifier.id not in (" +
 		            "			select inode_id from permission where " +
@@ -3348,13 +3347,13 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select identifier.id, ?, '" + IHTMLPage.class.getCanonicalName() + "' " +
 		            "	from identifier, " +
-		            "		(" + selectChildrenHTMLPageSQL + " and" +
+		            "		(" + SELECT_CHILD_HTMLPAGE_SQL + " and" +
 		            "		not exists (" +
 		            "			select asset_id from " + 
 		            "				permission_reference " +
 		            "				join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "               join identifier on (ref_folder.identifier=identifier.id) " +
-		            "				where asset_id = li.id and "+dotFolderPath+"(parent_path,asset_name) like ? " + 
+		            "				where asset_id = li.id and "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? " + 
 		            "				and permission_type = '" + IHTMLPage.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		not exists (" +
@@ -3376,11 +3375,11 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select identifier.id, ?, '" + Link.class.getCanonicalName() + "' " +
 		            "	from identifier, (" +
-		            "		" + selectChildrenLinkSQL + " and" +
+		            "		" + SELECT_CHILD_LINK_SQL + " and" +
 		            "		not exists (" +
 		            "			select asset_id from permission_reference join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "            join identifier ii on (ii.id=ref_folder.identifier) where asset_id = identifier.id and " +
-		            "			"+dotFolderPath+"(ii.parent_path,ii.asset_name) like ? and permission_type = '" + Link.class.getCanonicalName() + "'" +
+		            "			"+DOT_FOLDER_PATH+"(ii.parent_path,ii.asset_name) like ? and permission_type = '" + Link.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		not exists (" +
 		            "			select inode_id from permission where inode_id = identifier.id and " +
@@ -3398,7 +3397,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				    "insert into permission_reference (asset_id, reference_id, permission_type) " +
 				    "select ident.id, ?, '" + Template.class.getCanonicalName() + "'" +
 				    "	from identifier ident, " + 
-				    "		(" + selectChildrenTemplateSQL + 
+				    "		(" + SELECT_CHILD_TEMPLATE_SQL + 
 				    "		and identifier.id not in (" + 
 				    "			select inode_id " + 
 				    "				from permission " +
@@ -3420,7 +3419,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select ident.id, ?, '" + Container.class.getCanonicalName() + "'" +
 		            "	from identifier ident, " +
-		            "		(" + selectChildrenContainerSQL + " and " +
+		            "		(" + SELECT_CHILD_CONTAINER_SQL + " and " +
 		            "		 identifier.id not in (select inode_id from permission " +
 		            "			where permission_type = '" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "') and " +
 		            "		 identifier.id not in (select asset_id from permission_reference where " +
@@ -3434,11 +3433,11 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select identifier.id, ?, '" + Contentlet.class.getCanonicalName() + "' " +
 		            "	from identifier, (" +
-		            "		" + selectChildrenContentByPathSQL + " and" +
+		            "		" + SELECT_CHILD_CONTENT_BY_PATH_SQL + " and" +
 		            "		identifier.id not in (" +
 		            "			select asset_id from permission_reference join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "                                join identifier on (identifier.id=ref_folder.identifier) " +
-		            "			where "+dotFolderPath+"(parent_path,asset_name) like ? and permission_type = '" + Contentlet.class.getCanonicalName() + "'" +
+		            "			where "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? and permission_type = '" + Contentlet.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		identifier.id not in (" +
 		            "			select inode_id from permission where " +
@@ -3467,7 +3466,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "		li.id not in (" +
 		            "			select asset_id from permission_reference join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "                                join identifier on (ref_folder.identifier=identifier.id) " +
-		            "			where "+dotFolderPath+"(parent_path,asset_name) like ? and permission_type = '" + IHTMLPage.class.getCanonicalName() + "'" +
+		            "			where "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? and permission_type = '" + IHTMLPage.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		li.id not in (" +
 		            "			select inode_id from permission where permission_type = '" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "'" +
@@ -3483,11 +3482,11 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (asset_id, reference_id, permission_type) " +
 		            "select identifier.id, ?, '" + Link.class.getCanonicalName() + "' " +
 		            "	from identifier, (" +
-		            "		" + selectChildrenLinkSQL + " and" +
+		            "		" + SELECT_CHILD_LINK_SQL + " and" +
 		            "		identifier.id not in (" +
 		            "			select asset_id from permission_reference join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "            join identifier ii on (ii.id=ref_folder.identifier) where " +
-		            "			"+dotFolderPath+"(ii.parent_path,ii.asset_name) like ? and permission_type = '" + Link.class.getCanonicalName() + "'" +
+		            "			"+DOT_FOLDER_PATH+"(ii.parent_path,ii.asset_name) like ? and permission_type = '" + Link.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		identifier.id not in (" +
 		            "			select inode_id from permission where " +
@@ -3504,7 +3503,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				    "insert into permission_reference (asset_id, reference_id, permission_type) " +
 				    "select ident.id, ?, '" + Template.class.getCanonicalName() + "'" +
 				    "	from identifier ident, " +
-				    "		(" + selectChildrenTemplateSQL + " and " +
+				    "		(" + SELECT_CHILD_TEMPLATE_SQL + " and " +
 				    "		 identifier.id not in (select inode_id from permission " +
 				    "			where permission_type = '" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "') and " +
 				    "		 identifier.id not in (select asset_id from permission_reference where " +
@@ -3521,7 +3520,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (id, asset_id, reference_id, permission_type) " +
 		            "select permission_reference_seq.NEXTVAL, ident.id, ?, '" + Container.class.getCanonicalName() + "'" +
 		            "	from identifier ident, " + 
-		            "		(" + selectChildrenContainerSQL +
+		            "		(" + SELECT_CHILD_CONTAINER_SQL +
 		            " 			and not exists (" +
 		            "				select inode_id " + 
 		            "					from permission " +
@@ -3551,7 +3550,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "				from permission_reference " + 
 		            "				join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "           	join identifier on (identifier.id=ref_folder.identifier) " +
-		            "				where "+dotFolderPath+"(parent_path,asset_name) like ? " +
+		            "				where "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? " +
 		            "				and permission_type = '" + Contentlet.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		identifier.id not in (" +
@@ -3569,14 +3568,14 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (id, asset_id, reference_id, permission_type) " +
 		            "select permission_reference_seq.NEXTVAL, identifier.id, ?, '" + IHTMLPage.class.getCanonicalName() + "' " +
 		            "	from identifier, " +
-		            "	(" + selectChildrenHTMLPageSQL + " and " +
+		            "	(" + SELECT_CHILD_HTMLPAGE_SQL + " and " +
 		            "		not exists (" +
 		            "			select asset_id " +
 		            "				from permission_reference " +
 		            "				join folder ref_folder on (reference_id = ref_folder.inode) " +
 		            "           	join identifier on (ref_folder.identifier=identifier.id) " +
 		            "				where asset_id = li.id " +
-		            "				and " + dotFolderPath + "(parent_path,asset_name) like ? " + 
+		            "				and " + DOT_FOLDER_PATH + "(parent_path,asset_name) like ? " + 
 		            "				and permission_type = '" + IHTMLPage.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		not exists (" +
@@ -3599,14 +3598,14 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (id, asset_id, reference_id, permission_type) " +
 		            "select permission_reference_seq.NEXTVAL, identifier.id, ?, '" + Link.class.getCanonicalName() + "' " +
 		            "	from identifier, " + 
-		            "		(" + selectChildrenLinkSQL + " and" +
+		            "		(" + SELECT_CHILD_LINK_SQL + " and" +
 		            "		not exists (" +
 		            "			select asset_id " + 
 		            "				from permission_reference " + 
 		            "				join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "            	join identifier ii on (ii.id=ref_folder.identifier) " + 
 		            "				where asset_id = identifier.id " +
-		            "				and "+dotFolderPath+"(ii.parent_path,ii.asset_name) like ? " + 
+		            "				and "+DOT_FOLDER_PATH+"(ii.parent_path,ii.asset_name) like ? " + 
 		            "				and permission_type = '" + Link.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		not exists (" +
@@ -3630,7 +3629,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				    "insert into permission_reference (id, asset_id, reference_id, permission_type) " +
 				    "select permission_reference_seq.NEXTVAL, ident.id, ?, '" + Template.class.getCanonicalName() + "'" +
 				    "	from identifier ident, " + 
-				    "		(" + selectChildrenTemplateSQL + " and " +
+				    "		(" + SELECT_CHILD_TEMPLATE_SQL + " and " +
 				    "		 	not exists (" + 
 				    "				select inode_id " +
 				    "				from permission " +
@@ -3655,7 +3654,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (id, asset_id, reference_id, permission_type) " +
 		            "select nextval('permission_reference_seq'), ident.id, ?, '" + Container.class.getCanonicalName() + "'" +
 		            "	from identifier ident, " +
-		            "		(" + selectChildrenContainerSQL + " and " +
+		            "		(" + SELECT_CHILD_CONTAINER_SQL + " and " +
 		            "			identifier.id not in (" + 
 		            "				select inode_id from permission " +
 		            "				where permission_type = '" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "') " +
@@ -3673,13 +3672,13 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (id, asset_id, reference_id, permission_type) " +
 		            "select nextval('permission_reference_seq'), identifier.id, ?, '" + Contentlet.class.getCanonicalName() + "' " +
 		            "	from identifier, " +
-		            "		(" + selectChildrenContentByPathSQL + " and" +
+		            "		(" + SELECT_CHILD_CONTENT_BY_PATH_SQL + " and" +
 		            "			identifier.id not in (" +
 		            "				select asset_id " + 
 		            "					from permission_reference " + 
 		            "					join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "               	join identifier on (identifier.id=ref_folder.identifier) " +
-		            "					where "+dotFolderPath+"(parent_path,asset_name) like ? " +
+		            "					where "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? " +
 		            "					and permission_type = '" + Contentlet.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		identifier.id not in (" +
@@ -3697,13 +3696,13 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (id, asset_id, reference_id, permission_type) " +
 		            "select nextval('permission_reference_seq'), identifier.id, ?, '" + IHTMLPage.class.getCanonicalName() + "' " +
 		            "	from identifier, " +
-		            "   (" + selectChildrenHTMLPageSQL + " and" +
+		            "   (" + SELECT_CHILD_HTMLPAGE_SQL + " and" +
 		            "		li.id not in (" +
 		            "			select asset_id " +
 		            "				from permission_reference "+
 		            "				join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "           	join identifier on (ref_folder.identifier=identifier.id) " +
-		            "				where "+dotFolderPath+"(parent_path,asset_name) like ? " +
+		            "				where "+DOT_FOLDER_PATH+"(parent_path,asset_name) like ? " +
 		            "				and permission_type = '" + IHTMLPage.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		li.id not in (" +
@@ -3726,13 +3725,13 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		            "insert into permission_reference (id, asset_id, reference_id, permission_type) " +
 		            "select nextval('permission_reference_seq'), identifier.id, ?, '" + Link.class.getCanonicalName() + "' " +
 		            "	from identifier, " +
-		            "		(" + selectChildrenLinkSQL + " and" +
+		            "		(" + SELECT_CHILD_LINK_SQL + " and" +
 		            "		identifier.id not in (" +
 		            "			select asset_id " +
 		            "				from permission_reference " +
 		            "				join folder ref_folder on (reference_id = ref_folder.inode)" +
 		            "            	join identifier ii on (ii.id=ref_folder.identifier) "  +
-		            "				where " + dotFolderPath+"(ii.parent_path,ii.asset_name) like ? " + 
+		            "				where " + DOT_FOLDER_PATH+"(ii.parent_path,ii.asset_name) like ? " + 
 		            "				and permission_type = '" + Link.class.getCanonicalName() + "'" +
 		            "		) and " +
 		            "		identifier.id not in (" +
@@ -3755,7 +3754,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 				    "insert into permission_reference (id, asset_id, reference_id, permission_type) " +
 				    "select nextval('permission_reference_seq'), ident.id, ?, '" + Template.class.getCanonicalName() + "'" +
 				    "	from identifier ident, " +
-				    "		(" + selectChildrenTemplateSQL + " and " +
+				    "		(" + SELECT_CHILD_TEMPLATE_SQL + " and " +
 				    "		identifier.id not in (" +
 				    "			select inode_id from permission " +
 				    "			where permission_type = '" + PermissionAPI.INDIVIDUAL_PERMISSION_TYPE + "') " + 

--- a/dotCMS/src/main/java/com/dotmarketing/business/ajax/PermissionAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/ajax/PermissionAjax.java
@@ -1,13 +1,19 @@
 package com.dotmarketing.business.ajax;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import javax.servlet.http.HttpServletRequest;
 
 import com.dotcms.business.CloseDBIfOpened;
-import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.exception.NotFoundInDbException;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotcms.repackage.org.directwebremoting.WebContext;
 import com.dotcms.repackage.org.directwebremoting.WebContextFactory;
 import com.dotmarketing.beans.Host;
@@ -50,7 +56,6 @@ import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
 import com.liferay.portal.model.User;
 
-
 /**
  *
  * AJAX controller for permission related operations
@@ -59,7 +64,9 @@ import com.liferay.portal.model.User;
  *
  */
 public class PermissionAjax {
-		
+
+    private final ContentletAPI contentletAPI = APILocator.getContentletAPI();
+
 	/**
 	 * Retrieves a list of roles and its associated permissions for the given asset
 	 * @param assetId
@@ -116,7 +123,6 @@ public class PermissionAjax {
 		RoleAPI roleAPI = APILocator.getRoleAPI();
 		HostAPI hostAPI = APILocator.getHostAPI();
 		User systemUser = APILocator.getUserAPI().getSystemUser();
-		ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(systemUser);
 
 		String roleId = p.getRoleId();
 		Map<String, Object> roleMap = roles.get(roleId);
@@ -160,9 +166,15 @@ public class PermissionAjax {
 						roleMap.put("inheritedFromPath", APILocator.getIdentifierAPI().find((Folder)permParent).getPath());
 						roleMap.put("inheritedFromId", ((Folder)permParent).getInode());
 					} else if (permParent instanceof Structure) {
-						roleMap.put("inheritedFromType", "structure");
-						roleMap.put("inheritedFromPath", ((Structure)permParent).getName());
-						roleMap.put("inheritedFromId", ((Structure)permParent).getInode());
+					    roleMap.put("inheritedFromType", "structure");
+                        roleMap.put("inheritedFromPath", ((Structure) permParent).getName());
+                        roleMap.put("inheritedFromId", ((Structure) permParent).getInode());
+					} else if (permParent instanceof ContentType) {
+                        roleMap.put("inheritedFromType", "structure");
+                        final Structure contentType = new StructureTransformer(ContentType.class.cast(permParent)).asStructure();
+                        this.contentletAPI.refresh(contentType);
+                        roleMap.put("inheritedFromPath", contentType.getName());
+                        roleMap.put("inheritedFromId", contentType.getInode());
 					} else if (permParent instanceof Category) {
 						roleMap.put("inheritedFromType", "category");
 						roleMap.put("inheritedFromPath", ((Category)permParent).getCategoryName());
@@ -178,7 +190,6 @@ public class PermissionAjax {
 							roleMap.put("inheritedFromPath", host.getHostname());
 							roleMap.put("inheritedFromId", host.getIdentifier());
 						}
-
 					}
 				}
 			}
@@ -327,7 +338,6 @@ public class PermissionAjax {
 		HibernateUtil.closeAndCommitTransaction();
 	}
 
-	@SuppressWarnings("unchecked")
 	@CloseDBIfOpened
 	private Permissionable retrievePermissionable (String assetId, Long language, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
 		
@@ -419,30 +429,31 @@ public class PermissionAjax {
 		return perm;
 	}
 
-	  public void permissionIndividually(String assetId, Long languageId) throws Exception {
-			HibernateUtil.startTransaction();
-	    	try {
-	    		UserWebAPI userWebAPI = WebAPILocator.getUserWebAPI();
-	    		WebContext ctx = WebContextFactory.get();
-	    		HttpServletRequest request = ctx.getHttpServletRequest();
+	public void permissionIndividually(String assetId, Long languageId) throws Exception {
+		HibernateUtil.startTransaction();
+	   	try {
+	   		UserWebAPI userWebAPI = WebAPILocator.getUserWebAPI();
+	   		WebContext ctx = WebContextFactory.get();
+	   		HttpServletRequest request = ctx.getHttpServletRequest();
 
-	    		//Retrieving the current user
-	    		User user = userWebAPI.getLoggedInUser(request);
-	    		boolean respectFrontendRoles = !userWebAPI.isLoggedToBackend(request);
+	   		//Retrieving the current user
+	   		User user = userWebAPI.getLoggedInUser(request);
+	   		boolean respectFrontendRoles = !userWebAPI.isLoggedToBackend(request);
 
-	    		PermissionAPI permissionAPI = APILocator.getPermissionAPI();
-	    		Permissionable asset = retrievePermissionable(assetId, languageId, user, respectFrontendRoles);
-	    		Permissionable parentPermissionable = APILocator.getPermissionAPI().findParentPermissionable(asset);
+	   		PermissionAPI permissionAPI = APILocator.getPermissionAPI();
+	   		Permissionable asset = retrievePermissionable(assetId, languageId, user, respectFrontendRoles);
+	   		Permissionable parentPermissionable = APILocator.getPermissionAPI().findParentPermissionable(asset);
 
-	    		if(parentPermissionable!=null){
-	    			permissionAPI.permissionIndividually(parentPermissionable, asset, user);
-	    		}
-	    		HibernateUtil.closeAndCommitTransaction();
-	    	} catch (Exception e) {
-	    		HibernateUtil.rollbackTransaction();
-	    		throw e;
-	    	}
-	    }
+	   		if(parentPermissionable!=null){
+	   			permissionAPI.permissionIndividually(parentPermissionable, asset, user);
+	   		}
+	   		HibernateUtil.closeAndCommitTransaction();
+	   	} catch (Exception e) {
+	   		HibernateUtil.rollbackTransaction();
+	   		throw e;
+	   	}
+	}
+
     public PermissionableObjectDWR getAsset(String inodeOrIdentifier) throws DotHibernateException {
 		UserWebAPI userWebAPI = WebAPILocator.getUserWebAPI();
 		WebContext ctx = WebContextFactory.get();

--- a/dotCMS/src/main/java/com/dotmarketing/cmis/proxy/DotInvocationHandler.java
+++ b/dotCMS/src/main/java/com/dotmarketing/cmis/proxy/DotInvocationHandler.java
@@ -17,7 +17,10 @@ import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
 
-//http://jira.dotmarketing.net/browse/DOTCMS-3392
+/**
+* @deprecated CMIS is deprecated and slated for removal.
+*/
+@Deprecated
 public class DotInvocationHandler implements InvocationHandler{
     private final Map map;
 

--- a/dotCMS/src/main/java/com/dotmarketing/cmis/proxy/DotRequestProxy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/cmis/proxy/DotRequestProxy.java
@@ -8,7 +8,7 @@ import javax.servlet.http.HttpServletRequest;
  * This is Proxy for HTTPServletRequest, This extends Map to put and get objects.
  * 
  * @deprecated As of release 3.6 use {@link com.dotcms.mock.request.MockHttpRequest#request()}
- *             instead
+ *             instead. CMIS is deprecated and slated for removal.
  */
 @Deprecated
 public interface DotRequestProxy extends HttpServletRequest,Map{

--- a/dotCMS/src/main/java/com/dotmarketing/cmis/proxy/DotResponseProxy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/cmis/proxy/DotResponseProxy.java
@@ -8,7 +8,7 @@ import javax.servlet.http.HttpServletResponse;
  * This is Proxy for HTTPServletResponse, This extends Map to put and get objects.
  * 
  * @deprecated As of release 3.6 use {@link com.dotcms.mock.response.MockHttpResponse#response()}
- *             instead
+ *             instead. CMIS is deprecated and slated for removal.
  */
 @Deprecated
 public interface DotResponseProxy extends HttpServletResponse, Map {

--- a/dotCMS/src/main/java/com/dotmarketing/cmis/proxy/DotSessionProxy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/cmis/proxy/DotSessionProxy.java
@@ -8,7 +8,8 @@ import javax.servlet.http.HttpSession;
  * This is Proxy for HTTPServletRequest, This extends Map to put and get objects. This uses
  * DotRequestProxy.map to store and retrieve objects.
  * 
- * @deprecated As of release 3.6, replaced by {@link com.dotcms.mock.request.MockSession}
+ * @deprecated As of release 3.6, replaced by {@link com.dotcms.mock.request.MockSession}. CMIS is
+ *             deprecated and slated for removal.
  */
 @Deprecated
 public interface DotSessionProxy extends HttpSession, Map {

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -93,6 +93,9 @@ import com.liferay.portal.model.User;
  */
 public class ReindexThread extends Thread {
 
+    public static final int REINDEX_THREAD_SLEEP_DEFAULT_VALUE = 500;
+    public static final int REINDEX_THREAD_INIT_DELAY_DEFAULT_VALUE = 5000;
+    
 	private static final ContentletIndexAPI indexAPI = APILocator.getContentletIndexAPI();
     private final LinkedList<IndexJournal<String>> remoteQ = new LinkedList<IndexJournal<String>>();
     private final LinkedList<IndexJournal<String>> remoteDelQ = new LinkedList<IndexJournal<String>>();

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/ResetPermissionsJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/ResetPermissionsJob.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package com.dotmarketing.quartz.job;
 
 import java.util.ArrayList;
@@ -23,6 +20,7 @@ import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.business.Permissionable;
 import com.dotmarketing.business.UserAPI;
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.reindex.ReindexThread;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.db.HibernateUtil;
 import com.dotmarketing.exception.DotDataException;
@@ -39,31 +37,41 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 
 /**
+ * This job is called when the permissions on a given {@link Permissionable} have changed. A
+ * Permissionable is basically a dotCMS domain object that can be permissioned to be accessed or
+ * modified by specific roles or users only.
+ * 
  * @author David H Torres
  */
 public class ResetPermissionsJob implements Job {
 	
-	/* (non-Javadoc)
-	 * @see org.quartz.Job#execute(org.quartz.JobExecutionContext)
-	 */
-	
-	public static void triggerJobImmediately (Permissionable perm) {
-		String randomID = UUID.randomUUID().toString();
-		JobDataMap dataMap = new JobDataMap();
+    /**
+     * Triggers the execution of this permission rest job on the specified {@link Permissionable}.
+     * 
+     * @param perm - The {@link Permissionable} object, i.e., a Contentlet, a Content Type, an HTML
+     *        Page, etc.
+     */
+	public static void triggerJobImmediately (final Permissionable perm) {
+		final String randomID = UUID.randomUUID().toString();
+		final JobDataMap dataMap = new JobDataMap();
 		
 		dataMap.put("permissionableId", perm.getPermissionId());
 		
-		JobDetail jd = new JobDetail("ResetPermissionsJob-" + randomID, "dotcms_jobs", ResetPermissionsJob.class);
+		final JobDetail jd = new JobDetail("ResetPermissionsJob-" + randomID, "dotcms_jobs", ResetPermissionsJob.class);
 		jd.setJobDataMap(dataMap);
 		jd.setDurability(false);
 		jd.setVolatility(false);
 		jd.setRequestsRecovery(true);
 		
-		long startTime = System.currentTimeMillis();
-		SimpleTrigger trigger = new SimpleTrigger("permissionsResetTrigger-"+randomID, "dotcms_triggers",  new Date(startTime));
+		final long startTime = System.currentTimeMillis();
+		final SimpleTrigger trigger = new SimpleTrigger("permissionsResetTrigger-"+randomID, "dotcms_triggers",  new Date(startTime));
 		
 		try {
-			Scheduler sched = QuartzUtils.getSequentialScheduler();
+		    // First, make sure the Reindex Thread is up and running
+            if (!ReindexThread.getInstance().isWorking()) {
+                ReindexThread.getInstance().unpause();
+            }
+			final Scheduler sched = QuartzUtils.getSequentialScheduler();
 			sched.scheduleJob(jd, trigger);
 		} catch (SchedulerException e) {
 			Logger.error(ResetPermissionsJob.class, "Error scheduling the reset of permissions", e);
@@ -75,7 +83,13 @@ public class ResetPermissionsJob implements Job {
 	public ResetPermissionsJob() {
 		
 	}
-	
+
+	/**
+     * Triggers the permission reset operation on a given Permissionable object.
+     * 
+     * @param jobContext - The {@link JobExecutionContext} containing details and execution
+     *        parameters of the job.
+     */
 	public void execute(JobExecutionContext jobContext) throws JobExecutionException {
 		
 		JobDataMap map = jobContext.getJobDetail().getJobDataMap();
@@ -109,7 +123,6 @@ public class ResetPermissionsJob implements Job {
 		
 	}
 	
-	@SuppressWarnings("unchecked")
 	private Permissionable retrievePermissionable (String assetId) throws DotDataException, DotSecurityException {
 		
 		UserAPI userAPI = APILocator.getUserAPI();

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/InitServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/InitServlet.java
@@ -1,5 +1,31 @@
 package com.dotmarketing.servlets;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.net.UnknownHostException;
+import java.util.Date;
+import java.util.List;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+
+import org.apache.lucene.search.BooleanQuery;
+import org.quartz.SchedulerException;
+
 import com.dotcms.cluster.business.HazelcastUtil;
 import com.dotcms.content.elasticsearch.util.ESClient;
 import com.dotcms.enterprise.LicenseUtil;
@@ -11,6 +37,7 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.common.reindex.ReindexThread;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.db.HibernateUtil;
 import com.dotmarketing.exception.DotDataException;
@@ -26,33 +53,26 @@ import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.quartz.job.ShutdownHookThread;
-import com.dotmarketing.util.*;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.ConfigUtils;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
+import com.dotmarketing.util.VelocityUtil;
+import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.util.ReleaseInfo;
-import org.apache.lucene.search.BooleanQuery;
-import org.quartz.SchedulerException;
 
-import javax.management.*;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.net.*;
-import java.net.URLEncoder;
-import java.util.Date;
-import java.util.List;
-
+/**
+ * Initialization servlet for specific dotCMS components and features.
+ * 
+ * @author root
+ *
+ */
 public class InitServlet extends HttpServlet {
+
     private static final long serialVersionUID = 1L;
 
     PermissionAPI             permissionAPI    = APILocator.getPermissionAPI();
     private LanguageAPI langAPI = APILocator.getLanguageAPI();
-
-    //	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(Config
-    //			.getIntProperty("EXEC_NUM_OF_THREAD"));
 
     /**
      * @param permissionAPI
@@ -73,22 +93,14 @@ public class InitServlet extends HttpServlet {
     public static Date startupDate;
 
     /**
-     * Description of the Method
+     * Initializes several application features.
      *
      * @throws DotDataException
      */
     public void init(ServletConfig config) throws ServletException {
 
         startupDate = new java.util.Date();
-        // Config class Initialization
-//        Config.initializeConfig();
-//        com.dotmarketing.util.Config.setMyApp(config.getServletContext());
-
-
-
         new StartupLogger().log();
-        
-        
 
         //Check and start the ES Content Store
         APILocator.getContentletIndexAPI().checkAndInitialiazeIndex();
@@ -100,27 +112,10 @@ public class InitServlet extends HttpServlet {
 
         new PluginLoader().loadPlugins(config.getServletContext().getRealPath("/"),classPath);
 
-
-
-
-
-
-
-
-
         int mc = Config.getIntProperty("lucene_max_clause_count", 4096);
         BooleanQuery.setMaxClauseCount(mc);
 
         ImportAuditUtil.voidValidateAuditTableOnStartup();
-
-        // Set up the database
-//        try {
-//            DotCMSInitDb.InitializeDb();
-//        } catch (DotDataException e1) {
-//            throw new ServletException(e1);
-//        }
-
-
 
         // set the application context for use all over the site
         Logger.debug(this, "");
@@ -260,7 +255,9 @@ public class InitServlet extends HttpServlet {
         catch(Exception e){
             Logger.warn(this.getClass(), "Unable to record startup time :" + e);
         }
-
+        // Starting the re-indexation thread
+        ReindexThread.startThread(Config.getIntProperty("REINDEX_THREAD_SLEEP", 500),
+                        Config.getIntProperty("REINDEX_THREAD_INIT_DELAY", 5000));
     }
 
     protected void deleteFiles(java.io.File directory) {
@@ -453,4 +450,5 @@ public class InitServlet extends HttpServlet {
         }
 
     }
+
 }

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/InitServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/InitServlet.java
@@ -256,8 +256,9 @@ public class InitServlet extends HttpServlet {
             Logger.warn(this.getClass(), "Unable to record startup time :" + e);
         }
         // Starting the re-indexation thread
-        ReindexThread.startThread(Config.getIntProperty("REINDEX_THREAD_SLEEP", 500),
-                        Config.getIntProperty("REINDEX_THREAD_INIT_DELAY", 5000));
+        ReindexThread.startThread(Config.getIntProperty("REINDEX_THREAD_SLEEP", ReindexThread.REINDEX_THREAD_SLEEP_DEFAULT_VALUE),
+                        Config.getIntProperty("REINDEX_THREAD_INIT_DELAY",
+                                        ReindexThread.REINDEX_THREAD_INIT_DELAY_DEFAULT_VALUE));
     }
 
     protected void deleteFiles(java.io.File directory) {

--- a/dotCMS/src/main/webapp/html/portlet/ext/common/edit_permissions_tab_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/common/edit_permissions_tab_inc.jsp
@@ -1,3 +1,5 @@
+<%@page import="com.dotcms.contenttype.transform.contenttype.StructureTransformer"%>
+<%@page import="com.dotcms.contenttype.model.type.ContentType"%>
 <%@ include file="/html/portlet/ext/common/edit_permissions_tab_js_inc.jsp" %>
 
 <!-- START Loading Image Div -->
@@ -12,25 +14,27 @@
 <div id="assetPermissionsWrapper">
 <div style="padding-left:20px;padding-bottom:10px;white-space: nowrap;font-size:88%;" class="permissionType">
 	<%if(asset instanceof Folder){%>
-		 <%= LanguageUtil.get(pageContext, "Folder") %>: <b><%= APILocator.getIdentifierAPI().find((Folder) asset).getPath() %></b>
+		 <%= LanguageUtil.get(pageContext, "Folder") %>:  <b><%= APILocator.getIdentifierAPI().find((Folder) asset).getPath() %></b>
 	<%}else if(asset instanceof Host){%>
-		 <%= LanguageUtil.get(pageContext, "Host") %>: <b><%= ((Host) asset).getHostname() %></b>
+		 <%= LanguageUtil.get(pageContext, "Host") %>:  <b><%= ((Host) asset).getHostname() %></b>
 	<%}else if(asset instanceof Contentlet){%>
 		<%if( ((Contentlet) asset).getStructureInode().equals(APILocator.getHostAPI().findSystemHost().getStructureInode())){ %>
-			 <%= LanguageUtil.get(pageContext, "Host") %>: <b><%= ((Contentlet) asset).getTitle() %></b>
+			 <%= LanguageUtil.get(pageContext, "Host") %>:  <b><%= ((Contentlet) asset).getTitle() %></b>
 		<%}else if(!((Contentlet) asset).getPermissionId().isEmpty()) { %>
-			 <%= LanguageUtil.get(pageContext, "Content") %>: <b><%= ((Contentlet) asset).getTitle() %></b>		
+			 <%= LanguageUtil.get(pageContext, "Content") %>:  <b><%= ((Contentlet) asset).getTitle() %></b>		
 		<%} %>
 	<%}else if(asset instanceof Structure){%>
 		 <%= LanguageUtil.get(pageContext, "Structure") %>:  <b><%= ((Structure) asset).getName() %></b>
+	<%}else if(asset instanceof ContentType){%>
+         <%= LanguageUtil.get(pageContext, "Structure") %>:  <b><%= new StructureTransformer(ContentType.class.cast(asset)).asStructure().getName() %></b>
 	<%}else if(asset instanceof Category){%>
-		 <%= LanguageUtil.get(pageContext, "Category") %>: <b><%= ((Category) asset).getCategoryName() %></b>
+		 <%= LanguageUtil.get(pageContext, "Category") %>:  <b><%= ((Category) asset).getCategoryName() %></b>
 	<%}%>
 </div>
 <!-- START Button Row -->
 	<div id="inheritingFrom" class="permissions__bar-user-role" style="display: none;">
 		<div class="permissions__bar-user-role-main">
-			<b><%= LanguageUtil.get(pageContext, "Inheriting-Permissions-From") %>:</b>
+			<b><%= LanguageUtil.get(pageContext, "Inheriting-Permissions-From") %>:</b>&nbsp;
 			<span id="inheritingFromSources"></span>
 		</div>
 		<div class="permissions__bar-user-role-actions">

--- a/dotCMS/src/main/webapp/html/portlet/ext/common/edit_publishing_status_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/common/edit_publishing_status_inc.jsp
@@ -1,3 +1,5 @@
+<%@page import="com.dotcms.contenttype.transform.contenttype.StructureTransformer"%>
+<%@page import="com.dotcms.contenttype.model.type.ContentType"%>
 <%@page import="com.dotmarketing.portlets.languagesmanager.model.Language"%>
 <%@page import="java.util.*" %>
 <%@page import="com.dotmarketing.beans.*" %>
@@ -15,7 +17,8 @@
 	Object assetObject = request.getAttribute(com.dotmarketing.util.WebKeys.PERMISSIONABLE_EDIT);
     String assetId = assetObject==null ? "" :  assetObject instanceof Folder ? ((Folder)assetObject).getInode() :
     					assetObject instanceof Structure ? ((Structure)assetObject).getInode() :
-                        (assetObject instanceof Inode ? ((Inode)assetObject).getIdentifier() :
+    					    assetObject instanceof ContentType ? new StructureTransformer(ContentType.class.cast(assetObject)).asStructure().getInode() :
+    					    (assetObject instanceof Inode ? ((Inode)assetObject).getIdentifier() :
                             (assetObject instanceof Contentlet ? ((Contentlet)assetObject).getIdentifier() : ""));
 
 	List<PushedAsset> pushedAssets = assetObject!=null ? APILocator.getPushedAssetsAPI().getPushedAssets(assetId) : new ArrayList<PushedAsset>();


### PR DESCRIPTION
… as part of the changes for this ticket. Spawning the ReindexThread when starting up the system. Making sure the ReindexThread is un-paused in case of any error during the full re-indexation stop. Considering both Structure and ContentType classes in our business logic in the code. Removing unused/commented code and adding Javadoc. The permissions were not being reflected because the ReindexThread was not running after the startup.