### PR TITLE
#19245 when pages share info on the multitree the override does not d…

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -83,11 +83,11 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
     private static final String DELETE_ALL_MULTI_TREE_SQL = "delete from multi_tree where parent1=? AND relation_type != ?";
     private static final String DELETE_ALL_MULTI_TREE_SQL_BY_RELATION_AND_PERSONALIZATION = "delete from multi_tree where parent1=? AND relation_type != ? and personalization = ?";
     private static final String DELETE_ALL_MULTI_TREE_SQL_BY_RELATION_AND_PERSONALIZATION_PER_LANGUAGE_NOT_SQL =
-            "delete from multi_tree where relation_type != ? and personalization = ? and " +
+            "delete from multi_tree where relation_type != ? and personalization = ? and multi_tree.parent1 = ?  and " +
                     "child in (select distinct identifier from contentlet,multi_tree where multi_tree.child = contentlet.identifier and multi_tree.parent1 = ? and language_id = ?)";
 
     private static final String DELETE_ALL_MULTI_TREE_SQL_BY_RELATION_AND_PERSONALIZATION_PER_LANGUAGE_SQL =
-            "delete from multi_tree where relation_type != ? and personalization = ? and child in (%s)";
+            "delete from multi_tree where relation_type != ? and personalization = ? and multi_tree.parent1 = ?  and child in (%s)";
     private static final String SELECT_MULTI_TREE_BY_LANG =
             "select distinct contentlet.identifier from contentlet,multi_tree where multi_tree.child = contentlet.identifier and multi_tree.parent1 = ? and language_id = ?";
 
@@ -568,6 +568,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
                         .addParam(ContainerUUID.UUID_DEFAULT_VALUE)
                         .addParam(personalization)
                         .addParam(pageId)
+                        .addParam(pageId)
                         .addParam(languageIdOpt.get())
                         .loadResult();
             }
@@ -617,6 +618,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
             db.setSQL(String.format(DELETE_ALL_MULTI_TREE_SQL_BY_RELATION_AND_PERSONALIZATION_PER_LANGUAGE_SQL, Utility.joinList(",", multiTreesId)))
                     .addParam(ContainerUUID.UUID_DEFAULT_VALUE)
                     .addParam(personalization)
+                    .addParam(pageId)
                     .loadResult();
         }
     }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactoryImpl.java
@@ -225,15 +225,16 @@ public class ContainerFactoryImpl implements ContainerFactory {
 				contentletVersionInfo.getLiveInode() : contentletVersionInfo.getWorkingInode();
         Container container = containerCache.get(inode);
 
-        if(container==null) {
+        if(container==null || !InodeUtils.isSet(container.getInode())) {
 
             synchronized (identifier) {
 
-                if(container==null) {
+                if(container==null || !InodeUtils.isSet(container.getInode())) {
 
                     container = FileAssetContainerUtil.getInstance().fromAssets (host, folder,
 							this.findContainerAssets(folder, user, showLive), showLive, includeHostOnPath);
-                    if(container != null && container.getInode() != null) {
+                    if(container != null && InodeUtils.isSet(container.getInode())) {
+
                         containerCache.add(container);
                     }
                 }


### PR DESCRIPTION
When two or more pages shares a contentlet, when one of these pages saves a new contentlet the overrides were deleting the shared contentlets to the rest of the pages.
With this change, when a multitree is overriding only the page multitree changes, the rest of the pages still ok