### PR TITLE
#12761 potential fix

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/ContentResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/ContentResource.java
@@ -619,7 +619,7 @@ public class ContentResource {
 	@Produces(MediaType.TEXT_PLAIN)
 	@Consumes(MediaType.MULTIPART_FORM_DATA)
 	public Response multipartPUT(@Context HttpServletRequest request, @Context HttpServletResponse response,
-			FormDataMultiPart multipart,@PathParam("params") String params) throws URISyntaxException, DotDataException {
+			FormDataMultiPart multipart,@PathParam("params") String params) throws URISyntaxException, DotDataException, DotSecurityException {
 		return multipartPUTandPOST(request, response, multipart, params, "PUT");
 	}
 	
@@ -628,12 +628,12 @@ public class ContentResource {
 	@Produces(MediaType.TEXT_PLAIN)
 	@Consumes(MediaType.MULTIPART_FORM_DATA)
 	public Response multipartPOST(@Context HttpServletRequest request, @Context HttpServletResponse response,
-			FormDataMultiPart multipart,@PathParam("params") String params) throws URISyntaxException, DotDataException {
+			FormDataMultiPart multipart,@PathParam("params") String params) throws URISyntaxException, DotDataException, DotSecurityException {
 		return multipartPUTandPOST(request, response, multipart, params, "POST");
 	}
 	
 	private Response multipartPUTandPOST(HttpServletRequest request, HttpServletResponse response,
-			FormDataMultiPart multipart, String params, String method) throws URISyntaxException, DotDataException{
+			FormDataMultiPart multipart, String params, String method) throws URISyntaxException, DotDataException, DotSecurityException{
 
         InitDataObject init= webResource.init(params, true, request, false, null);
 		User user=init.getUser();
@@ -1206,7 +1206,7 @@ public class ContentResource {
 	}
 
 	@SuppressWarnings("unchecked")
-	protected void processJSON(Contentlet contentlet, InputStream input) throws JSONException, IOException, DotDataException {
+	protected void processJSON(Contentlet contentlet, InputStream input) throws JSONException, IOException, DotDataException, DotSecurityException {
 		processMap(contentlet, webResource.processJSON(input));
 	}
 	

--- a/dotCMS/src/main/java/com/dotcms/rest/ContentResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/ContentResource.java
@@ -1080,7 +1080,7 @@ public class ContentResource {
 					fieldMap.put(ff.getVelocityVarName(), ff);
 
 				// look for relationships
-				contentlet.setProperty(RELATIONSHIP_KEY, evaluateContentRelationships(contentlet, st, map));
+				contentlet.setProperty(RELATIONSHIP_KEY, addContentRelationships(contentlet, st, map));
 
 				// fill fields
 				for(Map.Entry<String,Object> entry : map.entrySet()) {
@@ -1240,36 +1240,37 @@ public class ContentResource {
 		}
 	}
 
-    private Map<Relationship, List<Contentlet>> evaluateContentRelationships(Contentlet contentlet, Structure st, Map<String,Object> map) throws DotDataException, DotSecurityException {
-        Map<Relationship,List<Contentlet>> relationships=new HashMap<Relationship,List<Contentlet>>();
-        List<Relationship> rels = FactoryLocator.getRelationshipFactory().byContentType(st);
-        for(Relationship rel : rels) {
-            String relname=rel.getRelationTypeValue();
-            String query=(String)map.get(relname);
-            if(UtilMethods.isSet(query)) {
-                try {
-                    List<Contentlet> cons=APILocator.getContentletAPI().search(
-                            query, 0, 0, null, APILocator.getUserAPI().getSystemUser(), false);
-                    if(cons.size()>0) {
-                        relationships.put(rel, cons);
-                    }
-                    Logger.info(this, "got "+cons.size()+" related contents");
-                } catch (Exception e) {
-                    Logger.warn(this, e.getMessage(), e);
-                }
-            } else {
-                if(!relationships.containsKey(rel)){
-                    relationships.put(rel, new ArrayList<Contentlet>());
-                }
-                List<Contentlet> cons = APILocator.getContentletAPI().getRelatedContent(
-                        contentlet, rel, APILocator.systemUser(), false);
-                for (Contentlet c : cons) {
-                    List<Contentlet> l = relationships.get(rel);
-                    l.add(c);
-                }
-            }
-        }
-        
-        return relationships;
-    }
+	private Map<Relationship, List<Contentlet>> addContentRelationships(Contentlet contentlet, Structure st, Map<String,Object> map) 
+	        throws DotDataException, DotSecurityException {
+	    Map<Relationship,List<Contentlet>> relationships=new HashMap<Relationship,List<Contentlet>>();
+	    List<Relationship> rels = FactoryLocator.getRelationshipFactory().byContentType(st);
+	    for(Relationship rel : rels) {
+	        String relname=rel.getRelationTypeValue();
+	        String query=(String)map.get(relname);
+	        if(UtilMethods.isSet(query)) {
+	            try {
+	                List<Contentlet> cons=APILocator.getContentletAPI().search(
+	                        query, 0, 0, null, APILocator.systemUser(), false);
+	                if(cons.size()>0) {
+	                    relationships.put(rel, cons);
+	                }
+	                Logger.info(this, "got "+cons.size()+" related contents");
+	            } catch (Exception e) {
+	                Logger.warn(this, e.getMessage(), e);
+	            }
+	        } else {
+	            if(!relationships.containsKey(rel)){
+	                relationships.put(rel, new ArrayList<Contentlet>());
+	            }
+	            List<Contentlet> cons = APILocator.getContentletAPI().getRelatedContent(
+	                    contentlet, rel, APILocator.systemUser(), false);
+	            for (Contentlet c : cons) {
+	                List<Contentlet> l = relationships.get(rel);
+	                l.add(c);
+	            }
+	        }
+	    }
+
+	    return relationships;
+	}
 }


### PR DESCRIPTION
Tested on master and with backported fix to 4.1.1 by following the steps on #12761.

Works OK. Once relationships are verified for the parent content type:

- If there's no Lucene Query on a REST API call given a specific Relationship, then it checks for existing ones on Index.
- If there's a Lucene Query on the REST API call given a specific Relationship, and it return valid contents, these ones are added as new relationships as well, wiping out existing ones. 

This behavior is the same we have on the Import Contents tool via CSV files.