### PR TITLE
#17612 Fixing performance problems

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/business/web/HostWebAPIImplIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/business/web/HostWebAPIImplIntegrationTest.java
@@ -71,7 +71,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session, anotherHost);
-        when(request.getParameter("host_id")).thenReturn(host.getIdentifier());
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(host.getIdentifier());
 
         final User user = createUser(host);
 
@@ -96,7 +96,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(host.getIdentifier());
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(host.getIdentifier());
 
         final User user = createBackendUser();
 
@@ -125,7 +125,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(host.getName());
 
         final User user = createBackendUser(host);
@@ -151,7 +151,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(host.getName());
 
         final User user = createUser(host);
@@ -178,7 +178,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(host.getName());
 
         final User user = createBackendUser();
@@ -208,7 +208,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(host.getName());
 
         final User user = createUser();
@@ -234,7 +234,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
         when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
 
@@ -261,7 +261,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
         when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
 
@@ -291,7 +291,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
         when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
 
@@ -318,7 +318,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
         when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
         when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
@@ -346,7 +346,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
         when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
         when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
@@ -408,7 +408,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
         when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
         when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
@@ -469,7 +469,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(null);
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
         when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
         when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
@@ -710,7 +710,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
 
         final Host anotherHost = host == null ? new SiteDataGen().nextPersisted() : host;
 
-        when(request.getParameter("host_id")).thenReturn(anotherHost.getIdentifier());
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(anotherHost.getIdentifier());
         when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(anotherHost.getName());
         when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(anotherHost);
         when(request.getServerName()).thenReturn(anotherHost.getName());

--- a/dotCMS/src/integration-test/java/com/dotmarketing/business/web/HostWebAPIImplIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/business/web/HostWebAPIImplIntegrationTest.java
@@ -26,6 +26,8 @@ import javax.servlet.http.HttpSession;
 
 public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
 
