### PR TITLE
Issue 17717

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
@@ -637,7 +637,7 @@ public class GraphqlAPITest extends IntegrationTestBase {
         IntegrationTestInitService.getInstance().init();
 
         // filter only Enterprise content types
-        List<ContentType> eeTypes = APILocator
+        final List<ContentType> eeTypes = APILocator
                 .getContentTypeAPI(APILocator.systemUser()).findAll().stream()
                 .filter((type)->type instanceof EnterpriseType).collect(Collectors.toList());
 
@@ -678,7 +678,6 @@ public class GraphqlAPITest extends IntegrationTestBase {
                 .collect(Collectors.toList());
     }
 
-    @Test
     @UseDataProvider("dataProviderEEBaseTypes")
     public void testGetSchema_GivenNoEELicense_EnterpriseBaseTypeCollectionsShouldNOTBeAvailableInSchema(
             final BaseContentType baseType)

--- a/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
@@ -1,4 +1,3 @@
-
 package com.dotcms.graphql.business;
 
 import static com.dotcms.graphql.InterfaceType.CONTENT_INTERFACE_NAME;

--- a/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
@@ -1,3 +1,4 @@
+
 package com.dotcms.graphql.business;
 
 import static com.dotcms.graphql.InterfaceType.CONTENT_INTERFACE_NAME;
@@ -17,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import com.dotcms.IntegrationTestBase;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.FieldAPI;
 import com.dotcms.contenttype.model.field.Field;
@@ -43,6 +45,7 @@ import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ContentTypeBuilder;
+import com.dotcms.contenttype.model.type.EnterpriseType;
 import com.dotcms.contenttype.model.type.SimpleContentType;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
@@ -62,18 +65,21 @@ import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
+import io.vavr.Tuple2;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(DataProviderRunner.class)
-public class GraphqlAPITest {
+public class GraphqlAPITest extends IntegrationTestBase {
 
     private static CustomRandom random = new CustomRandom();
 
@@ -624,6 +630,77 @@ public class GraphqlAPITest {
             }
         }
 
+    }
+
+    @DataProvider
+    public static List<Object> dataProviderEEContentTypes() throws Exception {
+        // data provider needs stuff to get initialized because of API access
+        IntegrationTestInitService.getInstance().init();
+
+        // filter only Enterprise content types
+        List<ContentType> eeTypes = APILocator
+                .getContentTypeAPI(APILocator.systemUser()).findAll().stream()
+                .filter((type)->type instanceof EnterpriseType).collect(Collectors.toList());
+
+        // returns a List of Tuple (typeName, baseType)
+        return eeTypes.stream().map((type)->
+                new Tuple2<>("my"+type.variable(), type.baseType())
+        ).collect(Collectors.toList());
+    }
+
+    @Test
+    @UseDataProvider("dataProviderEEContentTypes")
+    public void testGetSchema_GivenNoEELicense_EnterpriseTypesShouldNotBeAvailableInSchema(
+            final Tuple2<String, BaseContentType> testCase) throws Exception{
+        ContentType customType = null;
+
+        try {
+            // create custom persona type. 1=typeName, 2=BaseType
+            customType = createType(testCase._1,
+                    testCase._2);
+
+            runNoLicense(() -> {
+                final GraphQLSchema schema = APILocator.getGraphqlAPI().getSchema();
+                assertNull(schema.getType(testCase._1));
+            });
+        } finally {
+            if(customType!=null) {
+                APILocator.getContentTypeAPI(APILocator.systemUser()).delete(customType);
+            }
+        }
+    }
+
+    @DataProvider
+    public static List<Object> dataProviderEEBaseTypes() throws Exception {
+        // data provider needs stuff to get initialized because of API access
+        IntegrationTestInitService.getInstance().init();
+        // data provider needs to return List<Object>
+        return BaseContentType.getEnterpriseBaseTypes().stream().map(baseType->(Object)baseType)
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    @UseDataProvider("dataProviderEEBaseTypes")
+    public void testGetSchema_GivenNoEELicense_EnterpriseBaseTypeCollectionsShouldNOTBeAvailableInSchema(
+            final BaseContentType baseType)
+            throws Exception{
+        APILocator.getGraphqlAPI().invalidateSchema();
+        runNoLicense(() -> {
+            final GraphQLSchema schema = APILocator.getGraphqlAPI().getSchema();
+            assertNull(schema.getQueryType().getFieldDefinition(baseType.name().toLowerCase()
+                    + "BaseTypeCollection"));
+        });
+    }
+
+    @Test
+    @UseDataProvider("dataProviderEEBaseTypes")
+    public void testGetSchema_GivenEELicense_EnterpriseBaseTypeCollectionsShouldBeAvailableInSchema(
+        final BaseContentType baseType)
+            throws Exception{
+        APILocator.getGraphqlAPI().invalidateSchema();
+        final GraphQLSchema schema = APILocator.getGraphqlAPI().getSchema();
+        assertNotNull(schema.getQueryType().getFieldDefinition(baseType.name().toLowerCase()
+                +"BaseTypeCollection"));
     }
 
     private ContentType createAndSaveSimpleContentType(final String name) throws DotSecurityException, DotDataException {

--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/type/BaseContentType.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/type/BaseContentType.java
@@ -2,6 +2,9 @@ package com.dotcms.contenttype.model.type;
 
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Provides the different Content Types that can be used inside dotCMS. A
@@ -124,6 +127,12 @@ public enum BaseContentType {
 			}
 		}
 		return ANY.immutableClass;
+	}
+
+	public static List<BaseContentType> getEnterpriseBaseTypes() {
+		return Arrays.stream(BaseContentType.values()).filter((baseType ->
+				EnterpriseType.class.isAssignableFrom(baseType.immutableClass())))
+				.collect(Collectors.toList());
 	}
 
 }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/type/BaseContentType.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/type/BaseContentType.java
