### PR TITLE
#1437 handling the runtime exception on jersey

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/exception/mapper/RuntimeExceptionMapper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/exception/mapper/RuntimeExceptionMapper.java
@@ -1,0 +1,24 @@
+package com.dotcms.rest.exception.mapper;
+
+import com.dotcms.rest.api.v1.authentication.ResponseUtil;
+import com.dotmarketing.util.Logger;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Generic runtime exception handler to avoid cyclical issues with the stack trace mapping
+ * @author jsanca
+ */
+@Provider
+public class RuntimeExceptionMapper implements javax.ws.rs.ext.ExceptionMapper<RuntimeException> {
+
+    @Override
+    public Response toResponse(RuntimeException exception) {
+
+        //Log into our logs first.
+        Logger.warn(this.getClass(), exception.getMessage(), exception);
+
+        return ResponseUtil.mapExceptionResponse(exception);
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/servlet/ReloadableServletContainer.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/servlet/ReloadableServletContainer.java
@@ -185,7 +185,8 @@ public class ReloadableServletContainer extends HttpServlet  {
                 .register(DotSecurityExceptionMapper.class)
                 .register(DotDataExceptionMapper.class)
                 .register(ElasticsearchStatusExceptionMapper.class)
-                .register((new DotBadRequestExceptionMapper<InvalidFolderNameException>(){}).getClass());
+                .register((new DotBadRequestExceptionMapper<InvalidFolderNameException>(){}).getClass())
+                .register(RuntimeExceptionMapper.class);
                 //.register(ExceptionMapper.class); // temporaly unregister since some services are expecting just a plain message as an error instead of a json, so to keep the compatibility we won't apply this change yet.
     }
 }


### PR DESCRIPTION
runtime exceptions are being handling as a 500 by jersey.
However a runtime exception may be wrapping another handled exception, the idea is to use the causeBy to see if one of the inner classes is a handled class and returns as a part of the rest response the right status code