### PR TITLE
fix broken reindex on auth

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
@@ -141,7 +141,7 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 	}
 
     //Lazy Suppliers are memoized. Meaning that this truly guarantees the computation takes place once.
-    private final Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
+    private transient final Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
 
   /**
    * This access the physical file on disk

--- a/dotCMS/src/main/resources/es-sitesearch-mapping.json
+++ b/dotCMS/src/main/resources/es-sitesearch-mapping.json
@@ -4,6 +4,7 @@
       "content": {
         "type": "text",
         "analyzer": "standard_content",
+        "term_vector":"with_positions_offsets",
         "fields": {
           "untouched": {
             "type": "keyword",


### PR DESCRIPTION
When the field lazyComputeDimensions was introduced in FileAsset we didn't foresee certain side effects it had when serializing FileAssets. 
here's the exception this comes to solve
[08/07/20 05:00:00:873 GMT] ERROR bundlers.FileAssetBundler: cant get host for managing-content.svg reason Could not call io.vavr.Lazy.writeObject() : Could not initialize class org.apache.batik.bridge.DefaultFontFamilyResolver

That was breaking site search. 
Additionally, to that there's another issue related to indexing PDFs

which looks like:

Caused by: org.elasticsearch.ElasticsearchException: Elasticsearch exception [type=illegal_argument_exception, reason=The length of [content] field of [db4c2bed-451e-41ad-9afd-c427b683a0a4] doc of [cluster_dotcms-prod.sitesearch_20200629050000_62913211-b9c5-11ea-90d5-0242c0a84003] index has exceeded [1000000] - maximum allowed to be analyzed for highlighting. This maximum can be set by changing the [index.highlight.max_analyzed_offset] index level setting. For large texts, indexing with offsets or term vectors is recommended!]
	at org.elasticsearch.ElasticsearchException.innerFromXContent(ElasticsearchException.java:491) ~[elasticsearch-7.3.2.jar:7.3.2]
