### PR TITLE
#18298  adding back  missing required attribute

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/apps/AppsResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/apps/AppsResourceTest.java
@@ -3,6 +3,7 @@ package com.dotcms.rest.api.v1.apps;
 import static com.dotcms.rest.api.v1.apps.Input.newInputParam;
 import static com.dotcms.unittest.TestUtil.upperCaseRandom;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.mockito.Matchers.any;
@@ -545,6 +546,7 @@ public class AppsResourceTest extends IntegrationTestBase {
                         final Type type = Type.valueOf(deserializedView.get("type").toString());
                         final boolean hidden = Boolean.parseBoolean(deserializedView.get("hidden").toString());
                         final String value = deserializedView.get("value").toString();
+                        assertNotNull(deserializedView.get("required"));
 
                         Assert.assertEquals(
                                 "If it comes back as hidden it's because the descriptor also says it is hidden ",

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/view/SecretView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/view/SecretView.java
@@ -125,6 +125,7 @@ public class SecretView {
             buildCommonJson(paramDescriptor, map);
             map.put("hint", paramDescriptor.getHint());
             map.put("label", paramDescriptor.getLabel());
+            map.put("required", paramDescriptor.isRequired());
         }
 
         private void mergeSecretAndParam(final Secret secret,


### PR DESCRIPTION
Since I added a brand new Custom SecretSerializer to handle booleans and hidden secrets I forgot adding the required attribute required by Alfredo to mark whether or not fields are mandatory. 
This PR incorporates back such attributes in the game.