### PR TITLE
#15353 fixing a bad merge

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -3064,7 +3064,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                 final IndexPolicy indexPolicy             = contentlet.getIndexPolicy();
                 final IndexPolicy indexPolicyDependencies = contentlet.getIndexPolicyDependencies();
-
+                contentlet = applyNullProperties(contentlet);
                 if(saveWithExistingID) {
                     contentlet = contentFactory.save(contentlet, existingInode);
                 } else {


### PR DESCRIPTION
After restoring old formatting on the checkin method the call applyNullProperties got lost. 
This simply reintroduces such call.  