### PR TITLE
fixes #14052 2nd try

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -5068,6 +5068,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
             boolean isContentletLive = false;
             boolean isContentletWorking = false;
 
+            if(!contentlet.isLive() && !contentlet.isWorking()) {
+                //Let's exclude old versions
+                continue;
+            }
+
             if (user == null) {
                 throw new DotSecurityException("A user must be specified.");
             }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -5068,11 +5068,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
             boolean isContentletLive = false;
             boolean isContentletWorking = false;
 
-            if(!contentlet.isLive() && !contentlet.isWorking()) {
-                //Let's exclude old versions
-                continue;
-            }
-
             if (user == null) {
                 throw new DotSecurityException("A user must be specified.");
             }

--- a/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
@@ -1,15 +1,19 @@
 package com.dotcms.rest.elasticsearch;
 
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
+import com.dotcms.enterprise.LicenseUtil;
+import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.repackage.javax.ws.rs.*;
 import com.dotcms.repackage.javax.ws.rs.core.Context;
 import com.dotcms.repackage.javax.ws.rs.core.MediaType;
 import com.dotcms.repackage.javax.ws.rs.core.Response;
+import com.dotcms.repackage.javax.ws.rs.core.Response.Status;
 import com.dotcms.repackage.org.apache.commons.io.IOUtils;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONArray;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONException;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONObject;
 import com.dotcms.rest.*;
+import com.dotcms.rest.exception.mapper.ExceptionMapperUtil;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -40,14 +44,22 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 		User user = initData.getUser();
 		ResourceResponse responseResource = new ResourceResponse(initData.getParamsMap());
 
+		if(LicenseUtil.getLevel() < LicenseLevel.STANDARD.level){
+			final String noLicenseMessage = "Unable to execute ES API Requests. Please apply an Enterprise License";
+			RuntimeException e1 = new RuntimeException(noLicenseMessage);
+			Logger.warn(this.getClass(), noLicenseMessage);
+			return ExceptionMapperUtil.createResponse(e1, Response.Status.BAD_REQUEST);
+		}
+
 		PageMode mode = PageMode.get(request);
 
 		JSONObject esQuery;
