### PR TITLE
Issue 17541 fix container as file refs on copy site

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -6408,13 +6408,14 @@ public class ESContentletAPIImpl implements ContentletAPI {
     @WrapInTransaction
     @Override
     public Contentlet copyContentlet(final Contentlet sourceContentlet, final Host host, final Folder folder, final User user, final String copySuffix, final boolean respectFrontendRoles) throws DotDataException, DotSecurityException, DotContentletStateException {
+
         Contentlet copyContentlet = new Contentlet();
         String newIdentifier = StringPool.BLANK;
-        ArrayList<Contentlet> versionsToCopy = new ArrayList<>();
         List<Contentlet> versionsToMarkWorking = new ArrayList<>();
         Map<String, Map<String, Contentlet>> contentletsToCopyRules = Maps.newHashMap();
         final Identifier sourceContentletIdentifier = APILocator.getIdentifierAPI().find(sourceContentlet.getIdentifier());
-        versionsToCopy.addAll(findAllVersions(sourceContentletIdentifier, false, user, respectFrontendRoles));
+        List<Contentlet> versionsToCopy = new ArrayList<>(
+                findAllVersions(sourceContentletIdentifier, false, user, respectFrontendRoles));
 
         // we need to save the versions from older-to-newer to make sure the last save
         // is the current version
@@ -6422,8 +6423,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         for(Contentlet contentlet : versionsToCopy){
 
-            boolean isContentletLive = false;
-            boolean isContentletWorking = false;
+            final boolean isContentletLive = contentlet.isLive();
+            final boolean isContentletWorking = contentlet.isWorking();
 
             if (user == null) {
                 throw new DotSecurityException("A user must be specified.");
@@ -6437,11 +6438,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
             Contentlet newContentlet = new Contentlet();
             newContentlet.setStructureInode(contentlet.getStructureInode());
             copyProperties(newContentlet, contentlet.getMap(),true);
-
-            if(contentlet.isLive())
-                isContentletLive = true;
-            if(contentlet.isWorking())
-                isContentletWorking = true;
 
             newContentlet.setInode(StringPool.BLANK);
             newContentlet.setIdentifier(StringPool.BLANK);
@@ -6596,21 +6592,25 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
         }
 
-        for(Contentlet con : versionsToMarkWorking){
+        for(final Contentlet con : versionsToMarkWorking){
             APILocator.getVersionableAPI().setWorking(con);
         }
 
         if (sourceContentlet.isHTMLPage()) {
-            // If the content is an HTML Page then copy page associated contentlets
-            final List<MultiTree> pageContents = APILocator.getMultiTreeAPI().getMultiTrees(sourceContentlet.getIdentifier());
-            for (final MultiTree multitree : pageContents) {
-
-                APILocator.getMultiTreeAPI().saveMultiTree(new MultiTree(copyContentlet.getIdentifier(),
-                        multitree.getContainer(),
-                        multitree.getContentlet(),
-                        multitree.getRelationType(),
-                        multitree.getTreeOrder(), 
-                        multitree.getPersonalization()));
+            final boolean copyingSite = (!copyContentlet.getHost().equals(sourceContentlet.getHost()));
+            if (!copyingSite) { // We only want to execute this logic if we're not copying a whole site.
+                // If the content is an HTML Page then copy page associated contentlets
+                final List<MultiTree> pageContents = APILocator.getMultiTreeAPI()
+                        .getMultiTrees(sourceContentlet.getIdentifier());
+                for (final MultiTree multitree : pageContents) {
+                    APILocator.getMultiTreeAPI()
+                            .saveMultiTree(new MultiTree(copyContentlet.getIdentifier(),
+                                    multitree.getContainer(),
+                                    multitree.getContentlet(),
+                                    multitree.getRelationType(),
+                                    multitree.getTreeOrder(),
+                                    multitree.getPersonalization()));
+                }
             }
         }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtil.java
@@ -121,22 +121,32 @@ public class FileAssetContainerUtil {
     }
 
     //demo.dotcms.com/application/containers/test/
-    public String getHostName (final String path) {
-        String tmp = path;
-        final List<String> pageModePrefixList = Stream.of(PageMode.values()).map(pageMode -> String.format("/%s/",pageMode.name())).collect(Collectors.toList());
-        for(final String prefix: pageModePrefixList){
-           if(tmp.startsWith(prefix)){
-             tmp = tmp.substring(prefix.length());
-             break;
-           }
+    public String getHostName(final String path) {
+        try {
+            String tmp = path;
+            final List<String> pageModePrefixList = Stream.of(PageMode.values())
+                    .map(pageMode -> String.format("/%s/", pageMode.name()))
+                    .collect(Collectors.toList());
+            for (final String prefix : pageModePrefixList) {
+                if (tmp.startsWith(prefix)) {
+                    tmp = tmp.substring(prefix.length());
+                    break;
+                }
+            }
+
+            tmp = tmp.replaceAll(HOST_INDICATOR, "");
+            tmp = tmp.substring(0, tmp.indexOf(CONTAINER_FOLDER_PATH));
+            final String finalString = tmp;
+            Logger.warn(FileAssetContainerUtil.class,
+                    () -> String.format(" extracted hostName `%s`", finalString));
+
+            return (UtilMethods.isSet(tmp) ? tmp : null);
+        } catch (Exception e) {
+            Logger.error(FileAssetContainer.class, String.format(
+                    "An error occurred while extracting host name from path `%s` defaulting to systemHost ",
+                    path), e);
+            return null;
         }
-
-        tmp = tmp.replaceAll(HOST_INDICATOR,"");
-        tmp = tmp.substring(0,tmp.indexOf(CONTAINER_FOLDER_PATH));
-        final String finalString = tmp;
-        Logger.warn(FileAssetContainerUtil.class, ()->  String.format(" extracted hostName `%s`",finalString));
-
-        return (UtilMethods.isSet(tmp) ? tmp : null);
     }
 
     public String getContainerIdFromPath(final String fullPath) throws DotDataException {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtil.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.portlets.containers.business;
 
+import static com.dotmarketing.util.Constants.CONTAINER_FOLDER_PATH;
 import static com.dotmarketing.util.StringUtils.builder;
 import static com.liferay.util.StringPool.FORWARD_SLASH;
 
@@ -15,10 +16,12 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.containers.model.FileAssetContainer;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.fileassets.business.FileAsset;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.Constants;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.collect.ImmutableList;
@@ -31,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.context.Context;
@@ -106,24 +111,42 @@ public class FileAssetContainerUtil {
     }
 
     public Host getHost (final String path) throws DotSecurityException, DotDataException {
-
         return this.getHostFromHostname(this.getHostName(path));
     }
 
     public Host getHostFromHostname (final String hostname) throws DotSecurityException, DotDataException {
-
         return null == hostname?
-                APILocator.getHostAPI().resolveHostName(hostname, APILocator.systemUser(), false):
-                APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
+                APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false) :
+                APILocator.getHostAPI().resolveHostName(hostname, APILocator.systemUser(), false);
     }
 
     //demo.dotcms.com/application/containers/test/
     public String getHostName (final String path) {
+        String tmp = path;
+        final List<String> pageModePrefixList = Stream.of(PageMode.values()).map(pageMode -> String.format("/%s/",pageMode.name())).collect(Collectors.toList());
+        for(final String prefix: pageModePrefixList){
+           if(tmp.startsWith(prefix)){
+             tmp = tmp.substring(prefix.length());
+             break;
+           }
+        }
 
-        final int startsHost = null != path?     path.indexOf(HOST_INDICATOR): -1;
-        final int endsHost   = -1 != startsHost? path.indexOf(FORWARD_SLASH, startsHost+HOST_INDICATOR.length()): -1;
-        return startsHost != -1 && endsHost != -1?
-                path.substring(startsHost+HOST_INDICATOR.length(), endsHost): null;
+        tmp = tmp.replaceAll(HOST_INDICATOR,"");
+        tmp = tmp.substring(0,tmp.indexOf(CONTAINER_FOLDER_PATH));
+        final String finalString = tmp;
+        Logger.warn(FileAssetContainerUtil.class, ()->  String.format(" extracted hostName `%s`",finalString));
+
+        return (UtilMethods.isSet(tmp) ? tmp : null);
+
+        /*
+
+        final int startsHost = null != path ? path.indexOf(HOST_INDICATOR) : -1;
+        final int endsHost =
+                -1 != startsHost ? path.indexOf(FORWARD_SLASH, startsHost + HOST_INDICATOR.length())
+                        : -1;
+        return startsHost != -1 && endsHost != -1 ?
+                path.substring(startsHost + HOST_INDICATOR.length(), endsHost) : null;
+         */
     }
 
     public String getContainerIdFromPath(final String fullPath) throws DotDataException {
@@ -169,7 +192,7 @@ public class FileAssetContainerUtil {
 
     public boolean isFolderAssetContainerId(final String containerPath) {
 
-        return UtilMethods.isSet(containerPath) && containerPath.contains(Constants.CONTAINER_FOLDER_PATH);
+        return UtilMethods.isSet(containerPath) && containerPath.contains(CONTAINER_FOLDER_PATH);
     }
 
     /**
@@ -235,8 +258,8 @@ public class FileAssetContainerUtil {
         if (null == metaInfoFileAsset) {
 
             throw new NotFoundInDbException("On getting the container by folder, the folder: " + containerFolder.getPath() +
-                    " is not valid, it must be under: " + Constants.CONTAINER_FOLDER_PATH + " and must have a child file asset called: " +
-                    Constants.CONTAINER_META_INFO_FILE_NAME);
+                    " is not valid, it must be under: " + CONTAINER_FOLDER_PATH + " and must have a child file asset called: " +
+                    Constants.CONTAINER_META_INFO_FILE_NAME + " and one or more vtl assets to backup the supported contents." );
         }
 
         this.setContainerData(host, containerFolder, metaInfoFileAsset, containerStructures.build(), container,
@@ -415,5 +438,23 @@ public class FileAssetContainerUtil {
                                 .build();
     }
 
+
+    public boolean isFileAssetContainer(final Contentlet contentlet) {
+        if (null == contentlet || !contentlet.isFileAsset()) {
+            return false;
+        }
+        try {
+            final FileAsset asset = APILocator.getFileAssetAPI().fromContentlet(contentlet);
+            final Folder parentFolder = APILocator.getFolderAPI()
+                    .find(asset.getFolder(), APILocator.systemUser(), false);
+
+            return (CONTAINER_META_INFO.equals(asset.getFileName()) && UtilMethods
+                    .isSet(parentFolder.getPath()) && parentFolder.getPath()
+                    .startsWith(CONTAINER_FOLDER_PATH));
+        } catch (Exception e) {
+            Logger.error(FileAssetContainerUtil.class, "Unable to determine if contentlet is a fileAssetContainer ", e);
+        }
+        return false;
+    }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtil.java
@@ -137,16 +137,6 @@ public class FileAssetContainerUtil {
         Logger.warn(FileAssetContainerUtil.class, ()->  String.format(" extracted hostName `%s`",finalString));
 
         return (UtilMethods.isSet(tmp) ? tmp : null);
-
-        /*
-
-        final int startsHost = null != path ? path.indexOf(HOST_INDICATOR) : -1;
-        final int endsHost =
-                -1 != startsHost ? path.indexOf(FORWARD_SLASH, startsHost + HOST_INDICATOR.length())
-                        : -1;
-        return startsHost != -1 && endsHost != -1 ?
-                path.substring(startsHost + HOST_INDICATOR.length(), endsHost) : null;
-         */
     }
 
     public String getContainerIdFromPath(final String fullPath) throws DotDataException {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -30,6 +30,7 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.categories.business.Categorizable;
+import com.dotmarketing.portlets.containers.business.FileAssetContainerUtil;
 import com.dotmarketing.portlets.contentlet.business.BinaryFileFilter;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.business.ContentletCache;
@@ -1257,6 +1258,17 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 	public boolean isFileAsset() {
 		return getContentType().baseType() == BaseContentType.FILEASSET;
 	}
+
+
+	/**
+	 * It'll tell you if you're dealing with content of type FileAsset that is used as container
+	 * see Containers as files
+	 * @return
+	 */
+	@JsonIgnore
+	public boolean isFileAssetContainer(){
+       return FileAssetContainerUtil.getInstance().isFileAssetContainer(this);
+    }
 
 	/**
 	 * It'll tell you if you're dealing with content of type Host


### PR DESCRIPTION
The problem this PR intents to solve is basically that the copy site was replicating a lot of the stuff that existed on the original source-site. contentlets, templates, containers, pages, etc.. but the referenced elements on the page multi-tree were still the original elements from the source origin site.

The problem has been around for a long time but it became evident when containers as files were introduced. The copied references of the containers as files couldn't be displayed properly on the new site.

So this fix basically takes all the references that to the new copied elements and updates the Multi-Tree and the templates making them point to the new elements copied into the new site.

The new Containers as files were being treated by the copy functionality as regular containers and even though you would see all the respective files under /application/containers/ in the copy-site. They were getting copied there by the logic that replicates the file-assets. Meaning that the multi-tree on the new copy-page not only saw elements from the original site but the new copy-containers were getting created as regular containers. Not containers as files.

The copy order of the elements had to change a bit in order to fit the new Containers-as-files because by the time the containers are getting copied the folders didn't exist yet. So when an instance of a CAF was found we needed to make sure the proper folder structure was already in place to accommodate all the related file-assets that conform the CAF.

Also fixes a problem that was never evident on a FileAssetContainerUtil.getHostName
that method takes the template-name and extracts the site-name from it. The problem was never evident until I tested against a different site other than demo.