### PR TITLE
Issue 18132 content second lang not included site search

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/ContainerDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/ContainerDataGen.java
@@ -6,6 +6,10 @@ import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotmarketing.beans.ContainerStructure;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.exception.WebAssetException;
+import com.dotmarketing.factories.PublishFactory;
 import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.liferay.portal.model.User;
@@ -256,6 +260,13 @@ public class ContainerDataGen extends AbstractDataGen<Container> {
         }
 
         return container;
+    }
+
+    @WrapInTransaction
+    public static void publish(final Container container)
+            throws DotSecurityException, WebAssetException, DotDataException {
+        PublishFactory.publishAsset(container, APILocator.systemUser(),
+                false, false);
     }
 
     /**

--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/TemplateDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/TemplateDataGen.java
@@ -8,6 +8,8 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.exception.WebAssetException;
+import com.dotmarketing.factories.PublishFactory;
 import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.containers.model.FileAssetContainer;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
@@ -17,8 +19,11 @@ import com.dotmarketing.portlets.templates.model.Template;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liferay.util.StringPool;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -302,4 +307,10 @@ public class TemplateDataGen extends AbstractDataGen<Template> {
         }
     }
 
+    @WrapInTransaction
+    public static void publish(final Template template)
+            throws DotSecurityException, WebAssetException, DotDataException {
+        PublishFactory.publishAsset(template, APILocator.systemUser(),
+                false, false);
+    }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/TestDataUtils.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/TestDataUtils.java
@@ -68,10 +68,6 @@ public class TestDataUtils {
         return getBlogLikeContentType("Blog" + System.currentTimeMillis(), site);
     }
 
-    public static ContentType getBlogLikeContentType(final Host site, final String detailPage) {
-        return getBlogLikeContentType("Blog" + System.currentTimeMillis(), site);
-    }
-
     @WrapInTransaction
     public static ContentType getBlogLikeContentType(final String contentTypeName,
             final Host site, final Set <String> workflowIds) {

--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/TestDataUtils.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/TestDataUtils.java
@@ -18,6 +18,7 @@ import com.dotcms.contenttype.model.field.WysiwygField;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.util.ConfigTestHelper;
+import com.dotmarketing.beans.ContainerStructure;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.RelationshipAPI;
@@ -27,6 +28,7 @@ import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.templates.model.Template;
@@ -63,6 +65,10 @@ public class TestDataUtils {
     }
 
     public static ContentType getBlogLikeContentType(final Host site) {
+        return getBlogLikeContentType("Blog" + System.currentTimeMillis(), site);
+    }
+
+    public static ContentType getBlogLikeContentType(final Host site, final String detailPage) {
         return getBlogLikeContentType("Blog" + System.currentTimeMillis(), site);
     }
 
@@ -163,7 +169,6 @@ public class TestDataUtils {
                                 .relationType(contentTypeName + StringPool.PERIOD + "blogBlog")
                                 .next()
                 );*/
-
                 blogType = new ContentTypeDataGen()
                         .name(contentTypeName)
                         .velocityVarName(contentTypeName)
@@ -1625,6 +1630,19 @@ public class TestDataUtils {
         return youtubeType;
     }
 
