### PR TITLE
Changed logging level for file asset getter methods messages

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/BinaryMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/BinaryMap.java
@@ -195,7 +195,8 @@ public class BinaryMap {
                 fileDimension = ImageUtil.getInstance().getDimension(getFile());
             }
         } catch (Exception e) {
-            Logger.error(this, e.getMessage());
+            String contentId = (content == null ? null : content.getIdentifier());
+            Logger.debug(this, "Error getting height for binary map, id: " + contentId, e);
         }
 
         return fileDimension.height;
@@ -208,7 +209,8 @@ public class BinaryMap {
                 fileDimension = ImageUtil.getInstance().getDimension(getFile());
             }
         } catch (Exception e) {
-            Logger.error(this, e.getMessage());
+            String contentId = (content == null ? null : content.getIdentifier());
+            Logger.debug(this, "Error getting width for binary map, id: " + contentId, e);
         }
 
         return fileDimension.width;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -271,7 +271,7 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 
     	    return title;
 		} catch (Exception e) {
-			Logger.error(this,"Unable to get title.");
+			Logger.debug(this,"Unable to get title for contentlet, id: " + getIdentifier(), e);
 			return  "";
 		}
 	}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
@@ -99,7 +99,7 @@ public class FileAsset extends Contentlet implements IFileAsset {
                 fileDimension = ImageUtil.getInstance().getDimension(getFileAsset());
             }
         } catch (Exception e) {
-            Logger.error(this, e.getMessage());
+            Logger.debug(this, "Error getting height for file asset, id: " + getIdentifier(), e);
         }
 
         return fileDimension.height;
@@ -112,7 +112,7 @@ public class FileAsset extends Contentlet implements IFileAsset {
                 fileDimension = ImageUtil.getInstance().getDimension(getFileAsset());
             }
         } catch (Exception e) {
-            Logger.error(this, e.getMessage());
+            Logger.debug(this, "Error getting width for file asset, id: " + getIdentifier(), e);
         }
 
         return fileDimension.width;


### PR DESCRIPTION
Changed logging level for file asset getter methods:
- getTitle method from class com.dotmarketing.portlets.contentlet.model.Contentlet
- getHeight and getWidth methods from class com.dotmarketing.portlets.fileassets.business.FileAsset
- getHeight and getWidth methods from class com.dotcms.rendering.velocity.viewtools.content.BinaryMap