### PR TITLE
#19206 exclude persona fields if no license. Add test annotation to test

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/graphql/business/GraphqlAPITest.java
@@ -683,6 +683,7 @@ public class GraphqlAPITest extends IntegrationTestBase {
                 .collect(Collectors.toList());
     }
 
+    @Test
     @UseDataProvider("dataProviderEEBaseTypes")
     public void testGetSchema_GivenNoEELicense_EnterpriseBaseTypeCollectionsShouldNOTBeAvailableInSchema(
             final BaseContentType baseType)

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/PageAPIGraphQLTypesProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/PageAPIGraphQLTypesProvider.java
@@ -5,6 +5,7 @@ import static graphql.Scalars.GraphQLLong;
 import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLList.list;
 
+import com.dotcms.enterprise.license.LicenseManager;
 import com.dotcms.graphql.ContentFields;
 import com.dotcms.graphql.datafetcher.LanguageDataFetcher;
 import com.dotcms.graphql.datafetcher.MapFieldPropertiesDataFetcher;
@@ -157,8 +158,12 @@ public enum PageAPIGraphQLTypesProvider implements GraphQLTypesProvider {
         viewAsFields.put("mode", new TypeFetcher(GraphQLString,
                 PropertyDataFetcher.fetching((Function<ViewAsPageStatus, String>)
                         (viewAs)->viewAs.getPageMode().name())));
-        viewAsFields.put("persona", new TypeFetcher(GraphQLTypeReference.typeRef("PersonaBaseType"),
-                new PropertyDataFetcher<ViewAsPageStatus>("persona")));
+        if(LicenseManager.getInstance().isEnterprise()) {
+            viewAsFields
+                    .put("persona", new TypeFetcher(GraphQLTypeReference.typeRef("PersonaBaseType"),
+                            new PropertyDataFetcher<ViewAsPageStatus>("persona")));
+        }
+
 
         typeMap.put("ViewAs", TypeUtil.createObjectType("ViewAs", viewAsFields));
 
@@ -176,8 +181,11 @@ public enum PageAPIGraphQLTypesProvider implements GraphQLTypesProvider {
                 new TypeFetcher(list(GraphQLTypeReference.typeRef("WeightedPersona")),
                 PropertyDataFetcher.fetching((Function<Visitor, Set>)
                         (visitor)->visitor.getWeightedPersonas().entrySet())));
-        visitorFields.put("persona", new TypeFetcher(GraphQLTypeReference.typeRef("PersonaBaseType"),
-                new PropertyDataFetcher<Visitor>("persona")));
+        if(LicenseManager.getInstance().isEnterprise()) {
+            visitorFields
+                    .put("persona", new TypeFetcher(GraphQLTypeReference.typeRef("PersonaBaseType"),
+                            new PropertyDataFetcher<Visitor>("persona")));
+        }
         visitorFields.put("geo", new TypeFetcher(GraphQLTypeReference.typeRef("Geolocation"),
                 new PropertyDataFetcher<Visitor>("geo")));
 


### PR DESCRIPTION
With this PR we avoid to include `persona` fields if no license. 
Also, there was already a test that would have failed, but didn't have the @Test annotation, hence it was not being executed.