### PR TITLE
dotCMS/core#19165 [Layout] : Custom layout doesn't refresh after saving changes

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_menus_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_menus_js_inc.jsp
@@ -620,7 +620,7 @@
 	// HTMLPage popup
 	function showHTMLPagePopUp(page, cmsAdminUser, origReferer, e) {
 		var objId = page.inode;
-        var pageURI = page.inode;
+        var pageURI = page.pageURI;
 		var objIden = page.identifier;
 		var referer = encodeURIComponent(origReferer);
 


### PR DESCRIPTION
In the context menu we are sending the inode to open the edit mode, instead send the url to reflect the latest changes. 