### PR TITLE
#12881 : Creating two types of commit listeners to easily handle whic…

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -685,37 +685,33 @@ public class ContentletAPITest extends ContentletBaseTest {
     @Test
     public void cleanBinaryField() throws DotDataException, DotSecurityException {
 
-        try {
-            //Getting a known structure
-            Structure structure = structures.iterator().next();
+        //Getting a known structure
+        Structure structure = structures.iterator().next();
 
-            Long identifier = uniqueIdentifier.get(structure.getName());
+        Long identifier = uniqueIdentifier.get(structure.getName());
 
-            //Search the contentlet for this structure
-            List<Contentlet> contentletList = contentletAPI.findByStructure(structure, user, false, 0, 0);
-            Contentlet contentlet = contentletList.iterator().next();
+        //Search the contentlet for this structure
+        List<Contentlet> contentletList = contentletAPI.findByStructure(structure, user, false, 0, 0);
+        Contentlet contentlet = contentletList.iterator().next();
 
-            //Getting a known binary field for this structure
-            //TODO: The definition of the method getFieldByName receive a parameter named "String:structureType", some examples I saw send the Inode, but actually what it needs is the structure name....
+        //Getting a known binary field for this structure
+        //TODO: The definition of the method getFieldByName receive a parameter named "String:structureType", some examples I saw send the Inode, but actually what it needs is the structure name....
 
-            Field foundBinaryField = FieldFactory.getFieldByVariableName(structure.getInode(), "junitTestBinary" + identifier);
+        Field foundBinaryField = FieldFactory.getFieldByVariableName(structure.getInode(), "junitTestBinary" + identifier);
 
 
-            //Getting the current value for this field
-            Object value = contentletAPI.getFieldValue(contentlet, foundBinaryField);
+        //Getting the current value for this field
+        Object value = contentletAPI.getFieldValue(contentlet, foundBinaryField);
 
-            //Validations
-            assertNotNull(value);
-            assertTrue(((java.io.File) value).exists());
+        //Validations
+        assertNotNull(value);
+        assertTrue(((java.io.File) value).exists());
 
-            //Cleaning the binary field
-            contentletAPI.cleanField(structure, foundBinaryField, user, false);
+        //Cleaning the binary field
+        contentletAPI.cleanField(structure, foundBinaryField, user, false);
 
-            //Validations
-            assertFalse(((java.io.File) value).exists());
-        } finally {
-            HibernateUtil.setAsyncCommitListenersFinalization(true);
-        }
+        //Validations
+        assertFalse(((java.io.File) value).exists());
     }
 
     /**

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
@@ -113,86 +113,82 @@ public class HostAPITest {
     
     @Test
     public void makeDefault() throws Exception {
-	    try {
             User user = APILocator.getUserAPI().getSystemUser();
     	/*
     	 * Get the current Default host
     	 */
-            Host hdef = APILocator.getHostAPI().findDefaultHost(user, false);
-    	
+        Host hdef = APILocator.getHostAPI().findDefaultHost(user, false);
+
     	/*
     	 * Create a new Host and make it default
     	 */
-            Host host = new Host();
-            host.setHostname("test" + System.currentTimeMillis() + ".demo.dotcms.com");
-            host.setDefault(false);
-            try {
-                HibernateUtil.startTransaction();
-                host = APILocator.getHostAPI().save(host, user, false);
-                HibernateUtil.closeAndCommitTransaction();
-            } catch (Exception e) {
-                HibernateUtil.rollbackTransaction();
-                Logger.error(HostAPITest.class, e.getMessage());
-            }
-            APILocator.getHostAPI().publish(host, user, false);
-            APILocator.getHostAPI().makeDefault(host, user, false);
+        Host host = new Host();
+        host.setHostname("test" + System.currentTimeMillis() + ".demo.dotcms.com");
+        host.setDefault(false);
+        try {
+            HibernateUtil.startTransaction();
+            host = APILocator.getHostAPI().save(host, user, false);
+            HibernateUtil.closeAndCommitTransaction();
+        } catch (Exception e) {
+            HibernateUtil.rollbackTransaction();
+            Logger.error(HostAPITest.class, e.getMessage());
+        }
+        APILocator.getHostAPI().publish(host, user, false);
+        APILocator.getHostAPI().makeDefault(host, user, false);
 
-            host = APILocator.getHostAPI().find(host.getIdentifier(), user, false);
-            APILocator.getContentletAPI().isInodeIndexed(host.getInode());
-            APILocator.getContentletAPI().isInodeIndexed(host.getInode(), true);
-            hdef = APILocator.getHostAPI().find(hdef.getIdentifier(), user, false);
-            APILocator.getContentletAPI().isInodeIndexed(hdef.getInode());
-            APILocator.getContentletAPI().isInodeIndexed(hdef.getInode(), true);
-        
+        host = APILocator.getHostAPI().find(host.getIdentifier(), user, false);
+        APILocator.getContentletAPI().isInodeIndexed(host.getInode());
+        APILocator.getContentletAPI().isInodeIndexed(host.getInode(), true);
+        hdef = APILocator.getHostAPI().find(hdef.getIdentifier(), user, false);
+        APILocator.getContentletAPI().isInodeIndexed(hdef.getInode());
+        APILocator.getContentletAPI().isInodeIndexed(hdef.getInode(), true);
+
         /*
          * Validate if the previous default host. Is live and not default
          */
-            Assert.assertTrue(hdef.isLive());
-            Assert.assertFalse(hdef.isDefault());
-        
+        Assert.assertTrue(hdef.isLive());
+        Assert.assertFalse(hdef.isDefault());
+
         /*
          * get Back to default the previous host
          */
-            APILocator.getHostAPI().makeDefault(hdef, user, false);
+        APILocator.getHostAPI().makeDefault(hdef, user, false);
 
-            host = APILocator.getHostAPI().find(host.getIdentifier(), user, false);
-            APILocator.getContentletAPI().isInodeIndexed(host.getInode());
-            APILocator.getContentletAPI().isInodeIndexed(host.getInode(), true);
-            hdef = APILocator.getHostAPI().find(hdef.getIdentifier(), user, false);
-            APILocator.getContentletAPI().isInodeIndexed(hdef.getInode());
-            APILocator.getContentletAPI().isInodeIndexed(hdef.getInode(), true);
-        
+        host = APILocator.getHostAPI().find(host.getIdentifier(), user, false);
+        APILocator.getContentletAPI().isInodeIndexed(host.getInode());
+        APILocator.getContentletAPI().isInodeIndexed(host.getInode(), true);
+        hdef = APILocator.getHostAPI().find(hdef.getIdentifier(), user, false);
+        APILocator.getContentletAPI().isInodeIndexed(hdef.getInode());
+        APILocator.getContentletAPI().isInodeIndexed(hdef.getInode(), true);
+
         /*
          * Validate if the new host is not default anymore and if its live
          */
-            Assert.assertFalse(host.isDefault());
-            Assert.assertTrue(host.isLive());
+        Assert.assertFalse(host.isDefault());
+        Assert.assertTrue(host.isLive());
 
-            Assert.assertTrue(hdef.isLive());
-            Assert.assertTrue(hdef.isDefault());
-        
+        Assert.assertTrue(hdef.isLive());
+        Assert.assertTrue(hdef.isDefault());
+
         /*
          * Delete the new test host
          */
-            Thread.sleep(600); // wait a bit for the index
-            try {
-                HibernateUtil.startTransaction();
-                APILocator.getHostAPI().archive(host, user, false);
-                APILocator.getHostAPI().delete(host, user, false);
-                HibernateUtil.closeAndCommitTransaction();
-            } catch (Exception e) {
-                HibernateUtil.rollbackTransaction();
-                Logger.error(HostAPITest.class, e.getMessage());
-            }
-            Thread.sleep(600); // wait a bit for the index
+        Thread.sleep(600); // wait a bit for the index
+        try {
+            HibernateUtil.startTransaction();
+            APILocator.getHostAPI().archive(host, user, false);
+            APILocator.getHostAPI().delete(host, user, false);
+            HibernateUtil.closeAndCommitTransaction();
+        } catch (Exception e) {
+            HibernateUtil.rollbackTransaction();
+            Logger.error(HostAPITest.class, e.getMessage());
+        }
+        Thread.sleep(600); // wait a bit for the index
         /*
          * Validate if the current Original default host is the current default one
          */
-            host = APILocator.getHostAPI().findDefaultHost(user, false);
-            Assert.assertEquals(hdef.getIdentifier(), host.getIdentifier());
-        } finally {
-            HibernateUtil.setAsyncCommitListenersFinalization(true);
-        }
+        host = APILocator.getHostAPI().findDefaultHost(user, false);
+        Assert.assertEquals(hdef.getIdentifier(), host.getIdentifier());
     }
     
     @Test

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -1,20 +1,42 @@
 package com.dotcms.content.elasticsearch.business;
 
