### PR TITLE
#14060 fixes style of related contents table

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_relationships.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_relationships.jsp
@@ -721,7 +721,6 @@
 						 	var div = document.createElement("div");
 						 	div.style.width = '100%';
 						 	div.style.overflow = 'hidden';
-						 	div.style.height = '20px';
 						 	div.innerHTML = <%= functionName %>(item);
 							field<%= functionName %>TD.appendChild(div);
 							tr.appendChild(field<%= functionName %>TD);


### PR DESCRIPTION
#14060 

Tested on current master. 

Text is not cut off anymore. 

<img width="1393" alt="screen shot 2018-04-09 at 5 03 47 pm" src="https://user-images.githubusercontent.com/1717110/38525514-45df5dda-3c18-11e8-888a-bb66a6f1f45d.png">
