### PR TITLE
Issue 18705

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/publishing/PushPublishFiltersInitializerTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publishing/PushPublishFiltersInitializerTest.java
@@ -7,6 +7,7 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Logger;
 import com.google.common.collect.ImmutableMap;
+import com.liferay.util.FileUtil;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -58,6 +59,33 @@ public class PushPublishFiltersInitializerTest {
         Stream<Path> pathStream = Files.list(path.toPath());
 
         pathStream.forEach(path1 -> pushPublishFiltersInitializer.loadFilter(path1));
+
+        final List<FilterDescriptor> filterDescriptorList = APILocator.getPublisherAPI().getFiltersDescriptorsByRole(
+                TestUserUtils.getAdminUser());
+        Assert.assertFalse(filterDescriptorList.isEmpty());
+        Assert.assertTrue(filterDescriptorList.stream().anyMatch(filter -> filter.getKey().equalsIgnoreCase(filterDescriptor.getKey())));
+    }
+
+    /**
+     * Method to test: {@link PushPublishFiltersInitializer#loadFilter(Path)}
+     * Given Scenario: Given 2 yaml files, one without any error and one empty, the initializer reads both files and only loads the one without errors
+     * ExpectedResult: filter without errors is successfully added to the filterDescriptorMap
+     *
+     */
+    @Test
+    public void test_loadFilter_filterWithAnError_otherFiltersLoadSuccessfully() throws IOException, DotDataException {
+        //YAML file without issues
+        final Map<String,Object> filtersMap =
+                ImmutableMap.of("dependencies",true,"relationships",true,"excludeClasses","Host,Workflow");
+        final FilterDescriptor filterDescriptor =
+                new FilterDescriptor("filterTestWithoutAnError.yml","Filter Test Title",filtersMap,true,"Reviewer,dotcms.org.2789");
+        createFilterFile(filterDescriptor);
+
+        // Bad YAML file, it's empty
+        final File file = File.createTempFile("filterTestWithoutAnError", ".yml",path);
+        FileUtil.write(file, "");
+
+        Files.list(path.toPath()).forEach(path1 -> pushPublishFiltersInitializer.loadFilter(path1));
 
         final List<FilterDescriptor> filterDescriptorList = APILocator.getPublisherAPI().getFiltersDescriptorsByRole(
                 TestUserUtils.getAdminUser());

--- a/dotCMS/src/main/java/com/dotcms/publishing/PushPublishFiltersInitializer.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/PushPublishFiltersInitializer.java
@@ -55,9 +55,13 @@ public class PushPublishFiltersInitializer implements DotInitializer {
     protected void loadFilter(final Path path){
         final String fileName = path.getFileName().toString();
         Logger.info(PushPublishFiltersInitializer.class, " ymlFileName:  " + fileName);
-        final FilterDescriptor filterDescriptor = YamlUtil.parse(path,FilterDescriptor.class);
-        filterDescriptor.setKey(fileName);
-        Logger.info(PushPublishFiltersInitializer.class, filterDescriptor.toString());
-        APILocator.getPublisherAPI().addFilterDescriptor(filterDescriptor);
+        try {
+            final FilterDescriptor filterDescriptor = YamlUtil.parse(path, FilterDescriptor.class);
+            filterDescriptor.setKey(fileName);
+            Logger.info(PushPublishFiltersInitializer.class, filterDescriptor.toString());
+            APILocator.getPublisherAPI().addFilterDescriptor(filterDescriptor);
+        }catch(Exception e) {
+            Logger.warnAndDebug(this.getClass(), "unable to load PP filter:" + path.toString() + " cause: " + e.getMessage(), e);
+        }
     }
 }


### PR DESCRIPTION
Previously if we had a bad YAML any of the filters didn't load. Now if there is a bad YAML, we log the error and still load the other filters.