### PR TITLE
dotCMS/core#16046 : Display content key in key/value field

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -1004,9 +1004,6 @@
             <%if(keyValueMap!=null && !keyValueMap.isEmpty()){
                 int k = 0;
                 for(String key : keyValueMap.keySet()){
-                    if(key.equals("content")){
-                        continue;
-                    }
                     String str_style = "";
                     if ((k%2)==0) {
                         str_style = "class=\"dojoDndItem alternate_1\"";


### PR DESCRIPTION
Fix to display key/value entries when the key is the "content" word