### PR TITLE
#19006  a start date must be set even for Cron task

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/quartz/DotStatefulJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/DotStatefulJob.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -162,7 +163,7 @@ public abstract class DotStatefulJob extends DotJob implements StatefulJob {
             final ScheduledTask task = new CronScheduledTask(jobName,
                     groupName, description,
                     jobClass.getCanonicalName(), false,
-                    nextTriggerName, triggerGroup, null, null,
+                    nextTriggerName, triggerGroup, new Date(), null,
                     SimpleTrigger.MISFIRE_INSTRUCTION_FIRE_NOW, 10, true, jobProperties,
                     cronString);
             task.setDurability(true); //must be durable to preserve the detail across triggers.


### PR DESCRIPTION
it can happen that between the moment a task is scheduled and the time the task is fired. There can be a time gap wide enough for the scheduler to reject the task saying something like:  `Based on the configured schedule, the given trigger will never fire.`  This demonstrates and solves the problem.