### PR TITLE
Issue 18558 file as container can only be added once to a template

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -420,28 +420,13 @@ public class PageRenderUtil implements Serializable {
         String containerIdOrPath = null;
 
         if (FileAssetContainerUtil.getInstance().isFileAssetContainer(container)) {
-            containerIdOrPath = getRelativePathFromSite((FileAssetContainer) container);
+            containerIdOrPath = FileAssetContainerUtil.getInstance().getFullPath((FileAssetContainer) container);
         } else {
             containerIdOrPath = container.getIdentifier();
         }
 
         return !ParseContainer.isParserContainerUUID(uniqueId) &&
                 (templateLayout == null || !templateLayout.existsContainer(containerIdOrPath, uniqueId));
-    }
-
-    /**
-     * If the container's Host is equals to {@link PageRenderUtil#site} then return the relative path, but if the Host
-     * are different then it return the full path.
-     *
-     * @param container
-     * @return
-     * @throws DotSecurityException
-     * @throws DotDataException
-     */
-    private String getRelativePathFromSite(final FileAssetContainer container) {
-        return this.site.getIdentifier().equals(container.getHost().getIdentifier()) ?
-                container.getPath() :
-                FileAssetContainerUtil.getInstance().getFullPath(container);
     }
 
     private Contentlet getContentlet(final PersonalizedContentlet personalizedContentlet) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/FileAssetContainerUtil.java
@@ -503,7 +503,23 @@ public class FileAssetContainerUtil {
      * @throws DotDataException
      */
     public String getFullPath(final FileAssetContainer container) {
-        return builder(HOST_INDICATOR, container.getHost().getHostname(), container.getPath()).toString();
+        return getFullPath(container.getHost(), container.getPath());
     }
 
+    public String getFullPath(final String containerPath) {
+        try {
+            if (isFullPath(containerPath)) {
+                return containerPath;
+            } else {
+                final Host currentHost = WebAPILocator.getHostWebAPI().getCurrentHost();
+                return getFullPath(currentHost, containerPath);
+            }
+        } catch (DotDataException | DotSecurityException e) {
+            throw new DotRuntimeException(e);
+        }
+    }
+
+    private String getFullPath(final Host host, final String containerPath) {
+        return builder(HOST_INDICATOR, host.getHostname(), containerPath).toString();
+    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/PageView.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/PageView.java
@@ -136,13 +136,7 @@ public class PageView implements Serializable {
 
                 final Host host = ((FileAssetContainer) container).getHost();
 
-                String path = null;
-
-                if (host == null || this.site.getIdentifier().equals(host.getIdentifier())) {
-                    path = FileAssetContainer.class.cast(container).getPath();
-                } else {
-                    path = FileAssetContainerUtil.getInstance().getFullPath((FileAssetContainer) container);
-                }
+                final String path = FileAssetContainerUtil.getInstance().getFullPath((FileAssetContainer) container);
 
                 containerRawMap.put(path, containerRaw);
             } else {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/PageView.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/PageView.java
@@ -134,10 +134,7 @@ public class PageView implements Serializable {
 
             if (container instanceof FileAssetContainer) {
 
-                final Host host = ((FileAssetContainer) container).getHost();
-
                 final String path = FileAssetContainerUtil.getInstance().getFullPath((FileAssetContainer) container);
-
                 containerRawMap.put(path, containerRaw);
             } else {
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/templates/design/util/DesignTemplateUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/templates/design/util/DesignTemplateUtil.java
@@ -412,15 +412,16 @@ public class DesignTemplateUtil {
 
 		if (FileAssetContainerUtil.getInstance().isFolderAssetContainerId(containerId)) {
 
-			return containerId;
+			return FileAssetContainerUtil.getInstance().getFullPath(containerId);;
 		}
 
     	final ShortyIdAPI shortyIdAPI     = APILocator.getShortyAPI();
     	final IdentifierAPI identifierAPI = APILocator.getIdentifierAPI();
     	final Optional<ShortyId> shortyId = shortyIdAPI.getShorty(containerId);
 
-		return shortyId.isPresent() && shortyId.get().subType == ShortType.CONTAINER?
-				containerId: identifierAPI.find(containerId).getParentPath();
+		return shortyId.isPresent() && shortyId.get().subType == ShortType.CONTAINER ?
+				containerId:
+				FileAssetContainerUtil.getInstance().getFullPath(identifierAPI.find(containerId).getParentPath());
 	}
 
 	private static String cleanId(final String identifier) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/templates/design/util/DesignTemplateUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/templates/design/util/DesignTemplateUtil.java
@@ -412,7 +412,7 @@ public class DesignTemplateUtil {
 
 		if (FileAssetContainerUtil.getInstance().isFolderAssetContainerId(containerId)) {
 
-			return FileAssetContainerUtil.getInstance().getFullPath(containerId);;
+			return FileAssetContainerUtil.getInstance().getFullPath(containerId);
 		}
 
     	final ShortyIdAPI shortyIdAPI     = APILocator.getShortyAPI();


### PR DESCRIPTION
When a template is saved using relative path to the file container, and try to add the same container again into the page, the UUID are not set right because the container is taken as different containers (because one is using relative path and the another one is using the relative path)