### PR TITLE
Issue 18446 key value fields indexing

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
@@ -584,7 +584,7 @@ public class ESMappingAPITest {
     public void Test_Create_ContentType_With_KeyValue_Field_Test_Query_Expect_Success()
             throws DotDataException, DotSecurityException {
 
-        List<Field> fields = new ArrayList<>();
+        final List<Field> fields = new ArrayList<>();
         final String myKeyValueField = "myKeyValueField";
         fields.add(
                 new FieldDataGen()
@@ -614,12 +614,12 @@ public class ESMappingAPITest {
 
         final ESSearchResults searchResults = contentletAPI.esSearch(wrappedQuery, false,  user, false);
         Assert.assertFalse(searchResults.isEmpty());
-        for (Object searchResult : searchResults) {
+        for (final Object searchResult : searchResults) {
            final Contentlet contentlet = (Contentlet) searchResult;
             final String json = (String)contentlet.getMap().get("myKeyValueField");
-            Assert.assertNotNull(json);
+            assertNotNull(json);
             final Map<String, Object> map = KeyValueFieldUtil.JSONValueToHashMap(json);
-            Assert.assertTrue(map.containsKey("key"));
+            assertTrue(map.containsKey("key"));
         }
     }
 
@@ -634,7 +634,7 @@ public class ESMappingAPITest {
     public void Test_Create_FileAsset_Query_by_MetaData_Expect_Success()
             throws DotDataException, DotSecurityException {
 
-        final File binary = new File(ESMappingAPITest.class.getClassLoader().getResource("images/test.jpg").getFile());
+        final File binary = new File(Thread.currentThread().getContextClassLoader().getResource("images/test.jpg").getFile());
         final Host site = new SiteDataGen().nextPersisted();
         final FileAssetDataGen fileAssetDataGen = new FileAssetDataGen(site, binary);
         fileAssetDataGen.nextPersisted();
@@ -650,6 +650,6 @@ public class ESMappingAPITest {
                 + "}", queryString);
 
         final ESSearchResults searchResults = contentletAPI.esSearch(wrappedQuery, false,  user, false);
-        Assert.assertFalse(searchResults.isEmpty());
+        assertFalse(searchResults.isEmpty());
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
@@ -592,13 +592,8 @@ public class ESMappingAPITest {
                 .nextPersisted();
 
         new ContentletDataGen(contentType.id()).setProperty(myKeyValueField,
-                "{\"key1\":\"val1\"  }").nextPersisted();
-        new ContentletDataGen(contentType.id()).setProperty(myKeyValueField,
-                "{\"key1\":\"val1\", \"key2\":\"val2\"  }").nextPersisted();
-        new ContentletDataGen(contentType.id()).setProperty(myKeyValueField,
-                "{\"key1\":\"val1\", \"key2\":\"val2\", \"key3\":\"val3\"  }").nextPersisted();
-
-        final String  queryString =  String.format("+%s.%s.%s:val*",contentTypeName, myKeyValueField, "key1");
+                "{\"key\":\"key1\", value:\"val\" }").nextPersisted();
+        final String queryString =  String.format("+%s.%s.key:%s*",contentTypeName, myKeyValueField, "val");
         Logger.info(ESMappingAPITest.class, () -> String.format(" Query: %s ",queryString));
         final String wrappedQuery = String.format("{"
                 + "query: {"
@@ -609,15 +604,14 @@ public class ESMappingAPITest {
                 + "}", queryString);
 
         final ESSearchResults searchResults = contentletAPI.esSearch(wrappedQuery, false,  user, false);
-        Assert.assertEquals(3, searchResults.size());
+        Assert.assertFalse(searchResults.isEmpty());
         for (Object searchResult : searchResults) {
            final Contentlet contentlet = (Contentlet) searchResult;
             final String json = (String)contentlet.getMap().get("myKeyValueField");
-            Assert.assertNull(json);
+            Assert.assertNotNull(json);
             final Map<String, Object> map = KeyValueFieldUtil.JSONValueToHashMap(json);
-            Assert.assertTrue(map.containsKey("key1"));
+            Assert.assertTrue(map.containsKey("key"));
         }
-
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -740,9 +740,10 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
             final String keyValuePrefix = FileAssetAPI.META_DATA_FIELD.toLowerCase();
             keyValueMap.forEach((k, v) -> contentletMap.put(keyValuePrefix + StringPool.PERIOD + k, v));
 		} else {
-            keyValueMap.forEach((k, v) -> {
-				((List)contentletMap.computeIfAbsent(keyName, key -> new ArrayList<>())).add(ImmutableMap.of(k,v));
-            });
+			keyValueMap.forEach((k, v) -> {
+				((List)contentletMap.computeIfAbsent(keyName, key -> new ArrayList<>())).add(
+						ImmutableMap.of( "key", k, "value", v));
+			});
 		}
 	}
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -1,5 +1,13 @@
 package com.dotcms.content.elasticsearch.business;
 
+import static com.dotcms.content.elasticsearch.business.ESIndexAPI.INDEX_OPERATIONS_TIMEOUT_IN_MS;
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.PERSONA_KEY_TAG;
+import static com.dotcms.contenttype.model.field.LegacyFieldTypes.CUSTOM_FIELD;
+import static com.dotcms.contenttype.model.type.PersonaContentType.PERSONA_KEY_TAG_FIELD_VAR;
+import static com.dotmarketing.business.PermissionAPI.PERMISSION_PUBLISH;
+import static com.dotmarketing.business.PermissionAPI.PERMISSION_READ;
+import static com.dotmarketing.business.PermissionAPI.PERMISSION_WRITE;
+
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.content.business.ContentMappingAPI;
 import com.dotcms.content.business.DotMappingException;
@@ -50,20 +58,10 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.ThreadSafeSimpleDateFormat;
 import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.time.FastDateFormat;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.indices.GetMappingsRequest;
-import org.elasticsearch.client.indices.GetMappingsResponse;
-import org.elasticsearch.client.indices.PutMappingRequest;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.XContentType;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -79,14 +77,16 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static com.dotcms.content.elasticsearch.business.ESIndexAPI.INDEX_OPERATIONS_TIMEOUT_IN_MS;
-import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.PERSONA_KEY_TAG;
-import static com.dotcms.contenttype.model.field.LegacyFieldTypes.CUSTOM_FIELD;
-import static com.dotcms.contenttype.model.type.PersonaContentType.PERSONA_KEY_TAG_FIELD_VAR;
-import static com.dotmarketing.business.PermissionAPI.PERMISSION_PUBLISH;
-import static com.dotmarketing.business.PermissionAPI.PERMISSION_READ;
-import static com.dotmarketing.business.PermissionAPI.PERMISSION_WRITE;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.time.FastDateFormat;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
+import org.elasticsearch.client.indices.PutMappingRequest;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentType;
 
 /**
  * Implementation class for the {@link ContentMappingAPI}.
@@ -736,12 +736,14 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 					.addAll(tikaUtils.getConfiguredMetadataFields());
 
 			tikaUtils.filterMetadataFields(keyValueMap, allowedFields);
-		}
 
-		final String keyValuePrefix = fileMetadata ?
-				FileAssetAPI.META_DATA_FIELD.toLowerCase() : keyName;
-		keyValueMap.forEach((k, v) -> contentletMap
-				.put(keyValuePrefix + StringPool.PERIOD + k, v));
+            final String keyValuePrefix = FileAssetAPI.META_DATA_FIELD.toLowerCase();
+            keyValueMap.forEach((k, v) -> contentletMap.put(keyValuePrefix + StringPool.PERIOD + k, v));
+		} else {
+            keyValueMap.forEach((k, v) -> {
+				((List)contentletMap.computeIfAbsent(keyName, key -> new ArrayList<>())).add(ImmutableMap.of(k,v));
+            });
+		}
 	}
 
 	public String toJsonString(Map<String, Object> map) throws IOException{

--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/field/KeyValueField.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/field/KeyValueField.java
@@ -1,16 +1,14 @@
 package com.dotcms.contenttype.model.field;
 
-import java.util.Collection;
-import java.util.List;
+import static com.dotcms.util.CollectionsUtils.list;
 
-import org.immutables.value.Value;
-
-import com.google.common.collect.ImmutableList;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
-import static com.dotcms.util.CollectionsUtils.list;
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.List;
+import org.immutables.value.Value;
 
 @JsonSerialize(as = ImmutableKeyValueField.class)
 @JsonDeserialize(as = ImmutableKeyValueField.class)
@@ -46,7 +44,7 @@ public abstract class KeyValueField extends Field {
 	@JsonIgnore
 	public Collection<ContentTypeFieldProperties> getFieldContentTypeProperties(){
 		return list(ContentTypeFieldProperties.NAME, ContentTypeFieldProperties.REQUIRED, ContentTypeFieldProperties.HINT,
-				ContentTypeFieldProperties.SEARCHABLE);
+				ContentTypeFieldProperties.SEARCHABLE, ContentTypeFieldProperties.INDEXED);
 	}
 
 	@JsonIgnore


### PR DESCRIPTION
This comes to fulfill https://github.com/dotcms/core/issues/18446
Basically we're moving away from storing key-value fields on ES 
from something like this: 

```
"tmycontettype.keyval1.mykey1": "val1",
"tmycontettype.keyval1.mykey2": "val2",
"tmycontettype.keyval1.mykey3": ""
```

to something like this:

```
"tmycontenttype.mykeyvaluefield": [
      {
        "key": "key1",
        "value": "val1"
      },
      {
        "key": "key2",
        "value": "val2"
      }
    ]

```

The first approach was using loose fields that could grow without control and cause a crash on ES by surpassing the max number of allowed fields.

Supposedly the new approach only uses 3 fields

 there are only three fields mapped ("tmycontenttype.mykeyvaluefield", "key", "value"), additionally the nested structure allows each key/value to be associated together. 

The new approach for queries would look something like 
`+myContentTypeWithKeyValues.myKeyValueField.key:val*`

