### PR TITLE
Issue 17976 fixes

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publishing/job/SiteSearchJobImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/job/SiteSearchJobImpl.java
@@ -31,6 +31,8 @@ import com.dotmarketing.util.StringUtils;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import java.io.IOException;
@@ -132,178 +134,205 @@ public class SiteSearchJobImpl {
 
         HibernateUtil.startTransaction();
 
-        final JobDataMap dataMap = jobContext.getJobDetail().getJobDataMap();
-
-        String jobId = (String) dataMap.get(JOB_ID);
-        if (jobId == null) {
-            jobId = dataMap.getString(QUARTZ_JOB_NAME);
-        }
-
-        final boolean indexAll = UtilMethods.isSet((String) dataMap.get(INDEX_ALL));
-        final String[] indexHosts;
-        final Object obj = (dataMap.get(INDEX_HOST) != null) ? dataMap.get(INDEX_HOST) : new String[0];
-        if (obj instanceof String) {
-            indexHosts = new String[]{(String) obj};
-        } else {
-            indexHosts = (String[]) obj;
-        }
-
-        final boolean incrementalParam = dataMap.getBooleanFromString(INCREMENTAL);
-
-        final User userToRun = userAPI.getSystemUser();
-
-        final boolean include = ("all".equals(dataMap.getString(INCLUDE_EXCLUDE)) || INCLUDE
-                .equals(dataMap.getString(INCLUDE_EXCLUDE)));
-
-        String path = dataMap.getString(PATHS);
-        final List<String> paths = new ArrayList<>();
-        if (path != null) {
-            path = path.replace(',', '\r');
-            path = path.replace('\n', '\r');
-            for (String x : path.split("\r")) {
-                if (UtilMethods.isSet(x)) {
-                    paths.add(x);
-                }
-            }
-        }
-        final boolean isRunNowJob = dataMap.getBooleanFromString(RUN_NOW);
-        // Run now jobs can not get the incremental treatment.
-        final IndexMetaData indexMetaData = getIndexMetaData(dataMap.getString(INDEX_ALIAS));
-        final String newIndexName;
-        final String indexName;
-
-        final String jobName = dataMap.getString(QUARTZ_JOB_NAME);
-        final Date startDate, endDate;
-        final List<SiteSearchAudit> recentAudits = isRunNowJob ? Collections.emptyList()
-                : siteSearchAuditAPI.findRecentAudits(jobId, 0, 1);
-
-        final boolean incremental = (incrementalParam && !isRunNowJob && !indexMetaData.isNewIndex() && !indexMetaData.isEmpty() && !recentAudits.isEmpty());
-        //We can only run incrementally if all the above pre-requisites are met.
-        if (incremental) {
-            //Incremental mode is useful only if there's already an index previously built.
-            //Incremental mode also implies that we have to have a date range to work on.
-            //So if we have an empty index or we lack of audit data we can not run incrementally.
-            //Even if the user wants to.
-            newIndexName = null;
-            endDate = jobContext.getFireTime();
-            startDate = recentAudits.get(0).getFireDate();
-            //For incremental jobs, we write the bundle to the same folder every time.
-            bundleId = StringUtils.camelCaseLower(jobName);
-            //We'll be working directly into the final index.
-            indexName = indexMetaData.getIndexName();
-        } else {
-            //Set null explicitly just in case
-            startDate = endDate = null;
-            // For non-incremental jobs. We create a new folder using a date stamp.
-            // But even if this run was executed non-incrementally for not having met any of the pre-requisits
-            // The job originally was meant to run incrementally therefore the results must be stored in the job specific folder.
-            // So they will still be available in the next round.
-            bundleId = incrementalParam ? StringUtils.camelCaseLower(jobName) :
-            // Otherwise it is safe to create a unique  folder name.
-                       uniqueFolderName();
-            // We use a new index name only on non-incremental
-            newIndexName = newIndexName();
-            final String newAlias = indexMetaData.isNewIndex() ? indexMetaData.getAlias() : null ;
-            siteSearchAPI.createSiteSearchIndex(newIndexName, newAlias, 1);
-            // This is the old index we will swap from.
-            // if it doesnt exist. It doesnt matter here since we will end up with the new one.
-            indexName = indexMetaData.getIndexName();
-        }
-
-        Logger.info(SiteSearchJobImpl.class, () -> String
-                .format(" Incremental mode [%s]. current index is `%s`. new index is `%s`. bundle id is `%s` ",
-                        BooleanUtils.toStringYesNo(incremental), indexName ,
-                        UtilMethods.isSet(newIndexName) ? newIndexName : "N/A",
-                        bundleId));
-
-        final List<Host> hosts;
-        if (indexAll) {
-            hosts = hostAPI.findAll(userToRun, true);
-        } else {
-            hosts = Stream.of(indexHosts).map(h -> {
-                try {
-                   return hostAPI.find(h, userToRun, true);
-                } catch (DotDataException | DotSecurityException e) {
-                    Logger.error(SiteSearchJobImpl.class, e);
-                }
-                return null;
-            }).filter(Objects::nonNull).collect(Collectors.toList());
-        }
-
-        final List<String> languageToIndex = Arrays.asList((String[])dataMap.get(LANG_TO_INDEX));
-        final ListIterator<String> listIterator = languageToIndex.listIterator();
-        while (listIterator.hasNext()) {
-            final String lang = listIterator.next();
-            final SiteSearchConfig config = new SiteSearchConfig();
-            config.setJobId(jobId);
-            config.setLanguage(Long.parseLong(lang));
-            config.setJobName(jobName);
-            config.setHosts(hosts);
-            config.setNewIndexName(newIndexName);
-            config.setIndexName(indexName);
-            config.setId(bundleId);
-            config.setStartDate(startDate);
-            config.setEndDate(endDate);
-            config.setIncremental(incremental);
-            config.setUser(userToRun);
-
-            if(include) {
-                config.setIncludePatterns(paths);
-            } else {
-                config.setExcludePatterns(paths);
-            }
-
-            //We should always replace the index when performing on non-incremental mode.
-            //That means we drop the old one and re-use the alias.
-            //But we only activate the new index when the old one was the default.
-            //Or there wasn't any previous index.
-            //it must be done on the last round of our loop.
-            final boolean switchIndex = !incremental && !listIterator.hasNext();
-            config.setSwitchIndexWhenDone(switchIndex);
-            publisherAPI.publish(config, status);
-        }
-
-        int filesCount = 0, pagesCount = 0, urlmapCount = 0;
-        for (final BundlerStatus bs : status.getBundlerStatuses()) {
-            if (bs.getBundlerClass().equals(FileAssetBundler.class.getName())) {
-                filesCount += bs.getTotal();
-            } else if (bs.getBundlerClass().equals(URLMapBundler.class.getName())) {
-                urlmapCount += bs.getTotal();
-            } else if (bs.getBundlerClass().equals(HTMLPageAsContentBundler.class.getName())) {
-                pagesCount += bs.getTotal();
+        final PreparedJobContext preparedJobContext = prepareJob(jobContext);
+        synchronized (preparedJobContext.lockKey()) {
+            for (final SiteSearchConfig config : preparedJobContext.getConfigs()) {
+                publisherAPI.publish(config, status);
             }
         }
 
         try {
-            final SiteSearchAudit audit = new SiteSearchAudit();
-            audit.setPagesCount(pagesCount);
-            audit.setFilesCount(filesCount);
-            audit.setUrlmapsCount(urlmapCount);
-            audit.setAllHosts(indexAll);
-            audit.setFireDate(jobContext.getFireTime());
-            audit.setHostList(UtilMethods.join(indexHosts,",",true));
-            audit.setIncremental(incremental);
-            audit.setStartDate(startDate);
-            audit.setEndDate(endDate);
-            audit.setIndexName( UtilMethods.isSet(newIndexName) ? newIndexName :  indexName );
-            audit.setJobId(jobId);
-            audit.setJobName(dataMap.getString(QUARTZ_JOB_NAME));
-            audit.setLangList(UtilMethods.join(languageToIndex,","));
-            audit.setPath(paths.size() > 0 ? UtilMethods.join(paths,",") : "/*");
-            audit.setPathInclude(include);
-            siteSearchAuditAPI.save(audit);
-        }
-        catch(DotDataException ex) {
-            Logger.error(this, "can't save audit data",ex);
-        }
-        finally {
+
+                int filesCount = 0, pagesCount = 0, urlmapCount = 0;
+                for (final BundlerStatus bs : status.getBundlerStatuses()) {
+                    if (bs.getBundlerClass().equals(FileAssetBundler.class.getName())) {
+                        filesCount += bs.getTotal();
+                    } else if (bs.getBundlerClass().equals(URLMapBundler.class.getName())) {
+                        urlmapCount += bs.getTotal();
+                    } else if (bs.getBundlerClass()
+                            .equals(HTMLPageAsContentBundler.class.getName())) {
+                        pagesCount += bs.getTotal();
+                    }
+                }
+
+                final SiteSearchAudit audit = new SiteSearchAudit();
+                audit.setPagesCount(pagesCount);
+                audit.setFilesCount(filesCount);
+                audit.setUrlmapsCount(urlmapCount);
+                audit.setAllHosts(preparedJobContext.isIndexAll());
+                audit.setFireDate(jobContext.getFireTime());
+                audit.setHostList(preparedJobContext.getJoinedHosts());
+                audit.setIncremental(preparedJobContext.isIncremental());
+                audit.setStartDate(preparedJobContext.getStartDate());
+                audit.setEndDate(preparedJobContext.getEndDate());
+                audit.setIndexName(
+                        UtilMethods.isSet(preparedJobContext.getNewIndexName()) ? preparedJobContext
+                                .getNewIndexName() : preparedJobContext.getIndexName());
+                audit.setJobId(preparedJobContext.getJobId());
+                audit.setJobName(preparedJobContext.getJobName());
+                audit.setLangList(preparedJobContext.getLangList());
+                audit.setPath(preparedJobContext.getPaths());
+                audit.setPathInclude(preparedJobContext.isPathInclude());
+                siteSearchAuditAPI.save(audit);
+
+
+        } catch (DotDataException ex) {
+            Logger.error(this, "can't save audit data", ex);
+        } finally {
             HibernateUtil.closeSession();
         }
-
         date = DateUtil.getCurrentDate();
-        ActivityLogger.logInfo(getClass(), "Job Finished", "User: " +userAPI.getSystemUser().getUserId()+ "; Date: " + date + "; Job Identifier: " + SiteSearchAPI.ES_SITE_SEARCH_NAME  );
-        AdminLogger.log(getClass(), "Job Finished", "User: " +userAPI.getSystemUser().getUserId()+ "; Date: " + date + "; Job Identifier: " + SiteSearchAPI.ES_SITE_SEARCH_NAME );
+        ActivityLogger.logInfo(getClass(), " SiteSearch:::  Job Finished", "User: " +userAPI.getSystemUser().getUserId()+ "; Date: " + date + "; Job Identifier: " + SiteSearchAPI.ES_SITE_SEARCH_NAME  );
+        AdminLogger.log(getClass(), " SiteSearch::: Job Finished", "User: " +userAPI.getSystemUser().getUserId()+ "; Date: " + date + "; Job Identifier: " + SiteSearchAPI.ES_SITE_SEARCH_NAME );
     }
+
+     private synchronized PreparedJobContext prepareJob(final JobExecutionContext jobContext)
+             throws DotDataException, IOException, DotSecurityException {
+
+         final JobDataMap dataMap = jobContext.getJobDetail().getJobDataMap();
+         String jobId = (String) dataMap.get(JOB_ID);
+         if (jobId == null) {
+             jobId = dataMap.getString(QUARTZ_JOB_NAME);
+         }
+
+         final boolean indexAll = UtilMethods.isSet((String) dataMap.get(INDEX_ALL));
+         final String[] indexHosts;
+         final Object obj = (dataMap.get(INDEX_HOST) != null) ? dataMap.get(INDEX_HOST) : new String[0];
+         if (obj instanceof String) {
+             indexHosts = new String[]{(String) obj};
+         } else {
+             indexHosts = (String[]) obj;
+         }
+
+         final boolean incrementalParam = dataMap.getBooleanFromString(INCREMENTAL);
+
+         final User userToRun = userAPI.getSystemUser();
+
+         final boolean include = ("all".equals(dataMap.getString(INCLUDE_EXCLUDE)) || INCLUDE
+                 .equals(dataMap.getString(INCLUDE_EXCLUDE)));
+
+         String path = dataMap.getString(PATHS);
+         final List<String> paths = new ArrayList<>();
+         if (path != null) {
+             path = path.replace(',', '\r');
+             path = path.replace('\n', '\r');
+             for (String x : path.split("\r")) {
+                 if (UtilMethods.isSet(x)) {
+                     paths.add(x);
+                 }
+             }
+         }
+         final boolean isRunNowJob = dataMap.getBooleanFromString(RUN_NOW);
+         // Run now jobs can not get the incremental treatment.
+         final String indexAlias = dataMap.getString(INDEX_ALIAS);
+         final IndexMetaData indexMetaData = getIndexMetaData(indexAlias);
+         final String newIndexName;
+         final String indexName;
+
+
+         final String jobName = dataMap.getString(QUARTZ_JOB_NAME);
+         final Date startDate, endDate;
+         final List<SiteSearchAudit> recentAudits = isRunNowJob ? Collections.emptyList()
+                 : siteSearchAuditAPI.findRecentAudits(jobId, 0, 1);
+
+         final boolean incremental = (incrementalParam && !isRunNowJob && !indexMetaData.isNewIndex() && !indexMetaData.isEmpty() && !recentAudits.isEmpty());
+         //We can only run incrementally if all the above pre-requisites are met.
+         if (incremental) {
+             //Incremental mode is useful only if there's already an index previously built.
+             //Incremental mode also implies that we have to have a date range to work on.
+             //So if we have an empty index or we lack of audit data we can not run incrementally.
+             //Even if the user wants to.
+             newIndexName = null;
+             endDate = jobContext.getFireTime();
+             startDate = recentAudits.get(0).getFireDate();
+             //For incremental jobs, we write the bundle to the same folder every time.
+             bundleId = StringUtils.camelCaseLower(jobName);
+             //We'll be working directly into the final index.
+             indexName = indexMetaData.getIndexName();
+         } else {
+             //Set null explicitly just in case
+             startDate = endDate = null;
+             // For non-incremental jobs. We create a new folder using a date stamp.
+             // But even if this run was executed non-incrementally for not having met any of the pre-requisits
+             // The job originally was meant to run incrementally therefore the results must be stored in the job specific folder.
+             // So they will still be available in the next round.
+             bundleId = incrementalParam ? StringUtils.camelCaseLower(jobName) :
+                     // Otherwise it is safe to create a unique  folder name.
+                     uniqueFolderName();
+             // We use a new index name only on non-incremental
+             newIndexName = newIndexName();
+             final String newAlias = indexMetaData.isNewIndex() ? indexMetaData.getAlias() : null ;
+             siteSearchAPI.createSiteSearchIndex(newIndexName, newAlias, 1);
+             // This is the old index we will swap from.
+             // if it doesnt exist. It doesnt matter here since we will end up with the new one.
+             indexName = indexMetaData.getIndexName();
+         }
+
+         Logger.info(SiteSearchJobImpl.class, () -> String
+                 .format("SiteSearch::: Incremental mode [%s]. current index is `%s`. new index is `%s`. alias is `%s`  bundle id is `%s` ",
+                         BooleanUtils.toStringYesNo(incremental), indexName ,
+                         UtilMethods.isSet(newIndexName) ? newIndexName : "N/A",
+                         indexAlias,
+                         bundleId)
+                 );
+
+         final List<Host> hosts;
+         if (indexAll) {
+             hosts = hostAPI.findAll(userToRun, true);
+         } else {
+             hosts = Stream.of(indexHosts).map(h -> {
+                 try {
+                     return hostAPI.find(h, userToRun, true);
+                 } catch (DotDataException | DotSecurityException e) {
+                     Logger.error(SiteSearchJobImpl.class, e);
+                 }
+                 return null;
+             }).filter(Objects::nonNull).collect(Collectors.toList());
+         }
+
+         final Builder<SiteSearchConfig> builder = ImmutableList.builder();
+
+         final List<String> languageToIndex = Arrays.asList((String[])dataMap.get(LANG_TO_INDEX));
+         final ListIterator<String> listIterator = languageToIndex.listIterator();
+         while (listIterator.hasNext()) {
+             final String lang = listIterator.next();
+             final SiteSearchConfig config = new SiteSearchConfig();
+             config.setJobId(jobId);
+             config.setLanguage(Long.parseLong(lang));
+             config.setJobName(jobName);
+             config.setHosts(hosts);
+             config.setNewIndexName(newIndexName);
+             config.setIndexName(indexName);
+             config.setIndexAlias(indexAlias);
+             config.setId(bundleId);
+             config.setStartDate(startDate);
+             config.setEndDate(endDate);
+             config.setIncremental(incremental);
+             config.setUser(userToRun);
+
+             if(include) {
+                 config.setIncludePatterns(paths);
+             } else {
+                 config.setExcludePatterns(paths);
+             }
+
+             //We should always replace the index when performing on non-incremental mode.
+             //That means we drop the old one and re-use the alias.
+             //But we only activate the new index when the old one was the default.
+             //Or there wasn't any previous index.
+             //it must be done on the last round of our loop.
+             final boolean switchIndex = !incremental && !listIterator.hasNext();
+             config.setSwitchIndexWhenDone(switchIndex);
+             builder.add(config);
+         }
+         final String joinedHosts = UtilMethods.join(indexHosts,",",true);
+         final String langList = UtilMethods.join(languageToIndex, ",");
+         final String pathsAsString = paths.size() > 0 ? UtilMethods.join(paths,",") : "/*";
+         return new PreparedJobContext(indexName, newIndexName, indexAll, joinedHosts, incremental,
+                 startDate, endDate, jobId, jobName, langList, pathsAsString, include,
+                 builder.build()
+         );
+     }
 
      private String newIndexName(){
         return SiteSearchAPI.ES_SITE_SEARCH_NAME + StringPool.UNDERLINE
@@ -325,7 +354,7 @@ public class SiteSearchJobImpl {
             indexName = aliasMap.get(indexAlias);
             if (UtilMethods.isSet(indexName)) {
                 if (siteSearchAPI.isDefaultIndex(indexAlias)) {
-                    Logger.info(SiteSearchJobImpl.class, String.format("Index `%s` is currently Site-Search DEFAULT.",indexAlias));
+                    Logger.info(SiteSearchJobImpl.class, String.format("SiteSearch::: Index `%s` is currently Site-Search DEFAULT.",indexAlias));
                     defaultIndex = true;
                 }
             } else {
@@ -375,6 +404,108 @@ public class SiteSearchJobImpl {
 
         public boolean isEmpty() {
             return empty;
+        }
+    }
+
+    static class PreparedJobContext{
+
+        private final String indexName;
+        private final String newIndexName;
+        private final boolean indexAll;
+        private final String joinedHosts;
+        private final boolean incremental;
+        private final Date startDate;
+        private final Date endDate;
+        private final String jobId;
+        private final String jobName;
+        private final String langList;
+        private final String paths;
+        private final boolean pathInclude;
+        private final List<SiteSearchConfig> configs;
+
+        PreparedJobContext(
+                final String indexName,
+                final String newIndexName,
+                final boolean indexAll,
+                final String joinedHosts,
+                final boolean incremental,
+                final Date startDate,
+                final Date endDate,
+                final String jobId,
+                final String jobName,
+                final String langList,
+                final String paths,
+                final boolean pathInclude,
+                final List<SiteSearchConfig> configs) {
+            this.indexName = indexName;
+            this.newIndexName = newIndexName;
+            this.indexAll = indexAll;
+            this.joinedHosts = joinedHosts;
+            this.incremental = incremental;
+            this.startDate = startDate;
+            this.endDate = endDate;
+            this.jobId = jobId;
+            this.jobName = jobName;
+            this.langList = langList;
+            this.configs = configs;
+            this.pathInclude = pathInclude;
+            this.paths = paths;
+        }
+
+        String getIndexName() {
+            return indexName;
+        }
+
+        List<SiteSearchConfig> getConfigs() {
+            return configs;
+        }
+
+        String getNewIndexName() {
+            return newIndexName;
+        }
+
+        boolean isIndexAll() {
+            return indexAll;
+        }
+
+        String getJoinedHosts() {
+            return joinedHosts;
+        }
+
+        boolean isIncremental() {
+            return incremental;
+        }
+
+        Date getStartDate() {
+            return startDate;
+        }
+
+        Date getEndDate() {
+            return endDate;
+        }
+
+        String getJobId() {
+            return jobId;
+        }
+
+        String getJobName() {
+            return jobName;
+        }
+
+        String getLangList() {
+            return langList;
+        }
+
+        public String getPaths() {
+            return paths;
+        }
+
+        boolean isPathInclude() {
+            return pathInclude;
+        }
+
+        String lockKey(){
+           return ( UtilMethods.isSet(indexName) ? indexName  : newIndexName );
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/publishing/job/SiteSearchJobImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/job/SiteSearchJobImpl.java
@@ -182,8 +182,8 @@ public class SiteSearchJobImpl {
             HibernateUtil.closeSession();
         }
         date = DateUtil.getCurrentDate();
-        ActivityLogger.logInfo(getClass(), " SiteSearch:::  Job Finished", "User: " +userAPI.getSystemUser().getUserId()+ "; Date: " + date + "; Job Identifier: " + SiteSearchAPI.ES_SITE_SEARCH_NAME  );
-        AdminLogger.log(getClass(), " SiteSearch::: Job Finished", "User: " +userAPI.getSystemUser().getUserId()+ "; Date: " + date + "; Job Identifier: " + SiteSearchAPI.ES_SITE_SEARCH_NAME );
+        ActivityLogger.logInfo(getClass(), "Job Finished", "User: " +userAPI.getSystemUser().getUserId()+ "; Date: " + date + "; Job Identifier: " + SiteSearchAPI.ES_SITE_SEARCH_NAME  );
+        AdminLogger.log(getClass(), "Job Finished", "User: " +userAPI.getSystemUser().getUserId()+ "; Date: " + date + "; Job Identifier: " + SiteSearchAPI.ES_SITE_SEARCH_NAME );
     }
 
      private synchronized PreparedJobContext prepareJob(final JobExecutionContext jobContext)
@@ -269,7 +269,7 @@ public class SiteSearchJobImpl {
          }
 
          Logger.info(SiteSearchJobImpl.class, () -> String
-                 .format("SiteSearch::: Incremental mode [%s]. current index is `%s`. new index is `%s`. alias is `%s`  bundle id is `%s` ",
+                 .format("Incremental mode [%s]. current index is `%s`. new index is `%s`. alias is `%s`  bundle id is `%s` ",
                          BooleanUtils.toStringYesNo(incremental), indexName ,
                          UtilMethods.isSet(newIndexName) ? newIndexName : "N/A",
                          indexAlias,
@@ -354,7 +354,7 @@ public class SiteSearchJobImpl {
             indexName = aliasMap.get(indexAlias);
             if (UtilMethods.isSet(indexName)) {
                 if (siteSearchAPI.isDefaultIndex(indexAlias)) {
-                    Logger.info(SiteSearchJobImpl.class, String.format("SiteSearch::: Index `%s` is currently Site-Search DEFAULT.",indexAlias));
+                    Logger.info(SiteSearchJobImpl.class, String.format("Index `%s` is currently Site-Search DEFAULT.",indexAlias));
                     defaultIndex = true;
                 }
             } else {

--- a/dotCMS/src/main/java/com/dotcms/publishing/job/SiteSearchJobImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/job/SiteSearchJobImpl.java
@@ -144,14 +144,14 @@ public class SiteSearchJobImpl {
         try {
 
                 int filesCount = 0, pagesCount = 0, urlmapCount = 0;
-                for (final BundlerStatus bs : status.getBundlerStatuses()) {
-                    if (bs.getBundlerClass().equals(FileAssetBundler.class.getName())) {
-                        filesCount += bs.getTotal();
-                    } else if (bs.getBundlerClass().equals(URLMapBundler.class.getName())) {
-                        urlmapCount += bs.getTotal();
-                    } else if (bs.getBundlerClass()
+                for (final BundlerStatus bundlerStatus : status.getBundlerStatuses()) {
+                    if (bundlerStatus.getBundlerClass().equals(FileAssetBundler.class.getName())) {
+                        filesCount += bundlerStatus.getTotal();
+                    } else if (bundlerStatus.getBundlerClass().equals(URLMapBundler.class.getName())) {
+                        urlmapCount += bundlerStatus.getTotal();
+                    } else if (bundlerStatus.getBundlerClass()
                             .equals(HTMLPageAsContentBundler.class.getName())) {
-                        pagesCount += bs.getTotal();
+                        pagesCount += bundlerStatus.getTotal();
                     }
                 }
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotParse.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotParse.java
@@ -95,7 +95,7 @@ public class DotParse extends DotDirective {
       ContentletVersionInfo contentletVersionInfo = APILocator.getVersionableAPI()
               .getContentletVersionInfo(identifier.getId(), languageId);
 
-      if (contentletVersionInfo == null || contentletVersionInfo.isDeleted()) {
+      if (contentletVersionInfo == null  ||  UtilMethods.isNotSet(contentletVersionInfo.getIdentifier())  || contentletVersionInfo.isDeleted()) {
 
         final long defaultLang = APILocator.getLanguageAPI().getDefaultLanguage().getId();
         if (defaultLang != languageId) {
@@ -103,7 +103,7 @@ public class DotParse extends DotDirective {
         }
       }
 
-      if ( null == contentletVersionInfo ) {
+      if ( null == contentletVersionInfo || UtilMethods.isNotSet(contentletVersionInfo.getIdentifier()) ) {
           throwNotResourceNotFoundException(params, templatePath);
       }
 


### PR DESCRIPTION
This comes to solve problems when creating bundles for non-default languages.
The problem was in DotParse resolving `contentletVersionInfo` 

Additionally to that. Other problems related to concurrency were solved by refactoring and the structure of the large method of the job converting it into smaller synchronizable pieces.

And last but not least I solved an additional problem that surfaced while testing simultaneous running jobs where the alias names would eventually get lost. The alias name assigned to the old index name wasn't getting returned by the site search API.
 