### PR TITLE
#18846  local system event is broadcast on save

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/apps/AppsResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/apps/AppsResourceTest.java
@@ -107,8 +107,9 @@ public class AppsResourceTest extends IntegrationTestBase {
 
         final AppsAPI appsAPI = new AppsAPIImpl(APILocator.getUserAPI(), APILocator.getLayoutAPI(),
                 APILocator.getHostAPI(), APILocator.getContentletAPI(),
-                SecretsStore.INSTANCE.get(), CacheLocator
-                .getAppsCache(), new LicenseValiditySupplier() {
+                SecretsStore.INSTANCE.get(), CacheLocator.getAppsCache(),
+                APILocator.getLocalSystemEventsAPI(),
+                new LicenseValiditySupplier() {
                     @Override
                     public boolean hasValidLicense() {
                         return false;

--- a/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsAPIImplTest.java
@@ -18,6 +18,7 @@ import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.datagen.TestUserUtils;
 import com.dotcms.datagen.UserDataGen;
 import com.dotcms.system.event.local.business.LocalSystemEventsAPI;
+import com.dotcms.system.event.local.model.EventSubscriber;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.util.LicenseValiditySupplier;
 import com.dotmarketing.beans.Host;
@@ -802,11 +803,14 @@ public class AppsAPIImplTest {
         final AtomicInteger callsCount = new AtomicInteger(0);
         final AppsAPI api = APILocator.getAppsAPI();
         final LocalSystemEventsAPI localSystemEventsAPI = APILocator.getLocalSystemEventsAPI();
-        localSystemEventsAPI.subscribe(AppSecretSavedEvent.class, event -> {
-            Assert.assertTrue(event instanceof AppSecretSavedEvent);
-            callsCount.incrementAndGet();
+        localSystemEventsAPI.subscribe(AppSecretSavedEvent.class, new AppsSecretEventSubscriber(){
+            @Override
+            public void notify(AppSecretSavedEvent event) {
+                callsCount.incrementAndGet();
+            }
         });
-        final String appKey = "any-app-key";
+
+        final String appKey = AppsSecretEventSubscriber.appKey;
 
         final AppDescriptor descriptor = mock(AppDescriptor.class);
         when(descriptor.isAllowExtraParameters()).thenReturn(false);

--- a/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsAPIImplTest.java
@@ -803,7 +803,6 @@ public class AppsAPIImplTest {
         final AppsAPI api = APILocator.getAppsAPI();
         final LocalSystemEventsAPI localSystemEventsAPI = APILocator.getLocalSystemEventsAPI();
         localSystemEventsAPI.subscribe(AppSecretSavedEvent.class, event -> {
-            System.out.println(event);
             Assert.assertTrue(event instanceof AppSecretSavedEvent);
             callsCount.incrementAndGet();
         });

--- a/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsAPIImplTest.java
@@ -791,6 +791,12 @@ public class AppsAPIImplTest {
         nonValidLicenseAppsAPI.getSecrets("anyKey", true, systemHost, admin);
     }
 
+    /**
+     * Given scenario: We subscribe an event listener and save an event
+     * Expected Results: We expect that an event is fired and that after firing the event the AppsSecret that was initially passed to the save method is now destroyed
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
     @Test
     public void Test_Save_Secret_Expect_Event_Notification() throws DotDataException, DotSecurityException{
         final AtomicInteger callsCount = new AtomicInteger(0);
@@ -836,6 +842,11 @@ public class AppsAPIImplTest {
         }
     }
 
+    /**
+     * for internal use validate a secret has been destroyed
+     * @param chars
+     * @return
+     */
     private boolean isSecretDestroyed(final char [] chars){
         final char nullChar = (char) 0;
         for(final char chr: chars){

--- a/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsSecretEventSubscriber.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsSecretEventSubscriber.java
@@ -1,0 +1,14 @@
+package com.dotcms.security.apps;
+
+import com.dotcms.system.event.local.model.EventSubscriber;
+import com.dotcms.system.event.local.model.KeyFilterable;
+
+public abstract class AppsSecretEventSubscriber implements EventSubscriber<AppSecretSavedEvent>  ,  KeyFilterable {
+
+    static final String appKey = "any-app-key";
+
+    @Override
+    public Comparable getKey() {
+        return appKey;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/AppsHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/AppsHelper.java
@@ -1,5 +1,7 @@
 package com.dotcms.rest.api.v1.apps;
 
+import static com.dotmarketing.util.UtilMethods.isNotSet;
+
 import com.dotcms.rest.api.MultiPartUtils;
 import com.dotcms.rest.api.v1.apps.view.AppView;
 import com.dotcms.rest.api.v1.apps.view.SecretView;
@@ -499,8 +501,7 @@ class AppsHelper {
                 .entrySet()) {
             final String describedParamName = appDescriptorParam.getKey();
             final Input input = params.get(describedParamName);
-            if (appDescriptorParam.getValue().isRequired() && (input == null || UtilMethods
-                    .isNotSet(input.getValue()))) {
+            if (appDescriptorParam.getValue().isRequired() && (input == null || isNotSet(input.getValue()))) {
                 throw new IllegalArgumentException(
                         String.format(
                                 "Param `%s` is marked required in the descriptor but does not come with a value.",
@@ -574,7 +575,7 @@ class AppsHelper {
                         paramName));
             } else {
                 if (null != paramDescriptor && paramDescriptor.isRequired() && null != entry
-                        .getValue() && UtilMethods.isNotSet(entry.getValue().getValue())) {
+                        .getValue() && isNotSet(entry.getValue().getValue())) {
                     throw new IllegalArgumentException(
                             String.format(
                                     "Param `%s` is marked required in the descriptor but does not come with a value.",
@@ -671,6 +672,9 @@ class AppsHelper {
      * @return
      */
     private boolean isAllFilledWithAsters(final char [] chars){
+         if(isNotSet(chars)){
+           return false;
+         }
          for(final char chr: chars){
             if(chr != '*'){
                return false;

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppSecretSavedEvent.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppSecretSavedEvent.java
@@ -1,5 +1,6 @@
 package com.dotcms.security.apps;
 
+import com.dotcms.system.event.local.model.KeyFilterable;
 import com.dotmarketing.beans.Host;
 import java.io.Serializable;
 
@@ -7,7 +8,7 @@ import java.io.Serializable;
  * AppSecretSavedEvent
  * Broadcast when a secret is saved.
  */
-public class AppSecretSavedEvent implements Serializable {
+public class AppSecretSavedEvent implements Serializable, KeyFilterable {
 
    private final AppSecrets appSecrets;
 
@@ -37,5 +38,15 @@ public class AppSecretSavedEvent implements Serializable {
      */
     public Host getHost() {
         return host;
+    }
+
+    /**
+     * Only subscribers providing this key will receive this event.
+     * This way we minimize the audience receiving the secret.
+     * @return
+     */
+    @Override
+    public Comparable getKey() {
+        return appSecrets.getKey();
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppSecretSavedEvent.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppSecretSavedEvent.java
@@ -1,0 +1,41 @@
+package com.dotcms.security.apps;
+
+import com.dotmarketing.beans.Host;
+import java.io.Serializable;
+
+/**
+ * AppSecretSavedEvent
+ * Broadcast when a secret is saved.
+ */
+public class AppSecretSavedEvent implements Serializable {
+
+   private final AppSecrets appSecrets;
+
+   private final Host host;
+
+    /**
+     * Event constructor
+     * @param appSecrets
+     * @param host
+     */
+   AppSecretSavedEvent(final AppSecrets appSecrets, final Host host) {
+        this.appSecrets = appSecrets;
+        this.host = host;
+   }
+
+    /**
+     * AppSecrets Getter
+     * @return
+     */
+    public AppSecrets getAppSecrets() {
+        return appSecrets;
+    }
+
+    /**
+     * Host Getter
+     * @return
+     */
+    public Host getHost() {
+        return host;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/system/event/local/business/LocalSystemEventsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/system/event/local/business/LocalSystemEventsAPI.java
@@ -1,6 +1,7 @@
 package com.dotcms.system.event.local.business;
 
 import com.dotcms.system.event.local.model.DefaultOrphanEventSubscriber;
+import com.dotcms.system.event.local.model.EventCompletionHandler;
 import com.dotcms.system.event.local.model.EventSubscriber;
 import com.dotcms.system.event.local.type.OrphanEvent;
 
@@ -44,6 +45,14 @@ public interface LocalSystemEventsAPI {
      * @param subscriberId {@link String}
      */
     boolean unsubscribe (final Class<?> eventType, String subscriberId);
+
+    /**
+     * This method brings the possibility for event broadcasters to be non-blocking notified
+     * when all subscribers are done consuming their events.
+     * @param event {@link Object}
+     * @param completionHandler {@link EventCompletionHandler}
+     */
+    void asyncNotify(final Object event, final EventCompletionHandler completionHandler);
 
     /**
      * Creates an async notification to all registered handlers

--- a/dotCMS/src/main/java/com/dotcms/system/event/local/business/LocalSystemEventsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/system/event/local/business/LocalSystemEventsAPIImpl.java
@@ -217,7 +217,7 @@ class LocalSystemEventsAPIImpl implements LocalSystemEventsAPI {
                 if (event instanceof KeyFilterable) {
                     synchronized (this) {
                         //if we're broadcasting an event that is an instance of KeyFilterable
-                        //it means it is intended to a limited audience.
+                        //it means it is intended for a limited audience.
                         //Both the even and the receiver must be an instance of KeyFilterable
                         final KeyFilterable keyFilterableEvent = (KeyFilterable) event;
                         Logger.info(LocalSystemEventsAPIImpl.class, ()->" Broadcasting a Filterable Event.");
@@ -256,11 +256,11 @@ class LocalSystemEventsAPIImpl implements LocalSystemEventsAPI {
 
     /**
      * This method basically delivers the event to all the subscribers
-     * @param subscibers
+     * @param subscribers
      * @param event
      */
-    private void broadcast(final List<EventSubscriber> subscibers, final Object event){
-         subscibers.forEach(eventSubscriber -> {
+    private void broadcast(final List<EventSubscriber> subscribers, final Object event){
+         subscribers.forEach(eventSubscriber -> {
             if(null != eventSubscriber){
                 eventSubscriber.notify(event);
              }

--- a/dotCMS/src/main/java/com/dotcms/system/event/local/business/LocalSystemEventsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/system/event/local/business/LocalSystemEventsAPIImpl.java
@@ -1,15 +1,14 @@
 package com.dotcms.system.event.local.business;
 
+import com.dotcms.concurrent.DotConcurrentFactory;
+import com.dotcms.concurrent.DotSubmitter;
 import com.dotcms.system.event.local.model.DefaultOrphanEventSubscriber;
 import com.dotcms.system.event.local.model.EventCompletionHandler;
 import com.dotcms.system.event.local.model.EventSubscriber;
 import com.dotcms.system.event.local.model.KeyFilterable;
 import com.dotcms.system.event.local.type.OrphanEvent;
-import com.dotcms.concurrent.DotConcurrentFactory;
-import com.dotcms.concurrent.DotSubmitter;
 import com.dotmarketing.util.Logger;
 import com.google.common.annotations.VisibleForTesting;
-
 import io.vavr.control.Try;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +16,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/dotCMS/src/main/java/com/dotcms/system/event/local/business/LocalSystemEventsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/system/event/local/business/LocalSystemEventsAPIImpl.java
@@ -222,7 +222,7 @@ class LocalSystemEventsAPIImpl implements LocalSystemEventsAPI {
                         //it means it is intended to a limited audience.
                         //Both the even and the receiver must be an instance of KeyFilterable
                         final KeyFilterable keyFilterableEvent = (KeyFilterable) event;
-
+                        Logger.info(LocalSystemEventsAPIImpl.class, ()->" Broadcasting a Filterable Event.");
                         final Stream<KeyFilterable> keyAwareSubscribers = eventSubscribers.stream()
                                 .filter(eventSubscriber -> eventSubscriber instanceof KeyFilterable)
                                 .map(KeyFilterable.class::cast)
@@ -234,8 +234,10 @@ class LocalSystemEventsAPIImpl implements LocalSystemEventsAPI {
                                                 .compareTo(keyFilterableEvent.getKey()) == 0)
                                 .map(EventSubscriber.class::cast)
                                 .collect(Collectors.toList());
-
                         broadcast(eventAudience, event);
+                        Logger.info(LocalSystemEventsAPIImpl.class, () -> String
+                                .format(" Filtered Audience for event with key `%s`  is `%d` long. ",
+                                        keyFilterableEvent.getKey(), eventAudience.size()));
                     }
                 } else {
                     broadcast(eventSubscribers, event);

--- a/dotCMS/src/main/java/com/dotcms/system/event/local/model/EventCompletionHandler.java
+++ b/dotCMS/src/main/java/com/dotcms/system/event/local/model/EventCompletionHandler.java
@@ -1,0 +1,18 @@
+package com.dotcms.system.event.local.model;
+
+
+/**
+ * This EventCompletionHandler is consumer that will notify any event-broadcaster of the event completion
+ * Meaning once all the subscribers are done with the event processing this event functional interface will be invoked.
+ * It's mostly meant for non-blocking cleanup after asynchronous events are consumed.
+ */
+@FunctionalInterface
+public interface EventCompletionHandler {
+
+    /**
+     * The event completed method handler
+     * @param event
+     */
+    void onComplete(Object event);
+
+}

--- a/dotCMS/src/main/java/com/dotcms/system/event/local/model/KeyFilterable.java
+++ b/dotCMS/src/main/java/com/dotcms/system/event/local/model/KeyFilterable.java
@@ -1,0 +1,7 @@
+package com.dotcms.system.event.local.model;
+
+public interface KeyFilterable {
+
+    Comparable getKey();
+
+}

--- a/dotCMS/src/main/java/com/dotcms/system/event/local/model/KeyFilterable.java
+++ b/dotCMS/src/main/java/com/dotcms/system/event/local/model/KeyFilterable.java
@@ -1,5 +1,11 @@
 package com.dotcms.system.event.local.model;
 
+/**
+ * Intended to provide a key to be used for filtering purposes.
+ * e.g. We want to filter an event that can only be received by a group of subscribers
+ * Both (The Event and the subscriber) need to provide the same key.
+ */
+@FunctionalInterface
 public interface KeyFilterable {
 
     Comparable getKey();

--- a/dotCMS/src/test/java/com/dotcms/system/event/local/KeyFilterableEvent.java
+++ b/dotCMS/src/test/java/com/dotcms/system/event/local/KeyFilterableEvent.java
@@ -1,0 +1,17 @@
+package com.dotcms.system.event.local;
+
+import com.dotcms.system.event.local.model.KeyFilterable;
+
+public class KeyFilterableEvent implements KeyFilterable {
+
+    private final String key;
+
+    public KeyFilterableEvent(final String key) {
+        this.key = key;
+    }
+
+    @Override
+    public Comparable getKey() {
+        return key;
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/system/event/local/KeyFilterableEvent.java
+++ b/dotCMS/src/test/java/com/dotcms/system/event/local/KeyFilterableEvent.java
@@ -2,6 +2,9 @@ package com.dotcms.system.event.local;
 
 import com.dotcms.system.event.local.model.KeyFilterable;
 
+/**
+ * This implementation of KeyFilterable is intended for testing purposes
+ */
 public class KeyFilterableEvent implements KeyFilterable {
 
     private final String key;

--- a/dotCMS/src/test/java/com/dotcms/system/event/local/KeyFilterableTestSubscriberTest.java
+++ b/dotCMS/src/test/java/com/dotcms/system/event/local/KeyFilterableTestSubscriberTest.java
@@ -1,0 +1,20 @@
+package com.dotcms.system.event.local;
+
+import com.dotcms.system.event.local.model.EventSubscriber;
+import com.dotcms.system.event.local.model.KeyFilterable;
+
+public abstract class KeyFilterableTestSubscriberTest implements EventSubscriber<KeyFilterableEvent> , KeyFilterable {
+
+    private final String key;
+
+    public KeyFilterableTestSubscriberTest(final String key) {
+        this.key = key;
+    }
+
+    @Override
+    public Comparable getKey() {
+        return key;
+    }
+
+
+}

--- a/dotCMS/src/test/java/com/dotcms/system/event/local/LocalSystemEventsAPITest.java
+++ b/dotCMS/src/test/java/com/dotcms/system/event/local/LocalSystemEventsAPITest.java
@@ -2,10 +2,11 @@ package com.dotcms.system.event.local;
 
 import com.dotcms.UnitTestBase;
 import com.dotcms.system.event.local.business.LocalSystemEventsAPI;
-import com.dotcms.system.event.local.model.EventCompletionHandler;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.DateUtil;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
@@ -224,7 +225,6 @@ public class LocalSystemEventsAPITest extends UnitTestBase {
         final AtomicBoolean isOnCompleteCalled = new AtomicBoolean(false);
         final String message = "Async notify Event.";
         localSystemEventsAPI.asyncNotify(new TestEventType1(message), event -> {
-            System.out.println("event:" +  event );
             Assert.assertTrue(event instanceof TestEventType1);
             final TestEventType1 eventType1 = (TestEventType1)event;
             Assert.assertEquals(eventType1.getMsg(), message);
@@ -251,7 +251,6 @@ public class LocalSystemEventsAPITest extends UnitTestBase {
         final AtomicInteger callsCount = new AtomicInteger(0);
 
         localSystemEventsAPI.asyncNotify(new TestEventType2(message), event -> {
-            System.out.println("event:" +  event );
             Assert.assertTrue(event instanceof TestEventType2);
             final TestEventType2 eventType2 = (TestEventType2)event;
             Assert.assertEquals(eventType2.getMsg(), message);
@@ -261,5 +260,58 @@ public class LocalSystemEventsAPITest extends UnitTestBase {
         Assert.assertEquals(callsCount.get(), 1);
     }
 
+    /**
+     * Given scenario: We're testing that an event that implements KeyFilterable and is broadcast only reaches certain audience.
+     * We creating a few subscribers each one of the provides a key. The Event must reach only those which have the same id.
+     * Expected results: Only the subscribers with a matching id will be able to consume the event;
+     */
+    @Test
+    public void Test_Send_Event_For_Limited_Audience() {
 
-} // E:O:F:LocalSystemEventsAPITest.
+        final Map<String, AtomicInteger> callsCounts = ImmutableMap
+                .of("subscriber1", new AtomicInteger(0), "subscriber2", new AtomicInteger(0),
+                        "subscriber3", new AtomicInteger(0));
+
+        final KeyFilterableTestSubscriberTest subscriber1 = new KeyFilterableTestSubscriberTest("subscriber1"){
+            @Override
+            public void notify(final KeyFilterableEvent event) {
+                Assert.assertEquals(event.getKey(),"subscriber1");
+                callsCounts.get(event.getKey().toString()).incrementAndGet();
+            }
+        };
+        final KeyFilterableTestSubscriberTest subscriber2 = new KeyFilterableTestSubscriberTest("subscriber2"){
+            @Override
+            public void notify(final KeyFilterableEvent event) {
+                Assert.assertEquals(event.getKey(),"subscriber2");
+                callsCounts.get(event.getKey().toString()).incrementAndGet();
+            }
+        };
+        final KeyFilterableTestSubscriberTest subscriber3 = new KeyFilterableTestSubscriberTest("subscriber3"){
+            @Override
+            public void notify(final KeyFilterableEvent event) {
+                Assert.assertEquals(event.getKey(),"subscriber3");
+                callsCounts.get(event.getKey().toString()).incrementAndGet();
+            }
+        };
+
+        final LocalSystemEventsAPI localSystemEventsAPI = APILocator.getLocalSystemEventsAPI();
+
+        localSystemEventsAPI.subscribe(KeyFilterableEvent.class, subscriber1);
+        localSystemEventsAPI.subscribe(KeyFilterableEvent.class, subscriber2);
+        localSystemEventsAPI.subscribe(KeyFilterableEvent.class, subscriber3);
+
+        localSystemEventsAPI.notify(new KeyFilterableEvent("subscriber1"));
+        localSystemEventsAPI.notify(new KeyFilterableEvent("subscriber3"));
+
+        Assert.assertEquals(callsCounts.get("subscriber1").get(),1);
+        Assert.assertEquals(callsCounts.get("subscriber2").get(),0);
+        Assert.assertEquals(callsCounts.get("subscriber3").get(),1);
+
+        localSystemEventsAPI.asyncNotify(new KeyFilterableEvent("subscriber3"));
+
+        DateUtil.sleep(2000);
+        Assert.assertEquals(callsCounts.get("subscriber3").get(),2);
+    }
+
+
+    } // E:O:F:LocalSystemEventsAPITest.

--- a/dotCMS/src/test/java/com/dotcms/system/event/local/LocalSystemEventsAPITest.java
+++ b/dotCMS/src/test/java/com/dotcms/system/event/local/LocalSystemEventsAPITest.java
@@ -214,7 +214,10 @@ public class LocalSystemEventsAPITest extends UnitTestBase {
         Assert.assertTrue(isCalled.get());
     } // orphanSubscriberTest.
 
-
+    /**
+     * Given scenario: We're testing that even when no subscribers are added the asyncNotify callback gets called
+     * Expected results: We expect that the callback gets called.
+     */
     @Test
     public void Test_Non_Blocking_Notification_On_Event_Consumed_With_No_Subscribers() {
         final LocalSystemEventsAPI localSystemEventsAPI = APILocator.getLocalSystemEventsAPI();
@@ -230,6 +233,11 @@ public class LocalSystemEventsAPITest extends UnitTestBase {
         DateUtil.sleep(2000);
         Assert.assertTrue(isOnCompleteCalled.get());
     }
+
+    /**
+     * Given scenario: We're testing that even when subscribers are added  the asyncNotify callback gets called just once.
+     * Expected results: We expect that the callback gets called exactly once.
+     */
     @Test
     public void Test_Non_Blocking_Notification_On_Event_Consumed_With_Subscribers() {
         final String message = "Async notify Event 2.";


### PR DESCRIPTION
This changeset is meant to add a system local event (non-blocking and asynchronous)
The event is meant to be used to subscribe  event listeners for custom secret validation purposes.
A small modification was introduced in the LocalSystemEventsAPI adding a callback to the asyncNotify method that to guarantee that AppSecrets will continue to be destroyed after the event has been all consumed.