-import java.io.Serializable;
-import java.io.StringWriter;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
-
+import com.dotcms.content.business.DotMappingException;
+import com.dotcms.content.elasticsearch.business.IndiciesAPI.IndiciesInfo;
+import com.dotcms.content.elasticsearch.util.ESClient;
+import com.dotcms.notifications.business.NotificationAPI;
+import com.dotcms.repackage.net.sf.hibernate.ObjectNotFoundException;
+import com.dotcms.repackage.org.apache.commons.io.FileUtils;
+import com.dotcms.repackage.org.apache.commons.lang.StringUtils;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.beans.Identifier;
+import com.dotmarketing.business.*;
+import com.dotmarketing.business.query.ComplexCriteria;
+import com.dotmarketing.business.query.Criteria;
+import com.dotmarketing.business.query.GenericQueryFactory.Query;
+import com.dotmarketing.business.query.SimpleCriteria;
+import com.dotmarketing.business.query.ValidationException;
+import com.dotmarketing.cache.FieldsCache;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.db.HibernateUtil;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotHibernateException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.factories.InodeFactory;
+import com.dotmarketing.portlets.contentlet.business.ContentletCache;
+import com.dotmarketing.portlets.contentlet.business.ContentletFactory;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
+import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
+import com.dotmarketing.portlets.links.model.Link;
+import com.dotmarketing.portlets.structure.model.Field;
+import com.dotmarketing.portlets.structure.model.Structure;
+import com.dotmarketing.portlets.workflows.business.WorkFlowFactory;
+import com.dotmarketing.portlets.workflows.model.WorkflowTask;
+import com.dotmarketing.util.*;
+import com.liferay.portal.model.User;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.count.CountRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
@@ -33,55 +55,15 @@ import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.util.NumberUtils;
 
