### PR TITLE
#17918 Indicies stats type was changed from int to long to support bigger values

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESIndexAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESIndexAPITest.java
@@ -1,33 +1,44 @@
 package com.dotcms.content.elasticsearch.business;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
 import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.business.APILocator;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.indices.CreateIndexResponse;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ESIndexAPITest {
 
+    private static ESIndexAPI esIndexAPI;
+
     @BeforeClass
     public static void prepare() throws Exception {
         //Setting web app environment
         IntegrationTestInitService.getInstance().init();
+        esIndexAPI = APILocator.getESIndexAPI();
     }
 
     @Test
     public void test_createIndex_newIndexShouldHaveProperReplicasSetting() throws IOException {
         final String newIndexName = "mynewindex"+ UUID.randomUUID().toString().toLowerCase();
         try {
-            APILocator.getESIndexAPI().createIndex(newIndexName);
-            final String fullNewIndexName = APILocator.getESIndexAPI()
-                    .getNameWithClusterIDPrefix(newIndexName);
+            esIndexAPI.createIndex(newIndexName);
+            final String fullNewIndexName = esIndexAPI.getNameWithClusterIDPrefix(newIndexName);
             GetSettingsRequest request = new GetSettingsRequest().indices(fullNewIndexName);
             GetSettingsResponse getSettingsResponse = RestHighLevelClientProvider.getInstance()
                     .getClient().indices().getSettings(request, RequestOptions.DEFAULT);
@@ -37,9 +48,77 @@ public class ESIndexAPITest {
 
             Assert.assertEquals("0-all", replicasSetting);
         } finally {
-            APILocator.getESIndexAPI().delete(APILocator.getESIndexAPI()
-                    .getNameWithClusterIDPrefix(newIndexName));
+            esIndexAPI.delete(esIndexAPI.getNameWithClusterIDPrefix(newIndexName));
         }
     }
 
+    @Test
+    public void testGetIndicesStatsWhenStatsTypeIsLongShouldPass(){
+
+        final Map<String, Object> jsonMap = new HashMap<>();
+
+        final Map<String, Object> indices = new HashMap<>();
+        final Map<String, Object> indexDetails = new HashMap<>();
+        final Map<String, Object> statsMap = new HashMap<>();
+        final Map<String, Object> countMap = new HashMap<>();
+        final Map<String, Object> sizeMap = new HashMap<>();
+
+        countMap.put("count", Long.valueOf(5));
+        sizeMap.put("size_in_bytes", Long.valueOf(2000));
+
+        statsMap.put("docs", countMap);
+        statsMap.put("store", sizeMap);
+
+        indexDetails.put("primaries", statsMap);
+        indices.put("myDummyIndex", indexDetails);
+        jsonMap.put("indices", indices);
+
+        final ESIndexAPI indexAPI = spy(ESIndexAPI.class);
+        doReturn(jsonMap).when(indexAPI).performLowLevelRequest(any());
+        when(indexAPI.hasClusterPrefix(anyString())).thenReturn(true);
+
+        final  Map<String, IndexStats> result = indexAPI.getIndicesStats();
+
+        assertEquals(1, result.size());
+
+        final IndexStats stats = result.get("myDummyIndex");
+        assertNotNull(stats);
+        assertEquals(5, stats.getDocumentCount());
+        assertEquals(2000, stats.getSizeRaw());
+    }
+
+    @Test
+    public void testGetIndicesStatsWhenStatsTypeIsIntegerShouldPass(){
+
+        final Map<String, Object> jsonMap = new HashMap<>();
+
+        final Map<String, Object> indices = new HashMap<>();
+        final Map<String, Object> indexDetails = new HashMap<>();
+        final Map<String, Object> statsMap = new HashMap<>();
+        final Map<String, Object> countMap = new HashMap<>();
+        final Map<String, Object> sizeMap = new HashMap<>();
+
+        countMap.put("count", 5);
+        sizeMap.put("size_in_bytes", 2000);
+
+        statsMap.put("docs", countMap);
+        statsMap.put("store", sizeMap);
+
+        indexDetails.put("primaries", statsMap);
+        indices.put("myDummyIndex", indexDetails);
+        jsonMap.put("indices", indices);
+
+        final ESIndexAPI indexAPI = spy(ESIndexAPI.class);
+        doReturn(jsonMap).when(indexAPI).performLowLevelRequest(any());
+        when(indexAPI.hasClusterPrefix(anyString())).thenReturn(true);
+
+        final  Map<String, IndexStats> result = indexAPI.getIndicesStats();
+
+        assertEquals(1, result.size());
+
+        final IndexStats stats = result.get("myDummyIndex");
+        assertNotNull(stats);
+        assertEquals(5, stats.getDocumentCount());
+        assertEquals(2000, stats.getSizeRaw());
+    }
 }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESIndexAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESIndexAPI.java
@@ -165,7 +165,7 @@ public class ESIndexAPI {
 		final Request request = new Request("GET", "/_stats");
 		final Map<String, Object> jsonMap = performLowLevelRequest(request);
 
-		Map<String, IndexStats> indexStatsMap = new HashMap<>();
+		final Map<String, IndexStats> indexStatsMap = new HashMap<>();
 
 		final Map<String, Object> indices = (Map<String, Object>)jsonMap.get("indices");
 
@@ -175,11 +175,12 @@ public class ESIndexAPI {
                 final Map<String, Object> indexStats = (Map<String, Object>) ((Map<String, Object>)
                         indices.get(key)).get("primaries");
 
-                int numOfDocs = (int) ((Map<String, Object>) indexStats.get("docs"))
-                        .get("count");
+                final Object countObject = ((Map<String, Object>) indexStats.get("docs")).get("count");
+                final long numOfDocs = Long.valueOf(countObject!=null? countObject.toString():"0");
 
-                int sizeInBytes = (int) ((Map<String, Object>) indexStats.get("store"))
+                final Object sizeObject = ((Map<String, Object>) indexStats.get("store"))
                         .get("size_in_bytes");
+                final long sizeInBytes = Long.valueOf(sizeObject!=null? sizeObject.toString():"0");
 
                 final String indexNameWithoutPrefix = removeClusterIdFromName(key);
                 indexStatsMap.put(indexNameWithoutPrefix,
@@ -880,7 +881,7 @@ public class ESIndexAPI {
 		return indexes;
 	}
 
-    private boolean hasClusterPrefix(final String indexName) {
+	boolean hasClusterPrefix(final String indexName) {
         final String clusterId = getClusterIdFromIndexName(indexName).orElse(null);
         return clusterId != null && clusterId.equals(ClusterFactory.getClusterId());
     }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/IndexStats.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/IndexStats.java
@@ -5,18 +5,18 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 public class IndexStats {
 
     private String indexName;
-    private int documentCount;
-    private int size;
+    private long documentCount;
+    private long size;
     private String prettySize;
 
-    public IndexStats(String indexName, int documentCount, int size) {
+    public IndexStats(final String indexName, final long documentCount, final long size) {
         this.indexName = indexName;
         this.documentCount = documentCount;
         this.size = size;
         this.prettySize = new ByteSizeValue(size).toString();
     }
 
-    public int getDocumentCount() {
+    public long getDocumentCount() {
         return documentCount;
     }
 


### PR DESCRIPTION
Type values were modified to support bigger values. It was failing for large datasets. A couple of tests were implemented to verify both types (int and long) are supported