### PR TITLE
Issue 14819 stop wiping assets when importing starter.zip

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportExportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportExportUtil.java
@@ -1027,19 +1027,7 @@ public class ImportExportUtil {
             new File(assetRealPath);
 
         assetDirectory.mkdirs();
-        /*
-        final String[] assetsFileList = assetDirectory.list();
-        for (String fileName : assetsFileList) {
-            if(fileName.toLowerCase().startsWith(LICENSE_NAME)
-                || fileName.toLowerCase().startsWith(IMPORTED_LICENSE_PACK_PREFIX)) continue;
-            File f = new File(assetDirectory.getPath() + File.separator + fileName);
-            if(f.isDirectory()) {
-                FileUtil.deltree(f);
-            } else {
-                f.delete();
-            }
-        }
-        */
+
     }
 
     @WrapInTransaction

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportExportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportExportUtil.java
@@ -1027,6 +1027,7 @@ public class ImportExportUtil {
             new File(assetRealPath);
 
         assetDirectory.mkdirs();
+        /*
         final String[] assetsFileList = assetDirectory.list();
         for (String fileName : assetsFileList) {
             if(fileName.toLowerCase().startsWith(LICENSE_NAME)
@@ -1038,6 +1039,7 @@ public class ImportExportUtil {
                 f.delete();
             }
         }
+        */
     }
 
     @WrapInTransaction


### PR DESCRIPTION
for 5.0.1.  We have lost 2 days to this issue.

To test - 

1. start a fresh dotcms pointing at db1
2. Edit some files / images, verify that they are there on the filesystem under the /assets directory
3. replace context.xml with the default context.xml
4. start dotcms again, it thinks it is a new install and wipes out everything under the /assets on the fresh startup