### PR TITLE
Issue 17621 filtering content by date range does not seem to work

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
@@ -1,5 +1,7 @@
 package com.dotcms.content.elasticsearch.business;
 
+import static com.dotcms.content.elasticsearch.business.ESContentFactoryImpl.LUCENE_DATE_TIME_FORMAT_PATTERN;
+import static com.dotcms.content.elasticsearch.business.ESContentFactoryImpl.LUCENE_TIME_FORMAT_PATTERNS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -78,23 +80,9 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
 
     @DataProvider
     public static Object[] testCases() {
-        return new TestCase[]{
-                new TestCase("MM/dd/yyyy hh:mm:ssa"),
-                new TestCase("MM/dd/yyyy hh:mm:ss a"),
-                new TestCase("MM/dd/yyyy hh:mm a"),
-                new TestCase("MM/dd/yyyy hh:mma"),
-                new TestCase("MM/dd/yyyy HH:mm:ss"),
-                new TestCase("MM/dd/yyyy HH:mm"),
-                new TestCase("yyyyMMddHHmmss"),
-                new TestCase("yyyyMMdd"),
-                new TestCase("MM/dd/yyyy"),
-                new TestCase("hh:mm:ssa"),
-                new TestCase("hh:mm:ss a"),
-                new TestCase("HH:mm:ss"),
-                new TestCase("hh:mma"),
-                new TestCase("hh:mm a"),
-                new TestCase("HH:mm")
-        };
+        return LUCENE_DATE_TIME_FORMAT_PATTERN.keySet().stream()
+                .map(pattern -> new TestCase(pattern)).collect(Collectors.toList()).toArray();
+
     }
 
     @Test
@@ -397,9 +385,7 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
 
         final LocalDateTime now = LocalDateTime.now();
 
