### PR TITLE
#17661 List of related content map should be filtered by parent content language

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentMapTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentMapTest.java
@@ -213,7 +213,7 @@ public class ContentMapTest extends IntegrationTestBase {
                     userAPI.getAnonymousUser(),
                     PageMode.LIVE, defaultHost, velocityContext);
 
-            List<ContentMap> result = (List) contentMap.get(relationshipField.variable());
+            final List<ContentMap> result = (List) contentMap.get(relationshipField.variable());
             assertNotNull(result);
             assertEquals(2, result.size());
             assertEquals(contentletChild.getIdentifier(), result.get(0).get("identifier"));

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1215,7 +1215,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
                         relationshipAPI.isChildField(relationship, theField);
                 final ContentletRelationshipRecords records = contentletRelationships.new ContentletRelationshipRecords(
                         relationship, isChildField);
-                records.setRecords(contentlet.getRelated(theField.variable(), user, respectFrontEndRoles, isChildField));
+                records.setRecords(contentlet
+                        .getRelated(theField.variable(), user, respectFrontEndRoles, isChildField,
+                                contentlet.getLanguageId(), null));
                 contentletRelationships.setRelationshipsRecords(CollectionsUtils.list(records));
                 return contentletRelationships;
             } else {


### PR DESCRIPTION
Previously, related content map list didn't filter by language. Now, the parent content language is used to call getRelated.

Additionally, a test that recreates this scenario was implemented.