### PR TITLE
#17743 Consider relwith parameter only for the relationship it applies

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
@@ -1049,23 +1049,20 @@ public class ContentletWebAPIImpl implements ContentletWebAPI {
                 final String[] inodes = inodesSt.split(",");
 
                 final Relationship relationship = APILocator.getRelationshipAPI().byInode(inodes[0]);
+                final boolean isRelatingNewContent = isRelatingNewContent(contentletFormData,
+                        relationship);
 
-				//When you click the option Relate New Content, it adds the relwith key with the id of the contentlet that you edited at first and reltype with the relationship name.
-                //Also, it is important to verify that the reltype applies to the relationship that we are currently populating (case when there are multiple relationships). Issue:
-                //https://github.com/dotCMS/core/issues/17743
-                final boolean isRelatingNewContent =
-                        contentletFormData.containsKey("relwith") && relationship
-                                .getRelationTypeValue().equals(contentletFormData.get("reltype"));
-                final String relationHasParent =
-                        contentletFormData.get("relisparent") != null ? (String) contentletFormData
-                                .get("relisparent") : "";
-				//This boolean determines if the contentletFormData is a parent or a child
+                //This boolean determines if the contentletFormData is a parent or a child
 				//This is the proper behaviour of the boolean:
 				//if you are relating a new child should be false, because the contentletFormData is a child
 				//if you are relating a new parent should be true, because the contentletFormData is a parent
 				//if you are relating an existing child should be true, because the contentletFormData is a parent
 				//if you are relating an existing parent should be false, because the contentletFormData is a child
 				final boolean isContentletAParent = (key.contains("_P_")) ? !isRelatingNewContent : isRelatingNewContent;
+
+                final String relationHasParent =
+                        contentletFormData.get("relisparent") != null ? (String) contentletFormData
+                                .get("relisparent") : "";
 
 				if (relationshipsData == null){
 					relationshipsData = new ContentletRelationships(currentContentlet);
@@ -1095,7 +1092,22 @@ public class ContentletWebAPIImpl implements ContentletWebAPI {
 		return relationshipsData;
 	}
 
-	public void cancelContentEdit(String workingContentletInode,
+    /**
+     * When you click the option Relate New Content, it adds the relwith key with the id of the contentlet that you edited at first and reltype with the relationship name.
+     * Also, it is important to verify that the reltype applies to the relationship that we are currently populating (case when there are multiple relationships).
+     * View issue: https://github.com/dotCMS/core/issues/17743
+     * @param contentletFormData
+     * @param relationship
+     * @return
+     */
+    private boolean isRelatingNewContent(Map<String, Object> contentletFormData,
+            Relationship relationship) {
+
+        return contentletFormData.containsKey("relwith") && relationship
+                .getRelationTypeValue().equals(contentletFormData.get("reltype"));
+    }
+
+    public void cancelContentEdit(String workingContentletInode,
 			String currentContentletInode,User user) throws Exception {
 
 		HibernateUtil.startTransaction();

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
@@ -1040,8 +1040,22 @@ public class ContentletWebAPIImpl implements ContentletWebAPI {
 
 		for (String key : keys) {
 			if (key.startsWith("rel_") && key.endsWith("_inodes")) {
-				//When you click the option Relate New Content, it adds the relwith key with the id of the contentlet that you edited at first.
-				final boolean isRelatingNewContent =  contentletFormData.containsKey("relwith");
+
+                final String inodesSt = (String) contentletFormData.get(key);
+                if(!UtilMethods.isSet(inodesSt)){
+                    continue;
+                }
+
+                final String[] inodes = inodesSt.split(",");
+
+                final Relationship relationship = APILocator.getRelationshipAPI().byInode(inodes[0]);
+
+				//When you click the option Relate New Content, it adds the relwith key with the id of the contentlet that you edited at first and reltype with the relationship name.
+                //Also, it is important to verify that the reltype applies to the relationship that we are currently populating (case when there are multiple relationships). Issue:
+                //https://github.com/dotCMS/core/issues/17743
+                final boolean isRelatingNewContent =
+                        contentletFormData.containsKey("relwith") && relationship
+                                .getRelationTypeValue().equals(contentletFormData.get("reltype"));
                 final String relationHasParent =
                         contentletFormData.get("relisparent") != null ? (String) contentletFormData
                                 .get("relisparent") : "";
@@ -1052,13 +1066,6 @@ public class ContentletWebAPIImpl implements ContentletWebAPI {
 				//if you are relating an existing child should be true, because the contentletFormData is a parent
 				//if you are relating an existing parent should be false, because the contentletFormData is a child
 				final boolean isContentletAParent = (key.contains("_P_")) ? !isRelatingNewContent : isRelatingNewContent;
-				final String inodesSt = (String) contentletFormData.get(key);
-				if(!UtilMethods.isSet(inodesSt)){
-					continue;
-				}
-				final String[] inodes = inodesSt.split(",");
-
-				final Relationship relationship = APILocator.getRelationshipAPI().byInode(inodes[0]);
 
 				if (relationshipsData == null){
 					relationshipsData = new ContentletRelationships(currentContentlet);


### PR DESCRIPTION
When the `relwith` parameter was used to know if we were adding a New Related Content, it wasn't considering that it really applied for the key being evaluated, so it affected when multiple relationships were involved, where parents were being saved in DB as children and children as parents (as hasParent flag had a wrong value). 
 
The way to know if the `relwith` applies is to verify if `reltype` matches with the relationship being populated at that moment.
