### PR TITLE
Issue 18005 graphql file and image field types no fields available

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
@@ -762,12 +762,12 @@ public class GraphqlAPITest extends IntegrationTestBase {
     }
 
     private boolean areFileassetFieldsPresent(final GraphQLObjectType objectType) {
-        List<String> fileAssetFields = list(FILEASSET_FILE_NAME_FIELD_VAR,
+        final List<String> fileAssetFields = list(FILEASSET_FILE_NAME_FIELD_VAR,
                 FILEASSET_DESCRIPTION_FIELD_VAR, FILEASSET_FILEASSET_FIELD_VAR,
                 FILEASSET_METADATA_FIELD_VAR, FILEASSET_SHOW_ON_MENU_FIELD_VAR,
                 FILEASSET_SORT_ORDER_FIELD_VAR);
-        return objectType.getFieldDefinitions().stream().allMatch((fieldDefinition ->
-                fileAssetFields.contains(fieldDefinition.getName())));
+        return objectType.getFieldDefinitions().stream().allMatch(fieldDefinition ->
+                fileAssetFields.contains(fieldDefinition.getName()));
     }
 
     private ContentType createAndSaveSimpleContentType(final String name) throws DotSecurityException, DotDataException {

--- a/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
@@ -1,5 +1,11 @@
 package com.dotcms.graphql.business;
 
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_DESCRIPTION_FIELD_VAR;
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_FILEASSET_FIELD_VAR;
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_FILE_NAME_FIELD_VAR;
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_METADATA_FIELD_VAR;
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_SHOW_ON_MENU_FIELD_VAR;
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_SORT_ORDER_FIELD_VAR;
 import static com.dotcms.graphql.InterfaceType.CONTENT_INTERFACE_NAME;
 import static com.dotcms.graphql.InterfaceType.FILE_INTERFACE_NAME;
 import static com.dotcms.graphql.InterfaceType.FORM_INTERFACE_NAME;
@@ -8,6 +14,7 @@ import static com.dotcms.graphql.InterfaceType.PAGE_INTERFACE_NAME;
 import static com.dotcms.graphql.InterfaceType.PERSONA_INTERFACE_NAME;
 import static com.dotcms.graphql.InterfaceType.VANITY_URL_INTERFACE_NAME;
 import static com.dotcms.graphql.InterfaceType.WIDGET_INTERFACE_NAME;
+import static com.dotcms.util.CollectionsUtils.list;
 import static com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY.MANY_TO_MANY;
 import static com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY.MANY_TO_ONE;
 import static com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY.ONE_TO_ONE;
@@ -22,6 +29,8 @@ import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.FieldAPI;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.FieldBuilder;
+import com.dotcms.contenttype.model.field.FileField;
+import com.dotcms.contenttype.model.field.ImageField;
 import com.dotcms.contenttype.model.field.ImmutableBinaryField;
 import com.dotcms.contenttype.model.field.ImmutableCategoryField;
 import com.dotcms.contenttype.model.field.ImmutableCheckboxField;
@@ -45,7 +54,11 @@ import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ContentTypeBuilder;
 import com.dotcms.contenttype.model.type.EnterpriseType;
+import com.dotcms.contenttype.model.type.FileAssetContentType;
 import com.dotcms.contenttype.model.type.SimpleContentType;
+import com.dotcms.datagen.ContentTypeDataGen;
+import com.dotcms.datagen.FieldDataGen;
+import com.dotcms.graphql.CustomFieldType;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
@@ -699,6 +712,62 @@ public class GraphqlAPITest extends IntegrationTestBase {
         final GraphQLSchema schema = APILocator.getGraphqlAPI().getSchema();
         assertNotNull(schema.getQueryType().getFieldDefinition(baseType.name().toLowerCase()
                 +"BaseTypeCollection"));
+    }
+
+    /**
+     * This method tests that given a {@link Field} of type {@link com.dotcms.contenttype.model.field.FileField}
+     * or {@link com.dotcms.contenttype.model.field.ImageField}, the following GraphQL fields are
+     * available to query:
+     *
+     * {@link FileAssetContentType#FILEASSET_FILE_NAME_FIELD_VAR}
+     * {@link FileAssetContentType#FILEASSET_DESCRIPTION_FIELD_VAR}
+     * {@link FileAssetContentType#FILEASSET_FILEASSET_FIELD_VAR}
+     * {@link FileAssetContentType#FILEASSET_METADATA_FIELD_VAR}
+     * {@link FileAssetContentType#FILEASSET_SHOW_ON_MENU_FIELD_VAR}
+     * {@link FileAssetContentType#FILEASSET_SORT_ORDER_FIELD_VAR}
+     */
+
+    @Test
+    public void testAvailableGraphQLFieldsOnImageAndFileFields()
+            throws DotDataException, DotSecurityException {
+        ContentType contentType = null;
+        try {
+            contentType = new ContentTypeDataGen().nextPersisted();
+            final Field fileField = new FieldDataGen().contentTypeId(contentType.id())
+                    .type(FileField.class).nextPersisted();
+            final Field imageField = new FieldDataGen().contentTypeId(contentType.id())
+                    .type(ImageField.class).nextPersisted();
+
+            APILocator.getGraphqlAPI().invalidateSchema();
+
+            final GraphQLSchema schema = APILocator.getGraphqlAPI().getSchema();
+
+            final GraphQLFieldDefinition fileFieldDefinition = schema
+                    .getObjectType(contentType.variable())
+                    .getFieldDefinition(fileField.variable());
+
+            final GraphQLFieldDefinition imageFieldDefinition = schema
+                    .getObjectType(contentType.variable())
+                    .getFieldDefinition(imageField.variable());
+
+            assertEquals(CustomFieldType.FILEASSET.getType(), fileFieldDefinition.getType());
+
+            assertTrue(areFileassetFieldsPresent((GraphQLObjectType) fileFieldDefinition.getType()));
+            assertTrue(areFileassetFieldsPresent((GraphQLObjectType) imageFieldDefinition.getType()));
+
+            assertEquals(CustomFieldType.FILEASSET.getType(), imageFieldDefinition.getType());
+        } finally {
+            APILocator.getContentTypeAPI(APILocator.systemUser()).delete(contentType);
+        }
+    }
+
+    private boolean areFileassetFieldsPresent(final GraphQLObjectType objectType) {
+        List<String> fileAssetFields = list(FILEASSET_FILE_NAME_FIELD_VAR,
+                FILEASSET_DESCRIPTION_FIELD_VAR, FILEASSET_FILEASSET_FIELD_VAR,
+                FILEASSET_METADATA_FIELD_VAR, FILEASSET_SHOW_ON_MENU_FIELD_VAR,
+                FILEASSET_SORT_ORDER_FIELD_VAR);
+        return objectType.getFieldDefinitions().stream().allMatch((fieldDefinition ->
+                fileAssetFields.contains(fieldDefinition.getName())));
     }
 
     private ContentType createAndSaveSimpleContentType(final String name) throws DotSecurityException, DotDataException {

--- a/dotCMS/src/main/java/com/dotcms/graphql/CustomFieldType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/CustomFieldType.java
@@ -1,13 +1,24 @@
 package com.dotcms.graphql;
 
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_DESCRIPTION_FIELD_VAR;
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_FILEASSET_FIELD_VAR;
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_FILE_NAME_FIELD_VAR;
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_METADATA_FIELD_VAR;
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_SHOW_ON_MENU_FIELD_VAR;
+import static com.dotcms.contenttype.model.type.FileAssetContentType.FILEASSET_SORT_ORDER_FIELD_VAR;
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLID;
 import static graphql.Scalars.GraphQLInt;
 import static graphql.Scalars.GraphQLLong;
 import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLList.list;
 
+import com.dotcms.graphql.datafetcher.BinaryFieldDataFetcher;
+import com.dotcms.graphql.datafetcher.FieldDataFetcher;
+import com.dotcms.graphql.datafetcher.KeyValueFieldDataFetcher;
 import com.dotcms.graphql.datafetcher.MapFieldPropertiesDataFetcher;
 import com.dotcms.graphql.util.TypeUtil;
+import com.dotcms.graphql.util.TypeUtil.TypeFetcher;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import java.util.Collection;
@@ -22,7 +33,8 @@ public enum CustomFieldType {
     SITE_OR_FOLDER,
     KEY_VALUE,
     LANGUAGE,
-    USER;
+    USER,
+    FILEASSET;
 
     private static Map<String, GraphQLObjectType> customFieldTypes = new HashMap<>();
 
@@ -45,7 +57,7 @@ public enum CustomFieldType {
         categoryTypeFields.put("keywords", GraphQLString);
         categoryTypeFields.put("velocityVar", GraphQLString);
         customFieldTypes.put("CATEGORY", TypeUtil.createObjectType("Category", categoryTypeFields,
-            new MapFieldPropertiesDataFetcher()));
+            new FieldDataFetcher()));
 
         final Map<String, GraphQLOutputType> siteTypeFields = new HashMap<>();
         siteTypeFields.put("hostId", GraphQLString);
@@ -103,6 +115,17 @@ public enum CustomFieldType {
         userTypeFields.put("lastName", GraphQLString);
         userTypeFields.put("email", GraphQLString);
         customFieldTypes.put("USER", TypeUtil.createObjectType("User", userTypeFields, null));
+
+        final Map<String, TypeFetcher> fileAssetTypeFields = new HashMap<>();
+        fileAssetTypeFields.put(FILEASSET_FILE_NAME_FIELD_VAR, new TypeFetcher(GraphQLString, new FieldDataFetcher()));
+        fileAssetTypeFields.put(FILEASSET_DESCRIPTION_FIELD_VAR, new TypeFetcher(GraphQLString, new FieldDataFetcher()));
+        fileAssetTypeFields.put(FILEASSET_FILEASSET_FIELD_VAR,
+                new TypeFetcher(CustomFieldType.BINARY.getType(),new BinaryFieldDataFetcher()));
+        fileAssetTypeFields.put(FILEASSET_METADATA_FIELD_VAR,
+                new TypeFetcher(list(CustomFieldType.KEY_VALUE.getType()), new KeyValueFieldDataFetcher()));
+        fileAssetTypeFields.put(FILEASSET_SHOW_ON_MENU_FIELD_VAR, new TypeFetcher(list(GraphQLString), new FieldDataFetcher()));
+        fileAssetTypeFields.put(FILEASSET_SORT_ORDER_FIELD_VAR, new TypeFetcher(GraphQLInt, new FieldDataFetcher()));
+        customFieldTypes.put("FILEASSET", TypeUtil.createObjectType("Fileasset", fileAssetTypeFields));
     }
 
     public GraphQLObjectType getType() {

--- a/dotCMS/src/main/java/com/dotcms/graphql/CustomFieldType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/CustomFieldType.java
@@ -57,7 +57,7 @@ public enum CustomFieldType {
         categoryTypeFields.put("keywords", GraphQLString);
         categoryTypeFields.put("velocityVar", GraphQLString);
         customFieldTypes.put("CATEGORY", TypeUtil.createObjectType("Category", categoryTypeFields,
-            new FieldDataFetcher()));
+            new MapFieldPropertiesDataFetcher()));
 
         final Map<String, GraphQLOutputType> siteTypeFields = new HashMap<>();
         siteTypeFields.put("hostId", GraphQLString);

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
@@ -91,8 +91,8 @@ public class GraphqlAPIImpl implements GraphqlAPI {
         // custom type mappings
         this.fieldClassGraphqlTypeMap.put(BinaryField.class, CustomFieldType.BINARY.getType());
         this.fieldClassGraphqlTypeMap.put(CategoryField.class, list(CustomFieldType.CATEGORY.getType()));
-        this.fieldClassGraphqlTypeMap.put(ImageField.class, InterfaceType.FILEASSET.getType());
-        this.fieldClassGraphqlTypeMap.put(FileField.class, InterfaceType.FILEASSET.getType());
+        this.fieldClassGraphqlTypeMap.put(ImageField.class, CustomFieldType.FILEASSET.getType());
+        this.fieldClassGraphqlTypeMap.put(FileField.class, CustomFieldType.FILEASSET.getType());
         this.fieldClassGraphqlTypeMap.put(KeyValueField.class, list(CustomFieldType.KEY_VALUE.getType()));
         this.fieldClassGraphqlTypeMap.put(CheckboxField.class, list(GraphQLString));
         this.fieldClassGraphqlTypeMap.put(MultiSelectField.class, list(GraphQLString));

--- a/dotCMS/src/main/java/com/dotcms/graphql/util/TypeUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/util/TypeUtil.java
@@ -32,6 +32,23 @@ public class TypeUtil {
         return builder.build();
     }
 
+    public static GraphQLObjectType createObjectType(final String typeName,
+            final Map<String, TypeFetcher> fieldsTypesAndFetchers) {
+        final GraphQLObjectType.Builder builder = GraphQLObjectType.newObject().name(typeName);
+
+        fieldsTypesAndFetchers.keySet().forEach((key)->{
+            builder.field(newFieldDefinition()
+                    .name(key)
+                    .type(fieldsTypesAndFetchers.get(key).getType())
+                    .dataFetcher(fieldsTypesAndFetchers.get(key).getDataFetcher()!=null
+                            ?fieldsTypesAndFetchers.get(key).getDataFetcher()
+                            :new PropertyDataFetcher<String>(key))
+            );
+        });
+
+        return builder.build();
+    }
+
     public static GraphQLInterfaceType createInterfaceType(final String typeName,
                                                            final Map<String, TypeFetcher> fieldsTypesAndFetchers,
                                                            final TypeResolver typeResolver) {


### PR DESCRIPTION
As a part of t[his ticket](https://github.com/dotCMS/core/issues/17560), _dotCMS Base Types_ became empty _GraphQL interfaces_, meaning, they only work for grouping content of the same `dotCMS Base Type` but don't have common Interface fields anymore. Because of a missing change as a part of the mentioned ticket, the `File` and `Image` dotCMS Field Types were left without GraphQL fields, since they were still mapped to the now field-less _Fileasset GraphQL_ Interface. The solution was to create a new GraphQL Custom Type called `Fileasset`, that has all the fields removed from the `Fileasset` GraphQL Interface and map `File` and `Image` fields to this new Custom Type. 

Integration tests were added to verify that `Image` and `File` fields have the proper Custom Type and that the Custom Type has all the expected fields. 