### PR TITLE
#13168 add maxLength property to LanguageCode and CountryCode

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/languagesmanager/edit_language.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/languagesmanager/edit_language.jsp
@@ -59,6 +59,7 @@ dojo.ready(function() {
 	new dijit.form.ValidationTextBox({
 		name: "languageCode",
 		value: "<%=language.getLanguageCode()%>",
+        maxLength: 2,
 		style: "width: " + fieldWidth,
 		promptMessage: "<%= LanguageUtil.get(pageContext, "LanguageCode-Required") %>"
 	}, "languageCode");
@@ -66,6 +67,7 @@ dojo.ready(function() {
 	new dijit.form.TextBox({
 		name: "countryCode",
 		value: "<%=language.getCountryCode()%>",
+        maxLength: 2,
 		style: "width: " + fieldWidth
 	}, "countryCode");
 


### PR DESCRIPTION
Since we are using ISO 639-1 (two-letter codes) for language code and ISO 3166-1 alpha-2 for country code, now the maxLength is set to 2.