### PR TITLE
#18988 _text fields should be optional

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
@@ -1,5 +1,6 @@
 package com.dotcms.content.elasticsearch.business;
 
+import static com.dotcms.content.elasticsearch.business.ESMappingAPIImpl.TEXT;
 import static com.dotcms.datagen.TestDataUtils.getCommentsLikeContentType;
 import static com.dotcms.datagen.TestDataUtils.getNewsLikeContentType;
 import static com.dotcms.datagen.TestDataUtils.relateContentTypes;
@@ -34,6 +35,7 @@ import com.dotcms.contenttype.util.KeyValueFieldUtil;
 import com.dotcms.datagen.FieldDataGen;
 import com.dotcms.datagen.FileAssetDataGen;
 import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
@@ -59,6 +61,7 @@ import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
 import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import com.liferay.util.StringPool;
+import com.dotmarketing.util.Config;
 import java.io.File;
 
 import java.util.ArrayList;
@@ -142,6 +145,67 @@ public class ESMappingAPITest {
         assertEquals("text/plain; charset=iso-8859-1", contentletMap.get("metadata.contenttype").toString().toLowerCase());
         assertEquals(4, contentletMap.get("metadata.filesize"));
         assertTrue( contentletMap.get("metadata.content").toString().contains("lol!"));
+
+    }
+
+    @Test
+    public void test_toMap_when_textFieldShouldNotBeIncluded(){
+        final ESMappingAPIImpl esMappingAPI = new ESMappingAPIImpl();
+        Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", false);
+
+        final Map<String, Object> contentletMap = esMappingAPI.toMap(TestDataUtils
+                .getNewsContent(true, language.getId(),
+                        TestDataUtils.getNewsLikeContentType().id()));
+
+        assertNotNull(contentletMap);
+
+        assertFalse(contentletMap.containsKey((ESMappingConstants.STRUCTURE_TYPE + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.BASE_TYPE + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.MOD_DATE + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.LIVE + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.WORKING + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.LOCKED + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.DELETED + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.LANGUAGE_ID + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.PUBLISH_DATE + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.EXPIRE_DATE + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.VERSION_TS + TEXT).toLowerCase()));
+
+        assertFalse(contentletMap.containsKey((ESMappingConstants.WORKFLOW_MOD_DATE + TEXT).toLowerCase()));
+
+        assertFalse(contentletMap.containsKey((ESMappingConstants.OWNER_CAN_READ + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.OWNER_CAN_WRITE + TEXT).toLowerCase()));
+        assertFalse(contentletMap.containsKey((ESMappingConstants.OWNER_CAN_PUBLISH + TEXT).toLowerCase()));
+    }
+
+    @Test
+    public void test_toMap_when_textFieldShouldBeIncluded(){
+        final ESMappingAPIImpl esMappingAPI = new ESMappingAPIImpl();
+
+        Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", true);
+        final Map<String, Object> contentletMap = esMappingAPI.toMap(TestDataUtils
+                .getNewsContent(true, language.getId(),
+                        TestDataUtils.getNewsLikeContentType().id()));
+
+        assertNotNull(contentletMap);
+
+        assertTrue(contentletMap.containsKey((ESMappingConstants.STRUCTURE_TYPE + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.BASE_TYPE + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.MOD_DATE + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.LIVE + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.WORKING + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.LOCKED + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.DELETED + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.LANGUAGE_ID + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.PUBLISH_DATE + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.EXPIRE_DATE + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.VERSION_TS + TEXT).toLowerCase()));
+
+        assertTrue(contentletMap.containsKey((ESMappingConstants.WORKFLOW_MOD_DATE + TEXT).toLowerCase()));
+
+        assertTrue(contentletMap.containsKey((ESMappingConstants.OWNER_CAN_READ + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.OWNER_CAN_WRITE + TEXT).toLowerCase()));
+        assertTrue(contentletMap.containsKey((ESMappingConstants.OWNER_CAN_PUBLISH + TEXT).toLowerCase()));
 
     }
 

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
@@ -148,14 +148,18 @@ public class ESMappingAPITest {
 
     }
 
+    /**
+     * Method to test: {@link ESMappingAPIImpl#toMap(Contentlet)}
+     * Given Scenario: When the property `CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS` is set to false, _text fields shouldn't be included in the map
+     * ExpectedResult: The result map should not contain any _text field
+     */
     @Test
     public void test_toMap_when_textFieldShouldNotBeIncluded(){
         final ESMappingAPIImpl esMappingAPI = new ESMappingAPIImpl();
         Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", false);
 
         final Map<String, Object> contentletMap = esMappingAPI.toMap(TestDataUtils
-                .getNewsContent(true, language.getId(),
-                        TestDataUtils.getNewsLikeContentType().id()));
+                .getNewsContent(true, language.getId(), getNewsLikeContentType().id()));
 
         assertNotNull(contentletMap);
 
