### PR TITLE
Fix contentlet.getTitle 

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletCheckInTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletCheckInTest.java
@@ -29,7 +29,6 @@ import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.util.Config;
-import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
 import com.liferay.portal.model.User;
@@ -69,7 +68,7 @@ public class ContentletCheckInTest extends ContentletBaseTest{
       Contentlet con = new ContentletDataGen(contentType.id()).nextWithSampleTextValues();
       Contentlet newCon = contentletAPI.checkin(con, null, true);
       assertTrue("we saved a contentlet anonymously", newCon.getIdentifier()!=null);
-      assertTrue("the contentlet title was saved", UtilMethods.isSet(newCon.getTitle()));
+      assertTrue("the contentlet title was saved", newCon.getTitle().equals(con.getTitle()));
      
       assertTrue("contentlet is not live", newCon.isWorking() && !newCon.hasLiveVersion());
       

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletCheckInTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletCheckInTest.java
@@ -29,6 +29,7 @@ import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
 import com.liferay.portal.model.User;
@@ -68,7 +69,7 @@ public class ContentletCheckInTest extends ContentletBaseTest{
       Contentlet con = new ContentletDataGen(contentType.id()).nextWithSampleTextValues();
       Contentlet newCon = contentletAPI.checkin(con, null, true);
       assertTrue("we saved a contentlet anonymously", newCon.getIdentifier()!=null);
-      assertTrue("the contentlet title was saved", newCon.getTitle().equals(con.getTitle()));
+      assertTrue("the contentlet title was saved", UtilMethods.isSet(newCon.getTitle()));
      
       assertTrue("contentlet is not live", newCon.isWorking() && !newCon.hasLiveVersion());
       

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -277,20 +277,20 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 					filter(field -> field.variable().equals(TITTLE_KEY)).findAny();
 
 
-			if (fieldWithTitleFound.isPresent() && map.get(TITTLE_KEY)!=null) {
-				return map.get(TITTLE_KEY).toString();
-			} else if(!fieldWithTitleFound.isPresent()) {
+			if (fieldWithTitleFound.isPresent()) {
+				return map.get(TITTLE_KEY)!=null?map.get(TITTLE_KEY).toString():null;
+			} else {
 				// if there is no field with 'title' variable, let's look for variables starting with 'title'
 				Optional<com.dotcms.contenttype.model.field.Field> fieldWithSuspectTitleFound =
 						this.getContentType().fields().stream()
 								.filter(field -> UtilMethods.isSet(field.variable())
 										&& field.variable().startsWith(TITTLE_KEY)).findAny();
 
-				if (fieldWithSuspectTitleFound.isPresent()
-						&& map.get(fieldWithSuspectTitleFound.get().variable())!=null) {
-					return map.get(fieldWithSuspectTitleFound.get().variable()).toString();
+				if (fieldWithSuspectTitleFound.isPresent()) {
+					return map.get(fieldWithSuspectTitleFound.get().variable())!=null
+							?map.get(fieldWithSuspectTitleFound.get().variable()).toString()
+							:null;
 				}
-
 			}
 
 			String title = getContentletAPI().getName(this, getUserAPI().getSystemUser(), false);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -63,6 +63,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a content unit in the system. Ideally, every single domain object
@@ -280,11 +281,8 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 			if (fieldWithTitleFound.isPresent()) {
 				return map.get(TITTLE_KEY)!=null?map.get(TITTLE_KEY).toString():null;
 			} else {
-				// if there is no field with 'title' variable, let's look for variables starting with 'title'
-				Optional<com.dotcms.contenttype.model.field.Field> fieldWithSuspectTitleFound =
-						this.getContentType().fields().stream()
-								.filter(field -> UtilMethods.isSet(field.variable())
-										&& field.variable().startsWith(TITTLE_KEY)).findAny();
+				Optional<com.dotcms.contenttype.model.field.Field>
+						fieldWithSuspectTitleFound = getFieldWithVarStartingWithTitleWord();
 
 				if (fieldWithSuspectTitleFound.isPresent()) {
 					return map.get(fieldWithSuspectTitleFound.get().variable())!=null
@@ -303,7 +301,19 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 		}
 	}
 
-    @Override
+	/**
+	 * Looks for a field whose variable starts with "title" and if found returns it
+	 * @return the first field found whose variable starts with "title", if any
+	 */
+
+	@NotNull
+	private Optional<com.dotcms.contenttype.model.field.Field> getFieldWithVarStartingWithTitleWord() {
+		return this.getContentType().fields().stream()
+				.filter(field -> UtilMethods.isSet(field.variable())
+						&& field.variable().startsWith(TITTLE_KEY)).findAny();
+	}
+
+	@Override
     public String getVersionId() {
     	return getIdentifier();
     }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -273,20 +273,24 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
     	try {
 
     		//Verifies if the content type has defined a title field
-			Optional<com.dotcms.contenttype.model.field.Field> fieldFound = this.getContentType().fields().stream().
-					filter(field -> UtilMethods.isSet(field.variable()) && field.variable().startsWith(TITTLE_KEY)).findAny();
+			Optional<com.dotcms.contenttype.model.field.Field> fieldWithTitleFound = this.getContentType().fields().stream().
+					filter(field -> field.variable().equals(TITTLE_KEY)).findAny();
 
 
-			if (fieldFound.isPresent()) {
-				// let's try to get a field with var `title`. if not found, then the variable of the field found above, if not null.
-				String title = null;
+			if (fieldWithTitleFound.isPresent() && map.get(TITTLE_KEY)!=null) {
+				return map.get(TITTLE_KEY).toString();
+			} else if(!fieldWithTitleFound.isPresent()) {
+				// if there is no field with 'title' variable, let's look for variables starting with 'title'
+				Optional<com.dotcms.contenttype.model.field.Field> fieldWithSuspectTitleFound =
+						this.getContentType().fields().stream()
+								.filter(field -> UtilMethods.isSet(field.variable())
+										&& field.variable().startsWith(TITTLE_KEY)).findAny();
 
-				if(map.get(TITTLE_KEY)!=null) {
-					title = map.get(TITTLE_KEY).toString();
-				} else if(map.get(fieldFound.get().variable())!= null) {
-					title = map.get(fieldFound.get().variable()).toString();
+				if (fieldWithSuspectTitleFound.isPresent()
+						&& map.get(fieldWithSuspectTitleFound.get().variable())!=null) {
+					return map.get(fieldWithSuspectTitleFound.get().variable()).toString();
 				}
-				return title;
+
 			}
 
 			String title = getContentletAPI().getName(this, getUserAPI().getSystemUser(), false);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -274,11 +274,19 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 
     		//Verifies if the content type has defined a title field
 			Optional<com.dotcms.contenttype.model.field.Field> fieldFound = this.getContentType().fields().stream().
-					filter(field -> field.variable().equals(TITTLE_KEY)).findAny();
+					filter(field -> UtilMethods.isSet(field.variable()) && field.variable().startsWith(TITTLE_KEY)).findAny();
 
 
 			if (fieldFound.isPresent()) {
-				return map.get(TITTLE_KEY)!=null?map.get(TITTLE_KEY).toString():null;
+				// let's try to get a field with var `title`. if not found, then the variable of the field found above, if not null.
+				String title = null;
+
+				if(map.get(TITTLE_KEY)!=null) {
+					title = map.get(TITTLE_KEY).toString();
+				} else if(map.get(fieldFound.get().variable())!= null) {
+					title = map.get(fieldFound.get().variable()).toString();
+				}
+				return title;
 			}
 
 			String title = getContentletAPI().getName(this, getUserAPI().getSystemUser(), false);


### PR DESCRIPTION
Because of the fix for [this issue](https://github.com/dotCMS/core/issues/17515), now the `title` field variable is reserved for **new fields**, therefore the `contentlet.getTitle` method needed to be modified to account for fields whose variable not only were `equal` but also to `startWith` _title_ value, since new fields' variables trying to use that word will end up with a consecutive appended. e.g. `title1` 