@@ -130,8 +130,8 @@ public enum BaseContentType {
 	}
 
 	public static List<BaseContentType> getEnterpriseBaseTypes() {
-		return Arrays.stream(BaseContentType.values()).filter((baseType ->
-				EnterpriseType.class.isAssignableFrom(baseType.immutableClass())))
+		return Arrays.stream(BaseContentType.values()).filter(baseType ->
+				EnterpriseType.class.isAssignableFrom(baseType.immutableClass()))
 				.collect(Collectors.toList());
 	}
 

--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/type/EnterpriseType.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/type/EnterpriseType.java
@@ -1,0 +1,7 @@
+package com.dotcms.contenttype.model.type;
+
+/**
+ * Interface to mark types that are enterprise only
+ */
+public interface EnterpriseType {
+}

--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/type/FormContentType.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/type/FormContentType.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonDeserialize(as = ImmutableFormContentType.class)
 @Gson.TypeAdapters
 @Value.Immutable
-public abstract class FormContentType extends ContentType implements Expireable{
+public abstract class FormContentType extends ContentType implements Expireable, EnterpriseType {
 
 	public abstract static class Builder implements ContentTypeBuilder {}
 

--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/type/PersonaContentType.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/type/PersonaContentType.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonDeserialize(as = ImmutablePersonaContentType.class)
 @Gson.TypeAdapters
 @Value.Immutable
-public abstract class PersonaContentType extends ContentType implements Expireable{
+public abstract class PersonaContentType extends ContentType implements Expireable, EnterpriseType {
 
 
 

--- a/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
@@ -41,7 +41,6 @@ import com.dotcms.graphql.datafetcher.SiteFieldDataFetcher;
 import com.dotcms.graphql.datafetcher.TitleImageFieldDataFetcher;
 import com.dotcms.graphql.datafetcher.UserDataFetcher;
 import com.dotcms.graphql.resolver.ContentResolver;
-import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
 import com.dotmarketing.util.Logger;
 import graphql.schema.GraphQLInterfaceType;
 import java.util.HashMap;
@@ -133,7 +132,7 @@ public enum InterfaceType {
 
         for(final InterfaceType type : InterfaceType.values()) {
             if(type.getType()!=null) {
-                if((!EnterpriseType.class.isAssignableFrom(type.baseContentType) || isStandardOrEnterprise())) {
+                if(!EnterpriseType.class.isAssignableFrom(type.baseContentType) || isStandardOrEnterprise()) {
                     types.add(type.getType());
                 }
             }

--- a/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
@@ -23,12 +23,25 @@ import static graphql.Scalars.GraphQLID;
 import static graphql.Scalars.GraphQLString;
 
 import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.model.type.EnterpriseType;
+import com.dotcms.contenttype.model.type.FileAssetContentType;
+import com.dotcms.contenttype.model.type.FormContentType;
+import com.dotcms.contenttype.model.type.KeyValueContentType;
+import com.dotcms.contenttype.model.type.PageContentType;
+import com.dotcms.contenttype.model.type.PersonaContentType;
+import com.dotcms.contenttype.model.type.SimpleContentType;
+import com.dotcms.contenttype.model.type.VanityUrlContentType;
+import com.dotcms.contenttype.model.type.WidgetContentType;
+import com.dotcms.enterprise.LicenseUtil;
+import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.graphql.datafetcher.FolderFieldDataFetcher;
 import com.dotcms.graphql.datafetcher.LanguageDataFetcher;
 import com.dotcms.graphql.datafetcher.SiteFieldDataFetcher;
 import com.dotcms.graphql.datafetcher.TitleImageFieldDataFetcher;
 import com.dotcms.graphql.datafetcher.UserDataFetcher;
 import com.dotcms.graphql.resolver.ContentResolver;
+import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
 import com.dotmarketing.util.Logger;
 import graphql.schema.GraphQLInterfaceType;
 import java.util.HashMap;
@@ -37,15 +50,21 @@ import java.util.Map;
 import java.util.Set;
 
 public enum InterfaceType {
-    CONTENTLET,
-    CONTENT,
-    FILEASSET,
-    HTMLPAGE,
-    PERSONA,
-    WIDGET,
-    VANITY_URL,
-    KEY_VALUE,
-    FORM;
+    CONTENTLET(SimpleContentType.class),
+    CONTENT(SimpleContentType.class),
+    FILEASSET(FileAssetContentType.class),
+    HTMLPAGE(PageContentType.class),
+    PERSONA(PersonaContentType.class),
+    WIDGET(WidgetContentType.class),
+    VANITY_URL(VanityUrlContentType.class),
+    KEY_VALUE(KeyValueContentType.class),
+    FORM(FormContentType.class);
+
+    private Class<? extends ContentType> baseContentType;
+
+    InterfaceType(final Class<? extends ContentType> baseContentType) {
+        this.baseContentType = baseContentType;
+    }
 
     private static Map<String, GraphQLInterfaceType> interfaceTypes = new HashMap<>();
 
@@ -114,7 +133,9 @@ public enum InterfaceType {
 
         for(final InterfaceType type : InterfaceType.values()) {
             if(type.getType()!=null) {
-                types.add(type.getType());
+                if((!EnterpriseType.class.isAssignableFrom(type.baseContentType) || isStandardOrEnterprise())) {
+                    types.add(type.getType());
+                }
             }
         }
 
@@ -130,6 +151,10 @@ public enum InterfaceType {
         }
 
         return type;
+    }
+
+    private static boolean isStandardOrEnterprise() {
+        return LicenseUtil.getLevel() > LicenseLevel.COMMUNITY.level;
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
@@ -132,7 +132,8 @@ public enum InterfaceType {
 
         for(final InterfaceType type : InterfaceType.values()) {
             if(type.getType()!=null) {
-                if(!EnterpriseType.class.isAssignableFrom(type.baseContentType) || isStandardOrEnterprise()) {
+                if(!EnterpriseType.class.isAssignableFrom(type.baseContentType)
+                        || LicenseUtil.getLevel() > LicenseLevel.COMMUNITY.level) {
                     types.add(type.getType());
                 }
             }
@@ -151,9 +152,4 @@ public enum InterfaceType {
 
         return type;
     }
-
-    private static boolean isStandardOrEnterprise() {
-        return LicenseUtil.getLevel() > LicenseLevel.COMMUNITY.level;
-    }
-
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
@@ -259,7 +259,7 @@ public class GraphqlAPIImpl implements GraphqlAPI {
 
         List<ContentType> allTypes = contentTypeAPI.findAll();
         // exclude ee types when no license
-        if(!isStandardOrEnterprise()) {
+        if(LicenseUtil.getLevel() <= LicenseLevel.COMMUNITY.level) {
             allTypes = allTypes.stream().filter((type) ->!(type instanceof EnterpriseType))
                     .collect(Collectors.toList());
         }
@@ -347,9 +347,4 @@ public class GraphqlAPIImpl implements GraphqlAPI {
 
         return APILocator.getContentTypeAPI(user).find(relatedContentTypeId);
     }
-
-    private static boolean isStandardOrEnterprise() {
-        return LicenseUtil.getLevel() > LicenseLevel.COMMUNITY.level;
-    }
-
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
@@ -1,5 +1,14 @@
 package com.dotcms.graphql.business;
 
+import static com.dotcms.graphql.util.TypeUtil.BASE_TYPE_SUFFIX;
+import static graphql.Scalars.GraphQLFloat;
+import static graphql.Scalars.GraphQLInt;
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLList.list;
+import static graphql.schema.GraphQLNonNull.nonNull;
+import static graphql.schema.GraphQLObjectType.newObject;
+
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.model.field.BinaryField;
 import com.dotcms.contenttype.model.field.CategoryField;
@@ -34,7 +43,6 @@ import com.dotcms.graphql.datafetcher.RelationshipFieldDataFetcher;
 import com.dotcms.graphql.datafetcher.SiteOrFolderFieldDataFetcher;
 import com.dotcms.graphql.datafetcher.TagsFieldDataFetcher;
 import com.dotcms.graphql.util.TypeUtil;
-import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
 import com.dotcms.util.LogTime;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
@@ -46,17 +54,6 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.ConfigUtils;
 import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import graphql.scalars.ExtendedScalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLArgument;
@@ -68,16 +65,16 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
 import graphql.schema.idl.SchemaPrinter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
-
-import static com.dotcms.graphql.util.TypeUtil.BASE_TYPE_SUFFIX;
-import static graphql.Scalars.GraphQLFloat;
-import static graphql.Scalars.GraphQLInt;
-import static graphql.Scalars.GraphQLString;
-import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
-import static graphql.schema.GraphQLList.list;
-import static graphql.schema.GraphQLNonNull.nonNull;
-import static graphql.schema.GraphQLObjectType.newObject;
 
 public class GraphqlAPIImpl implements GraphqlAPI {
 


### PR DESCRIPTION
This PR excludes both the Base Types (collections) and Content Types whose Base Type is available in EE only.

To achieve this and to avoid having to hardcode the list of EE Base Types, a new Interface called `EnterpriseType` was created to label the EE Base Types. 

Also a convenience method to get the EE Base Types (using this new interface) was added to the `BaseContentType` Enum.

New Integration Tests for both EE Base Types and Content Types were added for both scenarios, running with and without valid ee license.
