### PR TITLE
Improve reindex mapping process

### DIFF
--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -3,7 +3,7 @@ dependencies {
 
     def eeType = dotcmsReleaseVersion.equals("master") ? '-SNAPSHOT' : ''
 
-    compile group: 'com.dotcms.enterprise', name: 'ee', version: '5.3.6', changing: true
+    compile group: 'com.dotcms.enterprise', name: 'ee', version: '5.3.6.1', changing: true
 
     compile group: 'com.dotcms', name: 'ant-tooling', version: '1.3.2'
     compile ('io.jsonwebtoken:jjwt:0.6.0'){

--- a/dotCMS/gradle.properties
+++ b/dotCMS/gradle.properties
@@ -1,4 +1,4 @@
-dotcmsReleaseVersion=5.3.6
+dotcmsReleaseVersion=5.3.6.1
 coreWebReleaseVersion=5.3.3-1595869932982
 webComponentsReleaseVersion=latest
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPI.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 
 public interface ContentletIndexAPI {
@@ -139,7 +138,7 @@ public interface ContentletIndexAPI {
 
     void stopFullReindexationAndSwitchover() throws DotDataException;
 
-    void reindexSwitchover(boolean forceSwitch) throws DotDataException;
+    boolean reindexSwitchover(boolean forceSwitch) throws DotDataException;
 
     void stopFullReindexation() throws DotDataException;
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -61,7 +61,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -258,10 +257,11 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
      * @throws SQLException An error occurred when interacting with the database.
      * @throws DotDataException The process to switch to the new failed.
      * @throws InterruptedException The established pauses to switch to the new index failed.
+     * @return
      */
     @Override
     @CloseDBIfOpened
-    public void reindexSwitchover(boolean forceSwitch) throws DotDataException {
+    public boolean reindexSwitchover(boolean forceSwitch) throws DotDataException {
 
         // We double check again. Only one node will enter this critical
         // region, then others will enter just to see that the switchover is
@@ -270,10 +270,10 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         if (forceSwitch || queueApi.recordsInQueue() == 0) {
             Logger.info(this, "Running Reindex Switchover");
             // Wait a bit while all records gets flushed to index
-            this.fullReindexSwitchover(forceSwitch);
+            return this.fullReindexSwitchover(forceSwitch);
             // Wait a bit while elasticsearch flushes it state
         }
-
+        return false;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -145,14 +145,9 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     public synchronized boolean createContentIndex(String indexName) throws ElasticsearchException, IOException {
-        boolean result;
-        try {
-            result = createContentIndex(indexName, 0);
-            HibernateUtil
-                    .addCommitListener(() -> ESMappingUtilHelper.getInstance().addCustomMapping(indexName));
-        } catch (DotHibernateException e) {
-            throw new ElasticsearchException(e);
-        }
+        boolean result = createContentIndex(indexName, 0);
+        ESMappingUtilHelper.getInstance().addCustomMapping(indexName);
+
         return result;
     }
 
@@ -218,8 +213,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
 
             APILocator.getIndiciesAPI().point(info);
 
-            HibernateUtil.addCommitListener(() -> ESMappingUtilHelper.getInstance()
-                    .addCustomMapping(info.getWorking(), info.getLive()));
+            ESMappingUtilHelper.getInstance()
+                    .addCustomMapping(info.getWorking(), info.getLive());
             return timeStamp;
         } catch (Exception e) {
             throw new ElasticsearchException(e.getMessage(), e);
@@ -309,8 +304,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
 
                 APILocator.getIndiciesAPI().point(info);
 
-                HibernateUtil.addCommitListener(() -> ESMappingUtilHelper.getInstance()
-                        .addCustomMapping(info.getReindexWorking(), info.getReindexLive()));
+                ESMappingUtilHelper.getInstance()
+                        .addCustomMapping(info.getReindexWorking(), info.getReindexLive());
 
                 return timeStamp;
             } catch (Exception e) {
@@ -342,7 +337,7 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     public boolean fullReindexSwitchover(Connection conn, final boolean forceSwitch) {
 
 
-        if(reindexTimeElapsedInLong()<Config.getLongProperty("REINDEX_THREAD_MINIMUM_RUNTIME_IN_SEC", 15)*1000) {
+        if(reindexTimeElapsedInLong()<Config.getLongProperty("REINDEX_THREAD_MINIMUM_RUNTIME_IN_SEC", 30)*1000) {
           Logger.info(this.getClass(), "Reindex has been running only " +reindexTimeElapsed().get() + ". Letting the reindex settle.");
           ThreadUtils.sleep(3000);
           return false;

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelper.java
@@ -296,7 +296,7 @@ public class ESMappingUtilHelper {
             final Set<String> mappedFields, final String... indexes) {
         final Map<String, JSONObject> contentTypeMapping = new HashMap();
         try {
-            contentType.fields().stream().forEach(field-> {
+            contentType.fields().forEach(field-> {
                     try {
                         addMappingForFieldIfNeeded(contentType, field,
                                 mappedFields, contentTypeMapping);

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsStoreKeyStoreImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsStoreKeyStoreImpl.java
@@ -129,7 +129,7 @@ public class SecretsStoreKeyStoreImpl implements SecretsStore {
             return keyStore;
 
         } catch (Exception e) {
-            Logger.error(this.getClass(), "unable to load secrets store " + SECRETS_STORE_FILE + ": " + e);
+            Logger.debug(this.getClass(), "unable to load secrets store " + SECRETS_STORE_FILE + ": " + e);
             throw new DotRuntimeException(e);
         }
 
@@ -167,7 +167,7 @@ public class SecretsStoreKeyStoreImpl implements SecretsStore {
         try {
             return getKeysFromCache().contains(variableKey);
         } catch (Exception e) {
-            Logger.error(SecretsStoreKeyStoreImpl.class,e);
+            Logger.debug(this,e.getMessage());
             throw new DotRuntimeException(e);
         }
     }

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -234,9 +234,10 @@ public class ReindexThread {
     private boolean switchOverIfNeeded() throws LanguageException, DotDataException, SQLException, InterruptedException {
         if (ESReindexationProcessStatus.inFullReindexation() && queueApi.recordsInQueue() == 0) {
             // The re-indexation process has finished successfully
-            indexAPI.reindexSwitchover(false);
-            // Generate and send an user notification
-            sendNotification("notification.reindexing.success", null, null, false);
+            if (indexAPI.reindexSwitchover(false)) {
+                // Generate and send an user notification
+                sendNotification("notification.reindexing.success", null, null, false);
+            }
             return true;
         }
         return false;


### PR DESCRIPTION
With this change, we make sure that a put mapping request for multiple fields is processed by content type. 

Additionally, I moved the `addCustomMapping` logic out of the commit listener to avoid race conditions in case the ReindexThread is executed before the `addCustomMapping` finishes