### PR TITLE
#15484 : PersonaTool getPersonas method for not authenticated users

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/PersonaTool.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/PersonaTool.java
@@ -114,7 +114,7 @@ public class PersonaTool implements ViewTool {
 		try {
 			
 			Host host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
-			List<Persona> personas = APILocator.getPersonaAPI().getPersonas(host, false, false, user, false);
+			List<Persona> personas = APILocator.getPersonaAPI().getPersonas(host, false, false, user, true);
 
 			return personas;
 		} catch (DotDataException | DotSecurityException | PortalException | SystemException e) {


### PR DESCRIPTION
Method `getPersonas` for `PersonaTool` viewtool has been fixed to work for not authenticated users, by changing `respectFrontEndRoles` parameter to `true` in the call to `APILocator.getPersonaAPI().getPersonas` method