### PR TITLE
#18382 one-liner error in log

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeAPIImplTest.java
@@ -1100,6 +1100,32 @@ public class ContentTypeAPIImplTest extends ContentTypeBaseTest {
 		}
 	}
 
+	@DataProvider
+	public static Object[] getReservedTypeNames() {
+		return ContentTypeAPI.reservedStructureNames.toArray();
+	}
+
+	/**
+	 * Given scenario: Content type with reserved name set
+	 * Expected result: {@link IllegalArgumentException} should be thrown
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	@UseDataProvider("getReservedTypeNames")
+	public void testSave_GivenTypeWithReservedNameAndNotSystem_ShouldThrowException(final String name)
+			throws DotSecurityException, DotDataException {
+
+		APILocator.getContentTypeAPI(APILocator.systemUser())
+				.save(ContentTypeBuilder
+						.builder(SimpleContentType.class)
+						.folder(FolderAPI.SYSTEM_FOLDER)
+						.host(Host.SYSTEM_HOST)
+						.name(name) // setting a reserved name
+						.system(false) // system false!
+						.owner(user.getUserId())
+						.build());
+
+	}
+
 
 	@Test
 	@UseDataProvider("testCasesUpdateTypePermissions")

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactoryImpl.java
@@ -381,10 +381,10 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
 
       if (isNew) {
           if (ContentTypeAPI.reservedStructureNames.contains(retType.name().toLowerCase()) && !retType.system()) {
-              throw new DotDataException("cannot save a structure with name:" + retType.name());
+              throw new IllegalArgumentException("cannot save a structure with name:" + retType.name());
           }
           if (ContentTypeAPI.reservedStructureVars.contains(retType.variable().toLowerCase()) && !retType.system()) {
-              throw new DotDataException("cannot save a structure with name:" + retType.name());
+              throw new IllegalArgumentException("cannot save a structure with name:" + retType.name());
           }
       }
 


### PR DESCRIPTION
Use IllegalArgumentException as the rest of validations for content type input data so the log is a one line instead of a full stack