### PR TITLE
#13621

### DIFF
--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -27,7 +27,8 @@ dependencies {
     compile group: 'com.dotcms.lib', name: 'dot.com.dotmarketing.jhlabs.images.filters', version:'ukv_2'
     compile group: 'com.dotcms.lib', name: 'dot.commons-cli', version:'1.2_2'
     compile group: 'com.dotcms.lib', name: 'dot.commons-dbcp', version:'1.3_2'
-    compile group: 'com.dotcms.lib', name: 'dot.commons-fileupload', version:'1.3.3'
+    compile group: 'com.dotcms.lib', name: 'dot.commons-fileupload', version:'1.3.3_1'
+    compile group: 'commons-fileupload', name: 'commons-fileupload', version: '1.3.3'
     compile group: 'com.dotcms.lib', name: 'dot.commons-httpclient', version:'3.1_3'
     compile group: 'com.dotcms.lib', name: 'dot.commons-io', version:'2.0.1_2'
     compile group: 'com.dotcms.lib', name: 'dot.commons-jci-core', version:'1.0.406301_2'
@@ -56,7 +57,7 @@ dependencies {
     compile group: 'org.apache.logging.log4j', name: 'log4j-jcl', version: '2.8.2'
     compile group: 'org.apache.logging.log4j', name: 'log4j-web', version: '2.8.2'
 
-    compile group: 'com.dotcms.lib', name: 'dot.fileupload-ext', version:'ukv_3_1'
+    compile group: 'com.dotcms.lib', name: 'dot.fileupload-ext', version:'ukv_3'
     compile group: 'com.dotcms.lib', name: 'dot.fop', version:'0.20.1_3'
     compile group: 'com.dotcms.lib', name: 'dot.gif89', version:'ukv_2'
     compile group: 'com.dotcms.lib', name: 'dot.google', version:'ukv_2'

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/AjaxFileUploadServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/AjaxFileUploadServlet.java
@@ -1,9 +1,9 @@
 package com.dotmarketing.servlets;
 
 import com.dotcms.repackage.com.missiondata.fileupload.MonitoredDiskFileItemFactory;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import com.dotcms.repackage.org.apache.commons.fileupload.FileItem;
+import com.dotcms.repackage.org.apache.commons.fileupload.FileItemFactory;
+import com.dotcms.repackage.org.apache.commons.fileupload.servlet.ServletFileUpload;
 import com.dotcms.util.CloseUtils;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.portlets.contentlet.util.ContentletUtil;


### PR DESCRIPTION
dependencies.gradle: include latest commons-fileupload from maven and the repackage one (fileupload-ext is a reference)
AjaxFileUploadServlet: we need to use the repackage version of the commons-fileupload here since we convert MonitoredDiskFileItemFactory to FileItemFactory and the MonitoredDiskFileItemFactory.class references the repackage one.