### PR TITLE
#18236 apps import must not run when no default password is set. We d…

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task201008LoadAppsSecretsTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task201008LoadAppsSecretsTest.java
@@ -200,6 +200,10 @@ public class Task201008LoadAppsSecretsTest {
         Assert.assertFalse(fileToImport.exists());
     }
 
+    /**
+     * Given scenario: We remove the default password property
+     * Expected Results: The Task must not run.
+     */
     @Test
     public void Test_UpgradeTask_Should_Not_Run_When_No_DefaultPassword_isSet(){
         final String stringProperty = Config.getStringProperty(APPS_IMPORT_EXPORT_DEFAULT_PASSWORD);

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task201008LoadAppsSecretsTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task201008LoadAppsSecretsTest.java
@@ -1,5 +1,8 @@
 package com.dotmarketing.startup.runonce;
 
+import static com.dotcms.security.apps.AppsUtil.APPS_IMPORT_EXPORT_DEFAULT_PASSWORD;
+import static com.liferay.util.StringPool.BLANK;
+
 import com.dotcms.datagen.AppDescriptorDataGen;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.datagen.TestUserUtils;
@@ -18,6 +21,7 @@ import com.dotmarketing.exception.AlreadyExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
+import com.dotmarketing.util.Config;
 import com.google.common.collect.ImmutableSet;
 import com.liferay.portal.model.User;
 import java.io.File;
@@ -68,7 +72,8 @@ public class Task201008LoadAppsSecretsTest {
         return api.createAppDescriptor(file, admin);
     }
 
-    private Path createSecretsAndExportThem(final AppDescriptor descriptor, final Key key, final Set<Host> sites)
+    private Path createSecretsAndExportThem(final AppDescriptor descriptor, final Key key,
+            final Set<Host> sites)
             throws IOException, DotDataException, DotSecurityException, AlreadyExistException {
 
         final AppsAPI api = APILocator.getAppsAPI();
@@ -90,6 +95,11 @@ public class Task201008LoadAppsSecretsTest {
 
     }
 
+    /**
+     * Given scenario: Happy path scenario We generate a file then we remove the secret store and we
+     * run the import task Expected Result: No exceptions are expected. We expect the secret store
+     * to have been regenerated then we verify the new secret exist.
+     */
     @Test
     public void Test_UpgradeTask()
             throws DotDataException, DotSecurityException, AlreadyExistException, IOException {
@@ -97,26 +107,32 @@ public class Task201008LoadAppsSecretsTest {
         final AppDescriptor descriptor = genAppDescriptor();
         destroySecretsStore();
         final Key key = AppsUtil.generateKey(AppsUtil.loadPass(null));
-        final File exportFile = createSecretsAndExportThem(descriptor, key, ImmutableSet.of(site)).toFile();
+        final File exportFile = createSecretsAndExportThem(descriptor, key, ImmutableSet.of(site))
+                .toFile();
 
         final Path serverDir = AppDescriptorHelper.getServerDirectory();
 
         final File fileToImport = new File(serverDir.toString(), "dotSecrets-import.xxx");
         //Task will match any file matching this name followed by any extension
-            exportFile.renameTo(fileToImport);
-            destroySecretsStore();
+        exportFile.renameTo(fileToImport);
+        destroySecretsStore();
 
-            final Task201008LoadAppsSecrets task = new Task201008LoadAppsSecrets();
-            Assert.assertTrue(task.forceRun());
-            task.executeUpgrade();
-            Assert.assertEquals(1, task.getImportCount());
-            final AppsAPI api = APILocator.getAppsAPI();
-            final Optional<AppSecrets> secrets = api.getSecrets(descriptor.getKey(), site, admin);
-            Assert.assertTrue(secrets.isPresent());
-            //finally test file got removed.
-            Assert.assertFalse(fileToImport.exists());
+        final Task201008LoadAppsSecrets task = new Task201008LoadAppsSecrets();
+        Assert.assertTrue(task.forceRun());
+        task.executeUpgrade();
+        Assert.assertEquals(1, task.getImportCount());
+        final AppsAPI api = APILocator.getAppsAPI();
+        final Optional<AppSecrets> secrets = api.getSecrets(descriptor.getKey(), site, admin);
+        Assert.assertTrue(secrets.isPresent());
+        //finally test file got removed.
+        Assert.assertFalse(fileToImport.exists());
     }
 
+    /**
+     * Given scenario: We generate an export file that has a secret associated to a site. Then Site
+     * gets removed to simulate a scenario on which we import a secret for a non-exiting site on a
+     * receiver node Expected Result: The import operation must fail.
+     */
     @Test(expected = DotDataException.class)
     public void Test_UpgradeTask_Expect_Failure_Due_To_Invalid_Site()
             throws DotDataException, DotSecurityException, AlreadyExistException, IOException {
@@ -124,7 +140,8 @@ public class Task201008LoadAppsSecretsTest {
         final AppDescriptor descriptor = genAppDescriptor();
         destroySecretsStore();
         final Key key = AppsUtil.generateKey(AppsUtil.loadPass(null));
-        final File exportFile = createSecretsAndExportThem(descriptor, key, ImmutableSet.of(site)).toFile();
+        final File exportFile = createSecretsAndExportThem(descriptor, key, ImmutableSet.of(site))
+                .toFile();
 
         final HostAPI hostAPI = APILocator.getHostAPI();
         hostAPI.archive(site, admin, false);
@@ -148,6 +165,11 @@ public class Task201008LoadAppsSecretsTest {
         Assert.assertFalse(fileToImport.exists());
     }
 
+    /**
+     * Given scenario: We generate an export file that has a secret associated to an app-descriptor.
+     * Then we remove the app-descriptor and attempt a reimport Expected Result: The import must
+     * fail due to the no longer existing descriptor.
+     */
     @Test(expected = DotDataException.class)
     public void Test_UpgradeTask_Expect_Failure_Due_To_Invalid_Descriptor()
             throws DotDataException, DotSecurityException, AlreadyExistException, IOException {
@@ -155,9 +177,10 @@ public class Task201008LoadAppsSecretsTest {
         final AppDescriptor descriptor = genAppDescriptor();
         destroySecretsStore();
         final Key key = AppsUtil.generateKey(AppsUtil.loadPass(null));
-        final File exportFile = createSecretsAndExportThem(descriptor, key, ImmutableSet.of(site)).toFile();
+        final File exportFile = createSecretsAndExportThem(descriptor, key, ImmutableSet.of(site))
+                .toFile();
 
-        api.removeApp(descriptor.getKey(), admin,true);
+        api.removeApp(descriptor.getKey(), admin, true);
 
         final Path serverDir = AppDescriptorHelper.getServerDirectory();
 
@@ -175,6 +198,18 @@ public class Task201008LoadAppsSecretsTest {
         Assert.assertTrue(secrets.isPresent());
         //finally test file got removed.
         Assert.assertFalse(fileToImport.exists());
+    }
+
+    @Test
+    public void Test_UpgradeTask_Should_Not_Run_When_No_DefaultPassword_isSet(){
+        final String stringProperty = Config.getStringProperty(APPS_IMPORT_EXPORT_DEFAULT_PASSWORD);
+       try{
+           Config.setProperty(APPS_IMPORT_EXPORT_DEFAULT_PASSWORD, BLANK);
+           final Task201008LoadAppsSecrets task = new Task201008LoadAppsSecrets();
+           Assert.assertFalse(task.forceRun());
+       }finally {
+           Config.setProperty(APPS_IMPORT_EXPORT_DEFAULT_PASSWORD, stringProperty);
+       }
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsUtil.java
@@ -47,8 +47,8 @@ import org.apache.commons.lang3.ArrayUtils;
 
 public class AppsUtil {
 
+    public static final String APPS_IMPORT_EXPORT_DEFAULT_PASSWORD = "APPS_IMPORT_EXPORT_DEFAULT_PASSWORD";
     private static final ObjectMapper mapper = DotObjectMapperProvider.getInstance().getDefaultObjectMapper();
-    private static final String APPS_IMPORT_EXPORT_DEFAULT_PASSWORD = "APPS_IMPORT_EXPORT_DEFAULT_PASSWORD";
 
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task201008LoadAppsSecrets.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task201008LoadAppsSecrets.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import static com.dotcms.security.apps.AppsUtil.APPS_IMPORT_EXPORT_DEFAULT_PASSWORD;
 import static com.dotcms.security.apps.AppsUtil.generateKey;
 import static com.dotcms.security.apps.AppsUtil.importSecrets;
 import static com.dotcms.security.apps.AppsUtil.internalKey;
@@ -7,6 +8,8 @@ import static com.dotcms.security.apps.AppsUtil.loadPass;
 import static com.dotcms.security.apps.AppsUtil.mapForValidation;
 import static com.dotcms.security.apps.AppsUtil.toJsonAsChars;
 import static com.dotcms.security.apps.AppsUtil.validateForSave;
+import static com.dotmarketing.util.UtilMethods.isSet;
+import static com.liferay.util.StringPool.*;
 
 import com.dotcms.security.apps.AppDescriptor;
 import com.dotcms.security.apps.AppDescriptorHelper;
@@ -19,7 +22,9 @@ import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.startup.StartupTask;
+import com.dotmarketing.util.Config;
 import com.google.common.annotations.VisibleForTesting;
+import com.liferay.util.StringPool;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -75,7 +80,7 @@ public class Task201008LoadAppsSecrets implements StartupTask {
 
     @Override
     public boolean forceRun() {
-        return keyStoreHelper.size() == 0;
+        return keyStoreHelper.size() == 0 && isSet(Config.getStringProperty(APPS_IMPORT_EXPORT_DEFAULT_PASSWORD, BLANK)) ;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task201008LoadAppsSecrets.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task201008LoadAppsSecrets.java
@@ -9,7 +9,7 @@ import static com.dotcms.security.apps.AppsUtil.mapForValidation;
 import static com.dotcms.security.apps.AppsUtil.toJsonAsChars;
 import static com.dotcms.security.apps.AppsUtil.validateForSave;
 import static com.dotmarketing.util.UtilMethods.isSet;
-import static com.liferay.util.StringPool.*;
+import static com.liferay.util.StringPool.BLANK;
 
 import com.dotcms.security.apps.AppDescriptor;
 import com.dotcms.security.apps.AppDescriptorHelper;
@@ -24,7 +24,6 @@ import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.startup.StartupTask;
 import com.dotmarketing.util.Config;
 import com.google.common.annotations.VisibleForTesting;
-import com.liferay.util.StringPool;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;

--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -901,5 +901,3 @@ api.cors.default.Access-Control-Expose-Headers=*
 # then all uris that begin with the value, e.g.
 
 # IGNORE_REFERER_FOR_PATHS=/html/common/css.jsp,/html/my-plugin/*
-
-APPS_IMPORT_EXPORT_DEFAULT_PASSWORD=WJM9wwu5YjBLAgjUmXgfxhLLCMSJpLyM


### PR DESCRIPTION
Removing the default secrets password from the dotmarketing-config (it's ok to leave it in the it-dotmarketing-config). 
If there is no default password set, then the import task should not run.