### PR TITLE
#18086 show pre-execute code regardless the mode

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/HTMLPageAssetRenderedTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/HTMLPageAssetRenderedTest.java
@@ -5,10 +5,12 @@ import static org.mockito.Mockito.mock;
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.model.field.Field;
+import com.dotcms.contenttype.model.field.FieldBuilder;
 import com.dotcms.contenttype.model.field.ImmutableConstantField;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ContentTypeBuilder;
+import com.dotcms.contenttype.model.type.WidgetContentType;
 import com.dotcms.datagen.*;
 import com.dotcms.mock.request.MockAttributeRequest;
 import com.dotcms.mock.request.MockHttpRequest;
@@ -1296,6 +1298,72 @@ public class HTMLPageAssetRenderedTest {
                 mockRequest, mockResponse);
 
         Assert.assertTrue(html.contains("content2content1"));
+    }
+
+    //Data Provider for the Widget Pre-execute code test
+    @DataProvider
+    public static Object[] dataProviderWidgetPreExecuteCode() {
+        return new Object[] {
+                new WidgetPreExecuteCodeTestCase(PageMode.EDIT_MODE),
+                new WidgetPreExecuteCodeTestCase(PageMode.PREVIEW_MODE),
+                new WidgetPreExecuteCodeTestCase(PageMode.LIVE),
+        };
+    }
+
+    private static class WidgetPreExecuteCodeTestCase {
+        final PageMode pageMode;
+
+        public WidgetPreExecuteCodeTestCase(final PageMode pageMode) {
+            this.pageMode = pageMode;
+        }
+    }
+
+    @Test
+    @UseDataProvider("dataProviderWidgetPreExecuteCode")
+    public void test_WidgetPreExecuteCodeShowRegardlessPageMode(final WidgetPreExecuteCodeTestCase testCase) throws Exception {
+
+        //Update the Preexecute Field to have some code in it
+        final String preExcuteCode = "PreExecute Code Displayed";
+        ContentType contentType = TestDataUtils.getWidgetLikeContentType();
+        final Field preExecuteField = APILocator.getContentTypeFieldAPI().byContentTypeIdAndVar(contentType.id(),WidgetContentType.WIDGET_PRE_EXECUTE_FIELD_VAR);
+        APILocator.getContentTypeFieldAPI()
+                .save(FieldBuilder.builder(preExecuteField).values(preExcuteCode).build(), systemUser);
+        // Assert that the widget has set the pre-execute field
+        Assert.assertTrue(APILocator.getContentTypeFieldAPI()
+                .byContentTypeIdAndVar(contentType.id(),WidgetContentType.WIDGET_PRE_EXECUTE_FIELD_VAR)
+                .values().equals(preExcuteCode));
+
+        //Create Contentlet
+        final Contentlet widgetContentlet = TestDataUtils.getWidgetContent(true,1,contentType.id());
+        addAnonymousPermissions(widgetContentlet);
+
+        //Create Container, Template and Page
+        final Container container = createContainer();
+        final Template template = createTemplate(container);
+
+        final String pageName = "testPage-"+System.currentTimeMillis();
+        final HTMLPageAsset page = createHtmlPageAsset(template, pageName, 1);
+
+        //Add contentlet to the page
+        MultiTree multiTree = new MultiTree(page.getIdentifier(), container.getIdentifier(),widgetContentlet.getIdentifier() ,UUID,0);
+        APILocator.getMultiTreeAPI().saveMultiTree(multiTree);
+
+        //Request page
+        final HttpServletRequest mockRequest = createHttpServletRequest(page);
+        final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+        final HttpSession session = createHttpSession(mockRequest);
+        Mockito.when(session.getAttribute(WebKeys.VISITOR)).thenReturn(null);
+        Mockito.when(session.getAttribute(WebKeys.CMS_USER)).thenReturn(systemUser);
+        final String html = APILocator.getHTMLPageAssetRenderedAPI().getPageHtml(
+                PageContextBuilder.builder()
+                        .setUser(systemUser)
+                        .setPageUri(page.getURI())
+                        .setPageMode(testCase.pageMode)
+                        .build(),
+                mockRequest, mockResponse);
+
+        //Page html must contains the pre-execute code
+        Assert.assertTrue("Page Mode: " + testCase.pageMode + " html: " + html,html.contains(preExcuteCode));
     }
 
     @NotNull

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageLoader.java
@@ -106,20 +106,7 @@ public class PageLoader implements DotLoader {
             }
         }
 
-        // Add the pre-execute code of a widget to the page, regardless the mode
-        final PageRenderUtil pce = new PageRenderUtil((HTMLPageAsset) htmlPage, sys, mode);
-        sb.append(pce.getWidgetPreExecute());
-
-        /**
-         * Serializes the page variables and pointers to 
-         * the content (multitree entries)
-         * in the page velocity template
-         */
-        if (mode == PageMode.LIVE) {
-          sb.append(pce.asString());
-        }
-      
-
+        addWidgetPreExecuteCodeAndPageInfo((HTMLPageAsset) htmlPage, mode, sb, sys);
 
         sb.append("#set($dotPageContent = $dotcontent.find(\"" + htmlPage.getInode() + "\" ))");
 
@@ -197,6 +184,15 @@ public class PageLoader implements DotLoader {
         return writeOutVelocity(filePath, sb.toString());
 
 
+    }
+
+    private void addWidgetPreExecuteCodeAndPageInfo(final HTMLPageAsset htmlPage, final PageMode mode,
+            final StringBuilder stringBuilder, final User user) throws DotSecurityException, DotDataException {
+        final PageRenderUtil pce = new PageRenderUtil(htmlPage, user, mode);
+        // Add the pre-execute code of a widget to the page
+        stringBuilder.append(pce.getWidgetPreExecute());
+        // Adds the page info
+        stringBuilder.append(pce.asString());
     }
 
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageLoader.java
@@ -106,14 +106,16 @@ public class PageLoader implements DotLoader {
             }
         }
 
+        // Add the pre-execute code of a widget to the page, regardless the mode
+        final PageRenderUtil pce = new PageRenderUtil((HTMLPageAsset) htmlPage, sys, mode);
+        sb.append(pce.getWidgetPreExecute());
+
         /**
          * Serializes the page variables and pointers to 
-         * the content (multitree ebtries)
+         * the content (multitree entries)
          * in the page velocity template
          */
         if (mode == PageMode.LIVE) {
-          final PageRenderUtil pce = new PageRenderUtil((HTMLPageAsset) htmlPage, sys, mode);
-          sb.append(pce.getWidgetPreExecute());
           sb.append(pce.asString());
         }
       


### PR DESCRIPTION
The pre-execute code of a widget should always execute regardless of the PageMode.