### PR TITLE
#19300 add missing column to hibernate mapping

### DIFF
--- a/dotCMS/src/main/resources/com/dotmarketing/beans/DotCMSId.hbm.xml
+++ b/dotCMS/src/main/resources/com/dotmarketing/beans/DotCMSId.hbm.xml
@@ -561,6 +561,7 @@
 			<key-property name="child" column="child" type="string" length="36" />
 			<key-property name="parent1" column="parent1" type="string" length="36" />
 			<key-property name="parent2" column="parent2" type="string" length="36" />
+			<key-property name="personalization" column="personalization" length="255" type="string" />
 		</composite-id>
 		<property name="relationType" type="string">
 			<column name="relation_type" length="64" index="idx_multitree_1" />

--- a/dotCMS/src/main/resources/com/dotmarketing/beans/DotCMSSeq.hbm.xml
+++ b/dotCMS/src/main/resources/com/dotmarketing/beans/DotCMSSeq.hbm.xml
@@ -562,6 +562,7 @@
 			<key-property name="child" column="child" type="string" length="36" />
 			<key-property name="parent1" column="parent1" type="string" length="36" />
 			<key-property name="parent2" column="parent2" type="string" length="36" />
+			<key-property name="personalization" column="personalization" length="255" type="string" />
 		</composite-id>
 		<property name="relationType" type="string">
 			<column name="relation_type" length="64" index="idx_multitree_1" />


### PR DESCRIPTION
The column was missing from hibernate mapping files, so when doing an export it uses the default value `dot:default`