### PR TITLE
calling same method

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/UserDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/UserDataGen.java
@@ -24,7 +24,7 @@ public class UserDataGen extends AbstractDataGen<User> {
     private String emailAddress = "testEmailAddress@" + currentTime + ".com";
     private String password = String.valueOf(currentTime);
     private String skinIdentifier = UUIDGenerator.generateUuid();
-    private String companyId = UUIDGenerator.generateUuid();
+    private String companyId = com.dotmarketing.cms.factories.PublicCompanyFactory.getDefaultCompany().getCompanyId();
     private List<Role> roles = new ArrayList<>();
 
     @SuppressWarnings("unused")

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/sql/FieldSql.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/sql/FieldSql.java
@@ -5,12 +5,7 @@ import com.dotmarketing.db.DbConnectionFactory;
 public abstract class FieldSql {
 
 
-		static FieldSql instance = DbConnectionFactory.isH2() 
-				? new FieldSqlMysql() : DbConnectionFactory.isMySql() 
-						? new FieldSqlMysql() : DbConnectionFactory.isPostgres() 
-								? new FieldSqlMysql()
-									: DbConnectionFactory.isMsSql() 
-										? new FieldSqlMysql() : new FieldSqlMysql();
+		static FieldSql instance = new FieldSqlMysql();
 
 		public static FieldSql getInstance() {
 			return instance;


### PR DESCRIPTION
placeholder to fix unit tests and integration tests failing in master

**FieldSql**: `if-else` is useless since regardless of the result will call the same method.
**UserDataGen**: use the default company when creating a new user to avoid that the user lives on another company and some methods from the UserAPI do not found them (like `loadByUserByEmail` or `userExistsWithEmail`)