### PR TITLE
Issue 19282 apps should not sync 2

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsCacheImpl.java
@@ -148,13 +148,13 @@ public class AppsCacheImpl extends AppsCache {
             return ImmutableSet.of();
         }
         // try again
-        synchronized (AppsCacheImpl.class) {
+
             keys = (Set<String>) cache.get(SECRETS_CACHE_KEY, SECRETS_CACHE_KEYS_GROUP);
             if(keys==null) {
                 keys = supplier.get();
                 putKeys(keys);
             }
-        }
+
         return keys;
         
     }
@@ -188,12 +188,10 @@ public class AppsCacheImpl extends AppsCache {
         }
         
         // try again
-        synchronized (AppsCacheImpl.class) {
-            retVal = (char[]) cache.getNoThrow(key, SECRETS_CACHE_GROUP);
-            if (retVal == null) {
-                retVal = supplier.get();
-                putSecret(key, retVal);
-            }
+        retVal = (char[]) cache.getNoThrow(key, SECRETS_CACHE_GROUP);
+        if (retVal == null) {
+            retVal = supplier.get();
+            putSecret(key, retVal);
         }
         
         return retVal;
@@ -223,10 +221,8 @@ public class AppsCacheImpl extends AppsCache {
      * All Secrets flush.
      */
     public  void flushSecret() {
-        synchronized (AppsCacheImpl.class) {
            cache.flushGroup(SECRETS_CACHE_GROUP);
            cache.flushGroup(SECRETS_CACHE_KEYS_GROUP);
-        }
     }
 
     /**
@@ -235,14 +231,15 @@ public class AppsCacheImpl extends AppsCache {
      * @throws DotCacheException
      */
     public void flushSecret(final String key) throws DotCacheException {
-        synchronized (AppsCacheImpl.class) {
-            cache.remove(key, SECRETS_CACHE_GROUP);
-            final Set<String> keys = (Set<String>)cache.get(SECRETS_CACHE_KEY, SECRETS_CACHE_KEYS_GROUP);
-            if(UtilMethods.isSet(keys)){
-                keys.remove(key);
-                putKeys(keys);
-            }
+
+        cache.remove(key, SECRETS_CACHE_GROUP);
+        final Set<String> keys = (Set<String>) cache
+                .get(SECRETS_CACHE_KEY, SECRETS_CACHE_KEYS_GROUP);
+        if (UtilMethods.isSet(keys)) {
+            keys.remove(key);
+            putKeys(keys);
         }
+
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsStoreKeyStoreImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsStoreKeyStoreImpl.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -401,7 +402,9 @@ public class SecretsStoreKeyStoreImpl implements SecretsStore {
         return cache.getKeysFromCache(() -> {
             final KeyStore keyStore = getSecretsStore();
             try {
-                return new HashSet<>(Collections.list(keyStore.aliases()));
+                final Set<String> keySet = ConcurrentHashMap.newKeySet();
+                keySet.addAll(Collections.list(keyStore.aliases()));
+                return keySet;
             } catch (KeyStoreException e) {
                 Logger.warn(SecretsStoreKeyStoreImpl.class, "Error building keystore keys cache. ", e);
                 throw new DotRuntimeException(e);

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsStoreKeyStoreImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsStoreKeyStoreImpl.java
@@ -373,7 +373,7 @@ public class SecretsStoreKeyStoreImpl implements SecretsStore {
      * @throws KeyStoreException
      * @throws DotCacheException
      */
-    private synchronized void putInCache(final String key, final char[] val)
+    private void putInCache(final String key, final char[] val)
             throws KeyStoreException, DotCacheException {
         cache.putSecret(key, val);
         putInCache(key);
@@ -385,7 +385,7 @@ public class SecretsStoreKeyStoreImpl implements SecretsStore {
      * @throws KeyStoreException
      * @throws DotCacheException
      */
-    private synchronized void putInCache(final String key) throws KeyStoreException, DotCacheException{
+    private void putInCache(final String key) throws KeyStoreException, DotCacheException{
          final Set <String> keys = getKeysFromCache();
          keys.add(key);
          cache.putKeys(keys);


### PR DESCRIPTION
We're getting rid of the synchronized blocks used in AppsCacheImpl per deadlocks appearing in one of our customers.