### PR TITLE
issue-18442-update-enterprise-screens-in-legacy-portlet fix

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/jsp/rules/include.jsp
+++ b/dotCMS/src/main/webapp/WEB-INF/jsp/rules/include.jsp
@@ -1,5 +1,3 @@
-<%@page import="com.dotcms.enterprise.LicenseUtil"%>
-<%@page import="com.dotcms.enterprise.license.LicenseLevel"%>
 <%@ page import="com.dotmarketing.util.Config" %>
 <%@page import="com.dotmarketing.business.APILocator"%>
 <%@page import="com.dotcms.repackage.org.apache.struts.Globals"%>
@@ -9,23 +7,6 @@
 
 <% Contentlet contentlet =  (Contentlet) APILocator.getContentletAPI().findContentletByIdentifierAnyLanguage(request.getParameter("id"));  %>
 
-
-
-<%if( LicenseUtil.getLevel() < LicenseLevel.STANDARD.level){ %>
-	<div class="portlet-wrapper">
-		<div class="subNavCrumbTrail">
-			<ul id="subNavCrumbUl">
-				<li class="lastCrumb">
-					<a href="#" ><%=LanguageUtil.get(pageContext, "com.dotcms.repackage.javax.portlet.title.rules")%></a>
-				</li>
-
-			</ul>
-			<div class="clear"></div>
-		</div>
-		<jsp:include page="/WEB-INF/jsp/rules/not_licensed.jsp"></jsp:include>
-
-	</div>
-<%return;}%>
 
 	
 	<div id="rules-engine-container" class="portlet-wrapper">

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -269,6 +269,7 @@ api.sites.ruleengine.rules.inputs.onOff.off.label = Off
 api.sites.ruleengine.rules.inputs.onOff.on.label = On
 api.sites.ruleengine.rules.inputs.onOff.tip = Prevent or allow this Rule to execute
 api.sites.ruleengine.rules.pushPublish.title = Push Publish
+api.sites.ruleengine.rules.contact.admin.error = Please contact an administrator...
 api.system.ruleengine.actionlet.send_redirect.input.url = Redirect URL
 api.system.ruleengine.actionlet.send_redirect.name = Redirect requests to
 api.system.ruleengine.actionlet.SetPersona.inputs.personaIdKey.placeholder = Choose a Persona

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -2788,6 +2788,7 @@ Once = Once
 One-line-for-each-record = One line for each record.
 One-to-Many = One to Many
 Ongoing-Events = Ongoing Events
+only-available-in-enterprise = is only available in dotCMS Enterprise Editions. For more information:
 only-containers-without-html-tag = You can only add Containers that do not contain main HTML tags.
 Only-Default-Scheme-is-available-in-Community = Only the &quot;System Workflow&quot; Scheme can be used in dotCMS Community Edition
 only-folder-can-be-moved-to-hosts = only folders can be moved to Sites

