### PR TITLE
Issue 16963 permission test fixes alt

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/business/PermissionAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/business/PermissionAPITest.java
@@ -404,7 +404,6 @@ public class PermissionAPITest extends IntegrationTestBase {
             mm.put("individual",Integer.toString(PermissionAPI.PERMISSION_READ | PermissionAPI.PERMISSION_WRITE));
             new RoleAjax().saveRolePermission(nrole.getId(), hh.getIdentifier(), mm, false);
 
-            permissionAPI.resetPermissionsUnder(hh);
             assertTrue(permissionAPI.findParentPermissionable(f4).equals(hh));
             assertTrue(permissionAPI.findParentPermissionable(f3).equals(hh));
             assertTrue(permissionAPI.findParentPermissionable(f2).equals(hh));
@@ -471,12 +470,10 @@ public class PermissionAPITest extends IntegrationTestBase {
             cont1=APILocator.getContentletAPI().checkin(cont1, sysuser, false);
 
             permissionAPI.permissionIndividually(permissionAPI.findParentPermissionable(f1), f1, sysuser);
-            permissionAPI.resetPermissionsUnder(f2);
             assertTrue(permissionAPI.findParentPermissionable(cont1).equals(f1));
 
             permissionAPI.permissionIndividually(permissionAPI.findParentPermissionable(f2), f2, sysuser);
             CacheLocator.getPermissionCache().clearCache();
-            permissionAPI.resetPermissionsUnder(f2);
             assertTrue(permissionAPI.findParentPermissionable(cont1).equals(f2));
         }
         finally {

--- a/dotCMS/src/integration-test/java/com/dotmarketing/business/PermissionAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/business/PermissionAPITest.java
@@ -1,5 +1,9 @@
 package com.dotmarketing.business;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.datagen.FolderDataGen;
 import com.dotcms.datagen.HTMLPageDataGen;
@@ -35,14 +39,15 @@ import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
 import com.liferay.portal.ejb.UserTestUtil;
 import com.liferay.portal.model.User;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.FileWriter;
-import java.util.*;
-
-import static org.junit.Assert.*;
 
 /**
  * This class tests the creation, copy, update, verification and setting of
@@ -399,6 +404,7 @@ public class PermissionAPITest extends IntegrationTestBase {
             mm.put("individual",Integer.toString(PermissionAPI.PERMISSION_READ | PermissionAPI.PERMISSION_WRITE));
             new RoleAjax().saveRolePermission(nrole.getId(), hh.getIdentifier(), mm, false);
 
+            permissionAPI.resetPermissionsUnder(hh);
             assertTrue(permissionAPI.findParentPermissionable(f4).equals(hh));
             assertTrue(permissionAPI.findParentPermissionable(f3).equals(hh));
             assertTrue(permissionAPI.findParentPermissionable(f2).equals(hh));
@@ -465,10 +471,12 @@ public class PermissionAPITest extends IntegrationTestBase {
             cont1=APILocator.getContentletAPI().checkin(cont1, sysuser, false);
 
             permissionAPI.permissionIndividually(permissionAPI.findParentPermissionable(f1), f1, sysuser);
+            permissionAPI.resetPermissionsUnder(f2);
             assertTrue(permissionAPI.findParentPermissionable(cont1).equals(f1));
 
             permissionAPI.permissionIndividually(permissionAPI.findParentPermissionable(f2), f2, sysuser);
             CacheLocator.getPermissionCache().clearCache();
+            permissionAPI.resetPermissionsUnder(f2);
             assertTrue(permissionAPI.findParentPermissionable(cont1).equals(f2));
         }
         finally {

--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
@@ -1001,34 +1001,24 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	}
 
 	@Override
-	protected List<Permission> getPermissions(Permissionable permissionable, boolean bitPermissions, boolean onlyIndividualPermissions, boolean forceLoadFromDB) throws DotDataException {
-
+	protected List<Permission> getPermissions(Permissionable permissionable, boolean bitPermissions,
+			boolean onlyIndividualPermissions, boolean forceLoadFromDB) throws DotDataException {
 
 		if (!InodeUtils.isSet(permissionable.getPermissionId())) {
-		    return new ArrayList<>();
+			return new ArrayList<>();
 		}
 
 		List<Permission> bitPermissionsList = null;
 
-		if(forceLoadFromDB) {
-		     /*
-			bitPermissionsList = permissionCache
-					.getPermissionsFromCache(permissionable.getPermissionId());
-		      */
-			permissionCache.remove(permissionable.getPermissionId());
-		}
+		bitPermissionsList = loadPermissions(permissionable, forceLoadFromDB);
+		bitPermissionsList = filterOnlyNonInheritablePermissions(bitPermissionsList,
+				permissionable.getPermissionId());
 
-		//No permissions in cache have to look for individual permissions or inherited permissions
-		//if (bitPermissionsList == null) {
-
-				bitPermissionsList = loadPermissions(permissionable);
-		//}
-		bitPermissionsList = filterOnlyNonInheritablePermissions(bitPermissionsList, permissionable.getPermissionId());
-
-		if(!bitPermissions) {
+		if (!bitPermissions) {
 			bitPermissionsList = convertToNonBitPermissions(bitPermissionsList);
 		}
-		return onlyIndividualPermissions?filterOnlyIndividualPermissions(bitPermissionsList, permissionable.getPermissionId()):bitPermissionsList;
+		return onlyIndividualPermissions ? filterOnlyIndividualPermissions(bitPermissionsList,
+				permissionable.getPermissionId()) : bitPermissionsList;
 	}
 
 	@Override

--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
@@ -1090,7 +1090,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		        ran06=false,ran07=false,ran08=false,ran09=false,ran10=false;
 
 		final List<Map<String, Object>> idsToClear = new ArrayList<>();
-		final List<Permission> permissions = filterOnlyInheritablePermissions(loadPermissions(permissionable), parentPermissionableId);
+		final List<Permission> permissions = filterOnlyInheritablePermissions(loadPermissions(permissionable, true), parentPermissionableId);
 		for(final Permission p : permissions) {
 
 			if (isHost || isFolder) {
@@ -1467,7 +1467,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		whileLoop: while(parentPermissionable != null) {
 			defaultReplacement = parentPermissionable;
 			String parentPermissionableId = parentPermissionable.getPermissionId();
-			List<Permission> permissions = filterOnlyInheritablePermissions(loadPermissions(parentPermissionable), parentPermissionableId);
+			final List<Permission> permissions = filterOnlyInheritablePermissions(loadPermissions(parentPermissionable, true), parentPermissionableId);
 			for(Permission p : permissions) {
 				if(typesToLookFor.contains(p.getType())) {
 					referenceReplacement.put(p.getType(), p.getInode());
@@ -1612,9 +1612,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		boolean updateReferencesOnAdd = false;
 		boolean removePermissionableReference = false;
 		boolean clearReferencesCache = false;
-
-		List<Permission> currentPermissions = filterAssetOnlyPermissions(loadPermissions(permissionable), permissionable.getPermissionId());
-
+		final List<Permission> currentPermissions = filterAssetOnlyPermissions(loadPermissions(permissionable, true), permissionable.getPermissionId());
 		for(Permission cp : currentPermissions) {
             if(containsPermission(permissions, cp)) {
             	deletePermission(cp);
@@ -2138,6 +2136,15 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 			Logger.debug(this.getClass(), cause);
 		}
 	}
+
+  @CloseDBIfOpened
+  @SuppressWarnings("unchecked")
+  private List<Permission> loadPermissions(final Permissionable permissionable, final boolean forceDB) throws DotDataException {
+     	if(forceDB){
+     	   permissionCache.remove(permissionable.getPermissionId());
+     	}
+     	return loadPermissions(permissionable);
+  }
 
   @CloseDBIfOpened
   @SuppressWarnings("unchecked")

--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
@@ -66,6 +66,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 
 /**
@@ -947,13 +948,8 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 
 	@Override
 	protected List<Permission> getInheritablePermissions(Permissionable permissionable, String type) throws DotDataException {
-		List<Permission> permissions = getInheritablePermissions(permissionable, true);
-		List<Permission> toReturn = new ArrayList<Permission>();
-		for(Permission p : permissions) {
-			if(p.getType().equals(type))
-				toReturn.add(p);
-		}
-		return toReturn;
+		final List<Permission> permissions = getInheritablePermissions(permissionable, true);
+		return permissions.stream().filter(permission -> permission.getType().equals(type)).collect(Collectors.toList());
 	}
 
 	@Override

--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
@@ -1001,24 +1001,34 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 	}
 
 	@Override
-	protected List<Permission> getPermissions(Permissionable permissionable, boolean bitPermissions,
-			boolean onlyIndividualPermissions, boolean forceLoadFromDB) throws DotDataException {
+	protected List<Permission> getPermissions(Permissionable permissionable, boolean bitPermissions, boolean onlyIndividualPermissions, boolean forceLoadFromDB) throws DotDataException {
+
 
 		if (!InodeUtils.isSet(permissionable.getPermissionId())) {
-			return new ArrayList<>();
+		    return new ArrayList<>();
 		}
 
 		List<Permission> bitPermissionsList = null;
 
-		bitPermissionsList = loadPermissions(permissionable, forceLoadFromDB);
-		bitPermissionsList = filterOnlyNonInheritablePermissions(bitPermissionsList,
-				permissionable.getPermissionId());
+		if(forceLoadFromDB) {
+		     /*
+			bitPermissionsList = permissionCache
+					.getPermissionsFromCache(permissionable.getPermissionId());
+		      */
+			permissionCache.remove(permissionable.getPermissionId());
+		}
 
-		if (!bitPermissions) {
+		//No permissions in cache have to look for individual permissions or inherited permissions
+		//if (bitPermissionsList == null) {
+
+				bitPermissionsList = loadPermissions(permissionable);
+		//}
+		bitPermissionsList = filterOnlyNonInheritablePermissions(bitPermissionsList, permissionable.getPermissionId());
+
+		if(!bitPermissions) {
 			bitPermissionsList = convertToNonBitPermissions(bitPermissionsList);
 		}
-		return onlyIndividualPermissions ? filterOnlyIndividualPermissions(bitPermissionsList,
-				permissionable.getPermissionId()) : bitPermissionsList;
+		return onlyIndividualPermissions?filterOnlyIndividualPermissions(bitPermissionsList, permissionable.getPermissionId()):bitPermissionsList;
 	}
 
 	@Override
@@ -1080,7 +1090,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		        ran06=false,ran07=false,ran08=false,ran09=false,ran10=false;
 
 		final List<Map<String, Object>> idsToClear = new ArrayList<>();
-		final List<Permission> permissions = filterOnlyInheritablePermissions(loadPermissions(permissionable, true), parentPermissionableId);
+		final List<Permission> permissions = filterOnlyInheritablePermissions(loadPermissions(permissionable), parentPermissionableId);
 		for(final Permission p : permissions) {
 
 			if (isHost || isFolder) {
@@ -1457,7 +1467,7 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		whileLoop: while(parentPermissionable != null) {
 			defaultReplacement = parentPermissionable;
 			String parentPermissionableId = parentPermissionable.getPermissionId();
-			final List<Permission> permissions = filterOnlyInheritablePermissions(loadPermissions(parentPermissionable, true), parentPermissionableId);
+			List<Permission> permissions = filterOnlyInheritablePermissions(loadPermissions(parentPermissionable), parentPermissionableId);
 			for(Permission p : permissions) {
 				if(typesToLookFor.contains(p.getType())) {
 					referenceReplacement.put(p.getType(), p.getInode());
@@ -1602,7 +1612,9 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 		boolean updateReferencesOnAdd = false;
 		boolean removePermissionableReference = false;
 		boolean clearReferencesCache = false;
-		final List<Permission> currentPermissions = filterAssetOnlyPermissions(loadPermissions(permissionable, true), permissionable.getPermissionId());
+
+		List<Permission> currentPermissions = filterAssetOnlyPermissions(loadPermissions(permissionable), permissionable.getPermissionId());
+
 		for(Permission cp : currentPermissions) {
             if(containsPermission(permissions, cp)) {
             	deletePermission(cp);
@@ -2126,15 +2138,6 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
 			Logger.debug(this.getClass(), cause);
 		}
 	}
-
-  @CloseDBIfOpened
-  @SuppressWarnings("unchecked")
-  private List<Permission> loadPermissions(final Permissionable permissionable, final boolean forceDB) throws DotDataException {
-     	if(forceDB){
-     	   permissionCache.remove(permissionable.getPermissionId());
-     	}
-     	return loadPermissions(permissionable);
-  }
 
   @CloseDBIfOpened
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Alternative fix that basically eliminates the necessity of having to reset permissions under a permisisonable before calling `findParentPermissionable`