### PR TITLE
#17794 adding first draft for finding by name without taking in consi…

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/workflow/helper/TestWorkflowHelper.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/workflow/helper/TestWorkflowHelper.java
@@ -1,0 +1,73 @@
+package com.dotcms.workflow.helper;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.datagen.ContentTypeDataGen;
+import com.dotcms.datagen.ContentletDataGen;
+import com.dotcms.datagen.FieldDataGen;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.contentlet.model.ContentletDependencies;
+import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
+import com.dotmarketing.portlets.workflows.business.SystemWorkflowConstants;
+import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
+import com.liferay.portal.model.User;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test {@link WorkflowHelper}
+ * @author jsanca
+ */
+public class TestWorkflowHelper extends IntegrationTestBase {
+
+    private static User user;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        //Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+        user = APILocator.getUserAPI().getSystemUser();
+    }
+
+    /**
+     * Test the getActionIdByName
+     */
+    @Test
+    public void test_getActionIdByName () throws Exception {
+
+        //1 create a content type and associated to system workflow
+        final ContentType contentGenericType = new ContentTypeDataGen().workflowId(SystemWorkflowConstants.SYSTEM_WORKFLOW_ID)
+                .baseContentType(BaseContentType.CONTENT)
+                .field(new FieldDataGen().name("title").velocityVarName("title").next())
+                .field(new FieldDataGen().name("body").velocityVarName("body").next()).nextPersisted();
+
+        final String unicodeText = "Numéro de téléphone";
+        final ContentletDataGen contentletDataGen = new ContentletDataGen(contentGenericType.id());
+        Contentlet contentlet    = contentletDataGen.setProperty("title", "TestContent")
+                .setProperty("body", unicodeText ).languageId(APILocator.getLanguageAPI().getDefaultLanguage().getId()).nextPersisted();
+
+        //2 get an action on the first step for a new contentlet
+        final WorkflowHelper workflowHelper = WorkflowHelper.getInstance();
+        final String saveActionId = workflowHelper.getActionIdByName("Save", contentlet, user);
+        Assert.assertEquals("The action returned should be Save", SystemWorkflowConstants.WORKFLOW_SAVE_ACTION_ID, saveActionId);
+
+        //3 get an action on the thrid step for a new contentlet
+        String archiveActionId = workflowHelper.getActionIdByName("Archive", contentlet, user);
+        Assert.assertEquals("The action returned should be Archive", SystemWorkflowConstants.WORKFLOW_ARCHIVE_ACTION_ID, archiveActionId);
+
+        final Contentlet contentletCheckin = APILocator.getWorkflowAPI().fireContentWorkflow(contentlet,
+                new ContentletDependencies.Builder().workflowActionId(saveActionId).modUser(user).indexPolicy(IndexPolicy.FORCE).build());
+
+        //4 get archive in a unpublish step
+        archiveActionId = workflowHelper.getActionIdByName("Archive", contentletCheckin, user);
+        Assert.assertEquals("The action returned should be Archive", SystemWorkflowConstants.WORKFLOW_ARCHIVE_ACTION_ID, archiveActionId);
+
+        //5 looking for non-existing Action
+        archiveActionId = workflowHelper.getActionIdByName("Non Existing Action", contentletCheckin, user);
+        Assert.assertNull("The action returned should be Archive", archiveActionId);
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
@@ -68,7 +68,6 @@ import com.dotmarketing.portlets.contentlet.model.ContentletDependencies;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicyProvider;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;
-import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.workflows.actionlet.WorkFlowActionlet;
 import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
 import com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction;
@@ -1287,7 +1286,7 @@ public class WorkflowResource {
                             ()->WebAPILocator.getLanguageWebAPI().getLanguage(request).getId(),
                             fireActionForm, initDataObject, mode);
 
-            actionId = this.workflowHelper.getActionIdByName
+            actionId = this.workflowHelper.getActionIdOnList
                     (fireActionForm.getActionName(), contentlet, initDataObject.getUser());
 
             Logger.debug(this, "fire ActionByName Multipart with the actionid: " + actionId);
@@ -1340,7 +1339,7 @@ public class WorkflowResource {
                             ()->WebAPILocator.getLanguageWebAPI().getLanguage(request).getId(),
                             fireActionForm, initDataObject, mode);
 
-            actionId = this.workflowHelper.getActionIdByName
+            actionId = this.workflowHelper.getActionIdOnList
                     (fireActionForm.getActionName(), contentlet, initDataObject.getUser());
 
             Logger.debug(this, "fire ActionByName with the actionid: " + actionId);

--- a/dotCMS/src/main/java/com/dotcms/workflow/helper/WorkflowHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/workflow/helper/WorkflowHelper.java
@@ -178,7 +178,7 @@ public class WorkflowHelper {
         for (final Aggregation aggregation : aggregations.asList()) {
 
             if (aggregation instanceof StringTerms) {
-                ((StringTerms) aggregation)
+                StringTerms.class.cast(aggregation)
                 .getBuckets().forEach(
                     bucket -> stepCounts.put(bucket.getKeyAsString(), bucket.getDocCount())
                 );
@@ -1331,7 +1331,7 @@ public class WorkflowHelper {
 
         Role role = null;
         final String newid = id.substring
-                (id.indexOf("-") + 1);
+                (id.indexOf("-") + 1, id.length());
 
         if(id.startsWith("user-")) {
 

--- a/dotCMS/src/main/java/com/dotcms/workflow/helper/WorkflowHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/workflow/helper/WorkflowHelper.java
@@ -178,7 +178,7 @@ public class WorkflowHelper {
         for (final Aggregation aggregation : aggregations.asList()) {
 
             if (aggregation instanceof StringTerms) {
-                StringTerms.class.cast(aggregation)
+                ((StringTerms) aggregation)
                 .getBuckets().forEach(
                     bucket -> stepCounts.put(bucket.getKeyAsString(), bucket.getDocCount())
                 );
@@ -293,6 +293,20 @@ public class WorkflowHelper {
         return bulkActions;
     }
 
+    private Optional<WorkflowAction> findActionsOn (final String actionName, final List<WorkflowAction>  workflowActions) {
+
+        if (UtilMethods.isSet(workflowActions)) {
+
+            final Optional<WorkflowAction> foundAction  =
+                    workflowActions.stream()
+                            .filter(action -> action.getName().equalsIgnoreCase(actionName)).findFirst();
+
+            return foundAction;
+        }
+
+        return Optional.empty();
+    }
+
     /**
      * Try to find an action by name
      * @param actionName {@link String}
@@ -307,17 +321,45 @@ public class WorkflowHelper {
                                     final Contentlet contentlet,
                                     final User user) throws DotSecurityException, DotDataException {
 
-        final List<WorkflowAction> availableActionsOnListing =
-                APILocator.getWorkflowAPI().findAvailableActionsListing(contentlet, user);
+        final WorkflowAPI workflowAPI                = APILocator.getWorkflowAPI();
+        final Optional<WorkflowStep> workflowStepOpt = workflowAPI.findCurrentStep(contentlet);
+        Optional<WorkflowScheme> schemeOpt           = Optional.empty();
+        Optional<WorkflowAction> foundAction         = Optional.empty();
+        if (workflowStepOpt.isPresent()) {
+            // 1) look for the actions on the same step
+            final WorkflowStep workflowStep = workflowStepOpt.get();
+            foundAction = this.findActionsOn(actionName, workflowAPI.findActions(workflowStep, user));
+            if (foundAction.isPresent()) {
 
-        final List<WorkflowAction> availableActionsOnEditing =
-                APILocator.getWorkflowAPI().findAvailableActionsEditing(contentlet, user);
+                return foundAction.get().getId();
+            }
 
-        final Optional<WorkflowAction> foundAction =
-                Stream.concat(availableActionsOnListing.stream(), availableActionsOnEditing.stream())
-                        .filter(action -> action.getName().equalsIgnoreCase(actionName)).findFirst();
+            // 2) look for the actions on the current scheme
+            final WorkflowScheme workflowScheme = workflowAPI.findScheme(workflowStep.getSchemeId());
+            schemeOpt   = Optional.ofNullable(workflowScheme);
+            foundAction = this.findActionsOn(actionName, workflowAPI.findActions(workflowScheme, user));
+            if (foundAction.isPresent()) {
 
-        return foundAction.isPresent()?foundAction.get().getId():null;
+                return foundAction.get().getId();
+            }
+        }
+
+        // 3) look for the actions on all schemes.
+        final List<WorkflowScheme>  workflowSchemes = workflowAPI.findSchemesForContentType(contentlet.getContentType());
+        for (final WorkflowScheme scheme : workflowSchemes) {
+
+            if (schemeOpt.isPresent() && schemeOpt.get().getId().equals(scheme.getId()))  {
+                continue; // we already analized this scheme
+            }
+
+            foundAction = this.findActionsOn(actionName, workflowAPI.findActions(scheme, user));
+            if (foundAction.isPresent()) {
+
+                return foundAction.get().getId();
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -1289,7 +1331,7 @@ public class WorkflowHelper {
 
         Role role = null;
         final String newid = id.substring
-                (id.indexOf("-") + 1, id.length());
+                (id.indexOf("-") + 1);
 
         if(id.startsWith("user-")) {
 

--- a/dotCMS/src/main/java/com/dotcms/workflow/helper/WorkflowHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/workflow/helper/WorkflowHelper.java
@@ -317,7 +317,7 @@ public class WorkflowHelper {
      * @throws DotDataException
      */
     @CloseDBIfOpened
-    public String getActionIdByName(final String actionName,
+    public String getActionIdOnList(final String actionName,
                                     final Contentlet contentlet,
                                     final User user) throws DotSecurityException, DotDataException {
 


### PR DESCRIPTION
Before this change, when you fire a workflow by name, it was using the available actions on listing and editing to get the actions, this was filtering by show when.
Consequently the user was not able to reach actions that were filtered by the show when logic.

Now, when an user sends a workflow name, the algorithm look for in the current step (if the content is in any), if can not found any action with the users name on the step, look for in the current scheme (all actions), otherwise tries to look for on all schemes actions.

This strategy might have a side effect, you can match an action with name that is not able in the step that the content is, but it is ok, since in the future this validation could be removed.