### PR TITLE
#18187 Using whitespace analyzer with the host aliases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "dotCMS/src/main/enterprise"]
 	path = dotCMS/src/main/enterprise
 	url = git@github.com:dotCMS/enterprise-2.x.git
-        branch = release-5.3.4
+        branch = master
 	ignore = dirty

--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -1,7 +1,7 @@
 //noinspection GroovyAssignabilityCheck
 dependencies {
 
-    compile group: 'com.dotcms.enterprise', name: 'ee', version: '5.3.4', changing: true
+    compile group: 'com.dotcms.enterprise', name: 'ee', version: 'master-SNAPSHOT', changing: true
 
     
     compile group: 'com.dotcms', name: 'ant-tooling', version: '1.3.2'

--- a/dotCMS/gradle.properties
+++ b/dotCMS/gradle.properties
@@ -1,4 +1,4 @@
-dotcmsReleaseVersion=5.3.4
+dotcmsReleaseVersion=master
 coreWebReleaseVersion=latest
 webComponentsReleaseVersion=latest
 

--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -25,6 +25,7 @@ import com.dotcms.rest.api.v1.user.UserResourceIntegrationTest;
 import com.dotcms.security.apps.AppsAPIImplTest;
 import com.dotmarketing.image.focalpoint.FocalPointAPITest;
 import com.dotmarketing.portlets.cmsmaintenance.factories.CMSMaintenanceFactoryTest;
+import com.dotmarketing.portlets.contentlet.business.HostAPITest;
 import com.dotmarketing.portlets.contentlet.model.IntegrationResourceLinkTest;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPIImplIntegrationTest;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPIImplTest;
@@ -290,7 +291,8 @@ import org.junit.runners.Suite.SuiteClasses;
         CMSMaintenanceFactoryTest.class,
         Task05350AddDotSaltClusterColumnTest.class,
         DotParseTest.class,
-        TestWorkflowAction.class
+        TestWorkflowAction.class,
+        HostAPITest.class
 })
 public class MainSuite {
 

--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/SiteDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/SiteDataGen.java
@@ -14,8 +14,8 @@ public class SiteDataGen extends AbstractDataGen<Host> {
     private final long currentTime = System.currentTimeMillis();
 
     private String name = "test" + currentTime + ".dotcms.com";
-    private String aliases = null;
-    private boolean isDefault = false;
+    private String aliases;
+    private boolean isDefault;
 
     public SiteDataGen name(final String name) {
         this.name = name;

--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/SiteDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/SiteDataGen.java
@@ -14,9 +14,21 @@ public class SiteDataGen extends AbstractDataGen<Host> {
     private final long currentTime = System.currentTimeMillis();
 
     private String name = "test" + currentTime + ".dotcms.com";
+    private String aliases = null;
+    private boolean isDefault = false;
 
     public SiteDataGen name(final String name) {
         this.name = name;
+        return this;
+    }
+
+    public SiteDataGen aliases(final String aliases) {
+        this.aliases = aliases;
+        return this;
+    }
+
+    public SiteDataGen setDefault(final boolean isDefault) {
+        this.isDefault = isDefault;
         return this;
     }
 
@@ -25,10 +37,14 @@ public class SiteDataGen extends AbstractDataGen<Host> {
 
         final Host site = new Host();
         site.setHostname(name);
-        site.setDefault(false);
+        site.setDefault(isDefault);
         site.setLanguageId(language.getId());
         site.setIndexPolicy(IndexPolicy.WAIT_FOR);
         site.setBoolProperty(Contentlet.IS_TEST_MODE, true);
+
+        if (aliases != null) {
+            site.setAliases(aliases);
+        }
 
         return site;
     }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
@@ -649,7 +649,7 @@ public class HostAPITest extends IntegrationTestBase  {
     @Test
     public void shouldReturnHostByAlias() throws DotSecurityException, DotDataException {
         final Host host = new SiteDataGen().aliases("demo.dotcms.com").nextPersisted();
-        final Host host_2 = new SiteDataGen().aliases("not-demo.dotcms.com").setDefault(true).nextPersisted();
+        final Host host_2 = new SiteDataGen().aliases("not-demo.dotcms.com").nextPersisted();
 
         final Role role = new RoleDataGen().nextPersisted();
         final User user = new UserDataGen().roles(role).nextPersisted();

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
@@ -660,4 +660,45 @@ public class HostAPITest extends IntegrationTestBase  {
         assertNotEquals(host_2, hostReturned);
     }
 
+    /**
+     * Method to test: {@link HostAPI#findByAlias(String, User, boolean)}
+     * When create one host with multiple alias
+     * Should return thehost by alias
+     */
+    @Test
+    public void whenHostHasMultipleAliasshouldReturnHostByAlias() throws DotSecurityException, DotDataException {
+        final Host host = new SiteDataGen().aliases("demo.dotcms.com\r\ntest.dotcms.com").nextPersisted();
+
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = new UserDataGen().roles(role).nextPersisted();
+
+        this.addPermission(role, host);
+
+        final Host hostReturned = APILocator.getHostAPI().findByAlias("test.dotcms.com", user, false);
+        assertEquals(host, hostReturned);
+    }
+
+    /**
+     * Method to test: {@link HostAPI#findByAlias(String, User, boolean)}
+     * When create two host with alias that both start by prod-
+     * Should return the right host by alias
+     */
+    @Test
+    public void whenBothAliasStartByProd() throws DotSecurityException, DotDataException {
+        final Host host = new SiteDataGen().aliases("prod-client.dotcms.com").nextPersisted();
+        final Host host_2 = new SiteDataGen().aliases("prod-anotherclient.dotcms.com").setDefault(true).nextPersisted();
+
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = new UserDataGen().roles(role).nextPersisted();
+
+        this.addPermission(role, host);
+
+        final Host hostReturned = APILocator.getHostAPI().findByAlias("prod-client.dotcms.com", user, false);
+        assertEquals(host, hostReturned);
+        assertNotEquals(host_2, hostReturned);
+
+        final Host hostReturned2 = APILocator.getHostAPI().findByAlias("prod-anotherclient.dotcms.com", user, false);
+        assertNotEquals(host, hostReturned2);
+        assertEquals(host_2, hostReturned2);
+    }
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
@@ -39,6 +39,8 @@ import com.liferay.portal.model.User;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+
+import io.vavr.API;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -647,18 +649,24 @@ public class HostAPITest extends IntegrationTestBase  {
      */
     @Test
     public void shouldReturnHostByAlias() throws DotSecurityException, DotDataException {
-        final Host host = new SiteDataGen().aliases("demo.dotcms.com").nextPersisted();
-        final Host host_2 = new SiteDataGen().aliases("not-demo.dotcms.com").setDefault(true).nextPersisted();
+        final Host defaultHost = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
 
-        final Role role = new RoleDataGen().nextPersisted();
-        final User user = new UserDataGen().roles(role).nextPersisted();
+        try {
+            final Host host = new SiteDataGen().aliases("demo.dotcms.com").nextPersisted();
+            final Host host_2 = new SiteDataGen().aliases("not-demo.dotcms.com").setDefault(true).nextPersisted();
 
-        this.addPermission(role, host);
-        this.addPermission(role, host_2);
-        
-        final Host hostReturned = APILocator.getHostAPI().findByAlias("demo.dotcms.com", user, false);
-        assertEquals(host, hostReturned);
-        assertNotEquals(host_2, hostReturned);
+            final Role role = new RoleDataGen().nextPersisted();
+            final User user = new UserDataGen().roles(role).nextPersisted();
+
+            this.addPermission(role, host);
+            this.addPermission(role, host_2);
+
+            final Host hostReturned = APILocator.getHostAPI().findByAlias("demo.dotcms.com", user, false);
+            assertEquals(host, hostReturned);
+            assertNotEquals(host_2, hostReturned);
+        } finally {
+            APILocator.getHostAPI().makeDefault(defaultHost, APILocator.systemUser(), false);
+        }
     }
 
     /**
@@ -686,21 +694,29 @@ public class HostAPITest extends IntegrationTestBase  {
      */
     @Test
     public void whenBothAliasStartByProd() throws DotSecurityException, DotDataException {
-        final Host host = new SiteDataGen().aliases("prod-client.dotcms.com").nextPersisted();
-        final Host host_2 = new SiteDataGen().aliases("prod-anotherclient.dotcms.com").setDefault(true).nextPersisted();
 
-        final Role role = new RoleDataGen().nextPersisted();
-        final User user = new UserDataGen().roles(role).nextPersisted();
+        final Host defaultHost = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
 
-        this.addPermission(role, host);
-        this.addPermission(role, host_2);
+        try {
+            final Host host = new SiteDataGen().aliases("prod-client.dotcms.com").nextPersisted();
+            final Host host_2 = new SiteDataGen().aliases("prod-anotherclient.dotcms.com").setDefault(true).nextPersisted();
 
-        final Host hostReturned = APILocator.getHostAPI().findByAlias("prod-client.dotcms.com", user, false);
-        assertEquals(host, hostReturned);
-        assertNotEquals(host_2, hostReturned);
+            final Role role = new RoleDataGen().nextPersisted();
+            final User user = new UserDataGen().roles(role).nextPersisted();
 
-        final Host hostReturned2 = APILocator.getHostAPI().findByAlias("prod-anotherclient.dotcms.com", user, false);
-        assertNotEquals(host, hostReturned2);
-        assertEquals(host_2, hostReturned2);
+            this.addPermission(role, host);
+            this.addPermission(role, host_2);
+
+            final Host hostReturned = APILocator.getHostAPI().findByAlias("prod-client.dotcms.com", user, false);
+            assertEquals(host, hostReturned);
+            assertNotEquals(host_2, hostReturned);
+
+            final Host hostReturned2 = APILocator.getHostAPI().findByAlias("prod-anotherclient.dotcms.com", user, false);
+            assertNotEquals(host, hostReturned2);
+            assertEquals(host_2, hostReturned2);
+
+        } finally {
+            APILocator.getHostAPI().makeDefault(defaultHost, APILocator.systemUser(), false);
+        }
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
@@ -639,4 +639,25 @@ public class HostAPITest extends IntegrationTestBase  {
         APILocator.getPermissionAPI().save(CollectionsUtils.list(permission), host, systemUser, false);
     }
 
+    /**
+     * Method to test: {@link HostAPI#findByAlias(String, User, boolean)}
+     * When create two host: first one with alias equals to demo.dotcms.com and second  one with alias equals to not-demo.dotcms.com
+     *      and find by  demo.dotcms.com
+     * Should return the first one
+     */
+    @Test
+    public void shouldReturnHostByAlias() throws DotSecurityException, DotDataException {
+        final Host host = new SiteDataGen().aliases("demo.dotcms.com").nextPersisted();
+        final Host host_2 = new SiteDataGen().aliases("not-demo.dotcms.com").setDefault(true).nextPersisted();
+
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = new UserDataGen().roles(role).nextPersisted();
+
+        this.addPermission(role, host);
+
+        final Host hostReturned = APILocator.getHostAPI().findByAlias("demo.dotcms.com", user, false);
+        assertEquals(host, hostReturned);
+        assertNotEquals(host_2, hostReturned);
+    }
+
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import io.vavr.API;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -649,24 +648,18 @@ public class HostAPITest extends IntegrationTestBase  {
      */
     @Test
     public void shouldReturnHostByAlias() throws DotSecurityException, DotDataException {
-        final Host defaultHost = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
+        final Host host = new SiteDataGen().aliases("demo.dotcms.com").nextPersisted();
+        final Host host_2 = new SiteDataGen().aliases("not-demo.dotcms.com").setDefault(true).nextPersisted();
 
-        try {
-            final Host host = new SiteDataGen().aliases("demo.dotcms.com").nextPersisted();
-            final Host host_2 = new SiteDataGen().aliases("not-demo.dotcms.com").setDefault(true).nextPersisted();
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = new UserDataGen().roles(role).nextPersisted();
 
-            final Role role = new RoleDataGen().nextPersisted();
-            final User user = new UserDataGen().roles(role).nextPersisted();
+        this.addPermission(role, host);
+        this.addPermission(role, host_2);
 
-            this.addPermission(role, host);
-            this.addPermission(role, host_2);
-
-            final Host hostReturned = APILocator.getHostAPI().findByAlias("demo.dotcms.com", user, false);
-            assertEquals(host, hostReturned);
-            assertNotEquals(host_2, hostReturned);
-        } finally {
-            APILocator.getHostAPI().makeDefault(defaultHost, APILocator.systemUser(), false);
-        }
+        final Host hostReturned = APILocator.getHostAPI().findByAlias("demo.dotcms.com", user, false);
+        assertEquals(host, hostReturned);
+        assertNotEquals(host_2, hostReturned);
     }
 
     /**
@@ -694,29 +687,21 @@ public class HostAPITest extends IntegrationTestBase  {
      */
     @Test
     public void whenBothAliasStartByProd() throws DotSecurityException, DotDataException {
+        final Host host = new SiteDataGen().aliases("prod-client.dotcms.com").nextPersisted();
+        final Host host_2 = new SiteDataGen().aliases("prod-anotherclient.dotcms.com").nextPersisted();
 
-        final Host defaultHost = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = new UserDataGen().roles(role).nextPersisted();
 
-        try {
-            final Host host = new SiteDataGen().aliases("prod-client.dotcms.com").nextPersisted();
-            final Host host_2 = new SiteDataGen().aliases("prod-anotherclient.dotcms.com").setDefault(true).nextPersisted();
+        this.addPermission(role, host);
+        this.addPermission(role, host_2);
 
-            final Role role = new RoleDataGen().nextPersisted();
-            final User user = new UserDataGen().roles(role).nextPersisted();
+        final Host hostReturned = APILocator.getHostAPI().findByAlias("prod-client.dotcms.com", user, false);
+        assertEquals(host, hostReturned);
+        assertNotEquals(host_2, hostReturned);
 
-            this.addPermission(role, host);
-            this.addPermission(role, host_2);
-
-            final Host hostReturned = APILocator.getHostAPI().findByAlias("prod-client.dotcms.com", user, false);
-            assertEquals(host, hostReturned);
-            assertNotEquals(host_2, hostReturned);
-
-            final Host hostReturned2 = APILocator.getHostAPI().findByAlias("prod-anotherclient.dotcms.com", user, false);
-            assertNotEquals(host, hostReturned2);
-            assertEquals(host_2, hostReturned2);
-
-        } finally {
-            APILocator.getHostAPI().makeDefault(defaultHost, APILocator.systemUser(), false);
-        }
+        final Host hostReturned2 = APILocator.getHostAPI().findByAlias("prod-anotherclient.dotcms.com", user, false);
+        assertNotEquals(host, hostReturned2);
+        assertEquals(host_2, hostReturned2);
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/HostAPITest.java
@@ -654,7 +654,8 @@ public class HostAPITest extends IntegrationTestBase  {
         final User user = new UserDataGen().roles(role).nextPersisted();
 
         this.addPermission(role, host);
-
+        this.addPermission(role, host_2);
+        
         final Host hostReturned = APILocator.getHostAPI().findByAlias("demo.dotcms.com", user, false);
         assertEquals(host, hostReturned);
         assertNotEquals(host_2, hostReturned);
@@ -692,6 +693,7 @@ public class HostAPITest extends IntegrationTestBase  {
         final User user = new UserDataGen().roles(role).nextPersisted();
 
         this.addPermission(role, host);
+        this.addPermission(role, host_2);
 
         final Host hostReturned = APILocator.getHostAPI().findByAlias("prod-client.dotcms.com", user, false);
         assertEquals(host, hostReturned);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
@@ -254,6 +254,7 @@ public class HostAPIImpl implements HostAPI {
         Host host = null;
 
         try {
+
             StringBuilder queryBuffer = new StringBuilder();
             queryBuffer.append(String.format("%s:%s", CONTENT_TYPE_CONDITION, Host.HOST_VELOCITY_VAR_NAME ));
             queryBuffer.append(String.format(" +working:true +%s.aliases:%s", Host.HOST_VELOCITY_VAR_NAME, alias));

--- a/dotCMS/src/main/resources/es-content-mapping.json
+++ b/dotCMS/src/main/resources/es-content-mapping.json
@@ -66,6 +66,15 @@
               }
           },
           {
+              "hostaliases" : {
+                  "path_match": "host.aliases",
+                  "mapping": {
+                      "analyzer": "whitespace",
+                      "type": "text"
+                  }
+              }
+          },
+          {
               "longmapping" : {
                   "match_pattern": "regex",
                   "match": "metadata.length|metadata.height|metadata.width",


### PR DESCRIPTION
Using the whitespace analizer to the host aliases to avoid the tokenizes

https://github.com/dotCMS/core/compare/issue-18187-Aliases-not-working-correctly?expand=1#diff-44746dc0a1c617ec2edbabe9d6fedf39R72

https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-whitespace-analyzer.html