### PR TITLE
#16299 avoid duplicate key map

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/util/RelationshipUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/RelationshipUtil.java
@@ -95,7 +95,7 @@ public class RelationshipUtil {
                         .putAll((isCheckout ? contentletAPI.checkoutWithQuery(elem, user, false)
                                 : contentletAPI.search(elem, 0, 0, sortBy, user, false)).stream()
                                 .collect(Collectors
-                                        .toMap(Contentlet::getIdentifier, Function.identity())));
+                                        .toMap(Contentlet::getIdentifier, Function.identity(),(oldValue, newValue) -> oldValue)));
             }
         }
 


### PR DESCRIPTION
The contentlet search could return the same contentlet multiple times, because of multilanguage, and since we're using the identifier as key we hit the `Duplicate Key Exception` when converting to Map. With this change, if that happens will use the first contentlet converted (it does not matter since the relationship is made by id, not by inode).