### PR TITLE
#16089 : use respectFrontendRoles parameter when saving content via REST

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1319,7 +1319,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
 
         try {
-            canLock(contentlet, user);
+            canLock(contentlet, user, respectFrontendRoles);
 
             if(contentlet.isLocked() ){
                 // persists the webasset
@@ -3051,7 +3051,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             if(contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME) == null) {
-                canLock(contentlet, user);
+                canLock(contentlet, user, respectFrontendRoles);
             }
             contentlet.setModUser(user.getUserId());
             // start up workflow

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/CheckinContentActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/CheckinContentActionlet.java
@@ -33,8 +33,8 @@ public class CheckinContentActionlet extends WorkFlowActionlet {
 		try {
 
 			APILocator.getContentletAPI().unlock(processor.getContentlet(), processor.getUser(),
-					processor.getContentletDependencies() != null ?
-							processor.getContentletDependencies().isRespectAnonymousPermissions() : false);
+					processor.getContentletDependencies() != null
+							&& processor.getContentletDependencies().isRespectAnonymousPermissions());
 		} catch (Exception e) {
 			Logger.error(this.getClass(),e.getMessage(),e);
 			throw new  WorkflowActionFailureException(e.getMessage(),e);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/CheckinContentActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/CheckinContentActionlet.java
@@ -32,7 +32,9 @@ public class CheckinContentActionlet extends WorkFlowActionlet {
 	public void executeAction(WorkflowProcessor processor,Map<String,WorkflowActionClassParameter>  params) throws WorkflowActionFailureException {
 		try {
 
-			APILocator.getContentletAPI().unlock(processor.getContentlet(), processor.getUser(), true);
+			APILocator.getContentletAPI().unlock(processor.getContentlet(), processor.getUser(),
+					processor.getContentletDependencies() != null ?
+							processor.getContentletDependencies().isRespectAnonymousPermissions() : false);
 		} catch (Exception e) {
 			Logger.error(this.getClass(),e.getMessage(),e);
 			throw new  WorkflowActionFailureException(e.getMessage(),e);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/PublishContentActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/PublishContentActionlet.java
@@ -58,10 +58,14 @@ public class PublishContentActionlet extends WorkFlowActionlet {
                  */
                 relatedNotPublished = PublishFactory.getUnpublishedRelatedAssetsForPage(htmlPageAsset, relatedNotPublished, true, processor.getUser(), false);
                 //Publish the page and the related content
-                PublishFactory.publishHTMLPage(htmlPageAsset, relatedNotPublished, processor.getUser(), false);
+                PublishFactory.publishHTMLPage(htmlPageAsset, relatedNotPublished, processor.getUser(),
+                        processor.getContentletDependencies() != null ?
+                                processor.getContentletDependencies().isRespectAnonymousPermissions() : false);
 
             } else {
-                APILocator.getContentletAPI().publish(processor.getContentlet(), processor.getUser(), false);
+                APILocator.getContentletAPI().publish(processor.getContentlet(), processor.getUser(),
+                        processor.getContentletDependencies() != null ?
+                                processor.getContentletDependencies().isRespectAnonymousPermissions() : false);
             }
 
         } catch (Exception e) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/PublishContentActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/PublishContentActionlet.java
@@ -59,13 +59,13 @@ public class PublishContentActionlet extends WorkFlowActionlet {
                 relatedNotPublished = PublishFactory.getUnpublishedRelatedAssetsForPage(htmlPageAsset, relatedNotPublished, true, processor.getUser(), false);
                 //Publish the page and the related content
                 PublishFactory.publishHTMLPage(htmlPageAsset, relatedNotPublished, processor.getUser(),
-                        processor.getContentletDependencies() != null ?
-                                processor.getContentletDependencies().isRespectAnonymousPermissions() : false);
+                        processor.getContentletDependencies() != null
+                                && processor.getContentletDependencies().isRespectAnonymousPermissions());
 
             } else {
                 APILocator.getContentletAPI().publish(processor.getContentlet(), processor.getUser(),
-                        processor.getContentletDependencies() != null ?
-                                processor.getContentletDependencies().isRespectAnonymousPermissions() : false);
+                        processor.getContentletDependencies() != null
+                                && processor.getContentletDependencies().isRespectAnonymousPermissions());
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
Parameter respectFrontentRoles has been added in missing places. This allows saving/publishing content by non authenticated users (CMS Anonymous) when the REST_API_CONTENT_ALLOW_FRONT_END_SAVING property is set to true.
The parameter has been included in this places in the code:
- calls to canLock() method from com.dotcms.content.elasticsearch.business.ESContentletAPIImpl class
- call to APILocator.getContentletAPI().publish() method from com.dotmarketing.portlets.workflows.actionlet.PublishContentActionlet class
- call to APILocator.getContentletAPI().unlock() method from com.dotmarketing.portlets.workflows.actionlet.CheckinContentActionlet class