### PR TITLE
Additional fix for 18525

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
@@ -734,4 +734,121 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
         assertFalse(
                 translatedQuery.getQuery().contains("-basetype:" + BaseContentType.FORM.getType()));
     }
+
+    /**
+     * Method to test: {@link ESContentFactoryImpl#findContentletByIdentifierAnyLanguage(String)}
+     * Given Scenario: Happy path to get a contentlet given its identifier regardless of the language
+     * ExpectedResult: The method should return a contentlet
+     *
+     * @throws DotSecurityException
+     * @throws DotDataException
+     */
+    @Test
+    public void test_findContentletByIdentifierAnyLanguage()
+            throws DotSecurityException, DotDataException {
+
+        final ContentletAPI contentletAPI = APILocator.getContentletAPI();
+        final User user = APILocator.systemUser();
+        final Language language1 = new LanguageDataGen().nextPersisted();
+        final Language language2 = new LanguageDataGen().nextPersisted();
+
+        final ContentType bannerLikeContentType = TestDataUtils.getBannerLikeContentType();
+
+        final Contentlet banner1 = TestDataUtils
+                .getBannerLikeContent(true, language1.getId(), bannerLikeContentType.id(), null);
+
+        Contentlet banner2 = contentletAPI.checkout(banner1.getInode(), APILocator.systemUser(), false);
+
+        banner2.setLanguageId(language2.getId());
+        banner2.setInode("");
+
+        banner2 = contentletAPI.checkin(banner2, user, false);
+
+        final Contentlet result = instance.findContentletByIdentifierAnyLanguage(banner1.getIdentifier());
+
+        assertNotNull(result);
+        assertEquals(banner2.getIdentifier(), result.getIdentifier());
+    }
+
+    /**
+     * Method to test: {@link ESContentFactoryImpl#findContentletByIdentifierAnyLanguage(String)}
+     * Given Scenario: Find a contentlet given its identifier regardless of the language and all versions
+     * of the contentlet are archived
+     * ExpectedResult: The method shouldn't return any contentlet
+     *
+     * @throws DotSecurityException
+     * @throws DotDataException
+     */
+    @Test
+    public void test_findContentletByIdentifierAnyLanguageNoArchived()
+            throws DotSecurityException, DotDataException {
+
+        final ContentletAPI contentletAPI = APILocator.getContentletAPI();
+        final User user = APILocator.systemUser();
+        final Language language1 = new LanguageDataGen().nextPersisted();
+        final Language language2 = new LanguageDataGen().nextPersisted();
+
+        final ContentType bannerLikeContentType = TestDataUtils.getBannerLikeContentType();
+
+        final Contentlet banner1 = TestDataUtils
+                .getBannerLikeContent(true, language1.getId(), bannerLikeContentType.id(), null);
+
+        Contentlet banner2 = contentletAPI.checkout(banner1.getInode(), APILocator.systemUser(), false);
+
+        banner2.setLanguageId(language2.getId());
+        banner2.setInode("");
+
+        banner2 = contentletAPI.checkin(banner2, user, false);
+
+        contentletAPI.archive(banner1, user, false);
+        contentletAPI.archive(banner2, user, false);
+
+        CacheLocator.getContentletCache().remove(banner1);
+        CacheLocator.getContentletCache().remove(banner2);
+
+        final Contentlet result = instance.findContentletByIdentifierAnyLanguage(banner1.getIdentifier());
+
+        assertNull(result);
+    }
+
+    /**
+     * Method to test: {@link ESContentFactoryImpl#findContentletByIdentifierAnyLanguage(String, boolean)} 
+     * Given Scenario: Get a contentlet given its identifier regardless of the language and its archived status
+     * ExpectedResult: The method should return a contentlet
+     *
+     * @throws DotSecurityException
+     * @throws DotDataException
+     */
+    @Test
+    public void test_findContentletByIdentifierAnyLanguageIncludeDeleted()
+            throws DotSecurityException, DotDataException {
+
+        final ContentletAPI contentletAPI = APILocator.getContentletAPI();
+        final User user = APILocator.systemUser();
+        final Language language1 = new LanguageDataGen().nextPersisted();
+        final Language language2 = new LanguageDataGen().nextPersisted();
+
+        final ContentType bannerLikeContentType = TestDataUtils.getBannerLikeContentType();
+
+        final Contentlet banner1 = TestDataUtils
+                .getBannerLikeContent(true, language1.getId(), bannerLikeContentType.id(), null);
+
+        Contentlet banner2 = contentletAPI.checkout(banner1.getInode(), APILocator.systemUser(), false);
+
+        banner2.setLanguageId(language2.getId());
+        banner2.setInode("");
+
+        banner2 = contentletAPI.checkin(banner2, user, false);
+
+        contentletAPI.archive(banner1, user, false);
+        contentletAPI.archive(banner2, user, false);
+
+        CacheLocator.getContentletCache().remove(banner1);
+        CacheLocator.getContentletCache().remove(banner2);
+
+        final Contentlet result = instance.findContentletByIdentifierAnyLanguage(banner1.getIdentifier(), true);
+
+        assertNotNull(result);
+        assertEquals(banner2.getIdentifier(), result.getIdentifier());
+    }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
@@ -760,7 +760,6 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
         Contentlet banner2 = contentletAPI.checkout(banner1.getInode(), APILocator.systemUser(), false);
 
         banner2.setLanguageId(language2.getId());
