### PR TITLE
#18901  lazy field must not be transient to avoid serialization issues…

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
@@ -132,8 +132,8 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 		if (fileDimension == null) {
 			try {
     				return (fileDimension = ImageUtil.getInstance().getDimension(file));
-			} catch (Exception e) {
-				Logger.debug(this,
+			} catch (Throwable e) {
+				Logger.warn(this,
 						"Error computing dimensions for file asset with id: " + getIdentifier(), e);
 			}
 		}
@@ -141,7 +141,7 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 	}
 
     //Lazy Suppliers are memoized. Meaning that this truly guarantees the computation takes place once.
-    private transient Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
+    private Lazy<Dimension> lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
 
   /**
    * This access the physical file on disk
@@ -382,20 +382,6 @@ public class FileAsset extends Contentlet implements IFileAsset, Loadable {
 				}
 			}
 		}
-	}
-
-	/**
-	 * field lazyComputeDimensions was made transient to avoid serialization problems
-	 * caused by NoClassDefFoundErrors produced by the libraries imported by ImageUtil
-	 *
-	 * So when these objects are coming back from cache they need to get initialized explicitly.
-	 * @param inputStream
-	 * @throws IOException
-	 * @throws ClassNotFoundException
-	 */
-	private void readObject(final java.io.ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
-		inputStream.defaultReadObject();
-		lazyComputeDimensions = Lazy.of(() -> computeFileDimension(getFileAsset()));
 	}
 
 }


### PR DESCRIPTION
we need to make sure we catch errors and exceptions. 
we're making the Lazy evaluated field non-transient to avoid serialization problems.