### PR TITLE
fixes #13397

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00020LoadClusterLicenses.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00020LoadClusterLicenses.java
@@ -34,7 +34,12 @@ public class Task00020LoadClusterLicenses implements StartupTask {
     @Override
     public boolean forceRun() {
         
-       return licensePackFiles().length>0;
+       File[] licPackFiles = licensePackFiles();
+       if(licPackFiles == null) {
+         Logger.warn(this.getClass(), "licPackFiles is NULL - this usually means something is wrong with the assets folder");
+         return false;
+       }
+       return licPackFiles.length>0;
 
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportExportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportExportUtil.java
@@ -1020,8 +1020,7 @@ public class ImportExportUtil {
         assetDirectory.mkdirs();
         final String[] assetsFileList = assetDirectory.list();
         for (String fileName : assetsFileList) {
-        	if(fileName.equalsIgnoreCase("license")) continue;
-        	
+            if(fileName.toLowerCase().startsWith("license")) continue;
             File f = new File(assetDirectory.getPath() + File.separator + fileName);
             if(f.isDirectory()) {
                 FileUtil.deltree(f);


### PR DESCRIPTION
Fix for license pack issue and also a change for Task00020LoadClusterLicenses.java because in testing around this issue found that the licensePackFiles method can return null which results in a NullPointerException if it is not handled properly.