### PR TITLE
Issue 17560 remove fields from interfaces

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
@@ -1,24 +1,5 @@
 package com.dotcms.graphql;
 
-import com.dotcms.contenttype.model.type.BaseContentType;
-import com.dotcms.graphql.datafetcher.ContentletDataFetcher;
-import com.dotcms.graphql.datafetcher.FolderFieldDataFetcher;
-import com.dotcms.graphql.datafetcher.LanguageDataFetcher;
-import com.dotcms.graphql.datafetcher.SiteFieldDataFetcher;
-import com.dotcms.graphql.datafetcher.TitleImageFieldDataFetcher;
-import com.dotcms.graphql.datafetcher.UserDataFetcher;
-import com.dotcms.graphql.resolver.ContentResolver;
-import com.dotmarketing.util.Logger;
-
-import graphql.schema.GraphQLOutputType;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import graphql.scalars.ExtendedScalars;
-import graphql.schema.GraphQLInterfaceType;
-
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.BASE_TYPE;
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.CONTENT_TYPE;
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.IDENTIFIER;
@@ -28,43 +9,8 @@ import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.MOD_
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.TITLE;
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.URL_MAP;
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.WORKING;
-import static com.dotcms.contenttype.model.type.FileAssetContentType.*;
-import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_FILEASSET_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_FILE_NAME_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_METADATA_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_SHOW_ON_MENU_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_SORT_ORDER_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_TITLE_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.FormContentType.*;
-import static com.dotcms.contenttype.model.type.KeyValueContentType.KEY_VALUE_KEY_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.KeyValueContentType.KEY_VALUE_VALUE_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_CACHE_TTL_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_FRIENDLY_NAME_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_HTTP_REQUIRED_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_PAGE_METADATA_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_REDIRECT_URL_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_SEO_DESCRIPTION_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_SEO_KEYWORDS_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_SHOW_ON_MENU_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_SORT_ORDER_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_TEMPLATE_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PageContentType.PAGE_URL_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PersonaContentType.PERSONA_DESCRIPTION_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PersonaContentType.PERSONA_KEY_TAG_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PersonaContentType.PERSONA_NAME_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PersonaContentType.PERSONA_OTHER_TAGS_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.PersonaContentType.PERSONA_PHOTO_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.VanityUrlContentType.ACTION_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.VanityUrlContentType.FORWARD_TO_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.VanityUrlContentType.ORDER_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.VanityUrlContentType.URI_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.WidgetContentType.WIDGET_CODE_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.WidgetContentType.WIDGET_PRE_EXECUTE_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.WidgetContentType.WIDGET_TITLE_FIELD_VAR;
-import static com.dotcms.contenttype.model.type.WidgetContentType.WIDGET_USAGE_FIELD_VAR;
 import static com.dotcms.graphql.util.TypeUtil.TypeFetcher;
 import static com.dotcms.graphql.util.TypeUtil.createInterfaceType;
-import static com.dotcms.graphql.util.TypeUtil.createObjectType;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.ARCHIVED_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.FOLDER_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.HOST_KEY;
@@ -74,9 +20,21 @@ import static com.dotmarketing.portlets.contentlet.model.Contentlet.OWNER_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.TITLE_IMAGE_KEY;
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLID;
-import static graphql.Scalars.GraphQLInt;
 import static graphql.Scalars.GraphQLString;
