### PR TITLE
Allow preview sidebar scrolling. Fixes dotCMS/core#12967.

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/preview_mode.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/preview_mode.vtl
@@ -137,7 +137,7 @@
 					<iframe id="frameMain" name="frameMain" style="border:0;margin:0;" marginheight="0" marginwidth="0" scrolling="auto" frameborder="0" src="${_baseURI}?mainFrame=1&livePage=$livePage&com.dotmarketing.htmlpage.language=$language&language=$language&host_id=${host.identifier}&$!{queryString}"></iframe>
 				</td>
 				<td>
-					<iframe id="frameMenu" name="frameMenu" style="width:240px;border:0;margin:0;padding:0;" width="240" marginheight="0" marginwidth="0" frameborder="0" scrolling="no" src="${_baseURI}?leftMenu=1&livePage=$livePage&com.dotmarketing.htmlpage.language=$language&language=$language&host_id=${host.identifier}&$!{queryString}"></iframe>
+					<iframe id="frameMenu" name="frameMenu" style="width:240px;border:0;margin:0;padding:0;" width="240" marginheight="0" marginwidth="0" frameborder="0" scrolling="yes" src="${_baseURI}?leftMenu=1&livePage=$livePage&com.dotmarketing.htmlpage.language=$language&language=$language&host_id=${host.identifier}&$!{queryString}"></iframe>
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
Change the value of the inline style 'scrolling' from 'no' to 'yes'. Fixes lack of scrolling in preview sidebar.