-        if (testCase.formatPattern.equals("hh:mm:ssa") || testCase.formatPattern.equals("hh:mm:ss a") ||
-             testCase.formatPattern.equals("HH:mm:ss") || testCase.formatPattern.equals("hh:mma") ||
-             testCase.formatPattern.equals("hh:mm a") || testCase.formatPattern.equals("HH:mm")){
+        if (LUCENE_TIME_FORMAT_PATTERNS.contains(testCase.formatPattern)){
             today = LocalDateTime.of(1970, 1, 1, now.getHour(), now.getMinute(), now.getSecond());
             yesterday = LocalDateTime.of(1970, 1, 1, 0, 0, 0);
             tomorrow = LocalDateTime.of(1970, 1, 1, 23, 59, 59);

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
@@ -432,7 +432,7 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
     private void buildLuceneQueryAndTest(final TestCase testCase, final LocalDateTime today,
             final LocalDateTime yesterday, final LocalDateTime tomorrow) {
         final ContentType contentType = TestDataUtils.getNewsLikeContentType();
-        Contentlet contentlet = createNewsContent(contentType, today);
+        final Contentlet contentlet = createNewsContent(contentType, today);
         final DateTimeFormatter myFormatObj = DateTimeFormatter.ofPattern(testCase.formatPattern);
 
         //Test time ranges with TO (upper case)

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
@@ -417,19 +417,32 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
 
         final DateTimeFormatter myFormatObj = DateTimeFormatter.ofPattern(testCase.formatPattern);
 
-        final String query = "+contentType:" + contentType.variable() + " +" + contentType.variable()
+        //Test date ranges with TO (upper case)
+        String query = "+contentType:" + contentType.variable() + " +" + contentType.variable()
                 + ".sysPublishDate:[" + yesterday.format(myFormatObj) + " TO " + tomorrow
                 .format(myFormatObj) + "]";
 
-        final SearchHits searchHits = instance.indexSearch(query,-1, -1, null);
+        SearchHits searchHits = instance.indexSearch(query,-1, -1, null);
+        validateQueryResults(contentlet, searchHits);
 
-        //Starting some validations
+        //Test date ranges with to (lower case)
+        query = "+contentType:" + contentType.variable() + " +" + contentType.variable()
+                + ".sysPublishDate:[" + yesterday.format(myFormatObj) + " to " + tomorrow
+                .format(myFormatObj) + "]";
+
+        searchHits = instance.indexSearch(query,-1, -1, null);
+
+        validateQueryResults(contentlet, searchHits);
+
+    }
+
+    private void validateQueryResults(final Contentlet contentlet, final SearchHits searchHits) {
+        //Validate results
         assertNotNull(searchHits.getTotalHits());
         assertTrue(searchHits.getTotalHits() > 0);
 
-        SearchHit[] hits = searchHits.getHits();
+        final SearchHit[] hits = searchHits.getHits();
         assertEquals(contentlet.getInode(), hits[0].getSourceAsMap().get("inode"));
-
     }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
@@ -1,6 +1,5 @@
 package com.dotcms.content.elasticsearch.business;
 
-import static com.dotcms.content.elasticsearch.business.ESContentFactoryImpl.LUCENE_DATE_TIME_FORMAT_PATTERN;
 import static com.dotcms.content.elasticsearch.business.ESContentFactoryImpl.LUCENE_TIME_FORMAT_PATTERNS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -80,9 +79,23 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
 
     @DataProvider
     public static Object[] testCases() {
-        return LUCENE_DATE_TIME_FORMAT_PATTERN.keySet().stream()
-                .map(pattern -> new TestCase(pattern)).collect(Collectors.toList()).toArray();
-
+        return new TestCase[]{
+                new TestCase("MM/dd/yyyy hh:mm:ssa"),
+                new TestCase("MM/dd/yyyy hh:mm:ss a"),
+                new TestCase("MM/dd/yyyy hh:mm a"),
+                new TestCase("MM/dd/yyyy hh:mma"),
+                new TestCase("MM/dd/yyyy HH:mm:ss"),
+                new TestCase("MM/dd/yyyy HH:mm"),
+                new TestCase("yyyyMMddHHmmss"),
+                new TestCase("yyyyMMdd"),
+                new TestCase("MM/dd/yyyy"),
+                new TestCase("hh:mm:ssa"),
+                new TestCase("hh:mm:ss a"),
+                new TestCase("HH:mm:ss"),
+                new TestCase("hh:mma"),
+                new TestCase("hh:mm a"),
+                new TestCase("HH:mm")
+        };
     }
 
     @Test

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
@@ -1,6 +1,5 @@
 package com.dotcms.content.elasticsearch.business;
 
-import static com.dotcms.content.elasticsearch.business.ESContentFactoryImpl.LUCENE_TIME_FORMAT_PATTERNS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -78,7 +77,7 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
     }
 
     @DataProvider
-    public static Object[] testCases() {
+    public static Object[] dateTimeTestCases() {
         return new TestCase[]{
                 new TestCase("MM/dd/yyyy hh:mm:ssa"),
                 new TestCase("MM/dd/yyyy hh:mm:ss a"),
@@ -88,7 +87,13 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
                 new TestCase("MM/dd/yyyy HH:mm"),
                 new TestCase("yyyyMMddHHmmss"),
                 new TestCase("yyyyMMdd"),
-                new TestCase("MM/dd/yyyy"),
+                new TestCase("MM/dd/yyyy")
+        };
+    }
+
+    @DataProvider
+    public static Object[] timeTestCases() {
+        return new TestCase[]{
                 new TestCase("hh:mm:ssa"),
                 new TestCase("hh:mm:ss a"),
                 new TestCase("HH:mm:ss"),
@@ -389,53 +394,85 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
     }
 
     @Test
-    @UseDataProvider("testCases")
-    public void testIndexSearchFilteringByDates(final TestCase testCase){
-        final long languageId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
-        final ContentType contentType = TestDataUtils.getNewsLikeContentType();
+    @UseDataProvider("dateTimeTestCases")
+    public void testIndexSearchFilteringByDateTime(final TestCase testCase){
 
         LocalDateTime today, yesterday, tomorrow;
 
         final LocalDateTime now = LocalDateTime.now();
 
-        if (LUCENE_TIME_FORMAT_PATTERNS.contains(testCase.formatPattern)){
-            today = LocalDateTime.of(1970, 1, 1, now.getHour(), now.getMinute(), now.getSecond());
-            yesterday = LocalDateTime.of(1970, 1, 1, 0, 0, 0);
-            tomorrow = LocalDateTime.of(1970, 1, 1, 23, 59, 59);
-        } else{
-            today = now;
-            yesterday = today.minusDays(1).withHour(0).withMinute(0).withSecond(0);
-            tomorrow = today.plusDays(1).withHour(23).withMinute(59).withSecond(59);
-        }
+        today = now;
+        yesterday = today.minusDays(1).withHour(0).withMinute(0).withSecond(0);
+        tomorrow = today.plusDays(1).withHour(23).withMinute(59).withSecond(59);
 
+        buildLuceneQueryAndTest(testCase, today, yesterday, tomorrow);
+    }
 
+    @Test
+    @UseDataProvider("timeTestCases")
+    public void testIndexSearchFilteringByTime(final TestCase testCase){
+
+        LocalDateTime today, yesterday, tomorrow;
+
+        final LocalDateTime now = LocalDateTime.now();
+        today = LocalDateTime.of(1970, 1, 1, now.getHour(), now.getMinute(), now.getSecond());
+        yesterday = LocalDateTime.of(1970, 1, 1, 0, 0, 0);
+        tomorrow = LocalDateTime.of(1970, 1, 1, 23, 59, 59);
+
+        buildLuceneQueryAndTest(testCase, today, yesterday, tomorrow);
+    }
+
+    /**
+     *
+     * @param testCase
+     * @param today
+     * @param yesterday
+     * @param tomorrow
+     */
+    private void buildLuceneQueryAndTest(final TestCase testCase, final LocalDateTime today,
+            final LocalDateTime yesterday, final LocalDateTime tomorrow) {
+        final ContentType contentType = TestDataUtils.getNewsLikeContentType();
+        Contentlet contentlet = createNewsContent(contentType, today);
+        final DateTimeFormatter myFormatObj = DateTimeFormatter.ofPattern(testCase.formatPattern);
+
+        //Test time ranges with TO (upper case)
+        String query = String.format(
+                "+contentType:%1$s +%1$s.sysPublishDate:[%2$s  TO  %3$s]", contentType.variable(),
+                yesterday.format(myFormatObj), tomorrow.format(myFormatObj));
+
+        runLuceneQueryAndValidateResults(query, contentlet);
+
+        //Test time ranges with to (lower case)
+        query = String.format(
+                "+contentType:%1$s +%1$s.sysPublishDate:[%2$s  to  %3$s]", contentType.variable(),
+                yesterday.format(myFormatObj), tomorrow.format(myFormatObj));
+
+        runLuceneQueryAndValidateResults(query, contentlet);
+    }
+
+    /**
+     * Creates a content with a specific publish date
+     * @param contentType
+     * @param today
+     * @return
+     */
+    private Contentlet createNewsContent(final ContentType contentType, final LocalDateTime today) {
+        final long languageId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
         Contentlet contentlet = TestDataUtils.getNewsContent(false, languageId, contentType.id());
         contentlet.setDateProperty("sysPublishDate", Date.from(today.atZone(ZoneId.systemDefault()).toInstant()));
 
         contentlet = ContentletDataGen.checkin(contentlet, IndexPolicy.WAIT_FOR);
-
-        final DateTimeFormatter myFormatObj = DateTimeFormatter.ofPattern(testCase.formatPattern);
-
-        //Test date ranges with TO (upper case)
-        String query = "+contentType:" + contentType.variable() + " +" + contentType.variable()
-                + ".sysPublishDate:[" + yesterday.format(myFormatObj) + " TO " + tomorrow
-                .format(myFormatObj) + "]";
-
-        SearchHits searchHits = instance.indexSearch(query,-1, -1, null);
-        validateQueryResults(contentlet, searchHits);
-
-        //Test date ranges with to (lower case)
-        query = "+contentType:" + contentType.variable() + " +" + contentType.variable()
-                + ".sysPublishDate:[" + yesterday.format(myFormatObj) + " to " + tomorrow
-                .format(myFormatObj) + "]";
-
-        searchHits = instance.indexSearch(query,-1, -1, null);
-
-        validateQueryResults(contentlet, searchHits);
-
+        return contentlet;
     }
 
-    private void validateQueryResults(final Contentlet contentlet, final SearchHits searchHits) {
+    /**
+     *
+     * @param query
+     * @param contentlet
+     */
+    private void runLuceneQueryAndValidateResults(final String query, final Contentlet contentlet) {
+        final SearchHits searchHits = instance.indexSearch(query,-1, -1, null);
+
         //Validate results
         assertNotNull(searchHits.getTotalHits());
         assertTrue(searchHits.getTotalHits() > 0);

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
@@ -26,9 +26,14 @@ import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -44,7 +49,9 @@ import org.elasticsearch.search.SearchHits;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(DataProviderRunner.class)
 public class ESContentFactoryImplTest extends IntegrationTestBase {
 
     private static Host site;
@@ -57,14 +64,38 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
 
         site = new SiteDataGen().nextPersisted();
     }
-
-    /*@AfterClass
-    public static void cleanup() throws DotDataException, DotSecurityException {
-
-        cleanupDebug(ESContentFactoryImplTest.class);
-    }*/
     
     final ESContentFactoryImpl instance = new ESContentFactoryImpl();
+
+    public static class TestCase {
+
+        String formatPattern;
+
+        public TestCase(final String formatPattern) {
+            this.formatPattern = formatPattern;
+        }
+    }
+
+    @DataProvider
+    public static Object[] testCases() {
+        return new TestCase[]{
+                new TestCase("MM/dd/yyyy hh:mm:ssa"),
+                new TestCase("MM/dd/yyyy hh:mm:ss a"),
+                new TestCase("MM/dd/yyyy hh:mm a"),
+                new TestCase("MM/dd/yyyy hh:mma"),
+                new TestCase("MM/dd/yyyy HH:mm:ss"),
+                new TestCase("MM/dd/yyyy HH:mm"),
+                new TestCase("yyyyMMddHHmmss"),
+                new TestCase("yyyyMMdd"),
+                new TestCase("MM/dd/yyyy"),
+                new TestCase("hh:mm:ssa"),
+                new TestCase("hh:mm:ss a"),
+                new TestCase("HH:mm:ss"),
+                new TestCase("hh:mma"),
+                new TestCase("hh:mm a"),
+                new TestCase("HH:mm")
+        };
+    }
 
     @Test
     public void test_indexCount_not_found_async() throws Exception {
@@ -122,8 +153,6 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
         Assert.assertEquals(0, inodesSet.size());
     }
 
-    
-    
     /**
      * When calling the findContentlets(List<String> inodes), it should return the 
      * contentlets in the same order as they were asked for, meaning, if the list
@@ -182,11 +211,6 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
         
         
     }
-    
-    
-    
-    
-    
     
     @Test
     public void saveContentlets() throws Exception {
@@ -361,6 +385,51 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
                         .delete(secondVersion.getContentType());
             }
         }
+    }
+
+    @Test
+    @UseDataProvider("testCases")
+    public void testIndexSearchFilteringByDates(final TestCase testCase){
+        final long languageId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+        final ContentType contentType = TestDataUtils.getNewsLikeContentType();
+
+        LocalDateTime today, yesterday, tomorrow;
+
+        final LocalDateTime now = LocalDateTime.now();
+
+        if (testCase.formatPattern.equals("hh:mm:ssa") || testCase.formatPattern.equals("hh:mm:ss a") ||
+             testCase.formatPattern.equals("HH:mm:ss") || testCase.formatPattern.equals("hh:mma") ||
+             testCase.formatPattern.equals("hh:mm a") || testCase.formatPattern.equals("HH:mm")){
+            today = LocalDateTime.of(1970, 1, 1, now.getHour(), now.getMinute(), now.getSecond());
+            yesterday = LocalDateTime.of(1970, 1, 1, 0, 0, 0);
+            tomorrow = LocalDateTime.of(1970, 1, 1, 23, 59, 59);
+        } else{
+            today = now;
+            yesterday = today.minusDays(1).withHour(0).withMinute(0).withSecond(0);
+            tomorrow = today.plusDays(1).withHour(23).withMinute(59).withSecond(59);
+        }
+
+
+        Contentlet contentlet = TestDataUtils.getNewsContent(false, languageId, contentType.id());
+        contentlet.setDateProperty("sysPublishDate", Date.from(today.atZone(ZoneId.systemDefault()).toInstant()));
+
+        contentlet = ContentletDataGen.checkin(contentlet, IndexPolicy.WAIT_FOR);
+
+        final DateTimeFormatter myFormatObj = DateTimeFormatter.ofPattern(testCase.formatPattern);
+
+        final String query = "+contentType:" + contentType.variable() + " +" + contentType.variable()
+                + ".sysPublishDate:[" + yesterday.format(myFormatObj) + " TO " + tomorrow
+                .format(myFormatObj) + "]";
+
+        final SearchHits searchHits = instance.indexSearch(query,-1, -1, null);
+
+        //Starting some validations
+        assertNotNull(searchHits.getTotalHits());
+        assertTrue(searchHits.getTotalHits() > 0);
+
+        SearchHit[] hits = searchHits.getHits();
+        assertEquals(contentlet.getInode(), hits[0].getSourceAsMap().get("inode"));
+
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -131,9 +131,8 @@ public class ESContentFactoryImpl extends ContentletFactory {
 	@VisibleForTesting
 	public static final String LUCENE_RESERVED_KEYWORDS_REGEX = "OR|AND|NOT|TO";
 
-    @VisibleForTesting
     //Date formats supported by dotCMS in lucene queries
-    static final Map<String, String> LUCENE_DATE_TIME_FORMAT_PATTERN = new LinkedHashMap<String, String>(){
+    private static final Map<String, String> LUCENE_DATE_TIME_FORMAT_PATTERN = new LinkedHashMap<String, String>(){
         {
             put("MM/dd/yyyy hh:mm:ssa",
                     "\\\"?(\\d{1,2}/\\d{1,2}/\\d{4}\\s+\\d{1,2}:\\d{1,2}:\\d{1,2}(?:AM|PM|am|pm))\\\"?");

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/LuceneQueryDateTimeFormatter.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/LuceneQueryDateTimeFormatter.java
@@ -1,0 +1,253 @@
+package com.dotcms.content.elasticsearch.business;
+
+import static com.dotcms.content.elasticsearch.business.ESMappingAPIImpl.dateFormat;
+import static com.dotcms.content.elasticsearch.business.ESMappingAPIImpl.datetimeFormat;
+
+import com.dotmarketing.business.CacheLocator;
+import com.dotmarketing.cache.FieldsCache;
+import com.dotmarketing.portlets.structure.model.Field;
+import com.dotmarketing.portlets.structure.model.Structure;
+import com.dotmarketing.util.DateUtil;
+import com.dotmarketing.util.RegEX;
+import com.dotmarketing.util.RegExMatch;
+import com.dotmarketing.util.UtilMethods;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ *
+ * @author nollymar
+ */
+public class LuceneQueryDateTimeFormatter {
+
+
+    //Date formats supported by dotCMS in lucene queries
+    private static final Map<String, String> LUCENE_DATE_TIME_FORMAT_PATTERN = new LinkedHashMap<String, String>(){
+        {
+            put("MM/dd/yyyy hh:mm:ssa",
+                    "\\\"?(\\d{1,2}/\\d{1,2}/\\d{4}\\s+\\d{1,2}:\\d{1,2}:\\d{1,2}(?:AM|PM|am|pm))\\\"?");
+
+            put("MM/dd/yyyy hh:mm:ss a",
+                    "\\\"?(\\d{1,2}/\\d{1,2}/\\d{4}\\s+\\d{1,2}:\\d{1,2}:\\d{1,2}\\s+(?:AM|PM|am|pm))\\\"?");
+
+            put("MM/dd/yyyy hh:mm a",
+                    "\\\"?(\\d{1,2}/\\d{1,2}/\\d{4}\\s+\\d{1,2}:\\d{1,2}\\s+(?:AM|PM|am|pm))\\\"?");
+
+            put("MM/dd/yyyy hh:mma",
+                    "\\\"?(\\d{1,2}/\\d{1,2}/\\d{4}\\s+\\d{1,2}:\\d{1,2}(?:AM|PM|am|pm))\\\"?");
+
+            put("MM/dd/yyyy HH:mm:ss",
+                    "\\\"?(\\d{1,2}/\\d{1,2}/\\d{4}\\s+\\d{1,2}:\\d{1,2}:\\d{1,2})\\\"?");
+
+            put("MM/dd/yyyy HH:mm",
+                    "\\\"?(\\d{1,2}/\\d{1,2}/\\d{4}\\s+\\d{1,2}:\\d{1,2})\\\"?");
+
+            put(datetimeFormat.getPattern(),
+                    "\\\"?(\\d{4}\\d{2}\\d{2}\\d{2}\\d{2}\\d{2})\\\"?");
+
+            put(dateFormat.getPattern(), "\\\"?(\\d{4}\\d{2}\\d{2})\\\"?");
+
+            put("MM/dd/yyyy", "\\\"?(\\d{1,2}/\\d{1,2}/\\d{4})\\\"?");
+
+            put("hh:mm:ssa", "\\\"?(\\d{1,2}:\\d{1,2}:\\d{1,2}(?:AM|PM|am|pm))\\\"?");
+
+            put("hh:mm:ss a", "\\\"?(\\d{1,2}:\\d{1,2}:\\d{1,2}\\s+(?:AM|PM|am|pm))\\\"?");
+
+            put("HH:mm:ss", "\\\"?(\\d{1,2}:\\d{1,2}:\\d{1,2})\\\"?");
+
+            put("hh:mma", "\\\"?(\\d{1,2}:\\d{1,2}(?:AM|PM|am|pm))\\\"?");
+
+            put("hh:mm a", "\\\"?(\\d{1,2}:\\d{1,2}\\s+(?:AM|PM|am|pm))\\\"?");
+
+            put("HH:mm", "\\\"?(\\d{1,2}:\\d{1,2})\\\"?");
+        }
+    };
+
+    private static final List<String> LUCENE_TIME_FORMAT_PATTERNS = new ArrayList<>(
+            Arrays.asList("hh:mm:ssa", "hh:mm:ss a", "HH:mm:ss", "hh:mma", "hh:mm a", "HH:mm"));
+    /**
+     *
+     * @param query
+     * @return
+     */
+    static String findAndReplaceQueryDates(String query) {
+        query = RegEX.replaceAll(query, " ", "\\s{2,}");
+
+        //delete additional blank spaces on date range
+        if(UtilMethods.contains(query, "[ ")) {
+            query = query.replace("[ ", "[");
+        }
+
+        if(UtilMethods.contains(query, " ]")) {
+            query = query.replace(" ]", "]");
+        }
+
+        String clausesStr = RegEX.replaceAll(query, "", "[\\+\\-\\(\\)]*");
+        String[] tokens = clausesStr.split(" ");
+        String token;
+        List<String> clauses = new ArrayList<String>();
+        for (int pos = 0; pos < tokens.length; ++pos) {
+            token = tokens[pos];
+            if (token.matches("\\S+\\.\\S+:\\S*")) {
+                clauses.add(token);
+            } else if (token.matches("\\d+:\\S*")) {
+                clauses.set(clauses.size() - 1, clauses.get(clauses.size() - 1) + " " + token);
+            } else if (token.matches("\\[\\S*")) {
+                clauses.set(clauses.size() - 1, clauses.get(clauses.size() - 1) + token);
+            } else if (token.matches("TO") || token.toLowerCase().matches("am") || token.toLowerCase().matches("pm")) {
+                clauses.set(clauses.size() - 1, clauses.get(clauses.size() - 1) + " " + token);
+            } else if (token.matches("\\S*\\]")) {
+                clauses.set(clauses.size() - 1, clauses.get(clauses.size() - 1) + " " + token);
+            } else if (token.matches("\\d{1,2}/\\d{1,2}/\\d{4}")) {
+                clauses.set(clauses.size() - 1, clauses.get(clauses.size() - 1) + " " + token);
+            } else {
+                clauses.add(token);
+            }
+        }
+
+        //DOTCMS - 4127
+        List<Field> dateFields = new ArrayList<Field>();
+        String tempStructureVarName;
+        Structure tempStructure;
+
+        for (String clause: clauses) {
+
+            // getting structure names from query
+            if(clause.indexOf('.') >= 0 && (clause.indexOf('.') < clause.indexOf(':'))){
+
+                tempStructureVarName = clause.substring(0, clause.indexOf('.'));
+                tempStructure = CacheLocator.getContentTypeCache().getStructureByVelocityVarName(tempStructureVarName);
+
+                if (UtilMethods.isSet(tempStructure) && UtilMethods.isSet(tempStructure.getVelocityVarName())) {
+                    List<Field> tempStructureFields = new ArrayList<>(FieldsCache
+                            .getFieldsByStructureVariableName(
+                                    tempStructure.getVelocityVarName()));
+
+                    for (int pos = 0; pos < tempStructureFields.size(); ) {
+
+                        if (tempStructureFields.get(pos).getFieldType()
+                                .equals(Field.FieldType.DATE_TIME.toString()) ||
+                                tempStructureFields.get(pos).getFieldType()
+                                        .equals(Field.FieldType.DATE.toString()) ||
+                                tempStructureFields.get(pos).getFieldType()
+                                        .equals(Field.FieldType.TIME.toString())) {
+                            ++pos;
+                        } else {
+                            tempStructureFields.remove(pos);
+                        }
+
+                    }
+
+                    dateFields.addAll(tempStructureFields);
+                }
+            }
+        }
+
+        String replace;
+        List<RegExMatch> matches;
+        String structureVarName;
+        for (String clause: clauses) {
+            for (Field field: dateFields) {
+
+                structureVarName = CacheLocator.getContentTypeCache()
+                        .getStructureByInode(field.getStructureInode()).getVelocityVarName()
+                        .toLowerCase();
+
+                if (clause.startsWith(structureVarName + "." + field.getVelocityVarName().toLowerCase() + ":") || clause.startsWith("moddate:")) {
+                    replace = new String(clause);
+                    if (field.getFieldType().equals(Field.FieldType.DATE_TIME.toString()) || clause.startsWith("moddate:")) {
+                        matches = RegEX.find(replace, "\\[(\\d{1,2}/\\d{1,2}/\\d{4}) TO ");
+                        for (RegExMatch regExMatch : matches) {
+                            replace = replace.replace("[" + regExMatch.getGroups().get(0).getMatch() + " TO ", "["
+                                    + regExMatch.getGroups().get(0).getMatch() + " 00:00:00 TO ");
+                        }
+
+                        matches = RegEX.find(replace, " TO (\\d{1,2}/\\d{1,2}/\\d{4})\\]");
+                        for (RegExMatch regExMatch : matches) {
+                            replace = replace.replace(" TO " + regExMatch.getGroups().get(0).getMatch() + "]", " TO "
+                                    + regExMatch.getGroups().get(0).getMatch() + " 23:59:59]");
+                        }
+                    }
+
+                    //if structureVarName or field.getVelocityVarName() has numbers, we need to split the clause to format only dates
+                    if (clause.startsWith(
+                            structureVarName + "." + field.getVelocityVarName().toLowerCase()
+                                    + ":")) {
+                        replace = structureVarName + "." + field.getVelocityVarName()
+                                .toLowerCase() + ":" + replaceDateTimeFormatInClause(
+                                replace.substring(replace.indexOf(":") + 1));
+                    } else {
+                        replace = replaceDateTimeFormatInClause(replace);
+                    }
+
+                    query = query.replace(clause, replace);
+
+                    break;
+                }
+            }
+        }
+
+        matches = RegEX.find(query, "\\[([0-9]*)(\\*+) TO ");
+        for (RegExMatch regExMatch : matches) {
+            query = query.replace("[" + regExMatch.getGroups().get(0).getMatch() + regExMatch.getGroups().get(1).getMatch() + " TO ", "["
+                    + regExMatch.getGroups().get(0).getMatch() + " TO ");
+        }
+
+        matches = RegEX.find(query, " TO ([0-9]*)(\\*+)\\]");
+        for (RegExMatch regExMatch : matches) {
+            query = query.replace(" TO " + regExMatch.getGroups().get(0).getMatch() + regExMatch.getGroups().get(1).getMatch() + "]", " TO "
+                    + regExMatch.getGroups().get(0).getMatch() + "]");
+        }
+
+        matches = RegEX.find(query, "\\[([0-9]*) (TO) ([0-9]*)\\]");
+        if(matches.isEmpty()){
+            matches = RegEX.find(query, "\\[([a-z0-9]*) (TO) ([a-z0-9]*)\\]");
+        }
+        for (RegExMatch regExMatch : matches) {
+            query = query.replace("[" + regExMatch.getGroups().get(0).getMatch() + " TO "
+                    + regExMatch.getGroups().get(2).getMatch() + "]", "["
+                    + replaceDateTimeFormatInClause(regExMatch.getGroups().get(0).getMatch())
+                    + " TO " + replaceDateTimeFormatInClause(
+                    regExMatch.getGroups().get(2).getMatch())
+                    + "]");
+        }
+
+        //https://github.com/elasticsearch/elasticsearch/issues/2980
+        if (query.contains( "/" )) {
+            query = query.replaceAll( "/", "\\\\/" );
+        }
+
+        return query;
+    }
+
+
+    /**
+     * Applies supported lucene format to dates in a query
+     * @param unformattedDate - Date or range of dates to be formatted
+     * @return
+     */
+    static String replaceDateTimeFormatInClause(final String unformattedDate) {
+        String result;
+
+        for (Map.Entry<String, String> pattern: LUCENE_DATE_TIME_FORMAT_PATTERN.entrySet()){
+            if (LUCENE_TIME_FORMAT_PATTERNS.contains(pattern.getKey())){
+                result = DateUtil
+                        .replaceTimeWithFormat(unformattedDate, pattern.getValue(), pattern.getKey());
+            } else{
+                result = DateUtil
+                        .replaceDateTimeWithFormat(unformattedDate, pattern.getValue(), pattern.getKey());
+            }
+
+            if (!result.equals(unformattedDate)){
+                return result;
+            }
+
+        }
+        return unformattedDate;
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/LuceneQueryDateTimeFormatter.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/LuceneQueryDateTimeFormatter.java
@@ -22,7 +22,7 @@ import java.util.Map;
  *
  * @author nollymar
  */
-public class LuceneQueryDateTimeFormatter {
+public final class LuceneQueryDateTimeFormatter {
 
     private LuceneQueryDateTimeFormatter(){
 
@@ -77,19 +77,19 @@ public class LuceneQueryDateTimeFormatter {
      * @param query
      * @return
      */
-    static String findAndReplaceQueryDates(String query) {
-        query = RegEX.replaceAll(query, " ", "\\s{2,}");
+    static String findAndReplaceQueryDates(final String query) {
+        String queryResult = RegEX.replaceAll(query, " ", "\\s{2,}");
 
         //delete additional blank spaces on date range
-        if(UtilMethods.contains(query, "[ ")) {
-            query = query.replace("[ ", "[");
+        if(UtilMethods.contains(queryResult, "[ ")) {
+            queryResult = queryResult.replace("[ ", "[");
         }
 
-        if(UtilMethods.contains(query, " ]")) {
-            query = query.replace(" ]", "]");
+        if(UtilMethods.contains(queryResult, " ]")) {
+            queryResult = queryResult.replace(" ]", "]");
         }
 
-        final String clausesStr = RegEX.replaceAll(query, "", "[\\+\\-\\(\\)]*");
+        final String clausesStr = RegEX.replaceAll(queryResult, "", "[\\+\\-\\(\\)]*");
         final String[] tokens = clausesStr.split(" ");
         final List<String> clauses = new ArrayList<>();
 
@@ -186,31 +186,31 @@ public class LuceneQueryDateTimeFormatter {
                         replace = replaceDateTimeFormatInClause(replace);
                     }
 
-                    query = query.replace(clause, replace);
+                    queryResult = queryResult.replace(clause, replace);
 
                     break;
                 }
             }
         }
 
-        matches = RegEX.find(query, "\\[([0-9]*)(\\*+) TO ");
+        matches = RegEX.find(queryResult, "\\[([0-9]*)(\\*+) TO ");
         for (final RegExMatch regExMatch : matches) {
-            query = query.replace("[" + regExMatch.getGroups().get(0).getMatch() + regExMatch.getGroups().get(1).getMatch() + " TO ", "["
+            queryResult = queryResult.replace("[" + regExMatch.getGroups().get(0).getMatch() + regExMatch.getGroups().get(1).getMatch() + " TO ", "["
                     + regExMatch.getGroups().get(0).getMatch() + " TO ");
         }
 
-        matches = RegEX.find(query, " TO ([0-9]*)(\\*+)\\]");
+        matches = RegEX.find(queryResult, " TO ([0-9]*)(\\*+)\\]");
         for (final RegExMatch regExMatch : matches) {
-            query = query.replace(" TO " + regExMatch.getGroups().get(0).getMatch() + regExMatch.getGroups().get(1).getMatch() + "]", " TO "
+            queryResult = queryResult.replace(" TO " + regExMatch.getGroups().get(0).getMatch() + regExMatch.getGroups().get(1).getMatch() + "]", " TO "
                     + regExMatch.getGroups().get(0).getMatch() + "]");
         }
 
-        matches = RegEX.find(query, "\\[([0-9]*) (TO) ([0-9]*)\\]");
+        matches = RegEX.find(queryResult, "\\[([0-9]*) (TO) ([0-9]*)\\]");
         if(matches.isEmpty()){
-            matches = RegEX.find(query, "\\[([a-z0-9]*) (TO) ([a-z0-9]*)\\]");
+            matches = RegEX.find(queryResult, "\\[([a-z0-9]*) (TO) ([a-z0-9]*)\\]");
         }
         for (final RegExMatch regExMatch : matches) {
-            query = query.replace("[" + regExMatch.getGroups().get(0).getMatch() + " TO "
+            queryResult = queryResult.replace("[" + regExMatch.getGroups().get(0).getMatch() + " TO "
                     + regExMatch.getGroups().get(2).getMatch() + "]", "["
                     + replaceDateTimeFormatInClause(regExMatch.getGroups().get(0).getMatch())
                     + " TO " + replaceDateTimeFormatInClause(
@@ -219,11 +219,11 @@ public class LuceneQueryDateTimeFormatter {
         }
 
         //https://github.com/elasticsearch/elasticsearch/issues/2980
-        if (query.contains( "/" )) {
-            query = query.replaceAll( "/", "\\\\/" );
+        if (queryResult.contains( "/" )) {
+            queryResult = queryResult.replaceAll( "/", "\\\\/" );
         }
 
-        return query;
+        return queryResult;
     }
 
 


### PR DESCRIPTION
This PR contains changes in the way we format dates in a lucene query. Filtering dates by range wasn't working because of changes on https://github.com/dotCMS/core/issues/16141 that prevented a good match for any clause that contained `TO` instead of `to`.

In addition to that, this PR includes: 
- A new date pattern to support dates with format `yyyyMMdd`
- Method `replaceDateTimeFormatInClause` was refactored to make it cleaner
- New ITs were implemented to test all the supported date formats
- A fix for dates that contain ` AM`, ` PM`, ` am` or ` pm` (the whitespace at the beginning was breaking the filter)
- A fix for a case when the lucene query contained a date field and the content type var had numbers. For example: `+News20191121180000.sysPublishDate:[20190620 TO 20191001]`
- Unnecessary code that parsed `structureVarName` was removed