### PR TITLE
#17747 Refactoring to add cluster id prefix to index alias

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
@@ -1224,7 +1224,7 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
 
             //Build the index name
             String timestamp = String.valueOf(new Date().getTime());
-            workingIndex = new ESIndexAPI().getIndexNameWithClusterIDPrefix(IndexType.WORKING.getPrefix() + "_" + timestamp);
+            workingIndex = new ESIndexAPI().getNameWithClusterIDPrefix(IndexType.WORKING.getPrefix() + "_" + timestamp);
 
             //Create a working index
             boolean result = indexAPI.createContentIndex(workingIndex);

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESSiteSearchAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESSiteSearchAPITest.java
@@ -1,6 +1,7 @@
 package com.dotcms.content.elasticsearch.business;
 
 import static com.dotmarketing.sitesearch.business.SiteSearchAPI.ES_SITE_SEARCH_NAME;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -55,6 +56,7 @@ public class ESSiteSearchAPITest {
             CacheLocator.getIndiciesCache().clearCache();
             assertNotNull(indiciesAPI.loadIndicies().getSiteSearch());
             assertTrue(indiciesAPI.loadIndicies().getSiteSearch().equals(indexName));
+            assertEquals(aliasName, indexAPI.getIndexAlias(indexName));
         } finally {
             siteSearchAPI.deactivateIndex(indexName);
             indexAPI.delete(indexName);
@@ -81,6 +83,7 @@ public class ESSiteSearchAPITest {
             CacheLocator.getIndiciesCache().clearCache();
             assertNotNull(indiciesAPI.loadIndicies().getSiteSearch());
             assertTrue(indiciesAPI.loadIndicies().getSiteSearch().equals(indexName));
+            assertEquals(aliasName, indexAPI.getIndexAlias(indexName));
         } finally {
             contentletIndexAPI.stopFullReindexation();
             siteSearchAPI.deactivateIndex(indexName);
@@ -114,6 +117,7 @@ public class ESSiteSearchAPITest {
             CacheLocator.getIndiciesCache().clearCache();
             assertNotNull(indiciesAPI.loadIndicies().getSiteSearch());
             assertTrue(indiciesAPI.loadIndicies().getSiteSearch().equals(indexName));
+            assertEquals(aliasName, indexAPI.getIndexAlias(indexName));
         } finally {
             contentletIndexAPI.stopFullReindexation();
             siteSearchAPI.deactivateIndex(indexName);

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -553,11 +553,11 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
         Logger.info(this, "Switching Server Id : " + ConfigUtils.getServerId() );
         Logger.info(this, "Old indicies        : [" + esIndexApi
-                .removeClusterIdFromIndexName(oldInfo.getWorking()) + "," + esIndexApi
-                .removeClusterIdFromIndexName(oldInfo.getLive()) + "]");
+                .removeClusterIdFromName(oldInfo.getWorking()) + "," + esIndexApi
+                .removeClusterIdFromName(oldInfo.getLive()) + "]");
         Logger.info(this, "New indicies        : [" + esIndexApi
-                .removeClusterIdFromIndexName(oldInfo.getReindexWorking()) + "," + esIndexApi
-                .removeClusterIdFromIndexName(oldInfo.getReindexLive()) + "]");
+                .removeClusterIdFromName(oldInfo.getReindexWorking()) + "," + esIndexApi
+                .removeClusterIdFromName(oldInfo.getReindexLive()) + "]");
         Logger.info(this, "-------------------------------");
 
     }
@@ -1241,8 +1241,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     public synchronized List<String> getCurrentIndex() throws DotDataException {
         final List<String> newIdx = new ArrayList<String>();
         final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
-        newIdx.add(esIndexApi.removeClusterIdFromIndexName(info.getWorking()));
-        newIdx.add(esIndexApi.removeClusterIdFromIndexName(info.getLive()));
+        newIdx.add(esIndexApi.removeClusterIdFromName(info.getWorking()));
+        newIdx.add(esIndexApi.removeClusterIdFromName(info.getLive()));
         return newIdx;
     }
 
@@ -1251,9 +1251,9 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
 
         if (info.getReindexWorking() != null)
-            newIdx.add(esIndexApi.removeClusterIdFromIndexName(info.getReindexWorking()));
+            newIdx.add(esIndexApi.removeClusterIdFromName(info.getReindexWorking()));
         if (info.getReindexLive() != null)
-            newIdx.add(esIndexApi.removeClusterIdFromIndexName(info.getReindexLive()));
+            newIdx.add(esIndexApi.removeClusterIdFromName(info.getReindexLive()));
         return newIdx;
     }
 
@@ -1261,9 +1261,9 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
 
         if (IndexType.WORKING.is(type)) {
-            return esIndexApi.removeClusterIdFromIndexName(info.getWorking());
+            return esIndexApi.removeClusterIdFromName(info.getWorking());
         } else if (IndexType.LIVE.is(type)) {
-            return esIndexApi.removeClusterIdFromIndexName(info.getLive());
+            return esIndexApi.removeClusterIdFromName(info.getLive());
         }
 
         return null;

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -120,7 +120,7 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 	public  boolean putMapping(String indexName, String mapping) throws ElasticsearchException, IOException{
 
         final PutMappingRequest request = new PutMappingRequest(
-                APILocator.getESIndexAPI().getIndexNameWithClusterIDPrefix(indexName));
+                APILocator.getESIndexAPI().getNameWithClusterIDPrefix(indexName));
         request.setTimeout(TimeValue.timeValueMillis(INDEX_OPERATIONS_TIMEOUT_IN_MS));
         request.source(mapping, XContentType.JSON);
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESReindexationProcessStatus.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESReindexationProcessStatus.java
@@ -44,16 +44,16 @@ public class ESReindexationProcessStatus implements Serializable {
     public static String currentIndexPath() throws DotDataException {
         final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
         final ESIndexAPI esIndexAPI = APILocator.getESIndexAPI();
-        return "[" + esIndexAPI.removeClusterIdFromIndexName(info.getWorking()) + "," + esIndexAPI
-                .removeClusterIdFromIndexName(info.getLive()) + "]";
+        return "[" + esIndexAPI.removeClusterIdFromName(info.getWorking()) + "," + esIndexAPI
+                .removeClusterIdFromName(info.getLive()) + "]";
     }
 
     @CloseDBIfOpened
     public static String getNewIndexPath() throws DotDataException {
         final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
         final ESIndexAPI esIndexAPI = APILocator.getESIndexAPI();
-        return "[" + esIndexAPI.removeClusterIdFromIndexName(info.getReindexWorking()) + ","
-                + esIndexAPI.removeClusterIdFromIndexName(info.getReindexLive()) + "]";
+        return "[" + esIndexAPI.removeClusterIdFromName(info.getReindexWorking()) + ","
+                + esIndexAPI.removeClusterIdFromName(info.getReindexLive()) + "]";
     }
 
     @CloseDBIfOpened


### PR DESCRIPTION
With this PR, the index alias is stored with a cluster id prefix (as it works for index names) to support multitenancy. Now, methods `ESIndexAPI.getNameWithClusterIDPrefix` and `ESIndexAPI.removeClusterIdFromName` are used to get index names/aliases with/without cluster prefix. It required a refactoring to rename these methods. 

Some ITs were modified to include asserts that verify that aliases are stored correctly in the ES server