### PR TITLE
#13249 fixes

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/integritycheckers/IntegrityUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/integritycheckers/IntegrityUtil.java
@@ -342,6 +342,9 @@ public class IntegrityUtil {
                         dc.executeStatement("drop table " + tempTableName);
                     }else if (DbConnectionFactory.isMySql()){
                         dc.executeStatement("drop table if exists " + tempTableName);
+                    } else if (DbConnectionFactory.isMsSql()){
+                        dc.executeStatement("IF OBJECT_ID('tempdb.dbo." + tempTableName + "', 'U') IS NOT NULL"
+                                + "  DROP TABLE " + tempTableName);
                     }
             	}
             }


### PR DESCRIPTION
For #13249, tested on current master and with backported fix for 4.2.x releases, using a SQL Server 2016 database. Issue is solved and temp tables are dropped after the Integrity Checker is run.