@@ -178,14 +182,18 @@ public class ESMappingAPITest {
         assertFalse(contentletMap.containsKey((ESMappingConstants.OWNER_CAN_PUBLISH + TEXT).toLowerCase()));
     }
 
+    /**
+     * Method to test: {@link ESMappingAPIImpl#toMap(Contentlet)}
+     * Given Scenario: When the property `CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS` is set to true, _text fields should be included in the map
+     * ExpectedResult: The result map should contain all _text fields
+     */
     @Test
     public void test_toMap_when_textFieldShouldBeIncluded(){
         final ESMappingAPIImpl esMappingAPI = new ESMappingAPIImpl();
 
         Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", true);
         final Map<String, Object> contentletMap = esMappingAPI.toMap(TestDataUtils
-                .getNewsContent(true, language.getId(),
-                        TestDataUtils.getNewsLikeContentType().id()));
+                .getNewsContent(true, language.getId(), getNewsLikeContentType().id()));
 
         assertNotNull(contentletMap);
 

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
@@ -192,28 +192,45 @@ public class ESMappingAPITest {
         final ESMappingAPIImpl esMappingAPI = new ESMappingAPIImpl();
 
         Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", true);
-        final Map<String, Object> contentletMap = esMappingAPI.toMap(TestDataUtils
-                .getNewsContent(true, language.getId(), getNewsLikeContentType().id()));
+        try {
+            final Map<String, Object> contentletMap = esMappingAPI.toMap(TestDataUtils
+                    .getNewsContent(true, language.getId(), getNewsLikeContentType().id()));
 
-        assertNotNull(contentletMap);
+            assertNotNull(contentletMap);
 
-        assertTrue(contentletMap.containsKey((ESMappingConstants.STRUCTURE_TYPE + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.BASE_TYPE + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.MOD_DATE + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.LIVE + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.WORKING + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.LOCKED + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.DELETED + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.LANGUAGE_ID + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.PUBLISH_DATE + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.EXPIRE_DATE + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.VERSION_TS + TEXT).toLowerCase()));
+            assertTrue(contentletMap
+                    .containsKey((ESMappingConstants.STRUCTURE_TYPE + TEXT).toLowerCase()));
+            assertTrue(
+                    contentletMap.containsKey((ESMappingConstants.BASE_TYPE + TEXT).toLowerCase()));
+            assertTrue(
+                    contentletMap.containsKey((ESMappingConstants.MOD_DATE + TEXT).toLowerCase()));
+            assertTrue(contentletMap.containsKey((ESMappingConstants.LIVE + TEXT).toLowerCase()));
+            assertTrue(
+                    contentletMap.containsKey((ESMappingConstants.WORKING + TEXT).toLowerCase()));
+            assertTrue(contentletMap.containsKey((ESMappingConstants.LOCKED + TEXT).toLowerCase()));
+            assertTrue(
+                    contentletMap.containsKey((ESMappingConstants.DELETED + TEXT).toLowerCase()));
+            assertTrue(contentletMap
+                    .containsKey((ESMappingConstants.LANGUAGE_ID + TEXT).toLowerCase()));
+            assertTrue(contentletMap
+                    .containsKey((ESMappingConstants.PUBLISH_DATE + TEXT).toLowerCase()));
+            assertTrue(contentletMap
+                    .containsKey((ESMappingConstants.EXPIRE_DATE + TEXT).toLowerCase()));
+            assertTrue(contentletMap
+                    .containsKey((ESMappingConstants.VERSION_TS + TEXT).toLowerCase()));
 
-        assertTrue(contentletMap.containsKey((ESMappingConstants.WORKFLOW_MOD_DATE + TEXT).toLowerCase()));
+            assertTrue(contentletMap
+                    .containsKey((ESMappingConstants.WORKFLOW_MOD_DATE + TEXT).toLowerCase()));
 
-        assertTrue(contentletMap.containsKey((ESMappingConstants.OWNER_CAN_READ + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.OWNER_CAN_WRITE + TEXT).toLowerCase()));
-        assertTrue(contentletMap.containsKey((ESMappingConstants.OWNER_CAN_PUBLISH + TEXT).toLowerCase()));
+            assertTrue(contentletMap
+                    .containsKey((ESMappingConstants.OWNER_CAN_READ + TEXT).toLowerCase()));
+            assertTrue(contentletMap
+                    .containsKey((ESMappingConstants.OWNER_CAN_WRITE + TEXT).toLowerCase()));
+            assertTrue(contentletMap
+                    .containsKey((ESMappingConstants.OWNER_CAN_PUBLISH + TEXT).toLowerCase()));
+        } finally {
+            Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", false);
+        }
 
     }
 

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelperTest.java
@@ -483,7 +483,6 @@ public class ESMappingUtilHelperTest {
         ContentType eventContentType;
         Contentlet event = null;
         try {
-            Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", true);
             try {
                 eventContentType = contentTypeAPI.find("calendarEvent");
 
@@ -526,7 +525,6 @@ public class ESMappingUtilHelperTest {
             assertTrue(UtilMethods.isSet(mapping.get("analyzer")));
             assertEquals("my_analyzer", mapping.get("analyzer"));
         }finally {
-            Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", false);
             if (event != null){
                 ContentletDataGen.destroy(event);
             }

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelperTest.java
@@ -43,6 +43,7 @@ import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.structure.model.Relationship;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
@@ -482,6 +483,7 @@ public class ESMappingUtilHelperTest {
         ContentType eventContentType;
         Contentlet event = null;
         try {
+            Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", true);
             try {
                 eventContentType = contentTypeAPI.find("calendarEvent");
 
@@ -524,6 +526,7 @@ public class ESMappingUtilHelperTest {
             assertTrue(UtilMethods.isSet(mapping.get("analyzer")));
             assertEquals("my_analyzer", mapping.get("analyzer"));
         }finally {
+            Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", false);
             if (event != null){
                 ContentletDataGen.destroy(event);
             }

--- a/dotCMS/src/integration-test/java/com/dotcms/util/IntegrationTestInitService.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/util/IntegrationTestInitService.java
@@ -43,6 +43,8 @@ public class IntegrationTestInitService {
                 FactoryLocator.init();
                 APILocator.init();
 
+                Config.setProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", true);
+
                 //Running the always run startup tasks
                 StartupTasksUtil.getInstance().init();
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -593,7 +593,7 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 	}
 
 	@SuppressWarnings("unchecked")
-	protected void loadPermissions(final Contentlet con, final Map<String,Object> m) throws DotDataException {
+	protected void loadPermissions(final Contentlet con, final Map<String,Object> contentletMap) throws DotDataException {
 		PermissionAPI permissionAPI = APILocator.getPermissionAPI();
 		List<Permission> permissions = permissionAPI.getPermissions(con, false, false, false);
 		StringBuilder permissionsSt = new StringBuilder();
@@ -618,15 +618,15 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 				}
 			}
 		}
-		m.put(ESMappingConstants.PERMISSIONS, permissionsSt.toString());
-		m.put(ESMappingConstants.OWNER_CAN_READ, ownerCanRead);
-		m.put(ESMappingConstants.OWNER_CAN_WRITE, ownerCanWrite);
-		m.put(ESMappingConstants.OWNER_CAN_PUBLISH, ownerCanPub);
+		contentletMap.put(ESMappingConstants.PERMISSIONS, permissionsSt.toString());
+		contentletMap.put(ESMappingConstants.OWNER_CAN_READ, ownerCanRead);
+		contentletMap.put(ESMappingConstants.OWNER_CAN_WRITE, ownerCanWrite);
+		contentletMap.put(ESMappingConstants.OWNER_CAN_PUBLISH, ownerCanPub);
 
         if (Config.getBooleanProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", false)) {
-            m.put(ESMappingConstants.OWNER_CAN_READ + TEXT, Boolean.toString(ownerCanRead));
-            m.put(ESMappingConstants.OWNER_CAN_WRITE + TEXT, Boolean.toString(ownerCanWrite));
-            m.put(ESMappingConstants.OWNER_CAN_PUBLISH + TEXT, Boolean.toString(ownerCanPub));
+            contentletMap.put(ESMappingConstants.OWNER_CAN_READ + TEXT, Boolean.toString(ownerCanRead));
+            contentletMap.put(ESMappingConstants.OWNER_CAN_WRITE + TEXT, Boolean.toString(ownerCanWrite));
+            contentletMap.put(ESMappingConstants.OWNER_CAN_PUBLISH + TEXT, Boolean.toString(ownerCanPub));
         }
 	}
 


### PR DESCRIPTION
With this change `_text` fields are indexed only if the CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS property is on