-        banner2.setInode("");
 
         banner2 = contentletAPI.checkin(banner2, user, false);
 
@@ -796,7 +795,6 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
         Contentlet banner2 = contentletAPI.checkout(banner1.getInode(), APILocator.systemUser(), false);
 
         banner2.setLanguageId(language2.getId());
-        banner2.setInode("");
 
         banner2 = contentletAPI.checkin(banner2, user, false);
 
@@ -836,7 +834,6 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
         Contentlet banner2 = contentletAPI.checkout(banner1.getInode(), APILocator.systemUser(), false);
 
         banner2.setLanguageId(language2.getId());
-        banner2.setInode("");
 
         banner2 = contentletAPI.checkin(banner2, user, false);
 

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -420,7 +420,7 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
      * Method to test: {@link ESContentletAPIImpl#filterRelatedContent(Contentlet, Relationship, User, boolean, Boolean, int, int)}
      * Given Scenario: When a related content is obtained from the index and in database this content
      *                  doesn't exist (the index hasn't been updated yet), the returned list should not
-     *                  contain this "dirty" related content
+     *                  contain this "dirty" related content. Only applies for legacy relationships
      * ExpectedResult: The method should return an empty list
      * @throws DotDataException
      * @throws DotSecurityException
@@ -473,11 +473,11 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
 
             final ESContentletAPIImpl contentletAPIImpl = Mockito.spy(new ESContentletAPIImpl());
 
-            Mockito.doReturn(new Contentlet()).when(contentletAPIImpl)
-                    .findContentletByIdentifierAnyLanguage(commentsContentlet.getIdentifier());
+            Mockito.doReturn(new Contentlet()).when(contentletAPIImpl).
+                    findContentletByIdentifierAnyLanguage(commentsContentlet.getIdentifier(), true);
 
             Mockito.doReturn(new Contentlet()).when(contentletAPIImpl)
-                    .findContentletByIdentifierAnyLanguage(newsContentlet.getIdentifier());
+                    .findContentletByIdentifierAnyLanguage(newsContentlet.getIdentifier(), true);
 
             //Pull related content from comment child
             List<Contentlet> result = contentletAPIImpl
@@ -494,6 +494,158 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
 
             assertNotNull(result);
             assertEquals(0,result.size());
