### PR TITLE
#17976 fixes on saving the index name

### DIFF
--- a/dotCMS/src/integration-test/resources/messages/Language_en_US.properties
+++ b/dotCMS/src/integration-test/resources/messages/Language_en_US.properties
@@ -2980,6 +2980,7 @@ Urlmaps-Count=UrlMaps
 Fire-Date=Fire Date
 sitesearch-audit-tab=Job Audit Data
 Create-SiteSearch-Index=Create SiteSearch Index
+Invalid-Index-Alias=Invalid Index alias
 schedule-site-search-success=Site search has been successfully scheduled
 select-hosts-to-index=Select Sites to index
 cron-expression=Cron Expression

--- a/dotCMS/src/main/java/com/dotcms/publishing/job/SiteSearchJobImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/job/SiteSearchJobImpl.java
@@ -420,8 +420,10 @@ public class SiteSearchJobImpl {
      */
     private String getAliasName(final String aliasName) throws DotDataException {
        if(UtilMethods.isSet(aliasName)){
-          final String cleanedUpAlias = aliasName.split("\\s+")[0].trim(); //This should grab only the first part of the alias name and drop the `(Default)` piece.
-          if(invalidAliasNamePattern.matcher(cleanedUpAlias).matches()){ //Now since we're saving the alias in the quartz job detail and the
+          final String cleanedUpAlias = aliasName.split("\\s+")[0].trim();
+          //This should grab only the first part of the alias name and drop the `(Default)` piece.
+          if(invalidAliasNamePattern.matcher(cleanedUpAlias).matches()){
+          //Since we're saving the alias in the quartz job detail we need to perform this cleanup before it runs.
              throw new DotDataException(String.format("Invalid Alias name `%s` ",aliasName));
           }
           return cleanedUpAlias;

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -968,6 +968,7 @@ Create-New-Campaign = Create New Campaign
 Create-New-Communication = Create New Communication
 Create-New-Make-Default = Create New Index and Make Default
 Create-SiteSearch-Index = Create Site Search Index
+Invalid-Index-Alias=Invalid Index alias
 Create-This-Page-Now = Create This Page Now
 Create-Working-Index = Create new Working Index
 Created-on = Created on

--- a/dotCMS/src/main/webapp/html/portlet/ext/sitesearch/site_search.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/sitesearch/site_search.jsp
@@ -472,13 +472,17 @@ function doCreateSiteSearch(alias,number) {
 	if(!number || !alias){
 		return;
 	}
-	
+
 	var shards = parseInt(number);
 	if(shards <1){
-		return;	
-	
+		return;
 	}
-	
+
+	if(/[^a-zA-Z0-9-_]/.test(alias.split(/\b\s+/)[0].trim())) {
+		showDotCMSErrorMessage("<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Invalid-Index-Alias")) %>");
+		return;
+	}
+
 	var xhrArgs = {
        url: "/DotAjaxDirector/com.dotmarketing.sitesearch.ajax.SiteSearchAjaxAction/cmd/createSiteSearchIndex/shards/" + shards +"/alias/"+alias,
        handleAs: "text",
@@ -560,8 +564,11 @@ function submitSchedule() {
 		showDotCMSErrorMessage("<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Choose-a-Language")) %>");
 		return;
 	}
-	
-	if(/^\s*$/.test(dojo.byId("indexAlias").value)) {
+
+	//Based on the error invalid_alias_name_exception returned by the ES
+	//Alias must not contain the following characters [ , \", *, \\, <, |, ,, >, /, ?]"}]
+	let indexAlias = dojo.byId("indexAlias").value;
+	if( !indexAlias || indexAlias === "" || /[^a-zA-Z0-9-_]/.test(indexAlias.split(/\b\s+/)[0].trim())) {
 		showDotCMSErrorMessage("<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Invalid-Index-Alias")) %>");
         return;
 	}


### PR DESCRIPTION
This comes to fix a minor thing that was happening when the original alias named was copied.
Some clean-up was required to remove the string "(Default)" from the alias name passed to the job
Additionally, since Elasticsearch warns you about the format error on the alias name I added a small validation to prevent the user from input invalid chars.