### PR TITLE
use contenttype.getParentPermissionable instead of passing the folder…

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeAPIImplTest.java
@@ -10,10 +10,7 @@ import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.datagen.FolderDataGen;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Permission;
-import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.FactoryLocator;
-import com.dotmarketing.business.PermissionAPI;
-import com.dotmarketing.business.PermissionLevel;
+import com.dotmarketing.business.*;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
@@ -677,7 +674,7 @@ public class ContentTypeAPIImplTest extends ContentTypeBaseTest {
 				APILocator.systemUser(), false);
 
 		final PermissionAPI permAPI = Mockito.spy(APILocator.getPermissionAPI());
-		Mockito.doReturn(true).when(permAPI).doesUserHavePermissions(folder,
+		Mockito.doReturn(true).when(permAPI).doesUserHavePermissions(contentType.getParentPermissionable(),
 				"PARENT:" + PermissionAPI.PERMISSION_CAN_ADD_CHILDREN + ", STRUCTURES:" + testCase.permissions,
 				limitedUserEditPermsPermOnCT);
 		//Give READ PERMISSIONS to the folder


### PR DESCRIPTION
…, because they're diff objects