### PR TITLE
#19210 Generating _dotraw and _text fields when a mapping is put before a reindex is run or a field is added to a content type

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/business/FieldAPITest.java
@@ -1475,6 +1475,15 @@ public class FieldAPITest extends IntegrationTestBase {
                                     .toLowerCase()).get(field.variable());
             assertTrue(UtilMethods.isSet(mapping.get("type")));
             assertEquals("date", mapping.get("type"));
+
+            //validate _dotraw fields
+            mapping = (Map<String, String>) mappingAPI
+                    .getFieldMappingAsMap(indiciesInfo.getLive(),
+                            (type.variable() + StringPool.PERIOD + field.variable() + "_dotraw")
+                                    .toLowerCase()).get(field.variable() + "_dotraw");
+            assertTrue(UtilMethods.isSet(mapping.get("type")));
+            assertEquals("keyword", mapping.get("type"));
+
         }finally{
             ContentTypeDataGen.remove(type);
         }


### PR DESCRIPTION
With these changes we are setting in advance an index mapping for `_dotraw` and `_text` fields (if needed). As the `_dotraw` fields were not being generated when a field was added to a content type, an exception arose when sorting by an empty field in the Content Search.

