### PR TITLE
#18025  deleting a bundle should not delete any pushedAssets

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publisher/assets/business/PushedAssetsCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/assets/business/PushedAssetsCacheImpl.java
@@ -49,7 +49,7 @@ public class PushedAssetsCacheImpl implements PushedAssetsCache, Cachable {
 		return cacheGroups;
 	}
 
-	public synchronized void clearCache() {
+	public void clearCache() {
 		cache.flushGroup(cacheGroup);
 	}
 

--- a/dotCMS/src/main/java/com/dotcms/publisher/bundle/business/BundleAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/bundle/business/BundleAPIImpl.java
@@ -132,8 +132,9 @@ public class BundleAPIImpl implements BundleAPI {
 			throw new DotDataException(e);
 		}
 
-		Logger.info(this, "Removing all pushed assets for a bundle: " + bundleId);
-		this.pushedAssetsAPI.deletePushedAssetsByBundleId(bundleId);
+        //According to https://github.com/dotcms/core/issues/18025
+        //any deleteBundle operation should NOT touch or delete pushedAssets.
+        //pushedAsset should only get removed when calling deletePushedAssetsByEnvironment endpoint.
 
 		Logger.info(this, "Removing all assets from bundle: " + bundleId);
 		this.bundleFactory.deleteAllAssetsFromBundle(bundleId);


### PR DESCRIPTION
According to this ticket https://github.com/dotcms/core/issues/18025
When deleting any bundle. No Pushed assets must be removed. So that's exactly what this change is intending to do.

The ticket also requested that the clearCache operation isn't synchronized   