### PR TITLE
#18021 added a logic to handle DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE on…

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/HTMLPageAssetRenderedTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/HTMLPageAssetRenderedTest.java
@@ -340,6 +340,7 @@ public class HTMLPageAssetRenderedTest {
     public void ContentFallbackFalse_PageFallbackTrue_PageEnglish_ViewEnglishContent1And2_ViewSpanishContent2And3(
             final Container container, final Template template) throws Exception{
 
+        Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", true);
         Config.setProperty(contentFallbackProperty,false);
         Config.setProperty(pageFallbackProperty,true);
 
@@ -1134,7 +1135,7 @@ public class HTMLPageAssetRenderedTest {
     @UseDataProvider("cases")
     public void shouldReturnParserContainerUUID(final Container container, final Template template) throws Exception {
 
-
+        Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", true);
         final String pageName = "test5Page-"+System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
@@ -1322,6 +1323,7 @@ public class HTMLPageAssetRenderedTest {
     @UseDataProvider("dataProviderWidgetPreExecuteCode")
     public void test_WidgetPreExecuteCodeShowRegardlessPageMode(final WidgetPreExecuteCodeTestCase testCase) throws Exception {
 
+        Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", true);
         //Update the Preexecute Field to have some code in it
         final String preExcuteCode = "PreExecute Code Displayed";
         ContentType contentType = TestDataUtils.getWidgetLikeContentType();

--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
@@ -436,6 +436,7 @@ public class PageResourceTest {
     public void testRenderWithContent() throws DotDataException, DotSecurityException {
 
         final User systemUser = APILocator.getUserAPI().getSystemUser();
+        final long languageId = 1l;
 
         final Structure structure = new StructureDataGen().nextPersisted();
         final Container localContainer = new ContainerDataGen().withStructure(structure,"").friendlyName("container-1-friendly-name").title("container-1-title").nextPersisted();
@@ -461,12 +462,14 @@ public class PageResourceTest {
 
         final ContentletDataGen contentletDataGen = new ContentletDataGen(contentGenericType.id());
         final Contentlet contentlet = contentletDataGen.setProperty("title", "title")
-                .setProperty("body", "body").languageId(1).nextPersisted();
+                .setProperty("body", "body").languageId(languageId).nextPersisted();
 
 
         final MultiTreeAPI multiTreeAPI = APILocator.getMultiTreeAPI();
         final MultiTree multiTree = new MultiTree(pageAsset.getIdentifier(), localContainer.getIdentifier(), contentlet.getIdentifier(), "1", 1);
         multiTreeAPI.saveMultiTree(multiTree);
+
+        when(request.getAttribute(WebKeys.HTMLPAGE_LANGUAGE)).thenReturn(String.valueOf(languageId));
 
         final Response response = pageResource
                 .loadJson(request, this.response, pagePath, "PREVIEW_MODE", null,
@@ -647,6 +650,8 @@ public class PageResourceTest {
         final MultiTree multiTree = new MultiTree(pageAsset.getIdentifier(), localContainer1.getIdentifier(), contentlet.getIdentifier(), "1", 1);
         multiTreeAPI.saveMultiTree(multiTree);
 
+        when(request.getAttribute(WebKeys.HTMLPAGE_LANGUAGE)).thenReturn(String.valueOf(languageId));
+
         final Response response = pageResource
                 .loadJson(request, this.response, pageUri, null, null,
                         String.valueOf(languageId), null);
@@ -715,7 +720,7 @@ public class PageResourceTest {
                 .setProperty("name", "name")
                 .setProperty("keyTag", "keyTag")
                 .host(host)
-                .languageId(1)
+                .languageId(languageId)
                 .nextPersisted();
 
         final Container container = pageRenderTest.getFirstContainer();
@@ -725,6 +730,8 @@ public class PageResourceTest {
                 page.getIdentifier(),
                 Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON + persona.getIdentifier()
         );
+
+        when(request.getAttribute(WebKeys.HTMLPAGE_LANGUAGE)).thenReturn(String.valueOf(languageId));
 
         final Response response = pageResource
                 .render(request, this.response, page.getURI(), null, persona.getIdentifier(),
@@ -763,6 +770,8 @@ public class PageResourceTest {
             final Container container = pageRenderTest.getContainer(id);
             pageRenderTest.createContent(container);
         }
+
+        when(request.getAttribute(WebKeys.HTMLPAGE_LANGUAGE)).thenReturn(String.valueOf(languageId));
 
         final Response response = pageResource
                 .render(request, this.response, page.getURI(), "EDIT_MODE", null,
@@ -857,6 +866,7 @@ public class PageResourceTest {
 
         final Language defaultLang = APILocator.getLanguageAPI().getDefaultLanguage();
         final long languageId = defaultLang.getId();
+        when(request.getAttribute(WebKeys.HTMLPAGE_LANGUAGE)).thenReturn(String.valueOf(languageId));
 
         final String pageName = "testPage-"+System.currentTimeMillis();
         final HTMLPageAsset page = new HTMLPageDataGen(folder, template)
@@ -873,7 +883,7 @@ public class PageResourceTest {
         when(initDataObject.getUser()).thenReturn(systemUser);
 
         final Contentlet contentlet1 = new ContentletDataGen(contentGenericType.id())
-                .languageId(1)
+                .languageId(languageId)
                 .folder(folder)
                 .host(host)
                 .setProperty("title", "content1")

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionletTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionletTest.java
@@ -30,6 +30,7 @@ import com.dotmarketing.portlets.workflows.business.BaseWorkflowIntegrationTest;
 import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
 import com.dotmarketing.portlets.workflows.model.WorkflowActionClass;
 import com.dotmarketing.portlets.workflows.model.WorkflowProcessor;
+import com.dotmarketing.util.Config;
 import com.liferay.portal.model.User;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -151,6 +152,7 @@ public class FourEyeApproverActionletTest extends BaseWorkflowIntegrationTest {
         Contentlet contentletToCleanUp = null;
 
         try {
+            Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", true);
             // Create a contentlet first and save it
             final long languageId = languageAPI.getDefaultLanguage().getId();
             final Contentlet cont = new Contentlet();

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -20,6 +20,7 @@ import com.dotmarketing.beans.MultiTree;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -35,6 +36,7 @@ import com.dotmarketing.portlets.contentlet.util.ContentletUtil;
 import com.dotmarketing.portlets.htmlpageasset.business.render.ContainerRaw;
 import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.personas.business.PersonaAPI;
 import com.dotmarketing.portlets.personas.model.IPersona;
 import com.dotmarketing.portlets.personas.model.Persona;
@@ -403,7 +405,7 @@ public class PageRenderUtil implements Serializable {
         try {
 
             final Contentlet contentlet = contentletAPI.findContentletByIdentifier
-                    (personalizedContentlet.getContentletId(), mode.showLive, languageId, user, mode.respectAnonPerms);
+                    (personalizedContentlet.getContentletId(), mode.showLive, this.resolveLanguageId(), user, mode.respectAnonPerms);
 
             return contentlet;
         } catch (final DotContentletStateException e) {
@@ -412,6 +414,22 @@ public class PageRenderUtil implements Serializable {
         } catch (Exception e) {
             throw new DotStateException(e);
         }
+    }
+
+    private long resolveLanguageId () {
+
+        final HttpServletRequest request = HttpServletRequestThreadLocal.INSTANCE.getRequest();
+        if (null != request) {
+
+            final Language currentLanguage =
+                    WebAPILocator.getLanguageWebAPI().getLanguage(request);
+            if (null != currentLanguage) {
+
+                return currentLanguage.getId();
+            }
+        }
+
+        return this.languageId;
     }
 
     private Contentlet getContentletOrFallback(final PersonalizedContentlet personalizedContentlet) {

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -446,7 +446,7 @@ public class PageRenderUtil implements Serializable {
 
     private Contentlet getContentlet(final PersonalizedContentlet personalizedContentlet) {
 
-        return (Config.getBooleanProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", false)) ?
+        return Config.getBooleanProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", false)?
                 getContentletOrFallback(personalizedContentlet) : getSpecificContentlet(personalizedContentlet);
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -289,7 +289,7 @@ public class PageRenderUtil implements Serializable {
                         continue;
                     }
 
-                    if (container.getMaxContentlets() < contentletIncludedCount++) {
+                    if (container.getMaxContentlets() < contentletIncludedCount) {
 
                         Logger.debug(this, ()-> "Contentlet: "          + contentlet.getIdentifier()
                                 + ", has been skipped. Max contentlet: "    + container.getMaxContentlets()
@@ -319,6 +319,7 @@ public class PageRenderUtil implements Serializable {
 
                         contentPrintableMap.put("contentType", contentlet.getContentType().variable());
                         personalizedContentletMap.add(contentPrintableMap);
+                        contentletIncludedCount++;
                     }
                 }
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -70,10 +70,10 @@ public class PageRenderUtil implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final PermissionAPI permissionAPI = APILocator.getPermissionAPI();
-    private final MultiTreeAPI  multiTreeAPI  = APILocator.getMultiTreeAPI();
+    private final MultiTreeAPI multiTreeAPI = APILocator.getMultiTreeAPI();
     private final ContentletAPI contentletAPI = APILocator.getContentletAPI();
-    private final TagAPI        tagAPI        = APILocator.getTagAPI();
-    private final PersonaAPI    personaAPI    = APILocator.getPersonaAPI();
+    private final TagAPI tagAPI = APILocator.getTagAPI();
+    private final PersonaAPI personaAPI = APILocator.getPersonaAPI();
 
     final IHTMLPage htmlPage;
     final User user;
@@ -105,7 +105,7 @@ public class PageRenderUtil implements Serializable {
         this.htmlPage = htmlPage;
         this.user = user;
         this.mode = mode;
-        this.languageId=languageId;
+        this.languageId = languageId;
         this.widgetPreExecute = new StringBuilder();
         final Template template = APILocator.getHTMLPageAssetAPI().getTemplate(htmlPage, !mode.showLive);
         this.templateLayout = template != null && template.isDrawed() ? DotTemplateTool.themeLayout(template.getInode()) : null;
@@ -115,7 +115,7 @@ public class PageRenderUtil implements Serializable {
 
     public PageRenderUtil(final HTMLPageAsset htmlPage, final User user, final PageMode mode)
             throws DotSecurityException, DotDataException {
-        this(htmlPage,user, mode, htmlPage.getLanguageId(), APILocator.getHostAPI().find(htmlPage.getHost(), user, false));
+        this(htmlPage, user, mode, htmlPage.getLanguageId(), APILocator.getHostAPI().find(htmlPage.getHost(), user, false));
     }
 
     private Map<String, Object> populateContext() throws DotDataException, DotSecurityException {
@@ -193,13 +193,13 @@ public class PageRenderUtil implements Serializable {
         return ctxMap;
     }
 
-    private Container getLiveContainerById (final String containerId) throws DotSecurityException, DotDataException {
+    private Container getLiveContainerById(final String containerId) throws DotSecurityException, DotDataException {
 
         final LiveContainerFinderByIdOrPathStrategyResolver strategyResolver =
                 LiveContainerFinderByIdOrPathStrategyResolver.getInstance();
         final Optional<ContainerFinderByIdOrPathStrategy> strategy = strategyResolver.get(containerId);
-        final ContainerFinderByIdOrPathStrategy liveStrategy    = strategy.isPresent()?strategy.get():strategyResolver.getDefaultStrategy();
-        final Supplier<Host>                  resourceHostSupplier = ()-> this.site;
+        final ContainerFinderByIdOrPathStrategy liveStrategy = strategy.isPresent() ? strategy.get() : strategyResolver.getDefaultStrategy();
+        final Supplier<Host> resourceHostSupplier = () -> this.site;
 
 
         Container container = null;
@@ -219,7 +219,7 @@ public class PageRenderUtil implements Serializable {
 
         final LiveContainerFinderByIdOrPathStrategyResolver strategyResolver =
                 LiveContainerFinderByIdOrPathStrategyResolver.getInstance();
-        final Optional<ContainerFinderByIdOrPathStrategy> strategy           = strategyResolver.get(containerIdOrPath);
+        final Optional<ContainerFinderByIdOrPathStrategy> strategy = strategyResolver.get(containerIdOrPath);
 
         return this.geContainerById(containerIdOrPath, user, template, strategy, strategyResolver.getDefaultStrategy());
     }
@@ -228,19 +228,19 @@ public class PageRenderUtil implements Serializable {
 
         final WorkingContainerFinderByIdOrPathStrategyResolver strategyResolver =
                 WorkingContainerFinderByIdOrPathStrategyResolver.getInstance();
-        final Optional<ContainerFinderByIdOrPathStrategy> strategy           = strategyResolver.get(containerIdOrPath);
+        final Optional<ContainerFinderByIdOrPathStrategy> strategy = strategyResolver.get(containerIdOrPath);
 
         return this.geContainerById(containerIdOrPath, user, template, strategy, strategyResolver.getDefaultStrategy());
     }
 
     private Container geContainerById(final String containerIdOrPath, final User user, final Template template,
                                       final Optional<ContainerFinderByIdOrPathStrategy> strategy,
-                                      final ContainerFinderByIdOrPathStrategy defaultContainerFinderByIdOrPathStrategy) throws NotFoundInDbException  {
+                                      final ContainerFinderByIdOrPathStrategy defaultContainerFinderByIdOrPathStrategy) throws NotFoundInDbException {
 
-        final Supplier<Host> resourceHostSupplier                            =  Sneaky.sneaked(()->APILocator.getTemplateAPI().getTemplateHost(template));
+        final Supplier<Host> resourceHostSupplier = Sneaky.sneaked(() -> APILocator.getTemplateAPI().getTemplateHost(template));
 
-        return strategy.isPresent()?
-                strategy.get().apply(containerIdOrPath, user, false, resourceHostSupplier):
+        return strategy.isPresent() ?
+                strategy.get().apply(containerIdOrPath, user, false, resourceHostSupplier) :
                 defaultContainerFinderByIdOrPathStrategy.apply(containerIdOrPath, user, false, resourceHostSupplier);
     }
 
@@ -262,8 +262,8 @@ public class PageRenderUtil implements Serializable {
             final WorkingContainerFinderByIdOrPathStrategyResolver strategyResolver =
                     WorkingContainerFinderByIdOrPathStrategyResolver.getInstance();
             final Optional<ContainerFinderByIdOrPathStrategy> strategy = strategyResolver.get(containerId);
-            final ContainerFinderByIdOrPathStrategy workingStrategy    = strategy.isPresent()?strategy.get():strategyResolver.getDefaultStrategy();
-            final Supplier<Host>                  resourceHostSupplier = ()-> this.site;
+            final ContainerFinderByIdOrPathStrategy workingStrategy = strategy.isPresent() ? strategy.get() : strategyResolver.getDefaultStrategy();
+            final Supplier<Host> resourceHostSupplier = () -> this.site;
 
             try {
                 if (live) {
@@ -284,7 +284,7 @@ public class PageRenderUtil implements Serializable {
             if (container == null) {
                 continue;
             }
-            
+
             final List<ContainerStructure> containerStructures = APILocator.getContainerAPI().getContainerStructures(container);
             final boolean hasWritePermissionOnContainer = permissionAPI.doesUserHavePermission(container, PERMISSION_WRITE, user, false)
                     && APILocator.getPortletAPI().hasContainerManagerRights(user);
@@ -296,22 +296,22 @@ public class PageRenderUtil implements Serializable {
                 contextMap.put("USE_CONTAINER_PERMISSION" + container.getIdentifier(), hasReadPermissionOnContainer);
             }
 
-            final Map<String, List<Map<String,Object>>> contentMaps = Maps.newLinkedHashMap();
+            final Map<String, List<Map<String, Object>>> contentMaps = Maps.newLinkedHashMap();
             final Map<String, List<String>> containerUuidPersona = Maps.newHashMap();
             for (final String uniqueId : pageContents.row(containerId).keySet()) {
 
                 final String uniqueUUIDForRender = needParseContainerPrefix(container, uniqueId) ?
-                                ParseContainer.getDotParserContainerUUID(uniqueId) :
-                                uniqueId;
+                        ParseContainer.getDotParserContainerUUID(uniqueId) :
+                        uniqueId;
 
-                if(ContainerUUID.UUID_DEFAULT_VALUE.equals(uniqueId)) {
+                if (ContainerUUID.UUID_DEFAULT_VALUE.equals(uniqueId)) {
                     continue;
                 }
 
                 final Collection<PersonalizedContentlet> personalizedContentletSet = pageContents.get(containerId, uniqueId);
                 final List<Map<String, Object>> personalizedContentletMap = Lists.newArrayList();
 
-                for (final PersonalizedContentlet  personalizedContentlet : personalizedContentletSet) {
+                for (final PersonalizedContentlet personalizedContentlet : personalizedContentletSet) {
                     final Contentlet contentlet = getContentlet(personalizedContentlet);
 
                     if (contentlet == null) {
@@ -319,10 +319,10 @@ public class PageRenderUtil implements Serializable {
                     }
 
                     containerUuidPersona
-                        .computeIfAbsent(containerId + uniqueUUIDForRender + personalizedContentlet.getPersonalization(), k-> Lists.newArrayList())
-                        .add(personalizedContentlet.getContentletId());
+                            .computeIfAbsent(containerId + uniqueUUIDForRender + personalizedContentlet.getPersonalization(), k -> Lists.newArrayList())
+                            .add(personalizedContentlet.getContentletId());
                     contextMap.put("EDIT_CONTENT_PERMISSION" + contentlet.getIdentifier(),
-                                    permissionAPI.doesUserHavePermission(contentlet, PERMISSION_WRITE, user));
+                            permissionAPI.doesUserHavePermission(contentlet, PERMISSION_WRITE, user));
 
                     final ContentType type = contentlet.getContentType();
                     if (type.baseType() == BaseContentType.WIDGET) {
@@ -342,10 +342,10 @@ public class PageRenderUtil implements Serializable {
                             this.pageFoundTags.addAll(contentletFoundTags);
                         }
                     }
-                    
-                    if(personalizedContentlet.getPersonalization().equals(includeContentFor)) {
-                        final Map<String,Object> contentPrintableMap = Try.of(()-> ContentletUtil.getContentPrintableMap(user, contentlet)).onFailure(f-> Logger.warn(this.getClass(), f.getMessage())).getOrNull();
-                        if(contentPrintableMap==null)continue;
+
+                    if (personalizedContentlet.getPersonalization().equals(includeContentFor)) {
+                        final Map<String, Object> contentPrintableMap = Try.of(() -> ContentletUtil.getContentPrintableMap(user, contentlet)).onFailure(f -> Logger.warn(this.getClass(), f.getMessage())).getOrNull();
+                        if (contentPrintableMap == null) continue;
                         contentPrintableMap.put("contentType", contentlet.getContentType().variable());
                         personalizedContentletMap.add(contentPrintableMap);
                     }
@@ -353,15 +353,15 @@ public class PageRenderUtil implements Serializable {
 
                 contentMaps.put(CONTAINER_UUID_PREFIX + uniqueUUIDForRender, personalizedContentletMap);
             }
-            for(Map.Entry<String,List<String>> entry : containerUuidPersona.entrySet()) {
+            for (Map.Entry<String, List<String>> entry : containerUuidPersona.entrySet()) {
                 contextMap.put("contentletList" + entry.getKey(), entry.getValue());
-                contextMap.put("totalSize"  + entry.getKey(), entry.getValue().size());
+                contextMap.put("totalSize" + entry.getKey(), entry.getValue().size());
             }
-            
+
 
             raws.add(new ContainerRaw(container, containerStructures, contentMaps));
         }
-        
+
         return raws;
     }
 
@@ -375,7 +375,7 @@ public class PageRenderUtil implements Serializable {
         }
 
         return !ParseContainer.isParserContainerUUID(uniqueId) &&
-                    (templateLayout == null || !templateLayout.existsContainer(containerIdOrPath, uniqueId));
+                (templateLayout == null || !templateLayout.existsContainer(containerIdOrPath, uniqueId));
     }
 
     /**
@@ -387,21 +387,23 @@ public class PageRenderUtil implements Serializable {
      * @throws DotSecurityException
      * @throws DotDataException
      */
-    private String getRelativePathFromSite(final FileAssetContainer container)  {
+    private String getRelativePathFromSite(final FileAssetContainer container) {
         return this.site.getIdentifier().equals(container.getHost().getIdentifier()) ?
                 container.getPath() :
                 FileAssetContainerUtil.getInstance().getFullPath(container);
     }
 
-    @Nullable
     private Contentlet getContentlet(final PersonalizedContentlet personalizedContentlet) {
+
+        return (Config.getBooleanProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", false)) ?
+                getContentletOrFallback(personalizedContentlet) : getSpecificContentlet(personalizedContentlet);
+    }
+
+    private Contentlet getSpecificContentlet(final PersonalizedContentlet personalizedContentlet) {
         try {
 
-           final Optional<Contentlet> contentletOpt = contentletAPI.findContentletByIdentifierOrFallback
+            final Contentlet contentlet = contentletAPI.findContentletByIdentifier
                     (personalizedContentlet.getContentletId(), mode.showLive, languageId, user, mode.respectAnonPerms);
-
-            final Contentlet contentlet =  contentletOpt.isPresent()
-                    ? contentletOpt.get() : contentletAPI.findContentletByIdentifierAnyLanguage(personalizedContentlet.getContentletId());
 
             return contentlet;
         } catch (final DotContentletStateException e) {
@@ -412,6 +414,23 @@ public class PageRenderUtil implements Serializable {
         }
     }
 
+    private Contentlet getContentletOrFallback(final PersonalizedContentlet personalizedContentlet) {
+        try {
+
+            final Optional<Contentlet> contentletOpt = contentletAPI.findContentletByIdentifierOrFallback
+                    (personalizedContentlet.getContentletId(), mode.showLive, languageId, user, mode.respectAnonPerms);
+
+            final Contentlet contentlet = contentletOpt.isPresent()
+                    ? contentletOpt.get() : contentletAPI.findContentletByIdentifierAnyLanguage(personalizedContentlet.getContentletId());
+
+            return contentlet;
+        } catch (final DotContentletStateException e) {
+            // Expected behavior, DotContentletState Exception is used for flow control
+            return null;
+        } catch (Exception e) {
+            throw new DotStateException(e);
+        }
+    }
 
 
     public List<Tag> getPageFoundTags() {
@@ -452,6 +471,7 @@ public class PageRenderUtil implements Serializable {
 
     /**
      * Return the Page's {@link ContainerRaw}
+     *
      * @return
      */
     public List<ContainerRaw> getContainersRaw() {
@@ -466,7 +486,7 @@ public class PageRenderUtil implements Serializable {
             iPersona = visitor.isPresent() && visitor.get().getPersona() != null ? visitor.get().getPersona() : null;
         }
 
-        final String currentPersonaTag =  iPersona == null ? MultiTree.DOT_PERSONALIZATION_DEFAULT
+        final String currentPersonaTag = iPersona == null ? MultiTree.DOT_PERSONALIZATION_DEFAULT
                 : Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON + iPersona.getKeyTag();
 
         final boolean hasPersonalizations = personalizationsForPage.contains(currentPersonaTag);

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/ContainerWebAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/ContainerWebAPI.java
@@ -6,6 +6,7 @@ import java.util.*;
 import javax.servlet.http.HttpServletRequest;
 
 import com.dotmarketing.portlets.templates.design.bean.ContainerUUID;
+import com.dotmarketing.util.PageMode;
 import org.apache.velocity.context.Context;
 import org.apache.velocity.tools.view.context.ViewContext;
 import org.apache.velocity.tools.view.tools.ViewTool;
@@ -116,6 +117,7 @@ public class ContainerWebAPI implements ViewTool {
                         : ImmutableSet.of(MultiTree.DOT_PERSONALIZATION_DEFAULT);
 
         String pTag = WebAPILocator.getPersonalizationWebAPI().getContainerPersonalization(request);
+        final PageMode pageMode = PageMode.get(request);
 
         pTag = (!availablePersonalizations.contains(pTag)) ? MultiTree.DOT_PERSONALIZATION_DEFAULT : pTag;
 
@@ -123,19 +125,19 @@ public class ContainerWebAPI implements ViewTool {
 		if (ContainerUUID.UUID_LEGACY_VALUE.equals(uuid)) {
 			contentlets.addAll(
 					Optional.ofNullable(
-								getContentsIdByUUID(containerId, pTag, ContainerUUID.UUID_START_VALUE)
+								getContentsIdByUUID(containerId, pTag, ContainerUUID.UUID_START_VALUE, pageMode)
 							).orElse(Collections.EMPTY_LIST)
 			);
 
 			contentlets.addAll(
 					Optional.ofNullable(
-							getContentsIdByUUID(containerId, pTag, ContainerUUID.UUID_LEGACY_VALUE)
+							getContentsIdByUUID(containerId, pTag, ContainerUUID.UUID_LEGACY_VALUE, pageMode)
 					).orElse(Collections.EMPTY_LIST)
 			);
 		} else {
 			contentlets.addAll(
 					Optional.ofNullable(
-							getContentsIdByUUID(containerId, pTag, uuid)
+							getContentsIdByUUID(containerId, pTag, uuid, pageMode)
 					).orElse(Collections.EMPTY_LIST));
 		}
 
@@ -151,12 +153,16 @@ public class ContainerWebAPI implements ViewTool {
         return new ArrayList<>();
     }
 
-	@Nullable
-	private List<String> getContentsIdByUUID(String containerId, String pTag, String uuid) {
-		// if live mode, the content list will not have a colon in the key- as it was a velocity variable
-		List<String> contentlets = (List<String>) ctx.get("contentletList" + containerId + uuid + pTag.replace(":", ""));
-		if(contentlets !=null ) {
-			return contentlets;
+	private List<String> getContentsIdByUUID(final String containerId, final String pTag, final String uuid, final PageMode pageMode) {
+
+		List<String> contentlets = null;
+
+		if (pageMode != PageMode.EDIT_MODE && pageMode != PageMode.PREVIEW_MODE) {
+			// if live mode, the content list will not have a colon in the key- as it was a velocity variable
+			contentlets = (List<String>) ctx.get("contentletList" + containerId + uuid + pTag.replace(":", ""));
+			if (contentlets != null) {
+				return contentlets;
+			}
 		}
 
 		// if edit or preview mode, the content list WILL have a colon in the key, as this is

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -13,6 +13,7 @@ import com.dotcms.rest.api.v1.personalization.PersonalizationPersonaPageViewPagi
 import com.dotcms.util.PaginationUtil;
 import com.dotcms.util.pagination.OrderDirection;
 import com.dotmarketing.business.web.WebAPILocator;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.collect.ImmutableMap;
 import com.liferay.portal.PortalException;
@@ -417,7 +418,9 @@ public class PageResource {
             final IHTMLPage page = pageResourceHelper.getPage(user, pageId, request);
 
             APILocator.getPermissionAPI().checkPermission(page, PermissionLevel.EDIT, user);
-            pageResourceHelper.saveContent(pageId, pageContainerForm.getContainerEntries());
+
+            final Language language = WebAPILocator.getLanguageWebAPI().getLanguage(request);
+            pageResourceHelper.saveContent(pageId, pageContainerForm.getContainerEntries(), language);
 
             return Response.ok(new ResponseEntityView("ok")).build();
         } catch(HTMLPageAssetNotFoundException e) {

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -97,7 +97,9 @@ public class PageResourceHelper implements Serializable {
 
 
     @WrapInTransaction
-    public void saveContent(final String pageId, final List<PageContainerForm.ContainerEntry> containerEntries) throws DotDataException {
+    public void saveContent(final String pageId,
+                            final List<PageContainerForm.ContainerEntry> containerEntries,
+                            final Language language) throws DotDataException {
 
         final Map<String, List<MultiTree>> multiTreesMap = new HashMap<>();
         for (final PageContainerForm.ContainerEntry containerEntry : containerEntries) {
@@ -129,7 +131,7 @@ public class PageResourceHelper implements Serializable {
         for (final String personalization : multiTreesMap.keySet()) {
 
             multiTreeAPI.overridesMultitreesByPersonalization(pageId, personalization,
-                    multiTreesMap.get(personalization));
+                    multiTreesMap.get(personalization), Optional.ofNullable(language.getId()));
         }
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPI.java
@@ -9,6 +9,7 @@ import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
 import com.google.common.collect.Table;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -360,6 +361,22 @@ public interface MultiTreeAPI {
      * @throws DotDataException
      */
     void overridesMultitreesByPersonalization(String pageId, String personalization, List<MultiTree> multiTrees)  throws DotDataException ;
+
+    /**
+     * Save a collection of {@link MultiTree} and link them with a page, Also delete all the
+     * {@link MultiTree} linked previously with the page.
+     *
+     * @param pageId {@link String} Page's identifier
+     * @param personalization {@link String} personalization token
+     * @param multiTrees {@link List} of {@link MultiTree} to safe
+     * @param languageIdOpt {@link Optional} {@link Long}  optional language, if present will deletes only the contentlets that have a version on this language.
+     *                                      Since it is by identifier, when deleting for instance in spanish, will remove the english and any other lang version too.
+     * @throws DotDataException
+     */
+    void overridesMultitreesByPersonalization(final String pageId,
+                                                     final String personalization,
+                                                     final List<MultiTree> multiTrees,
+                                                     final Optional<Long> languageIdOpt) throws DotDataException;
 
     /**
      * Updates the current personalization to a new personalization

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -78,6 +78,9 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
     private static final String DELETE_SQL_PERSONALIZATION_PER_PAGE = "delete from multi_tree where parent1=? and personalization = ?";
     private static final String DELETE_ALL_MULTI_TREE_SQL = "delete from multi_tree where parent1=? AND relation_type != ?";
     private static final String DELETE_ALL_MULTI_TREE_SQL_BY_RELATION_AND_PERSONALIZATION = "delete from multi_tree where parent1=? AND relation_type != ? and personalization = ?";
+    private static final String DELETE_ALL_MULTI_TREE_SQL_BY_RELATION_AND_PERSONALIZATION_PER_LANGUAGE =
+            "delete from multi_tree where relation_type != ? and personalization = ? and " +
+                    "child in (select distinct identifier from contentlet where identifier in (select child from multi_tree where parent1 = ?) and language_id = ?)";
     private static final String UPDATE_MULTI_TREE_PERSONALIZATION = "update multi_tree set personalization = ? where personalization = ?";
     private static final String SELECT_SQL = "select * from multi_tree where parent1 = ? and parent2 = ? and child = ? and  relation_type = ? and personalization = ?";
 
@@ -510,8 +513,30 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
     @Override
     @WrapInTransaction
     public void overridesMultitreesByPersonalization(final String pageId,
+                                                     final String personalization,
+                                                     final List<MultiTree> multiTrees) throws DotDataException {
+
+        this.overridesMultitreesByPersonalization(pageId, personalization, multiTrees,
+                Optional.empty());  // no lang passed, will deletes everything
+    }
+
+    /**
+     * Save a collection of {@link MultiTree} and link them with a page, Also delete all the
+     * {@link MultiTree} linked previously with the page.
+     *
+     * @param pageId {@link String} Page's identifier
+     * @param personalization {@link String} personalization token
+     * @param multiTrees {@link List} of {@link MultiTree} to safe
+     * @param languageIdOpt {@link Optional} {@link Long}   optional language, if present will deletes only the contentlets that have a version on this language.
+     *                                        Since it is by identifier, when deleting for instance in spanish, will remove the english and any other lang version too.
+     * @throws DotDataException
+     */
+    @Override
+    @WrapInTransaction
+    public void overridesMultitreesByPersonalization(final String pageId,
                                                     final String personalization,
-                                                    final List<MultiTree> multiTrees) throws DotDataException {
+                                                    final List<MultiTree> multiTrees,
+                                                     final Optional<Long> languageIdOpt) throws DotDataException {
 
         Logger.info(this, String.format(
                 "Overriding MutiTrees: pageId -> %s personalization -> %s multiTrees-> %s ",
@@ -525,10 +550,20 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
         Logger.debug(MultiTreeAPIImpl.class, ()->String.format("Saving page's content: %s", multiTrees));
 
         final DotConnect db = new DotConnect();
-        db.setSQL(DELETE_ALL_MULTI_TREE_SQL_BY_RELATION_AND_PERSONALIZATION)
-                .addParam(pageId)
-                .addParam(ContainerUUID.UUID_DEFAULT_VALUE)
-                .addParam(personalization).loadResult();
+        if (languageIdOpt.isPresent()) {
+            db.setSQL(DELETE_ALL_MULTI_TREE_SQL_BY_RELATION_AND_PERSONALIZATION_PER_LANGUAGE)
+                    .addParam(ContainerUUID.UUID_DEFAULT_VALUE)
+                    .addParam(personalization)
+                    .addParam(pageId)
+                    .addParam(languageIdOpt.get())
+                    .loadResult();
+        } else {
+
+            db.setSQL(DELETE_ALL_MULTI_TREE_SQL_BY_RELATION_AND_PERSONALIZATION)
+                    .addParam(pageId)
+                    .addParam(ContainerUUID.UUID_DEFAULT_VALUE)
+                    .addParam(personalization).loadResult();
+        }
 
         if (!multiTrees.isEmpty()) {
 
@@ -800,7 +835,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
                         ? pageContents.get(containerId, multiTree.getRelationType())
                         : new LinkedHashSet<>();
                 long byPersonaCount  = myContents.stream().filter(p->p.getPersonalization().equals(personalization)).count();
-                if (container != null && byPersonaCount < container.getMaxContentlets()) {
+                if (container != null && byPersonaCount < container.getMaxContentlets()) { // todo: we have to move this validation to another place
 
                     myContents.add(new PersonalizedContentlet(multiTree.getContentlet(), personalization));
                 }

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -834,8 +834,8 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
                 final Set<PersonalizedContentlet> myContents = pageContents.contains(containerId, multiTree.getRelationType())
                         ? pageContents.get(containerId, multiTree.getRelationType())
                         : new LinkedHashSet<>();
-                long byPersonaCount  = myContents.stream().filter(p->p.getPersonalization().equals(personalization)).count();
-                if (container != null && byPersonaCount < container.getMaxContentlets()) { // todo: we have to move this validation to another place
+                
+                if (container != null) {
 
                     myContents.add(new PersonalizedContentlet(multiTree.getContentlet(), personalization));
                 }

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -834,7 +834,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
                 final Set<PersonalizedContentlet> myContents = pageContents.contains(containerId, multiTree.getRelationType())
                         ? pageContents.get(containerId, multiTree.getRelationType())
                         : new LinkedHashSet<>();
-                
+
                 if (container != null) {
 
                     myContents.add(new PersonalizedContentlet(multiTree.getContentlet(), personalization));


### PR DESCRIPTION
Previously the content recovered on the page render was not taking the language id.
Now it is just recovering by language id, set. However DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE can. be activate in order to have a mix of languages.
By default spanish version of the page (for instance) only shows spanish content