### PR TITLE
#18795 Adding live:true condition automatically when Time Machine is …

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentToolTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentToolTest.java
@@ -504,7 +504,7 @@ public class ContentToolTest extends IntegrationTestBase {
     /**
      * Method to test: {@link ContentTool#pullPerPage(String, int, int, String)}
      * When: there is a content with a expire  date set to tomorrow and the time machine date is the date after tomorrow
-     * Should: return one content
+     * Should: return a empty list
      */
     @Test
     public void whenTheTimeMachineDateIsAfterTomorrowAndExpireDateIsTomorrowShouldNotReturnContent() {

--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentToolTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentToolTest.java
@@ -17,7 +17,6 @@ import com.dotcms.contenttype.model.type.ContentTypeBuilder;
 import com.dotcms.contenttype.model.type.SimpleContentType;
 import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.datagen.TestDataUtils;
-import com.dotcms.rendering.velocity.viewtools.content.util.ContentUtils;
 import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
@@ -510,7 +509,7 @@ public class ContentToolTest extends IntegrationTestBase {
     @Test
     public void whenTheTimeMachineDateIsAfterTomorrowAndExpireDateIsTomorrowShouldNotReturnContent() {
         final Calendar expireDate = Calendar.getInstance();
-        expireDate.add(Calendar.DATE, 2);
+        expireDate.add(Calendar.DATE, 1);
 
         final ContentType contentType = TestDataUtils.getNewsLikeContentType();
         new ContentletDataGen(contentType.id())
@@ -519,7 +518,7 @@ public class ContentToolTest extends IntegrationTestBase {
                 .nextPersisted();
 
         final Calendar afterTomorrow = Calendar.getInstance();
-        afterTomorrow.add(Calendar.DATE, 3);
+        afterTomorrow.add(Calendar.DATE, 2);
 
         final String query = String.format(QUERY_BY_STRUCTURE_NAME, contentType.variable());
 

--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentToolTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentToolTest.java
@@ -427,7 +427,7 @@ public class ContentToolTest extends IntegrationTestBase {
 
 
     /**
-     * Method to test: {@link ContentTool#pullPerPage(String, int, int, String)}
+     * Method to test: {@link ContentTool#pullPerPage(String, int, int, String)} 
      * When: there is a content with a publish date in the future and the time machine parameter in null
      * Should: Not return the content
      */

--- a/dotCMS/src/integration-test/java/com/dotcms/util/TimeMachineUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/util/TimeMachineUtilTest.java
@@ -1,0 +1,104 @@
+package com.dotcms.util;
+
+import com.dotcms.api.web.HttpServletRequestThreadLocal;
+import com.dotcms.enterprise.rules.RulesAPIImpl;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.rules.model.Condition;
+import com.dotmarketing.portlets.rules.model.ConditionGroup;
+import com.liferay.portal.model.User;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import java.util.Date;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TimeMachineUtilTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        //Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Method to Test: {@link TimeMachineUtil#getTimeMachineDate()}
+     * When: When Time Machine is not running
+     * Should: Return a {@link Optional#empty()}
+     */
+    @Test
+    public void shouldReturnOptionalEmptyWhenTimeMachineIsNotRunning(){
+        final HttpSession session = mock(HttpSession.class);
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession()).thenReturn(session);
+
+        HttpServletRequestThreadLocal.INSTANCE.setRequest(request);
+
+
+        final Optional<String> timeMachineDate = TimeMachineUtil.getTimeMachineDate();
+        assertFalse(timeMachineDate.isPresent());
+    }
+
+    /**
+     * Method to Test: {@link TimeMachineUtil#getTimeMachineDate()}
+     * When: When Time Machine is running
+     * Should: return the date in a {@link Optional}
+     */
+    @Test
+    public void shouldReturnOptionalWithValueWhenTimeMachineIsRunning(){
+        final HttpSession session = mock(HttpSession.class);
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession()).thenReturn(session);
+
+        final String time = Long.toString(new Date().getTime());
+
+        when(session.getAttribute("tm_date")).thenReturn(time);
+        HttpServletRequestThreadLocal.INSTANCE.setRequest(request);
+
+        final Optional<String> timeMachineDate = TimeMachineUtil.getTimeMachineDate();
+        assertTrue(timeMachineDate.isPresent());
+        assertEquals(time, timeMachineDate.get());
+    }
+
+    /**
+     * Method to Test: {@link TimeMachineUtil#isRunning()}
+     * When: When Time Machine is not running
+     * Should: Return a false
+     */
+    @Test
+    public void whenTimeMachineIsNotRunningShouldReturnFalse(){
+        final HttpSession session = mock(HttpSession.class);
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession()).thenReturn(session);
+
+        HttpServletRequestThreadLocal.INSTANCE.setRequest(request);
+
+        assertFalse(TimeMachineUtil.isRunning());
+    }
+
+    /**
+     * Method to Test: {@link TimeMachineUtil#getTimeMachineDate()}
+     * When: When Time Machine is running
+     * Should: return true
+     */
+    @Test
+    public void whenTimeMachineIsNotRunningShouldReturnTrue(){
+        final HttpSession session = mock(HttpSession.class);
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getSession()).thenReturn(session);
+
+        final String time = Long.toString(new Date().getTime());
+
+        when(session.getAttribute("tm_date")).thenReturn(time);
+        HttpServletRequestThreadLocal.INSTANCE.setRequest(request);
+
+        assertTrue(TimeMachineUtil.isRunning());
+    }
+}

--- a/dotCMS/src/integration-test/java/com/dotcms/util/TimeMachineUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/util/TimeMachineUtilTest.java
@@ -1,12 +1,6 @@
 package com.dotcms.util;
 
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
-import com.dotcms.enterprise.rules.RulesAPIImpl;
-import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.portlets.rules.model.Condition;
-import com.dotmarketing.portlets.rules.model.ConditionGroup;
-import com.liferay.portal.model.User;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/cms/urlmap/URLMapAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/cms/urlmap/URLMapAPIImplTest.java
@@ -83,6 +83,8 @@ public class URLMapAPIImplTest {
         session = mock(HttpSession.class);
 
         when(request.getSession()).thenReturn(session);
+        when(request.getSession(false)).thenReturn(session);
+
         HttpServletRequestThreadLocal.INSTANCE.setRequest(request);
     }
 
@@ -534,7 +536,6 @@ public class URLMapAPIImplTest {
     @Test
     public void shouldReturnURLInfoWhenContentExistsInFutureButTimeMachineIsSet()
             throws DotDataException, DotSecurityException {
-
 
         final String newsPatternPrefix =
                 TEST_PATTERN + System.currentTimeMillis() + "/";

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentTool.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentTool.java
@@ -3,6 +3,7 @@ package com.dotcms.rendering.velocity.viewtools.content;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.rendering.velocity.viewtools.content.util.ContentUtils;
+import com.dotcms.util.TimeMachineUtil;
 import com.dotcms.visitor.domain.Visitor;
 import com.dotcms.visitor.domain.Visitor.AccruedTag;
 import com.dotmarketing.beans.Host;
@@ -554,7 +555,7 @@ public class ContentTool implements ViewTool {
 		}
 
 	  	if(!(query.contains("live:") || query.contains("working:") )){
-			if(EDIT_OR_PREVIEW_MODE){
+			if(EDIT_OR_PREVIEW_MODE && !TimeMachineUtil.isRunning()){
 				q +=" +working:true ";
 			}else{
 				q +=" +live:true ";

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
@@ -2,6 +2,7 @@ package com.dotcms.rendering.velocity.viewtools.content.util;
 
 import com.dotcms.content.elasticsearch.business.ESMappingAPIImpl;
 import com.dotcms.rendering.velocity.viewtools.content.PaginatedContentList;
+import com.dotcms.util.TimeMachineUtil;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.FactoryLocator;
@@ -187,15 +188,9 @@ public class ContentUtils {
 
 		public static PaginatedArrayList<Contentlet> pull(final String query, final int offset, final int limit,
 														  final String sort, final User user, final boolean respectFrontendRoles) {
-			final String tmDate = getTimeMachine().orElse(null);
+			final String tmDate = TimeMachineUtil.getTimeMachineDate().orElse(null);
 			return pull(query, offset, limit, sort, user, tmDate, respectFrontendRoles);
 		}
-
-	private static Optional<String> getTimeMachine() {
-		final HttpSession session = HttpServletRequestThreadLocal.INSTANCE.getRequest().getSession();
-		final Object timeMachineObject = session != null ? session.getAttribute("tm_date") : null;
-		return Optional.ofNullable(timeMachineObject != null ? timeMachineObject.toString() : null);
-	}
 
 	public static PaginatedArrayList<Contentlet> pull(String query, final int offset, final int limit, final String sort, final User user, final String tmDate, final boolean respectFrontendRoles){
 		    final PaginatedArrayList<Contentlet> ret = new PaginatedArrayList<>();

--- a/dotCMS/src/main/java/com/dotcms/util/TimeMachineUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/TimeMachineUtil.java
@@ -1,0 +1,22 @@
+package com.dotcms.util;
+
+import com.dotcms.api.web.HttpServletRequestThreadLocal;
+
+import javax.servlet.http.HttpSession;
+import java.util.Optional;
+
+public class TimeMachineUtil {
+
+    private TimeMachineUtil(){}
+
+    public static Optional<String> getTimeMachineDate() {
+        final HttpSession session = HttpServletRequestThreadLocal.INSTANCE.getRequest().getSession();
+        final Object timeMachineObject = session != null ? session.getAttribute("tm_date") : null;
+        return Optional.ofNullable(timeMachineObject != null ? timeMachineObject.toString() : null);
+    }
+
+    public static boolean isRunning(){
+        final Optional<String> timeMachine = getTimeMachineDate();
+        return timeMachine.isPresent();
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/util/TimeMachineUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/TimeMachineUtil.java
@@ -5,16 +5,24 @@ import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import javax.servlet.http.HttpSession;
 import java.util.Optional;
 
-public class TimeMachineUtil {
+public final class TimeMachineUtil {
 
     private TimeMachineUtil(){}
 
+    /**
+     * If Time Machine is running return the timestamp of the Time Machine date
+     * @return
+     */
     public static Optional<String> getTimeMachineDate() {
-        final HttpSession session = HttpServletRequestThreadLocal.INSTANCE.getRequest().getSession();
+        final HttpSession session = HttpServletRequestThreadLocal.INSTANCE.getRequest().getSession(false);
         final Object timeMachineObject = session != null ? session.getAttribute("tm_date") : null;
         return Optional.ofNullable(timeMachineObject != null ? timeMachineObject.toString() : null);
     }
 
+    /**
+     * Return true if Time Machine is running, otherwise return false
+     * @return
+     */
     public static boolean isRunning(){
         final Optional<String> timeMachine = getTimeMachineDate();
         return timeMachine.isPresent();


### PR DESCRIPTION
When a lucene query is pass to the method:

https://github.com/dotCMS/core/blob/b91e4ecc94e8fe652653cefc5f3eec266b0df382/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentTool.java#L155

is called with a lucene query that not has the live:true condition and Time Machine is running, now we are adding the live:true condition automatically