### PR TITLE
#18939  File name comparison should not be case sensitive

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -737,7 +737,10 @@ public class AppsAPIImpl implements AppsAPI {
         final Set<Path> systemFileNames = systemFiles.stream().map(Path::getFileName)
                 .collect(Collectors.toSet());
         final Set<Path> filteredUserFiles = userFiles.stream()
-                .filter(path -> !systemFileNames.contains(path.getFileName())).collect(Collectors.toSet());
+                .filter(path -> systemFileNames.stream().noneMatch(
+                        systemPath -> systemPath.toString()
+                                .equalsIgnoreCase((path.getFileName().toString().toLowerCase()))))
+                .collect(Collectors.toSet());
 
         return Stream.concat(systemFiles.stream().map(path -> Tuple.of(path, true)),
                 filteredUserFiles.stream().map(path -> Tuple.of(path, false)))


### PR DESCRIPTION
This change fixes this [issue](https://github.com/dotCMS/core/issues/18939#issuecomment-664619927). 

Now, the file name / key validation for yml files does not allow to have two apps configurations with the similar names (same file name, different case - case insensitive)