--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsconfig/network/not_licensed.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsconfig/network/not_licensed.jsp
@@ -1,19 +1,32 @@
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <style>
-	.wrapperCluster{background:url(/html/images/skin/clustering-promo.png) no-repeat 0 0;height:757px;margin:0 auto;border:1px silver solid;padding:0px;overflow:hidden;}
-	.content{position:fixed;left:50%;top:50%;margin:-200px 0 0 -300px;width:600px;background:#333;opacity:.75;color:#fff;padding:20px 20px 35px 20px;-moz-border-radius: 15px;-webkit-border-radius: 15px;-moz-box-shadow:0px 0px 15px #666;-webkit-box-shadow:0px 0px 15px #666;}
-	.content h2{font-size:200%;}
-	.content p{margin:0;}
-	.content ul{margin:5px 0 25px 15px;padding:0 0 0 10px;list-style-position:outside; list-style:decimal;}
-	.content li{list-style-position:outside; list-style:disc;}
-	.content a{color:#fff;}
+    #dotAjaxMainHangerDiv, #dotAjaxMainDiv { height: 100%; }
+    .portlet-wrapper { display: flex; height: 100%; justify-content: center; }
+    .unlicense-content { align-self: center; margin-top: 24px; text-align: center; }
+    .unlicense-content i, .unlicense-content h4 { color: #b3b1b8 }
+    .unlicense-content h4 { font-size:24px; font-weight:400; line-height:36px; }
+    .unlicense-content p { font-size:14px; font-weight:400; line-height:21px; margin-block-end:14px; margin-block-start:14px; }
+    .unlicense-content ul { display: inline-block; margin-block-end: 14px; margin-block-start: 14px;}
+    .unlicense-content ul li { line-height: 21px; list-style-type:disc; text-align: left; }
+    .unlicense-content ul li a { color: var(--color-main); font-size:14px; }
+    .request-license-button { background: var(--color-main); border: solid 1px transparent; border-radius: 2px; color: #fff; display: inline-block; line-height: 36px; padding: 0 24px; text-decoration: none; text-transform: uppercase; }
+    .request-license-button:hover { background: var(--color-main_mod); border: solid 1px transparent; }
 </style>
-
-<div class="wrapperCluster">
-	<div class="content">
-		<h2><%=LanguageUtil.get(pageContext, "com.dotcms.repackage.javax.portlet.title.EXT_CLUSTERING_TOOL")%></h2>
-		<p><%= LanguageUtil.get(pageContext, "CLUSTERING-NOT-LICENSED") %></p>
-	</div>
+<div class="portlet-wrapper">
+    <div class="unlicense-content">
+        <i class="material-icons" style="font-size: 120px;">storage</i>
+        <h4><%=LanguageUtil.get(pageContext, "com.dotcms.repackage.javax.portlet.title.EXT_CLUSTERING_TOOL")%></h4>
+        <p><%=LanguageUtil.get(pageContext, "com.dotcms.repackage.javax.portlet.title.EXT_CLUSTERING_TOOL")%> <%=LanguageUtil.get(pageContext, "only-available-in-enterprise")%></p>
+        <ul>
+            <li>
+                <a target="_blank" href="https://dotcms.com/product/features/feature-list"><%=LanguageUtil.get(pageContext, "Learn-more-about-dotCMS-Enterprise")%></a>
+            </li>
+            <li>
+                <a target="_blank" href="https://dotcms.com/contact-us/"><%=LanguageUtil.get(pageContext, "Contact-Us-for-more-Information")%></a>
+            </li>
+        </ul>
+        <p style="display: block;">
+            <a class="request-license-button" href="https://dotcms.com/licensing/request-a-license-3/index"><%=LanguageUtil.get(pageContext, "request-trial-license")%></a>
+        </p>
+    </div>
 </div>
-
-

--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsconfig/publishing/not_licensed.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsconfig/publishing/not_licensed.jsp
@@ -1,19 +1,32 @@
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <style>
-	.wrapperPublishing{background:url(/html/images/skin/push-publishing-promo.png) no-repeat 0 0;height:724px;margin:0 auto;border:1px silver solid;padding:0px;overflow:hidden;}
-	.content{position:fixed;left:50%;top:50%;margin:-200px 0 0 -300px;width:600px;background:#333;opacity:.75;color:#fff;padding:20px 20px 35px 20px;-moz-border-radius: 15px;-webkit-border-radius: 15px;-moz-box-shadow:0px 0px 15px #666;-webkit-box-shadow:0px 0px 15px #666;}
-	.content h2{font-size:200%;}
-	.content p{margin:0;}
-	.content ul{margin:5px 0 25px 15px;padding:0 0 0 10px;list-style-position:outside; list-style:decimal;}
-	.content li{list-style-position:outside; list-style:disc;}
-	.content a{color:#fff;}
+    #dotAjaxMainHangerDiv, #dotAjaxMainDiv { height: 100%; }
+    .portlet-wrapper { display: flex; height: 100%; justify-content: center; }
+    .unlicense-content { align-self: center; margin-top: 24px; text-align: center; }
+    .unlicense-content i, .unlicense-content h4 { color: #b3b1b8 }
+    .unlicense-content h4 { font-size:24px; font-weight:400; line-height:36px; }
+    .unlicense-content p { font-size:14px; font-weight:400; line-height:21px; margin-block-end:14px; margin-block-start:14px; }
+    .unlicense-content ul { display: inline-block; margin-block-end: 14px; margin-block-start: 14px;}
+    .unlicense-content ul li { line-height: 21px; list-style-type:disc; text-align: left; }
+    .unlicense-content ul li a { color: var(--color-main); font-size:14px; }
+    .request-license-button { background: var(--color-main); border: solid 1px transparent; border-radius: 2px; color: #fff; display: inline-block; line-height: 36px; padding: 0 24px; text-decoration: none; text-transform: uppercase; }
+    .request-license-button:hover { background: var(--color-main_mod); border: solid 1px transparent; }
 </style>
-
-<div class="wrapperPublishing">
-	<div class="content">
-		<h2><%=LanguageUtil.get(pageContext, "publisher_Publishing_Environment")%></h2>
-		<p><%= LanguageUtil.get(pageContext, "PUBLISHING-NOT-LICENSED") %></p>
-	</div>
+<div class="portlet-wrapper">
+    <div class="unlicense-content">
+        <i class="material-icons" style="font-size: 120px;">cloud_upload</i>
+        <h4><%=LanguageUtil.get(pageContext, "com.dotcms.repackage.javax.portlet.title.publishing-queue")%></h4>
+        <p><%=LanguageUtil.get(pageContext, "com.dotcms.repackage.javax.portlet.title.publishing-queue")%> <%=LanguageUtil.get(pageContext, "only-available-in-enterprise")%></p>
+        <ul>
+            <li>
+                <a target="_blank" href="https://dotcms.com/product/features/feature-list"><%=LanguageUtil.get(pageContext, "Learn-more-about-dotCMS-Enterprise")%></a>
+            </li>
+            <li>
+                <a target="_blank" href="https://dotcms.com/contact-us/"><%=LanguageUtil.get(pageContext, "Contact-Us-for-more-Information")%></a>
+            </li>
+        </ul>
+        <p style="display: block;">
+            <a class="request-license-button" href="https://dotcms.com/licensing/request-a-license-3/index"><%=LanguageUtil.get(pageContext, "request-trial-license")%></a>
+        </p>
+    </div>
 </div>
-
-


### PR DESCRIPTION
We need to update the old "get Enterprise" messages in the different screens in the system. You can see the old messages in community edition here:

Time Machine
ESSearch
Workflows
Rules
Publishing queue