### PR TITLE
Issue 17515 graphql reserved names for certain types

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
@@ -1,6 +1,22 @@
 package com.dotcms.contenttype.business;
 
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.BASE_TYPE;
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.CONTENT_TYPE;
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.IDENTIFIER;
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.INODE;
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.LIVE;
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.MOD_DATE;
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.TITLE;
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.URL_MAP;
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.WORKING;
 import static com.dotcms.contenttype.business.ContentTypeAPIImpl.TYPES_AND_FIELDS_VALID_VARIABLE_REGEX;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.ARCHIVED_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.FOLDER_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.HOST_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.LOCKED_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.MOD_USER_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.OWNER_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.TITLE_IMAGE_KEY;
 import static com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY.MANY_TO_ONE;
 import static com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY.ONE_TO_MANY;
 import static org.junit.Assert.assertEquals;
@@ -15,7 +31,13 @@ import com.dotcms.contenttype.model.field.BinaryField;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.FieldBuilder;
 import com.dotcms.contenttype.model.field.FieldVariable;
+import com.dotcms.contenttype.model.field.ImmutableBinaryField;
+import com.dotcms.contenttype.model.field.ImmutableCategoryField;
+import com.dotcms.contenttype.model.field.ImmutableDateField;
 import com.dotcms.contenttype.model.field.ImmutableFieldVariable;
+import com.dotcms.contenttype.model.field.ImmutableHostFolderField;
+import com.dotcms.contenttype.model.field.ImmutableKeyValueField;
+import com.dotcms.contenttype.model.field.ImmutableTextField;
 import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.type.ContentType;
@@ -23,8 +45,6 @@ import com.dotcms.contenttype.model.type.ContentTypeBuilder;
 import com.dotcms.contenttype.model.type.SimpleContentType;
 import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.TestDataUtils;
-import com.dotcms.graphql.InterfaceType;
-import com.dotcms.graphql.util.GraphQLUtil;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
@@ -44,6 +64,7 @@ import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import io.vavr.Tuple2;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
 import java.util.List;
 import org.junit.Assert;
