### PR TITLE
Sending the full container path to the UI

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/ContainerLoaderTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/ContainerLoaderTest.java
@@ -8,7 +8,6 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.containers.model.FileAssetContainer;
 import com.dotmarketing.util.PageMode;
 import org.junit.BeforeClass;
@@ -18,7 +17,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ContainerLoaderTest {
@@ -58,5 +56,7 @@ public class ContainerLoaderTest {
                 "\" data-dot-identifier=\"//" + host.getName() + container.getPath() + "\"";
 
         assertTrue(velocityCode.contains(expected));
+
+        inputStream.close();
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/ContainerLoaderTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/ContainerLoaderTest.java
@@ -34,7 +34,7 @@ public class ContainerLoaderTest {
      * Should: return a div with the File Comntainer's id
      */
     @Test
-    public void aaa() throws DotDataException, DotSecurityException, IOException {
+    public void shouldTakeFullContainerPathAsId() throws DotDataException, DotSecurityException, IOException {
 
         final Host host = new SiteDataGen().nextPersisted();
 
@@ -48,15 +48,14 @@ public class ContainerLoaderTest {
         final ContainerLoader containerLoader = new ContainerLoader();
 
         final VelocityResourceKey velocityResourceKey = new VelocityResourceKey(fileAssetContainer, PageMode.EDIT_MODE);
-        final InputStream inputStream = containerLoader.writeObject(velocityResourceKey);
 
-        final String velocityCode = IOUtils.toString(inputStream, String.valueOf(StandardCharsets.UTF_8));
+        try (InputStream inputStream = containerLoader.writeObject(velocityResourceKey)) {
+            final String velocityCode = IOUtils.toString(inputStream, String.valueOf(StandardCharsets.UTF_8));
 
-        final String expected = "<div data-dot-object=\"container\" data-dot-inode=\"" + container.getInode() +
-                "\" data-dot-identifier=\"//" + host.getName() + container.getPath() + "\"";
+            final String expected = "<div data-dot-object=\"container\" data-dot-inode=\"" + container.getInode() +
+                    "\" data-dot-identifier=\"//" + host.getName() + container.getPath() + "\"";
 
-        assertTrue(velocityCode.contains(expected));
-
-        inputStream.close();
+            assertTrue(velocityCode.contains(expected));
+        }
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/ContainerLoaderTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/ContainerLoaderTest.java
@@ -1,0 +1,62 @@
+package com.dotcms.rendering.velocity.services;
+
+import com.dotcms.datagen.ContainerAsFileDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.repackage.org.apache.commons.io.IOUtils;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.containers.model.Container;
+import com.dotmarketing.portlets.containers.model.FileAssetContainer;
+import com.dotmarketing.util.PageMode;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ContainerLoaderTest {
+
+    @BeforeClass
+    public static void prepare () throws Exception {
+
+        //Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Method to test: {@link ContainerLoader#writeObject(VelocityResourceKey)}
+     * when: the File Container's html is build
+     * Should: return a div with the File Comntainer's id
+     */
+    @Test
+    public void aaa() throws DotDataException, DotSecurityException, IOException {
+
+        final Host host = new SiteDataGen().nextPersisted();
+
+        final FileAssetContainer fileAssetContainer = new ContainerAsFileDataGen()
+                .host(host)
+                .nextPersisted();
+
+        final FileAssetContainer container = (FileAssetContainer) APILocator.getContainerAPI()
+                .find(fileAssetContainer.getInode(), APILocator.systemUser(), true);
+
+        final ContainerLoader containerLoader = new ContainerLoader();
+
+        final VelocityResourceKey velocityResourceKey = new VelocityResourceKey(fileAssetContainer, PageMode.EDIT_MODE);
+        final InputStream inputStream = containerLoader.writeObject(velocityResourceKey);
+
+        final String velocityCode = IOUtils.toString(inputStream, String.valueOf(StandardCharsets.UTF_8));
+
+        final String expected = "<div data-dot-object=\"container\" data-dot-inode=\"" + container.getInode() +
+                "\" data-dot-identifier=\"//" + host.getName() + container.getPath() + "\"";
+
+        assertTrue(velocityCode.contains(expected));
+    }
+}

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtilTest.java
@@ -1,20 +1,13 @@
 package com.dotmarketing.portlets.containers.business;
 
 import com.dotcms.datagen.ContainerAsFileDataGen;
-import com.dotcms.datagen.FolderDataGen;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.portlets.ContentletBaseTest;
-import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.containers.model.FileAssetContainer;
-import com.dotmarketing.portlets.folders.model.Folder;
-import com.dotmarketing.util.Constants;
-import com.dotmarketing.util.HostUtil;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Optional;
 
 public class FileAssetContainerUtilTest extends ContentletBaseTest {
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtilTest.java
@@ -1,13 +1,48 @@
 package com.dotmarketing.portlets.containers.business;
 
+import com.dotcms.datagen.ContainerAsFileDataGen;
+import com.dotcms.datagen.FolderDataGen;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.portlets.ContentletBaseTest;
+import com.dotmarketing.portlets.containers.model.Container;
+import com.dotmarketing.portlets.containers.model.FileAssetContainer;
+import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.util.Constants;
+import com.dotmarketing.util.HostUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Optional;
+
 public class FileAssetContainerUtilTest extends ContentletBaseTest {
+
+    /**
+     * Method to Test: {@link FileAssetContainerUtil#getFullPath(FileAssetContainer)}
+     * When: Create a new {@link FileAssetContainer}
+     * should: return the full path
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetFullPathMethod() throws Exception {
+
+        final Host host = new SiteDataGen().nextPersisted();
+
+        final FileAssetContainer fileAssetContainer = new ContainerAsFileDataGen()
+                .host(host)
+                .nextPersisted();
+
+        final FileAssetContainer container = (FileAssetContainer) APILocator.getContainerAPI()
+                .find(fileAssetContainer.getInode(), APILocator.systemUser(), true);
+
+        final String fullPath = FileAssetContainerUtil.getInstance().getFullPath(container);
+
+        final String expected = "//" + host.getHostname() + (container).getPath();
+
+        Assert.assertEquals(expected, fullPath);
+    }
 
     @Test
     public void test_getPathFromFullPath_wrong_host_on_full_path() throws Exception {

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
@@ -150,10 +150,10 @@ public class ContainerLoader implements DotLoader {
         velocityResourceCache.remove(identifierKey);
     }
 
-    private String getDataDotIdentifier (final Container container) {
+    private String getDataDotIdentifier (final Container container) throws DotDataException, DotSecurityException {
 
-        return container instanceof FileAssetContainer?
-                FileAssetContainer.class.cast(container).getPath():
+        return container instanceof FileAssetContainer ?
+                FileAssetContainerUtil.getInstance().getFullPath((FileAssetContainer) container) :
                 container.getIdentifier();
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtil.java
@@ -344,9 +344,29 @@ public class FileAssetContainerUtil {
 
     private String buildPath(final Host host, final Folder containerFolder, final boolean includeHostOnPath) {
 
+        return buildPath(host, containerFolder.getPath(), includeHostOnPath);
+    }
+
+    /**
+     * Return the full path for a {@link FileAssetContainer}, with the follow sintax:
+     *
+     * //[host name]/[File Container path]
+     *
+     * @param container
+     * @return
+     * @throws DotSecurityException
+     * @throws DotDataException
+     */
+    public String getFullPath(final FileAssetContainer container) throws DotSecurityException, DotDataException {
+        final Host host = APILocator.getHostAPI().findParentHost(container, APILocator.systemUser(), false);
+        return buildPath(host, container.getPath(), true);
+    }
+
+    private String buildPath(final Host host, final String containerPath, final boolean includeHostOnPath) {
+
         return includeHostOnPath?
-                builder(HOST_INDICATOR, host.getHostname(), containerFolder.getPath()).toString():
-                containerFolder.getPath();
+                builder(HOST_INDICATOR, host.getHostname(), containerPath).toString() :
+                containerPath;
     }
 
     private boolean isContainerMetaInfo(final FileAsset fileAsset, final boolean showLive) {


### PR DESCRIPTION
The Multi tree was saved with the default host container id and not with the container's id in the new site, so now it is send the container full path  to the UI, then it is send back by the UI when a Multi tree is saved