### PR TITLE
#16715 log error message only in action

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/action/EditFolderAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/action/EditFolderAction.java
@@ -27,6 +27,7 @@ import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.portlets.folders.business.AddContentToFolderPermissionException;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.folders.business.FolderFactory;
+import com.dotmarketing.portlets.folders.exception.InvalidFolderNameException;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.folders.struts.FolderForm;
 import com.dotmarketing.portlets.links.model.Link;
@@ -397,16 +398,11 @@ public class EditFolderAction extends DotPortletAction {
 			SessionMessages.add(req, "message", message);
 			Logger.error(this, e.getMessage(), e);
 			throw e;
-		} catch(DotDataException ex) {
+		} catch(InvalidFolderNameException e ) {
 			HibernateUtil.rollbackTransaction();
-			if(ex.getMessage().contains("reserved folder name")) {
-				SessionMessages.add(req, "message", "message.folder.save.reservedName");
-				Logger.error(this,
-						"ERROR: Cannot save folder '" + parentPath + folderForm.getName());
-			} else {
-				SessionMessages.add(req, "message", "message.folder.save.error");
-				Logger.error(this, "ERROR: Cannot save folder '" + parentPath + folderForm.getName() + "'", ex);
-			}
+			SessionMessages.add(req, "message", "message.folder.save.reservedName");
+			Logger.error(this,
+					"ERROR: Cannot save folder '" + parentPath + folderForm.getName());
 		} catch(Exception ex) {
 			HibernateUtil.rollbackTransaction();
 			SessionMessages.add(req, "message", "message.folder.save.error");


### PR DESCRIPTION
New Exception called InvalidFolderNameException was already created as a part of previous changes,  so now we are catching it to log only the error message without including the error stack, instead of having to check the error message. 

Also the DotDataException catch was removed since it was doing the same as the Exception block, so just leaving the latter. 