+    public static final String HOST_ID_PARAMETER_NAME = "host_id";
+
     @BeforeClass
     public static void prepare () throws Exception {
         IntegrationTestInitService.getInstance().init();
@@ -43,7 +45,7 @@ public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
         final HttpSession session = mock(HttpSession.class);
 
         setAllParametersAndAttributes(request, session);
-        when(request.getParameter("host_id")).thenReturn(host.getIdentifier());
+        when(request.getParameter(HOST_ID_PARAMETER_NAME)).thenReturn(host.getIdentifier());
 
         final User user = createBackendUser(host);
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/business/web/HostWebAPIImplIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/business/web/HostWebAPIImplIntegrationTest.java
@@ -1,0 +1,719 @@
+package com.dotmarketing.business.web;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.datagen.RoleDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.UserDataGen;
+import com.dotcms.util.CollectionsUtils;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.beans.Permission;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.business.Role;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.*;
+
+import com.dotmarketing.util.WebKeys;
+import com.liferay.portal.model.User;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+public class HostWebAPIImplIntegrationTest extends IntegrationTestBase {
+
+    @BeforeClass
+    public static void prepare () throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: request host_id parameter is set and the user is a backend user
+     * Should: host_id parameter be take over any other source
+     */
+    @Test
+    public void useHostIDRequestAsCurrentHost() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(host.getIdentifier());
+
+        final User user = createBackendUser(host);
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(host.getIdentifier(), currentHost.getIdentifier());
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: request host_id parameter is set and the user is not a backend user
+     * Should: Host parameter should by taken
+     */
+    @Test
+    public void useHostIDRequestAsCurrentHostNotBackendUser() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final Host anotherHost = new SiteDataGen().nextPersisted();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session, anotherHost);
+        when(request.getParameter("host_id")).thenReturn(host.getIdentifier());
+
+        final User user = createUser(host);
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(anotherHost.getIdentifier(), currentHost.getIdentifier());
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: request host_id parameter is set and the user is a backend user but don't have permission
+     * Should: throw a {@link DotSecurityException}
+     */
+    @Test
+    public void useHostIdAndTheUserDontHavePermission() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(host.getIdentifier());
+
+        final User user = createBackendUser();
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        try {
+            hostWebAPI.getCurrentHost(request, user);
+            throw new RuntimeException("should throw a DotSecurityException");
+        } catch (DotSecurityException e) {
+
+        }
+
+        verify(request, never()).setAttribute(anyString(), anyObject());
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: request Host parameter is set and the user is a backend user
+     * Should: Host parameter should be taken
+     */
+    @Test
+    public void useHostNameParameterRequestAsCurrentHost() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(host.getName());
+
+        final User user = createBackendUser(host);
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(host.getIdentifier(), currentHost.getIdentifier());
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: request Host parameter is set and the user is not a backend user
+     * Should: Host parameter should be taken
+     */
+    @Test
+    public void useHostNameParameterRequestAsCurrentHostNotBackEndUser() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(host.getName());
+
+        final User user = createUser(host);
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(host.getIdentifier(), currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: request Host parameter is set and the user is a backend user but not have permission
+     * Should: throw {@link DotSecurityException}
+     */
+    @Test
+    public void useHostNameParameterAndUserNotHavePermission() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(host.getName());
+
+        final User user = createBackendUser();
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        try {
+            hostWebAPI.getCurrentHost(request, user);
+            throw new RuntimeException("should throw a DotSecurityException");
+        } catch (DotSecurityException e) {
+
+        }
+
+        verify(request, never()).setAttribute(anyString(), anyObject());
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: request Host parameter is set and the user is not a backend user
+     * Should: return the host
+     */
+    @Test
+    public void useHostNameParameterAndNotBackendUserNotHavePermission() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(host.getName());
+
+        final User user = createUser();
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+        assertEquals(host.getIdentifier(), currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: request Host parameter is set and the user is not a backend user
+     * Should: Host parameter should be taken
+     */
+    @Test
+    public void useHostAttributeRequestAsCurrentHost() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
+        when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
+
+        final User user = createUser(host);
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+        assertEquals(host.getIdentifier(), currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: request Host parameter is set and the user is  a backend user and not have permission
+     * Should: throw {@link DotSecurityException}
+     */
+    @Test
+    public void useHostAttributeRequestNotPermission() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
+        when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
+
+        final User user = createBackendUser();
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        try {
+            hostWebAPI.getCurrentHost(request, user);
+            throw new RuntimeException("should throw a DotSecurityException");
+        } catch (DotSecurityException e) {
+
+        }
+
+        verify(request, never()).setAttribute(anyString(), anyObject());
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: request Host parameter is set and the user is  not a backend user
+     * Should: return the host
+     */
+    @Test
+    public void useHostAttributeRequestNotPermissionAndNotBackendUser() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
+        when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
+
+        final User user = createUser();
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(host.getIdentifier(), currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: session Host parameter is set and the user is a backend user
+     * Should: session Host parameter should be taken
+     */
+    @Test
+    public void useHostAttributeSessionAsCurrentHost() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
+        when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
+        when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
+        when(session.getAttribute(WebKeys.CMS_SELECTED_HOST_ID)).thenReturn(host.getIdentifier());
+
+        final User user = createBackendUser(host);
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(host.getIdentifier(), currentHost.getIdentifier());
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: session Host parameter is set and the user is a backend user and not have permission
+     * Should: throw {@link DotSecurityException}
+     */
+    @Test
+    public void useHostAttributeSessionNotPermission() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
+        when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
+        when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
+
+        final User user = createBackendUser();
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        try {
+            hostWebAPI.getCurrentHost(request, user);
+            throw new RuntimeException("should throw a DotSecurityException");
+        } catch (DotSecurityException e) {
+
+        }
+
+        verify(request, never()).setAttribute(anyString(), anyObject());
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: session Host parameter is set and the user is a not backend user
+     * Should: should return default host
+     */
+    @Test
+    public void useHostAttributeSessionNotBackendUser() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
+
+        final Host defaultHost = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), true);
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = createUser(role, defaultHost);
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+        this.addPermission(role, defaultHost);
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(defaultHost.getIdentifier(), currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: session {@link WebKeys#CMS_SELECTED_HOST_ID} parameter is set and the user is a backend user
+     * Should: session {@link WebKeys#CMS_SELECTED_HOST_ID} parameter should be taken
+     */
+    @Test
+    public void useHostIdAttributeSessionAsCurrentHost() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
+        when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
+        when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
+        when(session.getAttribute(WebKeys.CMS_SELECTED_HOST_ID)).thenReturn(host.getIdentifier());
+
+        final User user = createBackendUser(host);
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(host.getIdentifier(), currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: session {@link WebKeys#CMS_SELECTED_HOST_ID} parameter is set and the user is not backend user
+     * Should: session {@link WebKeys#CMS_SELECTED_HOST_ID} parameter should not be taken and return the default host
+     */
+    @Test
+    public void useHostIdAttributeSessionAsCurrentHostNotBackendUser() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        when(session.getAttribute(WebKeys.CMS_SELECTED_HOST_ID)).thenReturn(host.getIdentifier());
+
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = createUser(role, host);
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+        final Host defaultHost = hostWebAPI.findDefaultHost(APILocator.systemUser(), true);
+
+        this.addPermission(role, defaultHost);
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(defaultHost.getIdentifier(),  currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: session {@link WebKeys#CMS_SELECTED_HOST_ID} parameter is set and the user is a backend user and not have permission
+     * Should: throw a {@link DotSecurityException}
+     */
+    @Test
+    public void useHostIdAttributeSessionNotPermission() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+
+        setAllParametersAndAttributes(request, session);
+        when(request.getParameter("host_id")).thenReturn(null);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(null);
+        when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
+        when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(null);
+        when(session.getAttribute(WebKeys.CMS_SELECTED_HOST_ID)).thenReturn(host.getIdentifier());
+
+        final User user = createBackendUser();
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        try {
+            hostWebAPI.getCurrentHost(request, user);
+            throw new RuntimeException("should throw a DotSecurityException");
+        } catch (DotSecurityException e) {
+
+        }
+
+        verify(request, never()).setAttribute(anyString(), anyObject());
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: the current host is not set in any scope
+     * Should: take the {@link HttpServletRequest#getServerName()}
+     */
+    @Test
+    public void useRequestServerNameAsCurrentHost() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getServerName()).thenReturn(host.getName());
+
+        final User user = createUser(host);
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(host.getIdentifier(), currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: the current host is not set in any scope and the {@link HttpServletRequest#getServerName()} is not a host
+     * Should: take the default host
+     */
+    @Test
+    public void whenRequestServerNameNosExistsAsDefaultHost() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getServerName()).thenReturn("not_exists_host");
+
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = createUser(role, host);
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+        final Host defaultHost = hostWebAPI.findDefaultHost(APILocator.systemUser(), true);
+
+        this.addPermission(role, defaultHost);
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(defaultHost.getIdentifier(), currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: There is not session
+     * Should: not throw a NullPointerException and return default host
+     */
+    @Test
+    public void whenNoSessionShouldNotThrowNullPointerException() throws DotDataException, DotSecurityException {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession(false)).thenReturn(null);
+
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = createBackendUser(role);
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+        final Host defaultHost = hostWebAPI.findDefaultHost(APILocator.systemUser(), true);
+        this.addPermission(role, defaultHost);
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(defaultHost.getIdentifier(), currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: the current host is not set in any scope and the {@link HttpServletRequest#getServerName()} is not a host
+     *       but the back end user not have permission over the default host
+     * Should: throw a {@link DotSecurityException}
+     */
+    @Test
+    public void whenDontHavePermissionInDefaultHost() throws DotDataException, DotSecurityException {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getServerName()).thenReturn("not_exists_host");
+
+        final User user = createBackendUser();
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+
+        try {
+            hostWebAPI.getCurrentHost(request, user);
+        }catch(DotSecurityException e) {
+
+        }
+
+        verify(request, never()).setAttribute(anyString(), anyObject());
+        verify(session, never()).setAttribute(anyString(), anyObject());
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: the current host is not set in any scope and the {@link HttpServletRequest#getServerName()} is not a host
+     *       but the user not have permission over the default host but this is not a backend user
+     * Should: return default host
+     */
+    @Test
+    public void whenDontHavePermissionInDefaultHostNotBackendUser() throws DotDataException, DotSecurityException {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getServerName()).thenReturn("not_exists_host");
+
+        final User user = createUser();
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+        final Host defaultHost = hostWebAPI.findDefaultHost(APILocator.systemUser(), true);
+
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+        assertEquals(defaultHost.getIdentifier(), currentHost.getIdentifier());
+
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+    }
+
+    /**
+     * Method to test: {@link HostWebAPIImpl#getCurrentHost(HttpServletRequest, User)} (HttpServletRequest)}
+     * When: session {@link WebKeys#CURRENT_HOST} attribute is set but is not equals to {@link WebKeys#CMS_SELECTED_HOST_ID}
+     * Should: session {@link WebKeys#CMS_SELECTED_HOST_ID} attribute should be taken
+     */
+    @Test
+    public void whenBothAreSetInSessionUseHostId() throws DotDataException, DotSecurityException {
+        final Host host = new SiteDataGen().nextPersisted();
+        final Host anotherHost = new SiteDataGen().nextPersisted();
+
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpSession session = mock(HttpSession.class);
+        when(request.getSession(false)).thenReturn(session);
+
+        when(session.getAttribute(WebKeys.CMS_SELECTED_HOST_ID)).thenReturn(host.getIdentifier());
+        when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(anotherHost);
+
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = createBackendUser(role, host);
+
+        this.addPermission(role, host);
+
+        final HostWebAPIImpl hostWebAPI = new HostWebAPIImpl();
+        final Host currentHost = hostWebAPI.getCurrentHost(request, user);
+
+        assertEquals(host.getIdentifier(), currentHost.getIdentifier());
+        verify(request).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+        verify(session).setAttribute(WebKeys.CURRENT_HOST, currentHost);
+    }
+
+    private User createUser() throws DotDataException, DotSecurityException {
+        return createUser( null);
+    }
+
+    private User createUser(final Host host) throws DotDataException, DotSecurityException {
+        return createUser(null, host);
+    }
+
+    private User createUser(final Role roleParam, final Host host)
+            throws DotDataException, DotSecurityException {
+        final Role role = roleParam == null ? new RoleDataGen().nextPersisted() : roleParam
+                ;
+        final User user = new UserDataGen().roles(role).nextPersisted();
+
+        if (host != null) {
+            this.addPermission(role, host);
+        }
+
+        return user;
+    }
+
+    private User createBackendUser( final Host host)
+            throws DotDataException, DotSecurityException {
+        return createBackendUser(null, host);
+    }
+
+    private User createBackendUser( final Role role)
+            throws DotDataException, DotSecurityException {
+        return createBackendUser(role, null);
+    }
+
+    private User createBackendUser()
+            throws DotDataException, DotSecurityException {
+        return createBackendUser(null, null);
+    }
+
+    private User createBackendUser(final Role role, final Host host)
+            throws DotDataException, DotSecurityException {
+        final User user = createUser(role, host);
+        APILocator.getRoleAPI().addRoleToUser(APILocator.getRoleAPI().loadBackEndUserRole(), user);
+        return user;
+    }
+
+    private void addPermission(final Role role, final Host host)
+            throws DotDataException, DotSecurityException {
+
+        final User systemUser = APILocator.systemUser();
+
+        final Permission permission = new Permission();
+        permission.setInode(host.getPermissionId());
+        permission.setRoleId(role.getId());
+        permission.setPermission(PermissionAPI.PERMISSION_READ);
+
+        APILocator.getPermissionAPI().save(CollectionsUtils.list(permission), host, systemUser, false);
+    }
+
+    private void setAllParametersAndAttributes(final HttpServletRequest request, final HttpSession session) {
+        setAllParametersAndAttributes(request, session, null);
+    }
+
+    private void setAllParametersAndAttributes(final HttpServletRequest request, final HttpSession session, final Host host) {
+        when(request.getSession(false)).thenReturn(session);
+
+        final Host anotherHost = host == null ? new SiteDataGen().nextPersisted() : host;
+
+        when(request.getParameter("host_id")).thenReturn(anotherHost.getIdentifier());
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(anotherHost.getName());
+        when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(anotherHost);
+        when(request.getServerName()).thenReturn(anotherHost.getName());
+
+        when(session.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(anotherHost);
+        when(session.getAttribute(WebKeys.CMS_SELECTED_HOST_ID)).thenReturn(anotherHost.getIdentifier());
+    }
+}

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/render/HTMLPageAssetRenderedAPIImplIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/render/HTMLPageAssetRenderedAPIImplIntegrationTest.java
@@ -56,6 +56,7 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
 
         session = mock(HttpSession.class);
         when(request.getSession()).thenReturn(session);
+        when(request.getSession(false)).thenReturn(session);
 
         response = mock(HttpServletResponse.class);
 
@@ -340,9 +341,8 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
     public void shouldUseHostNameParameterAndThrowDotSecurityException() throws DotDataException, DotSecurityException {
         init();
         final PageMode pageMode = PageMode.WORKING;
-        when(session.getAttribute( WebKeys.CMS_SELECTED_HOST_ID )).thenReturn(host.getIdentifier());
         when(request.getAttribute(com.liferay.portal.util.WebKeys.USER)).thenReturn(user);
-        when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
+        when(request.getParameter(Host.HOST_VELOCITY_VAR_NAME)).thenReturn(host.getName());
 
         final HTMLPageAssetRenderedAPIImpl htmlPageAssetRenderedAPIImpl = new HTMLPageAssetRenderedAPIImpl();
 
@@ -352,7 +352,7 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
     /**
      * Method to test: {@link HTMLPageAssetRenderedAPIImpl#getPageRendered(PageContext, HttpServletRequest, HttpServletResponse)
      * When The session host is set, but the user does not have permission over it
-     * Should return a right {@link PageView}
+     * Should throw a {@link DotSecurityException}
      * @throws DotDataException
      * @throws DotSecurityException
      * @throws InterruptedException
@@ -363,7 +363,6 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
         final PageMode pageMode = PageMode.WORKING;
         when(session.getAttribute( WebKeys.CMS_SELECTED_HOST_ID )).thenReturn(host.getIdentifier());
         when(request.getAttribute(com.liferay.portal.util.WebKeys.USER)).thenReturn(user);
-        when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
 
         final HTMLPageAssetRenderedAPIImpl htmlPageAssetRenderedAPIImpl = new HTMLPageAssetRenderedAPIImpl();
 
@@ -372,8 +371,8 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
 
     /**
      * Method to test: {@link HTMLPageAssetRenderedAPIImpl#getPageRendered(PageContext, HttpServletRequest, HttpServletResponse)
-     * When The session host is set, but the user does not have permission over it
-     * Should return a right {@link PageView}
+     * When The WebKeys.CURRENT_HOST request attribute is set, but the user does not have permission over it
+     * Should throw a {@link DotSecurityException}
      * @throws DotDataException
      * @throws DotSecurityException
      * @throws InterruptedException

--- a/dotCMS/src/main/java/com/dotmarketing/business/web/HostWebAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/web/HostWebAPI.java
@@ -10,10 +10,13 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.util.PageMode;
+import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
+import com.liferay.portal.model.User;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 /**
  * 
@@ -28,7 +31,28 @@ public interface HostWebAPI extends HostAPI {
 	
 	public Host getCurrentHost(HttpServletRequest req) throws DotDataException, DotSecurityException, PortalException, SystemException;
 
-	public Host getCurrentHost(final HttpServletRequest request, final PageMode mode) throws DotDataException, DotSecurityException, PortalException, SystemException;
+	/**
+	 * Return the current Host taking the host id or name from any of the follow source:
+	 *
+	 * - Current host id set by 'host_id' {@link HttpServletRequest} parameter, just in case the log in user is a backend user.
+	 * - Current host name set by 'Host' {@link HttpServletRequest} parameter
+	 * - Current {@link Host} object set by {@link WebKeys#CURRENT_HOST} {@link HttpServletRequest} attribute.
+	 * - Current {@link Host} object set by {@link WebKeys#CURRENT_HOST} {@link HttpSession} attribute,
+	 * - Current host id set by {@link WebKeys#CMS_SELECTED_HOST_ID} {@link HttpSession} attribute,
+	 * 	 just in case the log in user is a backend user..
+	 *   just in case the log in user is a backend user..
+	 * - Current host name get by {@link HttpServletRequest#getServerName()}
+	 * - Default Host
+	 *
+	 * @param request current {@link HttpServletRequest}
+	 * @param user User current login user
+	 * @return
+	 * @throws DotDataException
+	 * @throws DotSecurityException
+	 * @throws PortalException
+	 * @throws SystemException
+	 */
+	public Host getCurrentHost(final HttpServletRequest request, final User user) throws DotDataException, DotSecurityException;
 
 	public Host getHost(HttpServletRequest request);
 

--- a/dotCMS/src/main/java/com/dotmarketing/business/web/HostWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/web/HostWebAPIImpl.java
@@ -10,14 +10,11 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.PermissionAPI;
-import com.dotmarketing.business.PermissionLevel;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.HostAPIImpl;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.PageMode;
-import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
@@ -96,17 +93,19 @@ public class HostWebAPIImpl extends HostAPIImpl implements HostWebAPI {
         }
     }
 
-    private void checkHostPermission(User user, boolean respectAnonPerms, Host host) throws DotDataException, DotSecurityException {
-        if(!APILocator.getPermissionAPI().doesUserHavePermission(host, PermissionAPI.PERMISSION_READ, user, respectAnonPerms)){
-            String u = (user != null) ? user.getUserId() : null;
+    private void checkHostPermission(final User user, boolean respectAnonPerms, final Host host)
+            throws DotDataException, DotSecurityException {
 
-            String message = "User " + u + " does not have permission to host:" + host.getHostname();
+        if(!APILocator.getPermissionAPI().doesUserHavePermission(host, PermissionAPI.PERMISSION_READ, user, respectAnonPerms)){
+            final String userId = (user != null) ? user.getUserId() : null;
+
+            final String message = "User " + userId + " does not have permission to host:" + host.getHostname();
             Logger.error(HostAPIImpl.class, message);
             throw new DotSecurityException(message);
         }
     }
 
-    private Optional<Host> getCurrentHostFromSession(final HttpServletRequest request, User user, boolean respectAnonPerms)
+    private Optional<Host> getCurrentHostFromSession(final HttpServletRequest request, final User user, final boolean respectAnonPerms)
             throws DotSecurityException, DotDataException {
 
         final HttpSession session = request.getSession(false);
@@ -130,12 +129,12 @@ public class HostWebAPIImpl extends HostAPIImpl implements HostWebAPI {
         return Optional.ofNullable(host);
     }
 
-    private Optional<Host> getCurrentHostFromRequest(final HttpServletRequest request, final User user, boolean respectAnonPerms)
+    private Optional<Host> getCurrentHostFromRequest(final HttpServletRequest request, final User user, final boolean respectAnonPerms)
             throws DotDataException, DotSecurityException {
 
 	    final String hostId = request.getParameter("host_id");
 
-	    if ((hostId != null && user.isBackendUser())) {
+	    if (hostId != null && user.isBackendUser()) {
 	        return Optional.ofNullable(find(hostId, user, respectAnonPerms));
         } else if (request.getParameter(Host.HOST_VELOCITY_VAR_NAME) != null) {
             final String hostName = request.getParameter(Host.HOST_VELOCITY_VAR_NAME);

--- a/dotCMS/src/main/java/com/dotmarketing/business/web/HostWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/web/HostWebAPIImpl.java
@@ -7,11 +7,15 @@ import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.repackage.javax.portlet.ActionRequest;
 import com.dotcms.repackage.javax.portlet.RenderRequest;
 import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.DotStateException;
+import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.business.PermissionLevel;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.HostAPIImpl;
+import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
@@ -23,6 +27,7 @@ import com.liferay.portlet.RenderRequestImpl;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import java.util.Optional;
 
 /**
  * 
@@ -52,49 +57,97 @@ public class HostWebAPIImpl extends HostAPIImpl implements HostWebAPI {
 
     @CloseDBIfOpened
     public Host getCurrentHost(final HttpServletRequest request)
-            throws DotDataException, DotSecurityException, PortalException, SystemException {
+            throws DotDataException, DotSecurityException {
 
-        final PageMode mode = PageMode.get(request);
-
-        return this.getCurrentHost(request, mode);
+        return this.getCurrentHost(request, null);
     }
 
     @Override
     @CloseDBIfOpened
-    public Host getCurrentHost(final HttpServletRequest request, final PageMode mode)
-            throws DotDataException, DotSecurityException, PortalException, SystemException {
+    public Host getCurrentHost(final HttpServletRequest request, final User userParam)
+            throws DotDataException, DotSecurityException {
 
-        Host host = null;
-        final HttpSession session   = request.getSession(false);
         final UserWebAPI userWebAPI = WebAPILocator.getUserWebAPI();
-        final User systemUser       = userWebAPI.getSystemUser();
-        final boolean respectFrontendRoles = !userWebAPI.isLoggedToBackend(request);
-        final String pageHostId = request.getParameter("host_id");
+        final User user       = userParam != null ? userParam : userWebAPI.getSystemUser();
+        final boolean respectAnonPerms = user == null || !user.isBackendUser();
 
-        if (pageHostId != null && mode.isAdmin) {
-            host = find(pageHostId, systemUser, respectFrontendRoles);
-        } else {
-            if (session != null && mode.isAdmin && session.getAttribute(WebKeys.CURRENT_HOST) != null) {
-                host = (Host) session.getAttribute(WebKeys.CURRENT_HOST);
-            } else if (request.getAttribute(WebKeys.CURRENT_HOST) != null) {
-                host = (Host) request.getAttribute(WebKeys.CURRENT_HOST);
-            } else {
+        Optional<Host> optionalHost = this.getCurrentHostFromRequest(request, user, respectAnonPerms);
 
-                final String serverName = request.getServerName();
-                host = resolveHostName(serverName, systemUser, respectFrontendRoles);
-            }
+        if (!optionalHost.isPresent() && user.isBackendUser()){
+            optionalHost = this.getCurrentHostFromSession(request, user, respectAnonPerms);
         }
 
-        request.setAttribute(WebKeys.CURRENT_HOST, host);
-        if (session != null && mode.isAdmin) {
+        final Host host = optionalHost.isPresent() ? optionalHost.get() : resolveHostName(request.getServerName(),
+                user, respectAnonPerms);
 
-            session.setAttribute(WebKeys.CURRENT_HOST, host);
-        }
+        checkHostPermission(user, respectAnonPerms, host);
+        storeCurrentHost(request, user, host);
 
         return host;
     }
 
-	@Override
+    private void storeCurrentHost(final HttpServletRequest request, final User user, final Host host) {
+        final HttpSession session = request.getSession(false);
+
+        request.setAttribute(WebKeys.CURRENT_HOST, host);
+
+        if (session != null && user.isBackendUser()) {
+            session.setAttribute(WebKeys.CURRENT_HOST, host);
+        }
+    }
+
+    private void checkHostPermission(User user, boolean respectAnonPerms, Host host) throws DotDataException, DotSecurityException {
+        if(!APILocator.getPermissionAPI().doesUserHavePermission(host, PermissionAPI.PERMISSION_READ, user, respectAnonPerms)){
+            String u = (user != null) ? user.getUserId() : null;
+
+            String message = "User " + u + " does not have permission to host:" + host.getHostname();
+            Logger.error(HostAPIImpl.class, message);
+            throw new DotSecurityException(message);
+        }
+    }
+
+    private Optional<Host> getCurrentHostFromSession(final HttpServletRequest request, User user, boolean respectAnonPerms)
+            throws DotSecurityException, DotDataException {
+
+        final HttpSession session = request.getSession(false);
+
+        if (session == null){
+            return Optional.empty();
+        }
+
+        Host host = null;
+        if (session.getAttribute(WebKeys.CURRENT_HOST) != null) {
+            final Host hostFromSession = (Host) session.getAttribute(WebKeys.CURRENT_HOST);
+            final Object hostId = session.getAttribute(WebKeys.CMS_SELECTED_HOST_ID);
+            host = hostFromSession.getIdentifier().equals(hostId) ? hostFromSession : null;
+        }
+
+        if (host == null && session.getAttribute(WebKeys.CMS_SELECTED_HOST_ID) != null) {
+            final String hostId = (String) session.getAttribute(WebKeys.CMS_SELECTED_HOST_ID);
+            host = find(hostId, user, respectAnonPerms);
+        }
+
+        return Optional.ofNullable(host);
+    }
+
+    private Optional<Host> getCurrentHostFromRequest(final HttpServletRequest request, final User user, boolean respectAnonPerms)
+            throws DotDataException, DotSecurityException {
+
+	    final String hostId = request.getParameter("host_id");
+
+	    if ((hostId != null && user.isBackendUser())) {
+	        return Optional.ofNullable(find(hostId, user, respectAnonPerms));
+        } else if (request.getParameter(Host.HOST_VELOCITY_VAR_NAME) != null) {
+            final String hostName = request.getParameter(Host.HOST_VELOCITY_VAR_NAME);
+            return this.resolveHostNameWithoutDefault(hostName, user, respectAnonPerms);
+        } else if (request.getAttribute(WebKeys.CURRENT_HOST) != null) {
+	        return Optional.of((Host) request.getAttribute(WebKeys.CURRENT_HOST));
+        } else {
+	        return Optional.empty();
+        }
+    }
+
+    @Override
     public Host getCurrentHostNoThrow(HttpServletRequest request) {
        try {
            return getCurrentHost(request);

--- a/dotCMS/src/test/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImplTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImplTest.java
@@ -55,8 +55,6 @@ public class HTMLPageAssetRenderedAPIImplTest {
     private final HostWebAPI hostWebAPI = mock(HostWebAPI.class);
     private final LanguageAPI languageAPI = mock(LanguageAPI.class);
     private final HTMLPageAssetAPI htmlPageAssetAPI = mock(HTMLPageAssetAPI.class);
-    private final VersionableAPI versionableAPI = mock(VersionableAPI.class);
-    private final HostAPI hostAPI = mock(HostAPI.class);
     private final HttpSession httpSession = mock(HttpSession.class);
     private HTMLPageAssetRenderedAPIImpl hTMLPageAssetRenderedAPIImpl;
     private final URLMapAPIImpl urlMapAPIImpl = mock(URLMapAPIImpl.class);
@@ -71,13 +69,14 @@ public class HTMLPageAssetRenderedAPIImplTest {
 
         when(request.getServerName()).thenReturn(CURRENT_HOST_NAME);
         when(request.getSession()).thenReturn(httpSession);
+        when(request.getSession(false)).thenReturn(httpSession);
 
         when(languageAPI.getDefaultLanguage()).thenReturn(DEFAULT_LANGUAGE);
         when(DEFAULT_LANGUAGE.getId()).thenReturn(1l);
 
         hTMLPageAssetRenderedAPIImpl = new HTMLPageAssetRenderedAPIImpl(
-                permissionAPI, userAPI, hostWebAPI, languageAPI, htmlPageAssetAPI, versionableAPI,
-                hostAPI, urlMapAPIImpl, languageWebAPI);
+                permissionAPI, userAPI, hostWebAPI, languageAPI, htmlPageAssetAPI,
+                urlMapAPIImpl, languageWebAPI);
     }
 
     @Test
@@ -102,8 +101,7 @@ public class HTMLPageAssetRenderedAPIImplTest {
         when(this.permissionAPI.doesUserHavePermission(htmlPage, PermissionLevel.READ.getType(), systemUser,
                 PageMode.PREVIEW_MODE.respectAnonPerms)).thenReturn(true);
 
-        when(this.hostAPI.resolveHostName(CURRENT_HOST_NAME, systemUser, PageMode.PREVIEW_MODE.respectAnonPerms))
-                .thenReturn(currentHost);
+        when(this.hostWebAPI.getCurrentHost(request, systemUser)).thenReturn(currentHost);
 
         when(languageWebAPI.getLanguage(request)).thenReturn(DEFAULT_LANGUAGE);
 
@@ -139,8 +137,7 @@ public class HTMLPageAssetRenderedAPIImplTest {
                 PageMode.PREVIEW_MODE.respectAnonPerms)).thenReturn(true);
 
 
-        when(this.hostAPI.resolveHostName(CURRENT_HOST_NAME, systemUser, PageMode.PREVIEW_MODE.respectAnonPerms))
-                .thenReturn(currentHost);
+        when(this.hostWebAPI.getCurrentHost(request, systemUser)).thenReturn(currentHost);
         try {
             hTMLPageAssetRenderedAPIImpl.getDefaultEditPageMode(user, request, pageUri);
         } catch (final DotRuntimeException e) {
@@ -170,8 +167,7 @@ public class HTMLPageAssetRenderedAPIImplTest {
         when(this.permissionAPI.doesUserHavePermission(htmlPage, PermissionLevel.READ.getType(), systemUser,
                 PageMode.PREVIEW_MODE.respectAnonPerms)).thenReturn(true);
 
-        when(this.hostAPI.resolveHostName(CURRENT_HOST_NAME, systemUser, PageMode.PREVIEW_MODE.respectAnonPerms))
-                .thenReturn(currentHost);
+        when(this.hostWebAPI.getCurrentHost(request, systemUser)).thenReturn(currentHost);
 
         final PageMode defaultEditPageMode =
                 hTMLPageAssetRenderedAPIImpl.getDefaultEditPageMode(user, request, pageUri);
@@ -232,8 +228,7 @@ public class HTMLPageAssetRenderedAPIImplTest {
         when(urlMapAPIImpl.processURLMap(urlMapContext))
                 .thenReturn(Optional.of(urlMapInfo));
 
-        when(this.hostAPI.resolveHostName(CURRENT_HOST_NAME, systemUser, PageMode.PREVIEW_MODE.respectAnonPerms))
-                .thenReturn(currentHost);
+        when(this.hostWebAPI.getCurrentHost(request, systemUser)).thenReturn(currentHost);
 
         final PageMode defaultEditPageMode =
                 hTMLPageAssetRenderedAPIImpl.getDefaultEditPageMode(user, request, pageUri);
@@ -263,8 +258,7 @@ public class HTMLPageAssetRenderedAPIImplTest {
         when(this.permissionAPI.doesUserHavePermission(htmlPage, PermissionLevel.READ.getType(), systemUser,
                 PageMode.PREVIEW_MODE.respectAnonPerms)).thenReturn(true);
 
-        when(this.hostAPI.resolveHostName(CURRENT_HOST_NAME, systemUser, PageMode.PREVIEW_MODE.respectAnonPerms))
-                .thenReturn(currentHost);
+        when(this.hostWebAPI.getCurrentHost(request, systemUser)).thenReturn(currentHost);
 
         final PageMode defaultEditPageMode =
                 hTMLPageAssetRenderedAPIImpl.getDefaultEditPageMode(user, request, pageUri);


### PR DESCRIPTION
Fixing: https://github.com/dotCMS/core/issues/17612#issuecomment-570007342

The error was here:

https://github.com/dotCMS/core/pull/17759/files#diff-addcedfda0cc830f3c7ced2a64173641R117

when the Optional was empty then the get method throw an Exception, then the default host was not catching.

Really we have two methods to get the current Host in different API:

- https://github.com/dotCMS/core/blob/master/dotCMS/src/main/java/com/dotmarketing/business/web/HostWebAPIImpl.java#L64
- https://github.com/dotCMS/core/blob/master/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java#L364

so the change was remoce the method from HTMLPageAssetRenderedAPIImpl
