### PR TITLE
More work on 16563

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
@@ -148,19 +148,19 @@ public class ESMappingAPITest {
                     .setProperty("title", "Child Comment for Test")
                     .setProperty("email", "testing@dotcms.com")
                     .setProperty("comment", "Child Comment for Test")
-                    .next();
+                    .nextPersisted();
 
             //creates child contentlet
             parentContentlet = dataGen.languageId(language.getId())
                     .setProperty("title", "Parent Comment for Test")
                     .setProperty("email", "testing@dotcms.com")
                     .setProperty("comment", "Parent Comment for Test")
-                    .nextPersisted();
+                    .next();
 
             final Relationship relationship = relationshipAPI.byTypeValue("Comments-Comments");
 
-            childContentlet = contentletAPI.checkin(childContentlet,
-                    map(relationship, list(parentContentlet)),
+            parentContentlet = contentletAPI.checkin(parentContentlet,
+                    map(relationship, list(childContentlet)),
                     null, user, false);
 
             esMappingAPI.loadRelationshipFields(parentContentlet, esMap);

--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/RelationshipAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/RelationshipAPITest.java
@@ -20,6 +20,7 @@ import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.structure.factories.StructureFactory;
 import com.dotmarketing.portlets.structure.model.Relationship;
@@ -232,12 +233,11 @@ public class RelationshipAPITest extends IntegrationTestBase {
 
         final Map<Relationship, List<Contentlet>> relationshipListMap = Maps.newHashMap();
         relationshipListMap.put(relationship, relationshipList);
+        contentletParent.setIndexPolicy(IndexPolicy.WAIT_FOR);
+        contentletParent.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
         //Checkin of the parent to validate Relationships
         contentletParent = APILocator
                 .getContentletAPI().checkin(contentletParent,relationshipListMap,user,false);
-
-        //wait for reindex
-        DateUtil.sleep(4000);
 
         //List Related Contentlets
         List<Contentlet> relatedContent = APILocator.getContentletAPI()

--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentResourceTest.java
@@ -618,8 +618,8 @@ public class ContentResourceTest extends IntegrationTestBase {
         final Contentlet parent = contentletMap.get("parent");
         final Contentlet child = contentletMap.get("child");
 
-        assertEquals(parent.getIdentifier(), contentlet.getElementsByTagName(
-                IDENTIFIER).item(0).getTextContent());
+        assertEquals(parent.getInode(), contentlet.getElementsByTagName(
+                "inode").item(0).getTextContent());
 
         if (testCase.depth == null) {
             assertEquals(0, contentlet

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -5698,9 +5698,9 @@ public class ContentletAPITest extends ContentletBaseTest {
             Contentlet parentContent = dataGen.languageId(languageAPI.getDefaultLanguage().getId()).nextPersisted();
 
             Contentlet childContent = dataGen.languageId(languageAPI.getDefaultLanguage().getId()).next();
+            childContent.setRelated(childField.variable(), CollectionsUtils.list(parentContent));
 
-            childContent = contentletAPI.checkin(childContent, CollectionsUtils
-                    .map(relationship, CollectionsUtils.list(parentContent)), user, false);
+            childContent = contentletAPI.checkin(childContent, user, false);
 
             List<Contentlet> relatedContent = relationshipAPI.dbRelatedContent(relationship, childContent, false);
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/structure/transform/ContentletRelationshipsTransformerTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/structure/transform/ContentletRelationshipsTransformerTest.java
@@ -150,7 +150,7 @@ public class ContentletRelationshipsTransformerTest {
 
             //Check that contentletRelationship is not null and the hasParent is False
             assertNotNull(relationshipsData);
-            assertFalse(relationshipsData.getRelationshipsRecords().get(0).isHasParent());
+            assertTrue(relationshipsData.getRelationshipsRecords().get(0).isHasParent());
 
         }finally {
             if (parentContentType != null) {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1396,6 +1396,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
         return permissionAPI.filterCollection(contentFactory.getRelatedLinks(contentlet), PermissionAPI.PERMISSION_READ, respectFrontendRoles, user);
     }
 
+    @CloseDBIfOpened
+    @Override
     public List<Contentlet> filterRelatedContent(Contentlet contentlet, Relationship rel,
             User user, boolean respectFrontendRoles, Boolean pullByParent, int limit, int offset,
             String sortBy)
@@ -1408,25 +1410,29 @@ public class ESContentletAPIImpl implements ContentletAPI {
         final boolean isSameStructureRelationship = FactoryLocator.getRelationshipFactory()
                 .sameParentAndChild(rel);
 
-        if (isSameStructureRelationship){
-            if (pullByParent == null){
+        if (isSameStructureRelationship) {
+            if (pullByParent == null) {
                 return (List<Contentlet>) CollectionsUtils
-                        .join(getRelatedChildren(contentlet, rel, user, respectFrontendRoles, limit, offset, sortBy),
-                                getRelatedParents(contentlet, rel, user, respectFrontendRoles, limit, offset, sortBy)).stream()
+                        .join(getRelatedChildren(contentlet, rel, user, respectFrontendRoles, limit,
+                                offset, sortBy),
+                                getRelatedParents(contentlet, rel, user, respectFrontendRoles,
+                                        limit, offset, sortBy)).stream()
                         .collect(CollectionsUtils.toImmutableList());
             }
-            if (pullByParent){
-                return getRelatedChildren(contentlet, rel, user, respectFrontendRoles, limit, offset, sortBy).stream()
+            if (pullByParent) {
+                return getRelatedChildren(contentlet, rel, user, respectFrontendRoles, limit,
+                        offset, sortBy).stream()
                         .collect(CollectionsUtils.toImmutableList());
-            } else{
-                return getRelatedParents(contentlet, rel, user, respectFrontendRoles, limit, offset, sortBy).stream()
+            } else {
+                return getRelatedParents(contentlet, rel, user, respectFrontendRoles, limit, offset,
+                        sortBy).stream()
                         .collect(CollectionsUtils.toImmutableList());
             }
         } else {
-            if (rel.getChildStructureInode().equals(contentlet.getContentTypeId())){
+            if (rel.getChildStructureInode().equals(contentlet.getContentTypeId())) {
                 return getRelatedParents(contentlet, rel, user, respectFrontendRoles, limit, offset,
                         sortBy);
-            } else{
+            } else {
                 return getRelatedChildren(contentlet, rel, user, respectFrontendRoles, limit,
                         offset, sortBy);
             }
@@ -1536,17 +1542,20 @@ public class ESContentletAPIImpl implements ContentletAPI {
     public List<Contentlet> getRelatedContent(Contentlet contentlet, Relationship rel,
             Boolean pullByParent, User user, boolean respectFrontendRoles, int limit, int offset,
             String sortBy)
-            throws DotDataException, DotSecurityException {
+            throws DotDataException {
         try {
             final String fieldVariable = rel.isRelationshipField() ?
                     rel.getParentStructureInode().equals(contentlet.getContentTypeId()) ? rel
                             .getChildRelationName() : rel.getParentRelationName()
                     : rel.getRelationTypeValue();
-            return contentlet.getRelated(fieldVariable, user, respectFrontendRoles, pullByParent, limit, offset, sortBy);
+            return contentlet
+                    .getRelated(fieldVariable, user, respectFrontendRoles, pullByParent, limit,
+                            offset, sortBy);
         } catch (Exception e) {
             final String errorMessage =
                     "Unable to look up related content for contentlet with identifier "
-                            + contentlet.getIdentifier() + ". Relationship name: " + rel.getRelationTypeValue();
+                            + contentlet.getIdentifier() + ". Relationship name: " + rel
+                            .getRelationTypeValue();
             if (e instanceof SearchPhaseExecutionException || e
                     .getCause() instanceof SearchPhaseExecutionException) {
                 Logger.warnAndDebug(ESContentletAPIImpl.class,
@@ -1560,7 +1569,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
     @CloseDBIfOpened
     @Override
     public List<Contentlet> getRelatedContent(Contentlet contentlet, Relationship rel,
-            boolean pullByParent, User user, boolean respectFrontendRoles)
+            Boolean pullByParent, User user, boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException {
         return getRelatedContent(contentlet, rel, pullByParent, user, respectFrontendRoles, -1, -1,
                 null);

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
@@ -531,22 +531,6 @@ public class ContentUtils {
                 pullQuery.append(" ").append(condition);
                 return pull(pullQuery.toString(), offset, limit, sort, user, tmDate);
             } else {
-                String fieldVariable;
-                if ((selfRelated && pullByParent) || (!selfRelated && relationship
-                        .getParentStructureInode().equals(contentlet.getContentTypeId()))) {
-                    fieldVariable = relationship.getChildRelationName();
-                } else{
-                    fieldVariable = relationship.getParentRelationName();
-                }
-
-                //If no condition, get related content from cache (only if a relationship field exists).
-                if (relationshipName.contains(StringPool.PERIOD) && contentlet.getContentType()
-                        .fieldMap().containsKey(fieldVariable)) {
-                    return contentlet.getRelated(fieldVariable, user, false);
-                }
-
-                //Otherwise, it will go to the database or ES index
-                //(depending on the value set for GET_RELATED_CONTENT_FROM_DB)
                 return conAPI
                         .getRelatedContent(contentlet, relationship, pullByParent, user, false);
             }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
@@ -961,7 +961,7 @@ public class ContentletAjax {
 
 		before = System.currentTimeMillis();
 
-		//The reesults list returned to the page
+		//The results list returned to the page
 		List<Object> results = new ArrayList<Object>();
 
 		//Adding the result counters as the first row of the results

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -1,6 +1,5 @@
 package com.dotmarketing.portlets.contentlet.business;
 
-import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.content.business.DotMappingException;
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
 import com.dotmarketing.beans.Host;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -807,7 +807,7 @@ public interface ContentletAPI {
 	 * @throws DotDataException
 	 * @throws DotSecurityException
 	 */
-	public List<Contentlet> getRelatedContent(Contentlet contentlet, Relationship rel, boolean pullByParent, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException;
+	public List<Contentlet> getRelatedContent(Contentlet contentlet, Relationship rel, Boolean pullByParent, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException;
 
 	/**
 	 * 
@@ -1918,5 +1918,9 @@ public interface ContentletAPI {
      * @return
      */
     Optional<Contentlet> findInDb(String inode);
+
+    List<Contentlet> filterRelatedContent(Contentlet contentlet, Relationship rel,
+            User user, boolean respectFrontendRoles, Boolean pullByParent)
+            throws DotDataException, DotSecurityException;
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.portlets.contentlet.business;
 
+import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.content.business.DotMappingException;
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
 import com.dotmarketing.beans.Host;
@@ -774,7 +775,27 @@ public interface ContentletAPI {
 	 */
 	public void relateContent(Contentlet contentlet, ContentletRelationshipRecords related, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException, DotContentletStateException;
 
-	/**
+
+    /**
+     * Internally called by getRelatedContent methods (handles all the logic to filter by parents or children)
+     * @param contentlet
+     * @param rel
+     * @param user
+     * @param respectFrontendRoles
+     * @param pullByParent
+     * @param limit
+     * @param offset
+     * @param sortBy
+     * @return
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    List<Contentlet> filterRelatedContent(Contentlet contentlet, Relationship rel,
+            User user, boolean respectFrontendRoles, Boolean pullByParent, int limit, int offset,
+            String sortBy)
+            throws DotDataException, DotSecurityException;
+
+    /**
 	 * Gets all related content, if this method is invoked with the same structures (where the parent and child structures are the same type)
 	 * kind of relationship then all parents and children of the given contentlet will be retrieved in the same returned list
 	 * @param contentlet
@@ -809,8 +830,9 @@ public interface ContentletAPI {
      * @throws DotDataException
      */
     List<Contentlet> getRelatedContent(Contentlet contentlet, Relationship rel,
-            boolean pullByParent, User user, boolean respectFrontendRoles, int limit, int offset,
-            String sortBy)throws DotDataException;
+            Boolean pullByParent, User user, boolean respectFrontendRoles, int limit, int offset,
+            String sortBy)
+            throws DotDataException;
 
     /**
 	 * Gets all related content from the same structure (where the parent and child structures are the same type)
@@ -1941,9 +1963,5 @@ public interface ContentletAPI {
      * @return
      */
     Optional<Contentlet> findInDb(String inode);
-
-    List<Contentlet> filterRelatedContent(Contentlet contentlet, Relationship rel,
-            User user, boolean respectFrontendRoles, Boolean pullByParent)
-            throws DotDataException, DotSecurityException;
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -1135,7 +1135,7 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 
     @Override
     public List<Contentlet> getRelatedContent(Contentlet contentlet, Relationship rel,
-            boolean pullByParent, User user, boolean respectFrontendRoles, int limit, int offset,
+            Boolean pullByParent, User user, boolean respectFrontendRoles, int limit, int offset,
             String sortBy) throws DotDataException {
         for (ContentletAPIPreHook pre : preHooks) {
             boolean preResult = pre
@@ -1158,7 +1158,7 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
     }
 
     @Override
-	public List<Contentlet> getRelatedContent(Contentlet contentlet, Relationship rel, boolean pullByParent, User user,	boolean respectFrontendRoles) throws DotDataException,	DotSecurityException {
+	public List<Contentlet> getRelatedContent(Contentlet contentlet, Relationship rel, Boolean pullByParent, User user,	boolean respectFrontendRoles) throws DotDataException,	DotSecurityException {
 		for(ContentletAPIPreHook pre : preHooks){
 			boolean preResult = pre.getRelatedContent(contentlet, rel,pullByParent, user, respectFrontendRoles);
 			if(!preResult){
@@ -1534,7 +1534,30 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 		}
 	}
 
-	@Override
+    @Override
+    public List<Contentlet> filterRelatedContent(Contentlet contentlet, Relationship rel, User user,
+            boolean respectFrontendRoles, Boolean pullByParent, int limit, int offset,
+            String sortBy) throws DotDataException, DotSecurityException {
+        for(ContentletAPIPreHook pre : preHooks){
+            boolean preResult = pre.filterRelatedContent(contentlet, rel, user, respectFrontendRoles, pullByParent,
+                    limit, offset, sortBy);
+            if(!preResult){
+                Logger.error(this, "The following prehook failed " + pre.getClass().getName());
+                throw new DotRuntimeException("The following prehook failed " + pre.getClass().getName());
+            }
+        }
+        List<Contentlet> contentlets = conAPI
+                .filterRelatedContent(contentlet, rel, user, respectFrontendRoles, pullByParent,
+                        limit, offset, sortBy);
+        for(ContentletAPIPostHook post : postHooks){
+            post.filterRelatedContent(contentlet, rel, user, respectFrontendRoles, pullByParent,
+                    limit, offset, sortBy);
+        }
+
+        return contentlets;
+    }
+
+    @Override
 	public void restoreVersion(Contentlet contentlet, User user, boolean respectFrontendRoles) throws DotSecurityException,	DotContentletStateException, DotDataException {
 		for(ContentletAPIPreHook pre : preHooks){
 			boolean preResult = pre.restoreVersion(contentlet, user, respectFrontendRoles);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
@@ -54,7 +54,7 @@ public interface ContentletAPIPostHook {
 	/**
 	 * Returns a live Contentlet Object for a given language 
 	 * @param languageId
-	 * @param inode
+	 * @param contentletId
 	 * @param returnValue - value returned by primary API Method
 	 */
 	public default void findContentletForLanguage(long languageId, Identifier contentletId,Contentlet returnValue){}
@@ -92,7 +92,6 @@ public interface ContentletAPIPostHook {
 	/**
 	 * Retrieves a contentlet from the database based on its identifier
 	 * @param identifier
-	 * @param returnValue - value returned by primary API Method
 	 */
 	public default void findContentletByIdentifierAnyLanguage (String identifier) { }
 
@@ -266,7 +265,6 @@ public interface ContentletAPIPostHook {
 	 * sure to pass in an Admin User.  If a user doesn't have permissions to clean all teh contentlets it will clean 
 	 * as many as it can and throw the DotSecurityException  
 	 * @param structure
-	 * @param field
 	 * @param user
 	 * @param respectFrontendRoles
 	 */
@@ -480,7 +478,6 @@ public interface ContentletAPIPostHook {
 	 * @param contentlets
 	 * @param user
 	 * @param respectFrontendRoles
-	 * @param returnValue - value returned by primary API Method 
 	 */
 	public default void publish(List<Contentlet> contentlets, User user, boolean respectFrontendRoles){}
 
@@ -489,7 +486,6 @@ public interface ContentletAPIPostHook {
 	 * @param contentlet
 	 * @param user
 	 * @param respectFrontendRoles
-	 * @param returnValue - value returned by primary API Method 
 	 */
 	public default void unpublish(Contentlet contentlet, User user, boolean respectFrontendRoles){}
 	
@@ -807,11 +803,9 @@ public interface ContentletAPIPostHook {
 	/**
 	 * Will check in a new version of you contentlet. The inode of your contentlet must be 0.  
 	 * @param contentlet - The inode of your contentlet must be 0.
-	 * @param contentRelationships - throws IllegalArgumentException if null. Used to set relationships to new contentlet version 
-	 * @param cats - throws IllegalArgumentException if null. Used to set categories to new contentlet version
-	 * @param permissions - throws IllegalArgumentException if null. Used to set permissions to new contentlet version
 	 * @param user
 	 * @param respectFrontendRoles
+     * @param cats - throws IllegalArgumentException if null. Used to set categories to new contentlet version
 	 * @param returnValue - value returned by primary API Method 
 	 */
 	public default void checkin(Contentlet contentlet ,User user,boolean respectFrontendRoles,List<Category> cats,Contentlet returnValue){}
@@ -935,7 +929,6 @@ public interface ContentletAPIPostHook {
 	 * Will return all content assigned to a specified Categories
 	 * @param categories - List of categories to look for
 	 * @param languageId language to pull content for. If 0 will return all languages
-	 * @param category Category to look for
 	 * @param live should return live or working content
 	 * @param orderBy indexName(previously known as dbColumnName) to order by. Can be null or empty string
 	 * @param user
@@ -949,15 +942,13 @@ public interface ContentletAPIPostHook {
 	 * @param contentlet
 	 * @param field
 	 * @param value
-	 * @param user
-	 * @param respectFrontendRoles
 	 */
 	public default void setContentletProperty(Contentlet contentlet, Field field, Object value){}
 	
 	/**
 	 * Use to validate your contentlet.
 	 * @param contentlet
-	 * @param categories
+	 * @param cats - categories
 	 */
 	public default void validateContentlet(Contentlet contentlet,List<Category> cats){} 
 	
@@ -965,7 +956,7 @@ public interface ContentletAPIPostHook {
 	 * Use to validate your contentlet.
 	 * @param contentlet
 	 * @param contentRelationships
-	 * @param categories
+	 * @param cats - categories
 	 * Use the notValidFields property of the exception to get which fields where not valid
 	 */
 	public default void validateContentlet(Contentlet contentlet,Map<Relationship, List<Contentlet>> contentRelationships,List<Category> cats){} 
@@ -974,7 +965,7 @@ public interface ContentletAPIPostHook {
 	 * Use to validate your contentlet.
 	 * @param contentlet
 	 * @param contentRelationships
-	 * @param categories
+	 * @param cats - categories
 	 */
 	public default void validateContentlet(Contentlet contentlet, ContentletRelationships contentRelationships, List<Category> cats){} 
 	
@@ -1010,13 +1001,16 @@ public interface ContentletAPIPostHook {
 
 	/**
 	 * Converts a "fat" (legacy) contentlet into a new contentlet.
-	 * @param Fat contentlet to be converted.
+	 * @param fatty contentlet to be converted.
+     * @param returnValue
 	 */
 	public default void convertFatContentletToContentlet (com.dotmarketing.portlets.contentlet.business.Contentlet fatty,Contentlet returnValue){}
 	
 	/**
 	 * Converts a "light" contentlet into a "fat" (legacy) contentlet.
-	 * @param A "light" contentlet to be converted.
+	 * @param cont "light" contentlet to be converted.
+     * @param fatty
+     * @param returnValue
 	 */
 	public default void convertContentletToFatContentlet (Contentlet cont, com.dotmarketing.portlets.contentlet.business.Contentlet fatty,com.dotmarketing.portlets.contentlet.business.Contentlet returnValue){}
     
@@ -1035,13 +1029,15 @@ public interface ContentletAPIPostHook {
     * @return
     * @param returnValue - value returned by primary API Method */
 	public default void deleteOldContent(Date deleteFrom,int returnValue){}
-	
-	/**
-	 * 
-	 * @param deleteFrom
-	 * @param offset
-	 * @param returnValue - value returned by primary API Method 
-	 */
+
+    /**
+     *
+     * @param structureInode
+     * @param field
+     * @param user
+     * @param respectFrontEndRoles
+     * @param returnValue  - value returned by primary API Method
+     */
 	public default void findFieldValues(String structureInode, Field field, User user, boolean respectFrontEndRoles,List<String> returnValue){}
 	
 	/**
@@ -1160,12 +1156,10 @@ public interface ContentletAPIPostHook {
 	/**
 	 * Will check in a new version of you contentlet without indexing. The inode of your contentlet must be not set.  
 	 * @param contentlet - The inode of your contentlet must be not set.
-	 * @param contentRelationships - throws IllegalArgumentException if null. Used to set relationships to new contentlet version 
-	 * @param cats - throws IllegalArgumentException if null. Used to set categories to new contentlet version
-	 * @param permissions - throws IllegalArgumentException if null. Used to set permissions to new contentlet version
 	 * @param user
 	 * @param respectFrontendRoles
-	 * @param returnValue - value returned by primary API Method 
+     * @param cats - throws IllegalArgumentException if null. Used to set categories to new contentlet version
+     * @param returnValue - value returned by primary API Method
 	 */
 	public default void checkinWithNoIndex(Contentlet contentlet ,User user,boolean respectFrontendRoles,List<Category> cats,Contentlet returnValue){}
 	
@@ -1253,7 +1247,7 @@ public interface ContentletAPIPostHook {
 	
 	/**
 	 * Method will update hostInode of content to systemhost
-	 * @param identifier
+	 * @param hostIdentifier
 	 */	
 	public default void UpdateContentWithSystemHost(String hostIdentifier)throws DotDataException{}
 	
@@ -1541,5 +1535,24 @@ public interface ContentletAPIPostHook {
 
     public default void findInDb(String inode) {};
 
-
+    /**
+     * Internally called by getRelatedContent methods (handles all the logic to filter by parents or children)
+     * @param contentlet
+     * @param rel
+     * @param user
+     * @param respectFrontendRoles
+     * @param pullByParent
+     * @param limit
+     * @param offset
+     * @param sortBy
+     * @return
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    default boolean  filterRelatedContent(Contentlet contentlet, Relationship rel,
+            User user, boolean respectFrontendRoles, Boolean pullByParent, int limit, int offset,
+            String sortBy)
+            throws DotDataException, DotSecurityException{
+        return true;
+    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
@@ -55,7 +55,7 @@ public interface ContentletAPIPreHook {
 	/**
 	 * Returns a live Contentlet Object for a given language 
 	 * @param languageId
-	 * @param inode
+	 * @param contentletId
 	 * @return
 	 */
 	public default boolean findContentletForLanguage(long languageId, Identifier contentletId){
@@ -308,7 +308,6 @@ public interface ContentletAPIPreHook {
 	 * sure to pass in an Admin User.  If a user doesn't have permissions to clean all teh contentlets it will clean 
 	 * as many as it can and throw the DotSecurityException  
 	 * @param structure
-	 * @param field
 	 * @param user
 	 * @param respectFrontendRoles
 	 */
@@ -682,7 +681,6 @@ public interface ContentletAPIPreHook {
 	 * methods removes old associated content and reset the relatioships based
 	 * on the list of content passed as parameter
 	 * @param contentlet
-	 * @param rel
 	 * @param related
 	 * @param user
 	 * @param respectFrontendRoles
@@ -942,11 +940,9 @@ public interface ContentletAPIPreHook {
 	/**
 	 * Will check in a new version of you contentlet. The inode of your contentlet must be 0.  
 	 * @param contentlet - The inode of your contentlet must be 0.
-	 * @param contentRelationships - throws IllegalArgumentException if null. Used to set relationships to new contentlet version 
-	 * @param cats - throws IllegalArgumentException if null. Used to set categories to new contentlet version
-	 * @param permissions - throws IllegalArgumentException if null. Used to set permissions to new contentlet version
 	 * @param user
 	 * @param respectFrontendRoles
+     * @param cats - throws IllegalArgumentException if null. Used to set categories to new contentlet version
 	 */
 	public default boolean checkin(Contentlet contentlet ,User user,boolean respectFrontendRoles,List<Category> cats){
       return true;
@@ -1091,7 +1087,6 @@ public interface ContentletAPIPreHook {
 	 * Will return all content assigned to a specified Categories
 	 * @param categories - List of categories to look for
 	 * @param languageId language to pull content for. If 0 will return all languages
-	 * @param category Category to look for
 	 * @param live should return live or working content
 	 * @param orderBy indexName(previously known as dbColumnName) to order by. Can be null or empty string
 	 * @param user
@@ -1107,8 +1102,6 @@ public interface ContentletAPIPreHook {
 	 * @param contentlet
 	 * @param field
 	 * @param value
-	 * @param user
-	 * @param respectFrontendRoles
 	 */
 	public default boolean setContentletProperty(Contentlet contentlet, Field field, Object value){
       return true;
@@ -1117,7 +1110,7 @@ public interface ContentletAPIPreHook {
 	/**
 	 * Use to validate your contentlet.
 	 * @param contentlet
-	 * @param categories
+	 * @param cats - categories
 	 */
 	public default boolean validateContentlet(Contentlet contentlet,List<Category> cats){
       return true;
@@ -1127,7 +1120,7 @@ public interface ContentletAPIPreHook {
 	 * Use to validate your contentlet.
 	 * @param contentlet
 	 * @param contentRelationships
-	 * @param categories
+	 * @param cats - categories
 	 * Use the notValidFields property of the exception to get which fields where not valid
 	 */
 	public default boolean validateContentlet(Contentlet contentlet,Map<Relationship, List<Contentlet>> contentRelationships,List<Category> cats){
@@ -1138,7 +1131,7 @@ public interface ContentletAPIPreHook {
 	 * Use to validate your contentlet.
 	 * @param contentlet
 	 * @param contentRelationships
-	 * @param categories
+	 * @param cats - categories
 	 */
 	public default boolean validateContentlet(Contentlet contentlet, ContentletRelationships contentRelationships, List<Category> cats){
       return true;
@@ -1191,7 +1184,7 @@ public interface ContentletAPIPreHook {
 
 	/**
 	 * Converts a "fat" (legacy) contentlet into a new contentlet.
-	 * @param Fat contentlet to be converted.
+	 * @param fatty contentlet to be converted.
 	 * @return
 	 */
 	public default boolean convertFatContentletToContentlet (com.dotmarketing.portlets.contentlet.business.Contentlet fatty){
@@ -1200,7 +1193,8 @@ public interface ContentletAPIPreHook {
 	
 	/**
 	 * Converts a "light" contentlet into a "fat" (legacy) contentlet.
-	 * @param A "light" contentlet to be converted.
+	 * @param cont "light" contentlet to be converted.
+     * @param fatty
 	 * @return
 	 */
 	public default boolean convertContentletToFatContentlet (Contentlet cont, com.dotmarketing.portlets.contentlet.business.Contentlet fatty){
@@ -1226,13 +1220,16 @@ public interface ContentletAPIPreHook {
 	public default boolean deleteOldContent(Date deleteFrom){
       return true;
     }
-	
-	/**
-	 * 
-	 * @param deleteFrom
-	 * @param offset
-	 * @return
-	 */
+
+
+    /**
+     *
+     * @param structureInode
+     * @param field
+     * @param user
+     * @param respectFrontEndRoles
+     * @return
+     */
 	public default boolean findFieldValues(String structureInode, Field field, User user, boolean respectFrontEndRoles){
       return true;
     }
@@ -1368,11 +1365,9 @@ public interface ContentletAPIPreHook {
 	/**
 	 * Will check in a new version of you contentlet without indexing. The inode of your contentlet must be not set.  
 	 * @param contentlet - The inode of your contentlet must be not set.
-	 * @param contentRelationships - throws IllegalArgumentException if null. Used to set relationships to new contentlet version 
-	 * @param cats - throws IllegalArgumentException if null. Used to set categories to new contentlet version
-	 * @param permissions - throws IllegalArgumentException if null. Used to set permissions to new contentlet version
 	 * @param user
 	 * @param respectFrontendRoles
+     * @param cats - throws IllegalArgumentException if null. Used to set categories to new contentlet version
 	 */
 	public default boolean checkinWithNoIndex(Contentlet contentlet ,User user,boolean respectFrontendRoles,List<Category> cats){
       return true;
@@ -1475,7 +1470,7 @@ public interface ContentletAPIPreHook {
 
 	/**
 	 * Method will update hostInode of content to systemhost
-	 * @param identifier
+	 * @param hostIdentifier
 	 */	
 	public default boolean UpdateContentWithSystemHost(String hostIdentifier)throws DotDataException{
       return true;
@@ -1828,4 +1823,24 @@ public interface ContentletAPIPreHook {
         return true;
     }
 
+    /**
+     * Internally called by getRelatedContent methods (handles all the logic to filter by parents or children)
+     * @param contentlet
+     * @param rel
+     * @param user
+     * @param respectFrontendRoles
+     * @param pullByParent
+     * @param limit
+     * @param offset
+     * @param sortBy
+     * @return
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    default boolean  filterRelatedContent(Contentlet contentlet, Relationship rel,
+            User user, boolean respectFrontendRoles, Boolean pullByParent, int limit, int offset,
+            String sortBy)
+            throws DotDataException, DotSecurityException{
+        return true;
+    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -1622,6 +1622,9 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
             relationship =  APILocator.getRelationshipAPI().byTypeValue(variableName);
         }
 
+        if (relationship == null){
+            throw new DotStateException("No relationship found");
+        }
         relatedList = APILocator.getContentletAPI()
                 .filterRelatedContent(this, relationship, systemUser, false, pullByParent, limit, offset, sortBy);
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -1551,6 +1551,10 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 			final boolean respectFrontendRoles, Boolean pullByParents, final int limit, final int offset,
             final String sortBy) {
 
+	    if (variableName == null){
+	        return Collections.EMPTY_LIST;
+        }
+
 		if (!UtilMethods.isSet(this.relatedIds)){
 			relatedIds = Maps.newConcurrentMap();
 		}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/structure/transform/ContentletRelationshipsTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/structure/transform/ContentletRelationshipsTransformer.java
@@ -62,17 +62,8 @@ public class ContentletRelationshipsTransformer implements DBTransformer<Content
         for(final Map.Entry<Relationship, List<Contentlet>> relEntry : contentRelationships.entrySet()) {
 
             final Relationship relationship = relEntry.getKey();
-            final boolean hasChildren       = FactoryLocator.getRelationshipFactory().isChild(relationship, structure);
             boolean hasParent               = FactoryLocator.getRelationshipFactory().isParent(relationship, structure);
 
-            // self-join (same CT for parent and child) relationships return true to both, so if the
-            // parentRelationName is not set the relationship is one-sided so we add children
-            // if the parentRelationName is set there is no way to know if we are adding parents or children
-            // so we assume we are adding children
-            if (hasParent && hasChildren) {
-                hasParent = !UtilMethods.isSet(relationship.getParentRelationName());
-            }
-            
             final ContentletRelationships.ContentletRelationshipRecords
                     records = relationshipsData.new ContentletRelationshipRecords(relationship, hasParent);
             records.setRecords(relEntry.getValue());


### PR DESCRIPTION
Adding cache support on getRelatedContent implementations. In addition to that, some tests were fixed (self-related contents must be always saved as children, unless setRelated is run over the child field)