### PR TITLE
Release 5.3.4 cluster init fix

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -315,7 +315,7 @@ public class TaskLocatorUtil {
 		ret.add(Task00006CreateSystemLayout.class);
 		ret.add(Task00007RemoveSitesearchQuartzJob.class);
 		ret.add(Task00002LoadClusterLicenses.class);
-		ret.add(Task00030ClusterInitialize.class);
+		//ret.add(Task00030ClusterInitialize.class);
 		ret.add(Task00040CheckAnonymousUser.class);
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
 	}

--- a/dotCMS/src/main/java/com/liferay/portal/servlet/MainServlet.java
+++ b/dotCMS/src/main/java/com/liferay/portal/servlet/MainServlet.java
@@ -19,6 +19,7 @@
 
 package com.liferay.portal.servlet;
 
+import com.dotmarketing.startup.runalways.Task00030ClusterInitialize;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
@@ -111,13 +112,18 @@ public class MainServlet extends ActionServlet {
       new ESIndexAPI().waitUtilIndexReady();
       
       
-      
-      
+
+
 
       // Checking for execute upgrades
       try {
         StartupTasksExecutor.getInstance().executeStartUpTasks();
         StartupTasksExecutor.getInstance().executeUpgrades();
+
+        final Task00030ClusterInitialize clusterInitializeTask = new Task00030ClusterInitialize();
+        if(clusterInitializeTask.forceRun()){
+          clusterInitializeTask.executeUpgrade();
+        }
 
       } catch (Exception e1) {
         throw new DotRuntimeException(e1);


### PR DESCRIPTION
This comes to solve the following problem 
 cluster initialize gets called from StartUpTasks but now it depends on an Upgrade task that is executed much later. 
The fix for it would be calling cluster-initialize after all upgrade tasks have completed.