### PR TITLE
#14108 Changing the way metadata fields were handled

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/tika/TikaUtilsTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/tika/TikaUtilsTest.java
@@ -1,0 +1,102 @@
+package com.dotcms.tika;
+
+import com.dotmarketing.exception.DotDataException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TikaUtilsTest{
+
+    @Test
+    public void testGetConfiguredMetadataFields() throws DotDataException {
+        TikaUtils tikaUtils = new TikaUtils();
+        Set<String>  fields = tikaUtils.getConfiguredMetadataFields();
+
+        Assert.assertNotNull(fields);
+        Assert.assertTrue(!fields.isEmpty());
+    }
+
+    @Test
+    public void test_FilterMetadataFields_WhenMapEmpty_ReturnsEmptyMap() throws DotDataException {
+        TikaUtils tikaUtils = new TikaUtils();
+        Map<String, Object> metaMap = new HashMap<>();
+        Set<String> fields  = new HashSet<>();
+        fields.add("width");
+        tikaUtils.filterMetadataFields(metaMap, fields);
+
+        Assert.assertNotNull(metaMap);
+        Assert.assertTrue(metaMap.isEmpty());
+    }
+
+    @Test
+    public void test_FilterMetadataFields_WhenFieldsArrayIsEmpty_DoesNotModifyTheMap() throws DotDataException {
+        TikaUtils tikaUtils = new TikaUtils();
+        Map<String, Object> metaMap = new HashMap<>();
+
+        metaMap.put("content", "Test to filter metadata fields");
+        metaMap.put("width", "300px");
+
+        tikaUtils.filterMetadataFields(metaMap, null);
+
+        Assert.assertNotNull(metaMap);
+        Assert.assertTrue(metaMap.size() == 2);
+        Assert.assertTrue(metaMap.containsKey("width") && metaMap.containsKey("content"));
+    }
+
+    @Test
+    public void test_FilterMetadataFields_WhenFieldExistsInMap_ReturnsMapWithTheField() throws DotDataException {
+        TikaUtils tikaUtils = new TikaUtils();
+        Set<String> fields  = new HashSet<>();
+        Map<String, Object> metaMap = new HashMap<>();
+
+        fields.add("width");
+        fields.add("size");
+
+        metaMap.put("content", "Test to filter metadata fields");
+        metaMap.put("width", "300px");
+        tikaUtils.filterMetadataFields(metaMap, fields);
+
+        Assert.assertNotNull(metaMap);
+        Assert.assertTrue(metaMap.size() == 1);
+        Assert.assertTrue(metaMap.containsKey("width"));
+    }
+
+    @Test
+    public void test_FilterMetadataFields_WhenFieldMatchesRegex_ReturnsMapWithTheField() throws DotDataException {
+        TikaUtils tikaUtils = new TikaUtils();
+        Map<String, Object> metaMap = new HashMap<>();
+        Set<String> fields  = new HashSet<>();
+
+        fields.add("wid.*");
+        fields.add("size");
+
+        metaMap.put("content", "Test to filter metadata fields");
+        metaMap.put("width", "300px");
+        tikaUtils.filterMetadataFields(metaMap, fields);
+
+        Assert.assertNotNull(metaMap);
+        Assert.assertTrue(metaMap.size() == 1);
+        Assert.assertTrue(metaMap.containsKey("width"));
+    }
+
+    @Test
+    public void test_FilterMetadataFields_WhenFieldIsWildcard_ReturnsMapWithAllFields() throws DotDataException {
+        TikaUtils tikaUtils = new TikaUtils();
+        Map<String, Object> metaMap = new HashMap<>();
+        Set<String> fields  = new HashSet<>();
+
+        fields.add("*");
+
+        metaMap.put("content", "Test to filter metadata fields");
+        metaMap.put("width", "300px");
+        tikaUtils.filterMetadataFields(metaMap, fields);
+
+        Assert.assertNotNull(metaMap);
+        Assert.assertTrue(metaMap.size() == 2);
+        Assert.assertTrue(metaMap.containsKey("content"));
+        Assert.assertTrue(metaMap.containsKey("width"));
+    }
+}

