### PR TITLE
Fixing rule permission bug

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -2,6 +2,7 @@ package com.dotcms;
 
 import com.dotcms.content.elasticsearch.business.ESContentletAPIImplTest;
 import com.dotcms.contenttype.test.DotAssetAPITest;
+import com.dotcms.enterprise.rules.RulesAPIImplIntegrationTest;
 import com.dotcms.junit.MainBaseSuite;
 import com.dotcms.mock.request.CachedParameterDecoratorTest;
 import com.dotcms.publisher.bundle.business.BundleFactoryTest;
@@ -233,7 +234,8 @@ import org.junit.runners.Suite.SuiteClasses;
         com.dotcms.security.secret.ServiceIntegrationAPIImplTest.class,
         ServiceIntegrationResourceTest.class,
         VelocityServletIntegrationTest.class,
-        DotAssetAPITest.class
+        DotAssetAPITest.class,
+        RulesAPIImplIntegrationTest.class
 })
 public class MainSuite {
 

--- a/dotCMS/src/integration-test/java/com/dotcms/enterprise/rules/RulesAPIImplIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/enterprise/rules/RulesAPIImplIntegrationTest.java
@@ -94,7 +94,7 @@ public class RulesAPIImplIntegrationTest {
         final Role role = new RoleDataGen().nextPersisted();
         final User user = new UserDataGen().roles(role).nextPersisted();
         final Host host = new SiteDataGen().nextPersisted();
-        final Rule rule1 = new RuleDataGen().host(host).nextPersisted();
+        new RuleDataGen().host(host).nextPersisted();
 
         rulesAPI.getAllRulesByParent(host, user, false);
     }
@@ -265,7 +265,7 @@ public class RulesAPIImplIntegrationTest {
         hostReadPermission.setRoleId(role.getId());
         hostReadPermission.setPermission(PermissionAPI.PERMISSION_USE);
         permissions.add(hostReadPermission);
-            
+
         APILocator.getPermissionAPI().save(permissions, host, systemUser, false);
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/enterprise/rules/RulesAPIImplIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/enterprise/rules/RulesAPIImplIntegrationTest.java
@@ -247,6 +247,7 @@ public class RulesAPIImplIntegrationTest {
         readPermission.setInode(host.getPermissionId());
         readPermission.setRoleId(role.getId());
         readPermission.setPermission(PermissionAPI.PERMISSION_READ);
+        readPermission.setType(Rule.class.getName());
         permissions.add(readPermission);
 
         if (notAddPublishPermission) {
@@ -259,6 +260,12 @@ public class RulesAPIImplIntegrationTest {
             permissions.add(publishPermission);
         }
 
+        final Permission hostReadPermission = new Permission();
+        hostReadPermission.setInode(host.getPermissionId());
+        hostReadPermission.setRoleId(role.getId());
+        hostReadPermission.setPermission(PermissionAPI.PERMISSION_USE);
+        permissions.add(hostReadPermission);
+            
         APILocator.getPermissionAPI().save(permissions, host, systemUser, false);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/sites/ruleengine/rules/RuleResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/sites/ruleengine/rules/RuleResource.java
@@ -12,7 +12,9 @@ import com.dotcms.rest.exception.BadRequestException;
 import com.dotcms.rest.exception.ForbiddenException;
 import com.dotcms.rest.exception.InternalServerException;
 import com.dotcms.rest.exception.NotFoundException;
+import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.PermissionableProxy;
+import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.ApiProvider;
 import com.dotmarketing.business.Ruleable;
 import com.dotmarketing.db.HibernateUtil;
@@ -77,11 +79,15 @@ public class RuleResource {
     @Path("/rules")
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
-    public Map<String, RestRule> list(@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam("siteId") String siteId) {
+    public Map<String, RestRule> list(
+            @Context HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @PathParam("siteId") String siteId) throws DotSecurityException, DotDataException {
+
         siteId = checkNotEmpty(siteId, BadRequestException.class, "Site Id is required.");
         User user = getUser(request, response);
-        Ruleable proxy =  getParent(siteId, user);
-        List<RestRule> restRules = getRulesInternal(user, proxy);
+        final Host host = APILocator.getHostAPI().find(siteId, user, false);
+        final List<RestRule> restRules = getRulesInternal(user, host);
         Map<String, RestRule> hash = Maps.newHashMapWithExpectedSize(restRules.size());
         for (RestRule restRule : restRules) {
             hash.put(restRule.key, restRule);
@@ -103,7 +109,6 @@ public class RuleResource {
     public RestRule self(@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam("siteId") String siteId, @PathParam("ruleId") String ruleId) {
         siteId = checkNotEmpty(siteId, BadRequestException.class, "Site Id is required.");
         User user = getUser(request, response);
-        Ruleable proxy =  getParent(siteId, user);
         ruleId = checkNotEmpty(ruleId, BadRequestException.class, "Rule Id is required.");
         return getRuleInternal(ruleId, user);
     }
@@ -117,7 +122,6 @@ public class RuleResource {
     @POST
     @JSONP
     @Path("/rules")
-    
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Consumes(MediaType.APPLICATION_JSON)
     public Response add(@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam("siteId") String siteId, RestRule restRule) {
@@ -150,7 +154,6 @@ public class RuleResource {
         siteId = checkNotEmpty(siteId, BadRequestException.class, "Site Id is required.");
         ruleId = checkNotEmpty(ruleId, BadRequestException.class, "Rule Id is required.");
         User user = getUser(request, response);
-        Ruleable proxy =  getParent(siteId, user); // forces check that host exists. This should be handled by rulesAPI?
 
         updateRuleInternal(user, new RestRule.Builder().from(restRule).key(ruleId).build());
 
@@ -213,26 +216,19 @@ public class RuleResource {
         return webResource.init(request, response, true).getUser();
     }
 
-    private List<RestRule> getRulesInternal(User user, Ruleable host) {
-        try {
-            List<RestRule> restRules = new ArrayList<>();
+    private List<RestRule> getRulesInternal(User user, Ruleable host) throws DotSecurityException, DotDataException {
+        List<RestRule> restRules = new ArrayList<>();
 
-            List<Rule> rules = rulesAPI.getAllRulesByParent(host, user, false);
-            for (Rule rule : rules) {
-                try{
-                    restRules.add(ruleTransform.appToRest(rule, user));
-                } catch (Exception transEx) {
-                    String ruleName = UtilMethods.isSet(rule.getName()) ? rule.getName() : "N/A";
-                    Logger.error(this, "Error parsing Rule named: " + ruleName + " to ReST: " + transEx.getMessage());
-                }
+        List<Rule> rules = rulesAPI.getAllRulesByParent(host, user, false);
+        for (Rule rule : rules) {
+            try{
+                restRules.add(ruleTransform.appToRest(rule, user));
+            } catch (Exception transEx) {
+                String ruleName = UtilMethods.isSet(rule.getName()) ? rule.getName() : "N/A";
+                Logger.error(this, "Error parsing Rule named: " + ruleName + " to ReST: " + transEx.getMessage());
             }
-            return restRules;
-
-        } catch (DotDataException e) {
-            throw new BadRequestException(e, e.getMessage());
-        } catch (DotSecurityException e) {
-            throw new ForbiddenException(e, e.getMessage());
         }
+        return restRules;
     }
 
     private RestRule getRuleInternal(String ruleId, User user) {

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/sites/ruleengine/rules/RuleResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/sites/ruleengine/rules/RuleResource.java
@@ -80,7 +80,7 @@ public class RuleResource {
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     public Map<String, RestRule> list(
-            @Context HttpServletRequest request,
+            @Context final HttpServletRequest request,
             @Context final HttpServletResponse response,
             @PathParam("siteId") String siteId) throws DotSecurityException, DotDataException {
 
@@ -216,7 +216,10 @@ public class RuleResource {
         return webResource.init(request, response, true).getUser();
     }
 
-    private List<RestRule> getRulesInternal(User user, Ruleable host) throws DotSecurityException, DotDataException {
+    private List<RestRule> getRulesInternal(
+            final User user,
+            final Ruleable host) throws DotSecurityException, DotDataException {
+
         List<RestRule> restRules = new ArrayList<>();
 
         List<Rule> rules = rulesAPI.getAllRulesByParent(host, user, false);


### PR DESCRIPTION
Fixing: https://github.com/dotCMS/core/issues/17901#issuecomment-591155814

- Using the host object allow to check the permission correctly

https://github.com/dotCMS/core/compare/issue-17901-Unable-to-create-rules?expand=1#diff-8861622cb5192fca78268f8d23179f81R89

- Not catch the DotSecurityException to let the DotSecurityExceptionMapper  catch it, and response with the right format, this avoid a blank page when the user does not have permission

https://github.com/dotCMS/core/compare/issue-17901-Unable-to-create-rules?expand=1#diff-8861622cb5192fca78268f8d23179f81L231

