### PR TITLE
#17612 Avoit hitting ES with every request to get the default host

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
@@ -19,6 +19,7 @@ import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Permission;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.business.Role;
 import com.dotmarketing.common.db.DotConnect;
@@ -589,6 +590,25 @@ public class HostAPITest extends IntegrationTestBase  {
         final Optional<Host> optional = APILocator.getHostAPI().resolveHostNameWithoutDefault(
                 "not_exists_host", APILocator.systemUser(), false);
         assertFalse(optional.isPresent());
+    }
+
+    /**
+     * Method to test: {@link HostAPI#resolveHostName(String, User, boolean)}
+     * When the host does not exist
+     * Should return the default host and store it into host cache
+     */
+    @Test
+    public void shouldStoreDefaultHostIntoCache() throws DotSecurityException, DotDataException {
+        final String hostName = "not_exists_host";
+        final Host notExistsHost = APILocator.getHostAPI().resolveHostName(hostName
+                , APILocator.systemUser(), false);
+        final Host defaultHost = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), true);
+        assertEquals(notExistsHost.getIdentifier(), defaultHost.getIdentifier());
+
+        final HostCache hostCache = CacheLocator.getHostCache();
+        final Host hostByAlias = hostCache.getHostByAlias(hostName);
+
+        assertEquals(hostByAlias.getIdentifier(), defaultHost.getIdentifier());
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
@@ -113,17 +113,14 @@ public class HostAPIImpl implements HostAPI {
         User systemUser = APILocator.systemUser();
 
         if(host == null){
+
             try {
-                host = resolveHostNameWithoutDefault(serverName, systemUser, respectFrontendRoles).get();
+                final Optional<Host> optional = resolveHostNameWithoutDefault(serverName, systemUser, respectFrontendRoles);
+                host = optional.isPresent() ? optional.get() : findDefaultHost(systemUser, respectFrontendRoles);
             } catch (Exception e) {
-                return findDefaultHost(systemUser, respectFrontendRoles);
-            }
-            
-            //If no host matches then we set the default host.
-            if(host == null){
                 host = findDefaultHost(systemUser, respectFrontendRoles);
             }
-            
+
             if(host != null){
                 hostCache.addHostAlias(serverName, host);
             }


### PR DESCRIPTION
Fixing this:

https://github.com/dotCMS/core/issues/16684#issuecomment-577458340

When this Optional was returning a empty optional 

https://github.com/dotCMS/core/compare/avoid-hitting-elasticsearch-every-request-to-get-default-host?expand=1#diff-addcedfda0cc830f3c7ced2a64173641L117

then we was getting a error so the default host was not caching 

https://github.com/dotCMS/core/compare/avoid-hitting-elasticsearch-every-request-to-get-default-host?expand=1#diff-addcedfda0cc830f3c7ced2a64173641L119