### PR TITLE
adding a param that basically allows logging exception on dwr

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/web.xml
+++ b/dotCMS/src/main/webapp/WEB-INF/web.xml
@@ -248,6 +248,10 @@
 	      <param-name>debug</param-name>
     	  <param-value>false</param-value>
 	  </init-param>
+		<init-param>
+			<param-name>accessLogLevel</param-name>
+			<param-value>EXCEPTION</param-value>
+		</init-param>
 	  <init-param>
 	      <param-name>compressor</param-name>
     	  <param-value>none</param-value>


### PR DESCRIPTION
We have a problem with DWR controllers swallowing exceptions this basically adds the configuration necessary for unhandled  exceptions to be logged 