### PR TITLE
Issue 18210

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavToolTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavToolTest.java
@@ -441,4 +441,36 @@ public class NavToolTest extends IntegrationTestBase{
 
     }
 
+    /**
+     * Method to test: NavTool.getNav
+     * Given scenario: get navigation for system folder ("/")
+     * Expected result: getting the navigation should not change system folder's hostId
+     * @throws Exception exception
+     */
+
+    @Test
+    public void testNavTool_getNav_SystemFolder_ShouldNotChangeSystemFolderHostId() throws Exception
+    {
+        //Get SystemFolder
+        Folder systemFolder = APILocator.getFolderAPI().findSystemFolder();
+
+        //Create new Host
+        final Host host = new SiteDataGen().nextPersisted();
+
+        //Create contentlets on one host
+        final File file = File.createTempFile("fileTestEngTrue", ".txt");
+        FileUtil.write(file, "helloworld");
+        final Contentlet fileAssetOneHost = new FileAssetDataGen(systemFolder, file)
+                .host(host).setProperty(FileAssetAPI.SHOW_ON_MENU, "true").nextPersisted();
+        final Template template = new TemplateDataGen().nextPersisted();
+        final Contentlet pageAssetOneHost = new HTMLPageDataGen(systemFolder, template)
+                .showOnMenu(true).host(host).nextPersisted();
+        ContentletDataGen.publish(pageAssetOneHost);
+        ContentletDataGen.publish(fileAssetOneHost);
+
+        new NavTool().getNav(host, systemFolder.getPath());
+        systemFolder = APILocator.getFolderAPI().findSystemFolder();
+        assertEquals(Host.SYSTEM_HOST, systemFolder.getHostId());
+    }
+
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavToolTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavToolTest.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.beanutils.BeanUtils;
 import org.apache.velocity.tools.view.context.ViewContext;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -204,8 +205,15 @@ public class NavToolTest extends IntegrationTestBase{
                     .getNav(site, systemFolder.getPath(), 1, user);
             assertNotNull(navResult);
 
+            /* method below `findShowOnMenuUnderFolder` expects a mutated version of SYSTEM_FOLDER with the hostId altered.
+               So let's create a defensive copy of the SYSTEM_FOLDER, modify it and pass it to the method.
+            */
+            Folder modifiedSystemFolder = new Folder();
+            BeanUtils.copyProperties(modifiedSystemFolder, systemFolder);
+            modifiedSystemFolder.setHostId(site.getIdentifier());
+
             //Find out how many show on menu items we currently have
-            final int currentShowOnMenuItems = findShowOnMenuUnderFolder(systemFolder, user);
+            final int currentShowOnMenuItems = findShowOnMenuUnderFolder(modifiedSystemFolder, user);
 
             assertNotNull(navResult.getChildren());
             assertEquals(currentShowOnMenuItems,navResult.getChildren().size());

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavTool.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavTool.java
@@ -88,7 +88,6 @@ public class NavTool implements ViewTool {
             return null;
         }
 
-        // make a defensive copy to avoid mutating cached version
         Folder folder = getDefensiveCopyOfFolder(originalFolder);
 
         NavResult result = CacheLocator.getNavToolCache()
@@ -222,6 +221,11 @@ public class NavTool implements ViewTool {
         }
     }
 
+    /**
+     * Makes a defensive copy of the given folder to avoid mutating cached version
+     * @param originalFolder folder to make the defensive copy from
+     * @return defensive copy
+     */
     private Folder getDefensiveCopyOfFolder(Folder originalFolder) {
         Folder folder = new Folder();
         try {

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavTool.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavTool.java
@@ -89,13 +89,7 @@ public class NavTool implements ViewTool {
         }
 
         // make a defensive copy to avoid mutating cached version
-        Folder folder = new Folder();
-        try {
-            BeanUtils.copyProperties(folder, originalFolder);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            folder = originalFolder;
-            Logger.warnAndDebug(NavTool.class,"Defensive copy failed. Using original object", e);
-        }
+        Folder folder = getDefensiveCopyOfFolder(originalFolder);
 
         NavResult result = CacheLocator.getNavToolCache()
             .getNav(host.getIdentifier(), folder.getInode(), languageId);
@@ -226,6 +220,17 @@ public class NavTool implements ViewTool {
 
             return new NavResultHydrated(result, this.context);
         }
+    }
+
+    private Folder getDefensiveCopyOfFolder(Folder originalFolder) {
+        Folder folder = new Folder();
+        try {
+            BeanUtils.copyProperties(folder, originalFolder);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            folder = originalFolder;
+            Logger.warnAndDebug(NavTool.class,"Defensive copy failed. Using original object", e);
+        }
+        return folder;
     }
 
     private void addFolderToNav(Host host, long languageId, Folder folder, List<NavResult> children,

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
@@ -578,10 +578,8 @@ public class ContentletWebAPIImpl implements ContentletWebAPI {
 			if (parentFolder != null
 					&& InodeUtils.isSet(parentFolder.getInode())) {
 
-				final String hostIdentifier = parentFolder.getInode().equals(SYSTEM_FOLDER) ?
-						contentPage.getHost() : parentFolder.getHostId();
-
-				Host host = hostAPI.find(hostIdentifier, systemUser, true);
+				Host host = hostAPI.find(parentFolder.getHostId(), systemUser,
+						true);
 
 				String parentFolderPath = parentFolder.getPath();
 				if (UtilMethods.isSet(parentFolderPath)) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
@@ -57,6 +57,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static com.dotmarketing.portlets.contentlet.util.ActionletUtil.hasPushPublishActionlet;
+import static com.dotmarketing.portlets.folders.business.FolderAPI.SYSTEM_FOLDER;
 import static com.dotmarketing.portlets.workflows.actionlet.PushPublishActionlet.WHERE_TO_SEND;
 import static com.dotmarketing.portlets.workflows.actionlet.PushPublishActionlet.getEnvironmentsToSendTo;
 
@@ -404,7 +405,7 @@ public class ContentletWebAPIImpl implements ContentletWebAPI {
 					throw new DotSecurityException("User has no Add Children Permissions on selected host");
 				}
 				currentContentlet.setHost(hostId);
-				currentContentlet.setFolder(FolderAPI.SYSTEM_FOLDER);
+				currentContentlet.setFolder(SYSTEM_FOLDER);
 			}
 
 			if("folderInode".equalsIgnoreCase(elementName) &&
@@ -576,8 +577,12 @@ public class ContentletWebAPIImpl implements ContentletWebAPI {
 					false);
 			if (parentFolder != null
 					&& InodeUtils.isSet(parentFolder.getInode())) {
-				Host host = hostAPI.find(parentFolder.getHostId(), systemUser,
-						true);
+
+				final String hostIdentifier = parentFolder.getInode().equals(SYSTEM_FOLDER) ?
+						contentPage.getHost() : parentFolder.getHostId();
+
+				Host host = hostAPI.find(hostIdentifier, systemUser, true);
+
 				String parentFolderPath = parentFolder.getPath();
 				if (UtilMethods.isSet(parentFolderPath)) {
 					if (!parentFolderPath.startsWith("/")) {


### PR DESCRIPTION
The code in `NavTool.getNav`method was modifying the cache-stored copy of the SYSTEM_FOLDER, by replacing the hostId from SYSTEM_HOST to whatever the passed in for the method is. This was generating an issue in the validation when creating htmlpages. Now a defensive copy is made to avoid mutating the cache-stored copy. 