### PR TITLE
#18775 pull relatedContent parent when self joined

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -5658,7 +5658,7 @@ public class ContentletAPITest extends ContentletBaseTest {
             blogContent = contentletAPI.checkin(blogContent, relationships, categories, null, user,
                 false);
 
-            List<Contentlet> relatedContentFromDB = relationshipAPI.dbRelatedContent(relationship, blogContent);
+            List<Contentlet> relatedContentFromDB = relationshipAPI.dbRelatedContent(relationship, blogContent,false);
 
             assertTrue(relatedContentFromDB.containsAll(relatedContent));
 
@@ -5669,7 +5669,7 @@ public class ContentletAPITest extends ContentletBaseTest {
             Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutBlogContent, (ContentletRelationships) null,
                 null, null, user, false);
 
-            List<Contentlet> existingRelationships = relationshipAPI.dbRelatedContent(relationship, reCheckedinContent);
+            List<Contentlet> existingRelationships = relationshipAPI.dbRelatedContent(relationship, reCheckedinContent, false);
 
             assertTrue(existingRelationships.containsAll(relatedContent));
         } finally {

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/RelationshipFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/RelationshipFactoryImpl.java
@@ -307,9 +307,14 @@ public class RelationshipFactoryImpl implements RelationshipFactory{
         final boolean selfJoinRelationship = relationship.getParentStructureInode().equalsIgnoreCase(stInode)
                 && relationship.getChildStructureInode().equalsIgnoreCase(stInode);
 
-        final boolean hasParent = !selfJoinRelationship && relationship.getParentStructureInode().equalsIgnoreCase(stInode);
+        if(!selfJoinRelationship) {
+            final boolean hasParent = relationship.getParentStructureInode()
+                    .equalsIgnoreCase(stInode);
 
-        return dbRelatedContent(relationship, contentlet, hasParent);
+            return dbRelatedContent(relationship, contentlet, hasParent);
+        } else{//if the relationship is self joined, get the related content where the contentlet is parent
+            return  dbRelatedContent(relationship, contentlet, true);
+        }
     }
 
     @Override


### PR DESCRIPTION
If the contentlet that we're PP is the child content we **should not** be pushing the content parent, but the other way around yes, PP the parent contentlet **should** push the child content. The previous code worked the other way.

This method is only used at PP level, so when you PP a contentlet with relationships this should be the behavior:
```
Test1 and Test2, Test2(acting as parent) is related to Test1(acting as child):
- Send contentlet with relationships, should send other contentlets (Sending Test2 should send Test1 as well).
- Send contentlet without relationships, but it's related to another one (Sending Test1 should not send Test2).
```
