### PR TITLE
Issue 17698 webdav casing issues

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/webdav/DotWebdavHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/webdav/DotWebdavHelperTest.java
@@ -1,0 +1,118 @@
+package com.dotmarketing.webdav;
+
+import com.dotcms.datagen.FileAssetDataGen;
+import com.dotcms.datagen.FolderDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.repackage.com.bradmcevoy.http.FileResource;
+import com.dotcms.repackage.com.bradmcevoy.http.FolderResource;
+import com.dotcms.repackage.com.bradmcevoy.http.Resource;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.folders.model.Folder;
+import com.liferay.util.FileUtil;
+import java.io.IOException;
+import java.util.Random;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DotWebdavHelperTest {
+
+    private final DotWebdavHelper helper = new DotWebdavHelper();
+
+    @Test
+    public void Test_Get_Folder_Resource_Then_Get_File_Resource() throws IOException, DotDataException, DotSecurityException {
+        final SiteDataGen siteDataGen = new SiteDataGen();
+        final FolderDataGen folderDataGen = new FolderDataGen();
+        final Host host = siteDataGen.nextPersisted();
+        final Folder parent = folderDataGen.site(host).nextPersisted();
+        final Folder child = folderDataGen.parent(parent).nextPersisted();
+        java.io.File file = java.io.File.createTempFile("texto", ".txt");
+        FileUtil.write(file, "helloworld");
+        FileAssetDataGen fileAssetDataGen = new FileAssetDataGen(child, file);
+        fileAssetDataGen.nextPersisted();
+        final String folderPath = String.format("http://localhost:8080/webdav/live/1/%s/%s/",host.getName(),parent.getName());
+        final Resource folderResource = helper.getResourceFromURL(folderPath);
+        Assert.assertNotNull(folderResource);
+        Assert.assertTrue(folderResource instanceof FolderResource);
+        final String fileResourcePath = String.format("http://localhost:8080/webdav/live/1/%s/%s/%s/%s",host.getName(),parent.getName(),child.getName(),file.getName());
+        final Resource fileResource = helper.getResourceFromURL(fileResourcePath);
+        Assert.assertNotNull(fileResource);
+        Assert.assertTrue(fileResource instanceof FileResource);
+    }
+
+
+    @Test
+    public void Test_Get_Folder_Resource_Then_Get_File_Resource_Shuffled_Casing() throws IOException, DotDataException, DotSecurityException {
+        final SiteDataGen siteDataGen = new SiteDataGen();
+        final FolderDataGen folderDataGen = new FolderDataGen();
+        final Host host = siteDataGen.nextPersisted();
+        final Folder parent = folderDataGen.site(host).nextPersisted();
+        final Folder child = folderDataGen.parent(parent).nextPersisted();
+        java.io.File file = java.io.File.createTempFile("texto", ".txt");
+        FileUtil.write(file, "helloworld");
+        FileAssetDataGen fileAssetDataGen = new FileAssetDataGen(child, file);
+        fileAssetDataGen.nextPersisted();
+        final String folderPath = upperCaseRandom(String.format("http://localhost:8080/webdav/live/1/%s/%s/",host.getName(),parent.getName()), 8);
+
+        final Resource folderResource = helper.getResourceFromURL(folderPath);
+        Assert.assertNotNull(folderResource);
+        Assert.assertTrue(folderResource instanceof FolderResource);
+        final String fileResourcePath = upperCaseRandom(String.format("http://localhost:8080/webdav/live/1/%s/%s/%s/%s",host.getName(),parent.getName(),child.getName(),file.getName()),8);
+        final Resource fileResource = helper.getResourceFromURL(fileResourcePath);
+        Assert.assertNotNull(fileResource);
+        Assert.assertTrue(fileResource instanceof FileResource);
+    }
+
+    @Test
+    public void Test_Get_Folder_Resource_For_Non_Existing_Path() throws IOException, DotDataException, DotSecurityException {
+        String path = "http://localhost:8080/webdav/live/1/demo.dotcms.com/images/black.png";
+        final Resource folderResource = helper.getResourceFromURL(path);
+        Assert.assertNull(folderResource);
+    }
+
+    @Test
+    public void Test_Same_Resource_For_Paths_With_Different_Casing() throws IOException, DotDataException, DotSecurityException {
+        final SiteDataGen siteDataGen = new SiteDataGen();
+        final FolderDataGen folderDataGen = new FolderDataGen();
+        final Host host = siteDataGen.nextPersisted();
+        final Folder parent = folderDataGen.site(host).nextPersisted();
+        final Folder child = folderDataGen.parent(parent).nextPersisted();
+        java.io.File file = java.io.File.createTempFile("texto", ".txt");
+        FileUtil.write(file, "helloworld");
+        FileAssetDataGen fileAssetDataGen = new FileAssetDataGen(child, file);
+        fileAssetDataGen.nextPersisted();
+        final String path = String.format("http://localhost:8080/webdav/live/1/%s/%s/%s/%s",host.getName(),parent.getName(),child.getName(),file.getName());
+        final String fileResourcePath1 = upperCaseRandom(path,8);
+        final String fileResourcePath2 = upperCaseRandom(path,10);
+        Assert.assertNotEquals(fileResourcePath1,fileResourcePath2);
+        Assert.assertTrue(helper.isSameResourceURL(fileResourcePath1,fileResourcePath2, file.getName()));
+    }
+
+    private static String upperCaseRandom(final String input, final int n) {
+        final int length = input.length();
+        final StringBuilder output = new StringBuilder(input);
+        final boolean[] alreadyChecked = new boolean[length];
+        final Random random = new Random();
+
+        for (int i = 0, checks = 0; i < n && checks < length; i++) {
+            // Pick a place
+            final int position = random.nextInt(length);
+
+            // Check if lowercase alpha
+            if (!alreadyChecked[position]) {
+                if (Character.isLowerCase(output.charAt(position))) {
+                    output.setCharAt(position, Character.toUpperCase(output.charAt(position)));
+                } else {
+                    i--;
+                }
+                checks++;
+                alreadyChecked[position] = true;
+            } else {
+                i--;
+            }
+        }
+        return output.toString();
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -134,7 +134,7 @@ public class FolderAPIImpl implements FolderAPI  {
 		boolean renamed;
 
 		if (!permissionAPI.doesUserHavePermission(folder, PermissionAPI.PERMISSION_EDIT, user, respectFrontEndPermissions)) {
-			throw new DotSecurityException("User " + (user.getUserId() != null?user.getUserId() : BLANK) + " does not have permission to edit folder" + folder.getPath());
+			throw new DotSecurityException("User " + (user.getUserId() != null?user.getUserId() : BLANK) + " does not have permission to edit folder " + folder.getPath());
 		}
 
 		try {

--- a/dotCMS/src/main/java/com/dotmarketing/webdav/BasicFolderResourceImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/webdav/BasicFolderResourceImpl.java
@@ -63,7 +63,6 @@ public abstract class BasicFolderResourceImpl implements FolderResource {
         }
 
         newName = this.dotDavHelper.deleteSpecialCharacter(newName);
-        newName = newName.toLowerCase();
 
         if(!dotDavHelper.isTempResource(newName)) {
 

--- a/dotCMS/src/main/java/com/dotmarketing/webdav/HostResourceImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/webdav/HostResourceImpl.java
@@ -1,15 +1,5 @@
 package com.dotmarketing.webdav;
 
-import com.dotmarketing.portlets.folders.business.FolderAPIImpl;
-import com.dotmarketing.portlets.folders.exception.InvalidFolderNameException;
-import com.dotmarketing.util.UtilMethods;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import com.dotcms.repackage.com.bradmcevoy.http.Auth;
 import com.dotcms.repackage.com.bradmcevoy.http.CollectionResource;
 import com.dotcms.repackage.com.bradmcevoy.http.FolderResource;
@@ -18,7 +8,6 @@ import com.dotcms.repackage.com.bradmcevoy.http.LockInfo;
 import com.dotcms.repackage.com.bradmcevoy.http.LockResult;
 import com.dotcms.repackage.com.bradmcevoy.http.LockTimeout;
 import com.dotcms.repackage.com.bradmcevoy.http.LockToken;
-import com.dotcms.repackage.com.bradmcevoy.http.LockableResource;
 import com.dotcms.repackage.com.bradmcevoy.http.LockingCollectionResource;
 import com.dotcms.repackage.com.bradmcevoy.http.MakeCollectionableResource;
 import com.dotcms.repackage.com.bradmcevoy.http.PropFindableResource;
@@ -27,7 +16,6 @@ import com.dotcms.repackage.com.bradmcevoy.http.Request.Method;
 import com.dotcms.repackage.com.bradmcevoy.http.Resource;
 import com.dotcms.repackage.com.bradmcevoy.http.exceptions.BadRequestException;
 import com.dotcms.repackage.com.bradmcevoy.http.exceptions.ConflictException;
-import com.dotcms.repackage.com.bradmcevoy.http.exceptions.LockedException;
 import com.dotcms.repackage.com.bradmcevoy.http.exceptions.NotAuthorizedException;
 import com.dotcms.repackage.com.bradmcevoy.http.exceptions.PreConditionFailedException;
 import com.dotmarketing.beans.Host;
@@ -39,11 +27,17 @@ import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.fileassets.business.FileAsset;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
+import com.dotmarketing.portlets.folders.exception.InvalidFolderNameException;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 public class HostResourceImpl extends BasicFolderResourceImpl implements Resource, CollectionResource, FolderResource, PropFindableResource, MakeCollectionableResource, LockingCollectionResource{
 
@@ -118,20 +112,24 @@ public class HostResourceImpl extends BasicFolderResourceImpl implements Resourc
 	}
 
 	public Resource child(String childName) {
-	    User user=(User)HttpManager.request().getAuthorization().getTag();
-		String uri="/"+childName;
+		if (dotDavHelper.isSameTargetAndDestinationResourceOnMove(childName)) {
+			//This a small hack that prevents Milton's MoveHandler from removing the destination folder when the source and destination are the same.
+			return null;
+		}
+	    final User user = (User)HttpManager.request().getAuthorization().getTag();
+		final String uri="/"+childName;
 		
 		try {
-		    Identifier ident=APILocator.getIdentifierAPI().find(host, uri);
+		    final Identifier ident = APILocator.getIdentifierAPI().find(host, uri);
 		    if(ident!=null && InodeUtils.isSet(ident.getInode())) {
 		        if(ident.getAssetType().equals("folder")) {
-		            Folder folder = APILocator.getFolderAPI().findFolderByPath(uri, host, user, false);
+		            final Folder folder = APILocator.getFolderAPI().findFolderByPath(uri, host, user, false);
 		            if(folder!=null && InodeUtils.isSet(folder.getInode())) {
 		                return new FolderResourceImpl(folder,path+folder.getPath());
 		            }
 		        }
 		        else if(ident.getAssetType().equals("contentlet")) {
-		            Contentlet cont=APILocator.getContentletAPI().findContentletByIdentifier(ident.getId(), false, 1, user, false);
+					final Contentlet cont=APILocator.getContentletAPI().findContentletByIdentifier(ident.getId(), false, 1, user, false);
 		            if(cont!=null && InodeUtils.isSet(cont.getInode())) {
 		                return new FileResourceImpl(APILocator.getFileAssetAPI().fromContentlet(cont),path+uri);
 		            }

--- a/dotCMS/src/main/java/com/dotmarketing/webdav/ResourceFactorytImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/webdav/ResourceFactorytImpl.java
@@ -27,10 +27,10 @@ import com.liferay.util.FileUtil;
 public class ResourceFactorytImpl implements ResourceFactory, Initable {
 
 	private DotWebdavHelper dotDavHelper;
-	private static final String AUTOPUB_PATH = "/webdav/autopub";
-	private static final String NONPUB_PATH = "/webdav/nonpub";
-	private static final String LIVE_PATH = "/webdav/live";
-	private static final String WORKING_PATH = "/webdav/working";
+	static final String AUTOPUB_PATH = "/webdav/autopub";
+	static final String NONPUB_PATH = "/webdav/nonpub";
+	static final String LIVE_PATH = "/webdav/live";
+	static final String WORKING_PATH = "/webdav/working";
 	private HostAPI hostAPI = APILocator.getHostAPI();
 	
 	public ResourceFactorytImpl() {

--- a/dotCMS/src/main/java/com/dotmarketing/webdav/ResourceFactorytImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/webdav/ResourceFactorytImpl.java
@@ -43,26 +43,30 @@ public class ResourceFactorytImpl implements ResourceFactory, Initable {
 	 */
     @WrapInTransaction
 	public Resource getResource(String davHost, String url) {
+		return getResource(davHost, url, dotDavHelper, hostAPI);
+	}
+
+	public static Resource getResource(final String davHost, String url, final DotWebdavHelper dotDavHelper, final HostAPI hostAPI) {
 		url = url.toLowerCase();
-    	Logger.debug(this, "WebDav ResourceFactory: Host is " + davHost + " and the url is " + url);
+		Logger.debug(ResourceFactorytImpl.class, "WebDav ResourceFactory: Host is " + davHost + " and the url is " + url);
 		try{
 			dotDavHelper.stripMapping(url);//method also sets the language
 			boolean isFolder = false;
 			boolean isResource = false;
-			boolean isWebDavRoot = url.equals(AUTOPUB_PATH) || url.equals(NONPUB_PATH) || url.equals(LIVE_PATH + "/" +dotDavHelper.getLanguage()) || url.equals(WORKING_PATH + "/" +dotDavHelper.getLanguage()) 
+			boolean isWebDavRoot = url.equals(AUTOPUB_PATH) || url.equals(NONPUB_PATH) || url.equals(LIVE_PATH + "/" +dotDavHelper.getLanguage()) || url.equals(WORKING_PATH + "/" +dotDavHelper.getLanguage())
 					|| url.equals(AUTOPUB_PATH + "/") || url.equals(NONPUB_PATH + "/") || url.equals(LIVE_PATH + "/" +dotDavHelper.getLanguage() + "/") || url.equals(WORKING_PATH + "/" +dotDavHelper.getLanguage() + "/") ;
 			boolean live = url.startsWith(AUTOPUB_PATH) || url.startsWith(LIVE_PATH);
 			boolean working = url.startsWith(NONPUB_PATH) || url.startsWith(WORKING_PATH);
 			Host host =null;
-			String actualPath = url; 
-			
+			String actualPath = url;
+
 			// DAV ROOT
 			if(isWebDavRoot){
 				WebdavRootResourceImpl wr = new WebdavRootResourceImpl(url);
 				return wr;
 			}
-			
-			
+
+
 			//SETUP
 			if(live){
 				actualPath = actualPath.replaceAll(AUTOPUB_PATH, "");
@@ -79,54 +83,54 @@ public class ResourceFactorytImpl implements ResourceFactory, Initable {
 			}else{
 				return null;
 			}
-			
+
 			if(!Config.getBooleanProperty("WEBDAV_LEGACY_PATHING", false)){
 				actualPath = actualPath.substring(String.valueOf(dotDavHelper.getLanguage()).length()+1);
 			}
-			
+
 			String[] splitPath = actualPath.split("/");
-			
-			
+
+
 			User user=APILocator.getUserAPI().getSystemUser();
-			
-			
+
+
 			// Handle root SYSTEM or Root Host view
 			if(splitPath != null && splitPath.length == 1){
-			    if(dotDavHelper.isTempResource(url)){ 
-			        return null;
-			    }
-			    else {
-    				host = hostAPI.findByName(splitPath[0], user, false);
-    				if(splitPath[0].equalsIgnoreCase("system")){
-    					SystemRootResourceImpl sys = new SystemRootResourceImpl();
-    					return sys;
-    				}else{
-    					HostResourceImpl hr = new HostResourceImpl(url);
-    					return hr;
-    				}
-			    }
+				if(dotDavHelper.isTempResource(url)){
+					return null;
+				}
+				else {
+					host = hostAPI.findByName(splitPath[0], user, false);
+					if(splitPath[0].equalsIgnoreCase("system")){
+						SystemRootResourceImpl sys = new SystemRootResourceImpl();
+						return sys;
+					}else{
+						HostResourceImpl hr = new HostResourceImpl(url);
+						return hr;
+					}
+				}
 			}
-		
-			
+
+
 			// handle crappy dav clients temp files
 			if(dotDavHelper.isTempResource(url)){
 				java.io.File tempFile = dotDavHelper.loadTempFile(url);
 				if(tempFile == null || !tempFile.exists()){
 					return null;
 				}else if(tempFile.isDirectory()){
-						TempFolderResourceImpl tr = new TempFolderResourceImpl(url,tempFile,dotDavHelper.isAutoPub(url));
-						return tr;
+					TempFolderResourceImpl tr = new TempFolderResourceImpl(url,tempFile,dotDavHelper.isAutoPub(url));
+					return tr;
 				}else{
 					TempFileResourceImpl tr = new TempFileResourceImpl(tempFile,url,dotDavHelper.isAutoPub(url));
 					return tr;
 				}
 			}
-			
-			
+
+
 			// handle language files
-			if(actualPath.endsWith("system/languages") || actualPath.endsWith("system/languages/") 
+			if(actualPath.endsWith("system/languages") || actualPath.endsWith("system/languages/")
 					|| actualPath.endsWith("system/languages/archived") || actualPath.endsWith("system/languages/archived/")){
-		        java.io.File file = new java.io.File(FileUtil.getRealPath("/assets/messages"));
+				java.io.File file = new java.io.File(FileUtil.getRealPath("/assets/messages"));
 				if(file.exists() && file.isDirectory()){
 					if(actualPath.contains("/archived") && actualPath.endsWith("/")){
 						actualPath = actualPath.replace("system/languages/", "");
@@ -141,7 +145,7 @@ public class ResourceFactorytImpl implements ResourceFactory, Initable {
 					}
 				}
 			}
-			
+
 			// handle the language files
 			if(actualPath.endsWith("/")){
 				actualPath = actualPath.substring(0, actualPath.length()-1);
@@ -170,22 +174,22 @@ public class ResourceFactorytImpl implements ResourceFactory, Initable {
 					return lfr;
 				}
 			}
-			
+
 			if(dotDavHelper.isResource(url,user)){
 				isResource = true;
 			}
-			
+
 			if(dotDavHelper.isFolder(url,user)){
 				isFolder = true;
 			}
 			if(!isFolder && !isResource){
 				return null;
 			}
-			
+
 			if(!isFolder && isResource){
 				IFileAsset file = dotDavHelper.loadFile(url,user);
 				if(file == null || !InodeUtils.isSet(file.getInode())){
-					Logger.debug(this, "The file for url " + url + " returned null or not in db");
+					Logger.debug(ResourceFactorytImpl.class, "The file for url " + url + " returned null or not in db");
 					return null;
 				}
 				FileResourceImpl fr = new FileResourceImpl(file,url);
@@ -193,17 +197,18 @@ public class ResourceFactorytImpl implements ResourceFactory, Initable {
 			}else{
 				Folder folder = dotDavHelper.loadFolder(url,user);
 				if(folder == null || !InodeUtils.isSet(folder.getInode())){
-					Logger.debug(this, "The folder for url " + url + " returned null or not in db");
+					Logger.debug(ResourceFactorytImpl.class, "The folder for url " + url + " returned null or not in db");
 					return null;
 				}
 				FolderResourceImpl fr = new FolderResourceImpl(folder, url);
 				return fr;
 			}
 		} catch (Exception e) {
-			Logger.error(this, e.getMessage(), e);
+			Logger.error(ResourceFactorytImpl.class, e.getMessage(), e);
 			return null;
 		}
 	}
+
 
 	/* (non-Javadoc)
 	 * @see com.dotcms.repackage.com.bradmcevoy.http.ResourceFactory#getSupportedLevels()


### PR DESCRIPTION
Our implementation of WebDav currently does not support Different Casing. Everything uploaded via WebDav ends-up in lowercase. Another PR fixed that small problem.  But.. while testing that fix it was discovered that our implementation wasn't fully prepared to safely handle the rename operation. 

When we do rename a file and change the casing. The Operation is handled by the library as a 
`Move command` which takes a source and target. 
When we say rename the resource `/webdav/live/1/demo.dotcms.com/images/black.png`  to `/webdav/live/1/demo.dotcms.com/images/BLACK.png` 
we're instructing WebDav to move a file where the source and the destination are the same.
By default, the library takes the precaution to delete the destination resource to ensure the move is successful.  But in this case, the source and the destination are interpreted as the same resource.

meaning that 
 `/webdav/live/1/demo.dotcms.com/images/black.png` 
and 
`/webdav/live/1/demo.dotcms.com/images/BLACK.png` 

Are the same file.
This PR solves that problem.
