### PR TITLE
Issue 18872 sitesearch default status

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1249,6 +1249,13 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
 
 
     public void activateIndex(final String indexName) throws DotDataException {
+
+        if(IndexType.SITE_SEARCH.is(indexName)){
+            //This covers cases on which this API is used to work on site search indices.
+            APILocator.getSiteSearchAPI().activateIndex(indexName);
+            return;
+        }
+
         final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
         final IndiciesInfo.Builder builder = IndiciesInfo.Builder.copy(info);
         if(indexName==null) {
@@ -1272,6 +1279,13 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     public void deactivateIndex(String indexName) throws DotDataException, IOException {
+
+        if(IndexType.SITE_SEARCH.is(indexName)){
+            //This covers cases on which this API is used to work on site search indices.
+            APILocator.getSiteSearchAPI().deactivateIndex(indexName);
+            return;
+        }
+
         final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
         final IndiciesInfo.Builder builder = IndiciesInfo.Builder.copy(info);
 
@@ -1283,8 +1297,6 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
             builder.setReindexWorking(null);
         } else if (IndexType.REINDEX_LIVE.is(indexName)) {
             builder.setReindexLive(null);
-        } else if(IndexType.SITE_SEARCH.is(indexName)){
-            builder.setSiteSearch(null);
         }
         APILocator.getIndiciesAPI().point(builder.build());
     }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1264,6 +1264,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
             if(esIndexApi.getNameWithClusterIDPrefix(indexName).equals(info.getReindexLive())) {
                 builder.setReindexLive(null);
             }
+        } else if(IndexType.SITE_SEARCH.is(indexName)){
+              builder.setSiteSearch(indexName);
         }
         
         APILocator.getIndiciesAPI().point(builder.build());
@@ -1281,6 +1283,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
             builder.setReindexWorking(null);
         } else if (IndexType.REINDEX_LIVE.is(indexName)) {
             builder.setReindexLive(null);
+        } else if(IndexType.SITE_SEARCH.is(indexName)){
+            builder.setSiteSearch(null);
         }
         APILocator.getIndiciesAPI().point(builder.build());
     }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
@@ -141,7 +141,7 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 	}
 
     //Lazy Suppliers are memoized. Meaning that this truly guarantees the computation takes place once.
-    private final Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
+    private transient final Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
 
   /**
    * This access the physical file on disk

--- a/dotCMS/src/main/resources/es-sitesearch-mapping.json
+++ b/dotCMS/src/main/resources/es-sitesearch-mapping.json
@@ -4,6 +4,7 @@
       "content": {
         "type": "text",
         "analyzer": "standard_content",
+        "term_vector":"with_positions_offsets",
         "fields": {
           "untouched": {
             "type": "keyword",


### PR DESCRIPTION
Previously the class `IndexAjaxAction` used to perform the index activation and deactivation through `ESIndexResource` But this last one recently underwent refactoring and such behavior got removed. The activation and deactivation actions are were redirected to a direct call to `ContentletIndexAPIImpl` which didn't have any logic to do so. It was only aware of regular indices. This change adds logic to intercept any call performed on top of a site-search index redirecting it to the proper API. `SiteSearchAPIImpl`