-import com.dotcms.content.business.DotMappingException;
-import com.dotcms.content.elasticsearch.business.IndiciesAPI.IndiciesInfo;
-import com.dotcms.content.elasticsearch.util.ESClient;
-import com.dotcms.notifications.business.NotificationAPI;
-import com.dotcms.repackage.net.sf.hibernate.ObjectNotFoundException;
-import com.dotcms.repackage.org.apache.commons.io.FileUtils;
-import com.dotcms.repackage.org.apache.commons.lang.StringUtils;
-import com.dotmarketing.beans.Host;
-import com.dotmarketing.beans.Identifier;
-import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.CacheLocator;
-import com.dotmarketing.business.DotStateException;
-import com.dotmarketing.business.FactoryLocator;
-import com.dotmarketing.business.IdentifierAPI;
-import com.dotmarketing.business.PermissionAPI;
-import com.dotmarketing.business.query.ComplexCriteria;
-import com.dotmarketing.business.query.Criteria;
-import com.dotmarketing.business.query.GenericQueryFactory.Query;
-import com.dotmarketing.business.query.SimpleCriteria;
-import com.dotmarketing.business.query.ValidationException;
-import com.dotmarketing.cache.FieldsCache;
-import com.dotmarketing.common.db.DotConnect;
-import com.dotmarketing.db.DbConnectionFactory;
-import com.dotmarketing.db.FlushCacheRunnable;
-import com.dotmarketing.db.HibernateUtil;
-import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.exception.DotHibernateException;
-import com.dotmarketing.exception.DotRuntimeException;
-import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.factories.InodeFactory;
-import com.dotmarketing.portlets.contentlet.business.ContentletCache;
-import com.dotmarketing.portlets.contentlet.business.ContentletFactory;
-import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
-import com.dotmarketing.portlets.folders.model.Folder;
-import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
-import com.dotmarketing.portlets.links.model.Link;
-import com.dotmarketing.portlets.structure.model.Field;
-import com.dotmarketing.portlets.structure.model.Structure;
-import com.dotmarketing.portlets.workflows.business.WorkFlowFactory;
-import com.dotmarketing.portlets.workflows.model.WorkflowTask;
-import com.dotmarketing.util.Config;
-import com.dotmarketing.util.InodeUtils;
-import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.NumberUtil;
-import com.dotmarketing.util.RegEX;
-import com.dotmarketing.util.RegExMatch;
-import com.dotmarketing.util.UtilMethods;
-import com.liferay.portal.model.User;
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.Calendar;
 
 /**
  * Implementation class for the {@link ContentletFactory} interface. This class
@@ -1369,25 +1351,28 @@ public class ESContentFactoryImpl extends ContentletFactory {
 	   updateUserReferences(userToReplace,systemUser.getUserId(), systemUser );
 	}
 
-        /**
-         * Method will replace user references of the given User in Contentlets
-         * with the replacement user id
-         * @param userToReplace the user to replace
-         * @param replacementUserId Replacement User Id
-         * @param user the user requesting the operation
-         * @exception DotDataException There is a data inconsistency
-         * @throws DotSecurityException
-         */
-	protected void updateUserReferences(User userToReplace, String replacementUserId, User user) throws DotDataException, DotStateException, ElasticsearchException, DotSecurityException {
-        DotConnect dc = new DotConnect();
+    /**
+     * Replaces the references of a given user in contentlets
+     * with the ID of the user that will replace it.
+     *
+     * @param userToReplace     The user that is being replaced.
+     * @param replacementUserId The user ID that will replace the user that will be deleted.
+     * @param user              The user performing this operation.
+     * @throws DotDataException     An error occurred when interacting with the data source.
+     * @throws DotSecurityException The specified user does not have th required permissions to
+     *                              perform this action.
+     */
+    protected void updateUserReferences(final User userToReplace, final String replacementUserId,
+                                        final User user)
+            throws DotDataException, DotStateException, ElasticsearchException, DotSecurityException {
+        final DotConnect dc = new DotConnect();
         try {
-
-            String tempKeyword = DbConnectionFactory.getTempKeyword();
+            final String tempKeyword = DbConnectionFactory.getTempKeyword();
             // CTU content-to-update table
             final String tableName = (DbConnectionFactory.isMsSql()?"#":"") + "CTU_"
                 + UtilMethods.getRandomNumber(10000000);
 
-            StringBuilder createTempTable = new StringBuilder();
+            final StringBuilder createTempTable = new StringBuilder();
 
             if (DbConnectionFactory.isMsSql()) {
                 createTempTable.append("SELECT inode INTO ");
@@ -1401,99 +1386,107 @@ public class ESContentFactoryImpl extends ContentletFactory {
                 createTempTable.append(" TABLE ");
                 createTempTable.append(tableName);
                 createTempTable.append(DbConnectionFactory.isOracle() ? " ON COMMIT PRESERVE ROWS " : " ");
-                createTempTable.append("as select inode from contentlet ");
-                createTempTable.append("where mod_user = '");
+                createTempTable.append("AS SELECT inode FROM contentlet ");
+                createTempTable.append("WHERE mod_user = '");
                 createTempTable.append(userToReplace.getUserId());
                 createTempTable.append("'");
             }
 
             dc.executeStatement(createTempTable.toString());
 
-            dc.setSQL("UPDATE contentlet set mod_user = ? where mod_user = ? ");
+            dc.setSQL("UPDATE contentlet SET mod_user = ? WHERE mod_user = ? ");
             dc.addParam(replacementUserId);
             dc.addParam(userToReplace.getUserId());
             dc.loadResult();
 
-            dc.setSQL("update contentlet_version_info set locked_by=? where locked_by  = ?");
+            dc.setSQL("UPDATE contentlet_version_info SET locked_by = ? WHERE locked_by = ?");
             dc.addParam(replacementUserId);
             dc.addParam(userToReplace.getUserId());
             dc.loadResult();
 
-            FlushCacheRunnable reindexContent = new FlushCacheRunnable() {
-                @Override
-                public void run() {
+            HibernateUtil.addSyncCommitListener(() -> {
 
-                    NotificationAPI notAPI = APILocator.getNotificationAPI();
+                reindexReplacedUserContent(userToReplace, user, tableName);
 
-                    try {
-                        ESContentletIndexAPI indexAPI = new ESContentletIndexAPI();
-
-                        DotConnect dc = new DotConnect();
-                        dc.setSQL("select count(*) as count from " + tableName);
-                        List<Map<String,String>> results = dc.loadResults();
-                        long totalCount = Long.parseLong(results.get(0).get("count"));
-
-                        Connection conn = DbConnectionFactory.getConnection();
-                        try(PreparedStatement ps = conn.prepareStatement("select inode from " + tableName)) {
-
-                            List<Contentlet> contentToIndex = new ArrayList<>();
-                            int batchSize = 100;
-                            int completed = 0;
-
-                            try (ResultSet rs = ps.executeQuery()) {
-                                for (int i = 1; rs.next(); i++) {
-                                    String inode = rs.getString("inode");
-                                    cc.remove(inode);
-                                    Contentlet content = find(inode);
-                                    contentToIndex.add(content);
-                                    contentToIndex.addAll(indexAPI.loadDeps(content));
-
-                                    if (i % batchSize == 0) {
-                                        indexAPI.indexContentList(contentToIndex, null, false);
-                                        completed += batchSize;
-                                        contentToIndex = new ArrayList<>();
-                                        HibernateUtil.getSession().clear();
-                                        Logger.info(this,
-                                            String.format("Reindexing related content after deletion of user %s. "
-                                                + "Completed: " + completed + " out of " + totalCount,
-                                            userToReplace.getUserId() + "/" + userToReplace.getFullName()));
-                                    }
-                                }
-
-                                // index remaining records if any
-                                if(!contentToIndex.isEmpty()) {
-                                    indexAPI.indexContentList(contentToIndex, null, false);
-                                }
-                            }
-                        }
-
-                        dc.setSQL("DROP TABLE " + tableName);
-                        dc.loadResult();
-
-                        Logger.info(this, String.format("Reindex of updated related content after deleting user %s "
-                                + " has finished successfully.",
-                            userToReplace.getUserId() + "/" + userToReplace.getFullName()));
-
-                    } catch (Exception e) {
-                        Logger.error(this.getClass(),e.getMessage(),e);
-                        notAPI.error(String.format("Unable to Reindex updated related content for deleted user '%s'. "
-                            + "Please run a full Reindex.",
-                            userToReplace.getUserId() + "/" + userToReplace.getFullName()), user.getUserId());
-                    }
-                }
-            };
-
-            HibernateUtil.addCommitListener(reindexContent);
-
-
+            });
         } catch (DotDataException | SQLException e) {
             Logger.error(this.getClass(),e.getMessage(),e);
             throw new DotDataException(e.getMessage(), e);
         }
     }
 
-	@Override
-    protected Contentlet save(Contentlet contentlet) throws DotDataException, DotStateException, DotSecurityException {
+    /**
+     * Performs a re-indexation of contents whose user references have been updated with a new
+     * user ID. This change requires contents to be re-indexed for them to have the correct
+     * information. The Inodes of such contentlets are stored in a temporary table.
+     *
+     * @param userToReplace The user whose references will be removed.
+     * @param user          The user performing this operation.
+     * @param tableName     The name of the temporary table containing the contentlet Inodes.
+     */
+    private void reindexReplacedUserContent(final User userToReplace, final User user, final
+    String tableName) {
+        final DotConnect dc = new DotConnect();
+        final NotificationAPI notAPI = APILocator.getNotificationAPI();
+        final Connection conn = DbConnectionFactory.getConnection();
+        try {
+            final ESContentletIndexAPI indexAPI = new ESContentletIndexAPI();
+            dc.setSQL("SELECT COUNT(*) AS count FROM " + tableName);
+            final List<Map<String, String>> results = dc.loadResults();
+            final long totalCount = Long.parseLong(results.get(0).get("count"));
+            try (final PreparedStatement ps = conn.prepareStatement("SELECT inode FROM " +
+                    tableName)) {
+                List<Contentlet> contentToIndex = new ArrayList<>();
+                final int batchSize = 100;
+                int completed = 0;
+                try (final ResultSet rs = ps.executeQuery()) {
+                    for (int i = 1; rs.next(); i++) {
+                        final String inode = rs.getString("inode");
+                        cc.remove(inode);
+                        final Contentlet content = find(inode);
+                        contentToIndex.add(content);
+                        contentToIndex.addAll(indexAPI.loadDeps(content));
+                        if (i % batchSize == 0) {
+                            indexAPI.indexContentList(contentToIndex, null, false);
+                            completed += batchSize;
+                            contentToIndex = new ArrayList<>();
+                            HibernateUtil.getSession().clear();
+                            Logger.info(this, String.format("Reindexing related content after " +
+                                    "deletion of user '%s'. " + "Completed: " + completed + " out of " +
+                                    totalCount, userToReplace.getUserId() + "/" + userToReplace
+                                    .getFullName()));
+                        }
+                    }
+                    // index remaining records if any
+                    if (!contentToIndex.isEmpty()) {
+                        indexAPI.indexContentList(contentToIndex, null, false);
+                    }
+                }
+            }
+            dc.setSQL("DROP TABLE " + tableName);
+            dc.loadResult();
+            Logger.info(this, String.format("Reindexing of updated related content after " +
+                    "deleting user '%s' " + " has finished successfully.", userToReplace.getUserId() +
+                    "/" + userToReplace.getFullName()));
+        } catch (Exception e) {
+            Logger.error(this.getClass(), e.getMessage(), e);
+            notAPI.error(String.format("Unable to reindex updated related content for deleted " +
+                    "user '%s'. " + "Please run a full Reindex.", userToReplace.getUserId() + "/" +
+                    userToReplace.getFullName()), user.getUserId());
+        } finally {
+            if (null != conn) {
+                try {
+                    conn.close();
+                } catch (SQLException e) {
+                    // Connection could not be closed
+                }
+            }
+        }
+    }
+
+    @Override
+    protected Contentlet save(Contentlet contentlet) throws DotDataException, DotStateException,
+            DotSecurityException {
 	    return save(contentlet,null);
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/db/HibernateUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/HibernateUtil.java
@@ -1,26 +1,9 @@
 package com.dotmarketing.db;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Savepoint;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 import com.dotcms.repackage.net.sf.hibernate.*;
 import com.dotcms.repackage.net.sf.hibernate.cfg.Configuration;
 import com.dotcms.repackage.net.sf.hibernate.cfg.Mappings;
 import com.dotcms.repackage.net.sf.hibernate.type.Type;
-import com.dotcms.repackage.org.apache.poi.ss.formula.functions.T;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotHibernateException;
@@ -31,7 +14,19 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.WebKeys;
 
+import java.io.*;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
 /**
+ * This class provides a great number of utility methods that allow developers to interact with
+ * the underlying data source in dotCMS. Without regards to using the legacy Hibernate queries or
+ * the new {@link com.dotmarketing.common.db.DotConnect} class, developers can manage
+ * database transactions, connections, commit listeners, and many other configuration settings.
  *
  * @author will & david (2005)
  */
@@ -63,9 +58,6 @@ public class HibernateUtil {
 		ENABLED, DISABLED;
 	}
 
-	public static final String addToIndex="-add-to-index";
-	public static final String removeFromIndex="-remove-from-index";
-
 	/**
 	 * Status for listeners of thread-local -based transactions. This allows to control whether listeners are appended or not (ENABLED by default)
 	 */
@@ -77,11 +69,11 @@ public class HibernateUtil {
 
 	private static final ThreadLocal<Boolean> asyncCommitListenersFinalization = ThreadLocal.withInitial(()->true);
 	
-	private static final ThreadLocal< Map<String,DotRunnable> > commitListeners=new ThreadLocal<Map<String,DotRunnable>>() {
-	    protected java.util.Map<String,DotRunnable> initialValue() {
-	        return new LinkedHashMap<String,DotRunnable>();
-	    }
-	};
+	private static final ThreadLocal< Map<String,DotRunnable> > asyncCommitListeners = ThreadLocal
+			.withInitial(() -> new LinkedHashMap<>());
+
+	private static final ThreadLocal<Map<String, DotRunnable>> syncCommitListeners = ThreadLocal
+			.withInitial(() -> new LinkedHashMap<>());
 
 	private static final ThreadLocal< List<DotRunnable> > rollbackListeners=new ThreadLocal<List<DotRunnable>>() {
         protected java.util.List<DotRunnable> initialValue() {
@@ -783,21 +775,144 @@ public class HibernateUtil {
 	public static void setAsyncCommitListenersFinalization(boolean finalizeAsync) {
 		asyncCommitListenersFinalization.set(finalizeAsync);
 	}
-	
-	public static void addCommitListener(DotRunnable listener) throws DotHibernateException {
+
+	/**
+	 * Adds a commit listener to the current database transaction/session. There are several
+	 * types of commit listeners, namely:
+	 * <ul>
+	 * <li>{@link DotSyncRunnable}</li>
+	 * <li>{@link DotAsyncRunnable}</li>
+	 * <li>{@link FlushCacheRunnable}</li>
+	 * <li>{@link ReindexRunnable}</li>
+	 * <li>Among others.</li>
+	 * </ul>
+	 * Commit listeners allow developers to execute code after a transaction has been committed
+	 * or the session has ended.
+	 *
+	 * @param listener The commit listener wrapped as a {@link Runnable} object.
+	 * @throws DotHibernateException An error occurred when registering the commit listener.
+	 */
+	public static void addCommitListener(final DotRunnable listener) throws DotHibernateException {
 	    addCommitListener(UUIDGenerator.generateUuid(),listener);
 	}
 
-	public static void addCommitListener(String tag, DotRunnable listener) throws DotHibernateException {
+	/**
+	 * Allows you to add an asynchronous commit listener to the current database
+	 * session/transaction. This means that the current flow of the application will continue its
+	 * way and the specified commit listener will be spawned subsequently after the transaction
+	 * has been committed or the session has been closed.
+	 * <p>By default, asynchronous commit listeners will be spawned by a new thread. This means
+	 * that they will not share the same database connection information with the main thread of
+	 * the dotCMS application.</p>
+	 *
+	 * @param runnable The commit listener wrapped as a {@link Runnable} object.
+	 * @throws DotHibernateException An error occurred when registering the commit listener.
+	 */
+	public static void addAsyncCommitListener(final Runnable runnable) throws
+			DotHibernateException {
+		addCommitListener(new DotAsyncRunnable(runnable));
+	}
+
+	/**
+	 * Allows you to add an asynchronous commit listener to the current database
+	 * session/transaction. This means that the current flow of the application will take care of
+	 * running the specified commit listener. This is particularly useful when you need to keep
+	 * database objects that were created during the database transaction.
+	 * <p>For example, if you created a temporary table that your commit listener needs to
+	 * access, you will definitely need to create a synchronous listener for it to be able to
+	 * access the such a table as temporary tables are only available for the duration of the
+	 * transaction or the session. With synchronous commit listeners, dotCMS will use the its
+	 * main execution thread to call the listener; therefore, it can access the same database
+	 * connection and see the temporary table.</p>
+	 *
+	 * @param runnable The commit listener wrapped as a {@link Runnable} object.
+	 * @throws DotHibernateException An error occurred when registering the commit listener.
+	 */
+	public static void addSyncCommitListener(final Runnable runnable) throws
+			DotHibernateException {
+		addCommitListener(new DotSyncRunnable(runnable));
+	}
+
+	/**
+	 * Allows you to create an asynchronous commit listener, which represents code that will be
+	 * called after a database transaction has been committed or the session has been closed.
+	 * This type of listener will be spawned in a new thread. This way, the main dotCMS main thread
+	 * can move on.
+	 */
+	public static class DotAsyncRunnable extends DotRunnable {
+
+		private final Runnable runnable;
+
+		public DotAsyncRunnable(final Runnable runnable) {
+			this.runnable = runnable;
+		}
+
+		@Override
+		public void run() {
+			runnable.run();
+		}
+	}
+
+	/**
+	 * Allows you to create a synchronous commit listener, which represents code that will be
+	 * called after a database transaction has been committed or the session has been closed.
+	 * Synchronous listeners will NOT RUN ON A NEW THREAD, they will use the main dotCMS thread.
+	 */
+	public static class DotSyncRunnable extends DotRunnable {
+
+		private final Runnable runnable;
+
+		public DotSyncRunnable(final Runnable runnable) {
+			this.runnable = runnable;
+		}
+
+		@Override
+		public void run() {
+			runnable.run();
+		}
+	}
+
+	/**
+	 * Adds a commit listener to the current database transaction/session. There are several
+	 * types of commit listeners, namely:
+	 * <ul>
+	 * <li>{@link DotSyncRunnable}</li>
+	 * <li>{@link DotAsyncRunnable}</li>
+	 * <li>{@link FlushCacheRunnable}</li>
+	 * <li>{@link ReindexRunnable}</li>
+	 * <li>Among others.</li>
+	 * </ul>
+	 * Commit listeners allow developers to execute code after a transaction has been committed
+	 * or the session has ended. For listeners that are not instances of {@link DotSyncRunnable}
+	 * or {@link DotAsyncRunnable} a configuration property called {@code
+	 * REINDEX_ON_SAVE_IN_SEPARATE_THREAD} determines whether listeners are executed in a
+	 * separate thread, or in the same dotCMS thread. By default, they run in a brand new thread.
+	 *
+	 * @param tag      A unique ID for the specified listener.
+	 * @param listener The commit listener wrapped as a {@link Runnable} object.
+	 * @throws DotHibernateException An error occurred when registering the commit listener.
+	 */
+	public static void addCommitListener(final String tag, final DotRunnable listener) throws
+			DotHibernateException {
 		if (getTransactionListenersStatus() != TransactionListenerStatus.DISABLED) {
 			try {
-	    	    if(getSession().connection().getAutoCommit())
-	    	        listener.run();
-	    	    else {
-	    	    	commitListeners.get().put(tag,listener);
-	    	    }
-		    }
-		    catch(Exception ex) {
+	    	    if(getSession().connection().getAutoCommit()) {
+					listener.run();
+				} else {
+					if (listener instanceof DotSyncRunnable) {
+						syncCommitListeners.get().put(tag, listener);
+					} else if (listener instanceof DotAsyncRunnable) {
+						asyncCommitListeners.get().put(tag, listener);
+					} else {
+						if (getAsyncCommitListenersFinalization() && Config.getBooleanProperty
+								("REINDEX_ON_SAVE_IN_SEPARATE_THREAD", true)) {
+							asyncCommitListeners.get().put(tag, listener);
+						} else {
+							syncCommitListeners.get().put(tag, listener);
+						}
+					}
+				}
+			} catch(Exception ex) {
 		        throw new DotHibernateException(ex.getMessage(),ex);
 		    }
 		}
@@ -840,7 +955,7 @@ public class HibernateUtil {
 						Logger.debug(HibernateUtil.class, "Closing session. Commiting changes!");
 						session.connection().commit();
 						session.connection().setAutoCommit(true);
-						if(commitListeners.get().size()>0) {
+						if(asyncCommitListeners.get().size()>0) {
 							finalizeCommitListeners();
 						}
 					}
@@ -854,21 +969,27 @@ public class HibernateUtil {
 			throw new DotHibernateException("Unable to close Hibernate Session ", e);
 		}
 		finally {
-		    commitListeners.get().clear();
+		    asyncCommitListeners.get().clear();
 		    rollbackListeners.get().clear();
 		}
 	}
 
-	private static void finalizeCommitListeners() throws DotDataException{
-		final List<DotRunnable> listeners = new ArrayList<>(commitListeners.get().values());
-		commitListeners.get().clear();
-
-		final DotRunnableThread thread = new DotRunnableThread(listeners);
-
-		if(getAsyncCommitListenersFinalization()
-				&& Config.getBooleanProperty("REINDEX_ON_SAVE_IN_SEPARATE_THREAD",true)){
+	/**
+	 * Traverses the lists of both synchronous and asynchronous commit listeners and starts them
+	 * up. The asynchronous listeners are executed as separate threads, whereas synchronous
+	 * listeners use the main dotCMS thread to run.
+	 */
+	private static void finalizeCommitListeners() {
+		final List<DotRunnable> asyncListeners = new ArrayList<>(asyncCommitListeners.get().values());
+		final List<DotRunnable> syncListeners = new ArrayList<>(syncCommitListeners.get().values());
+		asyncCommitListeners.get().clear();
+		syncCommitListeners.get().clear();
+		if (!asyncListeners.isEmpty()) {
+			final DotRunnableThread thread = new DotRunnableThread(asyncListeners);
 			thread.start();
-		}  else{
+		}
+		if (!syncListeners.isEmpty()) {
+			final DotRunnableThread thread = new DotRunnableThread(syncListeners);
 			thread.run();
 		}
 	}
@@ -882,7 +1003,7 @@ public class HibernateUtil {
 		 */
 			getSession().connection().setAutoCommit(false);
 			rollbackListeners.get().clear();
-			commitListeners.get().clear();
+			asyncCommitListeners.get().clear();
 			Logger.debug(HibernateUtil.class, "Starting Transaction!");
 		}catch (Exception e) {
 			throw new DotHibernateException("Unable to set AutoCommit to false on Hibernate Session ", e);
@@ -908,7 +1029,7 @@ public class HibernateUtil {
 					Logger.debug(HibernateUtil.class, "Closing session. Commiting changes!");
 					session.connection().commit();
 					session.connection().setAutoCommit(true);
-					if(commitListeners.get().size()>0) {
+					if(asyncCommitListeners.get().size()>0) {
 						finalizeCommitListeners();
 					}
 				}
@@ -918,7 +1039,7 @@ public class HibernateUtil {
 			throw new DotHibernateException("Unable to close Hibernate Session ", e);
 		}
 		finally {
-			commitListeners.get().clear();
+			asyncCommitListeners.get().clear();
 			rollbackListeners.get().clear();
 		}
 	}
@@ -964,7 +1085,7 @@ public class HibernateUtil {
 	}
 
 	public static void sessionCleanupAndRollback()  throws DotHibernateException{
-	    commitListeners.get().clear();
+	    asyncCommitListeners.get().clear();
 		Logger.debug(HibernateUtil.class, "sessionCleanupAndRollback");
 		Session session = getSession();
 		session.clear();


### PR DESCRIPTION
…h are synchronous and asynchronous. Adding Javadoc. For deleting users, we needed the synchronous listener because we needed to use the main dotCMS thread to access the temporary table.