### PR TITLE
Make sure npm init before install dotcms-ui

### DIFF
--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -258,7 +258,7 @@ processResources {
 
 // By default the war task compiles everything under src/main/java into WEB-INF/classes/
 // but, instead, we want to compile everything on a .jar file and put it under WEB-INF/lib.
-war.dependsOn 'deployPlugins','installDotcmsUI'
+war.dependsOn 'deployPlugins','initNpm'
 
 war {
 
@@ -884,6 +884,12 @@ class DeployWarTomcatTask extends DefaultTask{
     }
 }
 
+task initNpm(type: NpmTask) {
+    args = ['init', '--yes']
+
+    finalizedBy 'installDotcmsUI'
+}
+
 task installDotcmsUI(type: NpmTask) {
     if ("latest".equals(coreWebReleaseVersion)) {
         args = ['install', 'dotcms-ui']
@@ -900,6 +906,8 @@ task makeDotAdminFolder(type: DefaultTask) {
 }
 
 task cleanNodeModules(type: Delete) {
+    delete './package.json'
+    delete './package-lock.json'
     delete "./node_modules"
     followSymlinks = true
 }


### PR DESCRIPTION
Looks like newer versions of `npm` are very picky so we need to `npm init` before install ant packages.