### PR TITLE
#17843 Fallback to Tomcat provider if the datasource initialization fails

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/db/DBPropertiesDataSourceStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/DBPropertiesDataSourceStrategy.java
@@ -29,7 +29,8 @@ public class DBPropertiesDataSourceStrategy implements DotDataSourceStrategy {
         propertiesFile = file;
     }
 
-    private DBPropertiesDataSourceStrategy(){
+    @VisibleForTesting
+    DBPropertiesDataSourceStrategy(){
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
         final URL resourceURL = loader.getResource(DB_PROPERTIES_FILE_NAME);
         if (resourceURL!=null){

--- a/dotCMS/src/main/java/com/dotmarketing/db/DBPropertiesDataSourceStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/DBPropertiesDataSourceStrategy.java
@@ -64,7 +64,7 @@ public class DBPropertiesDataSourceStrategy implements DotDataSourceStrategy {
                 throw new FileNotFoundException("DB properties file not found");
             }
 
-            properties.load(new FileInputStream(propertiesFile));
+            properties.load(new FileInputStream(getPropertiesFile()));
 
             final HikariConfig config = getHikariConfig(properties);
 
@@ -78,6 +78,11 @@ public class DBPropertiesDataSourceStrategy implements DotDataSourceStrategy {
 
             throw new DotRuntimeException(e.toString());
         }
+    }
+
+    @VisibleForTesting
+    File getPropertiesFile() {
+        return propertiesFile;
     }
 
     @VisibleForTesting

--- a/dotCMS/src/main/java/com/dotmarketing/db/DockerSecretDataSourceStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/DockerSecretDataSourceStrategy.java
@@ -24,7 +24,8 @@ public class DockerSecretDataSourceStrategy implements DotDataSourceStrategy {
 
     public static final String DOCKER_SECRET_FILE_PATH_PROPERTY = "DOCKER_SECRET_FILE_PATH";
 
-    private DockerSecretDataSourceStrategy(){
+    @VisibleForTesting
+    DockerSecretDataSourceStrategy(){
         systemEnvironmentProperties = new SystemEnvironmentProperties();
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/db/SystemEnvDataSourceStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/SystemEnvDataSourceStrategy.java
@@ -32,7 +32,8 @@ public class SystemEnvDataSourceStrategy implements DotDataSourceStrategy {
         this.systemEnvironmentProperties = systemEnvironmentProperties;
     }
 
-    private SystemEnvDataSourceStrategy(){
+    @VisibleForTesting
+    SystemEnvDataSourceStrategy(){
         systemEnvironmentProperties = new SystemEnvironmentProperties();
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/db/TomcatDataSourceStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/TomcatDataSourceStrategy.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.db;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import com.dotmarketing.exception.DotRuntimeException;
@@ -16,7 +17,8 @@ import javax.sql.DataSource;
  */
 public class TomcatDataSourceStrategy implements DotDataSourceStrategy {
 
-    private TomcatDataSourceStrategy(){}
+    @VisibleForTesting
+    TomcatDataSourceStrategy(){}
 
     private static class SingletonHelper{
         private static TomcatDataSourceStrategy INSTANCE = new TomcatDataSourceStrategy();

--- a/dotCMS/src/main/resources/db.properties
+++ b/dotCMS/src/main/resources/db.properties
@@ -1,16 +1,16 @@
 ##H2 default configuration
-##connection_db_driver=org.h2.Driver
-##connection_db_base_url=jdbc:h2:WEB-INF/H2_DATABASE/h2_dotcms_data;MVCC=TRUE;LOCK_TIMEOUT=15000
-##connection_db_username=sa
-##connection_db_password=sa
-##connection_db_validation_query=SELECT 1
+connection_db_driver=org.h2.Driver
+connection_db_base_url=jdbc:h2:WEB-INF/H2_DATABASE/h2_dotcms_data;MVCC=TRUE;LOCK_TIMEOUT=15000
+connection_db_username=sa
+connection_db_password=sa
+connection_db_validation_query=SELECT 1
 
 ##Postgres default configuration
-connection_db_driver=org.postgresql.Driver
-connection_db_base_url=jdbc:postgresql://database/dotcms
-connection_db_username=postgres
-connection_db_password=postgres
-connection_db_validation_query=SELECT 1
+##connection_db_driver=org.postgresql.Driver
+##connection_db_base_url=jdbc:postgresql://localhost/dotcms
+##connection_db_username=postgres
+##connection_db_password=postgres
+##connection_db_validation_query=SELECT 1
 
 
 ##MySQL default configuration

--- a/dotCMS/src/main/resources/db.properties
+++ b/dotCMS/src/main/resources/db.properties
@@ -8,10 +8,9 @@
 ##Postgres default configuration
 connection_db_driver=org.postgresql.Driver
 connection_db_base_url=jdbc:postgresql://localhost/dotcms
-connection_db_username=postgres
-connection_db_password=postgres
+connection_db_username=dotcms
+connection_db_password=dotcms
 connection_db_validation_query=SELECT 1
-
 
 ##MySQL default configuration
 ##connection_db_driver=com.mysql.jdbc.Driver

--- a/dotCMS/src/main/resources/db.properties
+++ b/dotCMS/src/main/resources/db.properties
@@ -1,16 +1,16 @@
 ##H2 default configuration
-connection_db_driver=org.h2.Driver
-connection_db_base_url=jdbc:h2:WEB-INF/H2_DATABASE/h2_dotcms_data;MVCC=TRUE;LOCK_TIMEOUT=15000
-connection_db_username=sa
-connection_db_password=sa
-connection_db_validation_query=SELECT 1
+##connection_db_driver=org.h2.Driver
+##connection_db_base_url=jdbc:h2:WEB-INF/H2_DATABASE/h2_dotcms_data;MVCC=TRUE;LOCK_TIMEOUT=15000
+##connection_db_username=sa
+##connection_db_password=sa
+##connection_db_validation_query=SELECT 1
 
 ##Postgres default configuration
-##connection_db_driver=org.postgresql.Driver
-##connection_db_base_url=jdbc:postgresql://localhost/dotcms
-##connection_db_username=postgres
-##connection_db_password=postgres
-##connection_db_validation_query=SELECT 1
+connection_db_driver=org.postgresql.Driver
+connection_db_base_url=jdbc:postgresql://localhost/dotcms
+connection_db_username=postgres
+connection_db_password=postgres
+connection_db_validation_query=SELECT 1
 
 
 ##MySQL default configuration

--- a/dotCMS/src/main/webapp/META-INF/context.xml
+++ b/dotCMS/src/main/webapp/META-INF/context.xml
@@ -37,7 +37,7 @@
         Documentation for Resource settings:  https://tomcat.apache.org/tomcat-8.5-doc/jdbc-pool.html
      -->
 
-    <!-- H2-->
+    <!-- H2
     <Resource name="jdbc/dotCMSPool" auth="Container"
               factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
               type="javax.sql.DataSource"
@@ -47,20 +47,20 @@
               removeAbandoned="true" removeAbandonedTimeout="60" logAbandoned="false"
               jdbcInterceptors="org.apache.tomcat.jdbc.pool.interceptor.ResetAbandonedTimer"
               timeBetweenEvictionRunsMillis="30000" validationQuery="SELECT 1" testOnBorrow="true" testWhileIdle="true"
-              abandonWhenPercentageFull="50"/>
+              abandonWhenPercentageFull="50"/>-->
 
-    <!-- POSTGRESQL
+    <!-- POSTGRESQL-->
     <Resource name="jdbc/dotCMSPool" auth="Container"
           type="javax.sql.DataSource"
           factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
           driverClassName="org.postgresql.Driver"
           url="jdbc:postgresql://localhost/dotcms"
-          username="{your db user}" password="{your db password}" maxActive="60" maxIdle="10" maxWait="60000"
+          username="dotcms" password="dotcms" maxActive="60" maxIdle="10" maxWait="60000"
           removeAbandoned="true" removeAbandonedTimeout="60" logAbandoned="true"
           jdbcInterceptors="org.apache.tomcat.jdbc.pool.interceptor.ResetAbandonedTimer"
           timeBetweenEvictionRunsMillis="30000" validationQuery="SELECT 1" testOnBorrow="true" testWhileIdle="true"
           abandonWhenPercentageFull="50"/>
--->
+
     <!-- MYSQL UTF8
     <Resource name="jdbc/dotCMSPool" auth="Container"
           factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"

--- a/dotCMS/src/test/java/com/dotmarketing/db/DataSourceStrategyProviderTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/db/DataSourceStrategyProviderTest.java
@@ -151,6 +151,7 @@ public class DataSourceStrategyProviderTest {
 
         if (testCase.equals("DBProperties")) {
             Mockito.when(dbStrategy.existsDBPropertiesFile()).thenReturn(true);
+            Mockito.when(dbStrategy.getPropertiesFile()).thenReturn(null);
         } else {
             Mockito.when(dbStrategy.existsDBPropertiesFile()).thenReturn(false);
         }


### PR DESCRIPTION
This logic was implemented to use context.xml as a fallback in case the datasource initialization fails using another provider