### PR TITLE
Issue 18443 prevent schema generation if rels fail

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
@@ -758,6 +758,12 @@ public class GraphqlAPITest extends IntegrationTestBase {
         }
     }
 
+    /**
+     * Method to rest: {@link GraphqlAPI#getSchema()}
+     * Given scenario: A bad relationship field which returns null when trying to get the
+     * {@link com.dotmarketing.portlets.structure.model.Relationship} out of it.
+     * Expected result: The schema should be able to generate but without that field present
+     */
     @Test
     public void testGetSchema_GivenFailuresInRelationshipField_SchemaShouldStillGenerate()
             throws DotDataException, DotSecurityException {

--- a/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
@@ -50,6 +50,7 @@ import com.dotcms.contenttype.model.field.ImmutableTextField;
 import com.dotcms.contenttype.model.field.ImmutableTimeField;
 import com.dotcms.contenttype.model.field.ImmutableWysiwygField;
 import com.dotcms.contenttype.model.field.RelationshipField;
+import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ContentTypeBuilder;
@@ -62,6 +63,7 @@ import com.dotcms.graphql.CustomFieldType;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.RelationshipAPI;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
@@ -89,6 +91,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 @RunWith(DataProviderRunner.class)
 public class GraphqlAPITest extends IntegrationTestBase {
@@ -750,6 +753,46 @@ public class GraphqlAPITest extends IntegrationTestBase {
             assertTrue(areFileassetFieldsPresent((GraphQLObjectType) imageFieldDefinition.getType()));
 
             assertEquals(CustomFieldType.FILEASSET.getType(), imageFieldDefinition.getType());
+        } finally {
+            APILocator.getContentTypeAPI(APILocator.systemUser()).delete(contentType);
+        }
+    }
+
+    @Test
+    public void testGetSchema_GivenFailuresInRelationshipField_SchemaShouldStillGenerate()
+            throws DotDataException, DotSecurityException {
+        ContentType contentType = null;
+        try {
+            contentType = new ContentTypeDataGen().nextPersisted();
+
+            Field relationshipField = FieldBuilder.builder(RelationshipField.class)
+                    .name("relationshipField")
+                    .contentTypeId(contentType.id())
+                    .values(String.valueOf(RELATIONSHIP_CARDINALITY.ONE_TO_MANY.ordinal()))
+                    .relationType(contentType.variable()).build();
+
+            final Field titleField = new FieldDataGen().contentTypeId(contentType.id())
+                    .type(TextField.class).nextPersisted();
+
+            APILocator.getGraphqlAPI().invalidateSchema();
+
+            RelationshipAPI relationshipAPI = Mockito.mock(RelationshipAPI.class);
+            Mockito.when(relationshipAPI.
+                    getRelationshipFromField(relationshipField, APILocator.systemUser()))
+                    .thenReturn(null);
+
+            final GraphQLSchema schema = new GraphqlAPIImpl(relationshipAPI).getSchema();
+
+            final GraphQLFieldDefinition relationshipFieldDefinition = schema
+                    .getObjectType(contentType.variable())
+                    .getFieldDefinition(relationshipField.variable());
+
+            final GraphQLFieldDefinition titleFieldDefinition = schema
+                    .getObjectType(contentType.variable())
+                    .getFieldDefinition(titleField.variable());
+
+            assertNull(relationshipFieldDefinition);
+            assertNotNull(titleFieldDefinition);
         } finally {
             APILocator.getContentTypeAPI(APILocator.systemUser()).delete(contentType);
         }

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
@@ -45,6 +45,7 @@ import com.dotcms.graphql.datafetcher.TagsFieldDataFetcher;
 import com.dotcms.graphql.util.TypeUtil;
 import com.dotcms.util.LogTime;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.RelationshipAPI;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -85,9 +86,16 @@ public class GraphqlAPIImpl implements GraphqlAPI {
 
     private volatile GraphQLSchema schema;
 
+    private RelationshipAPI relationshipAPI;
+
     public static final String TYPES_AND_FIELDS_VALID_NAME_REGEX = "[_A-Za-z][_0-9A-Za-z]*";
 
     public GraphqlAPIImpl() {
+        this(APILocator.getRelationshipAPI());
+    }
+
+    public GraphqlAPIImpl(final RelationshipAPI relationshipAPI) {
+        this.relationshipAPI = relationshipAPI;
         // custom type mappings
         this.fieldClassGraphqlTypeMap.put(BinaryField.class, CustomFieldType.BINARY.getType());
         this.fieldClassGraphqlTypeMap.put(CategoryField.class, list(CustomFieldType.CATEGORY.getType()));
@@ -215,7 +223,7 @@ public class GraphqlAPIImpl implements GraphqlAPI {
         Relationship relationship;
 
         try {
-            relationship = APILocator.getRelationshipAPI().getRelationshipFromField(field,
+            relationship = relationshipAPI.getRelationshipFromField(field,
                 APILocator.systemUser());
         } catch (DotDataException | DotSecurityException e) {
             throw new DotRuntimeException(e);
@@ -225,7 +233,7 @@ public class GraphqlAPIImpl implements GraphqlAPI {
         final ContentletRelationships.ContentletRelationshipRecords
             records = contentletRelationships.new ContentletRelationshipRecords(
             relationship,
-            APILocator.getRelationshipAPI().isChildField(relationship, field));
+            relationshipAPI.isChildField(relationship, field));
 
         GraphQLOutputType outputType = typesMap.get(relatedContentType.variable()) != null
             ? typesMap.get(relatedContentType.variable())
@@ -344,7 +352,7 @@ public class GraphqlAPIImpl implements GraphqlAPI {
     }
 
     private ContentType getRelatedContentTypeForField(final Field field, final User user) throws DotSecurityException, DotDataException {
-        final Relationship relationship = APILocator.getRelationshipAPI().getRelationshipFromField(field,
+        final Relationship relationship = relationshipAPI.getRelationshipFromField(field,
             user);
 
         if(relationship==null) {

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
@@ -45,6 +45,7 @@ import com.dotcms.graphql.datafetcher.TagsFieldDataFetcher;
 import com.dotcms.graphql.util.TypeUtil;
 import com.dotcms.util.LogTime;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.RelationshipAPI;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
@@ -189,7 +190,7 @@ public class GraphqlAPIImpl implements GraphqlAPI {
                 if (field instanceof RelationshipField) {
                     try {
                         handleRelationshipField(contentType, builder, field, graphqlObjectTypes);
-                    } catch(Exception e) {
+                    } catch(DotStateException e) {
                         Logger.error(this, "Unable to create relationship field", e);
                     }
                 } else {
@@ -217,7 +218,7 @@ public class GraphqlAPIImpl implements GraphqlAPI {
         try {
             relatedContentType = getRelatedContentTypeForField(field, APILocator.systemUser());
         } catch (DotSecurityException | DotDataException e) {
-            throw new DotRuntimeException("Unable to create relationship field type for field: " + contentType.variable() + "." + field.variable(), e);
+            throw new DotStateException("Unable to create relationship field type for field: " + contentType.variable() + "." + field.variable(), e);
         }
 
         Relationship relationship;

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
@@ -179,7 +179,11 @@ public class GraphqlAPIImpl implements GraphqlAPI {
 
             if(!(field instanceof RowField) && !(field instanceof ColumnField)) {
                 if (field instanceof RelationshipField) {
-                    handleRelationshipField(contentType, builder, field, graphqlObjectTypes);
+                    try {
+                        handleRelationshipField(contentType, builder, field, graphqlObjectTypes);
+                    } catch(Exception e) {
+                        Logger.error(this, "Unable to create relationship field", e);
+                    }
                 } else {
                     builder.field(newFieldDefinition()
                         .name(field.variable())
@@ -205,7 +209,7 @@ public class GraphqlAPIImpl implements GraphqlAPI {
         try {
             relatedContentType = getRelatedContentTypeForField(field, APILocator.systemUser());
         } catch (DotSecurityException | DotDataException e) {
-            throw new DotRuntimeException("Unable to create schema type for Content Type: " + contentType.variable(), e);
+            throw new DotRuntimeException("Unable to create relationship field type for field: " + contentType.variable() + "." + field.variable(), e);
         }
 
         Relationship relationship;
@@ -342,6 +346,11 @@ public class GraphqlAPIImpl implements GraphqlAPI {
     private ContentType getRelatedContentTypeForField(final Field field, final User user) throws DotSecurityException, DotDataException {
         final Relationship relationship = APILocator.getRelationshipAPI().getRelationshipFromField(field,
             user);
+
+        if(relationship==null) {
+            throw new DotDataException("Relationship with name:"
+                    + field.relationType() + " not found. Field var:" + field.variable() + ". Field ID: " + field.id());
+        }
 
         final String relatedContentTypeId = relationship.getParentStructureInode().equals(field.contentTypeId())
             ? relationship.getChildStructureInode() : relationship.getParentStructureInode();


### PR DESCRIPTION
Validate case when trying to obtain a relationship from a rel-field returns null. 
Before, we were getting a NPE that was preventing the entire schema generation. 
Now we throw an exception which is captured at a higher level and logged and we continue with the schema generation. Only consequence is that the relationship field won't be available.

Integration Test included 