### PR TITLE
 #9303 Create push history regardless of forcepush value

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/publisher/util/DependencySetTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publisher/util/DependencySetTest.java
@@ -1,0 +1,107 @@
+package com.dotcms.publisher.util;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.publisher.assets.bean.PushedAsset;
+import com.dotcms.publisher.bundle.bean.Bundle;
+import com.dotcms.publisher.endpoint.bean.PublishingEndPoint;
+import com.dotcms.publisher.endpoint.bean.impl.PushPublishingEndPoint;
+import com.dotcms.publisher.environment.bean.Environment;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Permission;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.util.UUIDGenerator;
+import com.liferay.portal.model.User;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(DataProviderRunner.class)
+public class DependencySetTest {
+
+    private final User systemUser = APILocator.systemUser();
+
+    @BeforeClass
+    public static void prepare() throws Exception{
+        //Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    @DataProvider(format = "%m: ForcePush: %p[0]")
+    public static Object[] dataProviderForcePush() {
+        return new Object[]{true, false};
+    }
+
+    @Test
+    @UseDataProvider("dataProviderForcePush")
+    public void addOrClean_shouldCreatePushedAssetEntry(final boolean forcePush) throws DotSecurityException, DotDataException {
+        Environment environment = createTestEnviroment();
+        PublishingEndPoint endPoint = createTestEndpoint(environment.getId());
+
+        Bundle testBundle = createTestBundle(forcePush, Collections.singletonList(environment));
+
+        final boolean IS_DOWNLOADING = false;
+        final boolean IS_PUBLISHING = true;
+        final boolean IS_STATIC = false;
+        final DependencySet dependencySet = new DependencySet(testBundle.getId(), "content", IS_DOWNLOADING,
+            IS_PUBLISHING, IS_STATIC);
+
+        final String ABOUT_QUEST_ID = "767509b1-2392-4661-a16b-e0e31ce27719";
+        final Contentlet contentlet = APILocator.getContentletAPI().findContentletByIdentifier(ABOUT_QUEST_ID,
+            false, 1, systemUser, false);
+
+        dependencySet.add(contentlet.getIdentifier(), new Date());
+
+        PushedAsset pushedAsset = APILocator.getPushedAssetsAPI().getLastPushForAsset(contentlet.getIdentifier(),
+            environment.getId(), endPoint.getId());
+
+        assertNotNull(pushedAsset);
+    }
+
+    private Bundle createTestBundle(final boolean forcePush, final List<Environment> environments)
+        throws DotDataException {
+        Bundle bundle = new Bundle();
+        bundle.setName("testBundle"+System.currentTimeMillis());
+        bundle.setForcePush(forcePush);
+        bundle.setPublishDate(new Date());
+        bundle.setOwner(systemUser.getUserId());
+        APILocator.getBundleAPI().saveBundle(bundle, environments);
+        return bundle;
+    }
+
+    private Environment createTestEnviroment() throws DotDataException, DotSecurityException {
+        Environment environment = new Environment();
+        environment.setName("testEnvironment"+System.currentTimeMillis());
+        environment.setPushToAll(true);
+        APILocator.getEnvironmentAPI().saveEnvironment(environment, null);
+        return environment;
+    }
+
+    private PublishingEndPoint createTestEndpoint(final String environmentId) throws DotDataException {
+        PublishingEndPoint publishingEndPoint = new PushPublishingEndPoint();
+        publishingEndPoint.setGroupId(environmentId);
+        publishingEndPoint.setServerName(new StringBuilder("testEndpoint").append(System.currentTimeMillis()));
+        publishingEndPoint.setAddress("x.x.x.x");
+        publishingEndPoint.setPort("8080");
+        publishingEndPoint.setProtocol("http");
+        publishingEndPoint.setEnabled(true);
+        publishingEndPoint.setAuthKey(new StringBuilder("key"));
+        publishingEndPoint.setSending(false);
+        APILocator.getPublisherEndPointAPI().saveEndPoint(publishingEndPoint);
+        return publishingEndPoint;
+    }
+
+}

--- a/dotCMS/src/integration-test/java/com/dotcms/publisher/util/DependencySetTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publisher/util/DependencySetTest.java
@@ -48,10 +48,10 @@ public class DependencySetTest {
     @Test
     @UseDataProvider("dataProviderForcePush")
     public void addOrClean_shouldCreatePushedAssetEntry(final boolean forcePush) throws DotSecurityException, DotDataException {
-        Environment environment = createTestEnviroment();
-        PublishingEndPoint endPoint = createTestEndpoint(environment.getId());
+        final Environment environment = createTestEnviroment();
+        final PublishingEndPoint endPoint = createTestEndpoint(environment.getId());
 
-        Bundle testBundle = createTestBundle(forcePush, Collections.singletonList(environment));
+        final Bundle testBundle = createTestBundle(forcePush, Collections.singletonList(environment));
 
         final boolean IS_DOWNLOADING = false;
         final boolean IS_PUBLISHING = true;
@@ -65,7 +65,7 @@ public class DependencySetTest {
 
         dependencySet.add(contentlet.getIdentifier(), new Date());
 
-        PushedAsset pushedAsset = APILocator.getPushedAssetsAPI().getLastPushForAsset(contentlet.getIdentifier(),
+        final PushedAsset pushedAsset = APILocator.getPushedAssetsAPI().getLastPushForAsset(contentlet.getIdentifier(),
             environment.getId(), endPoint.getId());
 
         assertNotNull(pushedAsset);
@@ -73,7 +73,7 @@ public class DependencySetTest {
 
     private Bundle createTestBundle(final boolean forcePush, final List<Environment> environments)
         throws DotDataException {
-        Bundle bundle = new Bundle();
+        final Bundle bundle = new Bundle();
         bundle.setName("testBundle"+System.currentTimeMillis());
         bundle.setForcePush(forcePush);
         bundle.setPublishDate(new Date());
@@ -83,7 +83,7 @@ public class DependencySetTest {
     }
 
     private Environment createTestEnviroment() throws DotDataException, DotSecurityException {
-        Environment environment = new Environment();
+        final Environment environment = new Environment();
         environment.setName("testEnvironment"+System.currentTimeMillis());
         environment.setPushToAll(true);
         APILocator.getEnvironmentAPI().saveEnvironment(environment, null);
@@ -91,7 +91,7 @@ public class DependencySetTest {
     }
 
     private PublishingEndPoint createTestEndpoint(final String environmentId) throws DotDataException {
-        PublishingEndPoint publishingEndPoint = new PushPublishingEndPoint();
+        final PublishingEndPoint publishingEndPoint = new PushPublishingEndPoint();
         publishingEndPoint.setGroupId(environmentId);
         publishingEndPoint.setServerName(new StringBuilder("testEndpoint").append(System.currentTimeMillis()));
         publishingEndPoint.setAddress("x.x.x.x");

--- a/dotCMS/src/integration-test/java/com/dotcms/publisher/util/DependencySetTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publisher/util/DependencySetTest.java
@@ -1,19 +1,15 @@
 package com.dotcms.publisher.util;
 
-import com.dotcms.IntegrationTestBase;
 import com.dotcms.publisher.assets.bean.PushedAsset;
 import com.dotcms.publisher.bundle.bean.Bundle;
 import com.dotcms.publisher.endpoint.bean.PublishingEndPoint;
 import com.dotcms.publisher.endpoint.bean.impl.PushPublishingEndPoint;
 import com.dotcms.publisher.environment.bean.Environment;
 import com.dotcms.util.IntegrationTestInitService;
-import com.dotmarketing.beans.Permission;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.util.UUIDGenerator;
 import com.liferay.portal.model.User;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -27,7 +23,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(DataProviderRunner.class)
 public class DependencySetTest {

--- a/dotCMS/src/main/java/com/dotcms/publisher/util/DependencySet.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/DependencySet.java
@@ -41,7 +41,8 @@ public class DependencySet extends HashSet<String> {
 	private static final String ENDPOINTS_SUFFIX = "_endpointIds";
 	private static final String PUBLISHER_SUFFIX = "_publisher";
 
-	public DependencySet(String bundleId, String assetType, boolean isDownload, boolean isPublish, boolean isStatic) {
+	public DependencySet(final String bundleId, final String assetType, final boolean isDownload,
+						 final boolean isPublish, final boolean isStatic) {
 		super();
 		cache = CacheLocator.getPushedAssetsCache();
 		this.assetType = assetType;
@@ -56,8 +57,8 @@ public class DependencySet extends HashSet<String> {
 		}
 		try {
 			for (Environment env : envs) {
-				String endpointIds = null;
-				String publisher = null;
+				String endpointIds;
+				String publisher;
 
 				List<PublishingEndPoint> allEndpoints = APILocator.getPublisherEndPointAPI().findSendingEndPointsByEnvironment(env.getId());
 				List<String> endpoints = new ArrayList<>();
@@ -87,10 +88,9 @@ public class DependencySet extends HashSet<String> {
 				publisher = StringUtils.join(publishers,",");
 				//comma separated string with the list of endpoint ids
 				endpointIds = StringUtils.join(endpoints,",");
-				if(!env.getPushToAll()) {
-					if(endpointIds != null && endpointIds.contains(",")){
-						endpointIds = endpointIds.substring(0, endpointIds.indexOf(","));
-					}
+
+				if(!env.getPushToAll() && endpointIds != null && endpointIds.contains(",")){
+					endpointIds = endpointIds.substring(0, endpointIds.indexOf(","));
 				}
 
 				//Add environment endpoints and publisher to map
@@ -99,7 +99,7 @@ public class DependencySet extends HashSet<String> {
 
 			}
 			//Search and remove all the environments that are not going to be used by this dependencySet
-			List<Environment> removeEnvironmentsList = new ArrayList<Environment>();
+			List<Environment> removeEnvironmentsList = new ArrayList<>();
 			for (Environment env : envs) {
 				if(StringUtils.isEmpty(environmentsEndpointsAndPublisher.get(env.getId()+ENDPOINTS_SUFFIX))){
 					removeEnvironmentsList.add(env);
@@ -119,7 +119,7 @@ public class DependencySet extends HashSet<String> {
 		}
 	}
 
-	public boolean add(String assetId, Date assetModDate) {
+	public boolean add(final String assetId, final Date assetModDate) {
 		return addOrClean( assetId, assetModDate, false);
 	}
 
@@ -132,11 +132,11 @@ public class DependencySet extends HashSet<String> {
 	 * @param assetModDate
 	 * @return
 	 */
-	public boolean addOrClean ( final String assetId, Date assetModDate) {
+	public boolean addOrClean ( final String assetId, final Date assetModDate) {
 		return addOrClean( assetId, assetModDate, true);
 	}
 
-	private boolean addOrClean ( final String assetId, final Date assetModDate, Boolean cleanForUnpublish) {
+	private boolean addOrClean ( final String assetId, final Date assetModDate, final Boolean cleanForUnpublish) {
 
 		if ( !isPublish ) {
 

--- a/dotCMS/src/main/java/com/dotcms/publisher/util/DependencySet.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/DependencySet.java
@@ -132,11 +132,11 @@ public class DependencySet extends HashSet<String> {
 	 * @param assetModDate
 	 * @return
 	 */
-	public boolean addOrClean ( String assetId, Date assetModDate) {
+	public boolean addOrClean ( final String assetId, Date assetModDate) {
 		return addOrClean( assetId, assetModDate, true);
 	}
 
-	private boolean addOrClean ( String assetId, Date assetModDate, Boolean cleanForUnpublish) {
+	private boolean addOrClean ( final String assetId, Date assetModDate, Boolean cleanForUnpublish) {
 
 		if ( !isPublish ) {
 

--- a/dotCMS/src/main/java/com/dotcms/publisher/util/DependencySet.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/DependencySet.java
@@ -136,7 +136,7 @@ public class DependencySet extends HashSet<String> {
 		return addOrClean( assetId, assetModDate, true);
 	}
 
-	private boolean addOrClean ( final String assetId, Date assetModDate, Boolean cleanForUnpublish) {
+	private boolean addOrClean ( final String assetId, final Date assetModDate, Boolean cleanForUnpublish) {
 
 		if ( !isPublish ) {
 
@@ -227,7 +227,7 @@ public class DependencySet extends HashSet<String> {
 		return false;
 	}
 
-    private void savePushedAsset(String assetId, Environment env) {
+    private void savePushedAsset(final String assetId, final Environment env) {
         try {
             //Insert the new pushed asset indicating to which endpoints will be sent and with what publisher class
             final PushedAsset


### PR DESCRIPTION
DependencySet: extract creation of pushedAsset object to be reutilized when force-pushing
DependencySetTest: test the proper creation of pushAsset entry when adding to the dependencySet with both forcePush 'true' and 'false'

#9309 