### PR TITLE
Updated VelocityLiveMode to set the velocityContext on the request #15701

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityLiveMode.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityLiveMode.java
@@ -146,6 +146,8 @@ public class VelocityLiveMode extends VelocityModeHandler {
                 persona = v.get().getPersona().getKeyTag();
             }
             final Context context = VelocityUtil.getInstance().getContext(request, response);
+            
+            request.setAttribute("velocityContext", context);
 
             final PageCacheParameters cacheParameters =
                     new BlockPageCache.PageCacheParameters(userId, language, urlMap, queryString, persona);


### PR DESCRIPTION
The velocityContext is not being set in Live Mode and would introduce bugs/problems when it eventually goes into getWebContext in VelocityUtil which would cause it to be a different instance hence losing information that has been set previously.