### PR TITLE
#17971 Adding support for multilingual related content

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
@@ -330,7 +330,7 @@
 
                  for (let i=0; i<data.contentlets.length;++i) {
                      let entity = data.contentlets[i];
-                     dataItems.items[i] = { label: entity.title, id: entity.identifier, searchMe : entity.title + " " + entity.identifier + " " + entity.inode };
+                     dataItems.items[i] = { label: entity.title, id: (entity.identifier + " " + entity.inode), searchMe : entity.title + " " + entity.identifier + " " + entity.inode };
                  }
                  
                  dojoRelationshipsStore = new dojo.data.ItemFileReadStore({

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
@@ -708,7 +708,7 @@
 	                    	  }
                          },
                          onChange : function(value){
-                        	 document.getElementById("${relationSearchField}Field").value=this.getValue();
+                        	 document.getElementById("${relationSearchField}Field").value=this.getValue().split(' ')[0];
                         	 doSearch(null, "<%=orderBy%>");
                          }
                          


### PR DESCRIPTION
As multilingual related contents share the same identifier, the id of the select box has to be a combination of content identifier + ' ' + content inode to make it unique and avoid a JS exception