### PR TITLE
Issue 17594 future time machine not showing working content

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
@@ -265,28 +265,30 @@ public class ContainerLoader implements DotLoader {
             // FOR LOOP
 
             velocityCodeBuilder.append("#foreach ($contentletId in $CONTENTLETS )");
-            
-                velocityCodeBuilder.append("#set($_show_working_=false)");
-                // if timemachine future enabled
-                velocityCodeBuilder.append("#if($UtilMethods.isSet($request.getSession(false)) && $request.session.getAttribute(\"tm_date\"))");
-                velocityCodeBuilder.append("#set($_tmdate=$date.toDate($webapi.parseLong($request.session.getAttribute(\"tm_date\"))))");
-                velocityCodeBuilder.append("#set($_ident=$webapi.findIdentifierById($contentletId))");
-    
-                // if the content has expired we rewrite the identifier so it isn't loaded
-                velocityCodeBuilder.append("#if($UtilMethods.isSet($_ident.sysExpireDate) && $_tmdate.after($_ident.sysExpireDate))");
-                velocityCodeBuilder.append("#set($contentletId='')");
-                velocityCodeBuilder.append("#end");
-    
-                // if the content should be published then force to show the working version
-                velocityCodeBuilder.append("#if($UtilMethods.isSet($_ident.sysPublishDate) && $_tmdate.after($_ident.sysPublishDate))");
-                velocityCodeBuilder.append("#set($_show_working_=true)");
-                velocityCodeBuilder.append("#end");
-    
-                velocityCodeBuilder.append("#if(! $webapi.contentHasLiveVersion($contentletId) && ! $_show_working_)")
+
+            velocityCodeBuilder.append("#set($_show_working_=false)");
+
+            //Time-machine block begin
+              velocityCodeBuilder.append("#if($UtilMethods.isSet($request.getSession(false)) && $request.session.getAttribute(\"tm_date\"))");
+                  velocityCodeBuilder.append("#set($_tmdate=$date.toDate($webapi.parseLong($request.session.getAttribute(\"tm_date\"))))");
+                  velocityCodeBuilder.append("#set($_ident=$webapi.findIdentifierById($contentletId))");
+                  // if the content has expired we rewrite the identifier so it isn't loaded
+                  velocityCodeBuilder.append("#if($UtilMethods.isSet($_ident.sysExpireDate) && $_tmdate.after($_ident.sysExpireDate))");
+                  velocityCodeBuilder.append("#set($contentletId='')");
+                  velocityCodeBuilder.append("#end");
+
+                  // if the content should be published then force to show the working version
+                  velocityCodeBuilder.append("#if($UtilMethods.isSet($_ident.sysPublishDate) && ($_tmdate.after($_ident.sysPublishDate) || $_tmdate.equals($_ident.sysPublishDate) ))");
+                  velocityCodeBuilder.append("#set($_show_working_=true)");
+                  velocityCodeBuilder.append("#end");
+
+                  velocityCodeBuilder.append("#if(! $webapi.contentHasLiveVersion($contentletId) && ! $_show_working_)")
                     .append("#set($contentletId='')") // working contentlet still not published
-                    .append("#end");
-                velocityCodeBuilder.append("#end");
-    
+                  .append("#end");
+
+            //end of time-machine block
+              velocityCodeBuilder.append("#end");
+
                 velocityCodeBuilder.append("#set($CONTENT_INODE = '')");
                 velocityCodeBuilder.append("#set($CONTENT_BASE_TYPE = '')");
                 velocityCodeBuilder.append("#set($CONTENT_LANGUAGE = '')");
@@ -298,9 +300,9 @@ public class ContainerLoader implements DotLoader {
                 velocityCodeBuilder.append("#if($contentletId != '')");
                 velocityCodeBuilder.append("#contentDetail($contentletId)");
                 velocityCodeBuilder.append("#end");
-    
+
                 velocityCodeBuilder.append("#set($HAVE_A_VERSION=($CONTENT_INODE != ''))");
-                
+
                 if (mode == PageMode.EDIT_MODE) {
                     velocityCodeBuilder.append("<div")
                         .append(" data-dot-object=")
@@ -331,31 +333,41 @@ public class ContainerLoader implements DotLoader {
                 velocityCodeBuilder.append("#if($HAVE_A_VERSION)");
                 
                     // ##Checking permission to see content
-                    if (mode.showLive) velocityCodeBuilder.append("#if($contents.doesUserHasPermission($CONTENT_INODE, 1, $user, true))");
+                    if (mode.showLive) {
+                        // flag `$_show_working_` is set to true only when time-machine is on
+                        //if time-machine's on.. no need to check for permissions since anonymous users can not visualize working content since 5.
+                        velocityCodeBuilder.append("#if($_show_working_ || $contents.doesUserHasPermission($CONTENT_INODE, 1, $user, true))");
+                    }
                     
                         // ### START BODY ###
                         velocityCodeBuilder.append("#if($isWidget==true)").append("$widgetCode");
                         velocityCodeBuilder.append("#elseif($isForm==true)").append("$formCode");
                         velocityCodeBuilder.append("#else");
-            
+
                             for (int i = 0; i < containerContentTypeList.size(); i++) {
                                 ContainerStructure cs = containerContentTypeList.get(i);
                                 String ifelse = (i == 0) ? "if" : "elseif";
                                 velocityCodeBuilder.append("#" + ifelse + "($ContentletStructure ==\"" + cs.getStructureId() + "\")");
                                 velocityCodeBuilder.append(cs.getCode());
                             }
-                            if (containerContentTypeList.size() > 0) velocityCodeBuilder.append("#end");
+                            if (containerContentTypeList.size() > 0) {
+                                velocityCodeBuilder.append("#end");
+                            }
                             
                         // ### END BODY ###
                         velocityCodeBuilder.append("#end");
         
-                    if (mode.showLive) velocityCodeBuilder.append("#end");
+                    if (mode.showLive) {
+                        velocityCodeBuilder.append("#end");
+                    }
                     
                 // end if content exists in language 
                 velocityCodeBuilder.append("#end");
 
                // end content dot-data-content
-            if (mode == PageMode.EDIT_MODE) velocityCodeBuilder.append("</div>");
+            if (mode == PageMode.EDIT_MODE) {
+                velocityCodeBuilder.append("</div>");
+            }
                 
                 // ##End of foreach loop
             velocityCodeBuilder.append("#end");

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
@@ -186,6 +186,10 @@ public class ContainerLoader implements DotLoader {
             .append(container.getInode())
             .append("')");
 
+        velocityCodeBuilder.append("#if(!$UtilMethods.isSet($user)) ")
+        .append("#set($user = $cmsuser.getLoggedInUser($request)) ")
+        .append("#end");
+
         // START CONTENT LOOP
 
         // the viewtool call to get the list of contents for the container
@@ -278,7 +282,7 @@ public class ContainerLoader implements DotLoader {
                   velocityCodeBuilder.append("#end");
 
                   // if the content should be published then force to show the working version
-                  velocityCodeBuilder.append("#if($UtilMethods.isSet($_ident.sysPublishDate) && ($_tmdate.after($_ident.sysPublishDate) || $_tmdate.equals($_ident.sysPublishDate) ))");
+                  velocityCodeBuilder.append("#if($UtilMethods.isSet($_ident.sysPublishDate) && ($_tmdate.equals($_ident.sysPublishDate) || $_tmdate.after($_ident.sysPublishDate)))");
                   velocityCodeBuilder.append("#set($_show_working_=true)");
                   velocityCodeBuilder.append("#end");
 
@@ -336,7 +340,7 @@ public class ContainerLoader implements DotLoader {
                     if (mode.showLive) {
                         // flag `$_show_working_` is set to true only when time-machine is on
                         //if time-machine's on.. no need to check for permissions since anonymous users can not visualize working content since 5.
-                        velocityCodeBuilder.append("#if($_show_working_ || $contents.doesUserHasPermission($CONTENT_INODE, 1, $user, true))");
+                        velocityCodeBuilder.append("#if($contents.doesUserHasPermission($CONTENT_INODE, 1, $user, true))");
                     }
                     
                         // ### START BODY ###

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/DotLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/DotLoader.java
@@ -7,17 +7,13 @@ import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.ConfigUtils;
-import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
-
-import java.io.BufferedWriter;
+import com.liferay.portal.model.User;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
-import com.liferay.portal.model.User;
 /**
  * The DotLoaders exist to distill CMS objects down to Velocity templates - 
  * which can then be cached in Velocity and parsed very quickly.
@@ -61,20 +57,24 @@ public interface DotLoader {
                 File f = new File(ConfigUtils.getDynamicVelocityPath() + java.io.File.separator + filePath);
                 f.mkdirs();
                 f.delete();
-                try (final VelocityPrettyWriter out = new VelocityPrettyWriter(new FileOutputStream(f))) {
+                try (final VelocityPrettyWriter out = new VelocityPrettyWriter(System.out)) {
                     out.write(strOut);
                 }
             } catch (Exception e) {
                 new DotStateException(e);
             }
         }
-        try {
-            return new ByteArrayInputStream(strOut.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e1) {
-            Logger.error(this.getClass(), e1.getMessage(), e1);
-            return new ByteArrayInputStream(strOut.getBytes());
 
-        }
+        //  This is very useful for debugging purposes un-comment as needed
+        //  try {
+        //    final VelocityPrettyWriter out = new VelocityPrettyWriter(System.out);
+        //    out.write(strOut);
+        //    out.flush();
+        //  } catch (Exception e) {
+        //      Logger.error(DotLoader.class,e);
+        //  }
+
+        return new ByteArrayInputStream(strOut.getBytes(StandardCharsets.UTF_8));
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/DotLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/DotLoader.java
@@ -11,6 +11,7 @@ import com.dotmarketing.util.PageMode;
 import com.liferay.portal.model.User;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
@@ -57,7 +58,7 @@ public interface DotLoader {
                 File f = new File(ConfigUtils.getDynamicVelocityPath() + java.io.File.separator + filePath);
                 f.mkdirs();
                 f.delete();
-                try (final VelocityPrettyWriter out = new VelocityPrettyWriter(System.out)) {
+                try (final VelocityPrettyWriter out = new VelocityPrettyWriter(new FileOutputStream(f))) {
                     out.write(strOut);
                 }
             } catch (Exception e) {

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/ContentsWebAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/ContentsWebAPI.java
@@ -1,6 +1,5 @@
 package com.dotcms.rendering.velocity.viewtools;
 
-import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotmarketing.beans.Identifier;
@@ -14,7 +13,6 @@ import com.dotmarketing.cache.FieldsCache;
 import com.dotmarketing.common.model.ContentletSearch;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.factories.InodeFactory;
 import com.dotmarketing.portlets.categories.business.CategoryAPI;
 import com.dotmarketing.portlets.categories.model.Category;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
@@ -1133,13 +1131,14 @@ public class ContentsWebAPI implements ViewTool {
 	 * This method checks if the logged in user (frontend) has the required permission over
 	 * the passed contentlet id
 	 */
-	public boolean doesUserHasPermission (String contentInode, int permission, User user, boolean respectFrontendRoles) throws DotDataException {
+	public boolean doesUserHasPermission (final String contentInode, final int permission, final User user, final boolean respectFrontendRoles) throws DotDataException {
 		try {
 			if(!InodeUtils.isSet(contentInode))
 				return false;
-			Contentlet cont = conAPI.find(contentInode, user, respectFrontendRoles);
+			final Contentlet cont = conAPI.find(contentInode, user, respectFrontendRoles);
 			return perAPI.doesUserHavePermission(cont, permission, user, respectFrontendRoles);
 		} catch (DotSecurityException e) {
+		    Logger.warn(ContainerWebAPI.class,()->String.format(" user `%s` does not have permission over content with inode `%s` ",user,contentInode) );
 			return false;
 		}
 	}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -3,6 +3,7 @@ package com.dotcms.rest.api.v1.page;
 
 
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
+import javax.servlet.http.HttpSession;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -229,6 +230,13 @@ public class PageResource {
 
         if (deviceInode != null) {
             request.getSession().setAttribute(WebKeys.CURRENT_DEVICE, deviceInode);
+        }
+
+        final HttpSession session = request.getSession(false);
+        if(null != session){
+            // Time Machine-Date affects the logic on the vtls that conform parts of the rendered pages.
+            // so.. we better get rid of it.
+            session.removeAttribute("tm_date");
         }
 
         final PageView pageRendered = this.htmlPageAssetRenderedAPI.getPageRendered(

--- a/dotCMS/src/main/java/com/dotcms/timemachine/ajax/TimeMachineAjaxAction.java
+++ b/dotCMS/src/main/java/com/dotcms/timemachine/ajax/TimeMachineAjaxAction.java
@@ -25,6 +25,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.liferay.portal.language.LanguageException;
+import com.liferay.portal.model.User;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -63,10 +64,14 @@ public class TimeMachineAjaxAction extends IndexAjaxAction {
         Class partypes[] = new Class[] { HttpServletRequest.class, HttpServletResponse.class };
         Object arglist[] = new Object[] { request, response };
         try {
-            if (getUser() == null ||
-                    !APILocator.getRoleAPI().doesUserHaveRole(getUser(), APILocator.getRoleAPI().loadCMSAdminRole())) {
+            final User user = getUser();
+            if (user == null ||
+                    !APILocator.getRoleAPI()
+                            .doesUserHaveRole(user, APILocator.getRoleAPI().loadCMSAdminRole())) {
                 SecurityLogger.logInfo(TimeMachineAjaxAction.class,
-                   ()-> "Only users with `admin` Role should be accessing Time-Machine otherwise the feature will not work correctly.");
+                        () -> String
+                                .format("User `%s` does not have an Admin Role. Only users with `admin` Role should be accessing Time-Machine otherwise this feature will not work correctly.",
+                                        user == null ? "unknown" : user.getUserId()));
                 response.sendError(401);
                 return;
             }

--- a/dotCMS/src/main/java/com/dotcms/timemachine/ajax/TimeMachineAjaxAction.java
+++ b/dotCMS/src/main/java/com/dotcms/timemachine/ajax/TimeMachineAjaxAction.java
@@ -20,6 +20,7 @@ import com.dotmarketing.util.ActivityLogger;
 import com.dotmarketing.util.AdminLogger;
 import com.dotmarketing.util.DateUtil;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.SecurityLogger;
 import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -64,6 +65,8 @@ public class TimeMachineAjaxAction extends IndexAjaxAction {
         try {
             if (getUser() == null ||
                     !APILocator.getRoleAPI().doesUserHaveRole(getUser(), APILocator.getRoleAPI().loadCMSAdminRole())) {
+                SecurityLogger.logInfo(TimeMachineAjaxAction.class,
+                   ()-> "Only users with `admin` Role should be accessing Time-Machine otherwise the feature will not work correctly.");
                 response.sendError(401);
                 return;
             }

--- a/dotCMS/src/main/java/org/apache/velocity/runtime/resource/ResourceManagerImpl.java
+++ b/dotCMS/src/main/java/org/apache/velocity/runtime/resource/ResourceManagerImpl.java
@@ -20,21 +20,19 @@ package org.apache.velocity.runtime.resource;
  */
 
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
-import com.dotcms.rendering.velocity.services.ContentletLoader;
 import com.dotcms.rendering.velocity.services.DotResourceLoader;
-import com.dotcms.rendering.velocity.services.VelocityResourceKey;
 import com.dotcms.rendering.velocity.services.VelocityType;
-
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Logger;
+import com.liferay.portal.model.User;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
-
-import com.liferay.portal.model.User;
+import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.collections.ExtendedProperties;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
@@ -46,8 +44,6 @@ import org.apache.velocity.runtime.resource.loader.ResourceLoaderFactory;
 import org.apache.velocity.util.ClassUtils;
 import org.apache.velocity.util.StringUtils;
 import org.jetbrains.annotations.Nullable;
-
-import javax.servlet.http.HttpServletRequest;
 
 
 /**
@@ -205,7 +201,7 @@ public class ResourceManagerImpl
          */
         if (cacheObject == null)
         {
-            cacheObject = new ResourceCacheImpl();
+            cacheObject = CacheLocator.getVeloctyResourceCache();
         }
 
         globalCache = (ResourceCache) cacheObject;

--- a/dotCMS/src/main/java/org/apache/velocity/runtime/resource/ResourceManagerImpl.java
+++ b/dotCMS/src/main/java/org/apache/velocity/runtime/resource/ResourceManagerImpl.java
@@ -23,7 +23,6 @@ import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.rendering.velocity.services.DotResourceLoader;
 import com.dotcms.rendering.velocity.services.VelocityType;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Logger;
@@ -201,7 +200,7 @@ public class ResourceManagerImpl
          */
         if (cacheObject == null)
         {
-            cacheObject = CacheLocator.getVeloctyResourceCache();
+            cacheObject = new ResourceCacheImpl();
         }
 
         globalCache = (ResourceCache) cacheObject;


### PR DESCRIPTION
The whole issue with time-machine is related to the recent changes that prevent anonymous users from being able to view **working** content. The variable `$user` in the vtl-code was always null.
which basically translates into anonymous
That didn't seem like an issue for published content. But it breaks the time-machine code.
So.. long story short initializing the user with the current logged in user seems to solve the problem.
I need to validate with QA that the behavior seen using the log-in-as functionality is what is expected here. It does seem so.

Additionally to that, the ResourceManager had its own private cache manager. One that was disconnected from the one provided by the CacheLocator. I changed that so when you invalidate the velocity cache from the UI. These templates are also invalidated. 

And last but not least I'm cleaning the `tm_date` session variable on the PageResource since the resulting page-rendered might conflict with that value which is supposed to only be set for the time machine.
 
