### PR TITLE
fixing url error

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/render/HTMLPageAssetRenderedAPIImplIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/render/HTMLPageAssetRenderedAPIImplIntegrationTest.java
@@ -69,6 +69,7 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
         final Template template = new TemplateDataGen().nextPersisted();
 
         htmlPageAsset = createPage(systemUser, role, template);
+        when(request.getRequestURI()).thenReturn(htmlPageAsset.getURI());
     }
 
     private HTMLPageAsset createPage(final User systemUser, final Role role, final Template template)
@@ -132,6 +133,7 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
 
         assertEquals(htmlPageAsset, pageRendered.getPageInfo().getPage());
         assertEquals(host, pageRendered.getSite());
+        assertEquals(htmlPageAsset.getURI(), pageRendered.getPageUrlMapper());
     }
 
     /**
@@ -160,6 +162,7 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
 
         assertEquals(htmlPageAsset, pageRendered.getPageInfo().getPage());
         assertEquals(this.host, pageRendered.getSite());
+        assertEquals(htmlPageAsset.getURI(), pageRendered.getPageUrlMapper());
     }
 
     /**
@@ -190,6 +193,7 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
 
         assertEquals(htmlPageAsset, pageRendered.getPageInfo().getPage());
         assertEquals(this.host, pageRendered.getSite());
+        assertEquals(htmlPageAsset.getURI(), pageRendered.getPageUrlMapper());
     }
 
     /**
@@ -220,6 +224,7 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
 
         assertEquals(htmlPageAsset, pageRendered.getPageInfo().getPage());
         assertEquals(this.host, pageRendered.getSite());
+        assertEquals(htmlPageAsset.getURI(), pageRendered.getPageUrlMapper());
     }
 
     /**
@@ -248,6 +253,7 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
 
         assertEquals(htmlPageAsset, pageRendered.getPageInfo().getPage());
         assertEquals(this.host, pageRendered.getSite());
+        assertEquals(htmlPageAsset.getURI(), pageRendered.getPageUrlMapper());
     }
 
     /**
@@ -276,6 +282,7 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
 
         assertEquals(htmlPageAsset, pageRendered.getPageInfo().getPage());
         assertEquals(defaultHost, pageRendered.getSite());
+        assertEquals(htmlPageAsset.getURI(), pageRendered.getPageUrlMapper());
     }
 
 
@@ -306,6 +313,7 @@ public class HTMLPageAssetRenderedAPIImplIntegrationTest extends IntegrationTest
 
         assertEquals(htmlPageAsset, pageRendered.getPageInfo().getPage());
         assertEquals(this.host, pageRendered.getSite());
+        assertEquals(htmlPageAsset.getURI(), pageRendered.getPageUrlMapper());
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java
@@ -391,7 +391,11 @@ public class HTMLPageAssetRenderedAPIImpl implements HTMLPageAssetRenderedAPI {
         }
 
         public String getPageUrlMapper() {
-            return urlMapInfo != null ? urlMapInfo.getUrlMapped() : htmlPage.getPageUrl();
+            try {
+                return urlMapInfo != null ? urlMapInfo.getUrlMapped() : htmlPage.getURI();
+            } catch (DotDataException e) {
+                throw new DotRuntimeException(e);
+            }
         }
 
         public IHTMLPage getHTMLPage() {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java
@@ -390,12 +390,8 @@ public class HTMLPageAssetRenderedAPIImpl implements HTMLPageAssetRenderedAPI {
             return htmlPage.getPageUrl();
         }
 
-        public String getPageUrlMapper() {
-            try {
-                return urlMapInfo != null ? urlMapInfo.getUrlMapped() : htmlPage.getURI();
-            } catch (DotDataException e) {
-                throw new DotRuntimeException(e);
-            }
+        public String getPageUrlMapper() throws DotDataException {
+            return urlMapInfo != null ? urlMapInfo.getUrlMapped() : htmlPage.getURI();
         }
 
         public IHTMLPage getHTMLPage() {


### PR DESCRIPTION
The method getPageUrl nor return the full URL

https://github.com/dotCMS/core/compare/issue-16684-fixing-url-error?expand=1#

for example, for 'first-time-investors' return '/first-time-investors' instead of '/services/first-time-investors'