### PR TITLE
Issue 17848 update esindexresource to only call api methods

### DIFF
--- a/dotCMS/src/curl-test/ESIndexResourceTests.json
+++ b/dotCMS/src/curl-test/ESIndexResourceTests.json
@@ -1,0 +1,330 @@
+{
+  "info": {
+    "_postman_id": "7df3dec7-9eb1-4b26-b88a-45284a185654",
+    "name": "ESIndexResource",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "GetActiveIndexes",
+      "item": [
+        {
+          "name": "GetActiveLive",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "8a82f312-2f3c-46a5-ae30-2e2b036c871a",
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () { pm.response.to.be.ok });",
+                  "",
+                  "pm.test(\"Active Live index returned\", function () {",
+                  "    pm.expect(pm.response.text()).to.include(\"live\");",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "basic",
+              "basic": [
+                {
+                  "key": "username",
+                  "value": "admin@dotcms.com",
+                  "type": "string"
+                },
+                {
+                  "key": "password",
+                  "value": "admin",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "name": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{serverURL}}/api/v1/esindex/active/type/live",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "esindex",
+                "active",
+                "type",
+                "live"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "GetActiveWorking",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "ab4e54d6-d791-4064-a612-159e70e294a5",
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () { pm.response.to.be.ok });",
+                  "",
+                  "pm.test(\"Active Working index returned\", function () {",
+                  "    pm.expect(pm.response.text()).to.include(\"working\");",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "basic",
+              "basic": [
+                {
+                  "key": "username",
+                  "value": "admin@dotcms.com",
+                  "type": "string"
+                },
+                {
+                  "key": "password",
+                  "value": "admin",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "name": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{serverURL}}/api/v1/esindex/active/type/working",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "esindex",
+                "active",
+                "type",
+                "working"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "protocolProfileBehavior": {}
+    },
+    {
+      "name": "GetIndexDocumentCount",
+      "item": [
+        {
+          "name": "Pre-test-GetActiveLiveIndex",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "3b06a06f-e2a0-434c-91f8-b502c1f6829f",
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () { pm.response.to.be.ok });",
+                  "",
+                  "pm.test(\"Active Live index returned\", function () {",
+                  "    pm.expect(pm.response.text()).to.include(\"live\");",
+                  "});",
+                  "",
+                  "pm.collectionVariables.set(\"indexName\", pm.response.text());"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "basic",
+              "basic": [
+                {
+                  "key": "username",
+                  "value": "admin@dotcms.com",
+                  "type": "string"
+                },
+                {
+                  "key": "password",
+                  "value": "admin",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "name": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{serverURL}}/api/v1/esindex/active/type/live",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "esindex",
+                "active",
+                "type",
+                "live"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "GetLiveDocumentCountSuccess",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "d91fc055-762d-4339-861d-78732ed8c889",
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () { pm.response.to.be.ok });",
+                  ""
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "id": "4d9caec7-9b67-4541-820c-1a50139e6acb",
+                "exec": [
+                  ""
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "basic",
+              "basic": [
+                {
+                  "key": "username",
+                  "value": "admin@dotcms.com",
+                  "type": "string"
+                },
+                {
+                  "key": "password",
+                  "value": "admin",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "name": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{serverURL}}/api/v1/esindex/docscount/index/{{indexName}}",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "esindex",
+                "docscount",
+                "index",
+                "{{indexName}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "GetDocumentCountWithInvalidIndexFails",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "75accc22-7c7e-4f9b-86f0-84750a30fd8e",
+                "exec": [
+                  "pm.test(\"Status code is 500\", function () { pm.response.to.have.status(500) });",
+                  ""
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "basic",
+              "basic": [
+                {
+                  "key": "username",
+                  "value": "admin@dotcms.com",
+                  "type": "string"
+                },
+                {
+                  "key": "password",
+                  "value": "admin",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "name": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{serverURL}}/api/v1/esindex/docscount/index/invalidIndex",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "esindex",
+                "docscount",
+                "index",
+                "invalidIndex"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "protocolProfileBehavior": {}
+    }
+  ],
+  "protocolProfileBehavior": {}
+}

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
@@ -367,7 +367,6 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @see ContentletIndexAPI
      * @see ContentletIndexAPIImpl
      */
-    @Ignore
     @Test
     public void activateDeactivateIndex () throws Exception {
 

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
@@ -88,6 +88,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -366,6 +367,7 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @see ContentletIndexAPI
      * @see ContentletIndexAPIImpl
      */
+    @Ignore
     @Test
     public void activateDeactivateIndex () throws Exception {
 

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
@@ -70,12 +70,14 @@ import com.dotmarketing.util.json.JSONObject;
 import com.google.common.collect.ImmutableList;
 import com.liferay.portal.model.User;
 import com.rainerhahnekamp.sneakythrow.Sneaky;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -86,7 +88,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -366,7 +367,6 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @see ContentletIndexAPIImpl
      */
     @Test
-    @Ignore
     public void activateDeactivateIndex () throws Exception {
 
         //Build the index names
@@ -531,7 +531,6 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @see ContentletIndexAPIImpl
      */
     @Test
-    @Ignore
     public void removeContentFromIndexByStructureInode () throws Exception {
 
         //Creating a test structure
@@ -1276,6 +1275,26 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
                 ContentTypeDataGen.remove(childContentType);
             }
         }
+    }
+
+    /**
+     * Method to test: {@link ContentletIndexAPI#getIndexDocumentCount(String)}
+     * Test Case: Tries to get the document count of an active index
+     * Expected Results: Value should be more than 0
+     */
+    @Test
+    public void testGetIndexDocumentCountSuccess() throws  DotDataException {
+        assertTrue(indexAPI.getIndexDocumentCount(indexAPI.getCurrentIndex().get(0)) > 0);
+    }
+
+    /**
+     * Method to test: {@link ContentletIndexAPI#getIndexDocumentCount(String)}
+     * Test Case: Tries to get the document count of an index that does not exist
+     * Expected Results: Throws ElasticsearchStatusException
+     */
+    @Test(expected= ElasticsearchStatusException.class)
+    public void testGetIndexDocumentCountWithInvalidIndexNameFails(){
+        indexAPI.getIndexDocumentCount("invalidIndexName");
     }
 
     public static Relationship createLegacyRelationship(final ContentType parentContentType,

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPI.java
@@ -101,6 +101,14 @@ public interface ContentletIndexAPI {
 
     void deactivateIndex(String indexName) throws DotDataException, IOException;
 
+    /**
+     * Gets the document count of a given index. In case the index does not exist, a runtime exception
+     * is thrown
+     * @param indexName
+     * @return Documents count - long
+     */
+    long getIndexDocumentCount(String indexName);
+
     public List<String> getCurrentIndex() throws DotDataException;
 
     public List<String> getNewIndex() throws DotDataException;

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1216,9 +1216,9 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         final IndiciesInfo.Builder builder = IndiciesInfo.Builder.copy(info);
 
         if (IndexType.WORKING.is(indexName)) {
-            builder.setWorking(indexName);
+            builder.setWorking(esIndexApi.getNameWithClusterIDPrefix(indexName));
         } else if (IndexType.LIVE.is(indexName)) {
-            builder.setLive(indexName);
+            builder.setLive(esIndexApi.getNameWithClusterIDPrefix(indexName));
         }
         APILocator.getIndiciesAPI().point(builder.build());
     }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1242,7 +1242,7 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     @Override
-    public long getIndexDocumentCount(String indexName) {
+    public long getIndexDocumentCount(final String indexName) {
         final CountRequest countRequest = new CountRequest(
                 esIndexApi.getNameWithClusterIDPrefix(indexName));
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
@@ -3,8 +3,12 @@ package com.dotcms.rest.api.v1.index;
 import static com.dotcms.util.DotPreconditions.checkArgument;
 
 import com.dotcms.business.CloseDBIfOpened;
-import com.dotcms.content.elasticsearch.business.*;
-import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
+import com.dotcms.content.elasticsearch.business.ContentletIndexAPIImpl;
+import com.dotcms.content.elasticsearch.business.DotIndexException;
+import com.dotcms.content.elasticsearch.business.ESIndexAPI;
+import com.dotcms.content.elasticsearch.business.ESIndexHelper;
+import com.dotcms.content.elasticsearch.business.IndiciesAPI;
+import com.dotcms.content.elasticsearch.business.IndiciesInfo;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
@@ -30,7 +34,6 @@ import com.google.gson.Gson;
 import com.liferay.portal.language.LanguageException;
 import com.liferay.portal.language.LanguageUtil;
 import com.liferay.portal.model.User;
-import com.rainerhahnekamp.sneakythrow.Sneaky;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -54,11 +57,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.core.CountRequest;
-import org.elasticsearch.client.core.CountResponse;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
@@ -208,17 +206,8 @@ public class ESIndexResource {
         AdminLogger.log(ESIndexResource.class, "deactivateIndex", "Index deactivated: " + indexName);
     }
 
-    public static long indexDocumentCount(String indexName) {
-
-        final CountRequest countRequest = new CountRequest(indexName);
-        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchSourceBuilder.query(QueryBuilders.matchAllQuery());
-        countRequest.source(searchSourceBuilder);
-
-        final CountResponse countResponse = Sneaky.sneak(() -> RestHighLevelClientProvider.getInstance().getClient()
-                .count(countRequest, RequestOptions.DEFAULT));
-
-        return countResponse.getCount();
+    public static long indexDocumentCount(final String indexName) {
+        return APILocator.getContentletIndexAPI().getIndexDocumentCount(indexName);
     }
 
     /**


### PR DESCRIPTION
The logic in `ESIndexResource.indexDocumentCount(final String indexName)` was moved to `ContentletIndexAPI.getIndexDocumentCount(String indexName)`

Also, new postman tests and ITs were created. Other than that, a couple of tests annotated as Ignored have been included to our tests suite