### PR TITLE
Refactoring some relationships methods

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/model/ContentletIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/model/ContentletIntegrationTest.java
@@ -13,10 +13,10 @@ import com.dotcms.contenttype.model.type.ContentTypeBuilder;
 import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.IntegrationTestInitService;
-import com.dotcms.util.RelationshipUtil;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.DotStateException;
+import com.dotmarketing.business.RelationshipAPI;
 import com.dotmarketing.business.UserAPI;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -44,6 +44,7 @@ public class ContentletIntegrationTest {
     private static HostAPI hostAPI;
     private static Language defaultLanguage;
     private static LanguageAPI languageAPI;
+    private static RelationshipAPI relationshipAPI;
     private static UserAPI userAPI;
     private static User user;
     private static Host defaultHost;
@@ -66,6 +67,7 @@ public class ContentletIntegrationTest {
 
         contentletAPI   = APILocator.getContentletAPI();
         contentTypeAPI  = APILocator.getContentTypeAPI(user);
+        relationshipAPI = APILocator.getRelationshipAPI();
         defaultHost     = hostAPI.findDefaultHost(user, false);
         defaultLanguage = languageAPI.getDefaultLanguage();
     }
@@ -140,8 +142,7 @@ public class ContentletIntegrationTest {
         final Field field = createAndSaveRelationshipField("myChild", parentContentType.id(),
                 childContentType.variable(), CARDINALITY);
 
-        final Relationship relationship = RelationshipUtil
-                .getRelationshipFromField(field, parentContentType.variable());
+        final Relationship relationship = relationshipAPI.getRelationshipFromField(field, user);
 
         //Save related content
         parentContentlet = contentletAPI.checkin(parentContentlet,

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1091,6 +1091,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
     public Object getFieldValue(Contentlet contentlet, Field theField){
         try {
 
+            final User user = APILocator.getUserAPI().getSystemUser();
             if(fieldAPI.isElementConstant(theField)){
                 if(contentlet.getMap().get(theField.getVelocityVarName())==null)
                     contentlet.getMap().put(theField.getVelocityVarName(), theField.getValues());
@@ -1104,11 +1105,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 else
                     return contentlet.getFolder();
             }else if(theField.getFieldType().equals(Field.FieldType.CATEGORY.toString())){
-                Category category = categoryAPI.find(theField.getValues(), APILocator.getUserAPI().getSystemUser(), false);
+                Category category = categoryAPI.find(theField.getValues(), user, false);
                 // Get all the Contentlets Categories
-                List<Category> selectedCategories = categoryAPI.getParents(contentlet, APILocator.getUserAPI().getSystemUser(), false);
+                List<Category> selectedCategories = categoryAPI.getParents(contentlet, user, false);
                 Set<Category> categoryList = new HashSet<Category>();
-                List<Category> categoryTree = categoryAPI.getAllChildren(category, APILocator.getUserAPI().getSystemUser(), false);
+                List<Category> categoryTree = categoryAPI.getAllChildren(category, user, false);
                 if (selectedCategories.size() > 0 && categoryTree != null) {
                     for (int k = 0; k < categoryTree.size(); k++) {
                         Category cat = (Category) categoryTree.get(k);
@@ -1121,14 +1122,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 }
                 return categoryList;
             }else if(theField.getFieldType().equals(FieldType.RELATIONSHIP.toString())) {
-
-                final String[] relationType = theField.getFieldRelationType().split("\\.");
-                final Relationship relationship = (relationType.length > 1) ? relationshipAPI
-                        .byTypeValue(theField.getFieldRelationType()) : relationshipAPI.byTypeValue(
-                        contentlet.getContentType().variable() + StringPool.PERIOD + theField
-                                .getVelocityVarName());
-
-                return relationshipAPI.dbRelatedContent(relationship, contentlet);
+                return relationshipAPI
+                        .dbRelatedContent(relationshipAPI.getRelationshipFromField(theField, user),
+                                contentlet);
             }else{
                 return contentlet.get(theField.getVelocityVarName());
             }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldAPIImpl.java
@@ -57,7 +57,6 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
 import com.liferay.portal.model.User;
-import com.liferay.util.StringPool;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang.StringUtils;
@@ -154,7 +153,7 @@ public class FieldAPIImpl implements FieldAPI {
         //if RelationshipField, Relationship record must be added/updated
         if (field instanceof RelationshipField) {
             Optional<Relationship> relationship = getRelationshipForField(result, contentTypeAPI,
-                  type);
+                  type, user);
 
             if (relationship.isPresent()) {
               relationshipAPI.save(relationship.get());
@@ -232,7 +231,7 @@ public class FieldAPIImpl implements FieldAPI {
      */
     @VisibleForTesting
     Optional<Relationship> getRelationshipForField(final Field field, final ContentTypeAPI contentTypeAPI,
-            final ContentType type) throws DotDataException, DotSecurityException {
+            final ContentType type, final User user) throws DotDataException, DotSecurityException {
         Relationship relationship;
         ContentType relatedContentType;
         try {
@@ -254,13 +253,8 @@ public class FieldAPIImpl implements FieldAPI {
                 return Optional.empty();
             }
 
-            //checking if the relationship is against a content type or an existing relationship
-            if (relationType.length > 1) {
-                relationship = relationshipAPI.byTypeValue(field.relationType());
-            } else {
-                relationship = relationshipAPI
-                        .byTypeValue(type.variable() + StringPool.PERIOD + field.variable());
-            }
+            //getting the existing relationship
+            relationship = relationshipAPI.getRelationshipFromField(field, user);
 
             //verify if the relationship already exists
             if (UtilMethods.isSet(relationship) && UtilMethods.isSet(relationship.getInode())) {

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/RelationshipFieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/RelationshipFieldDataFetcher.java
@@ -4,7 +4,6 @@ import com.dotcms.contenttype.model.field.Field;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.structure.model.Relationship;
-import com.liferay.util.StringPool;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -14,10 +13,10 @@ public class RelationshipFieldDataFetcher implements DataFetcher<Object> {
     public Object get(DataFetchingEnvironment environment) throws Exception {
         final Contentlet contentlet = environment.getSource();
         final String fieldVar = environment.getField().getName();
-        Field field = APILocator.getContentTypeFieldAPI().byContentTypeIdAndVar(contentlet.getContentTypeId(), fieldVar);
-        final String typeValue = contentlet.getContentType().variable() + StringPool.PERIOD + field
-            .variable();
-        Relationship relationship = APILocator.getRelationshipAPI().byTypeValue(typeValue);
+        Field field = APILocator.getContentTypeFieldAPI()
+                .byContentTypeIdAndVar(contentlet.getContentTypeId(), fieldVar);
+        Relationship relationship = APILocator.getRelationshipAPI()
+                .getRelationshipFromField(field, APILocator.getUserAPI().getSystemUser());
 
         return APILocator.getRelationshipAPI().dbRelatedContent(relationship, contentlet);
     }

--- a/dotCMS/src/main/java/com/dotcms/util/RelationshipUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/RelationshipUtil.java
@@ -10,7 +10,6 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.util.UUIDUtil;
@@ -36,37 +35,6 @@ public class RelationshipUtil {
 
     private final static RelationshipAPI relationshipAPI = APILocator.getRelationshipAPI();
 
-    /**
-     * Given a Relationship Field and a Content Type Velocity var name, returns the existing relationship
-     * @param field
-     * @param contentTypeVar
-     * @return
-     */
-    public static Relationship getRelationshipFromField(final Field field, final String contentTypeVar){
-        final String fieldRelationType = field.getFieldRelationType();
-        return APILocator.getRelationshipAPI().byTypeValue(
-                fieldRelationType.contains(StringPool.PERIOD) ? fieldRelationType
-                        :contentTypeVar + StringPool.PERIOD + field
-                                .getVelocityVarName());
-
-
-    }
-
-    /**
-     * Given a Relationship Field and a Content Type Velocity var name, returns the existing relationship
-     * @param field
-     * @param contentTypeVar
-     * @return
-     */
-    public static Relationship getRelationshipFromField(final com.dotcms.contenttype.model.field.Field field, final String contentTypeVar){
-        final String fieldRelationType = field.relationType();
-        return APILocator.getRelationshipAPI().byTypeValue(
-                fieldRelationType.contains(StringPool.PERIOD) ? fieldRelationType
-                        :contentTypeVar + StringPool.PERIOD + field
-                                .variable());
-
-
-    }
 
     /**
      * Returns a list of related contentlet given a comma separated list of lucene queries and/or contentlet identifiers

--- a/dotCMS/src/main/java/com/dotmarketing/business/RelationshipAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/RelationshipAPI.java
@@ -1,15 +1,17 @@
 package com.dotmarketing.business;
 
 import com.dotcms.contenttype.model.type.ContentType;
-import java.util.List;
-import java.util.Map;
-
 import com.dotcms.contenttype.model.type.ContentTypeIf;
 import com.dotmarketing.beans.Tree;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;
+import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.portlets.structure.model.Relationship;
+import com.liferay.portal.model.User;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface RelationshipAPI {
@@ -111,4 +113,21 @@ public interface RelationshipAPI {
 
   ContentletRelationships getContentletRelationshipsFromMap(final Contentlet contentlet, final Map<Relationship,
           List<Contentlet>> contentRelationships);
+
+  /**
+   * Given a Relationship Field, returns the existing relationship
+   * @param field
+   * @param user
+   * @return
+   */
+  Relationship getRelationshipFromField(Field field, final User user) throws DotDataException, DotSecurityException;
+
+  /**
+   * Given a Relationship Field, returns the existing relationship
+   * @param field
+   * @param user
+   * @return
+   */
+  Relationship getRelationshipFromField(final com.dotcms.contenttype.model.field.Field field, final User user)
+          throws DotDataException, DotSecurityException;
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/RelationshipAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/RelationshipAPIImpl.java
@@ -3,18 +3,23 @@ package com.dotmarketing.business;
 
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
+import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.RelationshipFactory;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ContentTypeIf;
 import com.dotcms.util.DotPreconditions;
 import com.dotmarketing.beans.Tree;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;
+import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.portlets.structure.model.Relationship;
 
 import com.dotmarketing.portlets.structure.transform.ContentletRelationshipsTransformer;
 import com.dotmarketing.util.UtilMethods;
+import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
 import java.util.List;
 import java.util.Optional;
 import java.util.Map;
@@ -233,4 +238,39 @@ public class RelationshipAPIImpl implements RelationshipAPI {
     public ContentletRelationships getContentletRelationshipsFromMap(Contentlet contentlet, final Map<Relationship, List<Contentlet>> contentRelationships) {
         return new ContentletRelationshipsTransformer(contentlet, contentRelationships).findFirst();
     }
+
+    @Override
+    public Relationship getRelationshipFromField(final Field field, final User user)
+            throws DotDataException, DotSecurityException {
+
+        final ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(user);
+
+        final String contentTypeVar    = contentTypeAPI.find(field.getStructureInode()).variable();
+        final String fieldRelationType = field.getFieldRelationType();
+
+        return APILocator.getRelationshipAPI().byTypeValue(
+                fieldRelationType.contains(StringPool.PERIOD) ? fieldRelationType
+                        : contentTypeVar + StringPool.PERIOD + field
+                                .getVelocityVarName());
+
+
+    }
+
+    @Override
+    public Relationship getRelationshipFromField(final com.dotcms.contenttype.model.field.Field field, final User user)
+            throws DotDataException, DotSecurityException {
+
+        final ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(user);
+
+        final String contentTypeVar    = contentTypeAPI.find(field.contentTypeId()).variable();
+
+        final String fieldRelationType = field.relationType();
+        return APILocator.getRelationshipAPI().byTypeValue(
+                fieldRelationType.contains(StringPool.PERIOD) ? fieldRelationType
+                        :contentTypeVar + StringPool.PERIOD + field
+                                .variable());
+
+
+    }
+
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -444,9 +444,8 @@ public class ImportUtil {
                         }
 
                         if (field.getFieldType().equals(FieldType.RELATIONSHIP.toString())) {
-                            contentTypeRelationshipsMap.put(field.getVelocityVarName(),
-                                    RelationshipUtil.getRelationshipFromField(field,
-                                            contentType.getVelocityVarName()));
+                            contentTypeRelationshipsMap.put(field.getVelocityVarName(), APILocator.getRelationshipAPI()
+                                    .getRelationshipFromField(field, user));
                         }
                         break;
                     }


### PR DESCRIPTION
- Contentlet.getRelated: Now we are caching an empty list when there isn't any related record for an existing relationship field
- Method RelationshipUtil.getRelationshipField was moved to RelationshipAPI. Additionally, this method doesn't receive a contentTypeVar anymore