### PR TITLE
#18382 New validation for content type vars: case-insensitive uniqueness

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeAPIImplTest.java
@@ -1053,6 +1053,53 @@ public class ContentTypeAPIImplTest extends ContentTypeBaseTest {
 		}
 	}
 
+	/**
+	 * Given scenario: Trying to save a content type whose variable already belongs to an existing type
+	 * but with different case
+	 * Expected result: An exception should be thrown upon attempting to save the content type
+	 */
+
+	@Test(expected = IllegalArgumentException.class)
+	public void test_saveContentTypeWithSameVariableOfExistingTypeButDifferentCase_ShouldThrowException()
+			throws DotSecurityException, DotDataException {
+
+		long time = System.currentTimeMillis();
+		ContentType type = null;
+		ContentType type2 = null;
+		try {
+			type = APILocator.getContentTypeAPI(APILocator.systemUser())
+					.save(ContentTypeBuilder
+							.builder(SimpleContentType.class)
+							.folder(FolderAPI.SYSTEM_FOLDER)
+							.host(Host.SYSTEM_HOST)
+							.variable("mivariable" + time)
+							.name("mivariable" + time)
+							.system(false) // system true!
+							.owner(user.getUserId())
+							.build());
+
+			type2 = APILocator.getContentTypeAPI(APILocator.systemUser())
+					.save(ContentTypeBuilder
+							.builder(SimpleContentType.class)
+							.folder(FolderAPI.SYSTEM_FOLDER)
+							.host(Host.SYSTEM_HOST)
+							.variable("Mivariable" + time) // same variable different case
+							.name("Mivariable" + time)
+							.system(false) // system true!
+							.owner(user.getUserId())
+							.build());
+
+		} finally {
+			if(type!=null) {
+				APILocator.getContentTypeAPI(APILocator.systemUser()).delete(type);
+			}
+
+			if(type2!=null) {
+				APILocator.getContentTypeAPI(APILocator.systemUser()).delete(type2);
+			}
+		}
+	}
+
 
 	@Test
 	@UseDataProvider("testCasesUpdateTypePermissions")

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactoryImpl.java
@@ -351,6 +351,9 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
 
     if (oldContentType == null) {
     	if (UtilMethods.isSet(saveType.variable())) {
+            if(doesTypeWithVariableExist(saveType.variable())) {
+              throw new IllegalArgumentException("Invalid content type variable: " + saveType.variable());
+            }
     		builder.variable(saveType.variable());
     	} else {
     		final String generatedVar = suggestVelocityVar(saveType.name());
@@ -414,6 +417,19 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
     }
 
     return retType;
+  }
+
+  private boolean doesTypeWithVariableExist(String variable) throws DotDataException {
+    boolean typeWithVariableExists = false;
+
+    try {
+      ContentType typeWithVariable = dbByVar(variable);
+      typeWithVariableExists = UtilMethods.isSet(typeWithVariable);
+    } catch(NotFoundInDbException e) {
+      // nothing to do - moving on
+    }
+
+    return typeWithVariableExists;
   }
 
   private void dbInodeUpdate(final ContentType type) throws DotDataException {


### PR DESCRIPTION
Avoid using same variable (case insensitive) of existing content types when creating a new one. 

Integration Tests