### PR TITLE
#17976 Extending index_name column length to 100 

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task05221UpdateIndexNameLength.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task05221UpdateIndexNameLength.java
@@ -1,0 +1,52 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.startup.AbstractJDBCStartupTask;
+import java.util.List;
+
+public class Task05221UpdateIndexNameLength extends AbstractJDBCStartupTask {
+
+    @Override
+    public String getMSSQLScript() {
+        return "DECLARE @SQL VARCHAR(4000)\n"
+                + "SET @SQL = 'ALTER TABLE dbo.Indicies DROP CONSTRAINT |ConstraintName| '\n"
+                + "\n"
+                + "SET @SQL = REPLACE(@SQL, '|ConstraintName|', ( SELECT   name\n"
+                + "                                               FROM     sysobjects\n"
+                + "                                               WHERE    xtype = 'PK'\n"
+                + "                                                        AND parent_obj =        OBJECT_ID('Indicies')))\n"
+                + "\n"
+                + "EXEC (@SQL)\n"
+                + "alter table indicies alter column index_name nvarchar(100) not null;\n"
+                + "alter table Indicies add primary key (index_name);";
+    }
+
+    @Override
+    public String getMySQLScript() {
+        return "alter table indicies modify index_name varchar(100);";
+    }
+
+    @Override
+    public String getOracleScript() {
+        return "alter table indicies modify index_name varchar2(100);";
+    }
+
+    @Override
+    public String getPostgresScript() {
+        return "alter table indicies alter column index_name type varchar(100);";
+    }
+
+    @Override
+    protected List<String> getTablesToDropConstraints() {
+        return null;
+    }
+
+    public boolean forceRun() {
+        return true;
+    }
+
+    @Override
+    public String getH2Script() {
+        return "alter table indicies alter column index_name type varchar(100);";
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -278,6 +278,7 @@ public class TaskLocatorUtil {
 		ret.add(Task05210CreateDefaultDotAsset.class);
 		ret.add(Task05215AddSystemWorkflowToDotAssetContentType.class);
 		ret.add(Task05220MakeFileAssetContentTypeBinaryFieldIndexedListed.class);
+		ret.add(Task05221UpdateIndexNameLength.class);
 		return ret;
 	}
 

--- a/dotCMS/src/main/resources/mssql.sql
+++ b/dotCMS/src/main/resources/mssql.sql
@@ -2480,7 +2480,7 @@ alter table tag alter column user_id NVARCHAR(MAX);
 
 -- ****** Indicies Data Storage *******
 create table indicies (
-  index_name NVARCHAR(30) primary key,
+  index_name NVARCHAR(100) primary key,
   index_type NVARCHAR(16) not null unique
 );
 -- ****** Log Console Table *******

--- a/dotCMS/src/main/resources/mysql.sql
+++ b/dotCMS/src/main/resources/mysql.sql
@@ -2137,7 +2137,7 @@ alter table tag_inode add constraint fk_tag_inode_tagid foreign key (tag_id) ref
 
 -- ****** Indicies Data Storage *******
 create table indicies (
-  index_name varchar(30) primary key,
+  index_name varchar(100) primary key,
   index_type varchar(16) not null unique
 );
 

--- a/dotCMS/src/main/resources/oracle.sql
+++ b/dotCMS/src/main/resources/oracle.sql
@@ -2319,7 +2319,7 @@ create index tag_user_id_index on tag(user_id) indextype is ctxsys.context;
 
 -- ****** Indicies Data Storage *******
 create table indicies (
-  index_name varchar2(30) primary key,
+  index_name varchar2(100) primary key,
   index_type varchar2(16) not null unique
 );
   -- ****** Log Console Table *******

--- a/dotCMS/src/main/resources/postgres.sql
+++ b/dotCMS/src/main/resources/postgres.sql
@@ -2267,7 +2267,7 @@ ALTER TABLE tag ALTER COLUMN user_id TYPE text;
 
 -- ****** Indicies Data Storage *******
 create table indicies (
-  index_name varchar(30) primary key,
+  index_name varchar(100) primary key,
   index_type varchar(16) not null unique
 );
 -- ****** Log Console Table *******


### PR DESCRIPTION
This change is required because uuid is appended to the index name to avoid duplicity in concurrent environments