### PR TITLE
#18229 Setting TrustSelfSignedStrategy to avoid validating ssl certificates by default

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/DotRestHighLevelClientProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/DotRestHighLevelClientProvider.java
@@ -116,9 +116,15 @@ public class DotRestHighLevelClientProvider extends RestHighLevelClientProvider 
     private RestClientBuilder getClientBuilder(final BasicCredentialsProvider credentialsProvider) {
         final String esAuthType = getESAuthType();
         final String esProtocol = Config.getStringProperty("ES_PROTOCOL", HTTPS_PROTOCOL);
-
-        Logger.info(this.getClass(),
-                "Initializing Elastic RestHighLevelClient using protocol " + esProtocol);
+        final boolean securedConnection = HTTPS_PROTOCOL.equals(esProtocol);
+        if (securedConnection){
+            Logger.info(this.getClass(),
+                    "Initializing Elastic RestHighLevelClient using a secured https connection");
+        } else{
+            Logger.warn(this.getClass(),
+                    "Initializing Elastic RestHighLevelClient using an insecured http connection");
+        }
+        
 
         final RestClientBuilder clientBuilder = RestClient
                 .builder(new HttpHost(Config.getStringProperty("ES_HOSTNAME", "127.0.0.1"),
@@ -126,7 +132,7 @@ public class DotRestHighLevelClientProvider extends RestHighLevelClientProvider 
                 .setHttpClientConfigCallback((httpClientBuilder) -> {
                     if (sslContextFromPem != null) {
                         httpClientBuilder.setSSLContext(sslContextFromPem);
-                    } else if (HTTPS_PROTOCOL.equals(esProtocol)){
+                    } else if (securedConnection){
                         try {
                             httpClientBuilder.setSSLContext(SSLContexts
                                     .custom().loadTrustMaterial(new TrustSelfSignedStrategy()).build());

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/DotRestHighLevelClientProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/DotRestHighLevelClientProvider.java
@@ -110,7 +110,8 @@ public class DotRestHighLevelClientProvider extends RestHighLevelClientProvider 
 
     private RestClientBuilder getClientBuilder(final BasicCredentialsProvider credentialsProvider) {
         final String esAuthType = getESAuthType();
-        final String esProtocol = Config.getStringProperty("ES_PROTOCOL", "https");
+        final String httpsProtocol = "https";
+        final String esProtocol = Config.getStringProperty("ES_PROTOCOL", httpsProtocol);
         final RestClientBuilder clientBuilder = RestClient
                 .builder(new HttpHost(Config.getStringProperty("ES_HOSTNAME", "127.0.0.1"),
                         Config.getIntProperty("ES_PORT", 9200), esProtocol))
@@ -118,7 +119,7 @@ public class DotRestHighLevelClientProvider extends RestHighLevelClientProvider 
                     if (sslContextFromPem != null) {
                         httpClientBuilder
                                 .setSSLContext(sslContextFromPem);
-                    } else if ("https".equals(esProtocol)){
+                    } else if (httpsProtocol.equals(esProtocol)){
                         try {
                             httpClientBuilder.setSSLContext(SSLContexts
                                     .custom().loadTrustMaterial(new TrustSelfSignedStrategy()).build());

--- a/dotCMS/src/main/resources/dotcms-config-cluster.properties
+++ b/dotCMS/src/main/resources/dotcms-config-cluster.properties
@@ -107,7 +107,7 @@ ES_AUTH_BASIC_USER=admin
 ES_AUTH_BASIC_PASSWORD=admin
 
 #Enable TLS for ES rest api layer. If ES_TLS_ENABLED=true, certificates must be specified (ES_AUTH_TLS_CLIENT_CERT, ES_AUTH_TLS_CLIENT_KEY, ES_AUTH_TLS_CA_CERT)
-ES_TLS_ENABLED=true
+ES_TLS_ENABLED=false
 #Path relative to assets folder
 ES_AUTH_TLS_CLIENT_CERT=certs/elasticsearch.pem
 ES_AUTH_TLS_CLIENT_KEY=certs/elasticsearch.key


### PR DESCRIPTION
With this change, we don't validate tls certificates. It is equivalent to using the `--insecure` flag when running from curl