### PR TITLE
#18364 : This "code fix" has been tested in several customer environm…

### DIFF
--- a/dotCMS/src/integration-test/resources/it-dotmarketing-config.properties
+++ b/dotCMS/src/integration-test/resources/it-dotmarketing-config.properties
@@ -510,9 +510,11 @@ ES_URL_ENDPOINT=http://localhost:9200/
 asset.cache.control.max.days=30
 
 ##################### dotCMS Cache Configuration #####################
-cache.default.chain			=com.dotmarketing.business.cache.provider.caffine.CaffineCache
-cache.contentletcache.chain =com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotmarketing.business.cache.provider.h22.H22Cache
-cache.velocitycache.chain   =com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotmarketing.business.cache.provider.h22.H22Cache
+cache.default.chain			    =com.dotmarketing.business.cache.provider.caffine.CaffineCache
+cache.contentletcache.chain     =com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotmarketing.business.cache.provider.h22.H22Cache
+cache.velocitycache.chain       =com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotmarketing.business.cache.provider.h22.H22Cache
+cache.vanityurlcache.chain      =com.dotmarketing.business.cache.provider.timedcache.TimedCacheProvider
+cache.cachedvanityurlgroup.chain=com.dotmarketing.business.cache.provider.timedcache.TimedCacheProvider
 #cache.default.chain=com.dotmarketing.business.cache.provider.hazelcast.HazelcastCacheProviderEmbedded
 #cache.default.chain=com.dotmarketing.business.cache.provider.hazelcast.HazelcastCacheProviderClient
 
@@ -547,8 +549,11 @@ cache.workflowactioncache.size=10000
 cache.workflowtaskcache.size=10000
 cache.shorty.size=25000
 cache.identifier404cache.size=5000
-cache.virtuallinkscache.size=25000
 cache.velocitycache.size=1000
+cache.vanityurlcache.seconds=60
+cache.vanityurlcache.size=1000
+cache.cachedvanityurlgroup.seconds=60
+cache.cachedvanityurlgroup.size=1000
 
 
 #Available cache regions

--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -495,8 +495,10 @@ PULLPERSONALIZED_PERSONA_WEIGHT=100
 asset.cache.control.max.days=30
 
 ##################### dotCMS Cache Configuration #####################
-cache.default.chain			=com.dotmarketing.business.cache.provider.caffine.CaffineCache
-cache.contentletcache.chain =com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotmarketing.business.cache.provider.h22.H22Cache
+cache.default.chain			    =com.dotmarketing.business.cache.provider.caffine.CaffineCache
+cache.contentletcache.chain     =com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotmarketing.business.cache.provider.h22.H22Cache
+cache.vanityurlcache.chain      =com.dotmarketing.business.cache.provider.timedcache.TimedCacheProvider
+cache.cachedvanityurlgroup.chain=com.dotmarketing.business.cache.provider.timedcache.TimedCacheProvider
 
 ## If you cache the velocity templates to disk, you should also cache
 ## the velocity macros to disk, otherwise, they might not reload on restarts. 
@@ -547,9 +549,12 @@ cache.workflowactioncache.size=10000
 cache.workflowtaskcache.size=10000
 cache.shorty.size=25000
 cache.identifier404cache.size=5000
-cache.virtuallinkscache.size=25000
 cache.velocitycache.size=1000
+cache.vanityurlcache.seconds=120
 cache.vanityurlcache.size=25000
+cache.cachedvanityurlgroup.seconds=120
+cache.cachedvanityurlgroup.size=25000
+
 
 #Available cache regions
 #cache.actionscache.size=1000

--- a/dotCMS/src/main/resources/hazelcast-client.xml
+++ b/dotCMS/src/main/resources/hazelcast-client.xml
@@ -278,7 +278,13 @@
         <in-memory-format>OBJECT</in-memory-format>
     </near-cache>
     
-    <near-cache name="virtuallinkscache">
+    <near-cache name="vanityurlcache">
+        <max-size>25000</max-size>
+        <eviction-policy>LFU</eviction-policy>
+        <in-memory-format>OBJECT</in-memory-format>
+    </near-cache>
+
+    <near-cache name="cachedvanityurlgroup">
         <max-size>25000</max-size>
         <eviction-policy>LFU</eviction-policy>
         <in-memory-format>OBJECT</in-memory-format>
@@ -562,8 +568,14 @@
         <in-memory-format>OBJECT</in-memory-format>
     </near-cache>
     
-    <near-cache name="virtuallinkscache">
-        <max-size>1000</max-size>
+    <near-cache name="vanityurlcache">
+        <max-size>25000</max-size>
+        <eviction-policy>LFU</eviction-policy>
+        <in-memory-format>OBJECT</in-memory-format>
+    </near-cache>
+
+    <near-cache name="cachedvanityurlgroup">
+        <max-size>25000</max-size>
         <eviction-policy>LFU</eviction-policy>
         <in-memory-format>OBJECT</in-memory-format>
     </near-cache>

--- a/dotCMS/src/main/resources/hazelcast-embedded.xml
+++ b/dotCMS/src/main/resources/hazelcast-embedded.xml
@@ -302,8 +302,13 @@
         <max-size>5000</max-size>
         <eviction-policy>LFU</eviction-policy>
     </map>
-    
-    <map name="virtuallinkscache">
+
+    <map name="vanityurlcache">
+        <max-size>25000</max-size>
+        <eviction-policy>LFU</eviction-policy>
+    </map>
+
+    <map name="cachedvanityurlgroup">
         <max-size>25000</max-size>
         <eviction-policy>LFU</eviction-policy>
     </map>
@@ -540,8 +545,13 @@
         <eviction-policy>LFU</eviction-policy>
     </map>
     
-    <map name="virtuallinkscache">
-        <max-size>1000</max-size>
+    <map name="vanityurlcache">
+        <max-size>25000</max-size>
+        <eviction-policy>LFU</eviction-policy>
+    </map>
+
+    <map name="cachedvanityurlgroup">
+        <max-size>25000</max-size>
         <eviction-policy>LFU</eviction-policy>
     </map>
     


### PR DESCRIPTION
…ents and has been the most effective solution to Vanity URL problems so far. However, the whole Vanity URL  API needs to be completely re-imagined. This fix is made up of three changes: (1) forcing an additional read in case the cache regions do not return valid data (which should not happen in normal circumstances), (2) explicitly define cache regions for the two Vanity URL regions, not just one of them, and (3) ALWAYS use the Timed Cache for the Vanity URL caches. The default 2-minute timeout works for most customers; however, some of them might require a timeout of 1 minute or less. Also, the legacy "virtuallinkscache" region has been replaced with the correct Vanity URL regions.