### PR TITLE
#19075 show filter title instead of filter key

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_audit_detail.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_audit_detail.jsp
@@ -129,7 +129,7 @@
     </tr>
     <tr>
         <th><b><%= LanguageUtil.get(pageContext, "contenttypes.content.push_publish.filters") %>: </b></th>
-        <td style="background: white"><%if ( UtilMethods.isSet(bundle) && UtilMethods.isSet(bundle.getFilterKey()) ) {%><%=bundle.getFilterKey() %><%}%></td>
+        <td style="background: white"><%if ( UtilMethods.isSet(bundle) && UtilMethods.isSet(bundle.getFilterKey()) ) {%><%=APILocator.getPublisherAPI().getFilterDescriptorByKey(bundle.getFilterKey()).getTitle() %><%}%></td>
 
     </tr>
     <tr>


### PR DESCRIPTION
Show filter title instead of filter key for consistency, because in the filter selector we show the title.