### PR TITLE
#17127 delete portlets or actionlets only on stop or undeploy

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/osgi/AJAX/OSGIAJAX.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/osgi/AJAX/OSGIAJAX.java
@@ -212,6 +212,9 @@ public class OSGIAJAX extends OSGIBaseAJAX {
 
     public void restart ( HttpServletRequest request, HttpServletResponse response ) throws ServletException, IOException {
 
+        //Remove portlets and actionlets references that were removed directly from the file system
+        remove();
+
         //First we need to stop the framework
         OSGIUtil.getInstance().stopFramework();
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/osgi/AJAX/OSGIAJAX.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/osgi/AJAX/OSGIAJAX.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.portlets.osgi.AJAX;
 
+import com.dotmarketing.business.APILocator;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.FileItemIterator;
 import org.apache.commons.fileupload.FileItemStream;
@@ -64,6 +65,7 @@ public class OSGIAJAX extends OSGIBaseAJAX {
         Boolean success = FileUtil.move( from, to );
         if ( success ) {
         	Logger.info( OSGIAJAX.class, "OSGI Bundle "+jar+ " Undeployed");
+            remove();// removes portlets and actionlets references
             writeSuccess( response, "OSGI Bundle "+jar+ " Undeployed" );
         } else {
             Logger.error( OSGIAJAX.class, "Error undeploying OSGI Bundle "+jar );
@@ -100,6 +102,7 @@ public class OSGIAJAX extends OSGIBaseAJAX {
                 OSGIUtil.getInstance().getBundle(bundleID).stop();
             }
             Logger.info( OSGIAJAX.class, "OSGI Bundle "+jar+ " Stopped");
+            remove();// removes portlets and actionlets references
         } catch ( BundleException e ) {
             Logger.error( OSGIAJAX.class, e.getMessage(), e );
             throw new ServletException( e.getMessage() + " Unable to stop bundle", e );
@@ -214,9 +217,25 @@ public class OSGIAJAX extends OSGIBaseAJAX {
 
         //Now we need to initialize it
         OSGIUtil.getInstance().initializeFramework();
-        
+
         //Send a respose
         writeSuccess( response, "OSGI Framework Restarted" );
+    }
+
+    private void remove () {
+
+        //Remove Portlets in the list
+        OSGIUtil.getInstance().portletIDsStopped.stream().forEach(p -> {APILocator.getPortletAPI().deletePortlet(p);});
+        Logger.info( this, "Portlets Removed: " + OSGIUtil.getInstance().portletIDsStopped.toString() );
+
+        //Remove Actionlets in the list
+        OSGIUtil.getInstance().actionletsStopped.stream().forEach(p -> {OSGIUtil.getInstance().workflowOsgiService.removeActionlet(p);});
+        Logger.info( this, "Actionlets Removed: " + OSGIUtil.getInstance().actionletsStopped.toString());
+
+        //Cleanup lists
+        OSGIUtil.getInstance().portletIDsStopped.clear();
+        OSGIUtil.getInstance().actionletsStopped.clear();
+
     }
 
 }

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -22,6 +22,7 @@ import java.io.StringWriter;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -48,7 +49,9 @@ public class OSGIUtil {
     //List of jar prefixes of the jars to be included in the osgi-extra-generated.conf file
     private List<String> dotCMSJarPrefixes = ImmutableList
             .copyOf(CollectionsUtils.list("dotcms", "ee-"));
-
+    public List<String> portletIDsStopped = new ArrayList<>();
+    public List<String> actionletsStopped = new ArrayList<>();
+    public WorkflowAPIOsgiService workflowOsgiService;
     private static final String WEB_INF_FOLDER = "/WEB-INF";
     private static final String FELIX_BASE_DIR = "felix.base.dir";
     private static final String FELIX_FILEINSTALL_DIR = "felix.fileinstall.dir";


### PR DESCRIPTION
The issue here was when a new fragment is uploaded all the plugins are restarted, so if there are any portlet or actionlet it gets removed from layouts and actions respectively. Now instead of deleting them when a portlet or actionlet is unregistered, it adds to a list, if is registered it pops out of the list (in case of the restart framework when uploading fragment). When you click over the `Stop` or `Undeploy` option it will add the portlet or actionlet to the list and call the new `remove` method that will delete all references to the portlet or actionlet.