+    @WrapInTransaction
+    public static Contentlet createNewsLikeURLMappedContent(final String newsPatternPrefix,
+            final Date sysPublishDate, final long languageId, final Host host,
+            final String detailPageIdentifier) {
 
+        final ContentType newsContentType = getNewsLikeContentType(
+                "News" + System.currentTimeMillis(),
+                host,
+                detailPageIdentifier,
+                newsPatternPrefix + "{urlTitle}");
+
+        return getNewsContent(true, languageId,
+                        newsContentType.id(), host, sysPublishDate);
+    }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/cms/urlmap/URLMapAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/cms/urlmap/URLMapAPIImplTest.java
@@ -321,15 +321,9 @@ public class URLMapAPIImplTest {
 
     private static Contentlet createURLMapperContentType(final String newsPatternPrefix, final Date sysPublishDate) {
 
-        final ContentType newsContentType = getNewsLikeContentType(
-                "News" + System.currentTimeMillis(),
-                host,
-                detailPage.getIdentifier(),
-                newsPatternPrefix + "{urlTitle}");
-
-        return TestDataUtils
-                .getNewsContent(true, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
-                        newsContentType.id(), host, sysPublishDate);
+        return TestDataUtils.createNewsLikeURLMappedContent(newsPatternPrefix, sysPublishDate,
+                APILocator.getLanguageAPI().getDefaultLanguage().getId(), host,
+                detailPage.getIdentifier());
     }
 
     private UrlMapContext getUrlMapContext(final User systemUser, final Host host, final String uri, final PageMode pageMode) {

--- a/dotCMS/src/integration-test/java/com/dotmarketing/cms/urlmap/URLMapAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/cms/urlmap/URLMapAPIImplTest.java
@@ -512,9 +512,15 @@ public class URLMapAPIImplTest {
             urlMapPatternToUse = urlMapPattern;
         }
 
-        return TestDataUtils.createNewsLikeURLMappedContent(newsPatternPrefix, sysPublishDate,
-                APILocator.getLanguageAPI().getDefaultLanguage().getId(), host,
-                detailPage.getIdentifier());
+        final ContentType newsContentType = getNewsLikeContentType(
+                "News" + System.currentTimeMillis(),
+                host,
+                detailPage.getIdentifier(),
+                urlMapPatternToUse);
+
+        return TestDataUtils
+                .getNewsContent(true, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
+                        newsContentType.id(), host, sysPublishDate, urlTitle);
 
     }
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/HTMLPageAssetAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/HTMLPageAssetAPIImplTest.java
@@ -1,10 +1,32 @@
 package com.dotmarketing.portlets.htmlpages.business;
 
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.datagen.ContentletDataGen;
+import com.dotcms.datagen.FolderDataGen;
+import com.dotcms.datagen.HTMLPageDataGen;
+import com.dotcms.datagen.LanguageDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.TemplateDataGen;
+import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.dotmarketing.portlets.templates.model.Template;
+import com.dotmarketing.util.Constants;
+import java.util.Date;
+import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class HTMLPageAssetAPIImplTest {
+
+    @BeforeClass
     public static void prepare () throws Exception {
         //Setting web app environment
         IntegrationTestInitService.getInstance().init();
@@ -12,11 +34,44 @@ public class HTMLPageAssetAPIImplTest {
 
     /**
      * Given scenario:
-     * - Given a URL-Mapped content
+     * a new URL-Mapped content in a second language (not default)
+     *
+     * Expected result:
+     * getHTML method should respond with the proper rendered content on the detail page
      */
 
     @Test
-    public void test_getHTML_GivenSpanishOnlyUrlMappedContent_shouldReturnURLMapDetailPage() {
+    public void test_getHTML_GivenSpanishOnlyUrlMappedContent_shouldReturnURLMapDetailPage()
+            throws DotSecurityException, DotDataException {
+        final Host site = new SiteDataGen().nextPersisted();
+        final Language language = new LanguageDataGen().nextPersisted();
+        final String newsPatternPrefix =
+                "/testpattern" + System.currentTimeMillis() + "/";
 
+        final String parent1Name = "news-events";
+        final Folder parent1 = new FolderDataGen().name(parent1Name).title(parent1Name).site(site)
+                .nextPersisted();
+        final String parent2Name = "news";
+        final Folder parent2 = new FolderDataGen().name(parent2Name).title(parent2Name).parent(parent1)
+                .nextPersisted();
+
+        final Template template = new TemplateDataGen().nextPersisted();
+
+        final HTMLPageAsset detailPage = new HTMLPageDataGen(parent2, template)
+                .pageURL("news-detail")
+                .title("news-detail")
+                .nextPersisted();
+
+        HTMLPageDataGen.publish(detailPage);
+
+        final Contentlet contentlet = TestDataUtils.createNewsLikeURLMappedContent(newsPatternPrefix, new Date(),
+                APILocator.getLanguageAPI().getDefaultLanguage().getId(), site,
+                detailPage.getIdentifier());
+
+        String html = APILocator.getHTMLPageAssetAPI().getHTML(detailPage.getURI(), site, true,
+                contentlet.getIdentifier(), APILocator.systemUser(), contentlet.getLanguageId(),  "");
+
+
+        Assert.assertEquals("", html);
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/HTMLPageAssetAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/HTMLPageAssetAPIImplTest.java
@@ -4,35 +4,26 @@ import static com.dotcms.rendering.velocity.directive.ParseContainer.getDotParse
 import static com.dotmarketing.util.Constants.USER_AGENT_DOTCMS_SITESEARCH;
 
 import com.dotcms.contenttype.model.type.ContentType;
-import com.dotcms.contenttype.model.type.ContentTypeBuilder;
 import com.dotcms.datagen.ContainerDataGen;
-import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.ContentletDataGen;
-import com.dotcms.datagen.FolderDataGen;
 import com.dotcms.datagen.HTMLPageDataGen;
 import com.dotcms.datagen.LanguageDataGen;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.datagen.TemplateDataGen;
 import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.util.IntegrationTestInitService;
-import com.dotmarketing.beans.ContainerStructure;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.MultiTree;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.exception.WebAssetException;
-import com.dotmarketing.factories.PublishFactory;
 import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.templates.model.Template;
-import com.dotmarketing.util.Constants;
 import com.dotmarketing.util.UUIDGenerator;
-import java.util.Collections;
-import java.util.Date;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -97,7 +88,7 @@ public class HTMLPageAssetAPIImplTest {
 
         APILocator.getMultiTreeAPI().saveMultiTree(multiTree);
 
-        String html = APILocator.getHTMLPageAssetAPI().getHTML(htmlPage.getURI(), site, true,
+        final String html = APILocator.getHTMLPageAssetAPI().getHTML(htmlPage.getURI(), site, true,
                 urlMappedContent.getIdentifier(), APILocator.systemUser(),
                 urlMappedContent.getLanguageId(),  USER_AGENT_DOTCMS_SITESEARCH);
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/HTMLPageAssetAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/HTMLPageAssetAPIImplTest.java
@@ -1,0 +1,22 @@
+package com.dotmarketing.portlets.htmlpages.business;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.business.APILocator;
+import org.junit.Test;
+
+public class HTMLPageAssetAPIImplTest {
+    public static void prepare () throws Exception {
+        //Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Given scenario:
+     * - Given a URL-Mapped content
+     */
+
+    @Test
+    public void test_getHTML_GivenSpanishOnlyUrlMappedContent_shouldReturnURLMapDetailPage() {
+
+    }
+}

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/HTMLPageAssetAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/htmlpages/business/HTMLPageAssetAPIImplTest.java
@@ -63,7 +63,7 @@ public class HTMLPageAssetAPIImplTest {
 
         // create detail page
         final Container container = new ContainerDataGen()
-                .withContentType(blogType, "myCode")
+                .withContentType(blogType, "$body")
                 .nextPersisted();
 
         ContainerDataGen.publish(container);
@@ -85,6 +85,7 @@ public class HTMLPageAssetAPIImplTest {
         // create URL-Mapped content
         final Contentlet urlMappedContent = new ContentletDataGen(blogType.id())
                 .languageId(language.getId())
+                .setProperty("body", "myBody")
                 .nextPersisted();
 
         ContentletDataGen.publish(urlMappedContent);
@@ -101,6 +102,6 @@ public class HTMLPageAssetAPIImplTest {
                 urlMappedContent.getLanguageId(),  USER_AGENT_DOTCMS_SITESEARCH);
 
 
-        Assert.assertEquals("<div>myCode</div>", html);
+        Assert.assertEquals("<div>myBody</div>", html);
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/HTMLPageAssetAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/HTMLPageAssetAPIImpl.java
@@ -753,7 +753,7 @@ public class HTMLPageAssetAPIImpl implements HTMLPageAssetAPI {
         
 
         ContentletVersionInfo cinfo = APILocator.getVersionableAPI().getContentletVersionInfo( ident.getId(), viewingLang );
-        if(cinfo==null && viewingLang!=languageAPI.getDefaultLanguage().getId() && languageAPI.canDefaultPageToDefaultLanguage()){
+        if((cinfo==null || cinfo.getLiveInode() == null) && viewingLang!=languageAPI.getDefaultLanguage().getId() && languageAPI.canDefaultPageToDefaultLanguage()){
           cinfo = APILocator.getVersionableAPI().getContentletVersionInfo( ident.getId(), languageAPI.getDefaultLanguage().getId() );
         }
         // if we still have nothing.


### PR DESCRIPTION
- When rendering a page's html, the content version info was being first looked up in the given language, and after not being found, the idea was to look for it in the default language, but the condition was not ok. It was just checking the contentInfo being null and not also its properties being null.

- A new integration test was added. 
- Utility methods for publish containers and templates were added to the respective dataGen classes.