### PR TITLE
#17848 Fixing error handling when an index is not found

### DIFF
--- a/dotCMS/src/curl-test/ESIndexResourceTests.json
+++ b/dotCMS/src/curl-test/ESIndexResourceTests.json
@@ -273,7 +273,7 @@
               "script": {
                 "id": "75accc22-7c7e-4f9b-86f0-84750a30fd8e",
                 "exec": [
-                  "pm.test(\"Status code is 500\", function () { pm.response.to.have.status(500) });",
+                  "pm.test(\"Status code is 404\", function () { pm.response.to.have.status(404) });",
                   ""
                 ],
                 "type": "text/javascript"

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
@@ -484,15 +484,18 @@ public class ESIndexResource {
     @Path("/docscount/{params:.*}")
     @Produces("text/plain")
     public Response getDocumentCount(@Context HttpServletRequest httpServletRequest, @Context final HttpServletResponse httpServletResponse, @PathParam("params") String params) {
+
+        InitDataObject init= null;
         try {
-            InitDataObject init=auth(params,httpServletRequest, httpServletResponse);
+            init = auth(params,httpServletRequest, httpServletResponse);
 
             //Creating an utility response object
             ResourceResponse responseResource = new ResourceResponse( init.getParamsMap() );
 
             String indexName = this.indexHelper.getIndexNameOrAlias(init.getParamsMap(),"index","alias",this.indexAPI);
             return responseResource.response( Long.toString( indexDocumentCount( indexName ) ) );
-        } catch (Exception e) {
+
+        } catch (DotSecurityException | DotDataException e) {
             Logger.error(this.getClass(),"Exception trying to get document count: " + e.getMessage(), e);
             return ResponseUtil.mapExceptionResponse(e);
         }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
@@ -485,7 +485,7 @@ public class ESIndexResource {
     @Produces("text/plain")
     public Response getDocumentCount(@Context HttpServletRequest httpServletRequest,
             @Context final HttpServletResponse httpServletResponse,
-            @PathParam("params") String params)
+            final @PathParam("params") String params)
             throws DotSecurityException {
 
         InitDataObject init= null;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
@@ -483,7 +483,10 @@ public class ESIndexResource {
     @GET
     @Path("/docscount/{params:.*}")
     @Produces("text/plain")
-    public Response getDocumentCount(@Context HttpServletRequest httpServletRequest, @Context final HttpServletResponse httpServletResponse, @PathParam("params") String params) {
+    public Response getDocumentCount(@Context HttpServletRequest httpServletRequest,
+            @Context final HttpServletResponse httpServletResponse,
+            @PathParam("params") String params)
+            throws DotSecurityException {
 
         InitDataObject init= null;
         try {
@@ -495,7 +498,7 @@ public class ESIndexResource {
             String indexName = this.indexHelper.getIndexNameOrAlias(init.getParamsMap(),"index","alias",this.indexAPI);
             return responseResource.response( Long.toString( indexDocumentCount( indexName ) ) );
 
-        } catch (DotSecurityException | DotDataException e) {
+        } catch (DotDataException e) {
             Logger.error(this.getClass(),"Exception trying to get document count: " + e.getMessage(), e);
             return ResponseUtil.mapExceptionResponse(e);
         }

--- a/dotCMS/src/main/java/com/dotcms/rest/exception/mapper/ElasticsearchStatusExceptionMapper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/exception/mapper/ElasticsearchStatusExceptionMapper.java
@@ -10,20 +10,20 @@ public class ElasticsearchStatusExceptionMapper implements ExceptionMapper<Elast
 
 
     @Override
-    public Response toResponse(ElasticsearchStatusException exception) {
+    public Response toResponse(final ElasticsearchStatusException exception) {
 
         //Log into our logs first.
         Logger.warn(this.getClass(), exception.getMessage(), exception);
 
         //Create the message.
-        String message = exception.getMessage();
+        final String message = exception.getMessage();
 
         //Creating the message in JSON format.
-        String entity = ExceptionMapperUtil.getJsonErrorAsString(message);
+        final String entity = ExceptionMapperUtil.getJsonErrorAsString(message);
 
         //Return 4xx message to the client.
         return ExceptionMapperUtil.createResponse(entity, message,
                 message.contains("index_not_found_exception") ? Status.NOT_FOUND
-                        : Status.BAD_REQUEST);
+                        : Status.INTERNAL_SERVER_ERROR);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/exception/mapper/ElasticsearchStatusExceptionMapper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/exception/mapper/ElasticsearchStatusExceptionMapper.java
@@ -1,0 +1,29 @@
+package com.dotcms.rest.exception.mapper;
+
+import com.dotmarketing.util.Logger;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.elasticsearch.ElasticsearchStatusException;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class ElasticsearchStatusExceptionMapper implements ExceptionMapper<ElasticsearchStatusException> {
+
+
+    @Override
+    public Response toResponse(ElasticsearchStatusException exception) {
+
+        //Log into our logs first.
+        Logger.warn(this.getClass(), exception.getMessage(), exception);
+
+        //Create the message.
+        String message = exception.getMessage();
+
+        //Creating the message in JSON format.
+        String entity = ExceptionMapperUtil.getJsonErrorAsString(message);
+
+        //Return 4xx message to the client.
+        return ExceptionMapperUtil.createResponse(entity, message,
+                message.contains("index_not_found_exception") ? Status.NOT_FOUND
+                        : Status.BAD_REQUEST);
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/servlet/ReloadableServletContainer.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/servlet/ReloadableServletContainer.java
@@ -184,7 +184,8 @@ public class ReloadableServletContainer extends HttpServlet implements Filter {
                 .register((new DotBadRequestExceptionMapper<JsonProcessingException>(){}).getClass())
                 .register((new DotBadRequestExceptionMapper<NumberFormatException>(){}).getClass())
                 .register(DotSecurityExceptionMapper.class)
-                .register(DotDataExceptionMapper.class);
+                .register(DotDataExceptionMapper.class)
+                .register(ElasticsearchStatusExceptionMapper.class);
                 //.register(ExceptionMapper.class); // temporaly unregister since some services are expecting just a plain message as an error instead of a json, so to keep the compatibility we won't apply this change yet.
     }
 }


### PR DESCRIPTION
A 404 error status is thrown instead of 500 if the index is not found when ESIndexResource. getDocumentCount is called