### PR TITLE
Add Content selector blows up for customers with lots of content types #18840

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelectorContent.jsp
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelectorContent.jsp
@@ -1,4 +1,11 @@
 <%@ page import="com.liferay.portal.language.LanguageUtil" %>
+<style>
+    .content-search-dialog__content-type-menu {
+        display: block;
+        max-height: 88vh;
+        overflow-y: auto !important;
+    }
+</style>
 <form
     dojoAttachPoint="search_form"
     onsubmit="return false;"
@@ -30,15 +37,19 @@
                 <div dojoAttachPoint="search_general">
                     <dl class="vertical">
                         <dt>
-                            <label><%= LanguageUtil.get(pageContext, "Search") %>:</label>
+                            <label
+                                ><%= LanguageUtil.get(pageContext, "Search")
+                                %>:</label
+                            >
                         </dt>
                         <dd>
-                        <input
-                            type="text"
-                            dojoType="dijit.form.TextBox"
-                            data-dojo-props="intermediateChanges:true"
-                            dojoAttachEvent="onKeyUp:_doSearchPage1"
-                            dojoAttachPoint="generalSearch" />
+                            <input
+                                type="text"
+                                dojoType="dijit.form.TextBox"
+                                data-dojo-props="intermediateChanges:true"
+                                dojoAttachEvent="onKeyUp:_doSearchPage1"
+                                dojoAttachPoint="generalSearch"
+                            />
                         </dd>
                     </dl>
                 </div>
@@ -65,7 +76,7 @@
                         dojoAttachEvent="onClick:_clearSearch"
                         iconClass="cancelIcon"
                         class="dijitButtonFlat"
-                        style="margin-top: 16px"
+                        style="margin-top: 16px;"
                     >
                         <%= LanguageUtil.get(pageContext, "Clear") %>
                     </button>
@@ -81,7 +92,7 @@
                 <div
                     dojoAttachPoint="matchingResultsDiv"
                     class="portlet-toolbar__matching-results"
-                    style="visibility: hidden"
+                    style="visibility: hidden;"
                 >
                     <%= LanguageUtil.get(pageContext, "Results") %>
                 </div>
@@ -89,7 +100,7 @@
                 <div
                     dojoAttachPoint="addContentletButton"
                     class="portlet-toolbar__add-contentlet"
-                    style="display: none"
+                    style="display: none;"
                 >
                     <button
                         dojoType="dijit.form.Button"

--- a/dotCMS/src/main/webapp/html/ng-contentlet-selector.jsp
+++ b/dotCMS/src/main/webapp/html/ng-contentlet-selector.jsp
@@ -155,7 +155,7 @@
 
         function loadAddContentTypePrimaryMenu() {
             var addContentDropdown = '<div data-dojo-type="dijit/form/DropDownButton" data-dojo-props=\'iconClass:"fa-plus", class:"dijitDropDownActionButton"\'><span></span>';
-            addContentDropdown+= '<ul data-dojo-type="dijit/Menu" >';
+            addContentDropdown+= '<ul class="content-search-dialog__content-type-menu" data-dojo-type="dijit/Menu" >';
             var addContentTypePrimaryMenu =  document.getElementById('addContentTypeDropdown');
             for ( var i = 1; contentSelector.containerStructures.length > i; i++) {
                 addContentDropdown+= '<li data-dojo-type="dijit/MenuItem" onClick="addNewContentlet(\'' + contentSelector.containerStructures[i].inode + '\')">' + contentSelector.containerStructures[i].name + '</li>';


### PR DESCRIPTION
If you have a customer with 50 widget types, the selector when adding one to a page does not scroll - instead you have to scroll the screen which looks pretty bad.