### PR TITLE
#18901  another side effect of having a field initialized through Laz…

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
@@ -17,6 +17,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
+import io.vavr.control.Try;
 import java.awt.Dimension;
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -119,12 +120,12 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 	private Dimension fileDimension = null;
 
 	public int getHeight() {
-		final Dimension fileDimension = lazyComputeDimensions.get();
+		final Dimension fileDimension = Try.of(lazyComputeDimensions::get).getOrNull();
 		return fileDimension == null ? 0 : fileDimension.height;
 	}
 
 	public int getWidth() {
-		final Dimension fileDimension = lazyComputeDimensions.get();
+		final Dimension fileDimension = Try.of(lazyComputeDimensions::get).getOrNull();
 		return fileDimension == null ? 0 : fileDimension.width;
 	}
 
@@ -141,7 +142,7 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 	}
 
     //Lazy Suppliers are memoized. Meaning that this truly guarantees the computation takes place once.
-    private transient final Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
+    private final Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
 
   /**
    * This access the physical file on disk

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
@@ -17,7 +17,6 @@ import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
-import io.vavr.control.Try;
 import java.awt.Dimension;
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -120,12 +119,12 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 	private Dimension fileDimension = null;
 
 	public int getHeight() {
-		final Dimension fileDimension = Try.of(lazyComputeDimensions::get).getOrNull();
+		final Dimension fileDimension = lazyComputeDimensions.get();
 		return fileDimension == null ? 0 : fileDimension.height;
 	}
 
 	public int getWidth() {
-		final Dimension fileDimension = Try.of(lazyComputeDimensions::get).getOrNull();
+		final Dimension fileDimension = lazyComputeDimensions.get();
 		return fileDimension == null ? 0 : fileDimension.width;
 	}
 
@@ -142,7 +141,7 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 	}
 
     //Lazy Suppliers are memoized. Meaning that this truly guarantees the computation takes place once.
-    private final Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
+    private transient Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
 
   /**
    * This access the physical file on disk
@@ -383,6 +382,20 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 				}
 			}
 		}
+	}
+
+	/**
+	 * field lazyComputeDimensions was made transient to avoid serialization problems
+	 * caused by NoClassDefFoundErrors produced by the libraries imported by ImageUtil
+	 *
+	 * So when these objects are coming back from cache they need to get initialized explicitly.
+	 * @param inputStream
+	 * @throws IOException
+	 * @throws ClassNotFoundException
+	 */
+	private void readObject(final java.io.ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
+		inputStream.defaultReadObject();
+		lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
 	}
 
 }


### PR DESCRIPTION
in order to fix the issue  https://github.com/dotCMS/core/pull/18868, We made the field FileAsset.lazyComputeDimensions  on  
FileAsset transient. That to avoid an issue that was breaking site-search. 
Now when deserializing the field from cache we discovered it is causing an NPE. 
We're approaching the error caused by the lazyComputeDimensions in a different way when the contentlent gets deserialized we're performing an explicit init
