### PR TITLE
#18158 adding the prefix PARSE_CONTAINER_UUID_PREFIX to the MultiTree…

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/factories/MultiTreeAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/factories/MultiTreeAPITest.java
@@ -2,6 +2,7 @@ package com.dotmarketing.factories;
 
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.datagen.*;
+import com.dotcms.rendering.velocity.directive.ParseContainer;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.MultiTree;
 import com.dotmarketing.business.APILocator;
@@ -13,10 +14,13 @@ import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 import com.dotmarketing.portlets.personas.model.Persona;
 import com.dotmarketing.portlets.structure.model.Structure;
+import com.dotmarketing.portlets.templates.design.bean.ContainerUUID;
 import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.startup.runonce.Task04315UpdateMultiTreePK;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UUIDGenerator;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -68,7 +72,48 @@ public class MultiTreeAPITest extends IntegrationTestBase {
         }
 
     }
-    
+
+    /**
+     * This test checks if the uuid does exact match on the table (same keys)
+     * @throws Exception
+     */
+    @Test
+    public  void testDoesPageContentsHaveContainer_no_prefix() throws Exception {
+
+        final Table<String, String, Set<PersonalizedContentlet>> pageContents = HashBasedTable.create();
+        final String  containerIdentifier = "12345";
+        final String  containeruuid       = "xxx";
+        final ContainerUUID containerUUID = new ContainerUUID(containerIdentifier, containeruuid);
+        final Container container         = new Container();
+        final MultiTreeAPIImpl multiTreeAPI = new MultiTreeAPIImpl();
+
+        container.setIdentifier(containerIdentifier);
+        pageContents.put(containerIdentifier, containeruuid, Sets.newConcurrentHashSet());
+
+        Assert.assertTrue("Should has the container", multiTreeAPI.doesPageContentsHaveContainer(pageContents, containerUUID, container));
+    }
+
+    /**
+     * This test checks if the uuid does match on the table but the table has a diff keys (with a dotParser_ prefix)
+     * @throws Exception
+     */
+    @Test
+    public  void testDoesPageContentsHaveContainer_with_prefix() throws Exception {
+
+        final Table<String, String, Set<PersonalizedContentlet>> pageContents = HashBasedTable.create();
+        final String  containerIdentifier = "12345";
+        final String  containeruuid       = "xxx";
+        final ContainerUUID containerUUID = new ContainerUUID(containerIdentifier, containeruuid);
+        final Container container         = new Container();
+        final MultiTreeAPIImpl multiTreeAPI = new MultiTreeAPIImpl();
+
+        container.setIdentifier(containerIdentifier);
+        pageContents.put(containerIdentifier, ParseContainer.PARSE_CONTAINER_UUID_PREFIX + containeruuid, Sets.newConcurrentHashSet());
+
+        Assert.assertTrue("Should has the container", multiTreeAPI.doesPageContentsHaveContainer(pageContents, containerUUID, container));
+    }
+
+
     @Test
     public  void testDeletes() throws Exception {
         deleteInitialData();

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -5,6 +5,7 @@ import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.contenttype.exception.NotFoundInDbException;
+import com.dotcms.rendering.velocity.directive.ParseContainer;
 import com.dotcms.rendering.velocity.services.PageLoader;
 import com.dotcms.rendering.velocity.viewtools.DotTemplateTool;
 import com.dotcms.util.transform.TransformerLocator;
@@ -904,6 +905,8 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
             final Container container) {
 
         if(pageContents.contains(container.getIdentifier(), containerUUID.getUUID())){
+            return true;
+        } else if(pageContents.contains(container.getIdentifier(), ParseContainer.PARSE_CONTAINER_UUID_PREFIX + containerUUID.getUUID())) {
             return true;
         } else if (ContainerUUID.UUID_LEGACY_VALUE.equals(containerUUID.getUUID())) {
             boolean pageContenstContains = pageContents.contains(containerUUID.getIdentifier(), ContainerUUID.UUID_START_VALUE);

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -899,7 +899,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
      * @param container container
      * @return true in case of the containerUUId is contains in pageContents
      */
-    private boolean doesPageContentsHaveContainer(
+    protected boolean doesPageContentsHaveContainer(
             final Table<String, String, Set<PersonalizedContentlet>> pageContents,
             final ContainerUUID containerUUID,
             final Container container) {


### PR DESCRIPTION
Adding the prefix PARSE_CONTAINER_UUID_PREFIX to the MultiTreeAPI in order to be align with the new instance convention for the empty containers on advance templates