### PR TITLE
#18334 Setting node -> download = true causes docker crashes when the dotCMS image is built

### DIFF
--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -30,7 +30,7 @@ node {
     distBaseUrl = 'https://nodejs.org/dist'
     // If true, it will download node using above parameters.
     // If false, it will try to use globally installed node.
-    download = true
+    download = false
 }
 import com.dotcms.repackage.org.apache.commons.io.FileUtils;
 


### PR DESCRIPTION
Forcing the download of a node version makes the generation of the dotCMS image crashes and it is not necessary because the docker image has a built-in node version:  https://github.com/dotCMS/docker/blob/master/images/dotcms-seed/Dockerfile#L14