### PR TITLE
#18316 Rolling back change when Host content was filtered out

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
@@ -624,6 +624,7 @@ public class ContentletAjax {
 		        }
 		    }
             luceneQuery.append("-contentType:forms ");
+            luceneQuery.append("-contentType:Host ");
 		}
 
         final String finalSort = getFinalSort(fields, orderBy, st, structureInodes);


### PR DESCRIPTION
This line is a rollback of the last change. Hosts shouldn't appear in Content Search because it can break other things