### PR TITLE
#18080 Remove backup indicies

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/cmsmaintenance/action/ViewCMSMaintenanceAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/cmsmaintenance/action/ViewCMSMaintenanceAction.java
@@ -888,14 +888,6 @@ public class ViewCMSMaintenanceAction extends DotPortletAction {
 			RulesImportExportUtil.getInstance().export(file);
 
 			final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
-
-			file = new File(backupTempFilePath + "/index_working.json");
-			new ESIndexAPI().backupIndex(info.getWorking(), file);
-
-
-			file = new File(backupTempFilePath + "/index_live.json");
-			new ESIndexAPI().backupIndex(info.getLive(), file);
-
 		} catch (Exception e) {
 			Logger.error(this,e.getMessage(),e);
 		}


### PR DESCRIPTION
Remove calls to backing up the live and working indices in the "Download data/assets" logic