### PR TITLE
#17864 fixed with test

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformerTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformerTest.java
@@ -4,10 +4,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
+import com.dotcms.contenttype.model.field.ConstantField;
+import com.dotcms.contenttype.model.field.Field;
+import com.dotcms.contenttype.model.field.FieldBuilder;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.rest.ContentHelper;
@@ -21,10 +24,14 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.struts.ContentletForm;
 import com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI;
 import com.dotmarketing.portlets.workflows.business.BaseWorkflowIntegrationTest;
+import com.dotmarketing.util.UUIDGenerator;
+import com.twelvemonkeys.util.LinkedSet;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,12 +47,14 @@ public class ContentletTransformerTest extends BaseWorkflowIntegrationTest {
         final ContentType bannerLikeContentType = TestDataUtils.getBannerLikeContentType();
         final ContentType newsLikeContentType = TestDataUtils.getNewsLikeContentType();
 
+
         // Creating the contentlets for they will be pulled-out from the index
         for (int i = 0; i <= 10; i++) {
             TestDataUtils.getEmployeeContent(true, 1, employeeLikeContentType.id());
             TestDataUtils.getBannerLikeContent(true, 1, bannerLikeContentType.id(), null);
             TestDataUtils.getNewsContent(true, 1, newsLikeContentType.id());
         }
+
     }
 
     @Test
@@ -166,6 +175,68 @@ public class ContentletTransformerTest extends BaseWorkflowIntegrationTest {
         assertEquals(urlExpected, newContentlet.getMap().get(HTMLPageAssetAPI.URL_FIELD));
         assertFalse(newContentlet.getMap().containsKey(Contentlet.NULL_PROPERTIES));
     }
+    
+    /**
+     * this test creates a widget type that has constant fields and a content of this type.
+     * It updates the constant field values and insures that the new constant field values are both
+     * in the content object and the newly transformed map
+     * @throws Exception
+     */
+    @Test
+    public void Test_Constant_fields_are_in_map() throws Exception {
+        
+        
+        // create a widget and a content of that widget;
+        final ContentType widgetLikeContenType = TestDataUtils.getWidgetLikeContentType();
+        final Contentlet newContentlet = TestDataUtils.getWidgetContent(true, 1, widgetLikeContenType.id());
+        assertNotNull(newContentlet);
+
+        final List<Field> constants = widgetLikeContenType.fields(ConstantField.class);
+        
+        final String constantVar1 = constants.get(0).variable();
+        final String constantVar2 = constants.get(1).variable();
+        
+        // assert our content type has no constant values in it
+        assertTrue(constants.size()>1);
+        assertNull(constants.get(0).values());
+        assertNull(constants.get(1).values());
+        
+        // assert our content Map has no constant values in it
+        Map<String,Object> map = new ContentletToMapTransformer(newContentlet).toMaps().get(0);
+        assertNull(map.get(constantVar1));
+        assertNull(map.get(constantVar2));
+        
+        
+        // update our Content Type constants to have values
+        final List<Field> allFields = new ArrayList<>(widgetLikeContenType.fields());
+        allFields.removeIf(f->constants.contains(f));
+        for(final Field field : constants) {
+            final String value = UUIDGenerator.generateUuid();
+            Field newField = FieldBuilder.builder(field).values(value).build();
+            allFields.add(newField);
+        }
+        ContentType updatedType =APILocator.getContentTypeAPI(APILocator.systemUser()).save(widgetLikeContenType, allFields);
+        
+        // contentlet.constantValue now have values
+        assertNotNull(newContentlet.get(constantVar1));  
+        assertNotNull(newContentlet.get(constantVar2));  
+        
+        // field.value == contentlet.constantValue 
+        assertEquals(updatedType.fieldMap().get(constantVar1).values(), newContentlet.get(constantVar1));  
+        assertEquals(updatedType.fieldMap().get(constantVar2).values(), newContentlet.get(constantVar2));  
+
+        
+        map = new ContentletToMapTransformer(newContentlet).toMaps().get(0);
+
+
+        // contentlet.constantValue ==  map.values
+        assertEquals(newContentlet.get(constantVar1), map.get(constantVar1));  
+        assertEquals(newContentlet.get(constantVar2), map.get(constantVar2));  
+        
+    }
+
+    
+    
 
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletToMapTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletToMapTransformer.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 
 import com.dotcms.content.elasticsearch.constants.ESMappingConstants;
+import com.dotcms.contenttype.model.field.ConstantField;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.rest.ContentHelper;
 import com.dotcms.util.CollectionsUtils;
@@ -107,7 +108,7 @@ public class ContentletToMapTransformer {
                 properties.put(HTMLPageAssetAPI.URL_FIELD, url);
             }
         }
-
+        addConstants(contentlet);
         setAdditionalProperties(contentlet);
         clean(contentlet);
         return contentlet.getMap();
@@ -150,6 +151,22 @@ public class ContentletToMapTransformer {
         return contentlet;
     }
 
+    
+    /**
+     * Use this method to add any additional property
+     * @param contentlet Same contentlet with any additional property added
+     */
+    private void addConstants(final Contentlet contentlet){
+        try {
+            contentlet.getContentType().fields(ConstantField.class)
+            .stream()
+            .filter(f->f.values()!=null)
+            .forEach(f-> contentlet.getMap().put(f.variable(), f.values()));
+        } catch (Exception e) {
+            Logger.warnAndDebug(getClass(),"Error Populating Constant Field: "  + e.getMessage(), e);
+        }
+    }
+    
     /**
      * Use this method to add any additional property
      * @param contentlet Same contentlet with any additional property added


### PR DESCRIPTION
Adds a new method that populates the content map with the values of any constant fields of its content type.