### PR TITLE
dotCMS/core#18102 Content editing screen errors when Radio field and Tab divider have same name

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet.jsp
@@ -231,7 +231,7 @@
 			fields.get(0).getFieldType().equals(Field.FieldType.TAB_DIVIDER.toString())){
 				Field f0 = fields.get(0);
 				fields.remove(0);%>
-			<div id="<%=f0.getVelocityVarName()%>" dojoType="dijit.layout.ContentPane" title="<%=f0.getFieldName()%>">
+			<div id="tab_<%=f0.getVelocityVarName()%>" dojoType="dijit.layout.ContentPane" title="<%=f0.getFieldName()%>">
 		<%} else {	%>
 			<div id="properties" dojoType="dijit.layout.ContentPane" title="<%= LanguageUtil.get(pageContext, "Content") %>">
 		<%}%>
@@ -307,7 +307,7 @@
 							</div>
 						</div>
 
-                        <div id="<%=f.getVelocityVarName()%>" class="custom-tab" dojoType="dijit.layout.ContentPane" title="<%=f.getFieldName()%>">
+                        <div id="tab_<%=f.getVelocityVarName()%>" class="custom-tab" dojoType="dijit.layout.ContentPane" title="<%=f.getFieldName()%>">
                             <div class="content-edit__advaced-form">
 
                     <%}else if(f.getFieldType().equals(Field.FieldType.CATEGORIES_TAB.toString()) && !categoriesTabFieldExists) {


### PR DESCRIPTION
When you create a Radio button field and a Tab divider with the same friendly name (e.g. both are named "Profile"), then depending on where you place the field and how you drag it in the content type editor, the content editing screen can either display completely blank, or the radio button can display so that the options are not all selectable.

In both cases, errors in the browser console indicate that there's some kind of a conflict with dojo id==profile1.