### PR TITLE
#19183 refactor on Logger

### DIFF
--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -166,7 +166,7 @@ dependencies {
     felix group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.25'
     felix group: 'com.dotcms.tika', name: 'com.dotcms.tika', version: '0.2'
 
-    felix group: 'com.dotcms.samlbundle', name: 'com.dotcms.samlbundle', version: '5.3.6'
+    felix group: 'com.dotcms.samlbundle', name: 'com.dotcms.samlbundle', version: '5.3.8'
     /**** And now the libs we pull in from internal company sources - libs stored in ./plugins, ./bin, ./libs, the starter site, etc. ****/
     compile fileTree("src/main/plugins/com.dotcms.config/build/jar").include('plugin-com.dotcms.config.jar')
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/logger/LoggerResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/logger/LoggerResource.java
@@ -2,7 +2,6 @@ package com.dotcms.rest.api.v1.system.logger;
 
 import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource;
-import com.dotcms.util.ReflectionUtils;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.Logger;
@@ -52,9 +51,10 @@ public class LoggerResource {
             throw new DotSecurityException("User is not admin");
         }
 
-        final Class loggerClass = ReflectionUtils.getClassFor(loggerName);
+        final Object loggerClass = Logger.getLogger(loggerName);
         if (null != loggerClass) {
-            return Response.ok(new ResponseEntityView(this.toView(Logger.getLogger(loggerClass)))).build();
+
+            return Response.ok(new ResponseEntityView(this.toView(loggerClass))).build();
         }
 
         throw new DoesNotExistException("Logger: " + loggerName + " does not exists");

--- a/dotCMS/src/main/java/com/dotcms/saml/DotLoggerMessageObserver.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/DotLoggerMessageObserver.java
@@ -10,38 +10,38 @@ import java.text.MessageFormat;
  */
 public class DotLoggerMessageObserver implements MessageObserver {
     @Override
-    public void updateError(final Class aClass, final String message) {
+    public void updateError(final String aClass, final String message) {
 
         Logger.error(aClass, message);
     }
 
     @Override
-    public void updateError(final Class aClass, final String message, final Throwable throwable) {
+    public void updateError(final String aClass, final String message, final Throwable throwable) {
 
         Logger.error(aClass, message, throwable);
     }
 
     @Override
-    public void updateError(final Class aClass, final String message, final Object... objects) {
+    public void updateError(final String aClass, final String message, final Object... objects) {
 
         final String finalMessage = MessageFormat.format(message, objects);
         Logger.error(aClass, finalMessage);
     }
 
     @Override
-    public void updateDebug(final Class aClass, final String message) {
+    public void updateDebug(final String aClass, final String message) {
 
         Logger.debug(aClass, ()->message);
     }
 
     @Override
-    public void updateInfo(final Class aClass, final String message) {
+    public void updateInfo(final String aClass, final String message) {
 
         Logger.info(aClass, message);
     }
 
     @Override
-    public void updateWarning(final Class aClass, final String message) {
+    public void updateWarning(final String aClass, final String message) {
 
         Logger.warn(aClass, ()->message);
     }

--- a/dotCMS/src/main/java/com/dotcms/saml/MessageObserver.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/MessageObserver.java
@@ -13,7 +13,7 @@ public interface MessageObserver {
      * @param clazz
      * @param message
      */
-    void updateError(Class clazz, String message);
+    void updateError(String clazz, String message);
 
     /**
      * Updates to the observers when there is an error.
@@ -21,28 +21,29 @@ public interface MessageObserver {
      * @param message
      * @param throwable
      */
-    void updateError(Class clazz, String message, Throwable throwable);
+    void updateError(String clazz, String message, Throwable throwable);
 
-    void updateError(Class clazz, String message, Object... arguments);
+    void updateError(String clazz, String message, Object... arguments);
 
     /**
      * Updates to the observers when there is an debug.
      * @param clazz
      * @param message
      */
-    void updateDebug(Class clazz, String message);
+    void updateDebug(String clazz, String message);
+
 
     /**
      * Updates to the observers when there is an info.
      * @param clazz
      * @param message
      */
-    void updateInfo(Class clazz, String message);
+    void updateInfo(String clazz, String message);
 
     /**
      * Updates to the observers when there is a warning
      * @param clazz
      * @param message
      */
-    void updateWarning(Class clazz, String message);
+    void updateWarning(String clazz, String message);
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/Logger.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Logger.java
@@ -31,14 +31,14 @@ public class Logger{
 	static {
 		Log4jUtil.configureDefaultSystemProperties();
 	}
-	private static WeakHashMap<Class, org.apache.logging.log4j.Logger> map = new WeakHashMap<>();
+	private static WeakHashMap<String, org.apache.logging.log4j.Logger> map = new WeakHashMap<>();
 
 	public static void clearLoggers(){
 		map.clear();
 	}
 
     public static org.apache.logging.log4j.Logger clearLogger ( Class clazz ) {
-        return map.remove( clazz );
+        return map.remove( clazz.getName() );
 	}
 
 	/**
@@ -47,11 +47,24 @@ public class Logger{
 	 * @return
 	 */
 	private synchronized static org.apache.logging.log4j.Logger loadLogger(Class cl){
-		if(map.get(cl) == null){
+		if(map.get(cl.getName()) == null){
 			org.apache.logging.log4j.Logger logger = LogManager.getLogger(cl);
-			map.put(cl, logger);
+			map.put(cl.getName(), logger);
 		}
-		return map.get(cl);
+		return map.get(cl.getName());
+	}
+
+	/**
+	 * This class is syncrozned.  It shouldn't be called. It is exposed so that
+	 * @param className
+	 * @return
+	 */
+	private synchronized static org.apache.logging.log4j.Logger loadLogger(final String className){
+		if(map.get(className) == null){
+			org.apache.logging.log4j.Logger logger = LogManager.getLogger(className);
+			map.put(className, logger);
+		}
+		return map.get(className);
 	}
 
 	public static void info(Class clazz, final Supplier<String> message) {
@@ -75,16 +88,31 @@ public class Logger{
     		velocityInfo(cl, message);
     		return;
     	}
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
         logger.info(message);
     }
 
+	public static void info(String cl, String message) {
+
+		org.apache.logging.log4j.Logger logger = map.get(cl);
+		if(logger == null){
+			logger = loadLogger(cl);
+		}
+		logger.info(message);
+	}
+
 	public static void debug(final Object ob, final Supplier<String> message) {
 		if (isDebugEnabled(ob.getClass())) {
 			debug(ob.getClass(), message.get());
+		}
+	}
+
+	public static void debug(final String className, final Supplier<String> message) {
+		if (isDebugEnabled(className)) {
+			debug(className, message.get());
 		}
 	}
 
@@ -107,19 +135,28 @@ public class Logger{
     		velocityDebug(cl, message);
     		return;
     	}
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
         logger.debug(message);
     }
 
+	public static void debug(String cl, String message) {
+
+		org.apache.logging.log4j.Logger logger = map.get(cl);
+		if(logger == null){
+			logger = loadLogger(cl);
+		}
+		logger.debug(message);
+	}
+
     public static void debug(Class cl, String message, Throwable ex) {
     	if(isVelocityMessage(cl)){
     		velocityDebug(cl, message, ex);
     		return;
     	}
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -142,7 +179,7 @@ public class Logger{
     		velocityError(cl, message);
     		return;
     	}
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -150,12 +187,22 @@ public class Logger{
         logger.error(message);
     }
 
+	public static void error(String cl, String message) {
+
+		org.apache.logging.log4j.Logger logger = map.get(cl);
+		if(logger == null){
+			logger = loadLogger(cl);
+		}
+
+		logger.error(message);
+	}
+
     public static void error(Class cl, String message, Throwable ex) {
     	if(isVelocityMessage(cl)){
     		velocityError(cl, message, ex);
     		return;
     	}
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -166,6 +213,18 @@ public class Logger{
     	    ex.printStackTrace();
     	}
     }
+
+	public static void error(String cl, String message, Throwable ex) {
+		org.apache.logging.log4j.Logger logger = map.get(cl);
+		if(logger == null){
+			logger = loadLogger(cl);
+		}
+		try{
+			logger.error(message, ex);
+		}catch(java.lang.IllegalStateException e){
+			ex.printStackTrace();
+		}
+	}
     /**
      * a map with a 5 minute max lifespan
      */
@@ -237,7 +296,7 @@ public class Logger{
      * @param ex
      */
     public static void warnAndDebug(Class cl, String message, Throwable ex) {
-        org.apache.logging.log4j.Logger logger = map.get(cl);
+        org.apache.logging.log4j.Logger logger = map.get(cl.getName());
         if(logger == null){
             logger = loadLogger(cl);    
         }
@@ -283,7 +342,7 @@ public class Logger{
     		velocityFatal(cl, message);
     		return;
     	}
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -295,7 +354,7 @@ public class Logger{
     		velocityFatal(cl, message, ex);
     		return;
     	}
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -305,6 +364,12 @@ public class Logger{
 	public static void warn(final Object ob, final Supplier<String> message) {
 		if (isWarnEnabled(ob.getClass())) {
 			warn(ob.getClass(), message.get());
+		}
+	}
+
+	public static void warn(final String className, final Supplier<String> message) {
+		if (isWarnEnabled(className)) {
+			warn(className, message.get());
 		}
 	}
 
@@ -327,7 +392,7 @@ public class Logger{
     		velocityWarn(cl, message);
     		return;
     	}
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -335,29 +400,47 @@ public class Logger{
         logger.warn(message);
     }
 
+	public static void warn(String cl, String message) {
+
+		org.apache.logging.log4j.Logger logger = map.get(cl);
+		if(logger == null){
+			logger = loadLogger(cl);
+		}
+
+		logger.warn(message);
+	}
+
     public static void warn(Class cl, String message, Throwable ex) {
     	if(isVelocityMessage(cl)){
     		velocityWarn(cl, message, ex);
     		return;
     	}
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
 
         logger.warn(message, ex);
     }
+
     public static boolean isDebugEnabled(Class cl) {
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
         return logger.isDebugEnabled();
-
     }
 
+	public static boolean isDebugEnabled(String cl) {
+		org.apache.logging.log4j.Logger logger = map.get(cl);
+		if(logger == null){
+			logger = loadLogger(cl);
+		}
+		return logger.isDebugEnabled();
+	}
+
     public static boolean isInfoEnabled(Class cl) {
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -365,24 +448,40 @@ public class Logger{
 
     }
     public static boolean isWarnEnabled(Class cl) {
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
         return logger.isWarnEnabled();
 
     }
+	public static boolean isWarnEnabled(String cl) {
+		org.apache.logging.log4j.Logger logger = map.get(cl);
+		if(logger == null){
+			logger = loadLogger(cl);
+		}
+		return logger.isWarnEnabled();
+
+	}
     public static boolean isErrorEnabled(Class cl) {
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
         return logger.isErrorEnabled();
 
     }
-    
+
+	public static org.apache.logging.log4j.Logger getLogger(final String className) {
+		org.apache.logging.log4j.Logger logger = map.get(className);
+		if(logger == null){
+			logger = loadLogger(className);
+		}
+		return logger;
+	}
+
     public static org.apache.logging.log4j.Logger getLogger(Class cl) {
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -392,7 +491,7 @@ public class Logger{
     
     
     public static void velocityError(Class cl, String message, Throwable thr){
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -400,7 +499,7 @@ public class Logger{
     }
     
     public static void velocityWarn(Class cl, String message, Throwable thr){
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -408,21 +507,21 @@ public class Logger{
     }
     
     public static void velocityInfo(Class cl, String message, Throwable thr){
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
 		logger.info(message + " @ " +  Thread.currentThread().getName(), thr);
     }
     public static void velocityFatal(Class cl, String message, Throwable thr){
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
 		logger.fatal(message + " @ " +  Thread.currentThread().getName(), thr);
 	}
     public static void velocityDebug(Class cl, String message, Throwable thr){
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -430,7 +529,7 @@ public class Logger{
 	}
 
     public static void velocityError(Class cl, String message){
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -438,7 +537,7 @@ public class Logger{
 	}
 	
 	public static void velocityWarn(Class cl, String message){
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -446,21 +545,21 @@ public class Logger{
 	}
 	
 	public static void velocityInfo(Class cl, String message){
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
 		logger.info(message + " @ " +  Thread.currentThread().getName());
 	}
 	public static void velocityFatal(Class cl, String message){
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
 		logger.fatal(message + " @ " +  Thread.currentThread().getName());
 	}
 	public static void velocityDebug(Class cl, String message){
-    	org.apache.logging.log4j.Logger logger = map.get(cl);
+    	org.apache.logging.log4j.Logger logger = map.get(cl.getName());
     	if(logger == null){
     		logger = loadLogger(cl);	
     	}
@@ -512,10 +611,9 @@ public class Logger{
 	 */
 	public static Object setLevel(final String loggerName, final String level) {
 
-    	final Class loggerClass = ReflectionUtils.getClassFor(loggerName);
-    	if (null != loggerClass) {
+    	final Object logger = getLogger(loggerName);
+    	if (null != logger) {
 
-			final org.apache.logging.log4j.Logger logger = getLogger(loggerClass);
 			if (logger instanceof org.apache.logging.log4j.core.Logger) {
 
 				final Level logLevel = Level.getLevel(level);


### PR DESCRIPTION
Currently the Logger uses the Class as a reference to look for the Logger and make the log
It works ok on dotCMS classpath, but classes from OSGI are not classpath reacheable (well they are with a hack).
This PR is adding a methods that uses class name (String) instead of (Class) with that change OSGI may uses our logger without any issue.
In addition the logger level my change dynamically by using LoggerResource and by log4j2.xml