### PR TITLE
Issue 18419 feedback

### DIFF
--- a/dotCMS/src/curl-test/FolderResource.postman_collection.json
+++ b/dotCMS/src/curl-test/FolderResource.postman_collection.json
@@ -7,7 +7,7 @@
 	},
 	"item": [
 		{
-			"name": "create folders success",
+			"name": "createFolders Success",
 			"event": [
 				{
 					"listen": "test",
@@ -23,6 +23,21 @@
 				}
 			],
 			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin@dotcms.com",
+							"type": "string"
+						}
+					]
+				},
 				"method": "POST",
 				"header": [],
 				"body": {
@@ -51,7 +66,66 @@
 			"response": []
 		},
 		{
-			"name": "Create Folders Invalid SiteName",
+			"name": "createFolders BadRequest with Restricted Name",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "6ca0531b-91fe-462f-8aed-cf3f45089238",
+						"exec": [
+							"pm.test(\"Status code should be 400\", function () {",
+							"    pm.response.to.have.status(400);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin@dotcms.com",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "[\"/dotcms\",\"/folder2/subfolder1\"]\n",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{serverURL}}/api/v1/folder/createfolders/demo.dotcms.com",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"folder",
+						"createfolders",
+						"demo.dotcms.com"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "createFolders BadRequest with Invalid SiteName",
 			"event": [
 				{
 					"listen": "test",
@@ -129,7 +203,7 @@
 			"response": []
 		},
 		{
-			"name": "Create Folders User without Permissions",
+			"name": "createFolders Forbidden User without Permissions",
 			"event": [
 				{
 					"listen": "test",

--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/folder/FolderResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/folder/FolderResourceTest.java
@@ -14,6 +14,7 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
+import com.dotmarketing.portlets.folders.exception.InvalidFolderNameException;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.liferay.portal.model.User;
 import com.liferay.util.Base64;
@@ -119,6 +120,22 @@ public class FolderResourceTest {
         final List<String> foldersToCreate = Arrays.asList("test"+currentTime+"/folder"+currentTime,"/test2"+currentTime+"/","test3"+currentTime);
 
         resource.createFolders(getHttpRequest(adminUser.getEmailAddress(),"admin"),response,foldersToCreate,"siteNameNotExists");
+
+    }
+
+    /**
+     * Method to test: createFolders in the FolderResource
+     * Given Scenario: Try to create a few folders using the admin user, but the folder name passed is restricted
+     * ExpectedResult: The endpoint should return InvalidFolderNameException that jersey will map to a 400 code and no folders created
+     *
+     */
+    @Test (expected = InvalidFolderNameException.class)
+    public void test_createFolders_restrictedFolderName_return400() throws DotDataException, DotSecurityException {
+        final Host newHost = new SiteDataGen().nextPersisted();
+        final User adminUser = TestUserUtils.getAdminUser();
+        final List<String> foldersToCreate = Arrays.asList("dotcms");
+
+        resource.createFolders(getHttpRequest(adminUser.getEmailAddress(),"admin"),response,foldersToCreate,newHost.getHostname());
 
     }
 

--- a/dotCMS/src/main/java/com/dotcms/exception/ExceptionUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/exception/ExceptionUtil.java
@@ -27,6 +27,7 @@ import com.dotmarketing.portlets.contentlet.business.DotContentletValidationExce
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.fileassets.business.FileAssetValidationException;
 import com.dotmarketing.portlets.folders.business.AddContentToFolderPermissionException;
+import com.dotmarketing.portlets.folders.exception.InvalidFolderNameException;
 import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.workflows.business.DotWorkflowException;
@@ -80,7 +81,8 @@ public class ExceptionUtil {
                     ValidationException.class,
                     BadRequestException.class,
                     JsonProcessingException.class,
-                    NumberFormatException.class
+                    NumberFormatException.class,
+                    InvalidFolderNameException.class
             );
 
 

--- a/dotCMS/src/main/java/com/dotcms/rest/servlet/ReloadableServletContainer.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/servlet/ReloadableServletContainer.java
@@ -48,6 +48,7 @@ import com.dotcms.rest.config.DotRestApplication;
 import com.dotcms.rest.exception.mapper.*;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.exception.AlreadyExistException;
+import com.dotmarketing.portlets.folders.exception.InvalidFolderNameException;
 import com.dotmarketing.util.Logger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
@@ -183,7 +184,8 @@ public class ReloadableServletContainer extends HttpServlet  {
                 .register((new DotBadRequestExceptionMapper<NumberFormatException>(){}).getClass())
                 .register(DotSecurityExceptionMapper.class)
                 .register(DotDataExceptionMapper.class)
-                .register(ElasticsearchStatusExceptionMapper.class);
+                .register(ElasticsearchStatusExceptionMapper.class)
+                .register((new DotBadRequestExceptionMapper<InvalidFolderNameException>(){}).getClass());
                 //.register(ExceptionMapper.class); // temporaly unregister since some services are expecting just a plain message as an error instead of a json, so to keep the compatibility we won't apply this change yet.
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/exception/InvalidFolderNameException.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/exception/InvalidFolderNameException.java
@@ -1,12 +1,12 @@
 package com.dotmarketing.portlets.folders.exception;
 
-import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.portlets.folders.model.Folder;
 
 /**
  * Exception thrown when a {@link com.dotmarketing.portlets.folders.model.Folder} is tried
  * to be persisted with an invalid name. Folder names are validated by
- * {@link com.dotmarketing.portlets.folders.business.FolderAPIImpl#validateFolderName(String)}
+ * {@link com.dotmarketing.portlets.folders.business.FolderFactoryImpl#validateFolderName(Folder)}
  *
  */
 


### PR DESCRIPTION
When a folder restricted name is passed in the endpoint should return 400.

Added InvalidFolderNameException to the ExceptionUtil (in case it is used that way) and to the ReloadableServletContainer (used by the jersey mapper, the right way to be called).