### PR TITLE
Oracle columns are uppercase, contains check case sensitive

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task05305AddPushPublishFilterColumn.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task05305AddPushPublishFilterColumn.java
@@ -42,7 +42,7 @@ public class Task05305AddPushPublishFilterColumn extends AbstractJDBCStartupTask
     @Override
     public boolean forceRun() {
         try {
-            return !new DotDatabaseMetaData().getColumnNames(DbConnectionFactory.getConnection(), "publishing_bundle").contains("filter_key");
+            return !new DotDatabaseMetaData().getColumnNames(DbConnectionFactory.getConnection(), "publishing_bundle").stream().anyMatch(dbcolumn -> dbcolumn.equalsIgnoreCase("filter_key"));
         } catch (SQLException e) {
             Logger.error(this, e.getMessage(),e);
             return false;


### PR DESCRIPTION
Using anymatch so we can compare the dbcolumn to `filter_key` ignoring the case.