### PR TITLE
#18479 : Data displayed for Key/Value fields must reflect the exact s…

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/json/JSONObject.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/json/JSONObject.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeSet;
 import org.apache.commons.lang.WordUtils;
@@ -105,7 +106,7 @@ public class JSONObject extends com.dotcms.repackage.org.codehaus.jettison.json.
     /**
      * The map where the JSONObject's properties are kept.
      */
-    private Map<String,Object> map = new HashMap<>();;
+    private Map<String,Object> map = new LinkedHashMap<>();
 
 
     /**


### PR DESCRIPTION
…ame order in which it's stored in the database. Replacing the previous HashMap with the new LinkedHashMap solves this problem. Even though a JSON structure is usually considered to be "an unordered set of name/value pairs", the order in this case is very important.