### PR TITLE
dotCMS/core#14359 fixes missing sort order for new multitree rels

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
@@ -1124,6 +1124,7 @@ public class BrowserAjax {
                 List<MultiTree> pageContents = MultiTreeFactory.getMultiTrees(cont.getIdentifier());
                 for(MultiTree m : pageContents){
                    	MultiTree mt = new MultiTree(newContentlet.getIdentifier(), m.getParent2(), m.getChild());
+                   	mt.setTreeOrder(m.getTreeOrder());
                    	MultiTreeFactory.saveMultiTree(mt);
                 }
 


### PR DESCRIPTION
Tested in Master.

Once a page is copied, their multi-tree relationships are stored correctly and order of contents under containers is retained.