### PR TITLE
#18356 Making the resource not found error a Warn message

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/DotResourceLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/DotResourceLoader.java
@@ -74,7 +74,7 @@ public class DotResourceLoader extends ResourceLoader {
                 }
 
             } catch (Exception e) {
-                Logger.error(this, "filePath: " + filePath + ", msg:" + e.getMessage(), e);
+                Logger.warn(this, "filePath: " + filePath + ", msg:" + e.getMessage(), e);
                 CacheLocator.getVeloctyResourceCache().addMiss(key.path);
                 throw new ResourceNotFoundException("Cannot parse velocity file : " + key.path, e);
             }


### PR DESCRIPTION
We're making the following message :

```
ERROR services.DotResourceLoader - filePath: /LIVE/e43ab447-a137-4cb4-a8e7-bee1872afc38_1.contentlet, msg:cannot find content for: VelocityResourceKey [path=/LIVE/e43ab447-a137-4cb4-a8e7-bee1872afc38_1.contentlet, language=1, id1=e43ab447-a137-4cb4-a8e7-bee1872afc38, id2=null, type=CONTENT, mode=LIVE] @ url:GET//demo.dotcms.com/html/portlet/ext/htmlpages/view_live_working_diff.jsp | lang:1 | ip:0:0:0:0:0:0:0:1 | Admin:true | start:06-03-2020 10:10:21 CST  ref:http://localhost:8080/dotAdmin/  ?id=2968e2ee-d1b7-4758-9419-2440ae4f38ec&pageLang=1&in_frame=true&frame=detailFrame&container=true&angularCurrentPortlet=edit-page&url=/lol/page2&language_id=1&host_id=48190c8c-42c4-46af-8d1a-0cd5db894797
org.apache.velocity.exception.ResourceNotFoundException: cannot find content for: VelocityResourceKey [path=/LIVE/e43ab447-a137-4cb4-a8e7-bee1872afc38_1.contentlet, language=1, id1=e43ab447-a137-4cb4-a8e7-bee1872afc38, id2=null, type=CONTENT, mode=LIVE]
```


a Warning since it is ignored and doesn't mean the page rendering is breaking.
