### PR TITLE
#17515 Avoid clash between field vars and graphql content fields

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
@@ -24,6 +24,7 @@ import com.dotcms.contenttype.model.type.SimpleContentType;
 import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.graphql.InterfaceType;
+import com.dotcms.graphql.util.GraphQLUtil;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
@@ -1046,7 +1047,7 @@ public class FieldAPITest extends IntegrationTestBase {
 
     @DataProvider
     public static Object[] dataProviderGraphQLReservedNames() {
-        return InterfaceType.RESERVED_GRAPHQL_FIELD_NAMES.toArray();
+        return GraphQLUtil.getFieldReservedWords().toArray();
     }
 
     @Test

--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
@@ -1057,16 +1057,39 @@ public class FieldAPITest extends IntegrationTestBase {
 
         final ContentType type = new ContentTypeDataGen().nextPersisted();
         try {
-            Field field = FieldBuilder.builder(TextField.class)
+            Field field1 = FieldBuilder.builder(TextField.class)
                     .name(fieldName)
                     .contentTypeId(type.id())
                     .indexed(false)
                     .listed(false)
                     .fixed(true)
                     .build();
-            field = fieldAPI.save(field, user);
+            field1 = fieldAPI.save(field1, user);
 
-            Assert.assertNotEquals(fieldName, field.variable());
+            Assert.assertNotNull(field1);
+            Assert.assertTrue(UtilMethods.isSet(field1.variable()));
+            Assert.assertNotEquals(fieldName, field1.variable());
+
+            // let's create a new field to make sure it's getting a new variable
+
+            Field field2 = FieldBuilder.builder(TextField.class)
+                    .name(fieldName)
+                    .contentTypeId(type.id())
+                    .indexed(false)
+                    .listed(false)
+                    .fixed(true)
+                    .build();
+            field2 = fieldAPI.save(field2, user);
+
+            Assert.assertNotNull(field2);
+            Assert.assertTrue(UtilMethods.isSet(field2.variable()));
+            Assert.assertNotEquals(fieldName, field2.variable());
+
+            // let's compare the two field vars are different
+
+            Assert.assertNotEquals(field1.variable(), field2.variable());
+
+
         } finally {
             contentTypeAPI.delete(type);
         }

--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
@@ -23,6 +23,7 @@ import com.dotcms.contenttype.model.type.ContentTypeBuilder;
 import com.dotcms.contenttype.model.type.SimpleContentType;
 import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.TestDataUtils;
+import com.dotcms.graphql.InterfaceType;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
@@ -1035,9 +1036,37 @@ public class FieldAPITest extends IntegrationTestBase {
             fieldAPI.save(variable, user);
 
             boolean anyMatch = field.fieldVariables().stream()
-                  .anyMatch((var)->var.key().equals(fieldVarKey));
+                    .anyMatch((var)->var.key().equals(fieldVarKey));
 
             Assert.assertTrue("Incorrect var key", anyMatch);
+        } finally {
+            contentTypeAPI.delete(type);
+        }
+    }
+
+    @DataProvider
+    public static Object[] dataProviderGraphQLReservedNames() {
+        return InterfaceType.RESERVED_GRAPHQL_FIELD_NAMES.toArray();
+    }
+
+    @Test
+    @UseDataProvider("dataProviderGraphQLReservedNames")
+    public void test_SaveFieldWithReservedGraphqlName_ShouldSuffixConsecutiveToVariable(
+            final String fieldName)
+            throws DotSecurityException, DotDataException {
+
+        final ContentType type = new ContentTypeDataGen().nextPersisted();
+        try {
+            Field field = FieldBuilder.builder(TextField.class)
+                    .name(fieldName)
+                    .contentTypeId(type.id())
+                    .indexed(false)
+                    .listed(false)
+                    .fixed(true)
+                    .build();
+            field = fieldAPI.save(field, user);
+
+            Assert.assertNotEquals(fieldName, field.variable());
         } finally {
             contentTypeAPI.delete(type);
         }

--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/FieldFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/FieldFactoryImplTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -503,7 +504,8 @@ public class FieldFactoryImplTest extends ContentTypeBaseTest {
 				// make sure variables work
 
 				String suggestion = fieldFactory.suggestVelocityVar(field.name(), ImmutableList.of());
-				String suggestion2 = fieldFactory.suggestVelocityVar(field.variable(), testFields);
+				String suggestion2 = fieldFactory.suggestVelocityVar(field.variable(),
+						testFields.stream().map(Field::variable).collect(Collectors.toList()));
 				try {
 					assertThat("we are not munging up existing vars", field.variable().equals(
 							fieldFactory.suggestVelocityVar(field.variable(), ImmutableList.of())));
@@ -524,7 +526,8 @@ public class FieldFactoryImplTest extends ContentTypeBaseTest {
 
 		testFields = new ArrayList<>();
 		for (String key : testingNames.keySet()) {
-			String suggest = fieldFactory.suggestVelocityVar(key, testFields);
+			String suggest = fieldFactory.suggestVelocityVar(key,
+					testFields.stream().map(Field::variable).collect(Collectors.toList()));
 			
 
 			
@@ -560,11 +563,10 @@ public class FieldFactoryImplTest extends ContentTypeBaseTest {
 
         List<Field> testFields = new ArrayList<>();
         for (String key : testingNames) {
-            String suggest = fieldFactory.suggestVelocityVar(key, testFields);
+            String suggest = fieldFactory.suggestVelocityVar(key, testFields
+					.stream().map(Field::variable).collect(Collectors.toList()));
             
             assertThat("variable " + key + " " + " returned an a generic fieldVar:" + suggest , suggest.startsWith(FieldFactory.GENERIC_FIELD_VAR));
-
-
 
             testFields.add(ImmutableTextField.builder()
                 .name(key)

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactoryImpl.java
@@ -11,7 +11,6 @@ import com.dotcms.contenttype.model.type.*;
 import com.dotcms.contenttype.transform.contenttype.DbContentTypeTransformer;
 import com.dotcms.contenttype.transform.contenttype.ImplClassContentTypeTransformer;
 import com.dotcms.repackage.javax.validation.constraints.NotNull;
-import com.dotcms.util.DotPreconditions;
 import com.dotmarketing.business.*;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.util.SQLUtil;

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactory.java
@@ -50,8 +50,16 @@ public interface FieldFactory {
 
     List<Field> selectByContentTypeInDb(String id) throws DotDataException;
 
+    /**
+     * Given an initial variable to try, it returns a version of it that sticks to the naming
+     * conventions for field variable names and avoiding using the names in the provided list.
+     * @param tryVar the initial variable to try
+     * @param takenFieldsVariables a list of field variable names to avoid using
+     * @return
+     * @throws DotDataException
+     */
 
-    String suggestVelocityVar(String tryVar, List<String> takenFields) throws DotDataException;
+    String suggestVelocityVar(String tryVar, List<String> takenFieldsVariables) throws DotDataException;
 
 
     FieldVariable save(FieldVariable fieldVar) throws DotDataException;

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactory.java
@@ -51,7 +51,7 @@ public interface FieldFactory {
     List<Field> selectByContentTypeInDb(String id) throws DotDataException;
 
 
-    String suggestVelocityVar(String tryVar, List<Field> takenFields) throws DotDataException;
+    String suggestVelocityVar(String tryVar, List<String> takenFields) throws DotDataException;
 
 
     FieldVariable save(FieldVariable fieldVar) throws DotDataException;

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
@@ -29,6 +29,7 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.StringUtils;
 import com.dotmarketing.util.UtilMethods;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -586,7 +587,8 @@ public class FieldFactoryImpl implements FieldFactory {
 public String suggestVelocityVar( String tryVar, List<String> takenFieldsVariables) throws DotDataException {
 
     // adds the GraphQL Reserved field names to the "taken fields variables" list
-    takenFieldsVariables.addAll(GraphQLUtil.getFieldReservedWords());
+    final List<String> forbiddenFieldVariables = new ArrayList<>(takenFieldsVariables);
+    forbiddenFieldVariables.addAll(GraphQLUtil.getFieldReservedWords());
 
     String var = StringUtils.camelCaseLower(tryVar);
     // if we don't get a var back, we are looking at UTF-8 or worse
@@ -594,7 +596,7 @@ public String suggestVelocityVar( String tryVar, List<String> takenFieldsVariabl
     if (!UtilMethods.isSet(var)) {
         tryVar= "field";
     }
-    for (String fieldVar : takenFieldsVariables) {
+    for (String fieldVar : forbiddenFieldVariables) {
         if (var.equalsIgnoreCase(fieldVar)) {
             var= null;
             break;
@@ -607,7 +609,7 @@ public String suggestVelocityVar( String tryVar, List<String> takenFieldsVariabl
 
     for (int i = 1; i < 100000; i++) {
         var = StringUtils.camelCaseLower(tryVar) + i;
-        for (String fieldVar : takenFieldsVariables) {
+        for (String fieldVar : forbiddenFieldVariables) {
             if (var.equalsIgnoreCase(fieldVar)) {
                 var = null;
                 break;

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
@@ -20,6 +20,7 @@ import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.transform.field.DbFieldTransformer;
 import com.dotcms.contenttype.transform.field.DbFieldVariableTransformer;
+import com.dotcms.graphql.InterfaceType;
 import com.dotcms.rendering.velocity.services.FieldLoader;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.common.db.DotConnect;
@@ -37,6 +38,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.commons.lang.time.DateUtils;
 
 public class FieldFactoryImpl implements FieldFactory {
@@ -232,8 +234,13 @@ public class FieldFactoryImpl implements FieldFactory {
       }
 
       // normalize our velocityvar
+      final List<String> takenFieldVars = fieldsAlreadyAdded.stream().map(Field::variable).collect(
+              Collectors.toList());
+      // let's add GraphQL reserved field names to the taken fields vars list
+      takenFieldVars.addAll(InterfaceType.RESERVED_GRAPHQL_FIELD_NAMES);
+
       String tryVar = (throwAwayField.variable() == null)
-          ? suggestVelocityVar(throwAwayField.name(), fieldsAlreadyAdded) : throwAwayField.variable();
+          ? suggestVelocityVar(throwAwayField.name(), takenFieldVars) : throwAwayField.variable();
       builder.variable(tryVar);
     }
     builder = FieldBuilder.builder(normalizeData(builder.build()));
@@ -578,7 +585,7 @@ public class FieldFactoryImpl implements FieldFactory {
 
 
   @Override
-public String suggestVelocityVar( String tryVar, List<Field> takenFields) throws DotDataException {
+public String suggestVelocityVar( String tryVar, List<String> takenFieldsVars) throws DotDataException {
 
 
     String var = StringUtils.camelCaseLower(tryVar);
@@ -587,8 +594,8 @@ public String suggestVelocityVar( String tryVar, List<Field> takenFields) throws
     if (!UtilMethods.isSet(var)) {
         tryVar= "field";
     }
-    for (Field f : takenFields) {
-        if (var.equalsIgnoreCase(f.variable())) {
+    for (String fieldVar : takenFieldsVars) {
+        if (var.equalsIgnoreCase(fieldVar)) {
             var= null;
             break;
         }
@@ -600,8 +607,8 @@ public String suggestVelocityVar( String tryVar, List<Field> takenFields) throws
 
     for (int i = 1; i < 100000; i++) {
         var = StringUtils.camelCaseLower(tryVar) + i;
-        for (Field f : takenFields) {
-            if (var.equalsIgnoreCase(f.variable())) {
+        for (String fieldVar : takenFieldsVars) {
+            if (var.equalsIgnoreCase(fieldVar)) {
                 var = null;
                 break;
             }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
@@ -20,7 +20,7 @@ import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.transform.field.DbFieldTransformer;
 import com.dotcms.contenttype.transform.field.DbFieldVariableTransformer;
-import com.dotcms.graphql.InterfaceType;
+import com.dotcms.graphql.util.GraphQLUtil;
 import com.dotcms.rendering.velocity.services.FieldLoader;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.common.db.DotConnect;
@@ -236,8 +236,6 @@ public class FieldFactoryImpl implements FieldFactory {
       // normalize our velocityvar
       final List<String> takenFieldVars = fieldsAlreadyAdded.stream().map(Field::variable).collect(
               Collectors.toList());
-      // let's add GraphQL reserved field names to the taken fields vars list
-      takenFieldVars.addAll(InterfaceType.RESERVED_GRAPHQL_FIELD_NAMES);
 
       String tryVar = (throwAwayField.variable() == null)
           ? suggestVelocityVar(throwAwayField.name(), takenFieldVars) : throwAwayField.variable();
@@ -585,8 +583,10 @@ public class FieldFactoryImpl implements FieldFactory {
 
 
   @Override
-public String suggestVelocityVar( String tryVar, List<String> takenFieldsVars) throws DotDataException {
+public String suggestVelocityVar( String tryVar, List<String> takenFieldsVariables) throws DotDataException {
 
+    // adds the GraphQL Reserved field names to the "taken fields variables" list
+    takenFieldsVariables.addAll(GraphQLUtil.getFieldReservedWords());
 
     String var = StringUtils.camelCaseLower(tryVar);
     // if we don't get a var back, we are looking at UTF-8 or worse
@@ -594,7 +594,7 @@ public String suggestVelocityVar( String tryVar, List<String> takenFieldsVars) t
     if (!UtilMethods.isSet(var)) {
         tryVar= "field";
     }
-    for (String fieldVar : takenFieldsVars) {
+    for (String fieldVar : takenFieldsVariables) {
         if (var.equalsIgnoreCase(fieldVar)) {
             var= null;
             break;
@@ -607,7 +607,7 @@ public String suggestVelocityVar( String tryVar, List<String> takenFieldsVars) t
 
     for (int i = 1; i < 100000; i++) {
         var = StringUtils.camelCaseLower(tryVar) + i;
-        for (String fieldVar : takenFieldsVars) {
+        for (String fieldVar : takenFieldsVariables) {
             if (var.equalsIgnoreCase(fieldVar)) {
                 var = null;
                 break;

--- a/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
@@ -65,6 +65,8 @@ public enum InterfaceType {
         this.baseContentType = baseContentType;
     }
 
+    public static Set<String> RESERVED_GRAPHQL_FIELD_NAMES = new HashSet<>();
+
     private static Map<String, GraphQLInterfaceType> interfaceTypes = new HashMap<>();
 
     public static final String CONTENT_INTERFACE_NAME = "ContentBaseType";
@@ -96,6 +98,8 @@ public enum InterfaceType {
         contentFields.put(URL_MAP, new TypeFetcher(GraphQLString));
         contentFields.put(OWNER_KEY, new TypeFetcher(CustomFieldType.USER.getType(), new UserDataFetcher()));
         contentFields.put(MOD_USER_KEY, new TypeFetcher(CustomFieldType.USER.getType(), new UserDataFetcher()));
+
+        RESERVED_GRAPHQL_FIELD_NAMES.addAll(contentFields.keySet());
 
         interfaceTypes.put("CONTENTLET", createInterfaceType("Contentlet", contentFields, new ContentResolver()));
 

--- a/dotCMS/src/main/java/com/dotcms/graphql/util/GraphQLUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/util/GraphQLUtil.java
@@ -1,0 +1,11 @@
+package com.dotcms.graphql.util;
+
+import com.dotcms.graphql.InterfaceType;
+import java.util.Set;
+
+public class GraphQLUtil {
+
+    public static Set<String> getFieldReservedWords() {
+        return InterfaceType.RESERVED_GRAPHQL_FIELD_NAMES;
+    }
+}


### PR DESCRIPTION
Since any GraphQL Type inherits a list of fields from the GraphQL `Contentlet` Interface, there was a possibility of name-clashing if you named a Content Type field the same as one of those inherited fields. 
With this PR those inherited field names are included in the list of taken variable names to avoid the clashing. 

Tests were included for each reserved field name to verify the resulting variable is different than the reserved name. 