### PR TITLE
#14232 add catch clause, let the process continue if no permref is in…

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -5222,8 +5222,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
             if(!UtilMethods.isSet(newIdentifier))
                 newIdentifier = newContentlet.getIdentifier();
 
-            permissionAPI.copyPermissions(contentlet, newContentlet);
-
+            try {
+                permissionAPI.copyPermissions(contentlet, newContentlet);
+            } catch (Exception e) {
+                Logger.warn(this, "Cannot insert Permission Reference of copied content. Process should continue" );
+                Logger.debug(this, "Cannot insert Permission Reference of copied content.", e);
+            }
 
             //Using a map to make sure one identifier per page.
             //Avoiding multi languages pages.

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -5225,8 +5225,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             try {
                 permissionAPI.copyPermissions(contentlet, newContentlet);
             } catch (Exception e) {
-                Logger.warn(this, "Cannot insert Permission Reference of copied content. Process should continue" );
-                Logger.debug(this, "Cannot insert Permission Reference of copied content.", e);
+                Logger.warn(this, "Cannot insert Permission Reference of copied content. Process should continue. " + e.getMessage());
             }
 
             //Using a map to make sure one identifier per page.


### PR DESCRIPTION
Tested in master. In case the process of copying a content fails because the permission ref couldn't be inserted, it should continue anyways. throwing this exception affects all related objects to content being copied, and content is left in an intermediate step.