### PR TITLE
#19147 : The evaluation order in Vanity URLs is still being used by s…

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
@@ -1,12 +1,6 @@
 package com.dotcms.vanityurl.business;
 
 
-import java.text.MessageFormat;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.contenttype.model.type.VanityUrlContentType;
@@ -35,6 +29,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Implementation class for the {@link VanityUrlAPI}.
@@ -125,11 +126,11 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
           vanityUrls.stream().map(vanity -> vanity.get("live_inode").toString()).collect(Collectors.toList());
       final List<Contentlet> contentlets = this.contentletAPI.findContentlets(vanityUrlInodes);
 
-      return contentlets.stream().map(contentlet -> new CachedVanityUrl(this.fromContentlet(contentlet))).collect(Collectors.toList());
+      return contentlets.stream().map(contentlet -> new CachedVanityUrl(this.fromContentlet(contentlet))).sorted().collect(Collectors.toList());
 
     } catch (final Exception e) {
       Logger.error(this,
-          String.format("An error occurred when retrieving Vanity URLs: siteId=[%s], " + "languageId=[%s], includeSystemHost=[%s]",
+          String.format("An error occurred when retrieving Vanity URLs: siteId=[%s], languageId=[%s]",
               host.getIdentifier(), language.getId()),
           e);
       throw new DotStateException(e);
@@ -137,10 +138,6 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
 
   }
 
-
-  
-  
-  
   private List<CachedVanityUrl> load(final Host host, final Language language) {
 
     List<CachedVanityUrl> cachedVanities = cache.getSiteMappings(host, language);
@@ -171,15 +168,15 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
     }
 
     // tries specific site, language and url
-    Optional<CachedVanityUrl> matched = load(host, language).parallelStream()
+    Optional<CachedVanityUrl> matched = load(host, language).stream()
             .filter(cachedVanityUrl ->
-                    cachedVanityUrl.url.equalsIgnoreCase(url)).findAny();
+                    cachedVanityUrl.url.equalsIgnoreCase(url)).findFirst();
 
     // tries specific site, language and pattern
     if(!matched.isPresent()) {
-      matched = load(host, language).parallelStream()
+      matched = load(host, language).stream()
               .filter(cachedVanityUrl ->
-                      cachedVanityUrl.pattern.matcher(url).matches()).findAny();
+                      cachedVanityUrl.pattern.matcher(url).matches()).findFirst();
     }
 
     

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/model/CachedVanityUrl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/model/CachedVanityUrl.java
@@ -1,10 +1,5 @@
 package com.dotcms.vanityurl.model;
 
-import static com.liferay.util.StringUtil.GROUP_REPLACEMENT_PREFIX;
-import java.io.Serializable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.servlet.http.HttpServletResponse;
 import com.dotcms.http.CircuitBreakerUrl;
 import com.dotcms.vanityurl.util.VanityUrlUtil;
 import com.dotmarketing.exception.DotRuntimeException;
@@ -14,15 +9,22 @@ import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.control.Try;
 
+import javax.servlet.http.HttpServletResponse;
+import java.io.Serializable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.liferay.util.StringUtil.GROUP_REPLACEMENT_PREFIX;
+
 /**
  * This class construct a reduced version of the {@link VanityUrl}
  * object to be saved on cache
  *
- * @author oswaldogallango
- * @version 4.2.0
- * @since June 22, 2017
+ * @author Will Ezell
+ * @version 5.3.3
+ * @since Jun 18, 2020
  */
-public class CachedVanityUrl implements Serializable {
+public class CachedVanityUrl implements Serializable, Comparable<CachedVanityUrl> {
 
     static final long serialVersionUID = 1L;
     final public Pattern pattern;
@@ -41,10 +43,10 @@ public class CachedVanityUrl implements Serializable {
      */
 
     public CachedVanityUrl(final VanityUrl vanityUrl) {
-        this(vanityUrl.getIdentifier(),vanityUrl.getURI(),vanityUrl.getLanguageId(),vanityUrl.getSite(),vanityUrl.getForwardTo(),vanityUrl.getAction());
+        this(vanityUrl.getIdentifier(),vanityUrl.getURI(),vanityUrl.getLanguageId(),vanityUrl.getSite(),vanityUrl.getForwardTo(),vanityUrl.getAction(), vanityUrl.getOrder());
     }
 
-    public CachedVanityUrl(final String vanityUrlId, final String url, final long languageId, final String siteId, final String forwardTo, final int response) {
+    public CachedVanityUrl(final String vanityUrlId, final String url, final long languageId, final String siteId, final String forwardTo, final int response, final int order) {
         final String regex = normalize(url);
         this.pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
         this.vanityUrlId = vanityUrlId;
@@ -53,7 +55,7 @@ public class CachedVanityUrl implements Serializable {
         this.siteId = siteId;
         this.forwardTo = forwardTo;
         this.response = response;
-        this.order    = 0;
+        this.order    = order;
     }
     
     /**
@@ -82,8 +84,6 @@ public class CachedVanityUrl implements Serializable {
       }
       return Tuple.of(newForward, queryString);
     }
-    
-    
 
     /**
      * This comes as fix for https://github.com/dotCMS/core/issues/16433
@@ -111,7 +111,19 @@ public class CachedVanityUrl implements Serializable {
         return VanityUrlUtil.isValidRegex(uriRegEx) ? uriRegEx : StringPool.BLANK;
     }
     
-    
+    /**
+     * Determines the behavior of the Vanity URL based on the selected action. There are three possible values:
+     * <ul>
+     *   <li>200 - Forward</li>
+     *   <li>301 - Permanent Redirect</li>
+     *   <li>302 - Temporary Redirect</li>
+     * </ul>
+     *
+     * @param uriIn    Incoming URL in the request.
+     * @param response The {@link HttpServletResponse} object.
+     *
+     * @return The appropriate result based on the selected action for the incoming URL.
+     */
     public VanityUrlResult handle(final String uriIn,
                     final HttpServletResponse response) {
         
@@ -137,12 +149,7 @@ public class CachedVanityUrl implements Serializable {
         }
 
         return new VanityUrlResult(rewrite, queryString, false);
-        
-        
     }
-    
-    
-
 
     @Override
     public int hashCode() {
@@ -155,8 +162,6 @@ public class CachedVanityUrl implements Serializable {
         result = prime * result + ((url == null) ? 0 : url.hashCode());
         return result;
     }
-
-
 
     @Override
     public boolean equals(Object obj) {
@@ -189,8 +194,6 @@ public class CachedVanityUrl implements Serializable {
         return true;
     }
 
-
-
     @Override
     public String toString() {
         return "CachedVanityUrl{" +
@@ -205,5 +208,9 @@ public class CachedVanityUrl implements Serializable {
                 '}';
     }
     
-    
+    @Override
+    public int compareTo(final CachedVanityUrl cachedVanityUrl) {
+        return this.order - cachedVanityUrl.order;
+    }
+
 }


### PR DESCRIPTION
…everal customers. The new version of the Vanity URL API was not setting the expected value for that. The API is now returning the Vanities in ascending order so that users can specify the appropriate way in which Vanities should match an incoming URL.