### PR TITLE
#14024 fixes

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -814,14 +814,14 @@ public class ESContentFactoryImpl extends ContentletFactory {
     }
 
 	@Override
-	protected List<Contentlet> findAllVersions(Identifier identifier, boolean includeAllVersions) throws DotDataException, DotStateException, DotSecurityException {
+	protected List<Contentlet> findAllVersions(Identifier identifier, boolean bringOldVersions) throws DotDataException, DotStateException, DotSecurityException {
 	    if(!InodeUtils.isSet(identifier.getInode()))
             return new ArrayList<Contentlet>();
 
         DotConnect dc = new DotConnect();
         StringBuffer query = new StringBuffer();
 
-        if(includeAllVersions) {
+        if(bringOldVersions) {
             query.append("SELECT inode FROM contentlet WHERE identifier=? order by mod_date desc");
 
         } else {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -5079,6 +5079,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
             boolean isContentletLive = false;
             boolean isContentletWorking = false;
 
+            if(!contentlet.isWorking() && !contentlet.isLive()){
+                //Old version, so let's skip it
+                continue;
+            }
+
             if (user == null) {
                 throw new DotSecurityException("A user must be specified.");
             }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -3759,8 +3759,14 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findAllVersions(Identifier identifier, User user,boolean respectFrontendRoles) throws DotSecurityException,DotDataException, DotStateException {
-        List<Contentlet> contentlets = contentFactory.findAllVersions(identifier);
+    public List<Contentlet> findAllVersions(Identifier identifier, User user, boolean respectFrontendRoles) throws DotSecurityException,DotDataException, DotStateException {
+        return findAllVersions(identifier, true, user, respectFrontendRoles);
+    }
+
+    @CloseDBIfOpened
+    @Override
+    public List<Contentlet> findAllVersions(Identifier identifier, boolean bringOldVersions, User user, boolean respectFrontendRoles) throws DotSecurityException,DotDataException, DotStateException {
+        List<Contentlet> contentlets = contentFactory.findAllVersions(identifier, bringOldVersions);
         if(contentlets.isEmpty())
             return new ArrayList<Contentlet>();
         if(!permissionAPI.doesUserHavePermission(contentlets.get(0), PermissionAPI.PERMISSION_READ, user, respectFrontendRoles)){
@@ -5064,7 +5070,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         List<Contentlet> versionsToMarkWorking = new ArrayList<Contentlet>();
         Map<String, Map<String, Contentlet>> contentletsToCopyRules = Maps.newHashMap();
 
-        versionsToCopy.addAll(findAllVersions(APILocator.getIdentifierAPI().find(contentletToCopy.getIdentifier()), user, respectFrontendRoles));
+        versionsToCopy.addAll(findAllVersions(APILocator.getIdentifierAPI().find(contentletToCopy.getIdentifier()), false, user, respectFrontendRoles));
 
         // we need to save the versions from older-to-newer to make sure the last save
         // is the current version
@@ -5078,11 +5084,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             boolean isContentletLive = false;
             boolean isContentletWorking = false;
-
-            if(!contentlet.isWorking() && !contentlet.isLive()){
-                //Old version, so let's skip it
-                continue;
-            }
 
             if (user == null) {
                 throw new DotSecurityException("A user must be specified.");

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -1136,10 +1136,10 @@ public interface ContentletAPI {
 	 * @throws DotSecurityException 
 	 */
 	public void restoreVersion(Contentlet contentlet, User user, boolean respectFrontendRoles) throws DotSecurityException, DotContentletStateException, DotDataException;
-	
+
 	/**
 	 * Retrieves all versions for a contentlet identifier
-	 * Note this method should not be used currently because it could pull too many versions. 
+	 * Note this method should not be used currently because it could pull too many versions.
 	 * @param identifier
 	 * @param user
 	 * @param respectFrontendRoles
@@ -1148,8 +1148,24 @@ public interface ContentletAPI {
 	 * @throws DotDataException
 	 * @throws DotStateException if the identifier is for contentlet
 	 */
+
 	public List<Contentlet> findAllVersions(Identifier identifier, User user, boolean respectFrontendRoles) throws DotSecurityException, DotDataException, DotStateException;
-	
+
+	/**
+	 * Retrieves all versions for a contentlet identifier
+	 * Note this method should not be used currently because it could pull too many versions.
+	 * @param identifier
+	 * @param bringOldVersions
+	 * @param user
+	 * @param respectFrontendRoles
+	 * @return
+	 * @throws DotSecurityException
+	 * @throws DotDataException
+	 * @throws DotStateException if the identifier is for contentlet
+	 */
+
+	public List<Contentlet> findAllVersions(Identifier identifier, boolean bringOldVersions, User user, boolean respectFrontendRoles) throws DotSecurityException, DotDataException, DotStateException;
+
 	/**
 	 * Retrieves all versions for a contentlet identifier checked in by a real user meaning not the system user
 	 * @param identifier
@@ -1160,6 +1176,7 @@ public interface ContentletAPI {
 	 * @throws DotDataException
 	 * @throws DotStateException if the identifier is for contentlet
 	 */
+
 	public List<Contentlet> findAllUserVersions(Identifier identifier, User user, boolean respectFrontendRoles) throws DotSecurityException, DotDataException, DotStateException;
 	
 	/**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -1139,7 +1139,7 @@ public interface ContentletAPI {
 
 	/**
 	 * Retrieves all versions for a contentlet identifier
-	 * Note this method should not be used currently because it could pull too many versions.
+	 * Note: This method could pull too many versions.
 	 * @param identifier
 	 * @param user
 	 * @param respectFrontendRoles
@@ -1152,12 +1152,14 @@ public interface ContentletAPI {
 	public List<Contentlet> findAllVersions(Identifier identifier, User user, boolean respectFrontendRoles) throws DotSecurityException, DotDataException, DotStateException;
 
 	/**
-	 * Retrieves all versions for a contentlet identifier
-	 * Note this method should not be used currently because it could pull too many versions.
-	 * @param identifier
-	 * @param bringOldVersions
-	 * @param user
-	 * @param respectFrontendRoles
+	 * Retrieves all versions for a contentlet identifier.
+	 * Note: This method could pull too many versions.
+	 * @param identifier - Identifier object that belongs to a contentlet
+	 * @param bringOldVersions - boolean value which determines if old versions (non-live, non-working
+	 * 	should be brought here). @see copyContentlet method, which requires passing in only live/working
+	 * 	versions of contents to be copied
+	 * @param user - User in context who has triggered this call.
+	 * @param respectFrontendRoles - For permissions validations
 	 * @return
 	 * @throws DotSecurityException
 	 * @throws DotDataException

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -696,17 +696,17 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 	}
 
 	@Override
-	public List<Contentlet> findAllVersions(Identifier identifier, boolean bringAllVersions, User user, boolean respectFrontendRoles) throws DotSecurityException,	DotDataException, DotStateException {
+	public List<Contentlet> findAllVersions(Identifier identifier, boolean bringOldVersions, User user, boolean respectFrontendRoles) throws DotSecurityException,	DotDataException, DotStateException {
 		for(ContentletAPIPreHook pre : preHooks){
-			boolean preResult = pre.findAllVersions(identifier, user, respectFrontendRoles);
+			boolean preResult = pre.findAllVersions(identifier, bringOldVersions, user, respectFrontendRoles);
 			if(!preResult){
 				Logger.error(this, "The following prehook failed " + pre.getClass().getName());
 				throw new DotRuntimeException("The following prehook failed " + pre.getClass().getName());
 			}
 		}
-		List<Contentlet> c = conAPI.findAllVersions(identifier, bringAllVersions, user, respectFrontendRoles);
+		List<Contentlet> c = conAPI.findAllVersions(identifier, bringOldVersions, user, respectFrontendRoles);
 		for(ContentletAPIPostHook post : postHooks){
-			post.findAllVersions(identifier, user, respectFrontendRoles,c);
+			post.findAllVersions(identifier, bringOldVersions, user, respectFrontendRoles,c);
 		}
 		return c;
 	}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -680,7 +680,7 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 	}
 
 	@Override
-	public List<Contentlet> findAllVersions(Identifier identifier, User user,boolean respectFrontendRoles) throws DotSecurityException,	DotDataException, DotStateException {
+	public List<Contentlet> findAllVersions(Identifier identifier, User user, boolean respectFrontendRoles) throws DotSecurityException,	DotDataException, DotStateException {
 		for(ContentletAPIPreHook pre : preHooks){
 			boolean preResult = pre.findAllVersions(identifier, user, respectFrontendRoles);
 			if(!preResult){
@@ -689,6 +689,22 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 			}
 		}
 		List<Contentlet> c = conAPI.findAllVersions(identifier, user, respectFrontendRoles);
+		for(ContentletAPIPostHook post : postHooks){
+			post.findAllVersions(identifier, user, respectFrontendRoles,c);
+		}
+		return c;
+	}
+
+	@Override
+	public List<Contentlet> findAllVersions(Identifier identifier, boolean bringAllVersions, User user, boolean respectFrontendRoles) throws DotSecurityException,	DotDataException, DotStateException {
+		for(ContentletAPIPreHook pre : preHooks){
+			boolean preResult = pre.findAllVersions(identifier, user, respectFrontendRoles);
+			if(!preResult){
+				Logger.error(this, "The following prehook failed " + pre.getClass().getName());
+				throw new DotRuntimeException("The following prehook failed " + pre.getClass().getName());
+			}
+		}
+		List<Contentlet> c = conAPI.findAllVersions(identifier, bringAllVersions, user, respectFrontendRoles);
 		for(ContentletAPIPostHook post : postHooks){
 			post.findAllVersions(identifier, user, respectFrontendRoles,c);
 		}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
@@ -827,6 +827,17 @@ public interface ContentletAPIPostHook {
 	 * @param returnValue - value returned by primary API Method 
 	 */
 	public default void findAllVersions(Identifier identifier, User user, boolean respectFrontendRoles,List<Contentlet> returnValue){}
+
+	/**
+	 * Retrieves all versions for a contentlet identifier
+	 * Note this method should not be used currently because it could pull too many versions.
+	 * @param identifier
+	 * @param bringOldVersions
+	 * @param user
+	 * @param respectFrontendRoles
+	 * @param returnValue - value returned by primary API Method
+	 */
+	public default void findAllVersions(Identifier identifier, boolean bringOldVersions, User user, boolean respectFrontendRoles,List<Contentlet> returnValue){}
 	
 	/**
 	 * Retrieves all versions for a contentlet identifier checked in by a real user meaning not the system user

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
@@ -831,10 +831,12 @@ public interface ContentletAPIPostHook {
 	/**
 	 * Retrieves all versions for a contentlet identifier
 	 * Note this method should not be used currently because it could pull too many versions.
-	 * @param identifier
-	 * @param bringOldVersions
-	 * @param user
-	 * @param respectFrontendRoles
+	 * @param identifier - Identifier object that belongs to a contentlet
+	 * @param bringOldVersions - boolean value which determines if old versions (non-live, non-working
+	 * 	should be brought here). @see copyContentlet method, which requires passing in only live/working
+	 * 	versions of contents to be copied
+	 * @param user - User in context who has triggered this call.
+	 * @param respectFrontendRoles - For permissions validations
 	 * @param returnValue - value returned by primary API Method
 	 */
 	public default void findAllVersions(Identifier identifier, boolean bringOldVersions, User user, boolean respectFrontendRoles,List<Contentlet> returnValue){}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
@@ -974,6 +974,19 @@ public interface ContentletAPIPreHook {
 	public default boolean findAllVersions(Identifier identifier, User user, boolean respectFrontendRoles){
       return true;
     }
+
+	/**
+	 * Retrieves all versions for a contentlet identifier
+	 * Note this method should not be used currently because it could pull too many versions.
+	 * @param identifier
+	 * @param bringOldVersions
+	 * @param user
+	 * @param respectFrontendRoles
+	 * @return
+	 */
+	public default boolean findAllVersions(Identifier identifier, boolean bringOldVersions, User user, boolean respectFrontendRoles){
+		return true;
+	}
 	
 	/**
 	 * Retrieves all versions for a contentlet identifier checked in by a real user meaning not the system user

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
@@ -976,12 +976,14 @@ public interface ContentletAPIPreHook {
     }
 
 	/**
-	 * Retrieves all versions for a contentlet identifier
-	 * Note this method should not be used currently because it could pull too many versions.
-	 * @param identifier
-	 * @param bringOldVersions
-	 * @param user
-	 * @param respectFrontendRoles
+	 * Retrieves all versions for a contentlet identifier.
+	 * Note: This method could pull too many versions.
+	 * @param identifier - Identifier object that belongs to a contentlet
+	 * @param bringOldVersions - boolean value which determines if old versions (non-live, non-working
+	 * 	should be brought here). @see copyContentlet method, which requires passing in only live/working
+	 * 	versions of contents to be copied
+	 * @param user - User in context who has triggered this call.
+	 * @param respectFrontendRoles - For permissions validations
 	 * @return
 	 */
 	public default boolean findAllVersions(Identifier identifier, boolean bringOldVersions, User user, boolean respectFrontendRoles){

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
@@ -236,13 +236,22 @@ public abstract class ContentletFactory {
 	/**
 	 * Retrieves all versions for a contentlet identifier
 	 * @param identifier
-	 * @param user
-	 * @param respectFrontendRoles
 	 * @return
 	 * @throws DotDataException
 	 * @throws DotSecurityException 
 	 */
 	protected abstract List<Contentlet> findAllVersions(Identifier identifier) throws DotDataException, DotSecurityException;
+
+	/**
+	 * Retrieves all versions for a contentlet identifier.
+	 * @param identifier
+	 * @param bringOldVersions Include old versions of contents, so it will return only live/working
+	 * versions of contents, regardless of their languages
+	 * @return
+	 * @throws DotDataException
+	 * @throws DotSecurityException
+	 */
+	protected abstract List<Contentlet> findAllVersions(Identifier identifier, boolean bringOldVersions) throws DotDataException, DotSecurityException;
 
 	/**
 	 * Converts a "fat" (legacy) contentlet into a new contentlet.


### PR DESCRIPTION
Tested against master:

- Contents with multiple versions see only their live and/or working version copied over, whenever we decide to copy a content, or its parent site.
- Contents with different language versions will their live and/or working versions copied, and old versions will be excluded as expected.
