### PR TITLE
#18846 Apps: making a defensive array copy prevents error delivering …

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsAPIImplTest.java
@@ -806,6 +806,11 @@ public class AppsAPIImplTest {
         localSystemEventsAPI.subscribe(AppSecretSavedEvent.class, new AppsSecretEventSubscriber(){
             @Override
             public void notify(AppSecretSavedEvent event) {
+                final AppSecrets appSecrets = event.getAppSecrets();
+                final Map<String, Secret> secrets = appSecrets.getSecrets();
+                secrets.forEach((s, secret) -> {
+                    Assert.assertFalse(isSecretDestroyed(secret.getValue()));
+                });
                 callsCount.incrementAndGet();
             }
         });

--- a/dotCMS/src/main/java/com/dotcms/security/apps/Secret.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/Secret.java
@@ -18,7 +18,8 @@ public final class Secret extends AbstractProperty<char[]> {
     public static Secret newSecret(@JsonProperty("value") final char[] value,
             @JsonProperty("type") final Type type,
             @JsonProperty("hidden") final boolean hidden) {
-        return new Secret(value, type, hidden);
+        final char[] defensiveCopy = Arrays.copyOf(value, value.length);
+        return new Secret(defensiveCopy, type, hidden);
     }
 
     public void destroy(){


### PR DESCRIPTION
Apps: Recently we opened the possibility to subscribe event listeners to the On AppSave Event.
The events are delivered asynchronously this comes to fix a problem that we had sharing a char array that was destroyed at the end of the HttpRequest causing all listeners to receive a Secret already destroyed. 