### PR TITLE
#17904 first draft for the reset approver actionlet

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionletTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionletTest.java
@@ -83,7 +83,7 @@ public class FourEyeApproverActionletTest extends BaseWorkflowIntegrationTest {
         contentletAPI = APILocator.getContentletAPI();
         languageAPI = APILocator.getLanguageAPI();
 
-        site = new SiteDataGen().name("site"+System.currentTimeMillis()).nextPersisted();
+        site = new SiteDataGen().nextPersisted();
         // Get the test role and two users from such a role
         final Role publisherRole = TestUserUtils.getOrCreatePublisherRole(site);
         publisher1 = TestUserUtils.getChrisPublisherUser(site);

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionletTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionletTest.java
@@ -83,7 +83,7 @@ public class FourEyeApproverActionletTest extends BaseWorkflowIntegrationTest {
         contentletAPI = APILocator.getContentletAPI();
         languageAPI = APILocator.getLanguageAPI();
 
-        site = new SiteDataGen().nextPersisted();
+        site = new SiteDataGen().name("site"+System.currentTimeMillis()).nextPersisted();
         // Get the test role and two users from such a role
         final Role publisherRole = TestUserUtils.getOrCreatePublisherRole(site);
         publisher1 = TestUserUtils.getChrisPublisherUser(site);

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/model/WorkflowHistoryTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/model/WorkflowHistoryTest.java
@@ -1,0 +1,48 @@
+package com.dotmarketing.portlets.workflows.model;
+
+import com.liferay.util.StringPool;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class WorkflowHistoryTest {
+
+    @Test
+    public void test_getChangeMap_null_description ()  {
+
+        final WorkflowHistory workflowHistory = new WorkflowHistory();
+        workflowHistory.setChangeDescription(null);
+        final Map<String, Object> changeMap = workflowHistory.getChangeMap();
+
+        Assert.assertNotNull("GetChangeMap must not return a null map",changeMap);
+        Assert.assertEquals("Should return a blank description", changeMap.get("description"), StringPool.BLANK);
+        Assert.assertEquals("Should return a comment type", changeMap.get("type"), WorkflowHistoryType.COMMENT);
+    }
+
+    @Test
+    public void test_getChangeMap_with_description ()  {
+
+        final WorkflowHistory workflowHistory = new WorkflowHistory();
+        workflowHistory.setChangeDescription("test");
+        final Map<String, Object> changeMap = workflowHistory.getChangeMap();
+
+        Assert.assertNotNull("GetChangeMap must not return a null map",changeMap);
+        Assert.assertEquals("Should return test description", workflowHistory.getChangeDescription(), "test");
+        Assert.assertEquals("Should return test description", changeMap.get("description"), "test");
+        Assert.assertEquals("Should return a comment type", changeMap.get("type"), WorkflowHistoryType.COMMENT);
+    }
+
+    @Test
+    public void test_getChangeMap_approval_type ()  {
+
+        final WorkflowHistory workflowHistory = new WorkflowHistory();
+        workflowHistory.setChangeDescription("{'description':'test', 'type':" + WorkflowHistoryType.APPROVAL.name() + "}");
+        final Map<String, Object> changeMap = workflowHistory.getChangeMap();
+
+        Assert.assertNotNull("GetChangeMap must not return a null map",changeMap);
+        Assert.assertEquals("Should return test description", workflowHistory.getChangeDescription(), "test");
+        Assert.assertEquals("Should return test description", changeMap.get("description"), "test");
+        Assert.assertEquals("Should return approval type", changeMap.get("type"), WorkflowHistoryType.APPROVAL.name());
+    }
+}

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/model/WorkflowHistoryTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/model/WorkflowHistoryTest.java
@@ -17,7 +17,8 @@ public class WorkflowHistoryTest {
 
         Assert.assertNotNull("GetChangeMap must not return a null map",changeMap);
         Assert.assertEquals("Should return a blank description", changeMap.get("description"), StringPool.BLANK);
-        Assert.assertEquals("Should return a comment type", changeMap.get("type"), WorkflowHistoryType.COMMENT);
+        Assert.assertEquals("Should return a comment type", changeMap.get("type"), WorkflowHistoryType.COMMENT.name());
+        Assert.assertEquals("Should return a comment type", changeMap.get("state"), WorkflowHistoryState.NONE.name());
     }
 
     @Test
@@ -30,19 +31,21 @@ public class WorkflowHistoryTest {
         Assert.assertNotNull("GetChangeMap must not return a null map",changeMap);
         Assert.assertEquals("Should return test description", workflowHistory.getChangeDescription(), "test");
         Assert.assertEquals("Should return test description", changeMap.get("description"), "test");
-        Assert.assertEquals("Should return a comment type", changeMap.get("type"), WorkflowHistoryType.COMMENT);
+        Assert.assertEquals("Should return a comment type", changeMap.get("type"), WorkflowHistoryType.COMMENT.name());
+        Assert.assertEquals("Should return a comment type", changeMap.get("state"), WorkflowHistoryState.NONE.name());
     }
 
     @Test
     public void test_getChangeMap_approval_type ()  {
 
         final WorkflowHistory workflowHistory = new WorkflowHistory();
-        workflowHistory.setChangeDescription("{'description':'test', 'type':" + WorkflowHistoryType.APPROVAL.name() + "}");
+        workflowHistory.setChangeDescription("{'description':'test', 'type':'" + WorkflowHistoryType.APPROVAL.name() + "', 'state':'"+  WorkflowHistoryState.NONE.name() +"' }");
         final Map<String, Object> changeMap = workflowHistory.getChangeMap();
 
         Assert.assertNotNull("GetChangeMap must not return a null map",changeMap);
         Assert.assertEquals("Should return test description", workflowHistory.getChangeDescription(), "test");
         Assert.assertEquals("Should return test description", changeMap.get("description"), "test");
         Assert.assertEquals("Should return approval type", changeMap.get("type"), WorkflowHistoryType.APPROVAL.name());
+        Assert.assertEquals("Should return a comment type", changeMap.get("state"), WorkflowHistoryState.NONE.name());
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/util/CollectionsUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/util/CollectionsUtils.java
@@ -1,11 +1,9 @@
 package com.dotcms.util;
 
 import com.dotcms.repackage.com.google.common.collect.ImmutableSet;
-import com.dotmarketing.portlets.workflows.model.WorkflowAction;
 import com.google.common.collect.ImmutableList;
 import com.liferay.util.StringPool;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.poi.ss.formula.functions.T;
 import org.elasticsearch.common.collect.MapBuilder;
 
 import java.io.Serializable;

--- a/dotCMS/src/main/java/com/dotcms/util/CollectionsUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/util/CollectionsUtils.java
@@ -1,6 +1,7 @@
 package com.dotcms.util;
 
 import com.dotcms.repackage.com.google.common.collect.ImmutableSet;
+import com.dotmarketing.portlets.workflows.model.WorkflowAction;
 import com.google.common.collect.ImmutableList;
 import com.liferay.util.StringPool;
 import org.apache.commons.lang3.StringUtils;
@@ -926,7 +927,27 @@ public class CollectionsUtils implements Serializable {
 	    return new ImmutableListCollector<>();
     }
 
-	private static class ImmutableListCollector<T> implements Collector<T, ImmutableList.Builder<T>, ImmutableList<T>> {
+    /**
+     * Finds a element into the list base on the function comparator (receives the element and returns true if match is right)
+     * @param items {@link List}
+     * @param comparator {@link Function} to determine if it is the match or not
+     * @param <T>
+     * @return Optional, return empty if not match, otherwise the first match element
+     */
+    public static <T> Optional<T> find(final List<T> items, final Function<T, Boolean> comparator) {
+
+	    for (final T item : items) {
+
+	        if (comparator.apply(item)) {
+
+	            return Optional.ofNullable(item);
+            }
+        }
+
+	    return Optional.empty();
+    }
+
+    private static class ImmutableListCollector<T> implements Collector<T, ImmutableList.Builder<T>, ImmutableList<T>> {
         @Override
         public Supplier<ImmutableList.Builder<T>> supplier() {
             return ImmutableList.Builder::new;

--- a/dotCMS/src/main/java/com/dotcms/util/CollectionsUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/util/CollectionsUtils.java
@@ -925,26 +925,6 @@ public class CollectionsUtils implements Serializable {
 	    return new ImmutableListCollector<>();
     }
 
-    /**
-     * Finds a element into the list base on the function comparator (receives the element and returns true if match is right)
-     * @param items {@link List}
-     * @param comparator {@link Function} to determine if it is the match or not
-     * @param <T>
-     * @return Optional, return empty if not match, otherwise the first match element
-     */
-    public static <T> Optional<T> find(final List<T> items, final Function<T, Boolean> comparator) {
-
-	    for (final T item : items) {
-
-	        if (comparator.apply(item)) {
-
-	            return Optional.ofNullable(item);
-            }
-        }
-
-	    return Optional.empty();
-    }
-
     private static class ImmutableListCollector<T> implements Collector<T, ImmutableList.Builder<T>, ImmutableList<T>> {
         @Override
         public Supplier<ImmutableList.Builder<T>> supplier() {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionlet.java
@@ -1,9 +1,5 @@
 package com.dotmarketing.portlets.workflows.actionlet;
 
-import static com.dotmarketing.portlets.workflows.util.WorkflowActionletUtil.getApproversFromHistory;
-import static com.dotmarketing.portlets.workflows.util.WorkflowActionletUtil.getParameterValue;
-import static com.dotmarketing.portlets.workflows.util.WorkflowActionletUtil.getUsersFromIds;
-
 import com.dotcms.util.ConversionUtils;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Role;
@@ -13,10 +9,13 @@ import com.dotmarketing.portlets.workflows.util.WorkflowEmailUtil;
 import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
 import io.vavr.Tuple2;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static com.dotmarketing.portlets.workflows.util.WorkflowActionletUtil.*;
 
 /**
  * Sometimes, customers would like content to be published if a specific number of people approve
@@ -171,6 +170,7 @@ public class FourEyeApproverActionlet extends WorkFlowActionlet {
                     }
                 }
             }
+
             final String[] emailsToSend = emails.toArray(new String[emails.size()]);
             processor.setWorkflowMessage(emailSubject);
             // Sending notification message

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionlet.java
@@ -8,11 +8,7 @@ import com.dotcms.util.ConversionUtils;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Role;
 import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.portlets.workflows.model.MultiUserReferenceParameter;
-import com.dotmarketing.portlets.workflows.model.WorkflowActionClassParameter;
-import com.dotmarketing.portlets.workflows.model.WorkflowActionletParameter;
-import com.dotmarketing.portlets.workflows.model.WorkflowHistory;
-import com.dotmarketing.portlets.workflows.model.WorkflowProcessor;
+import com.dotmarketing.portlets.workflows.model.*;
 import com.dotmarketing.portlets.workflows.util.WorkflowEmailUtil;
 import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
@@ -180,6 +176,8 @@ public class FourEyeApproverActionlet extends WorkFlowActionlet {
             // Sending notification message
             WorkflowEmailUtil.sendWorkflowEmail(processor, emailsToSend, emailSubject, emailBody, isHtml);
         }
+
+        processor.getContextMap().put("type", WorkflowHistoryType.APPROVAL);
     }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/MultipleApproverActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/MultipleApproverActionlet.java
@@ -2,14 +2,26 @@ package com.dotmarketing.portlets.workflows.actionlet;
 
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.portlets.workflows.model.*;
+import com.dotmarketing.portlets.workflows.model.MultiEmailParameter;
+import com.dotmarketing.portlets.workflows.model.WorkflowActionClassParameter;
+import com.dotmarketing.portlets.workflows.model.WorkflowActionFailureException;
+import com.dotmarketing.portlets.workflows.model.WorkflowActionletParameter;
+import com.dotmarketing.portlets.workflows.model.WorkflowHistory;
+import com.dotmarketing.portlets.workflows.model.WorkflowHistoryState;
+import com.dotmarketing.portlets.workflows.model.WorkflowHistoryType;
+import com.dotmarketing.portlets.workflows.model.WorkflowProcessor;
 import com.dotmarketing.portlets.workflows.util.WorkflowEmailUtil;
 import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import com.liferay.util.Validator;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
 
 /**
  * Based on a list of email, userid or roles won't continue the pipeline until all necessary users approve the workflow
@@ -70,7 +82,8 @@ public class MultipleApproverActionlet extends WorkFlowActionlet {
 					requiredApprovers.add(user);
 				} catch (Exception e) {
 
-					Logger.error(this.getClass(), "Unable to find user with email:" + userIdToken);
+					Logger.warnAndDebug(this.getClass(), "Unable to find user with email:" + userIdToken
+							+ ", message: " + e.getMessage(), e);
 				}
 			} else {
 				try {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/MultipleApproverActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/MultipleApproverActionlet.java
@@ -9,22 +9,18 @@ import java.util.StringTokenizer;
 
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.portlets.workflows.model.MultiEmailParameter;
-import com.dotmarketing.portlets.workflows.model.WorkflowActionClassParameter;
-import com.dotmarketing.portlets.workflows.model.WorkflowActionFailureException;
-import com.dotmarketing.portlets.workflows.model.WorkflowActionletParameter;
-import com.dotmarketing.portlets.workflows.model.WorkflowHistory;
-import com.dotmarketing.portlets.workflows.model.WorkflowProcessor;
+import com.dotmarketing.portlets.workflows.model.*;
 import com.dotmarketing.portlets.workflows.util.WorkflowEmailUtil;
 import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
 import com.liferay.util.Validator;
 
+/**
+ * Based on a list of email, userid or roles won't continue the pipeline until all necessary users approve the workflow
+ */
 public class MultipleApproverActionlet extends WorkFlowActionlet {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	public String getName() {
@@ -43,17 +39,16 @@ public class MultipleApproverActionlet extends WorkFlowActionlet {
 	public void executeAction(WorkflowProcessor processor, Map<String, WorkflowActionClassParameter> params)
 			throws WorkflowActionFailureException {
 
-		String userIds = (params.get("approvers") == null) ? "" : params.get("approvers").getValue();
-
-		String emailSubject = null;
-		String emailBody = null;
-		boolean isHtml = false;
+		final String userIds = (params.get("approvers") == null) ? "" : params.get("approvers").getValue();
+		String emailSubject  = null;
+		String emailBody     = null;
+		boolean isHtml       = false;
 
 		if (params.get("emailSubject") != null) {
 			emailSubject = params.get("emailSubject").getValue();
 		}
 		if (params.get("emailBody") != null) {
-			emailBody = params.get("emailBody").getValue();
+			emailBody    = params.get("emailBody").getValue();
 		}
 
 		if (params.get("isHtml") != null) {
@@ -64,54 +59,55 @@ public class MultipleApproverActionlet extends WorkFlowActionlet {
 			}
 		}
 
-		Set<User> requiredApprovers = new HashSet<User>();
-		Set<User> hasApproved = new HashSet<User>();
-		StringTokenizer st = new StringTokenizer(userIds, ", ");
-		while (st.hasMoreTokens()) {
-			String x = st.nextToken();
+		final Set<User> requiredApprovers = new HashSet<>();
+		final Set<User> hasApproved       = new HashSet<>();
+		final StringTokenizer userIdTokenizer = new StringTokenizer(userIds, StringPool.COMMA);
+		while (userIdTokenizer.hasMoreTokens()) {
 
-			if (Validator.isEmailAddress(x)) {
+			final String userIdToken = userIdTokenizer.nextToken();
+
+			if (Validator.isEmailAddress(userIdToken)) {
 				try {
-					User u = APILocator.getUserAPI().loadByUserByEmail(x, APILocator.getUserAPI().getSystemUser(), false);
 
-					requiredApprovers.add(u);
+					final User user = APILocator.getUserAPI().loadByUserByEmail(userIdToken,
+							APILocator.getUserAPI().getSystemUser(), false);
+
+					requiredApprovers.add(user);
 				} catch (Exception e) {
-					Logger.error(this.getClass(), "Unable to find user with email:" + x);
+
+					Logger.error(this.getClass(), "Unable to find user with email:" + userIdToken);
 				}
 			} else {
 				try {
 
-					User u = APILocator.getUserAPI().loadUserById(x, APILocator.getUserAPI().getSystemUser(), false);
-					requiredApprovers.add(u);
+					final User user = APILocator.getUserAPI().loadUserById(userIdToken,
+							APILocator.getUserAPI().getSystemUser(), false);
+					requiredApprovers.add(user);
 				} catch (Exception e) {
-					Logger.error(this.getClass(), "Unable to find user with userID:" + x);
+					Logger.error(this.getClass(), "Unable to find user with userID:" + userIdToken);
 				}
 
 			}
 		}
+
 		List<WorkflowHistory> histories = processor.getHistory();
 		
 		// add this approval to the history
-		WorkflowHistory h = new WorkflowHistory();
-		h.setActionId(processor.getAction().getId());
-		h.setMadeBy(processor.getUser().getUserId());
-		if(histories == null){
-			histories = new ArrayList<WorkflowHistory>();
-			histories.add(h);
-		}else histories.add(h);
+		final WorkflowHistory workflowHistory = new WorkflowHistory();
+		workflowHistory.setActionId(processor.getAction().getId());
+		workflowHistory.setMadeBy(processor.getUser().getUserId());
+		histories = histories == null?new ArrayList<>():histories;
+		histories.add(workflowHistory);
 		
-		for (User u : requiredApprovers) {
-
-			for (WorkflowHistory history : histories) {
+		for (final User requiredApprover : requiredApprovers) {
+			for (final WorkflowHistory history : histories) {
 				if (history.getActionId().equals(processor.getAction().getId())) {
-					if (u.getUserId().equals(history.getMadeBy())) {
-						hasApproved.add(u);
+					if (requiredApprover.getUserId().equals(history.getMadeBy())) {
+
+						hasApproved.add(requiredApprover);
 					}
-
 				}
-
 			}
-
 		}
 		
 		if (hasApproved.size() < requiredApprovers.size()) {
@@ -119,40 +115,33 @@ public class MultipleApproverActionlet extends WorkFlowActionlet {
 			shouldStop = true;
 			// keep the workflow process on the same step
 			processor.setNextStep( processor.getStep());
-			
-			
+
 			// only send emails to users who have not approved
-			List<String> emails = new ArrayList<String>();
-			for (User u : requiredApprovers) {
-				if(!hasApproved.contains(u)){
-					emails.add(u.getEmailAddress());					
+			final List<String> emails = new ArrayList<>();
+			for (final User user : requiredApprovers) {
+				if(!hasApproved.contains(user)){
+					emails.add(user.getEmailAddress());
 				}
 			}
 			
 			// to assign it for next assignee
-			for (User u : requiredApprovers) {
-				if(!hasApproved.contains(u)){					
+			for (final User requiredApprover : requiredApprovers) {
+				if(!hasApproved.contains(requiredApprover)){
 					try {
-	                   processor.setNextAssign(APILocator.getRoleAPI().getUserRole(u));
+	                   processor.setNextAssign(APILocator.getRoleAPI().getUserRole(requiredApprover));
 	                   break;
 	                } catch (DotDataException e) {
 	                   Logger.error(MultipleApproverActionlet.class,e.getMessage(),e);
 	                }
 				}
 			}
-			
-			
-			
-			
-			String[] emailsToSend = (String[]) emails.toArray(new String[emails.size()]);
 
-			
+			final String[] emailsToSend = emails.toArray(new String[emails.size()]);
 			processor.setWorkflowMessage(emailSubject);
-			
 			WorkflowEmailUtil.sendWorkflowEmail(processor, emailsToSend, emailSubject, emailBody, isHtml);
-
 		}
 
+		processor.getContextMap().put("type", WorkflowHistoryType.APPROVAL);
 	}
 
 	@Override
@@ -167,7 +156,7 @@ public class MultipleApproverActionlet extends WorkFlowActionlet {
 		if (paramList == null) {
 			synchronized (this.getClass()) {
 				if (paramList == null) {
-					paramList = new ArrayList<WorkflowActionletParameter>();
+					paramList = new ArrayList<>();
 					paramList.add(new MultiEmailParameter("approvers", "User IDs or Emails", null, true));
 					paramList.add(new WorkflowActionletParameter("emailSubject", "Email Subject", "Multiple Approval Required", false));
 					paramList.add(new WorkflowActionletParameter("emailBody", "Email Message", null, false));

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/MultipleApproverActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/MultipleApproverActionlet.java
@@ -1,12 +1,5 @@
 package com.dotmarketing.portlets.workflows.actionlet;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
-
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.workflows.model.*;
@@ -15,6 +8,8 @@ import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import com.liferay.util.Validator;
+
+import java.util.*;
 
 /**
  * Based on a list of email, userid or roles won't continue the pipeline until all necessary users approve the workflow
@@ -101,7 +96,11 @@ public class MultipleApproverActionlet extends WorkFlowActionlet {
 		
 		for (final User requiredApprover : requiredApprovers) {
 			for (final WorkflowHistory history : histories) {
-				if (history.getActionId().equals(processor.getAction().getId())) {
+
+				final Map<String, Object> changeMap = history.getChangeMap();
+				if (history.getActionId().equals(processor.getAction().getId()) && // if it is the action id and it is not reset.
+						!WorkflowHistoryState.RESET.name().equals(changeMap.get("state"))) {
+
 					if (requiredApprover.getUserId().equals(history.getMadeBy())) {
 
 						hasApproved.add(requiredApprover);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/ResetApproversActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/ResetApproversActionlet.java
@@ -1,0 +1,58 @@
+
+package com.dotmarketing.portlets.workflows.actionlet;
+
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.workflows.model.*;
+import com.dotmarketing.util.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Deletes the approvers of the workflow task
+ * @author jsanca
+ */
+public class ResetApproversActionlet extends WorkFlowActionlet {
+
+	@Override
+	public String getName() {
+		return "Reset Approvers";
+	}
+
+	@Override
+	public String getHowTo() {
+
+		return "This actionlet will reset workflow history approvers";
+	}
+
+	@Override
+	public void executeAction(final WorkflowProcessor processor,
+							  final Map<String,WorkflowActionClassParameter>  params) throws WorkflowActionFailureException {
+
+		try {
+
+			final List<WorkflowHistory> histories = processor.getHistory();
+			for (final WorkflowHistory history : histories) {
+				final Map<String, Object> changeMap = history.getChangeMap();
+				final Object type = changeMap.get("type");
+				if (WorkflowHistoryType.APPROVAL.name().equals(type)) {
+
+					APILocator.getWorkflowAPI().deleteWorkflowHistory(history);
+				}
+			}
+		} catch (DotDataException e) {
+			Logger.error(ResetApproversActionlet.class,e.getMessage(),e);
+		}
+	}
+
+	@Override
+	public  List<WorkflowActionletParameter> getParameters() {
+
+		return null;
+	}
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/ResetApproversActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/ResetApproversActionlet.java
@@ -5,16 +5,15 @@ import com.dotcms.util.CollectionsUtils;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.workflows.model.*;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
-import com.hazelcast.util.CollectionUtil;
 
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.dotmarketing.portlets.workflows.util.WorkflowActionletUtil.getParameterValue;
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/ResetApproversActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/ResetApproversActionlet.java
@@ -34,7 +34,7 @@ public class ResetApproversActionlet extends WorkFlowActionlet {
 		if (null == ACTIONLET_PARAMETERS) {
 			ACTIONLET_PARAMETERS = new ArrayList<>();
 			ACTIONLET_PARAMETERS
-					.add(new MultiUserReferenceParameter(PARAM_CONTENT_ACTIONS,
+					.add(new WorkflowActionletParameter(PARAM_CONTENT_ACTIONS,
 							"Optional Action ID, or Name", null,
 							false));
 		}
@@ -43,20 +43,20 @@ public class ResetApproversActionlet extends WorkFlowActionlet {
 
 	@Override
 	public String getName() {
-		return "Reset Approvers";
+		return "Reset Approvals";
 	}
 
 	@Override
 	public String getHowTo() {
 
-		return "This actionlet will reset workflow history approvers";
+		return "This actionlet will reset workflow history approvals";
 	}
 
 	private Optional<String> getWorkflowIdFromParameter (final WorkflowProcessor processor,
 														 final WorkflowActionClassParameter parameter)  {
 
 		final String value = getParameterValue(parameter);
-		if (null == value) {
+		if (null != value) {
 
 			if (!UUIDUtil.isUUID(value)) {
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/ResetApproversActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/ResetApproversActionlet.java
@@ -1,11 +1,17 @@
 
 package com.dotmarketing.portlets.workflows.actionlet;
 
-import com.dotcms.util.CollectionsUtils;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.portlets.workflows.model.*;
+import com.dotmarketing.portlets.workflows.model.WorkflowAction;
+import com.dotmarketing.portlets.workflows.model.WorkflowActionClassParameter;
+import com.dotmarketing.portlets.workflows.model.WorkflowActionFailureException;
+import com.dotmarketing.portlets.workflows.model.WorkflowActionletParameter;
+import com.dotmarketing.portlets.workflows.model.WorkflowHistory;
+import com.dotmarketing.portlets.workflows.model.WorkflowHistoryState;
+import com.dotmarketing.portlets.workflows.model.WorkflowHistoryType;
+import com.dotmarketing.portlets.workflows.model.WorkflowProcessor;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
@@ -69,8 +75,8 @@ public class ResetApproversActionlet extends WorkFlowActionlet {
 
 				if (UtilMethods.isSet(workflowActions)) {
 
-					final Optional<WorkflowAction> workflowAction = CollectionsUtils.find (workflowActions,
-							action -> action.getName().equalsIgnoreCase(value));
+					final Optional<WorkflowAction> workflowAction =
+							workflowActions.stream().filter(action -> action.getName().equalsIgnoreCase(value)).findFirst();
 					if (workflowAction.isPresent()) {
 
 						return Optional.ofNullable(workflowAction.get().getId());

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/ResetApproversActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/ResetApproversActionlet.java
@@ -1,23 +1,45 @@
 
 package com.dotmarketing.portlets.workflows.actionlet;
 
+import com.dotcms.util.CollectionsUtils;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.workflows.model.*;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UUIDUtil;
+import com.dotmarketing.util.UtilMethods;
+import com.hazelcast.util.CollectionUtil;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static com.dotmarketing.portlets.workflows.util.WorkflowActionletUtil.getParameterValue;
 
 /**
  * Deletes the approvers of the workflow task
  * @author jsanca
  */
 public class ResetApproversActionlet extends WorkFlowActionlet {
+
+	private static final String ID_DELIMITER = ",";
+	private static final String PARAM_CONTENT_ACTIONS = "action";
+
+	private static ArrayList<WorkflowActionletParameter> ACTIONLET_PARAMETERS = null;
+
+	@Override
+	public synchronized List<WorkflowActionletParameter> getParameters() {
+		if (null == ACTIONLET_PARAMETERS) {
+			ACTIONLET_PARAMETERS = new ArrayList<>();
+			ACTIONLET_PARAMETERS
+					.add(new MultiUserReferenceParameter(PARAM_CONTENT_ACTIONS,
+							"Optional Action ID, or Name", null,
+							false));
+		}
+		return ACTIONLET_PARAMETERS;
+	}
 
 	@Override
 	public String getName() {
@@ -30,29 +52,74 @@ public class ResetApproversActionlet extends WorkFlowActionlet {
 		return "This actionlet will reset workflow history approvers";
 	}
 
+	private Optional<String> getWorkflowIdFromParameter (final WorkflowProcessor processor,
+														 final WorkflowActionClassParameter parameter)  {
+
+		final String value = getParameterValue(parameter);
+		if (null == value) {
+
+			if (!UUIDUtil.isUUID(value)) {
+
+				final List<WorkflowAction> workflowActions;
+				try {
+					workflowActions = APILocator.getWorkflowAPI()
+							.findActions(processor.getScheme(), processor.getUser());
+				} catch (DotDataException | DotSecurityException e) {
+					throw new WorkflowActionFailureException(e.getMessage(), e);
+				}
+
+				if (UtilMethods.isSet(workflowActions)) {
+
+					final Optional<WorkflowAction> workflowAction = CollectionsUtils.find (workflowActions,
+							action -> action.getName().equalsIgnoreCase(value));
+					if (workflowAction.isPresent()) {
+
+						return Optional.ofNullable(workflowAction.get().getId());
+					}
+				}
+			}
+		}
+
+		return Optional.ofNullable(value);
+	}
+
 	@Override
 	public void executeAction(final WorkflowProcessor processor,
 							  final Map<String,WorkflowActionClassParameter>  params) throws WorkflowActionFailureException {
 
 		try {
 
-			final List<WorkflowHistory> histories = processor.getHistory();
+			final Optional<String> actionIdOpt = this.getWorkflowIdFromParameter(processor, params.get(PARAM_CONTENT_ACTIONS));
+			final List<WorkflowHistory> newHistories = new ArrayList<>();
+			final List<WorkflowHistory> histories    = processor.getHistory();
 			for (final WorkflowHistory history : histories) {
+
 				final Map<String, Object> changeMap = history.getChangeMap();
 				final Object type = changeMap.get("type");
 				if (WorkflowHistoryType.APPROVAL.name().equals(type)) {
 
-					APILocator.getWorkflowAPI().deleteWorkflowHistory(history);
+					// if wants to filter by action id
+					if (actionIdOpt.isPresent() && !actionIdOpt.get().equals(history.actionId())) {
+
+						newHistories.add(history);
+						continue;
+					}
+
+					final String description = "{'description':'"+ changeMap.get("description") +
+							"', 'type':'" + WorkflowHistoryType.APPROVAL.name() +
+							"', 'state':'"+  WorkflowHistoryState.RESET.name() +"' }";
+					history.setChangeDescription(description);
+					APILocator.getWorkflowAPI().saveWorkflowHistory(history);
 				}
+
+				newHistories.add(history);
 			}
+
+			processor.setHistory(newHistories);
 		} catch (DotDataException e) {
 			Logger.error(ResetApproversActionlet.class,e.getMessage(),e);
 		}
 	}
 
-	@Override
-	public  List<WorkflowActionletParameter> getParameters() {
 
-		return null;
-	}
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkFlowFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkFlowFactory.java
@@ -95,6 +95,11 @@ public interface WorkFlowFactory {
 
 	public void saveComment(WorkflowComment comment) throws DotDataException;
 
+	/**
+	 * Saves or Updates (if does not exists, based on a search by id) the history
+	 * @param history {@link WorkflowHistory}
+	 * @throws DotDataException
+	 */
 	public void saveWorkflowHistory(WorkflowHistory history) throws DotDataException;
 
 	/**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
@@ -1395,7 +1395,6 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 		final String comment = (UtilMethods.isSet(processor.getWorkflowMessage()))? processor.getWorkflowMessage()   : StringPool.BLANK;
 		final String nextAssignName = (UtilMethods.isSet(processor.getNextAssign()))? processor.getNextAssign().getName() : StringPool.BLANK;
 
-
 		try {
 
 			String description = LanguageUtil.format(processor.getUser().getLocale(), "workflow.history.description", new String[]{
@@ -1406,7 +1405,9 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 					comment}, false);
 
 			if ( processor.getContextMap().containsKey("type") && WorkflowHistoryType.APPROVAL == processor.getContextMap().get("type")) {
-				description = "{'description':'"+ description + "', 'type':" + WorkflowHistoryType.APPROVAL.name() + "}";
+				description = "{'description':'"+ description +
+						"', 'type':'" + WorkflowHistoryType.APPROVAL.name() +
+						"', 'state':'"+  WorkflowHistoryState.NONE.name() +"' }";
 			}
 
 			history.setChangeDescription(description);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
@@ -70,49 +70,8 @@ import com.dotmarketing.portlets.languagesmanager.business.LanguageDeletedEvent;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.portlets.workflows.LargeMessageActionlet;
 import com.dotmarketing.portlets.workflows.MessageActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.Actionlet;
-import com.dotmarketing.portlets.workflows.actionlet.ArchiveContentActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.BatchAction;
-import com.dotmarketing.portlets.workflows.actionlet.CheckURLAccessibilityActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.CheckinContentActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.CheckoutContentActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.CommentOnWorkflowActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.CopyActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.DeleteContentActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.DestroyContentActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.EmailActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.FourEyeApproverActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.MultipleApproverActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.NotifyAssigneeActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.NotifyUsersActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.PublishContentActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.PushNowActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.PushPublishActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.ReindexContentActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.ResetTaskActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.SaveContentActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.SaveContentAsDraftActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.SendFormEmailActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.SetValueActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.TranslationActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.TwitterActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.UnarchiveContentActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.UnpublishContentActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.VelocityScriptActionlet;
-import com.dotmarketing.portlets.workflows.actionlet.WorkFlowActionlet;
-import com.dotmarketing.portlets.workflows.model.SystemActionWorkflowActionMapping;
-import com.dotmarketing.portlets.workflows.model.WorkflowAction;
-import com.dotmarketing.portlets.workflows.model.WorkflowActionClass;
-import com.dotmarketing.portlets.workflows.model.WorkflowActionClassParameter;
-import com.dotmarketing.portlets.workflows.model.WorkflowComment;
-import com.dotmarketing.portlets.workflows.model.WorkflowHistory;
-import com.dotmarketing.portlets.workflows.model.WorkflowProcessor;
-import com.dotmarketing.portlets.workflows.model.WorkflowScheme;
-import com.dotmarketing.portlets.workflows.model.WorkflowSearcher;
-import com.dotmarketing.portlets.workflows.model.WorkflowState;
-import com.dotmarketing.portlets.workflows.model.WorkflowStep;
-import com.dotmarketing.portlets.workflows.model.WorkflowTask;
-import com.dotmarketing.portlets.workflows.model.WorkflowTimelineItem;
+import com.dotmarketing.portlets.workflows.actionlet.*;
+import com.dotmarketing.portlets.workflows.model.*;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.DateUtil;
 import com.dotmarketing.util.InodeUtils;
@@ -259,7 +218,8 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 				MessageActionlet.class,
 				VelocityScriptActionlet.class,
 				LargeMessageActionlet.class,
-				SendFormEmailActionlet.class
+				SendFormEmailActionlet.class,
+				ResetApproversActionlet.class
 		));
 
 		refreshWorkFlowActionletMap();
@@ -1437,14 +1397,19 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 
 
 		try {
-			history.setChangeDescription(
-					LanguageUtil.format(processor.getUser().getLocale(), "workflow.history.description", new String[]{
-							processor.getUser().getFullName(),
-							processor.getAction().getName(),
-							processor.getNextStep().getName(),
-							nextAssignName,
-							comment}, false)
-			);
+
+			String description = LanguageUtil.format(processor.getUser().getLocale(), "workflow.history.description", new String[]{
+					processor.getUser().getFullName(),
+					processor.getAction().getName(),
+					processor.getNextStep().getName(),
+					nextAssignName,
+					comment}, false);
+
+			if ( processor.getContextMap().containsKey("type") && WorkflowHistoryType.APPROVAL == processor.getContextMap().get("type")) {
+				description = "{'description':'"+ description + "', 'type':" + WorkflowHistoryType.APPROVAL.name() + "}";
+			}
+
+			history.setChangeDescription(description);
 		} catch (LanguageException e) {
 			Logger.error(WorkflowAPIImpl.class,e.getMessage());
 			Logger.debug(WorkflowAPIImpl.class,e.getMessage(),e);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowFactoryImpl.java
@@ -2175,7 +2175,7 @@ public class WorkflowFactoryImpl implements WorkFlowFactory {
 	private void setHistoryDBParams(WorkflowHistory history, DotConnect db) {
 		db.addParam(history.getCreationDate());
 		db.addParam(history.getMadeBy());
-		db.addParam(history.getChangeDescription());
+		db.addParam(history.getRawChangeDescription());
 		db.addParam(history.getWorkflowtaskId());
 		db.addParam(history.getActionId());
 		db.addParam(history.getStepId());

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistory.java
@@ -1,10 +1,15 @@
 package com.dotmarketing.portlets.workflows.model;
 
+import com.dotcms.util.marshal.MarshalFactory;
+import com.dotcms.util.marshal.MarshalUtils;
 import com.dotmarketing.util.UtilMethods;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.liferay.util.StringPool;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 public class WorkflowHistory  implements Serializable, WorkflowTimelineItem
@@ -65,7 +70,30 @@ public class WorkflowHistory  implements Serializable, WorkflowTimelineItem
     }
 
     public String getChangeDescription() {
-        return changeDescription;
+
+        if (UtilMethods.isSet(this.changeDescription) && this.changeDescription.trim().startsWith("{")) {
+            // if it is json
+            return(String) this.getChangeMap().get("description");
+        }
+
+        // if the representation of the json, if it is  json. otherwise is gonna be description, getChangeDescription
+        return this.changeDescription;
+    }
+
+    public String getRawChangeDescription() {
+        return this.changeDescription;
+    }
+
+    public Map<String, Object> getChangeMap () {
+
+        if (UtilMethods.isSet(this.changeDescription) && this.changeDescription.trim().startsWith("{")) {
+            // if it is json
+            return MarshalFactory.getInstance().getMarshalUtils().unmarshal(this.changeDescription, Map.class);
+        }
+
+        // if the representation of the json, if it is  json. otherwise is gonna be description, getChangeDescription
+        return ImmutableMap.of("description", null == this.changeDescription? StringPool.BLANK:this.changeDescription,
+                "type", WorkflowHistoryType.COMMENT);
     }
 
     public void setChangeDescription(String changeDescription) {
@@ -143,7 +171,6 @@ public class WorkflowHistory  implements Serializable, WorkflowTimelineItem
 
     @Override
     public String type() {
-        // TODO Auto-generated method stub
         return this.getClass().getSimpleName();
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistory.java
@@ -1,16 +1,15 @@
 package com.dotmarketing.portlets.workflows.model;
 
 import com.dotcms.util.marshal.MarshalFactory;
-import com.dotcms.util.marshal.MarshalUtils;
 import com.dotmarketing.util.UtilMethods;
+import com.google.common.collect.ImmutableMap;
+import com.liferay.util.StringPool;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
-import com.liferay.util.StringPool;
-import org.apache.commons.lang.builder.ToStringBuilder;
 
 public class WorkflowHistory  implements Serializable, WorkflowTimelineItem
 {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistory.java
@@ -93,7 +93,7 @@ public class WorkflowHistory  implements Serializable, WorkflowTimelineItem
 
         // if the representation of the json, if it is  json. otherwise is gonna be description, getChangeDescription
         return ImmutableMap.of("description", null == this.changeDescription? StringPool.BLANK:this.changeDescription,
-                "type", WorkflowHistoryType.COMMENT);
+                "type", WorkflowHistoryType.COMMENT.name(), "state", WorkflowHistoryState.NONE.name());
     }
 
     public void setChangeDescription(String changeDescription) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistory.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.portlets.workflows.model;
 
 import com.dotcms.util.marshal.MarshalFactory;
+import com.dotmarketing.util.StringUtils;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.collect.ImmutableMap;
 import com.liferay.util.StringPool;
@@ -85,7 +86,7 @@ public class WorkflowHistory  implements Serializable, WorkflowTimelineItem
 
     public Map<String, Object> getChangeMap () {
 
-        if (UtilMethods.isSet(this.changeDescription) && this.changeDescription.trim().startsWith("{")) {
+        if (UtilMethods.isSet(this.changeDescription) && StringUtils.isJson(this.changeDescription.trim())) {
             // if it is json
             return MarshalFactory.getInstance().getMarshalUtils().unmarshal(this.changeDescription, Map.class);
         }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistory.java
@@ -71,7 +71,7 @@ public class WorkflowHistory  implements Serializable, WorkflowTimelineItem
 
     public String getChangeDescription() {
 
-        if (UtilMethods.isSet(this.changeDescription) && this.changeDescription.trim().startsWith("{")) {
+        if (UtilMethods.isSet(this.changeDescription)  && StringUtils.isJson(this.changeDescription.trim())) {
             // if it is json
             return(String) this.getChangeMap().get("description");
         }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistoryState.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistoryState.java
@@ -1,0 +1,10 @@
+package com.dotmarketing.portlets.workflows.model;
+
+/**
+ * Says which is the state of a history change, usually it is NONE (non-state)
+ */
+public enum WorkflowHistoryState {
+
+    NONE,  // non-state
+    RESET  // means the row has been reset.
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistoryType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/model/WorkflowHistoryType.java
@@ -1,0 +1,15 @@
+package com.dotmarketing.portlets.workflows.model;
+
+/**
+ * Represent the type of the history, it could be just a comment or approval
+ *
+ * Approval means a comment history which is actually an approval
+ * Comment is basically anything else
+ *
+ * @author jsanca
+ */
+public enum WorkflowHistoryType {
+
+    COMMENT,
+    APPROVAL
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/util/WorkflowActionletUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/util/WorkflowActionletUtil.java
@@ -6,17 +6,15 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.workflows.model.WorkflowActionClassParameter;
 import com.dotmarketing.portlets.workflows.model.WorkflowHistory;
+import com.dotmarketing.portlets.workflows.model.WorkflowHistoryState;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import com.liferay.util.Validator;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.StringTokenizer;
+
+import java.util.*;
 
 /**
  * This utility class provides common-use methods that can be accessed by the different workflow
@@ -182,8 +180,12 @@ public class WorkflowActionletUtil {
         final Set<User> hasApproved = new HashSet<>();
         for (final User user : requiredApprovers) {
             for (final WorkflowHistory historyItem : historyList) {
-                if (historyItem.getActionId().equals(contentId) && user.getUserId()
-                        .equals(historyItem.getMadeBy())) {
+
+                final Map<String, Object> changeMap = historyItem.getChangeMap();
+                if (historyItem.getActionId().equals(contentId) &&
+                        user.getUserId().equals(historyItem.getMadeBy()) && // if it is the action id and it is not reset.
+                        !WorkflowHistoryState.RESET.name().equals(changeMap.get("state"))
+                ) {
                     hasApproved.add(user);
                     if (limit > 0 && hasApproved.size() >= limit) {
                         return hasApproved;

--- a/dotCMS/src/test/java/com/dotcms/util/CollectionsUtilsTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/CollectionsUtilsTest.java
@@ -21,21 +21,6 @@ import static org.junit.Assert.*;
 public class CollectionsUtilsTest extends UnitTestBase {
 
     @Test
-    public void find() {
-
-        final List<AssignCommentBean>     arrays = Arrays.asList(new AssignCommentBean("1","1"),
-                new AssignCommentBean("2","2"), new AssignCommentBean("3","3"), new AssignCommentBean("4","4"),
-                new AssignCommentBean("5","5"), new AssignCommentBean("6","6"), new AssignCommentBean("7","7"));
-        final Optional<AssignCommentBean> match1  = CollectionsUtils.find(arrays, assignCommentBean -> assignCommentBean.getAssign().equals("6"));
-        Assert.assertTrue(match1.isPresent());
-        Assert.assertEquals("6", match1.get().getAssign());
-        Assert.assertEquals("6", match1.get().getComment());
-
-        final Optional<AssignCommentBean> match2  = CollectionsUtils.find(arrays, assignCommentBean -> assignCommentBean.getAssign().equals("8"));
-        Assert.assertFalse(match2.isPresent());
-    }
-
-    @Test
     public void join_null() {
 
         final String string = CollectionsUtils.join(null, null, null);

--- a/dotCMS/src/test/java/com/dotcms/util/CollectionsUtilsTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/CollectionsUtilsTest.java
@@ -1,6 +1,7 @@
 package com.dotcms.util;
 
 import com.dotcms.UnitTestBase;
+import com.dotcms.workflow.form.AssignCommentBean;
 import com.liferay.util.StringPool;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
@@ -18,6 +19,21 @@ import static org.junit.Assert.*;
  * @author jsanca
  */
 public class CollectionsUtilsTest extends UnitTestBase {
+
+    @Test
+    public void find() {
+
+        final List<AssignCommentBean>     arrays = Arrays.asList(new AssignCommentBean("1","1"),
+                new AssignCommentBean("2","2"), new AssignCommentBean("3","3"), new AssignCommentBean("4","4"),
+                new AssignCommentBean("5","5"), new AssignCommentBean("6","6"), new AssignCommentBean("7","7"));
+        final Optional<AssignCommentBean> match1  = CollectionsUtils.find(arrays, assignCommentBean -> assignCommentBean.getAssign().equals("6"));
+        Assert.assertTrue(match1.isPresent());
+        Assert.assertEquals("6", match1.get().getAssign());
+        Assert.assertEquals("6", match1.get().getComment());
+
+        final Optional<AssignCommentBean> match2  = CollectionsUtils.find(arrays, assignCommentBean -> assignCommentBean.getAssign().equals("8"));
+        Assert.assertFalse(match2.isPresent());
+    }
 
     @Test
     public void join_null() {


### PR DESCRIPTION
Previously when the FourEyeApproverActionlet and the MultipleApproverActionlet actionlet were used it works the first time correctly, by saving in the history the necessary approvals.
However the second time that a approval was needed with the same task, since the old approvals still in the history, the new ones were not needed.

With this change, we have introduced a new actionlet call reset approvers which is not deleting but reseting the state of these history rows in order to allow the next approval validation after the reset.

It does not affect the history, basically it switched from a single text for the change description to a json (map object) with three attributes

description : all life description
type: comment (normal) or approve (the approval itselft)
state: NONE (no state specified) , RESET (the row still there but reseted, means not longer used to determine approvals)

On progress approval
```
"{'description':'Admin User completed action Four eyes', 'type':'APPROVAL', 'state':'NONE' }"
```


Reset approval
```
"{'description':'Admin User completed action Four eyes', 'type':'APPROVAL', 'state':'RESET' }"
```

With the changes the user is able to use approval actionlet, two, three, any times.