### PR TITLE
#14317 use right SAXParser

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/diff/helper/NekoHtmlParser.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/diff/helper/NekoHtmlParser.java
@@ -18,7 +18,7 @@ package com.dotmarketing.util.diff.helper;
 
 import java.io.IOException;
 
-import org.apache.xerces.parsers.SAXParser;
+import com.dotcms.repackage.org.cyberneko.html.parsers.SAXParser;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;


### PR DESCRIPTION
With the xerces SAXParser features of cyberneko can not be set, instead, use the SAXParer from the DaisyDiff jar.