### PR TITLE
Unable to create rules

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/enterprise/rules/RulesAPIImplIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/enterprise/rules/RulesAPIImplIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.dotcms.enterprise.rules;
+
+import com.dotcms.datagen.RoleDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.UserDataGen;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.beans.Permission;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.business.Role;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.rules.RuleDataGen;
+import com.dotmarketing.portlets.rules.model.Rule;
+import com.liferay.portal.model.User;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration test of {@link RulesAPIImpl}
+ */
+public class RulesAPIImplIntegrationTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        //Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Method to Test: {@link RulesAPIImpl#saveRule(Rule, User, boolean)}
+     * When: A not admin user with right permission try to save a new rule
+     * Should: Save the new rule
+     *
+     * @throws DotSecurityException
+     * @throws DotDataException
+     */
+    @Test
+    public void shouldSaveNewRule() throws DotSecurityException, DotDataException {
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = new UserDataGen().roles(role).nextPersisted();
+        final Host host = new SiteDataGen().nextPersisted();
+        final Rule rule = new RuleDataGen().host(host).next();
+
+        this.addPermission(role, host, true);
+        APILocator.getRulesAPI().saveRule(rule, user, false);
+
+        final List<Rule> rules = APILocator.getRulesAPI().getAllRulesByParent(host, APILocator.systemUser(), true);
+        assertEquals(1, rules.size());
+    }
+
+    /**
+     * Method to Test: {@link RulesAPIImpl#saveRule(Rule, User, boolean)}
+     * When: A not admin user without permission try to save a new rule
+     * Should: Not save the new rule
+     *
+     * @throws DotSecurityException
+     * @throws DotDataException
+     */
+    @Test
+    public void shouldNotSaveNewRule() throws DotSecurityException, DotDataException {
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = new UserDataGen().roles(role).nextPersisted();
+        final Host host = new SiteDataGen().nextPersisted();
+        final Rule rule = new RuleDataGen().host(host).next();
+
+        this.addPermission(role, host, false);
+
+        try {
+            APILocator.getRulesAPI().saveRule(rule, user, false);
+            throw new AssertionError("DotSecurityException expected");
+        } catch(DotSecurityException e) {
+            //expected//
+        }
+
+        final List<Rule> rules = APILocator.getRulesAPI().getAllRulesByParent(host, APILocator.systemUser(), true);
+        assertTrue(rules.isEmpty());
+    }
+
+    private void addPermission(final Role role, final Host host, final boolean notAddPublishPermission)
+            throws DotDataException, DotSecurityException {
+
+        final User systemUser = APILocator.systemUser();
+
+        final List<Permission> permissions = new ArrayList<>();
+        final Permission readPermission = new Permission();
+        readPermission.setInode(host.getPermissionId());
+        readPermission.setRoleId(role.getId());
+        readPermission.setPermission(PermissionAPI.PERMISSION_READ);
+        permissions.add(readPermission);
+
+        if (notAddPublishPermission) {
+            final Permission publishPermission = new Permission();
+            publishPermission.setInode(host.getPermissionId());
+            publishPermission.setRoleId(role.getId());
+            publishPermission.setPermission(PermissionAPI.PERMISSION_PUBLISH);
+            publishPermission.setType(Rule.class.getName());
+
+            permissions.add(publishPermission);
+        }
+
+        APILocator.getPermissionAPI().save(permissions, host, systemUser, false);
+    }
+}

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/rules/RuleDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/rules/RuleDataGen.java
@@ -30,6 +30,7 @@ public class RuleDataGen {
 
     private Rule.FireOn fireOn = Rule.FireOn.EVERY_PAGE;
     private String name = "defaultName";
+    private Host host;
 
     public RuleDataGen() {
     }
@@ -42,7 +43,7 @@ public class RuleDataGen {
 
         Rule rule = new Rule();
         rule.setName(name);
-        rule.setParent(defaultHost.getIdentifier());
+        rule.setParent(host != null ? host.getIdentifier() : defaultHost.getIdentifier());
         rule.setEnabled(true);
         rule.setFireOn(fireOn);
         return rule;
@@ -71,6 +72,11 @@ public class RuleDataGen {
 
     public RuleDataGen name(String name) {
         this.name = name;
+        return this;
+    }
+
+    public RuleDataGen host(final Host host) {
+        this.host = host;
         return this;
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitAPIImpl.java
@@ -1277,7 +1277,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 			if(this.isHost(permissionable)){
 
 				isHost = true;
-				host = (permissionable instanceof PermissionableProxy)?
+				host = !(permissionable instanceof Host)?
 						APILocator.getHostAPI()
 							.find(permissionable.getPermissionId(), APILocator.systemUser(),false):
 						(Host) permissionable;
@@ -1406,6 +1406,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	private boolean isHost(final Permissionable permissionable) {
 
 		return permissionable instanceof Host ||
+				(permissionable instanceof Contentlet && Host.class.getSimpleName().equals(((Contentlet) permissionable).getContentType().name())) ||
 				(null != permissionable && permissionable instanceof PermissionableProxy
 						&& Host.class.getName().equals(PermissionableProxy.class.cast(permissionable).getType()));
 	}

--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitAPIImpl.java
@@ -1406,7 +1406,7 @@ public class PermissionBitAPIImpl implements PermissionAPI {
 	private boolean isHost(final Permissionable permissionable) {
 
 		return permissionable instanceof Host ||
-				(permissionable instanceof Contentlet && Host.class.getSimpleName().equals(((Contentlet) permissionable).getContentType().name())) ||
+				(permissionable instanceof Contentlet && ((Contentlet) permissionable).isHost()) ||
 				(null != permissionable && permissionable instanceof PermissionableProxy
 						&& Host.class.getName().equals(PermissionableProxy.class.cast(permissionable).getType()));
 	}


### PR DESCRIPTION
The method Rule. getParentPermissionable return a Contentlet instance who represent a Host (when the Rule's parent is a Host)

https://github.com/dotCMS/core/blob/master/dotCMS/src/main/java/com/dotmarketing/portlets/rules/model/Rule.java#L238

When a rule is going to be created the parent permission are checking here:

https://github.com/dotCMS/enterprise-2.x/blob/master/src/main/java/com/dotcms/enterprise/rules/RulesAPIImpl.java#L557

The permission checking is different if the permissionable is a Host

https://github.com/dotCMS/core/blob/master/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitAPIImpl.java#L1277

When a Contentlet instance who represent a Host was pass to the isHost method as permissionable, it was returning false

https://github.com/dotCMS/core/compare/issue-17901-Unable-to-create-rules?expand=1#diff-89f38de07f469db99ca81817b7938ca5R1409

That is why the x did not process correctly and the method  'doesUserHavePermissions' allways was returning false for any not admin user.