### PR TITLE
dotCMS/core#18556 Popping open tail log window should resize with the popup window.

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log_popup.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log_popup.jsp
@@ -3,4 +3,10 @@
 <%@include file="/html/common/init.jsp"%>
 <%@include file="/html/common/top_inc.jsp"%>
 
+<style>
+	#headerContainer {
+		margin-top:16px;
+	}
+</style>
+
 <%@include file="/html/portlet/ext/cmsmaintenance/tail_log.jsp" %>


### PR DESCRIPTION
adding some space in the header only for the pop-up. 