@@ -1047,53 +1068,169 @@ public class FieldAPITest extends IntegrationTestBase {
 
     @DataProvider
     public static Object[] dataProviderGraphQLReservedNames() {
-        return GraphQLUtil.getFieldReservedWords().toArray();
+
+        final GraphQLFieldNameCompatibilityTestCase caseModDateIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseModDateIncompatible.fieldName = MOD_DATE;
+        caseModDateIncompatible.fieldType = ImmutableBinaryField.class;
+        caseModDateIncompatible.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseModDateCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseModDateCompatible.fieldName = MOD_DATE;
+        caseModDateCompatible.fieldType = ImmutableDateField.class;
+        caseModDateCompatible.shouldCreateNewVariable = false;
+
+        final GraphQLFieldNameCompatibilityTestCase caseTitleIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseTitleIncompatible.fieldName = TITLE;
+        caseTitleIncompatible.fieldType = ImmutableCategoryField.class;
+        caseTitleIncompatible.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseTitleCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseTitleCompatible.fieldName = TITLE;
+        caseTitleCompatible.fieldType = ImmutableTextField.class;
+        caseTitleCompatible.shouldCreateNewVariable = false;
+
+        final GraphQLFieldNameCompatibilityTestCase caseTitleImage = new GraphQLFieldNameCompatibilityTestCase();
+        caseTitleImage.fieldName = TITLE_IMAGE_KEY;
+        caseTitleImage.fieldType = ImmutableHostFolderField.class;
+        caseTitleImage.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseContentType = new GraphQLFieldNameCompatibilityTestCase();
+        caseContentType.fieldName = CONTENT_TYPE;
+        caseContentType.fieldType = ImmutableHostFolderField.class;
+        caseContentType.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseBaseType = new GraphQLFieldNameCompatibilityTestCase();
+        caseBaseType.fieldName = BASE_TYPE;
+        caseBaseType.fieldType = ImmutableKeyValueField.class;
+        caseBaseType.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseLive = new GraphQLFieldNameCompatibilityTestCase();
+        caseLive.fieldName = LIVE;
+        caseLive.fieldType = ImmutableCategoryField.class;
+        caseLive.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseWorking = new GraphQLFieldNameCompatibilityTestCase();
+        caseWorking.fieldName = WORKING;
+        caseWorking.fieldType = ImmutableCategoryField.class;
+        caseWorking.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseArchived = new GraphQLFieldNameCompatibilityTestCase();
+        caseArchived.fieldName = ARCHIVED_KEY;
+        caseArchived.fieldType = ImmutableCategoryField.class;
+        caseArchived.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseLocked = new GraphQLFieldNameCompatibilityTestCase();
+        caseLocked.fieldName = LOCKED_KEY;
+        caseLocked.fieldType = ImmutableCategoryField.class;
+        caseLocked.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseConLanguage = new GraphQLFieldNameCompatibilityTestCase();
+        caseConLanguage.fieldName = "conLanguage";
+        caseConLanguage.fieldType = ImmutableCategoryField.class;
+        caseConLanguage.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseIdentifier = new GraphQLFieldNameCompatibilityTestCase();
+        caseIdentifier.fieldName = IDENTIFIER;
+        caseIdentifier.fieldType = ImmutableCategoryField.class;
+        caseIdentifier.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseInode = new GraphQLFieldNameCompatibilityTestCase();
+        caseInode.fieldName = INODE;
+        caseInode.fieldType = ImmutableCategoryField.class;
+        caseInode.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseHost = new GraphQLFieldNameCompatibilityTestCase();
+        caseHost.fieldName = HOST_KEY;
+        caseHost.fieldType = ImmutableCategoryField.class;
+        caseHost.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseFolder = new GraphQLFieldNameCompatibilityTestCase();
+        caseFolder.fieldName = FOLDER_KEY;
+        caseFolder.fieldType = ImmutableCategoryField.class;
+        caseFolder.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseUrlMap = new GraphQLFieldNameCompatibilityTestCase();
+        caseUrlMap.fieldName = URL_MAP;
+        caseUrlMap.fieldType = ImmutableCategoryField.class;
+        caseUrlMap.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseOwner = new GraphQLFieldNameCompatibilityTestCase();
+        caseOwner.fieldName = OWNER_KEY;
+        caseOwner.fieldType = ImmutableCategoryField.class;
+        caseOwner.shouldCreateNewVariable = true;
+
+        final GraphQLFieldNameCompatibilityTestCase caseModUser = new GraphQLFieldNameCompatibilityTestCase();
+        caseModUser.fieldName = MOD_USER_KEY;
+        caseModUser.fieldType = ImmutableCategoryField.class;
+        caseModUser.shouldCreateNewVariable = true;
+
+        return new GraphQLFieldNameCompatibilityTestCase[] {
+                caseModDateIncompatible,
+                caseModDateCompatible,
+                caseTitleCompatible,
+                caseTitleIncompatible,
+                caseTitleImage,
+                caseContentType,
+                caseBaseType,
+                caseLive,
+                caseWorking,
+                caseArchived,
+                caseLocked,
+                caseConLanguage,
+                caseIdentifier,
+                caseInode,
+                caseHost,
+                caseFolder,
+                caseUrlMap,
+                caseOwner,
+                caseModUser
+        };
     }
 
     @Test
     @UseDataProvider("dataProviderGraphQLReservedNames")
-    public void test_SaveFieldWithReservedGraphqlName_ShouldSuffixConsecutiveToVariable(
-            final String fieldName)
+    public void test_SaveFieldWithIncompatibleGraphQLNameShouldUseDifferentName(
+            final GraphQLFieldNameCompatibilityTestCase testCase)
             throws DotSecurityException, DotDataException {
 
         final ContentType type = new ContentTypeDataGen().nextPersisted();
         try {
-            Field field1 = FieldBuilder.builder(TextField.class)
-                    .name(fieldName)
-                    .contentTypeId(type.id())
-                    .indexed(false)
-                    .listed(false)
-                    .fixed(true)
-                    .build();
-            field1 = fieldAPI.save(field1, user);
+            final ContentType contentType = new ContentTypeDataGen().nextPersisted();
+            final Field field = createField(contentType, testCase.fieldName,
+                    testCase.fieldType);
 
-            Assert.assertNotNull(field1);
-            Assert.assertTrue(UtilMethods.isSet(field1.variable()));
-            Assert.assertNotEquals(fieldName, field1.variable());
-
-            // let's create a new field to make sure it's getting a new variable
-
-            Field field2 = FieldBuilder.builder(TextField.class)
-                    .name(fieldName)
-                    .contentTypeId(type.id())
-                    .indexed(false)
-                    .listed(false)
-                    .fixed(true)
-                    .build();
-            field2 = fieldAPI.save(field2, user);
-
-            Assert.assertNotNull(field2);
-            Assert.assertTrue(UtilMethods.isSet(field2.variable()));
-            Assert.assertNotEquals(fieldName, field2.variable());
-
-            // let's compare the two field vars are different
-
-            Assert.assertNotEquals(field1.variable(), field2.variable());
-
-
+            if(testCase.shouldCreateNewVariable) {
+                Assert.assertNotEquals(testCase.fieldName, field.variable());
+            } else  {
+                Assert.assertEquals(testCase.fieldName, field.variable());
+            }
         } finally {
             contentTypeAPI.delete(type);
         }
+    }
+
+    static class GraphQLFieldNameCompatibilityTestCase {
+        String fieldName;
+        private Class<? extends Field> fieldType;
+        boolean shouldCreateNewVariable = true;
+    }
+
+    public static Field createField(final ContentType contentType, final String fieldName,
+            final Class<? extends Field> fieldType) {
+        try {
+            final FieldAPI fieldAPI = APILocator.getContentTypeFieldAPI();
+            final FieldBuilder fieldBuilder = getFieldBuilder(fieldType);
+            final Field field =  fieldBuilder.contentTypeId(contentType.id())
+                    .name(fieldName).build();
+            return fieldAPI.save(field, APILocator.systemUser());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static FieldBuilder getFieldBuilder(final Class<? extends Field> fieldType)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        return (FieldBuilder) fieldType.getMethod("builder").invoke(null);
     }
 
 

--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
@@ -1066,130 +1066,215 @@ public class FieldAPITest extends IntegrationTestBase {
         }
     }
 
-    @DataProvider
+
+    @DataProvider(format = "%m: %p[0]")
     public static Object[] dataProviderGraphQLReservedNames() {
 
         final GraphQLFieldNameCompatibilityTestCase caseModDateIncompatible = new GraphQLFieldNameCompatibilityTestCase();
         caseModDateIncompatible.fieldName = MOD_DATE;
         caseModDateIncompatible.fieldType = ImmutableBinaryField.class;
         caseModDateIncompatible.shouldCreateNewVariable = true;
+        caseModDateIncompatible.testCaseName = "caseModDateIncompatible";
 
         final GraphQLFieldNameCompatibilityTestCase caseModDateCompatible = new GraphQLFieldNameCompatibilityTestCase();
         caseModDateCompatible.fieldName = MOD_DATE;
         caseModDateCompatible.fieldType = ImmutableDateField.class;
         caseModDateCompatible.shouldCreateNewVariable = false;
+        caseModDateCompatible.testCaseName = "caseModDateCompatible";
 
         final GraphQLFieldNameCompatibilityTestCase caseTitleIncompatible = new GraphQLFieldNameCompatibilityTestCase();
         caseTitleIncompatible.fieldName = TITLE;
         caseTitleIncompatible.fieldType = ImmutableCategoryField.class;
         caseTitleIncompatible.shouldCreateNewVariable = true;
+        caseTitleIncompatible.testCaseName = "caseTitleIncompatible";
 
         final GraphQLFieldNameCompatibilityTestCase caseTitleCompatible = new GraphQLFieldNameCompatibilityTestCase();
         caseTitleCompatible.fieldName = TITLE;
         caseTitleCompatible.fieldType = ImmutableTextField.class;
         caseTitleCompatible.shouldCreateNewVariable = false;
+        caseTitleCompatible.testCaseName = "caseTitleCompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseTitleImage = new GraphQLFieldNameCompatibilityTestCase();
-        caseTitleImage.fieldName = TITLE_IMAGE_KEY;
-        caseTitleImage.fieldType = ImmutableHostFolderField.class;
-        caseTitleImage.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseTitleImageIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseTitleImageIncompatible.fieldName = TITLE_IMAGE_KEY;
+        caseTitleImageIncompatible.fieldType = ImmutableHostFolderField.class;
+        caseTitleImageIncompatible.shouldCreateNewVariable = true;
+        caseTitleImageIncompatible.testCaseName = "caseTitleImageIncompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseContentType = new GraphQLFieldNameCompatibilityTestCase();
-        caseContentType.fieldName = CONTENT_TYPE;
-        caseContentType.fieldType = ImmutableHostFolderField.class;
-        caseContentType.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseTitleImageCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseTitleImageCompatible.fieldName = TITLE_IMAGE_KEY;
+        caseTitleImageCompatible.fieldType = ImmutableBinaryField.class;
+        caseTitleImageCompatible.shouldCreateNewVariable = false;
 
-        final GraphQLFieldNameCompatibilityTestCase caseBaseType = new GraphQLFieldNameCompatibilityTestCase();
-        caseBaseType.fieldName = BASE_TYPE;
-        caseBaseType.fieldType = ImmutableKeyValueField.class;
-        caseBaseType.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseContentTypeIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseContentTypeIncompatible.fieldName = CONTENT_TYPE;
+        caseContentTypeIncompatible.fieldType = ImmutableHostFolderField.class;
+        caseContentTypeIncompatible.shouldCreateNewVariable = true;
+        caseContentTypeIncompatible.testCaseName = "caseContentTypeIncompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseLive = new GraphQLFieldNameCompatibilityTestCase();
-        caseLive.fieldName = LIVE;
-        caseLive.fieldType = ImmutableCategoryField.class;
-        caseLive.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseContentTypeCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseContentTypeCompatible.fieldName = CONTENT_TYPE;
+        caseContentTypeCompatible.fieldType = ImmutableTextField.class;
+        caseContentTypeCompatible.shouldCreateNewVariable = false;
+        caseContentTypeCompatible.testCaseName = "caseContentTypeCompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseWorking = new GraphQLFieldNameCompatibilityTestCase();
-        caseWorking.fieldName = WORKING;
-        caseWorking.fieldType = ImmutableCategoryField.class;
-        caseWorking.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseBaseTypeIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseBaseTypeIncompatible.fieldName = BASE_TYPE;
+        caseBaseTypeIncompatible.fieldType = ImmutableKeyValueField.class;
+        caseBaseTypeIncompatible.shouldCreateNewVariable = true;
+        caseBaseTypeIncompatible.testCaseName = "caseBaseTypeIncompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseArchived = new GraphQLFieldNameCompatibilityTestCase();
-        caseArchived.fieldName = ARCHIVED_KEY;
-        caseArchived.fieldType = ImmutableCategoryField.class;
-        caseArchived.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseBaseTypeCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseBaseTypeCompatible.fieldName = BASE_TYPE;
+        caseBaseTypeCompatible.fieldType = ImmutableTextField.class;
+        caseBaseTypeCompatible.shouldCreateNewVariable = false;
+        caseBaseTypeCompatible.testCaseName = "caseBaseTypeCompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseLocked = new GraphQLFieldNameCompatibilityTestCase();
-        caseLocked.fieldName = LOCKED_KEY;
-        caseLocked.fieldType = ImmutableCategoryField.class;
-        caseLocked.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseLiveIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseLiveIncompatible.fieldName = LIVE;
+        caseLiveIncompatible.fieldType = ImmutableCategoryField.class;
+        caseLiveIncompatible.shouldCreateNewVariable = true;
+        caseLiveIncompatible.testCaseName = "caseLiveIncompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseConLanguage = new GraphQLFieldNameCompatibilityTestCase();
-        caseConLanguage.fieldName = "conLanguage";
-        caseConLanguage.fieldType = ImmutableCategoryField.class;
-        caseConLanguage.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseLiveCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseLiveCompatible.fieldName = LIVE;
+        caseLiveCompatible.fieldType = ImmutableTextField.class;
+        caseLiveCompatible.shouldCreateNewVariable = false;
+        caseLiveCompatible.testCaseName = "caseLiveCompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseIdentifier = new GraphQLFieldNameCompatibilityTestCase();
-        caseIdentifier.fieldName = IDENTIFIER;
-        caseIdentifier.fieldType = ImmutableCategoryField.class;
-        caseIdentifier.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseWorkingIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseWorkingIncompatible.fieldName = WORKING;
+        caseWorkingIncompatible.fieldType = ImmutableCategoryField.class;
+        caseWorkingIncompatible.shouldCreateNewVariable = true;
+        caseWorkingIncompatible.testCaseName = "caseWorkingIncompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseInode = new GraphQLFieldNameCompatibilityTestCase();
-        caseInode.fieldName = INODE;
-        caseInode.fieldType = ImmutableCategoryField.class;
-        caseInode.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseWorkingCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseWorkingCompatible.fieldName = WORKING;
+        caseWorkingCompatible.fieldType = ImmutableTextField.class;
+        caseWorkingCompatible.shouldCreateNewVariable = false;
+        caseWorkingCompatible.testCaseName = "caseWorkingCompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseHost = new GraphQLFieldNameCompatibilityTestCase();
-        caseHost.fieldName = HOST_KEY;
-        caseHost.fieldType = ImmutableCategoryField.class;
-        caseHost.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseArchivedIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseArchivedIncompatible.fieldName = ARCHIVED_KEY;
+        caseArchivedIncompatible.fieldType = ImmutableCategoryField.class;
+        caseArchivedIncompatible.shouldCreateNewVariable = true;
+        caseArchivedIncompatible.testCaseName = "caseArchivedIncompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseFolder = new GraphQLFieldNameCompatibilityTestCase();
-        caseFolder.fieldName = FOLDER_KEY;
-        caseFolder.fieldType = ImmutableCategoryField.class;
-        caseFolder.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseArchivedCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseArchivedCompatible.fieldName = ARCHIVED_KEY;
+        caseArchivedCompatible.fieldType = ImmutableTextField.class;
+        caseArchivedCompatible.shouldCreateNewVariable = false;
+        caseArchivedCompatible.testCaseName = "caseArchivedCompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseUrlMap = new GraphQLFieldNameCompatibilityTestCase();
-        caseUrlMap.fieldName = URL_MAP;
-        caseUrlMap.fieldType = ImmutableCategoryField.class;
-        caseUrlMap.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseLockedIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseLockedIncompatible.fieldName = LOCKED_KEY;
+        caseLockedIncompatible.fieldType = ImmutableCategoryField.class;
+        caseLockedIncompatible.shouldCreateNewVariable = true;
+        caseLockedIncompatible.testCaseName = "caseLockedIncompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseOwner = new GraphQLFieldNameCompatibilityTestCase();
-        caseOwner.fieldName = OWNER_KEY;
-        caseOwner.fieldType = ImmutableCategoryField.class;
-        caseOwner.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseLockedCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseLockedCompatible.fieldName = LOCKED_KEY;
+        caseLockedCompatible.fieldType = ImmutableTextField.class;
+        caseLockedCompatible.shouldCreateNewVariable = false;
+        caseLockedCompatible.testCaseName = "caseLockedCompatible";
 
-        final GraphQLFieldNameCompatibilityTestCase caseModUser = new GraphQLFieldNameCompatibilityTestCase();
-        caseModUser.fieldName = MOD_USER_KEY;
-        caseModUser.fieldType = ImmutableCategoryField.class;
-        caseModUser.shouldCreateNewVariable = true;
+        final GraphQLFieldNameCompatibilityTestCase caseConLanguageIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseConLanguageIncompatible.fieldName = "conLanguage";
+        caseConLanguageIncompatible.fieldType = ImmutableCategoryField.class;
+        caseConLanguageIncompatible.shouldCreateNewVariable = true;
+        caseConLanguageIncompatible.testCaseName = "caseConLanguageIncompatible";
+
+        final GraphQLFieldNameCompatibilityTestCase caseIdentifierIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseIdentifierIncompatible.fieldName = IDENTIFIER;
+        caseIdentifierIncompatible.fieldType = ImmutableCategoryField.class;
+        caseIdentifierIncompatible.shouldCreateNewVariable = true;
+        caseIdentifierIncompatible.testCaseName = "caseIdentifierIncompatible";
+
+        final GraphQLFieldNameCompatibilityTestCase caseIdentifierCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseIdentifierCompatible.fieldName = IDENTIFIER;
+        caseIdentifierCompatible.fieldType = ImmutableTextField.class;
+        caseIdentifierCompatible.shouldCreateNewVariable = false;
+        caseIdentifierCompatible.testCaseName = "caseIdentifierCompatible";
+
+        final GraphQLFieldNameCompatibilityTestCase caseInodeIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseInodeIncompatible.fieldName = INODE;
+        caseInodeIncompatible.fieldType = ImmutableCategoryField.class;
+        caseInodeIncompatible.shouldCreateNewVariable = true;
+        caseInodeIncompatible.testCaseName = "caseInodeIncompatible";
+
+        final GraphQLFieldNameCompatibilityTestCase caseInodeCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseInodeCompatible.fieldName = INODE;
+        caseInodeCompatible.fieldType = ImmutableTextField.class;
+        caseInodeCompatible.shouldCreateNewVariable = false;
+        caseInodeCompatible.testCaseName = "caseInodeCompatible";
+
+        final GraphQLFieldNameCompatibilityTestCase caseHostIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseHostIncompatible.fieldName = HOST_KEY;
+        caseHostIncompatible.fieldType = ImmutableCategoryField.class;
+        caseHostIncompatible.shouldCreateNewVariable = true;
+        caseHostIncompatible.testCaseName = "caseHostIncompatible";
+
+        final GraphQLFieldNameCompatibilityTestCase caseFolderIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseFolderIncompatible.fieldName = FOLDER_KEY;
+        caseFolderIncompatible.fieldType = ImmutableCategoryField.class;
+        caseFolderIncompatible.shouldCreateNewVariable = true;
+        caseFolderIncompatible.testCaseName = "caseFolderIncompatible";
+
+        final GraphQLFieldNameCompatibilityTestCase caseUrlMapIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseUrlMapIncompatible.fieldName = URL_MAP;
+        caseUrlMapIncompatible.fieldType = ImmutableCategoryField.class;
+        caseUrlMapIncompatible.shouldCreateNewVariable = true;
+        caseUrlMapIncompatible.testCaseName = "caseUrlMapIncompatible";
+
+        final GraphQLFieldNameCompatibilityTestCase caseUrlMapCompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseUrlMapCompatible.fieldName = URL_MAP;
+        caseUrlMapCompatible.fieldType = ImmutableTextField.class;
+        caseUrlMapCompatible.shouldCreateNewVariable = false;
+        caseUrlMapCompatible.testCaseName = "caseUrlMapCompatible";
+
+        final GraphQLFieldNameCompatibilityTestCase caseOwnerIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseOwnerIncompatible.fieldName = OWNER_KEY;
+        caseOwnerIncompatible.fieldType = ImmutableCategoryField.class;
+        caseOwnerIncompatible.shouldCreateNewVariable = true;
+        caseOwnerIncompatible.testCaseName = "caseOwnerIncompatible";
+
+        final GraphQLFieldNameCompatibilityTestCase caseModUserIncompatible = new GraphQLFieldNameCompatibilityTestCase();
+        caseModUserIncompatible.fieldName = MOD_USER_KEY;
+        caseModUserIncompatible.fieldType = ImmutableCategoryField.class;
+        caseModUserIncompatible.shouldCreateNewVariable = true;
+        caseModUserIncompatible.testCaseName = "caseModUserIncompatible";
 
         return new GraphQLFieldNameCompatibilityTestCase[] {
                 caseModDateIncompatible,
                 caseModDateCompatible,
                 caseTitleCompatible,
                 caseTitleIncompatible,
-                caseTitleImage,
-                caseContentType,
-                caseBaseType,
-                caseLive,
-                caseWorking,
-                caseArchived,
-                caseLocked,
-                caseConLanguage,
-                caseIdentifier,
-                caseInode,
-                caseHost,
-                caseFolder,
-                caseUrlMap,
-                caseOwner,
-                caseModUser
+                caseTitleImageIncompatible,
+                caseTitleImageCompatible,
+                caseContentTypeIncompatible,
+                caseContentTypeCompatible,
+                caseBaseTypeIncompatible,
+                caseBaseTypeCompatible,
+                caseLiveIncompatible,
+                caseLiveCompatible,
+                caseWorkingCompatible,
+                caseArchivedCompatible,
+                caseLockedCompatible,
+                caseIdentifierIncompatible,
+                caseIdentifierCompatible,
+                caseInodeIncompatible,
+                caseInodeCompatible,
+                caseHostIncompatible,
+                caseFolderIncompatible,
+                caseUrlMapIncompatible,
+                caseUrlMapCompatible,
+                caseOwnerIncompatible,
+                caseModUserIncompatible
         };
     }
 
     @Test
     @UseDataProvider("dataProviderGraphQLReservedNames")
-    public void test_SaveFieldWithIncompatibleGraphQLNameShouldUseDifferentName(
+    public void test_SaveFieldVariableNameCompatibilityWithGraphQL(
             final GraphQLFieldNameCompatibilityTestCase testCase)
             throws DotSecurityException, DotDataException {
 
@@ -1213,6 +1298,12 @@ public class FieldAPITest extends IntegrationTestBase {
         String fieldName;
         private Class<? extends Field> fieldType;
         boolean shouldCreateNewVariable = true;
+        String testCaseName;
+
+        @Override
+        public String toString() {
+            return testCaseName;
+        }
     }
 
     public static Field createField(final ContentType contentType, final String fieldName,

--- a/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
@@ -748,7 +748,7 @@ public class GraphqlAPITest extends IntegrationTestBase {
         }
     }
 
-    private Field createField(final ContentType contentType, final String fieldVarName, final Class<? extends Field> fieldType,
+    public static Field createField(final ContentType contentType, final String fieldVarName, final Class<? extends Field> fieldType,
             final boolean fieldRequired) {
         try {
             final FieldAPI fieldAPI = APILocator.getContentTypeFieldAPI();

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
@@ -238,6 +238,11 @@ public class FieldFactoryImpl implements FieldFactory {
       final List<String> takenFieldVars = fieldsAlreadyAdded.stream().map(Field::variable).collect(
               Collectors.toList());
 
+      // check if the field variable is compatible with GraphQL
+      if(!GraphQLUtil.isVariableGraphQLCompatible(throwAwayField)) {
+          takenFieldVars.add(throwAwayField.name());
+      }
+
       String tryVar = (throwAwayField.variable() == null)
           ? suggestVelocityVar(throwAwayField.name(), takenFieldVars) : throwAwayField.variable();
       builder.variable(tryVar);
@@ -588,7 +593,7 @@ public String suggestVelocityVar( String tryVar, List<String> takenFieldsVariabl
 
     // adds the GraphQL Reserved field names to the "taken fields variables" list
     final List<String> forbiddenFieldVariables = new ArrayList<>(takenFieldsVariables);
-    forbiddenFieldVariables.addAll(GraphQLUtil.getFieldReservedWords());
+//    forbiddenFieldVariables.addAll(GraphQLUtil.getFieldReservedWords());
 
     String var = StringUtils.camelCaseLower(tryVar);
     // if we don't get a var back, we are looking at UTF-8 or worse

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
@@ -593,7 +593,6 @@ public String suggestVelocityVar( String tryVar, List<String> takenFieldsVariabl
 
     // adds the GraphQL Reserved field names to the "taken fields variables" list
     final List<String> forbiddenFieldVariables = new ArrayList<>(takenFieldsVariables);
-//    forbiddenFieldVariables.addAll(GraphQLUtil.getFieldReservedWords());
 
     String var = StringUtils.camelCaseLower(tryVar);
     // if we don't get a var back, we are looking at UTF-8 or worse

--- a/dotCMS/src/main/java/com/dotcms/graphql/CustomFieldType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/CustomFieldType.java
@@ -3,6 +3,8 @@ package com.dotcms.graphql;
 import com.dotcms.graphql.datafetcher.MapFieldPropertiesDataFetcher;
 import com.dotcms.graphql.util.TypeUtil;
 
+import graphql.schema.GraphQLType;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -108,5 +110,9 @@ public enum CustomFieldType {
 
     public GraphQLObjectType getType() {
         return customFieldTypes.get(this.name());
+    }
+
+    public static Collection<GraphQLObjectType> getCustomFieldTypes() {
+        return customFieldTypes.values();
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/CustomFieldType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/CustomFieldType.java
@@ -1,21 +1,18 @@
 package com.dotcms.graphql;
 
-import com.dotcms.graphql.datafetcher.MapFieldPropertiesDataFetcher;
-import com.dotcms.graphql.util.TypeUtil;
-
-import graphql.schema.GraphQLType;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLOutputType;
-
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLID;
 import static graphql.Scalars.GraphQLInt;
 import static graphql.Scalars.GraphQLLong;
 import static graphql.Scalars.GraphQLString;
+
+import com.dotcms.graphql.datafetcher.MapFieldPropertiesDataFetcher;
+import com.dotcms.graphql.util.TypeUtil;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 public enum CustomFieldType {
     BINARY,

--- a/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
@@ -78,9 +78,9 @@ public enum InterfaceType {
     public static final String KEY_VALUE_INTERFACE_NAME = "KeyValueBaseType";
     public static final String FORM_INTERFACE_NAME = "FormBaseType";
 
-    static {
+    private static final Map<String, TypeFetcher> contentFields = new HashMap<>();
 
-        final Map<String, TypeFetcher> contentFields = new HashMap<>();
+    static {
         contentFields.put(MOD_DATE, new TypeFetcher(GraphQLString));
         contentFields.put(TITLE, new TypeFetcher(GraphQLString));
         contentFields.put(TITLE_IMAGE_KEY, new TypeFetcher(CustomFieldType.BINARY.getType(), new TitleImageFieldDataFetcher()));
@@ -155,5 +155,9 @@ public enum InterfaceType {
         }
 
         return type;
+    }
+
+    public static Map<String, TypeFetcher> getContentletInheritedFields() {
+        return contentFields;
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
@@ -65,7 +65,7 @@ public enum InterfaceType {
         this.baseContentType = baseContentType;
     }
 
-    public static Set<String> RESERVED_GRAPHQL_FIELD_NAMES = new HashSet<>();
+    public static Set<String> CONTENT_INTERFACE_FIELDS = new HashSet<>();
 
     private static Map<String, GraphQLInterfaceType> interfaceTypes = new HashMap<>();
 
@@ -99,7 +99,7 @@ public enum InterfaceType {
         contentFields.put(OWNER_KEY, new TypeFetcher(CustomFieldType.USER.getType(), new UserDataFetcher()));
         contentFields.put(MOD_USER_KEY, new TypeFetcher(CustomFieldType.USER.getType(), new UserDataFetcher()));
 
-        RESERVED_GRAPHQL_FIELD_NAMES.addAll(contentFields.keySet());
+        CONTENT_INTERFACE_FIELDS.addAll(contentFields.keySet());
 
         interfaceTypes.put("CONTENTLET", createInterfaceType("Contentlet", contentFields, new ContentResolver()));
 

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPI.java
@@ -3,6 +3,8 @@ package com.dotcms.graphql.business;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotmarketing.exception.DotDataException;
 
+import graphql.schema.GraphQLObjectType;
+import java.util.Collection;
 import java.util.Map;
 
 import graphql.schema.GraphQLOutputType;
@@ -10,7 +12,12 @@ import graphql.schema.GraphQLSchema;
 
 public interface GraphqlAPI {
     GraphQLSchema getSchema() throws DotDataException;
+
     GraphQLOutputType getGraphqlTypeForFieldClass(final Class<? extends Field> fieldClass, final Field field);
+
     void invalidateSchema();
 
+    Map<Class<? extends Field>, GraphQLOutputType> getFieldTypesWithCustomGraphQLTypes();
+
+    Collection<GraphQLObjectType> getCustomFieldTypes();
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
@@ -69,6 +69,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -346,5 +347,15 @@ public class GraphqlAPIImpl implements GraphqlAPI {
             ? relationship.getChildStructureInode() : relationship.getParentStructureInode();
 
         return APILocator.getContentTypeAPI(user).find(relatedContentTypeId);
+    }
+
+    @Override
+    public Map<Class<? extends Field>, GraphQLOutputType> getFieldTypesWithCustomGraphQLTypes() {
+        return fieldClassGraphqlTypeMap;
+    }
+
+    @Override
+    public Collection<GraphQLObjectType> getCustomFieldTypes() {
+        return CustomFieldType.getCustomFieldTypes();
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/util/GraphQLUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/util/GraphQLUtil.java
@@ -3,17 +3,11 @@ package com.dotcms.graphql.util;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.graphql.InterfaceType;
 import com.dotmarketing.business.APILocator;
+import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLType;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 public class GraphQLUtil {
-
-    public static Set<String> getFieldReservedWords() {
-        return InterfaceType.RESERVED_GRAPHQL_FIELD_NAMES;
-    }
 
     public static boolean isVariableGraphQLCompatible(final Field field) {
         // first let's check if there's an inherited field with the same variable
@@ -38,6 +32,8 @@ public class GraphQLUtil {
     }
 
     private static boolean isCustomFieldType(final GraphQLType type) {
-        return APILocator.getGraphqlAPI().getCustomFieldTypes().contains(type);
+           return  type instanceof GraphQLList ? APILocator.getGraphqlAPI().getCustomFieldTypes()
+                   .contains(((GraphQLList) type).getWrappedType())
+                   : APILocator.getGraphqlAPI().getCustomFieldTypes().contains(type);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/util/GraphQLUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/util/GraphQLUtil.java
@@ -1,11 +1,42 @@
 package com.dotcms.graphql.util;
 
+import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.graphql.InterfaceType;
+import com.dotmarketing.business.APILocator;
+import graphql.schema.GraphQLType;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 public class GraphQLUtil {
 
     public static Set<String> getFieldReservedWords() {
         return InterfaceType.RESERVED_GRAPHQL_FIELD_NAMES;
+    }
+
+    public static boolean isVariableGraphQLCompatible(final Field field) {
+        // first let's check if there's an inherited field with the same variable
+        if(InterfaceType.getContentletInheritedFields().containsKey(field.name())) {
+            // now let's check if the graphql types are compatible
+
+            // get inherited graphql field type
+            GraphQLType inheritedFieldGraphQLType = InterfaceType.getContentletInheritedFields()
+                    .get(field.name()).getType();
+
+            // get new field type
+            GraphQLType fieldGraphQLType = APILocator.getGraphqlAPI()
+                    .getGraphqlTypeForFieldClass(field.type(), field);
+
+            return (!isCustomFieldType(inheritedFieldGraphQLType)
+                    && !isCustomFieldType(fieldGraphQLType))
+                    || inheritedFieldGraphQLType.equals(fieldGraphQLType);
+        }
+
+        return true;
+    }
+
+    private static boolean isCustomFieldType(final GraphQLType type) {
+        return APILocator.getGraphqlAPI().getCustomFieldTypes().contains(type);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/util/GraphQLUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/util/GraphQLUtil.java
@@ -20,14 +20,15 @@ public class GraphQLUtil {
         if(InterfaceType.getContentletInheritedFields().containsKey(field.name())) {
             // now let's check if the graphql types are compatible
 
-            // get inherited graphql field type
+            // get inherited field's graphql type
             GraphQLType inheritedFieldGraphQLType = InterfaceType.getContentletInheritedFields()
                     .get(field.name()).getType();
 
-            // get new field type
+            // get new field's type
             GraphQLType fieldGraphQLType = APILocator.getGraphqlAPI()
                     .getGraphqlTypeForFieldClass(field.type(), field);
 
+            // if at least one of them is a custom type, they need to be equal to be compatible
             return (!isCustomFieldType(inheritedFieldGraphQLType)
                     && !isCustomFieldType(fieldGraphQLType))
                     || inheritedFieldGraphQLType.equals(fieldGraphQLType);

--- a/dotCMS/src/main/java/com/dotcms/graphql/util/GraphQLUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/util/GraphQLUtil.java
@@ -15,11 +15,11 @@ public class GraphQLUtil {
             // now let's check if the graphql types are compatible
 
             // get inherited field's graphql type
-            GraphQLType inheritedFieldGraphQLType = InterfaceType.getContentletInheritedFields()
+            final GraphQLType inheritedFieldGraphQLType = InterfaceType.getContentletInheritedFields()
                     .get(field.name()).getType();
 
             // get new field's type
-            GraphQLType fieldGraphQLType = APILocator.getGraphqlAPI()
+            final GraphQLType fieldGraphQLType = APILocator.getGraphqlAPI()
                     .getGraphqlTypeForFieldClass(field.type(), field);
 
             // if at least one of them is a custom type, they need to be equal to be compatible


### PR DESCRIPTION
In GraphQL we have a few custom field types for some composed types. These are:

_[BINARY, CATEGORY, SITE, FOLDER,SITE_OR_FOLDER, KEY_VALUE, LANGUAGE, USER]._

In addition to this, each GraphQL Type inherits a number of fields from a common Interface, called `Contentlet`. 

Conflicts occur when you try to use the name of one of those inherited fields and also either change its type from being a custom type to not being one, or vice versa. 

With this PR we now check - on field save/update time - if the name/variable of the field is compatible with GraphQL by doing a couple of things:
1. Checking if the name/variable of the field is the name of the inherited fields from Contentlet interface
2. If 1 is true, then we check if the types of either the inherited field or the field to save/update are Custom types, in which case they need to be of the same type to be compatible. 

Also test cases were added for both compatible and incompatible scenarios. 