### PR TITLE
#18901 in order to avoid npe we restore transient fields after on deserialize.

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
@@ -141,7 +141,7 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 	}
 
     //Lazy Suppliers are memoized. Meaning that this truly guarantees the computation takes place once.
-    private transient final Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
+    private transient Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
 
   /**
    * This access the physical file on disk
@@ -382,6 +382,20 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 				}
 			}
 		}
+	}
+
+	/**
+	 * field lazyComputeDimensions was made transient to avoid serialization problems
+	 * caused by NoClassDefFoundErrors produced by the libraries imported by ImageUtil
+	 *
+	 * So when these objects are coming back from cache they need to get initialized explicitly.
+	 * @param inputStream
+	 * @throws IOException
+	 * @throws ClassNotFoundException
+	 */
+	private void readObject(final java.io.ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
+		inputStream.defaultReadObject();
+		lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
 	}
 
 }


### PR DESCRIPTION
in order to fix the issue #18868, We made the field FileAsset.lazyComputeDimensions on
FileAsset transient. That to avoid an issue that was breaking site-search.
Now when deserializing the field from cache we discovered it is causing an NPE.
We're approaching the error caused by the lazyComputeDimensions in a different way when the contentlent gets deserialized we're performing an explicit init.