### PR TITLE
Fix tests mysql postgres

### DIFF
--- a/dotCMS/src/functional-test/java/com/dotmarketing/portlets/contentlet/business/FileAssetTest.java
+++ b/dotCMS/src/functional-test/java/com/dotmarketing/portlets/contentlet/business/FileAssetTest.java
@@ -55,6 +55,9 @@ public class FileAssetTest {
   	  	User systemUser = APILocator.getUserAPI().getSystemUser();
   	  	Contentlet result = contentletAPI.findContentletByIdentifier(fileInSpanish.getIdentifier(), false, spanish, systemUser , false);
   	  	contentletAPI.publish(result, systemUser, false);
+		result = contentletAPI.findContentletByIdentifier(fileInSpanish.getIdentifier(), true, spanish, systemUser , false);
+		contentletAPI.isInodeIndexed(fileInSpanish.getInode(),true);
+
 
   	  	//Request by Resource Link (SpeedyAssetServlet)
   	  	Response response = webTarget.path(result.getTitle()).queryParam("language_id", result.getLanguageId()).request().get();

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -55,7 +55,6 @@ import org.apache.velocity.context.Context;
 import org.apache.velocity.context.InternalContextAdapterImpl;
 import org.apache.velocity.runtime.parser.node.SimpleNode;
 import org.jetbrains.annotations.NotNull;
-import org.jruby.RubyProcess.Sys;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -2122,7 +2121,7 @@ public class ContentletAPITest extends ContentletBaseTest {
         final long count = APILocator.getContentletAPI().indexCount(q, user, false);
         assertEquals(1, count);
         APILocator.getStructureAPI().delete(testStructure, user);
-    }//HASTA ACA LLEGA EL TEST
+    }
 
     private boolean compareDates(Date date1, Date date2) {
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -55,6 +55,7 @@ import org.apache.velocity.context.Context;
 import org.apache.velocity.context.InternalContextAdapterImpl;
 import org.apache.velocity.runtime.parser.node.SimpleNode;
 import org.jetbrains.annotations.NotNull;
+import org.jruby.RubyProcess.Sys;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -2046,7 +2047,9 @@ public class ContentletAPITest extends ContentletBaseTest {
         StructureFactory.saveStructure(testStructure);
 
         // some dates to play with
-        Date d1= new Date();
+
+        String date = "11-08-1992 10:20:56";
+        Date d1= dateFormat.parse(date);
         Date d2=new Date(d1.getTime()+60000L);
         Date d3=new Date(d2.getTime()+60000L);
         Date d4=new Date(d3.getTime()+60000L);
@@ -2119,7 +2122,7 @@ public class ContentletAPITest extends ContentletBaseTest {
         final long count = APILocator.getContentletAPI().indexCount(q, user, false);
         assertEquals(1, count);
         APILocator.getStructureAPI().delete(testStructure, user);
-    }
+    }//HASTA ACA LLEGA EL TEST
 
     private boolean compareDates(Date date1, Date date2) {
 


### PR DESCRIPTION
FileAssetTest: sometimes it returns 404, let's check that the contentlet is in the live index before making the requests.

ContentletAPITest: in MySQL, we are not saving the milliseconds so it's rounding up the seconds, and because of that sometimes the assert fails. Now using a specific date and time, this does not affect what we are testing.