### PR TITLE
#16684 fixing menu error

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityServlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityServlet.java
@@ -60,6 +60,7 @@ public class VelocityServlet extends HttpServlet {
                 return;
             }
 
+            request.setRequestUri(uri);
             final PageMode mode = PageMode.getWithNavigateMode(request);
             try {
                 final String pageHtml = APILocator.getHTMLPageAssetRenderedAPI().getPageHtml(


### PR DESCRIPTION
the NavTool.getNav methos take the current path from the request.getRequestURI method

https://github.com/dotCMS/core/blob/master/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavTool.java#L286

according to this route it is decided which menu loaded, before the requet uri was set here

https://github.com/dotCMS/core/commit/197c338287f5b7cbc9728fd280a337dd59e7e8e8#diff-649328ff21d8eacd69736b13e6d0208eL65

and then the /servlets/VelocityServlet uri was changed by the page uri requested 