### PR TITLE
#16433 vanity url trailing forward slash support

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/vanityurl/model/CachedVanityUrl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/model/CachedVanityUrl.java
@@ -30,10 +30,9 @@ public class CachedVanityUrl implements Serializable {
      *
      * @param vanityUrl The vanityurl Url to cache
      */
-    public CachedVanityUrl(VanityUrl vanityUrl) {
+    public CachedVanityUrl(final VanityUrl vanityUrl) {
         //if the VanityUrl URI is not a valid regex
-        String regex = VanityUrlUtil.isValidRegex(vanityUrl.getURI()) ? vanityUrl.getURI()
-                : StringPool.BLANK;
+        final String regex = normalize(vanityUrl.getURI());
         this.pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
         this.vanityUrlId = vanityUrl.getIdentifier();
         this.url = vanityUrl.getURI();
@@ -53,7 +52,7 @@ public class CachedVanityUrl implements Serializable {
     public CachedVanityUrl(CachedVanityUrl fromCachedVanityUrl, String url) {
 
         //if the VanityUrl URI is not a valid regex
-        String regex = VanityUrlUtil.isValidRegex(url) ? url : StringPool.BLANK;
+        final String regex = normalize(url);
 
         this.pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
         this.vanityUrlId = fromCachedVanityUrl.getVanityUrlId();
@@ -151,6 +150,32 @@ public class CachedVanityUrl implements Serializable {
      */
     public String getVanityUrlId() {
         return vanityUrlId;
+    }
+
+    /**
+     * This comes as fix for https://github.com/dotCMS/core/issues/16433
+     * If the uri ends with forward slash `/`
+     * This method will make that piece optional.
+     * @param uri the uri stored in the contentlet.
+     * @return the uri regexp with the optional forward slash support added.
+     */
+    private String addOptionalForwardSlashSupport(final String uri){
+        if(uri.endsWith(StringPool.FORWARD_SLASH)){
+            String regex = uri;
+            regex = regex.substring(0, regex.length() -1 );
+            return regex + "(/)*";
+        }
+        return uri;
+    }
+
+    /**
+     * This takes the uir that was originally stored in the contentlet adds validates it.
+     * @param uri the uri stored in the contentlet.
+     * @return normalized uri.
+     */
+    private String normalize(final String uri){
+        final String uriRegEx = addOptionalForwardSlashSupport(uri);
+        return VanityUrlUtil.isValidRegex(uriRegEx) ? uriRegEx : StringPool.BLANK;
     }
 
 


### PR DESCRIPTION
This PR comes to solve 
https://github.com/dotCMS/core/issues/16433
The solution was adding a conditional statement to the regexp that basically adds support to match an optional forward slash at the end of the URI.
It is added behind the scenes to the VanityURL that lives in the cache 
for which the uri matching regexp will remain the same. 