### PR TITLE
#13682 delete old versions of the contentlet

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1788,7 +1788,15 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     }
                     //TODO we still have several things that need cleaning here:
                     //TODO https://github.com/dotCMS/core/issues/9146
-                    contentFactory.delete(Arrays.asList(new Contentlet[]{con}), false);
+                    Identifier identifier = APILocator.getIdentifierAPI().find(con.getIdentifier());
+                    List<Contentlet> allVersionsList = findAllVersions(identifier,user,false);
+                    List <Contentlet> contentletsLanguageList = new ArrayList<>(); //All versions of the contentlet with specific lang to be deleted
+                    for(Contentlet contentlet : allVersionsList){
+                        if(contentlet.getLanguageId()==con.getLanguageId()){
+                            contentletsLanguageList.add(contentlet);
+                        }
+                    }
+                    contentFactory.delete(contentletsLanguageList, false);
 
                     for (Contentlet contentlet : contentlets) {
                         try {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1790,12 +1790,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     //TODO https://github.com/dotCMS/core/issues/9146
                     Identifier identifier = APILocator.getIdentifierAPI().find(con.getIdentifier());
                     List<Contentlet> allVersionsList = findAllVersions(identifier,user,false);
-                    List <Contentlet> contentletsLanguageList = new ArrayList<>(); //All versions of the contentlet with specific lang to be deleted
-                    for(Contentlet contentlet : allVersionsList){
-                        if(contentlet.getLanguageId()==con.getLanguageId()){
-                            contentletsLanguageList.add(contentlet);
-                        }
-                    }
+                    List <Contentlet> contentletsLanguageList  = allVersionsList.stream().
+                            filter(contentlet -> contentlet.getLanguageId()==con.getLanguageId()).collect(Collectors.toList());
                     contentFactory.delete(contentletsLanguageList, false);
 
                     for (Contentlet contentlet : contentlets) {


### PR DESCRIPTION
We were deleting only the working/live version of the contentlet that has more than one language version, now it gets all the versions that exist and filters by the contentlet language that wants to be deleted and removes it.