### PR TITLE
#18446  isContentlet  must be part of the properties on DotAsset

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/PageViewStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/PageViewStrategy.java
@@ -74,6 +74,7 @@ public class PageViewStrategy extends WebAssetStrategy<HTMLPageAsset> {
         map.put("name", page.getPageUrl());
         map.put("description", page.getFriendlyName());
         map.put("extension", "page");
+        map.put("isContentlet", true);
         map.put("statusIcons", UtilHTML.getStatusIcons(page));
         map.put("__icon__", IconType.HTMLPAGE.iconName());
 


### PR DESCRIPTION
@wezell found that the property named "isContentlet" is still required by certain pieces of functionality. We can not simply let it go. 
The property is part again of pages and dotAssets as it used to be on the code we had on BrowserAPIImpl 