### PR TITLE
#17994 : As of many versions ago, pushing an archived content would m…

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/PushNowActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/PushNowActionlet.java
@@ -52,11 +52,11 @@ public class PushNowActionlet extends WorkFlowActionlet {
     private static final String PARAM_ENVIRONMENT = "environment";
     private static final String PARAM_FORCE_PUSH = "force";
 
-    private PublisherAPI publisherAPI = PublisherAPI.getInstance();
-    private EnvironmentAPI environmentAPI = APILocator.getEnvironmentAPI();
-    private BundleAPI bundleAPI = APILocator.getBundleAPI();
-    private UserAPI userAPI = APILocator.getUserAPI();
-    private RoleAPI roleAPI = APILocator.getRoleAPI();
+    private final PublisherAPI publisherAPI = PublisherAPI.getInstance();
+    private final EnvironmentAPI environmentAPI = APILocator.getEnvironmentAPI();
+    private final BundleAPI bundleAPI = APILocator.getBundleAPI();
+    private final UserAPI userAPI = APILocator.getUserAPI();
+    private final RoleAPI roleAPI = APILocator.getRoleAPI();
 
     @Override
     public List<WorkflowActionletParameter> getParameters() {
@@ -84,7 +84,6 @@ public class PushNowActionlet extends WorkFlowActionlet {
         final User user = processor.getUser();
         final String environments = params.get(PARAM_ENVIRONMENT).getValue();
         try {
-            final boolean forcePush = "true".equals(params.get(PARAM_FORCE_PUSH).getValue()) ? Boolean.TRUE : Boolean.FALSE;
             if (!UtilMethods.isSet(environments)) {
                 Logger.error(this, "There are no Push Publishing environments set to send the bundle.");
             }
@@ -133,6 +132,7 @@ public class PushNowActionlet extends WorkFlowActionlet {
             // Push Publish now
             final Date publishDate = new Date();
             identifiers.add(contentlet.getIdentifier());
+            final boolean forcePush = "true".equals(params.get(PARAM_FORCE_PUSH).getValue()) ? Boolean.TRUE : Boolean.FALSE;
             final Bundle bundle = new Bundle(null, publishDate, null, user.getUserId(), forcePush);
             this.bundleAPI.saveBundle(bundle, finalEnvs);
             this.publisherAPI.addContentsToPublish(identifiers, bundle.getId(), publishDate, user);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/PushNowActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/PushNowActionlet.java
@@ -1,11 +1,15 @@
 package com.dotmarketing.portlets.workflows.actionlet;
 
 import com.dotcms.publisher.bundle.bean.Bundle;
+import com.dotcms.publisher.bundle.business.BundleAPI;
 import com.dotcms.publisher.business.DotPublisherException;
 import com.dotcms.publisher.business.PublisherAPI;
 import com.dotcms.publisher.environment.bean.Environment;
+import com.dotcms.publisher.environment.business.EnvironmentAPI;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Role;
+import com.dotmarketing.business.RoleAPI;
+import com.dotmarketing.business.UserAPI;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.workflows.model.WorkflowActionClassParameter;
@@ -14,122 +18,135 @@ import com.dotmarketing.portlets.workflows.model.WorkflowActionletParameter;
 import com.dotmarketing.portlets.workflows.model.WorkflowProcessor;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
+import com.liferay.portal.model.User;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * This Workflow Actionlet allows users to Push Publish a piece of Content when executing a Workflow Action. It takes
+ * two parameters:
+ * <ol>
+ *     <li><b>Name of the Environment (String):</b> The name of the Push Publishing environment that will receive the
+ *     Contentlet.</li>
+ *     <li><b>Force the Push? true or false (String):</b> Type in true if the push will be forced. Otherwise, type in
+ *     false. Defaults to false.</li>
+ * </ol>
+ * It's worth noting that, as its name implies, this Workflow Actionlet <b>allows users to {@code Push} content ONLY,
+ * and NOT to {@code Remove} or {@code Push Remove}.</b>
+ *
+ * @author Oscar Arrieta
+ * @version 3.2
+ * @since Mar 4, 2015
+ */
 public class PushNowActionlet extends WorkFlowActionlet {
 
     private static final long serialVersionUID = 1L;
+
+    private static final String ENVIRONMENT_DELIMITER = ",";
+    private static final String ACTIONLET_NAME = "Push Now";
+    private static final String ACTIONLET_DESCRIPTION = "This actionlet will automatically publish the the content " +
+            "object to the specified environment(s). Multiple environments can be separated by a comma (',')";
+    private static final String PARAM_ENVIRONMENT = "environment";
+    private static final String PARAM_FORCE_PUSH = "force";
+
     private PublisherAPI publisherAPI = PublisherAPI.getInstance();
+    private EnvironmentAPI environmentAPI = APILocator.getEnvironmentAPI();
+    private BundleAPI bundleAPI = APILocator.getBundleAPI();
+    private UserAPI userAPI = APILocator.getUserAPI();
+    private RoleAPI roleAPI = APILocator.getRoleAPI();
 
     @Override
     public List<WorkflowActionletParameter> getParameters() {
-        List<WorkflowActionletParameter> params = new ArrayList<WorkflowActionletParameter>();
-
-        params.add(new WorkflowActionletParameter("environment", "Name of the Enviroment", "", true));
-        params.add(new WorkflowActionletParameter("force", "Force the Push? true or false", "false", true));
-
+        final List<WorkflowActionletParameter> params = new ArrayList<>();
+        params.add(new WorkflowActionletParameter(PARAM_ENVIRONMENT, "Name of the Environment", "", true));
+        params.add(new WorkflowActionletParameter(PARAM_FORCE_PUSH, "Force the Push? true or false", "false", true));
         return params;
     }
 
     @Override
     public String getName() {
-        return "Push Now";
+        return ACTIONLET_NAME;
     }
 
     @Override
     public String getHowTo() {
-        return "This actionlet will automatically publish the the content object to the specified enviroment(s). Multiple Environments can be separated by a comma";
+        return ACTIONLET_DESCRIPTION;
     }
 
-    public void executeAction(WorkflowProcessor processor, Map<String, WorkflowActionClassParameter> params)
+    @Override
+    public void executeAction(final WorkflowProcessor processor, final Map<String, WorkflowActionClassParameter> params)
             throws WorkflowActionFailureException {
+        final List<String> identifiers = new ArrayList<>();
+        final Contentlet contentlet = processor.getContentlet();
+        final User user = processor.getUser();
+        final String environments = params.get(PARAM_ENVIRONMENT).getValue();
         try {
-            // Gets available languages
-            // List<Language> languages = languagesAPI.getLanguages();
-
-            Contentlet ref = processor.getContentlet();
-
-            boolean _contentPushNeverExpire = true;
-
-            boolean forcePush = ("true".equals(params.get("force").getValue())) ? true : false;
-            String envrions = params.get("environment").getValue();
-            if (envrions == null) {
-                Logger.error(this.getClass(), "There are no environments set to push to");
+            final boolean forcePush = "true".equals(params.get(PARAM_FORCE_PUSH).getValue()) ? Boolean.TRUE : Boolean.FALSE;
+            if (!UtilMethods.isSet(environments)) {
+                Logger.error(this, "There are no Push Publishing environments set to send the bundle.");
             }
-
-            String[] whereToSend = envrions.split(",");
-
-            List<Environment> envsToSendTo = new ArrayList<Environment>();
-            List<Environment> permissionedEnv = new ArrayList<Environment>();
-            List<Environment> finalEnvs = new ArrayList<Environment>();
-
-
+            final String[] whereToSend = environments.split(ENVIRONMENT_DELIMITER);
+            final List<Environment> envsToSendTo = new ArrayList<>();
             // Lists of Environments to push to
-            for (String name : whereToSend) {
-                if (UtilMethods.isSet(name)) {
-                    name = name.trim();
-                    final Environment e = APILocator.getEnvironmentAPI().findEnvironmentByName(name);
-                    if (e != null) {
-
-                        envsToSendTo.add(e);
-                    }else{
-                        Logger.error(PushNowActionlet.class, "The Environment " + name + " does not exists");
+            for (String environmentName : whereToSend) {
+                if (UtilMethods.isSet(environmentName)) {
+                    environmentName = environmentName.trim();
+                    final Environment environment = this.environmentAPI.findEnvironmentByName(environmentName);
+                    if (null != environment && UtilMethods.isSet(environment.getId())) {
+                        envsToSendTo.add(environment);
+                    } else {
+                        Logger.error(this, "The Environment '" + environmentName + "' does not exist.");
                     }
                 }
-
             }
-
-            if(envsToSendTo.isEmpty()){
-                throw new DotPublisherException("There are no enviroments to send the bundle");
+            if (envsToSendTo.isEmpty()) {
+                throw new WorkflowActionFailureException("There are no environments to send the bundle.");
             }
-
-
             // make sure the user has permissions to push
-            boolean isAdmin = APILocator.getUserAPI().isCMSAdmin(processor.getUser());
-            List<Role> roles = APILocator.getRoleAPI().loadRolesForUser(processor.getUser().getUserId(),true);
-            if(isAdmin){
-                List<Environment> app = APILocator.getEnvironmentAPI().findEnvironmentsWithServers();
-                for(Environment e:app)
-                    permissionedEnv.add(e);
-            }
-            else{
-                for(Role r: roles){
+            final boolean isAdmin = this.userAPI.isCMSAdmin(user);
+            final List<Role> roleList = this.roleAPI.loadRolesForUser(user.getUserId(),true);
+            final List<Environment> permissionedEnv = new ArrayList<>();
+            if (isAdmin) {
+                final List<Environment> environmentList = this.environmentAPI.findEnvironmentsWithServers();
+                for (final Environment environment : environmentList) {
+                    permissionedEnv.add(environment);
+                }
+            } else {
+                for (final Role role : roleList){
                     try {
-                        permissionedEnv.addAll(APILocator.getEnvironmentAPI().findEnvironmentsByRole(r.getId()));
-                    } catch (Exception e) {
-                        Logger.error(PushNowActionlet.class, e.getMessage());
+                        permissionedEnv.addAll(this.environmentAPI.findEnvironmentsByRole(role.getId()));
+                    } catch (final Exception e) {
+                        Logger.warn(this, String.format("An error occurred when verifying Role '%s' [%s]: %s", role
+                                .getName(), role.getId(), e.getMessage()));
                     }
                 }
             }
-            for(Environment e : envsToSendTo){
-                if(permissionedEnv.contains(e)){
-                    finalEnvs.add(e);
+            final List<Environment> finalEnvs = new ArrayList<>();
+            for (final Environment environment : envsToSendTo) {
+                if (permissionedEnv.contains(environment)) {
+                    finalEnvs.add(environment);
                 }
             }
-
-            // publish now
-            Date publishDate = new Date();
-
-            List<String> identifiers = new ArrayList<String>();
-            identifiers.add(ref.getIdentifier());
-
-            Bundle bundle = new Bundle(null, publishDate, null, processor.getUser().getUserId(), forcePush);
-            APILocator.getBundleAPI().saveBundle(bundle, finalEnvs);
-
-            publisherAPI.addContentsToPublish(identifiers, bundle.getId(), publishDate, processor.getUser());
-
-        } catch (DotPublisherException e) {
-            Logger.debug(PushNowActionlet.class, e.getMessage());
-            throw new WorkflowActionFailureException(e.getMessage(),e);
-        } catch (DotDataException e) {
-            Logger.debug(PushNowActionlet.class, e.getMessage());
-            throw new WorkflowActionFailureException(e.getMessage(),e);
+            // Push Publish now
+            final Date publishDate = new Date();
+            identifiers.add(contentlet.getIdentifier());
+            final Bundle bundle = new Bundle(null, publishDate, null, user.getUserId(), forcePush);
+            this.bundleAPI.saveBundle(bundle, finalEnvs);
+            this.publisherAPI.addContentsToPublish(identifiers, bundle.getId(), publishDate, user);
+        } catch (final DotPublisherException e) {
+            final String errorMsg = String.format("An error occurred when adding Contentlet with ID '%s' to the " +
+                    "bundle for Environments [%s]: %s", contentlet.getIdentifier(), environments, e.getMessage());
+            Logger.debug(this, errorMsg);
+            throw new WorkflowActionFailureException(errorMsg, e);
+        } catch (final DotDataException e) {
+            final String errorMsg = String.format("An error occurred when saving the bundle for Environments [%s]: " +
+                    "%s", environments, e.getMessage());
+            Logger.debug(this, errorMsg);
+            throw new WorkflowActionFailureException(errorMsg, e);
         }
-
     }
 
 }

--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/RemotePublisherDialog.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/RemotePublisherDialog.js
@@ -77,11 +77,11 @@ dojo.declare("dotcms.dijit.RemotePublisherDialog", null, {
             	dijit.byId("iwtExpire").set("disabled", true) ;
             	dijit.byId("iwtPublishExpire").set("disabled", true) ;
             }
-            
+            // For archived Content, allow users to "Push" and "Push Remove" ONLY
             if (removeOnly) {
-            	dijit.byId("iwtExpire").set("checked", true);
-            	dijit.byId("iwtPublish").set("disabled", true);
-            	dijit.byId("iwtPublishExpire").set("disabled", true);
+                dijit.byId("iwtPublish").set("checked", true);
+                dijit.byId("iwtPublishExpire").set("disabled", true);
+                dijit.byId("iwtExpire").set("disabled", false);
             }
 
             dojo.connect(dijit.byId("iwtExpire"), "onChange", function(){

--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
@@ -1636,8 +1636,7 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
      *
      * objId - The Identifier or inode of the object to push.
      * referrer - The referrer page.
-     * isArchived - If true, only the "Remove" option in the Push Dialog
-     *              will be displayed.
+     * isArchived - If true, allow users to ONLY do a "Push" or "Remove", NOT a "Push & Remove".
      */
     function remotePublish (objId, referrer, isArchived) {
         if (isArchived != undefined && isArchived != null) {


### PR DESCRIPTION
…ake dotCMS delete it altogether in the receiving instance, which is incorrect. This change allows the Push Publishing feature and the Push Now actionlet the flexibility to push an archived content to the receiver for: (1) Simply flagging it as Archived, or (2) to delete it completely.