### PR TITLE
#12886 : Displaying the appropriate error message in the logs instead…

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -4782,3 +4782,4 @@ no.vanity.url.content.types=There are not content types created with the Vanity 
 
 missing.field=Missing field: {0}, id: {1}
 
+workflows.task.attachedfiles.permissionerror=An error occurred when retrieving the files attached to this workflow.

--- a/dotCMS/src/main/webapp/html/portlet/ext/workflows/view_workflow_task.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/workflows/view_workflow_task.jsp
@@ -41,7 +41,7 @@
 	List<WorkflowComment> comments = APILocator.getWorkflowAPI().findWorkFlowComments(task);
 	List<WorkflowHistory> history = APILocator.getWorkflowAPI().findWorkflowHistory(task);
 	Collections.reverse(history);
-	List<IFileAsset> files = new ArrayList<>();
+	List<IFileAsset> files = Collections.EMPTY_LIST;
 	String errorRetrievingFilesMsg = null;
 	try {
 		files = APILocator.getWorkflowAPI().findWorkflowTaskFilesAsContent(task, user);


### PR DESCRIPTION
… of all the stack trace coming from the back-end JSP files. In the Workflow Task page, displaying a clear human-readable error message pointing out that an error occurred when listing the files attached to the task.