### PR TITLE
#17917 A new HighRestClientProvider was implemented

### DIFF
--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -1,8 +1,9 @@
 //noinspection GroovyAssignabilityCheck
 dependencies {
 
-    compile group: 'com.dotcms.enterprise', name: 'ee', version: '5.0.0-SNAPSHOT', changing: true
+    //compile group: 'com.dotcms.enterprise', name: 'ee', version: '5.0.0-SNAPSHOT', changing: true
 
+    compile fileTree(dir: 'src/main/enterprise/build/libs', include: ['ee_clean.jar'])
     
     compile group: 'com.dotcms', name: 'ant-tooling', version: '1.3.2'
     compile ('io.jsonwebtoken:jjwt:0.6.0'){
@@ -327,48 +328,9 @@ dependencies {
     compile group: 'com.dotcms.lib', name: 'dot.aws-java-sdk-kms', version:'1.11.66_2'
     compile group: 'com.dotcms.lib', name: 'dot.aws-java-sdk-s3', version:'1.11.66_2'
     compile group: 'com.dotcms.lib', name: 'dot.jmespath-java', version:'1.11.66_2'
-
-
-    compile group: 'org.springframework', name: 'spring-asm', version:'3.1.0.RELEASE'
-    compile(group: 'org.springframework', name: 'spring-beans', version:'3.1.0.RELEASE') {
-        exclude(module: 'commons-logging')
-    }
-    compile(group: 'org.springframework', name: 'spring-context', version:'3.1.0.RELEASE') {
-        exclude(module: 'commons-logging')
-        exclude(module: 'aopalliance')
-        exclude(module: 'spring-aop')
-        exclude(module: 'spring-context-support')
-    }
-    compile(group: 'org.springframework', name: 'spring-core', version:'3.1.0.RELEASE') {
-        exclude(module: 'commons-logging')
-    }
-    compile(group: 'org.springframework', name: 'spring-expression', version:'3.1.0.RELEASE') {
-        exclude(module: 'commons-logging')
-    }
-    compile(group: 'org.springframework', name: 'spring-jdbc', version:'3.1.0.RELEASE') {
-        exclude(module: 'commons-logging')
-        exclude(module: 'aopalliance')
-        exclude(module: 'spring-aop')
-    }
-    compile(group: 'org.springframework', name: 'spring-tx', version:'3.1.0.RELEASE') {
-        exclude(module: 'commons-logging')
-        exclude(module: 'aopalliance')
-        exclude(module: 'spring-aop')
-    }
-    compile(group: 'org.springframework', name: 'spring-web', version:'3.1.0.RELEASE') {
-        exclude(module: 'commons-logging')
-        exclude(module: 'aopalliance')
-        exclude(module: 'spring-aop')
-    }
-    compile(group: 'org.springframework', name: 'spring-webmvc', version:'3.1.0.RELEASE') {
-        exclude(module: 'spring-aop')
-        exclude(module: 'aopalliance')
-        exclude(module: 'commons-logging')
-        exclude(module: 'spring-context-support')
-    }
+    
     compile group: 'com.h2database', name: 'h2', version:'1.3.176'
     compile group: 'eu.bitwalker', name: 'UserAgentUtils', version:'1.19'
-
 
     compile group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version:'3.2.1'
     compile group: 'com.twelvemonkeys.imageio', name: 'imageio-metadata', version:'3.2.1'
@@ -490,6 +452,22 @@ dependencies {
         exclude(group: 'org.apache.logging.log4j')
         exclude(group: 'com.fasterxml.jackson.core')
     }
+
+    compile (group: 'org.elasticsearch.client', name: 'transport', version: '7.3.2'){
+        exclude(group: 'org.apache.logging.log4j')
+    }
+
+    compile ('org.springframework.data:spring-data-elasticsearch:3.2.5.RELEASE'){
+        exclude(group: 'com.fasterxml.jackson.core')
+        exclude(group: 'org.elasticsearch')
+        exclude(group: 'org.elasticsearch.client')
+        exclude(group: 'org.slf4j')
+    }
+
+    compile group: 'org.springframework', name: 'spring-webflux', version: '5.2.4.RELEASE'
+    compile group: 'org.springframework', name: 'spring-webmvc', version: '5.2.4.RELEASE'
+    compile group: 'io.projectreactor.netty', name: 'reactor-netty', version: '0.9.5.RELEASE'
+
 
     //https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html
     providedCompile (group: 'com.oracle.jdbc', name: 'ojdbc8', version: '19.3') {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -834,7 +834,7 @@ public class ESContentFactoryImpl extends ContentletFactory {
         searchRequest.source(searchSourceBuilder);
 
         final SearchResponse response = Sneaky.sneak(()->
-                RestHighLevelClientProvider.getInstance().getClient().search(searchRequest, RequestOptions.DEFAULT));
+                RestHighLevelClientProvider.getInstance().getReactiveClient().search(searchRequest, RequestOptions.DEFAULT));
         SearchHits hits = response.getHits();
         List<Contentlet> cons = new ArrayList<>();
 
@@ -974,7 +974,7 @@ public class ESContentFactoryImpl extends ContentletFactory {
 			searchRequest.indices((live ? info.getLive() : info.getWorking()));
 
             final SearchResponse response = Sneaky.sneak(()->
-                    RestHighLevelClientProvider.getInstance().getClient().search(searchRequest, RequestOptions.DEFAULT));
+                    RestHighLevelClientProvider.getInstance().getReactiveClient().search(searchRequest, RequestOptions.DEFAULT));
             SearchHits hits = response.getHits();
 
 			return find(hits.getAt(0).getSourceAsMap().get("inode").toString());
@@ -1073,7 +1073,7 @@ public class ESContentFactoryImpl extends ContentletFactory {
     @NotNull
     private List<Contentlet> getContentletsFromSearchResponse(SearchRequest searchRequest) {
         final SearchResponse response = Sneaky.sneak(()->
-                RestHighLevelClientProvider.getInstance().getClient().search(searchRequest, RequestOptions.DEFAULT));
+                RestHighLevelClientProvider.getInstance().getReactiveClient().search(searchRequest, RequestOptions.DEFAULT));
 
         SearchHits hits = response.getHits();
 
@@ -1378,7 +1378,7 @@ public class ESContentFactoryImpl extends ContentletFactory {
         searchRequest.indices(indexToHit);
 
         final SearchResponse response = Sneaky.sneak(()->
-                RestHighLevelClientProvider.getInstance().getClient().search(searchRequest, RequestOptions.DEFAULT));
+                RestHighLevelClientProvider.getInstance().getReactiveClient().search(searchRequest, RequestOptions.DEFAULT));
        return response.getHits().getTotalHits().value;
 	}
 
@@ -1405,7 +1405,7 @@ public class ESContentFactoryImpl extends ContentletFactory {
                 info.getLive(): info.getWorking());
 
         final SearchResponse response = Sneaky.sneak(()->
-                RestHighLevelClientProvider.getInstance().getClient().search(searchRequest, RequestOptions.DEFAULT));
+                RestHighLevelClientProvider.getInstance().getReactiveClient().search(searchRequest, RequestOptions.DEFAULT));
         return response.getHits().getTotalHits().value;
     }
 
@@ -1583,7 +1583,7 @@ public class ESContentFactoryImpl extends ContentletFactory {
             }
 
             searchRequest.source(searchSourceBuilder);
-            response = RestHighLevelClientProvider.getInstance().getClient().search(searchRequest, RequestOptions.DEFAULT);
+            response = RestHighLevelClientProvider.getInstance().getReactiveClient().search(searchRequest, RequestOptions.DEFAULT);
 
 
         } catch (ElasticsearchStatusException | IndexNotFoundException | SearchPhaseExecutionException infe ) {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESIndexAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESIndexAPI.java
@@ -292,7 +292,7 @@ public class ESIndexAPI {
 			searchRequest.source(searchSourceBuilder);
 
 			final SearchResponse searchResponse = Sneaky.sneak(()->
-					RestHighLevelClientProvider.getInstance().getClient().search(searchRequest,
+					RestHighLevelClientProvider.getInstance().getReactiveClient().search(searchRequest,
 							RequestOptions.DEFAULT));
 
 			String scrollId = searchResponse.getScrollId();
@@ -302,8 +302,6 @@ public class ESIndexAPI {
 				// new way
 				SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
 				scrollRequest.scroll(TimeValue.timeValueMinutes(2));
-				SearchResponse searchScrollResponse = RestHighLevelClientProvider.getInstance()
-						.getClient().scroll(scrollRequest, RequestOptions.DEFAULT);
 
 				scrollId = searchResponse.getScrollId();
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/DotReactiveElasticsearchClient.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/DotReactiveElasticsearchClient.java
@@ -1,0 +1,874 @@
+package com.dotcms.content.elasticsearch.util;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.JdkSslContext;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import javax.net.ssl.SSLContext;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.admin.indices.flush.FlushResponse;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.get.MultiGetRequest;
+import org.elasticsearch.action.get.MultiGetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.main.MainRequest;
+import org.elasticsearch.action.main.MainResponse;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.ClearScrollResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.core.CountRequest;
+import org.elasticsearch.client.core.CountResponse;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.Scroll;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.reactivestreams.Publisher;
+import org.springframework.data.elasticsearch.ElasticsearchException;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.ClientLogger;
+import org.springframework.data.elasticsearch.client.ElasticsearchHost;
+import org.springframework.data.elasticsearch.client.NoReachableHostException;
+import org.springframework.data.elasticsearch.client.reactive.HostProvider;
+import org.springframework.data.elasticsearch.client.reactive.HostProvider.Verification;
+import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient;
+import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.Indices;
+import org.springframework.data.elasticsearch.client.reactive.RequestBodyEncodingException;
+import org.springframework.data.elasticsearch.client.reactive.WebClientProvider;
+import org.springframework.data.elasticsearch.client.util.RequestConverters;
+import org.springframework.data.util.Lazy;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.reactive.function.BodyExtractors;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClient.RequestBodySpec;
+import reactor.core.publisher.EmitterProcessor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.tcp.TcpClient;
+
+public class DotReactiveElasticsearchClient implements ReactiveElasticsearchClient, Indices {
+
+    private final HostProvider hostProvider;
+
+    /**
+     * Create a new {@link DotReactiveElasticsearchClient} using the given {@link HostProvider} to obtain server
+     * connections.
+     *
+     * @param hostProvider must not be {@literal null}.
+     */
+    public DotReactiveElasticsearchClient(HostProvider hostProvider) {
+
+        Assert.notNull(hostProvider, "HostProvider must not be null");
+
+        this.hostProvider = hostProvider;
+    }
+
+    /**
+     * Create a new {@link DotReactiveElasticsearchClient} aware of the given nodes in the cluster. <br />
+     * <strong>NOTE</strong> If the cluster requires authentication be sure to provide the according {@link HttpHeaders}
+     * correctly.
+     *
+     * @param headers Use {@link HttpHeaders} to provide eg. authentication data. Must not be {@literal null}.
+     * @param hosts must not be {@literal null} nor empty!
+     * @return new instance of {@link DotReactiveElasticsearchClient}.
+     */
+    public static ReactiveElasticsearchClient create(HttpHeaders headers, String... hosts) {
+
+        Assert.notNull(headers, "HttpHeaders must not be null");
+        Assert.notEmpty(hosts, "Elasticsearch Cluster needs to consist of at least one host");
+
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder().connectedTo(hosts)
+                .withDefaultHeaders(headers).build();
+        return create(clientConfiguration);
+    }
+
+    /**
+     * Create a new {@link DotReactiveElasticsearchClient} given {@link ClientConfiguration}. <br />
+     * <strong>NOTE</strong> If the cluster requires authentication be sure to provide the according {@link HttpHeaders}
+     * correctly.
+     *
+     * @param clientConfiguration Client configuration. Must not be {@literal null}.
+     * @return new instance of {@link DotReactiveElasticsearchClient}.
+     */
+    public static ReactiveElasticsearchClient create(ClientConfiguration clientConfiguration) {
+
+        Assert.notNull(clientConfiguration, "ClientConfiguration must not be null");
+
+        WebClientProvider provider = getWebClientProvider(clientConfiguration);
+
+        HostProvider hostProvider = HostProvider.provider(provider,
+                clientConfiguration.getEndpoints().toArray(new InetSocketAddress[0]));
+        return new DotReactiveElasticsearchClient(hostProvider);
+    }
+
+    private static WebClientProvider getWebClientProvider(ClientConfiguration clientConfiguration) {
+
+        Duration connectTimeout = clientConfiguration.getConnectTimeout();
+        Duration soTimeout = clientConfiguration.getSocketTimeout();
+
+        TcpClient tcpClient = TcpClient.create();
+
+        if (!connectTimeout.isNegative()) {
+            tcpClient = tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(connectTimeout.toMillis()));
+        }
+
+        if (!soTimeout.isNegative()) {
+
+            tcpClient = tcpClient.doOnConnected(connection -> connection //
+                    .addHandlerLast(new ReadTimeoutHandler(soTimeout.toMillis(), TimeUnit.MILLISECONDS))
+                    .addHandlerLast(new WriteTimeoutHandler(soTimeout.toMillis(), TimeUnit.MILLISECONDS)));
+        }
+
+        String scheme = "http";
+        HttpClient httpClient = HttpClient.from(tcpClient);
+
+        if (clientConfiguration.useSsl()) {
+
+            httpClient = httpClient.secure(sslConfig -> {
+
+                Optional<SSLContext> sslContext = clientConfiguration.getSslContext();
+                sslContext.ifPresent(it -> sslConfig.sslContext(new JdkSslContext(it, true, ClientAuth.NONE)));
+            });
+
+            scheme = "https";
+        }
+
+        ReactorClientHttpConnector connector = new ReactorClientHttpConnector(httpClient);
+        WebClientProvider provider = WebClientProvider.create(scheme, connector);
+
+        if (clientConfiguration.getPathPrefix() != null) {
+            provider = provider.withPathPrefix(clientConfiguration.getPathPrefix());
+        }
+
+        provider = provider.withDefaultHeaders(clientConfiguration.getDefaultHeaders()) //
+                .withWebClientConfigurer(clientConfiguration.getWebClientConfigurer());
+        return provider;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#ping(org.springframework.http.HttpHeaders)
+     */
+    @Override
+    public Mono<Boolean> ping(HttpHeaders headers) {
+
+        return sendRequest(new MainRequest(), DotReactiveElasticsearchClient.RequestCreator.ping(), RawActionResponse.class, headers) //
+                .map(response -> response.statusCode().is2xxSuccessful()) //
+                .onErrorResume(NoReachableHostException.class, error -> Mono.just(false)).next();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#info(org.springframework.http.HttpHeaders)
+     */
+    @Override
+    public Mono<MainResponse> info(HttpHeaders headers) {
+
+        return sendRequest(new MainRequest(), DotReactiveElasticsearchClient.RequestCreator.info(), MainResponse.class, headers) //
+                .next();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#get(org.springframework.http.HttpHeaders, org.elasticsearch.action.get.GetRequest)
+     */
+    @Override
+    public Mono<GetResult> get(HttpHeaders headers, GetRequest getRequest) {
+
+        return sendRequest(getRequest, DotReactiveElasticsearchClient.RequestCreator.get(), GetResponse.class, headers) //
+                .filter(GetResponse::isExists) //
+                .map(DotReactiveElasticsearchClient::getResponseToGetResult) //
+                .next();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#multiGet(org.springframework.http.HttpHeaders, org.elasticsearch.action.get.MultiGetRequest)
+     */
+    @Override
+    public Flux<GetResult> multiGet(HttpHeaders headers, MultiGetRequest multiGetRequest) {
+
+        return sendRequest(multiGetRequest, DotReactiveElasticsearchClient.RequestCreator.multiGet(), MultiGetResponse.class, headers)
+                .map(MultiGetResponse::getResponses) //
+                .flatMap(Flux::fromArray) //
+                .filter(it -> !it.isFailed() && it.getResponse().isExists()) //
+                .map(it -> DotReactiveElasticsearchClient.getResponseToGetResult(it.getResponse()));
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#exists(org.springframework.http.HttpHeaders, org.elasticsearch.action.get.GetRequest)
+     */
+    @Override
+    public Mono<Boolean> exists(HttpHeaders headers, GetRequest getRequest) {
+
+        return sendRequest(getRequest, DotReactiveElasticsearchClient.RequestCreator.exists(), RawActionResponse.class, headers) //
+                .map(response -> response.statusCode().is2xxSuccessful()) //
+                .next();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#ping(org.springframework.http.HttpHeaders, org.elasticsearch.action.index.IndexRequest)
+     */
+    @Override
+    public Mono<IndexResponse> index(HttpHeaders headers, IndexRequest indexRequest) {
+        return sendRequest(indexRequest, DotReactiveElasticsearchClient.RequestCreator.index(), IndexResponse.class, headers).publishNext();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#indices()
+     */
+    @Override
+    public Indices indices() {
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#ping(org.springframework.http.HttpHeaders, org.elasticsearch.action.update.UpdateRequest)
+     */
+    @Override
+    public Mono<UpdateResponse> update(HttpHeaders headers, UpdateRequest updateRequest) {
+        return sendRequest(updateRequest, DotReactiveElasticsearchClient.RequestCreator.update(), UpdateResponse.class, headers).publishNext();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#ping(org.springframework.http.HttpHeaders, org.elasticsearch.action.delete.DeleteRequest)
+     */
+    @Override
+    public Mono<DeleteResponse> delete(HttpHeaders headers, DeleteRequest deleteRequest) {
+
+        return sendRequest(deleteRequest, DotReactiveElasticsearchClient.RequestCreator.delete(), DeleteResponse.class, headers) //
+                .publishNext();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#count(org.springframework.http.HttpHeaders, org.elasticsearch.action.search.SearchRequest)
+     */
+    @Override
+    public Mono<Long> count(HttpHeaders headers, CountRequest countRequest) {
+        return sendRequest(countRequest, DotReactiveElasticsearchClient.RequestCreator.count(), CountResponse.class, headers) //
+                .map(CountResponse::getCount) //
+                .next();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#ping(org.springframework.http.HttpHeaders, org.elasticsearch.action.search.SearchRequest)
+     */
+    @Override
+    public Flux<SearchHit> search(HttpHeaders headers, SearchRequest searchRequest) {
+
+        return sendRequest(searchRequest, DotReactiveElasticsearchClient.RequestCreator.search(), SearchResponse.class, headers) //
+                .map(SearchResponse::getHits) //
+                .flatMap(Flux::fromIterable);
+    }
+
+    public SearchResponse search(SearchRequest searchRequest, RequestOptions options){
+        return sendRequest(searchRequest, DotReactiveElasticsearchClient.RequestCreator.search(), SearchResponse.class, HttpHeaders.EMPTY).blockFirst();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#scroll(org.springframework.http.HttpHeaders, org.elasticsearch.action.search.SearchRequest)
+     */
+    @Override
+    public Flux<SearchHit> scroll(HttpHeaders headers, SearchRequest searchRequest) {
+
+        TimeValue scrollTimeout = searchRequest.scroll() != null ? searchRequest.scroll().keepAlive()
+                : TimeValue.timeValueMinutes(1);
+
+        if (searchRequest.scroll() == null) {
+            searchRequest.scroll(scrollTimeout);
+        }
+
+        EmitterProcessor<ActionRequest> outbound = EmitterProcessor.create(false);
+        FluxSink<ActionRequest> request = outbound.sink();
+
+        EmitterProcessor<SearchResponse> inbound = EmitterProcessor.create(false);
+
+        Flux<SearchResponse> exchange = outbound.startWith(searchRequest).flatMap(it -> {
+
+            if (it instanceof SearchRequest) {
+                return sendRequest((SearchRequest) it, DotReactiveElasticsearchClient.RequestCreator
+                        .search(), SearchResponse.class, headers);
+            } else if (it instanceof SearchScrollRequest) {
+                return sendRequest((SearchScrollRequest) it, DotReactiveElasticsearchClient.RequestCreator
+                        .scroll(), SearchResponse.class, headers);
+            } else if (it instanceof ClearScrollRequest) {
+                return sendRequest((ClearScrollRequest) it, DotReactiveElasticsearchClient.RequestCreator
+                        .clearScroll(), ClearScrollResponse.class, headers)
+                        .flatMap(discard -> Flux.empty());
+            }
+
+            throw new IllegalArgumentException(
+                    String.format("Cannot handle '%s'. Please make sure to use a 'SearchRequest' or 'SearchScrollRequest'.", it));
+        });
+
+        return Flux.usingWhen(Mono.fromSupplier(DotReactiveElasticsearchClient.ScrollState::new),
+
+                scrollState -> {
+
+                    Flux<SearchHit> searchHits = inbound.<SearchResponse> handle((searchResponse, sink) -> {
+
+                        scrollState.updateScrollId(searchResponse.getScrollId());
+                        if (isEmpty(searchResponse.getHits())) {
+
+                            inbound.onComplete();
+                            outbound.onComplete();
+
+                        } else {
+
+                            sink.next(searchResponse);
+
+                            SearchScrollRequest searchScrollRequest = new SearchScrollRequest(scrollState.getScrollId())
+                                    .scroll(scrollTimeout);
+                            request.next(searchScrollRequest);
+                        }
+
+                    }).map(SearchResponse::getHits) //
+                            .flatMap(Flux::fromIterable);
+
+                    return searchHits.doOnSubscribe(ignore -> exchange.subscribe(inbound));
+
+                }, state -> cleanupScroll(headers, state), //
+                state -> cleanupScroll(headers, state), //
+                state -> cleanupScroll(headers, state)); //
+    }
+
+    private static boolean isEmpty(@Nullable SearchHits hits) {
+        return hits != null && hits.getHits() != null && hits.getHits().length == 0;
+    }
+
+    private Publisher<?> cleanupScroll(HttpHeaders headers, DotReactiveElasticsearchClient.ScrollState state) {
+
+        if (state.getScrollIds().isEmpty()) {
+            return Mono.empty();
+        }
+
+        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
+        clearScrollRequest.scrollIds(state.getScrollIds());
+
+        // just send the request, resources get cleaned up anyways after scrollTimeout has been reached.
+        return sendRequest(clearScrollRequest, DotReactiveElasticsearchClient.RequestCreator.clearScroll(), ClearScrollResponse.class, headers);
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#ping(org.springframework.http.HttpHeaders, org.elasticsearch.index.reindex.DeleteByQueryRequest)
+     */
+    public Mono<BulkByScrollResponse> deleteBy(HttpHeaders headers, DeleteByQueryRequest deleteRequest) {
+
+        return sendRequest(deleteRequest, DotReactiveElasticsearchClient.RequestCreator.deleteByQuery(), BulkByScrollResponse.class, headers) //
+                .publishNext();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#bulk(org.springframework.http.HttpHeaders, org.elasticsearch.action.bulk.BulkRequest)
+     */
+    @Override
+    public Mono<BulkResponse> bulk(HttpHeaders headers, BulkRequest bulkRequest) {
+        return sendRequest(bulkRequest, DotReactiveElasticsearchClient.RequestCreator.bulk(), BulkResponse.class, headers) //
+                .publishNext();
+    }
+
+    // --> INDICES
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.Indices#existsIndex(org.springframework.http.HttpHeaders, org.elasticsearch.action.admin.indices.get.GetIndexRequest)
+     */
+    @Override
+    public Mono<Boolean> existsIndex(HttpHeaders headers, GetIndexRequest request) {
+
+        return sendRequest(request, DotReactiveElasticsearchClient.RequestCreator.indexExists(), RawActionResponse.class, headers) //
+                .map(response -> response.statusCode().is2xxSuccessful()) //
+                .next();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.Indices#deleteIndex(org.springframework.http.HttpHeaders, org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest)
+     */
+    @Override
+    public Mono<Void> deleteIndex(HttpHeaders headers, DeleteIndexRequest request) {
+
+        return sendRequest(request, DotReactiveElasticsearchClient.RequestCreator.indexDelete(), AcknowledgedResponse.class, headers) //
+                .then();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.Indices#createIndex(org.springframework.http.HttpHeaders, org.elasticsearch.action.admin.indices.create.CreateIndexRequest)
+     */
+    @Override
+    public Mono<Void> createIndex(HttpHeaders headers, CreateIndexRequest createIndexRequest) {
+
+        return sendRequest(createIndexRequest, DotReactiveElasticsearchClient.RequestCreator.indexCreate(), AcknowledgedResponse.class, headers) //
+                .then();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.Indices#openIndex(org.springframework.http.HttpHeaders, org.elasticsearch.action.admin.indices.open.OpenIndexRequest)
+     */
+    @Override
+    public Mono<Void> openIndex(HttpHeaders headers, OpenIndexRequest request) {
+
+        return sendRequest(request, DotReactiveElasticsearchClient.RequestCreator.indexOpen(), AcknowledgedResponse.class, headers) //
+                .then();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.Indices#closeIndex(org.springframework.http.HttpHeaders, org.elasticsearch.action.admin.indices.close.CloseIndexRequest)
+     */
+    @Override
+    public Mono<Void> closeIndex(HttpHeaders headers, CloseIndexRequest closeIndexRequest) {
+
+        return sendRequest(closeIndexRequest, DotReactiveElasticsearchClient.RequestCreator.indexClose(), AcknowledgedResponse.class, headers) //
+                .then();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.Indices#refreshIndex(org.springframework.http.HttpHeaders, org.elasticsearch.action.admin.indices.refresh.RefreshRequest)
+     */
+    @Override
+    public Mono<Void> refreshIndex(HttpHeaders headers, RefreshRequest refreshRequest) {
+
+        return sendRequest(refreshRequest, DotReactiveElasticsearchClient.RequestCreator.indexRefresh(), RefreshResponse.class, headers) //
+                .then();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.Indices#updateMapping(org.springframework.http.HttpHeaders, org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest)
+     */
+    @Override
+    public Mono<Void> updateMapping(HttpHeaders headers, PutMappingRequest putMappingRequest) {
+
+        return sendRequest(putMappingRequest, DotReactiveElasticsearchClient.RequestCreator.putMapping(), AcknowledgedResponse.class, headers) //
+                .then();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.Indices#flushIndex(org.springframework.http.HttpHeaders, org.elasticsearch.action.admin.indices.flush.FlushRequest)
+     */
+    @Override
+    public Mono<Void> flushIndex(HttpHeaders headers, FlushRequest flushRequest) {
+
+        return sendRequest(flushRequest, DotReactiveElasticsearchClient.RequestCreator.flushIndex(), FlushResponse.class, headers) //
+                .then();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient#ping(org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.ReactiveElasticsearchClientCallback)
+     */
+    @Override
+    public Mono<ClientResponse> execute(ReactiveElasticsearchClientCallback callback) {
+
+        return this.hostProvider.getActive(Verification.LAZY) //
+                .flatMap(callback::doWithClient) //
+                .onErrorResume(throwable -> {
+
+                    if (throwable instanceof ConnectException) {
+
+                        return hostProvider.getActive(Verification.ACTIVE) //
+                                .flatMap(callback::doWithClient);
+                    }
+
+                    return Mono.error(throwable);
+                });
+    }
+
+    @Override
+    public Mono<Status> status() {
+
+        return hostProvider.clusterInfo() //
+                .map(it -> new DotReactiveElasticsearchClient.ClientStatus(it.getNodes()));
+    }
+
+    // --> Private Response helpers
+
+    private static GetResult getResponseToGetResult(GetResponse response) {
+
+        return new GetResult(response.getIndex(), response.getType(), response.getId(), response.getSeqNo(),
+                response.getPrimaryTerm(), response.getVersion(), response.isExists(), response.getSourceAsBytesRef(),
+                response.getFields(), null);
+    }
+
+    // -->
+
+    private <Req extends ActionRequest, Resp> Flux<Resp> sendRequest(Req request, Function<Req, Request> converter,
+            Class<Resp> responseType, HttpHeaders headers) {
+        return sendRequest(converter.apply(request), responseType, headers);
+    }
+
+    private <Resp> Flux<Resp> sendRequest(Request request, Class<Resp> responseType, HttpHeaders headers) {
+
+        String logId = ClientLogger.newLogId();
+
+        return execute(webClient -> sendRequest(webClient, logId, request, headers))
+                .flatMapMany(response -> readResponseBody(logId, request, response, responseType));
+    }
+
+    private Mono<ClientResponse> sendRequest(WebClient webClient, String logId, Request request, HttpHeaders headers) {
+
+        RequestBodySpec requestBodySpec = webClient.method(HttpMethod.valueOf(request.getMethod().toUpperCase())) //
+                .uri(builder -> {
+
+                    builder = builder.path(request.getEndpoint());
+
+                    if (!ObjectUtils.isEmpty(request.getParameters())) {
+                        for (Entry<String, String> entry : request.getParameters().entrySet()) {
+                            builder = builder.queryParam(entry.getKey(), entry.getValue());
+                        }
+                    }
+                    return builder.build();
+                }) //
+                .attribute(ClientRequest.LOG_ID_ATTRIBUTE, logId) //
+                .headers(theHeaders -> {
+
+                    // add all the headers explicitly set
+                    theHeaders.addAll(headers);
+
+                    // and now those that might be set on the request.
+                    if (request.getOptions() != null) {
+
+                        if (!ObjectUtils.isEmpty(request.getOptions().getHeaders())) {
+                            request.getOptions().getHeaders().forEach(it -> theHeaders.add(it.getName(), it.getValue()));
+                        }
+                    }
+                });
+
+        if (request.getEntity() != null) {
+
+            Lazy<String> body = bodyExtractor(request);
+
+            ClientLogger.logRequest(logId, request.getMethod().toUpperCase(), request.getEndpoint(), request.getParameters(),
+                    body::get);
+
+            requestBodySpec.contentType(MediaType.valueOf(request.getEntity().getContentType().getValue()));
+            requestBodySpec.body(Mono.fromSupplier(body::get), String.class);
+        } else {
+            ClientLogger.logRequest(logId, request.getMethod().toUpperCase(), request.getEndpoint(), request.getParameters());
+        }
+
+        return requestBodySpec //
+                .exchange() //
+                .onErrorReturn(ConnectException.class, ClientResponse.create(HttpStatus.SERVICE_UNAVAILABLE).build());
+    }
+
+    private Lazy<String> bodyExtractor(Request request) {
+
+        return Lazy.of(() -> {
+
+            try {
+                return EntityUtils.toString(request.getEntity());
+            } catch (IOException e) {
+                throw new RequestBodyEncodingException("Error encoding request", e);
+            }
+        });
+    }
+
+    private <T> Publisher<? extends T> readResponseBody(String logId, Request request, ClientResponse response,
+            Class<T> responseType) {
+
+        if (RawActionResponse.class.equals(responseType)) {
+
+            ClientLogger.logRawResponse(logId, response.statusCode());
+            return Mono.just(responseType.cast(RawActionResponse.create(response)));
+        }
+
+        if (response.statusCode().is5xxServerError()) {
+
+            ClientLogger.logRawResponse(logId, response.statusCode());
+            return handleServerError(request, response);
+        }
+
+        return response.body(BodyExtractors.toMono(byte[].class)) //
+                .map(it -> new String(it, StandardCharsets.UTF_8)) //
+                .doOnNext(it -> ClientLogger.logResponse(logId, response.statusCode(), it)) //
+                .flatMap(content -> doDecode(response, responseType, content));
+    }
+
+    private static <T> Mono<T> doDecode(ClientResponse response, Class<T> responseType, String content) {
+
+        String mediaType = response.headers().contentType().map(MediaType::toString).orElse(
+                XContentType.JSON.mediaType());
+
+        try {
+
+            Method fromXContent = ReflectionUtils
+                    .findMethod(responseType, "fromXContent", XContentParser.class);
+
+            return Mono.justOrEmpty(responseType
+                    .cast(ReflectionUtils.invokeMethod(fromXContent, responseType, createParser(mediaType, content))));
+
+        } catch (Throwable errorParseFailure) { // cause elasticsearch also uses AssertionError
+
+            try {
+                return Mono.error(
+                        BytesRestResponse.errorFromXContent(createParser(mediaType, content)));
+            } catch (Exception e) {
+
+                return Mono
+                        .error(new ElasticsearchStatusException(content, RestStatus
+                                .fromCode(response.statusCode().value())));
+            }
+        }
+    }
+
+    private static XContentParser createParser(String mediaType, String content) throws IOException {
+
+        return XContentType.fromMediaTypeOrFormat(mediaType) //
+                .xContent() //
+                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, content);
+    }
+
+    private static <T> Publisher<? extends T> handleServerError(Request request, ClientResponse response) {
+
+        return Mono.error(
+                new HttpServerErrorException(response.statusCode(), String.format("%s request to %s returned error code %s.",
+                        request.getMethod(), request.getEndpoint(), response.statusCode().value())));
+    }
+
+    static class RequestCreator {
+
+        static Function<SearchRequest, Request> search() {
+            return RequestConverters::search;
+        }
+
+        static Function<SearchScrollRequest, Request> scroll() {
+            return RequestConverters::searchScroll;
+        }
+
+        static Function<ClearScrollRequest, Request> clearScroll() {
+            return RequestConverters::clearScroll;
+        }
+
+        static Function<IndexRequest, Request> index() {
+            return RequestConverters::index;
+        }
+
+        static Function<GetRequest, Request> get() {
+            return RequestConverters::get;
+        }
+
+        static Function<MainRequest, Request> ping() {
+            return (request) -> RequestConverters.ping();
+        }
+
+        static Function<MainRequest, Request> info() {
+            return (request) -> RequestConverters.info();
+        }
+
+        static Function<MultiGetRequest, Request> multiGet() {
+            return RequestConverters::multiGet;
+        }
+
+        static Function<GetRequest, Request> exists() {
+            return RequestConverters::exists;
+        }
+
+        static Function<UpdateRequest, Request> update() {
+            return RequestConverters::update;
+        }
+
+        static Function<DeleteRequest, Request> delete() {
+            return RequestConverters::delete;
+        }
+
+        static Function<DeleteByQueryRequest, Request> deleteByQuery() {
+
+            return request -> {
+
+                try {
+                    return RequestConverters.deleteByQuery(request);
+                } catch (IOException e) {
+                    throw new ElasticsearchException("Could not parse request", e);
+                }
+            };
+        }
+
+        static Function<BulkRequest, Request> bulk() {
+
+            return request -> {
+
+                try {
+                    return RequestConverters.bulk(request);
+                } catch (IOException e) {
+                    throw new ElasticsearchException("Could not parse request", e);
+                }
+            };
+        }
+
+        // --> INDICES
+
+        static Function<GetIndexRequest, Request> indexExists() {
+            return RequestConverters::indexExists;
+        }
+
+        static Function<DeleteIndexRequest, Request> indexDelete() {
+            return RequestConverters::indexDelete;
+        }
+
+        static Function<CreateIndexRequest, Request> indexCreate() {
+            return RequestConverters::indexCreate;
+        }
+
+        static Function<OpenIndexRequest, Request> indexOpen() {
+            return RequestConverters::indexOpen;
+        }
+
+        static Function<CloseIndexRequest, Request> indexClose() {
+            return RequestConverters::indexClose;
+        }
+
+        static Function<RefreshRequest, Request> indexRefresh() {
+            return RequestConverters::indexRefresh;
+        }
+
+        static Function<PutMappingRequest, Request> putMapping() {
+            return RequestConverters::putMapping;
+        }
+
+        static Function<FlushRequest, Request> flushIndex() {
+            return RequestConverters::flushIndex;
+        }
+
+        static Function<CountRequest, Request> count() {
+            return RequestConverters::count;
+        }
+
+    }
+
+    /**
+     * Reactive client {@link ReactiveElasticsearchClient.Status} implementation.
+     *
+     * @author Christoph Strobl
+     */
+    class ClientStatus implements Status {
+
+        private final Collection<ElasticsearchHost> connectedHosts;
+
+        ClientStatus(Collection<ElasticsearchHost> connectedHosts) {
+            this.connectedHosts = connectedHosts;
+        }
+
+        /*
+         * (non-Javadoc)
+         * @see org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient.Status#hosts()
+         */
+        @Override
+        public Collection<ElasticsearchHost> hosts() {
+            return connectedHosts;
+        }
+    }
+
+    /**
+     * Mutable state object holding scrollId to be used for {@link SearchScrollRequest#scroll(Scroll)}
+     *
+     * @author Christoph Strobl
+     * @since 3.2
+     */
+    private static class ScrollState {
+
+        private final Object lock = new Object();
+
+        private final List<String> pastIds = new ArrayList<>(1);
+        private String scrollId;
+
+        String getScrollId() {
+            return scrollId;
+        }
+
+        List<String> getScrollIds() {
+
+            synchronized (lock) {
+                return Collections.unmodifiableList(new ArrayList<>(pastIds));
+            }
+        }
+
+        void updateScrollId(String scrollId) {
+
+            if (StringUtils.hasText(scrollId)) {
+
+                synchronized (lock) {
+
+                    this.scrollId = scrollId;
+                    pastIds.add(scrollId);
+                }
+            }
+        }
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/RawActionResponse.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/RawActionResponse.java
@@ -1,0 +1,42 @@
+package com.dotcms.content.elasticsearch.util;
+
+
+import org.elasticsearch.action.ActionResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+import org.springframework.web.reactive.function.BodyExtractor;
+import org.springframework.web.reactive.function.client.ClientResponse;
+
+class RawActionResponse extends ActionResponse {
+
+    private final ClientResponse delegate;
+
+    private RawActionResponse(ClientResponse delegate) {
+        this.delegate = delegate;
+    }
+
+    static RawActionResponse create(ClientResponse response) {
+        return new RawActionResponse(response);
+    }
+
+    public HttpStatus statusCode() {
+        return delegate.statusCode();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.web.reactive.function.client.ClientResponse#headers()
+     */
+    public ClientResponse.Headers headers() {
+        return delegate.headers();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.web.reactive.function.client.ClientResponse#body(org.springframework.web.reactive.function.BodyExtractor)
+     */
+    public <T> T body(BodyExtractor<T, ? super ClientHttpResponse> extractor) {
+        return delegate.body(extractor);
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/RestHighLevelClientProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/RestHighLevelClientProvider.java
@@ -3,6 +3,7 @@ package com.dotcms.content.elasticsearch.util;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient;
 
 /**
  * Provider used to load custom High Level Rest clients to handle API requests in Elastic
@@ -35,6 +36,8 @@ public abstract class RestHighLevelClientProvider {
     }
 
     public abstract RestHighLevelClient getClient();
+
+    public abstract DotReactiveElasticsearchClient getReactiveClient();
 
     public abstract void setClient(final RestHighLevelClient client);
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/monitor/MonitorHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/monitor/MonitorHelper.java
@@ -147,7 +147,7 @@ class MonitorHelper {
                         searchRequest.indices(index);
 
                         final SearchResponse response = Sneaky.sneak(()->
-                                RestHighLevelClientProvider.getInstance().getClient().search(searchRequest,
+                                RestHighLevelClientProvider.getInstance().getReactiveClient().search(searchRequest,
                                         RequestOptions.DEFAULT));
                         return response.getHits().getTotalHits().value>0;
                     }finally{


### PR DESCRIPTION
**DO NOT MERGE!!!**
DotReactiveElasticsearchClient.java has been implemented as an alternative to handle ES search requests. It is based on the DefaultReactiveElasticsearchClient implementation of Spring Elasticsearch Data which uses Reactive Stream concepts and internally initializes a netty webclient