### PR TITLE
dotCMS/core#18117 Login As is not working

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserResource.java
@@ -351,7 +351,7 @@ public class UserResource implements Serializable {
 			
 			// if we don't have a user or 
 			if (newUser==null || session.getAttribute(WebKeys.PRINCIPAL_USER_ID) != null) {
-				throw new DotSecurityException("user is already logged in as somebody else");
+				throw new DotSecurityException("user is already loginAs somebody else");
 			}
 			
 			session.setAttribute(WebKeys.PRINCIPAL_USER_ID, sessionData.get(WebKeys.PRINCIPAL_USER_ID));

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserResource.java
@@ -81,7 +81,7 @@ public class UserResource implements Serializable {
 	}
 
 	@VisibleForTesting
-	protected UserResource(final WebResource webResource,  final UserAPI userAPI, final UserResourceHelper userHelper,
+	public UserResource(final WebResource webResource,  final UserAPI userAPI, final UserResourceHelper userHelper,
 			final ErrorResponseHelper errorHelper) {
 		this.webResource = webResource;
 		this.userAPI = userAPI;
@@ -345,11 +345,17 @@ public class UserResource implements Serializable {
 		Response response = null;
 		try {
 			Map<String, Object> sessionData = this.helper.doLoginAs(currentUser, loginAsUserId, loginAsUserPwd, serverName);
+			
+            final String newUserId = (String) sessionData.get(WebKeys.USER_ID);
 			HttpSession session = request.getSession();
-			if (session.getAttribute(WebKeys.PRINCIPAL_USER_ID) == null) {
-				session.setAttribute(WebKeys.PRINCIPAL_USER_ID, sessionData.get(WebKeys.PRINCIPAL_USER_ID));
+			if (newUserId==null && session.getAttribute(WebKeys.PRINCIPAL_USER_ID) != null) {
+				throw new DotSecurityException("user is already logged in as");
 			}
-			session.setAttribute(WebKeys.USER_ID, sessionData.get(WebKeys.USER_ID));
+			
+			session.setAttribute(WebKeys.PRINCIPAL_USER_ID, sessionData.get(WebKeys.PRINCIPAL_USER_ID));
+			session.setAttribute(WebKeys.USER,userAPI.loadUserById(newUserId));
+			session.setAttribute(WebKeys.USER_ID, newUserId);
+			
 			PrincipalThreadLocal.setName(loginAsUserId);
 			session.setAttribute(com.dotmarketing.util.WebKeys.CURRENT_HOST,
 					sessionData.get(com.dotmarketing.util.WebKeys.CURRENT_HOST));
@@ -436,19 +442,25 @@ public class UserResource implements Serializable {
 				.requestAndResponse(httpServletRequest, httpServletResponse)
 				.rejectWhenNoUser(true)
 				.init();
+		
+		
+        User currentLoginAsUser = new User();
+        Response response = null;
+        final String serverName = httpServletRequest.getServerName();
+        String principalUserId = null;
+        HttpSession session = httpServletRequest.getSession();
+        try {
+            principalUserId = session.getAttribute(WebKeys.PRINCIPAL_USER_ID).toString();
+    		if (principalUserId == null) {
+    		    throw new DotSecurityException("There is no principle user in this session");
+    		}
 
-		final String serverName = httpServletRequest.getServerName();
-		String principalUserId = null;
-		HttpSession session = httpServletRequest.getSession();
-		if (session.getAttribute(WebKeys.PRINCIPAL_USER_ID) != null) {
-			principalUserId = httpServletRequest.getSession().getAttribute(WebKeys.PRINCIPAL_USER_ID).toString();
-		}
-		User currentLoginAsUser = new User();
-		Response response = null;
-		try {
+    		
 			currentLoginAsUser = PortalUtil.getUser(httpServletRequest);
 			Map<String, Object> sessionData = this.helper.doLogoutAs(principalUserId, currentLoginAsUser, serverName);
+			session.removeAttribute(WebKeys.USER);
 			session.setAttribute(WebKeys.USER_ID, principalUserId);
+            session.setAttribute(WebKeys.USER, userAPI.loadUserById(principalUserId));
 			session.removeAttribute(WebKeys.PRINCIPAL_USER_ID);
 			session.setAttribute(com.dotmarketing.util.WebKeys.CURRENT_HOST,
 					sessionData.get(com.dotmarketing.util.WebKeys.CURRENT_HOST));


### PR DESCRIPTION
LoginAs was broken because it relied on setting only the `user_id` in session without removing the `user` from session.  In #18076, for better or worse, the `PortalUtils` was changed to take the `session.getAttribute("user")` into account BEFORE it looked for a `session.getAttribute("user_id")`, which meant that the session user was never changed by the loginAs.