--- a/dotCMS/src/integration-test/java/com/dotcms/tika/TikaUtilsTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/tika/TikaUtilsTest.java
@@ -15,8 +15,8 @@ public class TikaUtilsTest{
 
     @Test
     public void testGetConfiguredMetadataFields() throws DotDataException {
-        TikaUtils tikaUtils = new TikaUtils();
-        Set<String>  fields = tikaUtils.getConfiguredMetadataFields();
+        final TikaUtils tikaUtils = new TikaUtils();
+        final Set<String>  fields = tikaUtils.getConfiguredMetadataFields();
 
         Assert.assertNotNull(fields);
         Assert.assertTrue(!fields.isEmpty());

--- a/dotCMS/src/integration-test/java/com/dotcms/tika/TikaUtilsTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/tika/TikaUtilsTest.java
@@ -8,6 +8,9 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * @author nollymar
+ */
 public class TikaUtilsTest{
 
     @Test
@@ -21,9 +24,9 @@ public class TikaUtilsTest{
 
     @Test
     public void test_FilterMetadataFields_WhenMapEmpty_ReturnsEmptyMap() throws DotDataException {
-        TikaUtils tikaUtils = new TikaUtils();
-        Map<String, Object> metaMap = new HashMap<>();
-        Set<String> fields  = new HashSet<>();
+        final TikaUtils tikaUtils = new TikaUtils();
+        final Map<String, Object> metaMap = new HashMap<>();
+        final Set<String> fields  = new HashSet<>();
         fields.add("width");
         tikaUtils.filterMetadataFields(metaMap, fields);
 
@@ -33,8 +36,8 @@ public class TikaUtilsTest{
 
     @Test
     public void test_FilterMetadataFields_WhenFieldsArrayIsEmpty_DoesNotModifyTheMap() throws DotDataException {
-        TikaUtils tikaUtils = new TikaUtils();
-        Map<String, Object> metaMap = new HashMap<>();
+        final TikaUtils tikaUtils = new TikaUtils();
+        final Map<String, Object> metaMap = new HashMap<>();
 
         metaMap.put("content", "Test to filter metadata fields");
         metaMap.put("width", "300px");
@@ -48,9 +51,9 @@ public class TikaUtilsTest{
 
     @Test
     public void test_FilterMetadataFields_WhenFieldExistsInMap_ReturnsMapWithTheField() throws DotDataException {
-        TikaUtils tikaUtils = new TikaUtils();
-        Set<String> fields  = new HashSet<>();
-        Map<String, Object> metaMap = new HashMap<>();
+        final TikaUtils tikaUtils = new TikaUtils();
+        final Set<String> fields  = new HashSet<>();
+        final Map<String, Object> metaMap = new HashMap<>();
 
         fields.add("width");
         fields.add("size");
@@ -66,9 +69,9 @@ public class TikaUtilsTest{
 
     @Test
     public void test_FilterMetadataFields_WhenFieldMatchesRegex_ReturnsMapWithTheField() throws DotDataException {
-        TikaUtils tikaUtils = new TikaUtils();
-        Map<String, Object> metaMap = new HashMap<>();
-        Set<String> fields  = new HashSet<>();
+        final TikaUtils tikaUtils = new TikaUtils();
+        final Map<String, Object> metaMap = new HashMap<>();
+        final Set<String> fields  = new HashSet<>();
 
         fields.add("wid.*");
         fields.add("size");
@@ -84,9 +87,9 @@ public class TikaUtilsTest{
 
     @Test
     public void test_FilterMetadataFields_WhenFieldIsWildcard_ReturnsMapWithAllFields() throws DotDataException {
-        TikaUtils tikaUtils = new TikaUtils();
-        Map<String, Object> metaMap = new HashMap<>();
-        Set<String> fields  = new HashSet<>();
+        final TikaUtils tikaUtils = new TikaUtils();
+        final Map<String, Object> metaMap = new HashMap<>();
+        final Set<String> fields  = new HashSet<>();
 
         fields.add("*");
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -4042,6 +4042,19 @@ public class ContentletAPITest extends ContentletBaseTest {
         }
     }
 
+    @Test
+    public void testSearchFileAssetByMetadata() throws DotSecurityException, DotDataException {
+
+        final String query = "+contentType:FileAsset +metaData.contentType:*image/jpeg*";
+        List<Contentlet> result = contentletAPI.search(query, 100, 0, null, user, false);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertFalse(result.stream().anyMatch(
+                e -> !(e.getStringProperty("fileName").contains("jpg") || e
+                        .getStringProperty("fileName").contains("jpeg"))));
+    }
+
     private File getBinaryAsset(String inode, String varName, String binaryName) {
 
         FileAssetAPI fileAssetAPI = APILocator.getFileAssetAPI();

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -1994,21 +1994,28 @@ public class ESContentFactoryImpl extends ContentletFactory {
                     tempStructureVarName = clause.substring(0, clause.indexOf('.'));
                     tempStructure = CacheLocator.getContentTypeCache().getStructureByVelocityVarName(tempStructureVarName);
 
-                    List<Field> tempStructureFields = new ArrayList<>(FieldsCache.getFieldsByStructureVariableName(tempStructure.getVelocityVarName()));
+                    if (UtilMethods.isSet(tempStructure) && UtilMethods.isSet(tempStructure.getVelocityVarName())) {
+                        List<Field> tempStructureFields = new ArrayList<>(FieldsCache
+                                .getFieldsByStructureVariableName(
+                                        tempStructure.getVelocityVarName()));
 
-                    for (int pos = 0; pos < tempStructureFields.size();) {
+                        for (int pos = 0; pos < tempStructureFields.size(); ) {
 
-                        if (tempStructureFields.get(pos).getFieldType().equals(Field.FieldType.DATE_TIME.toString()) ||
-                                tempStructureFields.get(pos).getFieldType().equals(Field.FieldType.DATE.toString()) ||
-                                tempStructureFields.get(pos).getFieldType().equals(Field.FieldType.TIME.toString())) {
-                            ++pos;
-                        } else {
-                            tempStructureFields.remove(pos);
+                            if (tempStructureFields.get(pos).getFieldType()
+                                    .equals(Field.FieldType.DATE_TIME.toString()) ||
+                                    tempStructureFields.get(pos).getFieldType()
+                                            .equals(Field.FieldType.DATE.toString()) ||
+                                    tempStructureFields.get(pos).getFieldType()
+                                            .equals(Field.FieldType.TIME.toString())) {
+                                ++pos;
+                            } else {
+                                tempStructureFields.remove(pos);
+                            }
+
                         }
 
+                        dateFields.addAll(tempStructureFields);
                     }
-
-                    dateFields.addAll(tempStructureFields);
                 }
             }
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -293,8 +293,6 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 
 					String contentData=APILocator.getFileAssetAPI().getContentMetadataAsString(contentMeta);
 
-					String lvar=con.getStructure().getVelocityVarName().toLowerCase();
-
 					mlowered.put(FileAssetAPI.META_DATA_FIELD.toLowerCase() + StringPool.PERIOD + "content", contentData);
 					sw.append(contentData).append(' ');
 				}

--- a/dotCMS/src/main/java/com/dotcms/tika/TikaUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/tika/TikaUtils.java
@@ -8,7 +8,6 @@ import com.dotmarketing.business.FactoryLocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.portlets.contentlet.util.ContentletUtil;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.util.Config;
@@ -27,8 +26,13 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 
@@ -201,13 +205,49 @@ public class TikaUtils {
             metaMap.put(FileAssetAPI.SIZE_FIELD, String.valueOf(binFile.length()));
         }
 
-        //Getting the original content's map
-        final Map<String, Object> additionProps = getAdditionalProperties(inode);
-        for (final Map.Entry<String, Object> entry : additionProps.entrySet()) {
-            metaMap.put(entry.getKey().toLowerCase(), entry.getValue().toString().toLowerCase());
-        }
+        filterMetadataFields(metaMap, getConfiguredMetadataFields());
 
         return metaMap;
+    }
+
+    /**
+     * Reads INDEX_METADATA_FIELDS from configuration
+     * @return
+     */
+    public Set<String> getConfiguredMetadataFields(){
+        final String configFields=Config.getStringProperty("INDEX_METADATA_FIELDS", null);
+
+        if (UtilMethods.isSet(configFields)) {
+
+            return new HashSet<>(Arrays.asList( configFields.split(",")));
+
+        }
+        return Collections.EMPTY_SET;
+    }
+
+    /**
+     * Filters fields from a map given a set of fields to be kept
+     * @param metaMap
+     * @param configFieldsSet
+     */
+    public void filterMetadataFields(final Map<String, ? extends Object> metaMap, final Set<String> configFieldsSet){
+
+        if (UtilMethods.isSet(metaMap) && UtilMethods.isSet(configFieldsSet)) {
+            metaMap.entrySet()
+                    .removeIf(entry -> !configFieldsSet.contains("*")
+                            && !checkIfFieldMatches(entry.getKey(), configFieldsSet));
+        }
+    }
+
+    /**
+     * Verifies if a string matches in a set of regex/strings
+     * @param key
+     * @param configFieldsSet
+     * @return
+     */
+    private boolean checkIfFieldMatches(final String key, final Set<String> configFieldsSet){
+        Predicate<String> condition = e -> key.matches(e);
+        return configFieldsSet.stream().anyMatch(condition);
     }
 
     /**
@@ -295,21 +335,6 @@ public class TikaUtils {
                 return writeMetadata(contentReader, contentMetadataFile);
             }
         }
-    }
-
-    /**
-     * Returns a {@link Map} that includes original content's map entries and also special entries for string
-     * representation of the values of binary, category fields and also tags
-     */
-    private Map<String, Object> getAdditionalProperties(final String inode) {
-        Map<String, Object> additionProps = new HashMap<>();
-        try {
-            additionProps = ContentletUtil.getContentPrintableMap(this.systemUser,
-                    APILocator.getContentletAPI().find(inode, this.systemUser, true));
-        } catch (Exception e) {
-            Logger.error(this, "Unable to add additional metadata to map", e);
-        }
-        return additionProps;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/tika/TikaUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/tika/TikaUtils.java
@@ -246,7 +246,7 @@ public class TikaUtils {
      * @return
      */
     private boolean checkIfFieldMatches(final String key, final Set<String> configFieldsSet){
-        Predicate<String> condition = e -> key.matches(e);
+        final Predicate<String> condition = e -> key.matches(e);
         return configFieldsSet.stream().anyMatch(condition);
     }
 

--- a/dotCMS/src/main/java/com/dotcms/tika/TikaUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/tika/TikaUtils.java
@@ -222,7 +222,7 @@ public class TikaUtils {
             return new HashSet<>(Arrays.asList( configFields.split(",")));
 
         }
-        return Collections.EMPTY_SET;
+        return Collections.emptySet();
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
@@ -704,7 +704,13 @@ public class ContentletAjax {
 									metakey = StringUtils.camelCaseLower(metakey);
 									String metaVal = "*" +splitter[splitter.length-1]+"*";
 									fieldValue = metakey + ":" + metaVal;
-									luceneQuery.append("+" + st.getVelocityVarName() + "." + fieldVelocityVarName + "." + fieldValue.toString().replaceAll(specialCharsToEscapeForMetaData, "\\\\$1") + " ");
+
+									if (fieldVelocityVarName.equals(FileAssetAPI.META_DATA_FIELD)){
+										luceneQuery.append("+" + fieldVelocityVarName + "." + fieldValue.toString().replaceAll(specialCharsToEscapeForMetaData, "\\\\$1") + " ");
+									}else{
+										luceneQuery.append("+" + st.getVelocityVarName() + "." + fieldVelocityVarName + "." + fieldValue.toString().replaceAll(specialCharsToEscapeForMetaData, "\\\\$1") + " ");
+									}
+
 								} catch (Exception e) {
 									Logger.debug(this, "An error occured when processing field name '" + fieldbcontentname + "'");
 								}

--- a/dotCMS/src/main/resources/es-content-mapping.json
+++ b/dotCMS/src/main/resources/es-content-mapping.json
@@ -1,11 +1,6 @@
 {
     "content": {
         "date_detection": true,
-        "_source": {
-            "excludes": [
-                "metadata.*"
-            ]
-        },
         "dynamic_date_formats": [
             "yyyy-MM-dd'T'HH:mm:ss||MMM d, yyyy hh:mm:ss aaa||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
         ],


### PR DESCRIPTION
1. Now, metadata fields saved in DB and indexed are defined through this property: INDEX_METADATA_FIELDS
2. Lucene queries that include metadata fields have to be referenced as metadata.{field} instead of fileAsset.metadata.{field}