### PR TITLE
core#19335 fix issue-19335-After-upload-image-list-not-refreshed

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/FileBrowserDialog.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/FileBrowserDialog.js
@@ -522,9 +522,7 @@ dojo.declare("dotcms.dijit.FileBrowserDialog", [dijit._Widget, dijit._Templated]
 		this.addAFileIFrame.src = addFilePorletURL;
 		this.addFileDialog.show();
 		dojo.global.closeAddFileDialog = dojo.hitch(this, this._closeAddFileDialog);
-		/* hack for IE only - iframe onload doesn't work */
-		if(dojo.isIE)
-			dojo.global.fileSubmitted = dojo.hitch(this, this._fileSubmitted);
+    	dojo.global.fileSubmitted = dojo.hitch(this, this._fileSubmitted);
 	},
 
 	_getRequestParameter: function (name, url)


### PR DESCRIPTION
Bug: After you upload a new image we are not auto refreshing the modal, then we are unable to see the uploaded image, we need to manually refresh the folder in order to select the uploaded image