+
 		try {
 			esQuery = new JSONObject(esQueryStr);
 		} catch (Exception e1) {
-			Logger.warn(this.getClass(), "unable to create JSONObject");
-			throw new DotDataException("malformed json : " + e1.getMessage());
+			Logger.warn(this.getClass(), "Unable to create JSONObject", e1);
+			return ExceptionMapperUtil.createResponse(e1, Response.Status.BAD_REQUEST);
 		}
 
 		try {

--- a/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
@@ -1,21 +1,15 @@
 package com.dotcms.rest.elasticsearch;
 
-import static com.dotcms.util.CollectionsUtils.map;
-
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
-import com.dotcms.enterprise.LicenseUtil;
-import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.repackage.javax.ws.rs.*;
 import com.dotcms.repackage.javax.ws.rs.core.Context;
 import com.dotcms.repackage.javax.ws.rs.core.MediaType;
 import com.dotcms.repackage.javax.ws.rs.core.Response;
-import com.dotcms.repackage.javax.ws.rs.core.Response.Status;
 import com.dotcms.repackage.org.apache.commons.io.IOUtils;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONArray;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONException;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONObject;
 import com.dotcms.rest.*;
-import com.dotcms.rest.exception.mapper.ExceptionMapperUtil;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -46,15 +40,6 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 		User user = initData.getUser();
 		ResourceResponse responseResource = new ResourceResponse(initData.getParamsMap());
 
-		if(LicenseUtil.getLevel() < LicenseLevel.STANDARD.level){
-			final String noLicenseMessage = "Unable to execute ES API Requests. Please apply an Enterprise License";
-			Logger.warn(this.getClass(), noLicenseMessage);
-			return Response.status(Status.FORBIDDEN)
-					.entity(map("message", noLicenseMessage))
-					.header("error-message", noLicenseMessage)
-					.build();
-		}
-
 		PageMode mode = PageMode.get(request);
 
 		JSONObject esQuery;
@@ -62,8 +47,8 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 		try {
 			esQuery = new JSONObject(esQueryStr);
 		} catch (Exception e1) {
-			Logger.warn(this.getClass(), "Unable to create JSONObject", e1);
-			return ExceptionMapperUtil.createResponse(e1, Response.Status.BAD_REQUEST);
+			Logger.warn(this.getClass(), "unable to create JSONObject");
+			throw new DotDataException("malformed json : " + e1.getMessage());
 		}
 
 		try {

--- a/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
@@ -9,6 +9,7 @@ import com.dotcms.repackage.javax.ws.rs.*;
 import com.dotcms.repackage.javax.ws.rs.core.Context;
 import com.dotcms.repackage.javax.ws.rs.core.MediaType;
 import com.dotcms.repackage.javax.ws.rs.core.Response;
+import com.dotcms.repackage.javax.ws.rs.core.Response.Status;
 import com.dotcms.repackage.org.apache.commons.io.IOUtils;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONArray;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONException;
@@ -48,7 +49,7 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 		if(LicenseUtil.getLevel() < LicenseLevel.STANDARD.level){
 			final String noLicenseMessage = "Unable to execute ES API Requests. Please apply an Enterprise License";
 			Logger.warn(this.getClass(), noLicenseMessage);
-			return Response.status(Response.Status.BAD_REQUEST)
+			return Response.status(Status.FORBIDDEN)
 					.entity(map("message", noLicenseMessage))
 					.header("error-message", noLicenseMessage)
 					.build();

--- a/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
@@ -47,7 +47,6 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 
 		if(LicenseUtil.getLevel() < LicenseLevel.STANDARD.level){
 			final String noLicenseMessage = "Unable to execute ES API Requests. Please apply an Enterprise License";
-			final RuntimeException e1 = new RuntimeException(noLicenseMessage);
 			Logger.warn(this.getClass(), noLicenseMessage);
 			return Response.status(Response.Status.BAD_REQUEST)
 					.entity(map("message", noLicenseMessage))

--- a/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
@@ -1,15 +1,21 @@
 package com.dotcms.rest.elasticsearch;
 
+import static com.dotcms.util.CollectionsUtils.map;
+
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
+import com.dotcms.enterprise.LicenseUtil;
+import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.repackage.javax.ws.rs.*;
 import com.dotcms.repackage.javax.ws.rs.core.Context;
 import com.dotcms.repackage.javax.ws.rs.core.MediaType;
 import com.dotcms.repackage.javax.ws.rs.core.Response;
+import com.dotcms.repackage.javax.ws.rs.core.Response.Status;
 import com.dotcms.repackage.org.apache.commons.io.IOUtils;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONArray;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONException;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONObject;
 import com.dotcms.rest.*;
+import com.dotcms.rest.exception.mapper.ExceptionMapperUtil;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -40,6 +46,15 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 		User user = initData.getUser();
 		ResourceResponse responseResource = new ResourceResponse(initData.getParamsMap());
 
+		if(LicenseUtil.getLevel() < LicenseLevel.STANDARD.level){
+			final String noLicenseMessage = "Unable to execute ES API Requests. Please apply an Enterprise License";
+			Logger.warn(this.getClass(), noLicenseMessage);
+			return Response.status(Status.FORBIDDEN)
+					.entity(map("message", noLicenseMessage))
+					.header("error-message", noLicenseMessage)
+					.build();
+		}
+
 		PageMode mode = PageMode.get(request);
 
 		JSONObject esQuery;
@@ -47,8 +62,8 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 		try {
 			esQuery = new JSONObject(esQueryStr);
 		} catch (Exception e1) {
-			Logger.warn(this.getClass(), "unable to create JSONObject");
-			throw new DotDataException("malformed json : " + e1.getMessage());
+			Logger.warn(this.getClass(), "Unable to create JSONObject", e1);
+			return ExceptionMapperUtil.createResponse(e1, Response.Status.BAD_REQUEST);
 		}
 
 		try {

--- a/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
@@ -46,7 +46,7 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 
 		if(LicenseUtil.getLevel() < LicenseLevel.STANDARD.level){
 			final String noLicenseMessage = "Unable to execute ES API Requests. Please apply an Enterprise License";
-			RuntimeException e1 = new RuntimeException(noLicenseMessage);
+			final RuntimeException e1 = new RuntimeException(noLicenseMessage);
 			Logger.warn(this.getClass(), noLicenseMessage);
 			return ExceptionMapperUtil.createResponse(e1, Response.Status.BAD_REQUEST);
 		}

--- a/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
@@ -7,7 +7,6 @@ import com.dotcms.repackage.javax.ws.rs.*;
 import com.dotcms.repackage.javax.ws.rs.core.Context;
 import com.dotcms.repackage.javax.ws.rs.core.MediaType;
 import com.dotcms.repackage.javax.ws.rs.core.Response;
-import com.dotcms.repackage.javax.ws.rs.core.Response.Status;
 import com.dotcms.repackage.org.apache.commons.io.IOUtils;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONArray;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONException;

--- a/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
@@ -1,5 +1,7 @@
 package com.dotcms.rest.elasticsearch;
 
+import static com.dotcms.util.CollectionsUtils.map;
+
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
@@ -47,7 +49,10 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 			final String noLicenseMessage = "Unable to execute ES API Requests. Please apply an Enterprise License";
 			final RuntimeException e1 = new RuntimeException(noLicenseMessage);
 			Logger.warn(this.getClass(), noLicenseMessage);
-			return ExceptionMapperUtil.createResponse(e1, Response.Status.BAD_REQUEST);
+			return Response.status(Response.Status.BAD_REQUEST)
+					.entity(map("message", noLicenseMessage))
+					.header("error-message", noLicenseMessage)
+					.build();
 		}
 
 		PageMode mode = PageMode.get(request);


### PR DESCRIPTION
Tested against master:

Notes to reviewer: 

- Exception is created manually so the ExceptionMapperUtil returns a JSONObject with the proper error messages. Passing in only a null entity and a hardcoded message will make the application to return an Error 400 page from application server itself.
- After further discussion with R&D, this ES API endpoint should be available for Enterprise-licensed environments. 