### PR TITLE
#17727 New starter fixes

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionBitFactoryImpl.java
@@ -2062,8 +2062,9 @@ public class PermissionBitFactoryImpl extends PermissionFactory {
     })).onFailure(e -> {
       throw new DotRuntimeException(e);
     });
-    Logger.info(this.getClass(), "permission inherited: " + Try.of(()->type.substring(type.lastIndexOf(".")+1, type.length())).getOrElse(type)  + " : "  + permissionKey + " -> " +finalNewReference);
-    
+  	Logger.debug(this.getClass(), () -> "permission inherited: " + Try
+			  .of(() -> type.substring(type.lastIndexOf(".") + 1)).getOrElse(type)
+			  + " : " + permissionKey + " -> " + finalNewReference);
 	permissionCache.addToPermissionCache(permissionKey, permissionList);
     return permissionList;
 

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -461,7 +461,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
     @Override
     @WrapInTransaction
     public void saveMultiTree(final MultiTree mTree) throws DotDataException {
-        Logger.info(this, String.format("Saving MutiTree: %s", mTree));
+        Logger.debug(this, () -> String.format("Saving MutiTree: %s", mTree));
         _reorder(mTree);
         updateHTMLPageVersionTS(mTree.getHtmlPage());
         refreshPageInCache(mTree.getHtmlPage());
@@ -587,7 +587,8 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
     @Override
     @WrapInTransaction
     public void saveMultiTrees(final String pageId, final List<MultiTree> mTrees) throws DotDataException {
-        Logger.info(this, String.format("Saving MutiTrees: pageId -> %s multiTrees-> %s", pageId, mTrees));
+        Logger.debug(this, () -> String
+                .format("Saving MutiTrees: pageId -> %s multiTrees-> %s", pageId, mTrees));
         if (mTrees == null) {
             throw new DotDataException("empty list passed in");
         }
@@ -647,7 +648,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
 
     private void _dbInsert(final MultiTree multiTree) throws DotDataException {
 
-        Logger.info(this, String.format("_dbInsert -> Saving MutiTree: %s", multiTree));
+        Logger.debug(this, () -> String.format("_dbInsert -> Saving MutiTree: %s", multiTree));
 
         new DotConnect().setSQL(INSERT_SQL).addParam(multiTree.getHtmlPage()).addParam(multiTree.getContainerAsID()).addParam(multiTree.getContentlet())
                 .addParam(multiTree.getRelationType()).addParam(multiTree.getTreeOrder()).addObject(multiTree.getPersonalization()).loadResult();

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/cmsmaintenance/factories/CMSMaintenanceFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/cmsmaintenance/factories/CMSMaintenanceFactory.java
@@ -38,7 +38,11 @@ public class CMSMaintenanceFactory {
 		Calendar runDate = Calendar.getInstance();
 		runDate.setTime(assetsOlderThan);
 		runDate.add(Calendar.YEAR, -2);
-		
+		runDate.set(Calendar.HOUR_OF_DAY, 0);
+		runDate.set(Calendar.MINUTE, 0);
+		runDate.set(Calendar.SECOND, 0);
+		runDate.set(Calendar.MILLISECOND, 0);
+
         try{
     		DotConnect dc = new DotConnect();
             String minIdateSQL = "select idate from inode order by idate";
@@ -82,6 +86,13 @@ public class CMSMaintenanceFactory {
 				auxCount = APILocator.getMenuLinkAPI().deleteOldVersions(runDate.getTime());
 				counter += auxCount;
 				Logger.info(CMSMaintenanceFactory.class, "Removed "+ auxCount+ " Links");
+
+				Logger.info(CMSMaintenanceFactory.class, "Removing Workflow history");
+				auxCount = APILocator.getWorkflowAPI()
+						.deleteWorkflowHistoryOldVersions(runDate.getTime());
+				counter += auxCount;
+				Logger.info(CMSMaintenanceFactory.class,
+						"Removed " + auxCount + " Workflow History records");
 	
 				Logger.info(CMSMaintenanceFactory.class, "Finished removing old asset versions, removed "+counter+" assets");
 				

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/RuleComponentDefinition.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/RuleComponentDefinition.java
@@ -10,10 +10,15 @@ import com.dotmarketing.portlets.rules.exception.RuleEvaluationFailedException;
 import com.dotmarketing.portlets.rules.model.ParameterModel;
 import com.dotmarketing.portlets.rules.parameter.ParameterDefinition;
 import com.dotmarketing.util.Logger;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.io.Serializable;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.elasticsearch.common.Nullable;
 
 /**
  * @author Geoff M. Granum
@@ -26,7 +31,20 @@ public abstract class RuleComponentDefinition<T extends RuleComponentInstance> i
     private final Map<String, ParameterDefinition> parameterDefinitions;
 
     protected RuleComponentDefinition(String i18nKey, ParameterDefinition... parameterDefinitions) {
-        this.id = this.getClass().getSimpleName();
+        this(null, i18nKey, parameterDefinitions);
+    }
+
+    /**
+     * @deprecated Do not use this method directly, it exists only for the <em>Jackson</em>-binding
+     * infrastructure
+     */
+    protected RuleComponentDefinition(String id, String i18nKey,
+            ParameterDefinition... parameterDefinitions) {
+
+        if (null == id) {
+            id = this.getClass().getSimpleName();
+        }
+        this.id = id;
         this.i18nKey = i18nKey;
         Map<String, ParameterDefinition> defs = Maps.newLinkedHashMap();
         for (ParameterDefinition def : parameterDefinitions) {
@@ -120,5 +138,41 @@ public abstract class RuleComponentDefinition<T extends RuleComponentInstance> i
     }
 
     public abstract boolean evaluate(HttpServletRequest request, HttpServletResponse response, T instance);
-}
 
+    /**
+     * Utility type used to correctly read immutable object from JSON representation.
+     *
+     * @deprecated Do not use this type directly, it exists only for the <em>Jackson</em>-binding
+     * infrastructure
+     */
+    @Deprecated
+    @JsonDeserialize
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE)
+    static protected final class Json {
+
+        @javax.annotation.Nullable
+        public String id;
+        @javax.annotation.Nullable
+        public String i18nKey;
+        @javax.annotation.Nullable
+        public Map<String, ParameterDefinition> parameterDefinitions;
+
+        @JsonProperty("id")
+        public void setId(@Nullable String id) {
+            this.id = id;
+        }
+
+        @JsonProperty("i18nKey")
+        public void setI18nKey(@Nullable String i18nKey) {
+            this.i18nKey = i18nKey;
+        }
+
+        @JsonProperty("parameterDefinitions")
+        public void setParameterDefinitions(
+                @Nullable Map<String, ParameterDefinition> parameterDefinitions) {
+            this.parameterDefinitions = parameterDefinitions;
+        }
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/RuleComponentDefinition.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/RuleComponentDefinition.java
@@ -159,12 +159,12 @@ public abstract class RuleComponentDefinition<T extends RuleComponentInstance> i
         public Map<String, ParameterDefinition> parameterDefinitions;
 
         @JsonProperty("id")
-        public void setId(@Nullable String id) {
+        public void setId(@Nullable final String id) {
             this.id = id;
         }
 
         @JsonProperty("i18nKey")
-        public void setI18nKey(@Nullable String i18nKey) {
+        public void setI18nKey(@Nullable final String i18nKey) {
             this.i18nKey = i18nKey;
         }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/conditionlet/Conditionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/conditionlet/Conditionlet.java
@@ -3,12 +3,50 @@ package com.dotmarketing.portlets.rules.conditionlet;
 import com.dotmarketing.portlets.rules.RuleComponentDefinition;
 import com.dotmarketing.portlets.rules.RuleComponentInstance;
 import com.dotmarketing.portlets.rules.parameter.ParameterDefinition;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public abstract class Conditionlet<T extends RuleComponentInstance> extends RuleComponentDefinition<T> {
 
     public static final String COMPARISON_KEY = "comparison";
 
+    /**
+     * @deprecated Do not use this method directly, it exists only for the <em>Jackson</em>-binding
+     * infrastructure
+     */
+    protected Conditionlet(String id, String i18nKey, ParameterDefinition... parameterDefinitions) {
+        super(id, i18nKey, parameterDefinitions);
+    }
+
     protected Conditionlet(String i18nKey, ParameterDefinition... parameterDefinitions) {
         super(i18nKey, parameterDefinitions);
     }
+
+    /**
+     * @param json A JSON-bindable data structure
+     * @deprecated Do not use this method directly, it exists only for the <em>Jackson</em>-binding
+     * infrastructure
+     */
+    @Deprecated
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    static Conditionlet fromJson(RuleComponentDefinition.Json json) {
+
+        return new Conditionlet(json.id, json.i18nKey,
+                json.parameterDefinitions.values().toArray(new ParameterDefinition[]{})) {
+
+            @Override
+            public RuleComponentInstance instanceFrom(Map parameters) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean evaluate(HttpServletRequest request, HttpServletResponse response,
+                    RuleComponentInstance instance) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/conditionlet/Conditionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/conditionlet/Conditionlet.java
@@ -16,7 +16,7 @@ public abstract class Conditionlet<T extends RuleComponentInstance> extends Rule
      * @deprecated Do not use this method directly, it exists only for the <em>Jackson</em>-binding
      * infrastructure
      */
-    protected Conditionlet(String id, String i18nKey, ParameterDefinition... parameterDefinitions) {
+    protected Conditionlet(String id, String i18nKey, final ParameterDefinition... parameterDefinitions) {
         super(id, i18nKey, parameterDefinitions);
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/ParameterDefinition.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/ParameterDefinition.java
@@ -6,7 +6,13 @@ import com.dotmarketing.portlets.rules.exception.RuleEngineException;
 import com.dotmarketing.portlets.rules.model.ParameterModel;
 import com.dotmarketing.portlets.rules.parameter.display.Input;
 import com.dotmarketing.portlets.rules.parameter.type.DataType;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.common.Nullable;
 
 public class ParameterDefinition<T extends DataType> {
 
@@ -58,5 +64,67 @@ public class ParameterDefinition<T extends DataType> {
     public void checkValid(ParameterModel model) throws InvalidRuleParameterException, RuleEngineException {
     	this.inputType.checkValid(model.getValue());
     }
-}
 
+    /**
+     * Utility type used to correctly read immutable object from JSON representation.
+     *
+     * @deprecated Do not use this type directly, it exists only for the <em>Jackson</em>-binding
+     * infrastructure
+     */
+    @Deprecated
+    @JsonDeserialize
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE)
+    static final class Json {
+
+        @javax.annotation.Nullable
+        String key;
+        @javax.annotation.Nullable
+        String i18nBaseKey;
+        @javax.annotation.Nullable
+        String defaultValue;
+        @javax.annotation.Nullable
+        Input inputType;
+        @javax.annotation.Nullable
+        int priority;
+
+        @JsonProperty("key")
+        public void setKey(@Nullable String key) {
+            this.key = key;
+        }
+
+        @JsonProperty("i18nBaseKey")
+        public void setI18nBaseKey(@Nullable String i18nBaseKey) {
+            this.i18nBaseKey = i18nBaseKey;
+        }
+
+        @JsonProperty("defaultValue")
+        public void setDefaultValue(@Nullable String defaultValue) {
+            this.defaultValue = defaultValue;
+        }
+
+        @JsonProperty("inputType")
+        public void setInputType(@Nullable Input inputType) {
+            this.inputType = inputType;
+        }
+
+        @JsonProperty("priority")
+        public void setPriority(@Nullable int priority) {
+            this.priority = priority;
+        }
+
+    }
+
+    /**
+     * @param json A JSON-bindable data structure
+     * @deprecated Do not use this method directly, it exists only for the <em>Jackson</em>-binding
+     * infrastructure
+     */
+    @Deprecated
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    static ParameterDefinition fromJson(ParameterDefinition.Json json) {
+        return new ParameterDefinition(json.priority, json.key, json.i18nBaseKey, json.inputType,
+                json.defaultValue);
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/ParameterDefinition.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/ParameterDefinition.java
@@ -89,17 +89,17 @@ public class ParameterDefinition<T extends DataType> {
         int priority;
 
         @JsonProperty("key")
-        public void setKey(@Nullable String key) {
+        public void setKey(@Nullable final String key) {
             this.key = key;
         }
 
         @JsonProperty("i18nBaseKey")
-        public void setI18nBaseKey(@Nullable String i18nBaseKey) {
+        public void setI18nBaseKey(@Nullable final String i18nBaseKey) {
             this.i18nBaseKey = i18nBaseKey;
         }
 
         @JsonProperty("defaultValue")
-        public void setDefaultValue(@Nullable String defaultValue) {
+        public void setDefaultValue(@Nullable final String defaultValue) {
             this.defaultValue = defaultValue;
         }
 
@@ -109,7 +109,7 @@ public class ParameterDefinition<T extends DataType> {
         }
 
         @JsonProperty("priority")
-        public void setPriority(@Nullable int priority) {
+        public void setPriority(@Nullable final int priority) {
             this.priority = priority;
         }
 
@@ -122,7 +122,7 @@ public class ParameterDefinition<T extends DataType> {
      */
     @Deprecated
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    static ParameterDefinition fromJson(ParameterDefinition.Json json) {
+    static ParameterDefinition fromJson(final ParameterDefinition.Json json) {
         return new ParameterDefinition(json.priority, json.key, json.i18nBaseKey, json.inputType,
                 json.defaultValue);
     }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/display/Input.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/display/Input.java
@@ -75,7 +75,7 @@ public class Input<T extends DataType> {
      */
     @Deprecated
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    static Input fromJson(Input.Json json) {
+    static Input fromJson(final Input.Json json) {
         return new Input(json.id, json.dataType);
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/display/Input.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/display/Input.java
@@ -2,6 +2,12 @@ package com.dotmarketing.portlets.rules.parameter.display;
 
 import com.dotcms.rest.exception.InvalidRuleParameterException;
 import com.dotmarketing.portlets.rules.parameter.type.DataType;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.elasticsearch.common.Nullable;
 
 /**
  * @author Geoff M. Granum
@@ -32,5 +38,45 @@ public class Input<T extends DataType> {
     public void checkValid(String value)  throws InvalidRuleParameterException{
     	return;
     }
-}
 
+    /**
+     * Utility type used to correctly read immutable object from JSON representation.
+     *
+     * @deprecated Do not use this type directly, it exists only for the <em>Jackson</em>-binding
+     * infrastructure
+     */
+    @Deprecated
+    @JsonDeserialize
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE)
+    static final class Json {
+
+        @javax.annotation.Nullable
+        String id;
+        @javax.annotation.Nullable
+        DataType dataType;
+
+        @JsonProperty("id")
+        public void setKey(@Nullable String id) {
+            this.id = id;
+        }
+
+        @JsonProperty("dataType")
+        public void setDataType(@Nullable DataType dataType) {
+            this.dataType = dataType;
+        }
+
+    }
+
+    /**
+     * @param json A JSON-bindable data structure
+     * @deprecated Do not use this method directly, it exists only for the <em>Jackson</em>-binding
+     * infrastructure
+     */
+    @Deprecated
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    static Input fromJson(Input.Json json) {
+        return new Input(json.id, json.dataType);
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/type/DataType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/type/DataType.java
@@ -110,12 +110,12 @@ public abstract class DataType<T> {
         Map<String, TypeConstraint> restrictions;
 
         @JsonProperty("id")
-        public void setKey(@Nullable String id) {
+        public void setKey(@Nullable final String id) {
             this.id = id;
         }
 
         @JsonProperty("errorMessageKey")
-        public void setDataType(@Nullable String errorMessageKey) {
+        public void setDataType(@Nullable final String errorMessageKey) {
             this.errorMessageKey = errorMessageKey;
         }
 
@@ -133,7 +133,7 @@ public abstract class DataType<T> {
      */
     @Deprecated
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    static DataType fromJson(DataType.Json json) {
+    static DataType fromJson(final DataType.Json json) {
         return new DataType(json.id, json.errorMessageKey, json.restrictions) {
             @Override
             public Object convert(String from) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/type/DataType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/parameter/type/DataType.java
@@ -3,9 +3,15 @@ package com.dotmarketing.portlets.rules.parameter.type;
 import com.dotcms.repackage.com.google.common.collect.ImmutableMap;
 import com.dotcms.repackage.com.google.common.collect.Maps;
 import com.dotmarketing.portlets.rules.parameter.type.constraint.TypeConstraint;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.common.Nullable;
 
 /**
  * @author Geoff M. Granum
@@ -21,6 +27,12 @@ public abstract class DataType<T> {
     public DataType(String id, String errorMessageKey) {
         this.id = id;
         this.errorMessageKey = errorMessageKey;
+    }
+
+    public DataType(String id, String errorMessageKey, Map<String, TypeConstraint> restrictions) {
+        this.id = id;
+        this.errorMessageKey = errorMessageKey;
+        this.restrictions = restrictions;
     }
 
     public String getId() {
@@ -77,5 +89,57 @@ public abstract class DataType<T> {
     public Map<String, TypeConstraint> getConstraints() {
         return ImmutableMap.copyOf(this.restrictions);
     }
+
+    /**
+     * Utility type used to correctly read immutable object from JSON representation.
+     *
+     * @deprecated Do not use this type directly, it exists only for the <em>Jackson</em>-binding
+     * infrastructure
+     */
+    @Deprecated
+    @JsonDeserialize
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE)
+    static final class Json {
+
+        @javax.annotation.Nullable
+        String id;
+        @javax.annotation.Nullable
+        String errorMessageKey;
+        @javax.annotation.Nullable
+        Map<String, TypeConstraint> restrictions;
+
+        @JsonProperty("id")
+        public void setKey(@Nullable String id) {
+            this.id = id;
+        }
+
+        @JsonProperty("errorMessageKey")
+        public void setDataType(@Nullable String errorMessageKey) {
+            this.errorMessageKey = errorMessageKey;
+        }
+
+        @JsonProperty("constraints")
+        public void setRestrictions(@Nullable Map<String, TypeConstraint> restrictions) {
+            this.restrictions = restrictions;
+        }
+
+    }
+
+    /**
+     * @param json A JSON-bindable data structure
+     * @deprecated Do not use this method directly, it exists only for the <em>Jackson</em>-binding
+     * infrastructure
+     */
+    @Deprecated
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    static DataType fromJson(DataType.Json json) {
+        return new DataType(json.id, json.errorMessageKey, json.restrictions) {
+            @Override
+            public Object convert(String from) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
 }
- 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/util/RulesImportExportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/util/RulesImportExportUtil.java
@@ -3,7 +3,6 @@ package com.dotmarketing.portlets.rules.util;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.enterprise.rules.RulesAPI;
-import com.dotcms.util.CloseUtils;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Ruleable;
 import com.dotmarketing.exception.DotDataException;
@@ -19,11 +18,11 @@ import com.liferay.portal.model.User;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Reader;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 
 /**
@@ -69,21 +68,14 @@ public class RulesImportExportUtil {
 		}
 	}
 
-	public void importRules(File file) throws IOException {
-
-		this.importRules(new FileReader(file));
-	}
-
-	public void importRules(final Reader reader) throws IOException {
+	public void importRules(final File file) throws IOException {
 
 		final ObjectMapper mapper = new ObjectMapper();
 		final StringWriter stringWriter = new StringWriter();
-		BufferedReader bufferedReader = null;
 		RulesImportExportObject importer = null;
 
-		try {
+		try (BufferedReader bufferedReader = Files.newBufferedReader(Paths.get(file.toURI()))) {
 
-			bufferedReader = new BufferedReader(reader);
 			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
 			String str;
@@ -97,8 +89,6 @@ public class RulesImportExportUtil {
 			this.importRules(importer, APILocator.systemUser());
 		} catch (Exception e) {
 			Logger.error(this.getClass(), "Error: " + e.getMessage(), e);
-		} finally {
-			CloseUtils.closeQuietly(bufferedReader);
 		}
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/util/RulesImportExportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/util/RulesImportExportUtil.java
@@ -1,18 +1,9 @@
 package com.dotmarketing.portlets.rules.util;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.List;
-
-
+import com.dotcms.business.CloseDBIfOpened;
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.enterprise.rules.RulesAPI;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.dotcms.util.CloseUtils;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Ruleable;
 import com.dotmarketing.exception.DotDataException;
@@ -22,7 +13,18 @@ import com.dotmarketing.portlets.rules.model.ConditionGroup;
 import com.dotmarketing.portlets.rules.model.Rule;
 import com.dotmarketing.portlets.rules.model.RuleAction;
 import com.dotmarketing.util.Logger;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liferay.portal.model.User;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.util.List;
 
 /**
  * 
@@ -35,10 +37,6 @@ public class RulesImportExportUtil {
 
 	private static RulesImportExportUtil rulesImportExportUtil;
 
-	/**
-	 * 
-	 * @return
-	 */
 	public static RulesImportExportUtil getInstance() {
 		if (rulesImportExportUtil == null) {
 			synchronized ("RulesImportExportUtil.class") {
@@ -50,23 +48,11 @@ public class RulesImportExportUtil {
 		return rulesImportExportUtil;
 	}
 
-	/**
-	 * 
-	 * @return
-	 * @throws IOException
-	 * @throws DotDataException
-	 * @throws DotSecurityException
-	 */
 	public String exportToJson() throws IOException, DotDataException, DotSecurityException {
 		ObjectMapper mapper = new ObjectMapper();
 		return mapper.writeValueAsString(buildExportObject(null));
 	}
 
-	/**
-	 * 
-	 * @param file
-	 * @throws IOException
-	 */
 	public void export(File file) throws IOException {
 
 		BufferedWriter out = null;
@@ -83,69 +69,79 @@ public class RulesImportExportUtil {
 		}
 	}
 
-	/**
-	 * 
-	 * @param file
-	 * @throws IOException
-	 */
 	public void importRules(File file) throws IOException {
 
-		RulesAPI rapi = APILocator.getRulesAPI();
+		this.importRules(new FileReader(file));
+	}
 
-		BufferedReader in = null;
+	public void importRules(final Reader reader) throws IOException {
+
+		final ObjectMapper mapper = new ObjectMapper();
+		final StringWriter stringWriter = new StringWriter();
+		BufferedReader bufferedReader = null;
+		RulesImportExportObject importer = null;
+
 		try {
-			User user = APILocator.getUserAPI().getSystemUser();
-			FileReader fstream = new FileReader(file);
-			in = new BufferedReader(fstream);
-			ObjectMapper mapper = new ObjectMapper();
+
+			bufferedReader = new BufferedReader(reader);
 			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-			StringWriter sw = new StringWriter();
+
 			String str;
-			while ((str = in.readLine()) != null) {
-				sw.append(str);
+			while ((str = bufferedReader.readLine()) != null) {
+				stringWriter.append(str);
 			}
 
-			RulesImportExportObject importer = mapper.readValue(sw.toString(), RulesImportExportObject.class);
+			importer = mapper.readValue
+					((String) stringWriter.toString(), RulesImportExportObject.class);
+
+			this.importRules(importer, APILocator.systemUser());
+		} catch (Exception e) {
+			Logger.error(this.getClass(), "Error: " + e.getMessage(), e);
+		} finally {
+			CloseUtils.closeQuietly(bufferedReader);
+		}
+	}
+
+	@WrapInTransaction
+	public void importRules(final RulesImportExportObject importer,
+			final User user) throws IOException, DotDataException {
+
+		try {
+			final RulesAPI rulesAPI = APILocator.getRulesAPI();
 
 			//Saving the rules.
 			for (Rule rule : importer.getRules()) {
 				rule.setParentPermissionable(RulePermissionableUtil.findParentPermissionable(rule.getParent()));
-				rapi.saveRule(rule, user, false);
+				rulesAPI.saveRule(rule, user, false);
 
 				//Saving the Condition Groups.
 				for (ConditionGroup group : rule.getGroups()) {
-					rapi.saveConditionGroup(group, user, false);
+					rulesAPI.saveConditionGroup(group, user, false);
 					//Saving the Condition for each group.
 					for (Condition condition : group.getConditions()) {
-						rapi.saveCondition(condition, user, false);
+						rulesAPI.saveCondition(condition, user, false);
 					}
 				}
 				//Saving the Action.
 				for (RuleAction action : rule.getRuleActions()) {
-					rapi.saveRuleAction(action, user, false);
+					rulesAPI.saveRuleAction(action, user, false);
 				}
 			}
-
 		} catch (Exception e) {
 			Logger.error(this.getClass(), "Error: " + e.getMessage(), e);
-		} finally {
-			in.close();
+			throw new DotDataException(e);
 		}
 	}
 
-	/**
-	 * 
-	 * @param parent
-	 * @return
-	 * @throws DotDataException
-	 * @throws DotSecurityException
-	 */
-	public RulesImportExportObject buildExportObject(Ruleable parent) throws DotDataException, DotSecurityException {
+	@CloseDBIfOpened
+	public RulesImportExportObject buildExportObject(Ruleable parent)
+			throws DotDataException, DotSecurityException {
 
-		RulesAPI rapi = APILocator.getRulesAPI();
+		RulesAPI rulesAPI = APILocator.getRulesAPI();
 		User user = APILocator.getUserAPI().getSystemUser();
 
-		List<Rule> rules = (parent == null) ? rapi.getAllRules(user, false) : rapi.getAllRulesByParent(parent, user, false);
+		List<Rule> rules = (parent == null) ? rulesAPI.getAllRules(user, false)
+				: rulesAPI.getAllRulesByParent(parent, user, false);
 
 		RulesImportExportObject export = new RulesImportExportObject();
 		export.setRules(rules);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/rules/util/RulesImportExportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/rules/util/RulesImportExportUtil.java
@@ -72,7 +72,6 @@ public class RulesImportExportUtil {
 
 		final ObjectMapper mapper = new ObjectMapper();
 		final StringWriter stringWriter = new StringWriter();
-		RulesImportExportObject importer = null;
 
 		try (BufferedReader bufferedReader = Files.newBufferedReader(Paths.get(file.toURI()))) {
 
@@ -83,7 +82,7 @@ public class RulesImportExportUtil {
 				stringWriter.append(str);
 			}
 
-			importer = mapper.readValue
+			RulesImportExportObject importer = mapper.readValue
 					((String) stringWriter.toString(), RulesImportExportObject.class);
 
 			this.importRules(importer, APILocator.systemUser());

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkFlowFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkFlowFactory.java
@@ -9,6 +9,7 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.workflows.model.*;
 import com.liferay.portal.model.User;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -31,6 +32,11 @@ public interface WorkFlowFactory {
 	public void deleteComment(WorkflowComment comment) throws DotDataException;
 
 	public void deleteWorkflowHistory(WorkflowHistory history) throws DotDataException;
+
+	/**
+	 * Deletes the workflow history records older than the given date
+	 */
+	public int deleteWorkflowHistoryOldVersions(final Date olderThan) throws DotDataException;
 
 	/**
 	 * Deletes the workflow task

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPI.java
@@ -31,6 +31,7 @@ import com.dotmarketing.portlets.workflows.model.WorkflowTask;
 import com.dotmarketing.portlets.workflows.model.WorkflowTimelineItem;
 import com.liferay.portal.model.User;
 import java.util.Collection;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -198,6 +199,11 @@ public interface WorkflowAPI {
 	 * @throws DotDataException
 	 */
 	public void deleteWorkflowHistory(WorkflowHistory history) throws DotDataException;
+
+	/**
+	 * Deletes the workflow history records older than the given date
+	 */
+	public int deleteWorkflowHistoryOldVersions(final Date olderThan) throws DotDataException;
 
 	/**
 	/**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
@@ -1276,6 +1276,13 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 
 	@Override
 	@WrapInTransaction
+	public int deleteWorkflowHistoryOldVersions(final Date olderThan) throws DotDataException {
+
+		return this.workFlowFactory.deleteWorkflowHistoryOldVersions(olderThan);
+	}
+
+	@Override
+	@WrapInTransaction
 	public void saveWorkflowHistory(final WorkflowHistory history) throws DotDataException {
 
 		this.workFlowFactory.saveWorkflowHistory(history);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowFactoryImpl.java
@@ -496,6 +496,30 @@ public class WorkflowFactoryImpl implements WorkFlowFactory {
 	}
 
 	@Override
+	public int deleteWorkflowHistoryOldVersions(final Date olderThan) throws DotDataException {
+
+		DotConnect dotConnect = new DotConnect();
+
+		//Get the count of the workflow history records before deleting.
+		String countSQL = "select count(*) as count from workflow_history";
+		dotConnect.setSQL(countSQL);
+		List<Map<String, String>> result = dotConnect.loadResults();
+		final int before = Integer.parseInt(result.get(0).get("count"));
+
+		// Delete the records using a given date
+		dotConnect.setSQL("delete from workflow_history where creation_date < ?");
+		dotConnect.addParam(olderThan);
+		dotConnect.loadResult();
+
+		//Get the count of the workflow history records after deleting.
+		dotConnect.setSQL(countSQL);
+		result = dotConnect.loadResults();
+		final int after = Integer.parseInt(result.get(0).get("count"));
+
+		return before - after;
+	}
+
+	@Override
 	public void deleteWorkflowTaskByContentletIdAnyLanguage(final String webAsset) throws DotDataException {
 
 		final DotConnect db = new DotConnect();

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/util/WorkflowImportExportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/util/WorkflowImportExportUtil.java
@@ -131,14 +131,14 @@ public class WorkflowImportExportUtil {
 
 			for (final WorkflowScheme scheme : importer.getSchemes()) {
 
-				Logger.info(this,"Importing scheme: " + scheme);
+				Logger.debug(this, () -> "Importing scheme: " + scheme);
 				workflowAPI.saveScheme(scheme, user);
 			}
 
 			List<Tuple2<String, String>> stepsWithActions = new ArrayList<>();
 			for (final WorkflowStep step : importer.getSteps()) {
 
-				Logger.info(this, "Importing step: " + step);
+				Logger.debug(this, () -> "Importing step: " + step);
 			    if(step.getEscalationAction()!=null) {
 			        stepsWithActions.add(new Tuple2<String, String>(step.getId(), step.getEscalationAction()));
 			        step.setEscalationAction(null);
@@ -148,7 +148,7 @@ public class WorkflowImportExportUtil {
 
 			for (final WorkflowAction action : importer.getActions()) {
 
-				Logger.info(this, "Importing action: " + action);
+				Logger.debug(this, () -> "Importing action: " + action);
 				workflowAPI.saveAction(action, null, user);
 			}
 			
@@ -162,7 +162,7 @@ public class WorkflowImportExportUtil {
 			
 			for(final Map<String, String> actionStepMap : importer.getActionSteps()){
 
-				Logger.info(this, "Importing actionStepMap: " + actionStepMap);
+				Logger.debug(this, () -> "Importing actionStepMap: " + actionStepMap);
 				workflowAPI.saveAction(actionStepMap.get(ACTION_ID),
 						actionStepMap.get(STEP_ID),
 						user,
@@ -171,14 +171,14 @@ public class WorkflowImportExportUtil {
 
  			for (final WorkflowActionClass actionClass : importer.getActionClasses()) {
 
-				Logger.info(this, "Importing actionClass: " + actionClass);
+				Logger.debug(this, () -> "Importing actionClass: " + actionClass);
 				workflowAPI.saveActionClass(actionClass, user);
 			}
 
 			if (UtilMethods.isSet(importer.getWorkflowStructures())) {
 				for (final Map<String, String> map : importer.getWorkflowStructures()) {
 
-					Logger.info(this, "Importing WorkflowStructures: " + map);
+					Logger.debug(this, () -> "Importing WorkflowStructures: " + map);
 					DotConnect dc = new DotConnect();
 					dc.setSQL("delete from workflow_scheme_x_structure where id=?");
 					dc.addParam(map.get("id"));
@@ -192,7 +192,8 @@ public class WorkflowImportExportUtil {
 				}
 			}
 
-			Logger.info(this, "Importing ActionClassParams: " + importer.getActionClassParams());
+			Logger.debug(this,
+					() -> "Importing ActionClassParams: " + importer.getActionClassParams());
 			workflowAPI.saveWorkflowActionClassParameters(importer.getActionClassParams(), user);
 
 			this.saveSchemeSystemActionMappings      (workflowAPI, importer.getSchemeSystemActionWorkflowActionMappings());


### PR DESCRIPTION
Related to #17727
* `"Drop Old Assets Versions"` now drops workflow history records. 
* Changing `Logger.info`'s to debug (those infos were actually debug info)
* The import starter process was unable to import Rules (and related tables) data