### PR TITLE
#17671 qa feedback

### DIFF
--- a/dotCMS/src/curl-test/LanguageResourceTests.json
+++ b/dotCMS/src/curl-test/LanguageResourceTests.json
@@ -321,6 +321,7 @@
 									"    pm.expect(jsonData.entity.countryCode).to.eql(\"IT\");",
 									"    pm.expect(jsonData.entity.language).to.eql(\"Italian Updated\");",
 									"    pm.expect(jsonData.entity.country).to.eql(\"Italy\");",
+									"    pm.expect(jsonData.entity.id).to.eql(pm.collectionVariables.get(\"languageId\"))",
 									"});"
 								],
 								"type": "text/javascript"
@@ -791,9 +792,9 @@
 	],
 	"variable": [
 		{
-			"id": "54d5f0f8-b355-455a-9ce6-4983b8c0a292",
+			"id": "660e642e-fca8-4a93-b5b3-25f63619bef3",
 			"key": "languageId",
-			"value": 1575488414435,
+			"value": 1576101466295,
 			"type": "number"
 		}
 	],

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v2/languages/LanguagesResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v2/languages/LanguagesResource.java
@@ -190,6 +190,7 @@ public class LanguagesResource {
         if (StringUtils.isSet(languageId)) {
             final Language origLanguage = this.languageAPI.getLanguage(languageId);
             Sneaky.sneaked(()->BeanUtils.copyProperties(newLanguage, origLanguage));
+            newLanguage.setId(origLanguage.getId());
         }
 
         newLanguage.setLanguageCode(form.getLanguageCode());

--- a/dotCMS/src/main/java/com/dotcms/rest/exception/mapper/DoesNotExistExceptionMapper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/exception/mapper/DoesNotExistExceptionMapper.java
@@ -15,7 +15,6 @@ public class DoesNotExistExceptionMapper
     @Override
     public Response toResponse(final DoesNotExistException exception) {
         SecurityLogger.logInfo(DoesNotExistExceptionMapper.class, exception.getMessage());
-
         return ExceptionMapperUtil.createResponse(exception, ERROR_KEY, Response.Status.NOT_FOUND);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/exception/mapper/DotBadRequestExceptionMapper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/exception/mapper/DotBadRequestExceptionMapper.java
@@ -1,5 +1,6 @@
 package com.dotcms.rest.exception.mapper;
 
+import com.dotmarketing.util.SecurityLogger;
 import javax.ws.rs.core.Response;
 
 /**
@@ -17,6 +18,7 @@ public class DotBadRequestExceptionMapper<T extends Throwable> extends DotExcept
 
     @Override
     public Response toResponse(final T exception) {
+        SecurityLogger.logInfo(DotBadRequestExceptionMapper.class, exception.getMessage());
         return ExceptionMapperUtil.createResponse(exception, this.getErrorKey(), this.getErrorStatus());
     }
 


### PR DESCRIPTION
The id of the original Language being updated wasn't taking into consideration, hence a new one was created every time. 

A new log message was added to be consistent with the messages when handling exceptions. 