### PR TITLE
dotCMS/core#16955 Setting up X-Content-Type-Options header causes blank screens in the backend

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/workflows/schemes/workflow_js.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/workflows/schemes/workflow_js.jsp
@@ -1,5 +1,5 @@
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
-<%response.setContentType("text/html");%>
+<%response.setContentType("text/javascript");%>
 dojo.require("dijit.form.Form");
 dojo.require("dijit.form.Button");
 dojo.require("dijit.form.ValidationTextBox");


### PR DESCRIPTION
Due to the header `X-Content-Type-Options=nosniff` the workflows JS imported does not match the MIME content defined in the JSP, causing the browser to reject it