+
+        } finally {
+            if (newsContentlet != null && UtilMethods.isSet(newsContentlet.getInode())) {
+                ContentletDataGen.remove(newsContentlet);
+            }
+
+            if (commentsContentlet != null && UtilMethods.isSet(commentsContentlet.getInode())) {
+                ContentletDataGen.remove(commentsContentlet);
+            }
+
+        }
+    }
+
+    /**
+     * Method to test: {@link ESContentletAPIImpl#getRelatedContent(Contentlet, Relationship, User, boolean)}
+     * Given Scenario: A child is related to an archived parent. Only applies for legacy relationships
+     * ExpectedResult: The method should return a contentlet list with the archived parent
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    @Test
+    public void testGetArchivedRelatedParent()
+            throws DotDataException, DotSecurityException {
+
+        final ContentType news = getNewsLikeContentType("News");
+        final ContentType comments = getCommentsLikeContentType("Comments");
+        relateContentTypes(news, comments);
+
+        final ContentType newsContentType = contentTypeAPI.find("News");
+        final ContentType commentsContentType = contentTypeAPI.find("Comments");
+
+        Contentlet newsContentlet = null;
+        Contentlet commentsContentlet = null;
+
+        try {
+            //creates parent contentlet
+            ContentletDataGen dataGen = new ContentletDataGen(newsContentType.id());
+
+            //English version
+            newsContentlet = dataGen.languageId(languageAPI.getDefaultLanguage().getId())
+                    .setProperty("title", "News Test")
+                    .setProperty("urlTitle", "news-test").setProperty("byline", "news-test")
+                    .setProperty("sysPublishDate", new Date()).setProperty("story", "news-test")
+                    .next();
+
+            //creates child contentlet
+            dataGen = new ContentletDataGen(commentsContentType.id());
+            commentsContentlet = dataGen
+                    .languageId(languageAPI.getDefaultLanguage().getId())
+                    .setProperty("title", "Comment for News")
+                    .setProperty("email", "testing@dotcms.com")
+                    .setProperty("comment", "Comment for News")
+                    .setPolicy(IndexPolicy.FORCE).nextPersisted();
+
+            //Saving relationship
+            final Relationship relationship = relationshipAPI.byTypeValue("News-Comments");
+
+            newsContentlet.setIndexPolicy(IndexPolicy.FORCE);
+
+            newsContentlet = contentletAPI.checkin(newsContentlet,
+                    map(relationship, list(commentsContentlet)),
+                    null, user, false);
+
+            //archive parent
+            contentletAPI.archive(newsContentlet, user, false);
+
+            CacheLocator.getContentletCache().remove(commentsContentlet);
+            CacheLocator.getContentletCache().remove(newsContentlet);
+
+            //Pull related content from comment child
+            List<Contentlet> result = contentletAPI
+                    .getRelatedContent(commentsContentlet, relationship, user, false);
+
+            assertNotNull(result);
+            assertEquals(1,result.size());
+            assertEquals(newsContentlet.getIdentifier(), result.get(0).getIdentifier());
+
+        } finally {
+            if (newsContentlet != null && UtilMethods.isSet(newsContentlet.getInode())) {
+                ContentletDataGen.remove(newsContentlet);
+            }
+
+            if (commentsContentlet != null && UtilMethods.isSet(commentsContentlet.getInode())) {
+                ContentletDataGen.remove(commentsContentlet);
+            }
+
+        }
+    }
+
+    /**
+     * Method to test: {@link ESContentletAPIImpl#getRelatedContent(Contentlet, Relationship, User, boolean)}
+     * Given Scenario: A parent is related to an archived child. Only applies for legacy relationships
+     * ExpectedResult: The method should return a contentlet list with the archived child
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    @Test
+    public void testGetArchivedRelatedChild()
+            throws DotDataException, DotSecurityException {
+
+        final ContentType news = getNewsLikeContentType("News");
+        final ContentType comments = getCommentsLikeContentType("Comments");
+        relateContentTypes(news, comments);
+
+        final ContentType newsContentType = contentTypeAPI.find("News");
+        final ContentType commentsContentType = contentTypeAPI.find("Comments");
+
+        Contentlet newsContentlet = null;
+        Contentlet commentsContentlet = null;
+
+        try {
+            //creates parent contentlet
+            ContentletDataGen dataGen = new ContentletDataGen(newsContentType.id());
+
+            //English version
+            newsContentlet = dataGen.languageId(languageAPI.getDefaultLanguage().getId())
+                    .setProperty("title", "News Test")
+                    .setProperty("urlTitle", "news-test").setProperty("byline", "news-test")
+                    .setProperty("sysPublishDate", new Date()).setProperty("story", "news-test")
+                    .next();
+
+            //creates child contentlet
+            dataGen = new ContentletDataGen(commentsContentType.id());
+            commentsContentlet = dataGen
+                    .languageId(languageAPI.getDefaultLanguage().getId())
+                    .setProperty("title", "Comment for News")
+                    .setProperty("email", "testing@dotcms.com")
+                    .setProperty("comment", "Comment for News")
+                    .setPolicy(IndexPolicy.FORCE).nextPersisted();
+
+            //Saving relationship
+            final Relationship relationship = relationshipAPI.byTypeValue("News-Comments");
+
+            newsContentlet.setIndexPolicy(IndexPolicy.FORCE);
+
+            newsContentlet = contentletAPI.checkin(newsContentlet,
+                    map(relationship, list(commentsContentlet)),
+                    null, user, false);
+
+            //archive parent
+            contentletAPI.archive(commentsContentlet, user, false);
+
+            CacheLocator.getContentletCache().remove(commentsContentlet);
+            CacheLocator.getContentletCache().remove(newsContentlet);
+
+            //Pull related content from comment child
+            List<Contentlet> result = contentletAPI
+                    .getRelatedContent(newsContentlet, relationship, user, false);
+
+            assertNotNull(result);
+            assertEquals(1,result.size());
+            assertEquals(commentsContentlet.getIdentifier(), result.get(0).getIdentifier());
 
         } finally {
             if (newsContentlet != null && UtilMethods.isSet(newsContentlet.getInode())) {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -984,14 +984,22 @@ public class ESContentFactoryImpl extends ContentletFactory {
     protected Contentlet findContentletByIdentifierAnyLanguage(final String identifier) throws DotDataException, DotSecurityException {
 	    
 	    // Looking content up this way can avoid any DB hits as these calls are all cached.
-	    final List<Language> langs = APILocator.getLanguageAPI().getLanguages();
-	    for(final Language language : langs) {
-	        final ContentletVersionInfo cvi = APILocator.getVersionableAPI().getContentletVersionInfo(identifier, language.getId());
-	        if(cvi != null  && UtilMethods.isSet(cvi.getIdentifier()) && !cvi.isDeleted()) {
-	            return find(cvi.getWorkingInode());
-	        }
-	    }
-	    return null;
+	    return findContentletByIdentifierAnyLanguage(identifier, false);
+
+    }
+
+    @Override
+    protected Contentlet findContentletByIdentifierAnyLanguage(final String identifier, final boolean includeDeleted) throws DotDataException, DotSecurityException {
+
+        // Looking content up this way can avoid any DB hits as these calls are all cached.
+        final List<Language> langs = APILocator.getLanguageAPI().getLanguages();
+        for(final Language language : langs) {
+            final ContentletVersionInfo cvi = APILocator.getVersionableAPI().getContentletVersionInfo(identifier, language.getId());
+            if(cvi != null  && UtilMethods.isSet(cvi.getIdentifier()) && (includeDeleted || !cvi.isDeleted())) {
+                return find(cvi.getWorkingInode());
+            }
+        }
+        return null;
 
     }
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -447,8 +447,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
             throw new DotContentletStateException("Can't find contentlet: " + identifier + " lang:" + incomingLangId + " live:" + live, e);
         }
     }
-    
-    
+
+    @CloseDBIfOpened
+    @Override
+    public Contentlet findContentletByIdentifierAnyLanguage(final String identifier, final boolean includeDeleted) throws DotDataException {
+        try {
+            return contentFactory.findContentletByIdentifierAnyLanguage(identifier, includeDeleted);
+
+        } catch (Exception e) {
+            throw new DotContentletStateException("Can't find contentlet: " + identifier, e);
+        }
+    }
     
     
     @CloseDBIfOpened
@@ -461,6 +470,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             throw new DotContentletStateException("Can't find contentlet: " + identifier, e);
         }
     }
+
 
     @CloseDBIfOpened
     @Override
@@ -1589,12 +1599,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                     relatedIdentifiers.stream().forEach(child -> {
                         try {
-                            final Contentlet mappedContentlet = findContentletByIdentifierAnyLanguage(child);
+                            final Contentlet mappedContentlet = findContentletByIdentifierAnyLanguage(child, true);
                             if (null != mappedContentlet && UtilMethods.isSet(mappedContentlet.getIdentifier())) {
                                 result.add(mappedContentlet);
                             } else {
                                 Logger.warn(this, String.format("Child Contentlet with ID '%s' for relationship '%s' " +
-                                                "was not found. Verify that it exists in the database and it's NOT archived", child,
+                                                "was not found. Verify that it exists in the database", child,
                                         rel.getRelationTypeValue()));
                             }
                         } catch (final Exception e) {
@@ -1656,12 +1666,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     final Map<String, Object> sourceMap = sh.getSourceAsMap();
                     final String identifier = (String) sourceMap.get("identifier");
                     if (identifier != null && !relatedMap.containsKey(identifier)) {
-                        final Contentlet mappedContentlet = findContentletByIdentifierAnyLanguage(identifier);
+                        final Contentlet mappedContentlet = findContentletByIdentifierAnyLanguage(identifier, true);
                         if (null != mappedContentlet && UtilMethods.isSet(mappedContentlet.getIdentifier())) {
                             relatedMap.put(identifier, mappedContentlet);
                         } else {
                             Logger.warn(this, String.format("Parent Contentlet with ID '%s' for relationship '%s' was" +
-                                            " not found. Verify that it exists in the database and it's NOT archived", identifier,
+                                            " not found. Verify that it exists in the database", identifier,
                                     rel.getRelationTypeValue()));
                         }
                     }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -116,8 +116,19 @@ public interface ContentletAPI {
 	 */
 	public Contentlet findContentletByIdentifier(String identifier, boolean live, long languageId, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException, DotContentletStateException;
 
-	/**
-	 * Retrieves a contentlet from the database by its identifier and the working version
+    /**
+     * Retrieves a contentlet from the database by its identifier and the working version.
+     * It includes archive content if includeDeleted is true
+     * @param identifier
+     * @param includeDeleted
+     * @return Contentlet object
+     * @throws DotSecurityException
+     * @throws DotDataException
+     */
+    Contentlet findContentletByIdentifierAnyLanguage(String identifier, boolean includeDeleted) throws DotDataException;
+
+    /**
+	 * Retrieves a contentlet from the database by its identifier and the working version. Ignores archived content
 	 * @param identifier
 	 * @return Contentlet object
 	 * @throws DotSecurityException

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -835,6 +835,22 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 		return c;
 	}
 
+    @Override
+    public Contentlet findContentletByIdentifierAnyLanguage(String identifier, final boolean includeDeleted) throws DotDataException {
+        for(ContentletAPIPreHook pre : preHooks){
+            boolean preResult = pre.findContentletByIdentifierAnyLanguage(identifier, includeDeleted);
+            if(!preResult){
+                Logger.error(this, "The following prehook failed " + pre.getClass().getName());
+                throw new DotRuntimeException("The following prehook failed " + pre.getClass().getName());
+            }
+        }
+        Contentlet c = conAPI.findContentletByIdentifierAnyLanguage(identifier, includeDeleted);
+        for(ContentletAPIPostHook post : postHooks){
+            post.findContentletByIdentifierAnyLanguage(identifier, includeDeleted);
+        }
+        return c;
+    }
+
 	@Override
 	public Contentlet findContentletByIdentifierAnyLanguage(String identifier) throws DotDataException {
 		for(ContentletAPIPreHook pre : preHooks){

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
@@ -1613,4 +1613,8 @@ public interface ContentletAPIPostHook {
     default void invalidateRelatedContentCache(Contentlet contentlet, Relationship relationship, boolean hasParent){
 
     }
+
+    default void findContentletByIdentifierAnyLanguage(String identifier, boolean includeDeleted){
+
+    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
@@ -1901,4 +1901,8 @@ public interface ContentletAPIPreHook {
     default boolean invalidateRelatedContentCache(Contentlet contentlet, Relationship relationship, boolean hasParent){
         return true;
     }
+
+    default boolean findContentletByIdentifierAnyLanguage(String identifier, boolean includeDeleted) {
+        return true;
+    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
@@ -53,14 +53,26 @@ public abstract class ContentletFactory {
 	
 	/**
 	 * This method gets a Contentlet object given the inode
-	 * @param id
+	 * @param inode
 	 * @return 
 	 * @throws DotDataException
 	 * @throws DotSecurityException 
 	 */
 	protected abstract Contentlet find(String inode) throws DotDataException, DotSecurityException;
-	
-	/**
+
+    /**
+     * Retrieves a contentlet from the database by its identifier and the working version.
+     * It includes archive content if includeDeleted is true
+     * @param identifier
+     * @param includeDeleted
+     * @return
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    protected abstract Contentlet findContentletByIdentifierAnyLanguage(String identifier,
+            boolean includeDeleted) throws DotDataException, DotSecurityException;
+
+    /**
 	 * Returns a live Contentlet Object for a given language
 	 * @param languageId
 	 * @param contentletId

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/tiny_mce_config_default.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/tiny_mce_config_default.jsp
@@ -23,7 +23,7 @@ String insertImageLabel = LanguageUtil.get(pageContext, "insert-image");
 
 %>
 
-const dotCMSHasLicense = <%=licenseLevel > licenseStandard%>
+var dotCMSHasLicense = <%=licenseLevel > licenseStandard%>
 
 var tinyMCEProps = {
     dotLanguageStrings: {


### PR DESCRIPTION
This PR fixes two issues in the Edit Content screen if legacy relationships exist: 
* A javascript error didn't allow to display related content (tiny_mce_config_default.jsp)
* Archived related content wasn't being listed 