### PR TITLE
#18018 sometimes the binary is not able, in some part of the transfor…

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -5647,7 +5647,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                         final String transientNameKey = DotAssetContentType.ASSET_FIELD_VAR + "name";
                         final String dotAssetName     = contentlet.getStringProperty(transientNameKey);
                         String assetName              = dotAssetName;
-                        if (!UtilMethods.isSet(dotAssetName)) {
+                        if (!UtilMethods.isSet(dotAssetName) && null != contentlet.getBinary(DotAssetContentType.ASSET_FIELD_VAR)) {
                             assetName = contentlet.getBinary(DotAssetContentType.ASSET_FIELD_VAR).getName();
                             contentlet.setStringProperty(transientNameKey, assetName);
                         }


### PR DESCRIPTION
Sometimes the binary to figure out the title is not blind into the contentlet, there are moments into the contentlet lifecycle that the binaries are not tied to it.
So doing NPE checking to avoid the issue.

Consequently when a dotAsset is being added, the name is show as an identifier, just wait a few seconds and refresh, the name will be properly displayed