### PR TITLE
#16875  pageMode LIVE if not backend user

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/PageMode.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PageMode.java
@@ -107,15 +107,6 @@ public enum PageMode {
 
             final User user = PortalUtil.getUser(request);
 
-            /*if(user != null && user.isAnonymousUser()){
-                final PageMode pageModeRef = pageMode;
-                if (Try.of(()-> APILocator.getPermissionAPI().doesUserHavePermission(
-                     WebAPILocator.getHostWebAPI().getCurrentHost(req, pageModeRef), PermissionLevel.READ.getType(), user)).getOrElse(false)
-                   ) {
-                    pageMode = DEFAULT_PAGE_MODE;
-                }
-            } else*/
-
             if (user == null || !user.isBackendUser()) {
                 pageMode = DEFAULT_PAGE_MODE;
             }

--- a/dotCMS/src/main/java/com/liferay/portal/model/User.java
+++ b/dotCMS/src/main/java/com/liferay/portal/model/User.java
@@ -302,11 +302,14 @@ public class User extends UserModel implements Recipient {
         setModified(true);
     }
 
+  public boolean isAnonymousUser(){
+      return UserAPI.CMS_ANON_USER_ID.equals(this.getUserId());
+  }
 
   public boolean isBackendUser() {
 
     return Try.of(() -> {
-      if (UserAPI.CMS_ANON_USER_ID.equals(this.getUserId())) {
+      if (isAnonymousUser()) {
         return false;
       }
       return (APILocator.getRoleAPI().doesUserHaveRole(this, APILocator.getRoleAPI().loadBackEndUserRole()));
@@ -318,7 +321,7 @@ public class User extends UserModel implements Recipient {
   public boolean isFrontendUser() {
 
     return Try.of(() -> {
-      if (UserAPI.CMS_ANON_USER_ID.equals(this.getUserId())) {
+      if (isAnonymousUser()) {
         return true;
       }
       return (APILocator.getRoleAPI().doesUserHaveRole(this, APILocator.getRoleAPI().loadFrontEndUserRole()));
@@ -330,7 +333,7 @@ public class User extends UserModel implements Recipient {
 	
   public boolean hasConsoleAccess() {
     return Try.of(() -> {
-      if (UserAPI.CMS_ANON_USER_ID.equals(this.getUserId()) || UserAPI.SYSTEM_USER_ID.equals(this.getUserId()) ) {
+      if (isAnonymousUser() || UserAPI.SYSTEM_USER_ID.equals(this.getUserId()) ) {
         return false;
       }
       return isActive() && isBackendUser() && !APILocator.getLayoutAPI().loadLayoutsForUser(this).isEmpty();


### PR DESCRIPTION
The commented code block :
` /*if(user != null && user.isAnonymousUser()){
                final PageMode pageModeRef = pageMode;
                if (Try.of(()-> APILocator.getPermissionAPI().doesUserHavePermission(
                     WebAPILocator.getHostWebAPI().getCurrentHost(req, pageModeRef), PermissionLevel.READ.getType(), user)).getOrElse(false)
                   ) {
                    pageMode = DEFAULT_PAGE_MODE;
                }
            } else*/`
Was left there on purpose. I believe it is no longer needed. after changing the logic to deal with non-backend users. But If you really don't want that code to be removed I beleive that's probably the best spot for it.  So please gimme feedback.
I tested enabling the logger and the original behavior seems to be preserved.