-import static graphql.schema.GraphQLList.list;
+
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.graphql.datafetcher.FolderFieldDataFetcher;
+import com.dotcms.graphql.datafetcher.LanguageDataFetcher;
+import com.dotcms.graphql.datafetcher.SiteFieldDataFetcher;
+import com.dotcms.graphql.datafetcher.TitleImageFieldDataFetcher;
+import com.dotcms.graphql.datafetcher.UserDataFetcher;
+import com.dotcms.graphql.resolver.ContentResolver;
+import com.dotmarketing.util.Logger;
+import graphql.schema.GraphQLInterfaceType;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public enum InterfaceType {
     CONTENTLET,

--- a/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
@@ -1,6 +1,7 @@
 package com.dotcms.graphql;
 
 import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.graphql.datafetcher.ContentletDataFetcher;
 import com.dotcms.graphql.datafetcher.FolderFieldDataFetcher;
 import com.dotcms.graphql.datafetcher.LanguageDataFetcher;
 import com.dotcms.graphql.datafetcher.SiteFieldDataFetcher;
@@ -9,6 +10,7 @@ import com.dotcms.graphql.datafetcher.UserDataFetcher;
 import com.dotcms.graphql.resolver.ContentResolver;
 import com.dotmarketing.util.Logger;
 
+import graphql.schema.GraphQLOutputType;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -62,6 +64,7 @@ import static com.dotcms.contenttype.model.type.WidgetContentType.WIDGET_TITLE_F
 import static com.dotcms.contenttype.model.type.WidgetContentType.WIDGET_USAGE_FIELD_VAR;
 import static com.dotcms.graphql.util.TypeUtil.TypeFetcher;
 import static com.dotcms.graphql.util.TypeUtil.createInterfaceType;
+import static com.dotcms.graphql.util.TypeUtil.createObjectType;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.ARCHIVED_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.FOLDER_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.HOST_KEY;
@@ -120,69 +123,27 @@ public enum InterfaceType {
 
         interfaceTypes.put("CONTENTLET", createInterfaceType("Contentlet", contentFields, new ContentResolver()));
 
-
         interfaceTypes.put("CONTENT", createInterfaceType(CONTENT_INTERFACE_NAME, contentFields, new ContentResolver()));
 
         final Map<String, TypeFetcher> fileAssetFields = new HashMap<>(contentFields);
-        fileAssetFields.put(FILEASSET_FILE_NAME_FIELD_VAR, new TypeFetcher(GraphQLString));
-        fileAssetFields.put(FILEASSET_DESCRIPTION_FIELD_VAR, new TypeFetcher(GraphQLString));
-        fileAssetFields.put(FILEASSET_FILEASSET_FIELD_VAR, new TypeFetcher(CustomFieldType.BINARY.getType()));
-        fileAssetFields.put(FILEASSET_METADATA_FIELD_VAR, new TypeFetcher(list(CustomFieldType.KEY_VALUE.getType())));
-        fileAssetFields.put(FILEASSET_SHOW_ON_MENU_FIELD_VAR, new TypeFetcher(list(GraphQLString)));
-        fileAssetFields.put(FILEASSET_SORT_ORDER_FIELD_VAR, new TypeFetcher(GraphQLInt));
-
         interfaceTypes.put("FILEASSET", createInterfaceType(FILE_INTERFACE_NAME, fileAssetFields, new ContentResolver()));
 
         final Map<String, TypeFetcher> pageAssetFields = new HashMap<>(contentFields);
-        pageAssetFields.put(PAGE_URL_FIELD_VAR, new TypeFetcher(GraphQLString));
-        pageAssetFields.put(PAGE_TEMPLATE_FIELD_VAR, new TypeFetcher(GraphQLString));
-        pageAssetFields.put(PAGE_SHOW_ON_MENU_FIELD_VAR, new TypeFetcher(list(GraphQLString)));
-        pageAssetFields.put(PAGE_SORT_ORDER_FIELD_VAR, new TypeFetcher(GraphQLInt));
-        pageAssetFields.put(PAGE_CACHE_TTL_FIELD_VAR, new TypeFetcher(GraphQLString));
-        pageAssetFields.put(PAGE_FRIENDLY_NAME_FIELD_VAR, new TypeFetcher(GraphQLString));
-        pageAssetFields.put(PAGE_REDIRECT_URL_FIELD_VAR, new TypeFetcher(GraphQLString));
-        pageAssetFields.put(PAGE_HTTP_REQUIRED_FIELD_VAR, new TypeFetcher(list(GraphQLString)));
-        pageAssetFields.put(PAGE_SEO_DESCRIPTION_FIELD_VAR, new TypeFetcher(GraphQLString));
-        pageAssetFields.put(PAGE_SEO_KEYWORDS_FIELD_VAR, new TypeFetcher(GraphQLString));
-        pageAssetFields.put(PAGE_PAGE_METADATA_FIELD_VAR, new TypeFetcher(GraphQLString));
-
         interfaceTypes.put("HTMLPAGE", createInterfaceType(PAGE_INTERFACE_NAME, pageAssetFields, new ContentResolver()));
 
         final Map<String, TypeFetcher> personaFields = new HashMap<>(contentFields);
-        personaFields.put(PERSONA_NAME_FIELD_VAR, new TypeFetcher(GraphQLString));
-        personaFields.put(PERSONA_KEY_TAG_FIELD_VAR, new TypeFetcher(GraphQLString));
-        personaFields.put(PERSONA_PHOTO_FIELD_VAR, new TypeFetcher(CustomFieldType.BINARY.getType()));
-        personaFields.put(PERSONA_OTHER_TAGS_FIELD_VAR, new TypeFetcher(list(GraphQLString)));
-        personaFields.put(PERSONA_DESCRIPTION_FIELD_VAR, new TypeFetcher(GraphQLString));
-
         interfaceTypes.put("PERSONA", createInterfaceType(PERSONA_INTERFACE_NAME, personaFields, new ContentResolver()));
 
         final Map<String, TypeFetcher> widgetFields = new HashMap<>(contentFields);
-        widgetFields.put(WIDGET_TITLE_FIELD_VAR, new TypeFetcher(GraphQLString));
-        widgetFields.put(WIDGET_CODE_FIELD_VAR, new TypeFetcher(GraphQLString));
-        widgetFields.put(WIDGET_USAGE_FIELD_VAR, new TypeFetcher(GraphQLString));
-        widgetFields.put(WIDGET_PRE_EXECUTE_FIELD_VAR, new TypeFetcher(GraphQLString));
-
         interfaceTypes.put("WIDGET", createInterfaceType(WIDGET_INTERFACE_NAME, widgetFields, new ContentResolver()));
 
         final Map<String, TypeFetcher> vanityUrlFields = new HashMap<>(contentFields);
-        vanityUrlFields.put(URI_FIELD_VAR, new TypeFetcher(GraphQLString));
-        vanityUrlFields.put(FORWARD_TO_FIELD_VAR, new TypeFetcher(GraphQLString));
-        vanityUrlFields.put(ACTION_FIELD_VAR, new TypeFetcher(GraphQLString));
-        vanityUrlFields.put(ORDER_FIELD_VAR, new TypeFetcher(GraphQLInt));
-
         interfaceTypes.put("VANITY_URL", createInterfaceType(VANITY_URL_INTERFACE_NAME, vanityUrlFields, new ContentResolver()));
 
         final Map<String, TypeFetcher> keyValueFields = new HashMap<>(contentFields);
-        keyValueFields.put(KEY_VALUE_KEY_FIELD_VAR, new TypeFetcher(GraphQLString));
-        keyValueFields.put(KEY_VALUE_VALUE_FIELD_VAR, new TypeFetcher(GraphQLString));
-
         interfaceTypes.put("KEY_VALUE", createInterfaceType(KEY_VALUE_INTERFACE_NAME, keyValueFields, new ContentResolver()));
 
         final Map<String, TypeFetcher> formFields = new HashMap<>(contentFields);
-        formFields.put(FORM_SUCCESS_CALLBACK, new TypeFetcher(GraphQLString));
-        formFields.put(FORM_EMAIL_FIELD_VAR, new TypeFetcher(GraphQLString));
-
         interfaceTypes.put("FORM", createInterfaceType(FORM_INTERFACE_NAME, formFields, new ContentResolver()));
     }
 

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
@@ -161,13 +161,10 @@ public class GraphqlAPIImpl implements GraphqlAPI {
         // add CONTENT interface fields
         builder.fields(InterfaceType.CONTENTLET.getType().getFieldDefinitions());
 
-        // TODO commented while pending for researching. Do not remove 
-        /*
         if(InterfaceType.getInterfaceForBaseType(contentType.baseType())!=null) {
             builder.withInterface(InterfaceType.getInterfaceForBaseType(contentType.baseType()));
         }
-        */
-        
+
         final List<Field> fields = contentType.fields();
 
         fields.forEach((field)->{


### PR DESCRIPTION
GraphQL interfaces fields were removed to avoid customers breaking when we change the dotCMS BaseeType fields and they are upgrading from older versions.  