### PR TITLE
#17620 Moving getAbsoluteAssetsRootPath method to ConfigUtils

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/filters/CMSFilter.java
+++ b/dotCMS/src/main/java/com/dotmarketing/filters/CMSFilter.java
@@ -28,7 +28,7 @@ public class CMSFilter implements Filter {
     private final HttpServletResponseThreadLocal responseThreadLocal = HttpServletResponseThreadLocal.INSTANCE;
     private CMSUrlUtil urlUtil = CMSUrlUtil.getInstance();
     private static VisitorAPI visitorAPI = APILocator.getVisitorAPI();
-    private final String RELATIVE_ASSET_PATH = APILocator.getFileAssetAPI().getRelativeAssetsRootPath();
+    private final String RELATIVE_ASSET_PATH = ConfigUtils.getRelativeAssetsRootPath();
     public static final String CMS_INDEX_PAGE = Config.getStringProperty("CMS_INDEX_PAGE", "index");
 
     public enum IAm {

--- a/dotCMS/src/main/java/com/dotmarketing/filters/CMSFilter.java
+++ b/dotCMS/src/main/java/com/dotmarketing/filters/CMSFilter.java
@@ -28,7 +28,7 @@ public class CMSFilter implements Filter {
     private final HttpServletResponseThreadLocal responseThreadLocal = HttpServletResponseThreadLocal.INSTANCE;
     private CMSUrlUtil urlUtil = CMSUrlUtil.getInstance();
     private static VisitorAPI visitorAPI = APILocator.getVisitorAPI();
-    private final String RELATIVE_ASSET_PATH = ConfigUtils.getRelativeAssetsRootPath();
+    private final String RELATIVE_ASSET_PATH = APILocator.getFileAssetAPI().getRelativeAssetsRootPath();
     public static final String CMS_INDEX_PAGE = Config.getStringProperty("CMS_INDEX_PAGE", "index");
 
     public enum IAm {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/cmsmaintenance/ajax/CMSMaintenanceAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/cmsmaintenance/ajax/CMSMaintenanceAjax.java
@@ -18,7 +18,6 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.cms.factories.PublicCompanyFactory;
 import com.dotmarketing.common.db.DotConnect;
-import com.dotmarketing.common.reindex.ReindexThread;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.db.HibernateUtil;
 import com.dotmarketing.exception.DotDataException;
@@ -65,7 +64,6 @@ import com.thoughtworks.xstream.io.xml.DomDriver;
 import com.thoughtworks.xstream.mapper.Mapper;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -395,24 +393,19 @@ public class CMSMaintenanceAjax {
 			Logger.info(this, "Deleted " + count + " Files");
 		}
 
-		public void moveAssetsToBackupDir() throws FileNotFoundException, IOException{
+		public void moveAssetsToBackupDir() throws IOException{
 			validateUser();
-			String assetDir;
-			File backupDir = new File(backupTempFilePath);
+			final String assetDir = ConfigUtils.getAbsoluteAssetsRootPath();
+			final File backupDir = new File(backupTempFilePath);
 			backupDir.mkdirs();
 			Logger.info(this, "Moving assets to back up directory: " + backupTempFilePath);
-			if(!UtilMethods.isSet(assetRealPath)){
-				assetDir = FileUtil.getRealPath(assetPath);
-			}else{
-				assetDir = assetRealPath;
-			}
 			FileUtil.copyDirectory(assetDir, backupTempFilePath + File.separator + "asset", new AssetFileNameFilter());
 
 			//do not ship the license.
-			String f = backupTempFilePath + File.separator + "asset" + File.separator + "license";
+			final String f = backupTempFilePath + File.separator + "asset" + File.separator + "license";
 			FileUtil.deltree(f);
 
-			String d = backupTempFilePath + File.separator + "asset" + File.separator + "dotGenerated";
+			final String d = backupTempFilePath + File.separator + "asset" + File.separator + "dotGenerated";
 			FileUtil.deltree(d);
 
 		}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
@@ -38,6 +38,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import com.liferay.util.StringPool;
+import io.vavr.control.Try;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -596,7 +597,10 @@ public class FileAssetAPIImpl implements FileAssetAPI {
      * @return the relative folder of where assets are stored
 	 */
 	public String getRelativeAssetsRootPath() {
-        return ConfigUtils.getRelativeAssetsRootPath();
+        String path = "";
+        path = Try.of(() -> Config.getStringProperty("ASSET_PATH", DEFAULT_RELATIVE_ASSET_PATH))
+                .getOrElse(DEFAULT_RELATIVE_ASSET_PATH);
+        return path;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
@@ -31,13 +31,13 @@ import com.dotmarketing.portlets.structure.factories.FieldFactory;
 import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.ConfigUtils;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import com.liferay.util.StringPool;
-import io.vavr.control.Try;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -596,9 +596,7 @@ public class FileAssetAPIImpl implements FileAssetAPI {
      * @return the relative folder of where assets are stored
 	 */
 	public String getRelativeAssetsRootPath() {
-        String path = "";
-        path = Try.of(()->Config.getStringProperty("ASSET_PATH", DEFAULT_RELATIVE_ASSET_PATH)).getOrElse(DEFAULT_RELATIVE_ASSET_PATH);
-        return path;
+        return ConfigUtils.getRelativeAssetsRootPath();
     }
 
     /**
@@ -607,13 +605,7 @@ public class FileAssetAPIImpl implements FileAssetAPI {
      * @return the root folder of where assets are stored
      */
     public String getRealAssetsRootPath() {
-        String realPath = Try.of(()->Config.getStringProperty("ASSET_REAL_PATH")).getOrNull();
-        if (UtilMethods.isSet(realPath) && !realPath.endsWith(java.io.File.separator))
-            realPath = realPath + java.io.File.separator;
-        if (!UtilMethods.isSet(realPath))
-            return FileUtil.getRealPath(getRelativeAssetsRootPath());
-        else
-            return realPath;
+        return ConfigUtils.getAbsoluteAssetsRootPath();
     }
 
 	public String getRealAssetPath(String inode) {

--- a/dotCMS/src/main/java/com/dotmarketing/util/ConfigUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ConfigUtils.java
@@ -126,8 +126,8 @@ public class ConfigUtils {
      */
     public static String getAbsoluteAssetsRootPath() {
         String realPath = Config.getStringProperty("ASSET_REAL_PATH", null);
-        if (UtilMethods.isSet(realPath) && !realPath.endsWith(java.io.File.separator)) {
-            realPath = realPath + java.io.File.separator;
+        if (UtilMethods.isSet(realPath) && !realPath.endsWith(File.separator)) {
+            realPath = realPath + File.separator;
         }
         if (!UtilMethods.isSet(realPath)) {
             return FileUtil.getRealPath(getRelativeAssetsRootPath());

--- a/dotCMS/src/main/java/com/dotmarketing/util/ConfigUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ConfigUtils.java
@@ -130,21 +130,12 @@ public class ConfigUtils {
             realPath = realPath + File.separator;
         }
         if (!UtilMethods.isSet(realPath)) {
-            return FileUtil.getRealPath(getRelativeAssetsRootPath());
+            final String path = Try
+                    .of(() -> Config.getStringProperty("ASSET_PATH", DEFAULT_RELATIVE_ASSET_PATH))
+                    .getOrElse(DEFAULT_RELATIVE_ASSET_PATH);
+            return FileUtil.getRealPath(path);
         } else {
             return realPath;
         }
-    }
-
-    /**
-     * This method returns the relative path for assets
-     *
-     * @return the relative folder of where assets are stored
-     */
-    public static String getRelativeAssetsRootPath() {
-        String path = "";
-        path = Try.of(() -> Config.getStringProperty("ASSET_PATH", DEFAULT_RELATIVE_ASSET_PATH))
-                .getOrElse(DEFAULT_RELATIVE_ASSET_PATH);
-        return path;
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/ConfigUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ConfigUtils.java
@@ -2,8 +2,8 @@ package com.dotmarketing.util;
 
 import com.dotmarketing.business.APILocator;
 import com.liferay.util.FileUtil;
+import io.vavr.control.Try;
 import java.io.File;
-import java.util.UUID;
 
 /**
  * Generic class to get return configuration parameters, and any logic required
@@ -20,6 +20,8 @@ public class ConfigUtils {
      * This property determine if the app is running on dev mode.
      */
     public static final String DEV_MODE_KEY = "dotcms.dev.mode";
+
+    private final static String DEFAULT_RELATIVE_ASSET_PATH = "/assets";
 
 	/**
 	 * Returns true if app is running on dev mode.
@@ -117,4 +119,32 @@ public class ConfigUtils {
 	}
 
 
+    /**
+     * This method returns the absolute root path for assets
+     *
+     * @return the root folder of where assets are stored
+     */
+    public static String getAbsoluteAssetsRootPath() {
+        String realPath = Config.getStringProperty("ASSET_REAL_PATH", null);
+        if (UtilMethods.isSet(realPath) && !realPath.endsWith(java.io.File.separator)) {
+            realPath = realPath + java.io.File.separator;
+        }
+        if (!UtilMethods.isSet(realPath)) {
+            return FileUtil.getRealPath(getRelativeAssetsRootPath());
+        } else {
+            return realPath;
+        }
+    }
+
+    /**
+     * This method returns the relative path for assets
+     *
+     * @return the relative folder of where assets are stored
+     */
+    public static String getRelativeAssetsRootPath() {
+        String path = "";
+        path = Try.of(() -> Config.getStringProperty("ASSET_PATH", DEFAULT_RELATIVE_ASSET_PATH))
+                .getOrElse(DEFAULT_RELATIVE_ASSET_PATH);
+        return path;
+    }
 }


### PR DESCRIPTION
The logic in `FileAssetAPIImpl.getRealAssetsRootPath` was moved to `ConfigUtils.getAbsoluteAssetsRootPath`

Additionally, `CMSMaintenanceAjax.moveAssetsToBackupDir` invokes `ConfigUtils.getAbsoluteAssetsRootPath` to fix the issue