### PR TITLE
#15563 Set fake site as the default site when there is not a default site set

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
@@ -414,7 +414,7 @@ public class HostAPIImpl implements HostAPI {
         }
         Host savedHost =  new Host(contentletHost);
 
-        updateDefaultHost(host, user, respectFrontendRoles);
+        updateDefaultHost(savedHost, user, respectFrontendRoles);
         hostCache.clearAliasCache();
         return savedHost;
 


### PR DESCRIPTION
Method `save` from class `com.dotmarketing.portlets.contentlet.business.HostAPIImpl` has been fixed to use send the appropriate variable `savedHost` to the `updateDefaultHost`.
The variable `savedHost` includes the identifier for the new fake site added when there's not a default site, then the `updateDefaultHost` method matches the identifier, and leaves this new fake site at the only default site.