### PR TITLE
#19141 checkbox id was using the id, change to inode

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/ajax/WfTaskAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/ajax/WfTaskAjax.java
@@ -119,7 +119,7 @@ public class WfTaskAjax extends WfBaseAction {
 					continue;
 				}
 
-				final Identifier id = APILocator.getIdentifierAPI().find(token);
+				final Identifier id = APILocator.getIdentifierAPI().findFromInode(token);
 				Contentlet contentlet = null;
 
 				try {

--- a/dotCMS/src/main/webapp/html/portlet/ext/workflows/view_tasks_list.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/workflows/view_tasks_list.jsp
@@ -187,7 +187,7 @@
 		<tr class="alternate_1">
 			<td>
 
-				<input <%if(!singleStep){ %>disabled="true"<%} %> type="checkbox" dojoType="dijit.form.CheckBox" id="<%=task.getWebasset() %>" class="taskCheckBox" value="<%=task.getId() %>"  data-action-inode="<%=contentlet.getInode()%>" />
+				<input <%if(!singleStep){ %>disabled="true"<%} %> type="checkbox" dojoType="dijit.form.CheckBox" id="<%=contentlet.getInode() %>" class="taskCheckBox" value="<%=task.getId() %>"  data-action-inode="<%=contentlet.getInode()%>" />
 
 
 			</td>


### PR DESCRIPTION
Checkbox was using the id of the content as the widgetId, so it was causing issues when the contentlet exist in another language. Using inode instead.