### PR TITLE
dotCMS/core#18556 Popping open tail log window should resize with the popup window.

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log_popup.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log_popup.jsp
@@ -4,8 +4,8 @@
 <%@include file="/html/common/top_inc.jsp"%>
 
 <style>
-	#headerContainer {
-		margin-top:16px;
+	body {
+		padding-top:16px;
 	}
 </style>
 


### PR DESCRIPTION
respect padding when scrolling - feedback