### PR TITLE
dotCMS/core#18401 Drag and drop images into the WYSIWYG

### DIFF
--- a/dotCMS/src/main/webapp/html/js/tinymce/js/tinymce/plugins/doteditimage/plugin.min.js
+++ b/dotCMS/src/main/webapp/html/js/tinymce/js/tinymce/plugins/doteditimage/plugin.min.js
@@ -58,7 +58,7 @@ tinymce.PluginManager.add("doteditimage", function (editor) {
 
 	function addToolbars() {
 		var toolbarItems = "alignleft aligncenter alignright | imageProperties";
-		if (dotCMS.hasLicense) {
+		if (dotCMSHasLicense) {
 			toolbarItems = "alignleft aligncenter alignright | editimage | imageProperties";
 		}
 		editor.addContextToolbar(isEditableImage, toolbarItems);

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/tiny_mce_config_default.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/tiny_mce_config_default.jsp
@@ -23,8 +23,7 @@ String insertImageLabel = LanguageUtil.get(pageContext, "insert-image");
 
 %>
 
-var dotCMS = dotCMS || {};
-dotCMS.hasLicense = <%=licenseLevel > licenseStandard%>
+const dotCMSHasLicense = <%=licenseLevel > licenseStandard%>
 
 var tinyMCEProps = {
     dotLanguageStrings: {


### PR DESCRIPTION
make license validation a  constant to avoid manipulation