### PR TITLE
#16988 make container handler more robust, adding tests

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/containers/business/ContainerAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/containers/business/ContainerAPIImplTest.java
@@ -2,6 +2,7 @@ package com.dotmarketing.portlets.containers.business;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -58,16 +59,36 @@ public class ContainerAPIImplTest extends IntegrationTestBase  {
 
     private static final String TEST_CONTAINER = "/testcontainer" + System.currentTimeMillis();
     private static ContentType newsLikeContentType,documentLikeContentType,productLikeContentType;
-
+    private static Host defaultHost  = null;
     @BeforeClass
     public static void prepare() throws Exception {
         //Setting web app environment
         IntegrationTestInitService.getInstance().init();
         OSGIUtil.getInstance().initializeFramework(Config.CONTEXT);
-        final Host defaultHost  = APILocator.getHostAPI().findDefaultHost( APILocator.systemUser(), false );
+        defaultHost  = APILocator.getHostAPI().findDefaultHost( APILocator.systemUser(), false );
         checkApplicationContainerFolder(defaultHost);
     }
 
+    
+    @Test
+    public void test_containerapi_find_by_inode() throws DotDataException, DotSecurityException {
+      String title = "myContainer" + System.currentTimeMillis();
+      Container container =  new ContainerDataGen().site(defaultHost).title(title).nextPersisted();
+      
+      assertNotNull(container);
+      assertNotNull(container.getInode());
+      Container containerFromDB = APILocator.getContainerAPI().find(container.getInode(), APILocator.systemUser(), false);
+      assertEquals(containerFromDB.getTitle(), container.getTitle());
+      assertEquals(containerFromDB.getInode(), container.getInode());
+      
+      Container nullContainer = APILocator.getContainerAPI().find("nope", APILocator.systemUser(), false);
+      assertNull(nullContainer);
+
+    }
+    
+    
+    
+    
     @Test
     public void getContentTypesInContainer() throws DotDataException, DotSecurityException {
         Container container = null;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerAPIImpl.java
@@ -30,6 +30,7 @@ import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
+import io.vavr.control.Try;
 
 import java.util.*;
 import java.util.function.Supplier;
@@ -218,7 +219,7 @@ public class ContainerAPIImpl extends BaseWebAssetAPI implements ContainerAPI {
     @SuppressWarnings("unchecked")
     public Container find(final String inode, final User user, final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
 
-	    final  Identifier  identifier = APILocator.getIdentifierAPI().findFromInode(inode);
+	      final  Identifier  identifier = Try.of(()->APILocator.getIdentifierAPI().findFromInode(inode)).getOrNull();
         final Container container = this.isContainerFile(identifier)?
 				this.getWorkingContainerByFolderPath(identifier.getParentPath(), identifier.getHostId(), user, respectFrontendRoles):
                 containerFactory.find(inode);


### PR DESCRIPTION
ContainerAPI.find was throwing a DotStateException if it was passed a container inode it did not know about.  Should return a null.