### PR TITLE
#18236 import/export bugs fixed

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -58,7 +58,7 @@ import com.dotmarketing.startup.runonce.Task05370AddAppsPortletToLayoutTest;
 import com.dotmarketing.startup.runonce.Task05380ChangeContainerPathToAbsoluteTest;
 import com.dotmarketing.startup.runonce.Task05390MakeRoomForLongerJobDetailTest;
 import com.dotmarketing.startup.runonce.Task05395RemoveEndpointIdForeignKeyInIntegrityResolverTablesIntegrationTest;
-import com.dotmarketing.startup.runonce.Task201008LoadAppsSecretsTest;
+import com.dotmarketing.startup.runalways.Task00050LoadAppsSecretsTest;
 import com.dotmarketing.startup.runonce.Task201013AddNewColumnsToIdentifierTableTest;
 import com.dotmarketing.startup.runonce.Task201014UpdateColumnsValuesInIdentifierTableTest;
 import com.dotmarketing.util.ConfigTest;
@@ -343,7 +343,7 @@ import org.junit.runners.Suite.SuiteClasses;
         Task05390MakeRoomForLongerJobDetailTest.class,
         IntegrityDataGenerationJobTest.class,
         Task05395RemoveEndpointIdForeignKeyInIntegrityResolverTablesIntegrationTest.class,
-        Task201008LoadAppsSecretsTest.class,
+        Task00050LoadAppsSecretsTest.class,
         StoragePersistenceAPITest.class,
         FileMetadataAPITest.class,
         StartupTasksExecutorTest.class,

--- a/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/security/apps/AppsAPIImplTest.java
@@ -17,6 +17,7 @@ import com.dotcms.datagen.RoleDataGen;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.datagen.TestUserUtils;
 import com.dotcms.datagen.UserDataGen;
+import com.dotcms.rest.api.v1.apps.ExportSecretForm;
 import com.dotcms.system.event.local.business.LocalSystemEventsAPI;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.util.LicenseValiditySupplier;
@@ -547,9 +548,13 @@ public class AppsAPIImplTest {
             descriptorDataGen.param(entry.getKey(), entry.getValue());
         }
         final File file = descriptorDataGen.nextPersistedDescriptor();
-        final AppsAPI api = APILocator.getAppsAPI();
-        final User admin = TestUserUtils.getAdminUser();
-        return api.createAppDescriptor(file, admin);
+        try {
+            final AppsAPI api = APILocator.getAppsAPI();
+            final User admin = TestUserUtils.getAdminUser();
+            return api.createAppDescriptor(file, admin);
+        } finally {
+            file.delete();
+        }
 
     }
 
@@ -915,7 +920,7 @@ public class AppsAPIImplTest {
      * @throws URISyntaxException
      */
     @Test(expected = DotSecurityException.class)
-    public void Test_Add_System_File_Retrieve_Descriptors_Verify_()
+    public void Test_Add_System_File_Retrieve_Descriptors_Verify()
             throws DotDataException, DotSecurityException, IOException, URISyntaxException {
             //Generate a yml file
         final AppDescriptorDataGen dataGen = new AppDescriptorDataGen()
@@ -926,29 +931,35 @@ public class AppsAPIImplTest {
                 .withDescription("system-app-demo")
                 .withExtraParameters(false);
         final File file = dataGen.nextPersistedDescriptor();
+        try {
+            //Move the file to the system folder
+            final Path systemAppsDescriptorDirectory = AppDescriptorHelper
+                    .getSystemAppsDescriptorDirectory();
+            final boolean result = file.renameTo(new File(
+                    systemAppsDescriptorDirectory.toString() + File.separator + file.getName()));
+            assertTrue(result);
 
-        //Move the file to the system folder
-        final Path systemAppsDescriptorDirectory = AppDescriptorHelper.getSystemAppsDescriptorDirectory();
-        final boolean result = file.renameTo(new File(systemAppsDescriptorDirectory.toString() + File.separator + file.getName()));
-        assertTrue(result);
+            final User admin = TestUserUtils.getAdminUser();
+            final AppsAPI api = APILocator.getAppsAPI();
+            final AppsCache appsCache = CacheLocator.getAppsCache();
 
-        final User admin = TestUserUtils.getAdminUser();
-        final AppsAPI api = APILocator.getAppsAPI();
-        final AppsCache appsCache = CacheLocator.getAppsCache();
+            //Invalidate cache so the new descriptors get picked
+            appsCache.invalidateDescriptorsCache();
+            final List<AppDescriptor> appDescriptors = api.getAppDescriptors(admin);
 
-        //Invalidate cache so the new descriptors get picked
-        appsCache.invalidateDescriptorsCache();
-        final List<AppDescriptor> appDescriptors = api.getAppDescriptors(admin);
-
-        //Verify the file we just submitted is recognized as a system-app-file
-        final Optional<AppDescriptor> optional = appDescriptors.stream()
-                .filter(appDescriptor -> dataGen.getKey().equals(appDescriptor.getKey())).findFirst();
-        assertTrue(optional.isPresent());
-        final AppDescriptor descriptor = optional.get();
-        final AppDescriptorImpl impl = (AppDescriptorImpl)descriptor;
-        assertTrue(impl.isSystemApp());
-        //Now attempt a delete and instruct the api to remove the system app
-        api.removeApp(descriptor.getKey(), admin, true);
+            //Verify the file we just submitted is recognized as a system-app-file
+            final Optional<AppDescriptor> optional = appDescriptors.stream()
+                    .filter(appDescriptor -> dataGen.getKey().equals(appDescriptor.getKey()))
+                    .findFirst();
+            assertTrue(optional.isPresent());
+            final AppDescriptor descriptor = optional.get();
+            final AppDescriptorImpl impl = (AppDescriptorImpl) descriptor;
+            assertTrue(impl.isSystemApp());
+            //Now attempt a delete and instruct the api to remove the system app
+            api.removeApp(descriptor.getKey(), admin, true);
+        } finally {
+            file.delete();
+        }
     }
 
     /**
@@ -976,32 +987,42 @@ public class AppsAPIImplTest {
                 .withDescription("system-app")
                 .withExtraParameters(false);
         final File file = dataGen.nextPersistedDescriptor();
+        try {
+            //Move the file to the system folder
+            final Path systemAppsDescriptorDirectory = AppDescriptorHelper
+                    .getSystemAppsDescriptorDirectory();
+            final boolean result = file.renameTo(new File(
+                    systemAppsDescriptorDirectory.toString() + File.separator + file.getName()));
+            assertTrue(result);
+            //Even though we just moved the file under apps-system-folder this should recreate the file again.
+            //But before that.. lets make a small change so we can tell the difference between the tow files.
+            dataGen.withDescription("user-app");
+            final File newFile = dataGen.nextPersistedDescriptor();
+            try{
+                api.createAppDescriptor(newFile, admin);
 
-        //Move the file to the system folder
-        final Path systemAppsDescriptorDirectory = AppDescriptorHelper.getSystemAppsDescriptorDirectory();
-        final boolean result = file.renameTo(new File(systemAppsDescriptorDirectory.toString() + File.separator + file.getName()));
-        assertTrue(result);
-        //Even though we just moved the file under apps-system-folder this should recreate the file again.
-        //But before that.. lets make a small change so we can tell the difference between the tow files.
-        dataGen.withDescription("user-app");
-        final File newFile = dataGen.nextPersistedDescriptor();
-         api.createAppDescriptor(newFile, admin);
+                //Invalidate cache so the new descriptors get picked
+                appsCache.invalidateDescriptorsCache();
+                final List<AppDescriptor> appDescriptors = api.getAppDescriptors(admin);
 
-        //Invalidate cache so the new descriptors get picked
-        appsCache.invalidateDescriptorsCache();
-        final List<AppDescriptor> appDescriptors = api.getAppDescriptors(admin);
-
-        //Verify the file we just submitted is recognized as a system-app-file
-        final Optional<AppDescriptor> optional = appDescriptors.stream()
-                .filter(appDescriptor -> dataGen.getKey().equals(appDescriptor.getKey())).findFirst();
-        assertTrue(optional.isPresent());
-        //
-        final AppDescriptor descriptor = optional.get();
-        final AppDescriptorImpl impl = (AppDescriptorImpl)descriptor;
-        assertTrue(impl.isSystemApp());
-        //This proves that even though we had two files named the same. 1 in the user apps folder and another 1 in the system-apps folder.
-        //The one from the system-folder takes precedence.
-        assertEquals("system-app", impl.getDescription());
+                //Verify the file we just submitted is recognized as a system-app-file
+                final Optional<AppDescriptor> optional = appDescriptors.stream()
+                        .filter(appDescriptor -> dataGen.getKey().equals(appDescriptor.getKey()))
+                        .findFirst();
+                assertTrue(optional.isPresent());
+                //
+                final AppDescriptor descriptor = optional.get();
+                final AppDescriptorImpl impl = (AppDescriptorImpl) descriptor;
+                assertTrue(impl.isSystemApp());
+                //This proves that even though we had two files named the same. 1 in the user apps folder and another 1 in the system-apps folder.
+                //The one from the system-folder takes precedence.
+                assertEquals("system-app", impl.getDescription());
+            } finally {
+                newFile.delete();
+            }
+        } finally {
+            file.delete();
+        }
     }
 
     /**
@@ -1030,42 +1051,52 @@ public class AppsAPIImplTest {
                 .withDescription("system-app")
                 .withExtraParameters(false);
         final File file = dataGen.nextPersistedDescriptor();
+        try {
+            //Move the file to the system folder and save it in upper case
+            final Path systemAppsDescriptorDirectory = AppDescriptorHelper
+                    .getSystemAppsDescriptorDirectory();
+            final boolean result = file.renameTo(new File(
+                    systemAppsDescriptorDirectory.toString() + File.separator + file.getName()
+                            .toUpperCase().replace("YML", "yml")));
+            assertTrue(result);
+            //Even though we just moved the file under apps-system-folder this should recreate the file again.
+            //But before that.. lets make a small change so we can tell the difference between the two files.
+            dataGen.withDescription("user-app");
+            final File newFile = dataGen.nextPersistedDescriptor();
+            try{
+                api.createAppDescriptor(newFile, admin);
 
-        //Move the file to the system folder and save it in upper case
-        final Path systemAppsDescriptorDirectory = AppDescriptorHelper.getSystemAppsDescriptorDirectory();
-        final boolean result = file.renameTo(new File(
-                systemAppsDescriptorDirectory.toString() + File.separator + file.getName()
-                        .toUpperCase().replace("YML", "yml")));
-        assertTrue(result);
-        //Even though we just moved the file under apps-system-folder this should recreate the file again.
-        //But before that.. lets make a small change so we can tell the difference between the two files.
-        dataGen.withDescription("user-app");
-        final File newFile = dataGen.nextPersistedDescriptor();
-        api.createAppDescriptor(newFile, admin);
+                //Invalidate cache so the new descriptors get picked
+                appsCache.invalidateDescriptorsCache();
+                final List<AppDescriptor> appDescriptors = api.getAppDescriptors(admin);
 
-        //Invalidate cache so the new descriptors get picked
-        appsCache.invalidateDescriptorsCache();
-        final List<AppDescriptor> appDescriptors = api.getAppDescriptors(admin);
-
-        //Verify the file we just submitted is recognized as a system-app-file
-        assertEquals(1, appDescriptors.stream()
-                .filter(appDescriptor -> dataGen.getKey().equalsIgnoreCase(appDescriptor.getKey())).count());
-        final Optional<AppDescriptor> optional = appDescriptors.stream()
-                .filter(appDescriptor -> dataGen.getKey().equalsIgnoreCase(appDescriptor.getKey())).findFirst();
-        assertTrue(optional.isPresent());
-        //
-        final AppDescriptor descriptor = optional.get();
-        final AppDescriptorImpl impl = (AppDescriptorImpl)descriptor;
-        assertTrue(impl.isSystemApp());
-        //This proves that even though we had two files named the same. 1 in the user apps folder and another 1 in the system-apps folder.
-        //The one from the system-folder takes precedence.
-        assertEquals("system-app", impl.getDescription());
+                //Verify the file we just submitted is recognized as a system-app-file
+                assertEquals(1, appDescriptors.stream()
+                        .filter(appDescriptor -> dataGen.getKey()
+                                .equalsIgnoreCase(appDescriptor.getKey())).count());
+                final Optional<AppDescriptor> optional = appDescriptors.stream()
+                        .filter(appDescriptor -> dataGen.getKey()
+                                .equalsIgnoreCase(appDescriptor.getKey())).findFirst();
+                assertTrue(optional.isPresent());
+                //
+                final AppDescriptor descriptor = optional.get();
+                final AppDescriptorImpl impl = (AppDescriptorImpl) descriptor;
+                assertTrue(impl.isSystemApp());
+                //This proves that even though we had two files named the same. 1 in the user apps folder and another 1 in the system-apps folder.
+                //The one from the system-folder takes precedence.
+                assertEquals("system-app", impl.getDescription());
+            }finally {
+                newFile.delete();
+            }
+        } finally {
+            file.delete();
+        }
     }
 
     /**
      * Method to test {@link AppsAPIImpl#exportSecrets(Key, boolean, Map, User)} and {@link AppsAPIImpl#importSecretsAndSave(Path, Key, User)}
-     * Given Scenario: This test creates secrets then exports them Then re-imports the file with the generated secrets.
-     * Expected Result: The test should be Able to recreate the secrets from the generated file.
+     * Given Scenario: This test creates secrets then exports them Then re-imports the file with the generated secrets for different host.
+     * Expected Result: The test should be Able to recreate the secrets from the generated file regardless of the host.
      * @throws DotDataException
      * @throws DotSecurityException
      * @throws IOException
@@ -1073,61 +1104,76 @@ public class AppsAPIImplTest {
      * @throws ClassNotFoundException
      */
     @Test
-    public void Test_Create_Secrets_Then_Export_Them_Then_Import_Then_Save()
+    @UseDataProvider("getTargetSitesTestCases")
+    public void Test_Create_Secrets_Then_Export_Them_Then_Import_Then_Save(final Host site)
             throws DotDataException, DotSecurityException, IOException, EncryptorException, AlreadyExistException {
         final User admin = TestUserUtils.getAdminUser();
-        final Host site = new SiteDataGen().nextPersisted();
         final AppsAPI api = APILocator.getAppsAPI();
         //generate a descriptor
         final AppSecrets.Builder builder1 = new AppSecrets.Builder();
         final AppDescriptorDataGen dataGen = new AppDescriptorDataGen()
-                .stringParam("p1", false,  true)
-                .stringParam("p2", false,  true)
+                .stringParam("p1", false, true)
+                .stringParam("p2", false, true)
                 .withName("system-app-example")
                 .withDescription("system-app")
                 .withExtraParameters(false);
         final File file = dataGen.nextPersistedDescriptor();
-        api.createAppDescriptor(file, admin);
+        try {
+            api.createAppDescriptor(file, admin);
 
-        final String appKey = dataGen.getKey();
-        //generate secrets
-        AppSecrets secrets = builder1.withKey(appKey)
-                .withHiddenSecret("p1", "secret-1")
-                .withHiddenSecret("p2", "secret-2")
-                .build();
-        //Save it
-        api.saveSecrets(secrets, site, admin);
-        final Optional<AppSecrets> secretsOptional = api.getSecrets(appKey, site, admin);
-        Assert.assertTrue(secretsOptional.isPresent());
-        secrets = secretsOptional.get();
+            final String appKey = dataGen.getKey();
+            //generate secrets
+            AppSecrets secrets = builder1.withKey(appKey)
+                    .withHiddenSecret("p1", "secret-1")
+                    .withHiddenSecret("p2", "secret-2")
+                    .build();
+            //Save it
+            api.saveSecrets(secrets, site, admin);
+            final Optional<AppSecrets> secretsOptional = api.getSecrets(appKey, site, admin);
+            Assert.assertTrue(secretsOptional.isPresent());
+            secrets = secretsOptional.get();
 
-        //AES only supports security Key of sizes of 16, 24 or 32 bytes.
-        final String password = RandomStringUtils.randomAlphanumeric(32);
-        final Key securityKey = AppsUtil.generateKey(password);
+            //AES only supports security Key of sizes of 16, 24 or 32 bytes.
+            final String password = RandomStringUtils.randomAlphanumeric(32);
+            final Key securityKey = AppsUtil.generateKey(password);
 
-        //Now that we have a valid key lets dump our selection of secrets
-        final Map<String,Set<String>> appKeysBySite = ImmutableMap.of(site.getIdentifier(), ImmutableSet.of(appKey));
-        final Path exportSecretsFile = api.exportSecrets(securityKey, false, appKeysBySite, admin);
-        assertTrue(exportSecretsFile.toFile().exists());
+            //Now that we have a valid key lets dump our selection of secrets
+            final Map<String, Set<String>> appKeysBySite = ImmutableMap
+                    .of(site.getIdentifier(), ImmutableSet.of(appKey));
+            final Path exportSecretsFile = api
+                    .exportSecrets(securityKey, false, appKeysBySite, admin);
+            assertTrue(exportSecretsFile.toFile().exists());
 
-        //Remove the secret we dumped we can re import it.
-        api.deleteSecrets(appKey, site, admin);
+            //Remove the secret we dumped we can re import it.
+            api.deleteSecrets(appKey, site, admin);
 
-        //import it
-        api.importSecretsAndSave(exportSecretsFile, securityKey, admin);
+            //import it
+            api.importSecretsAndSave(exportSecretsFile, securityKey, admin);
 
-        //verify
-        final Optional<AppSecrets> secretsOptionalPostImport = api.getSecrets(appKey, site, admin);
-        assertTrue(secretsOptionalPostImport.isPresent());
-        final AppSecrets restoredSecrets = secretsOptionalPostImport.get();
+            //verify
+            final Optional<AppSecrets> secretsOptionalPostImport = api
+                    .getSecrets(appKey, site, admin);
+            assertTrue(secretsOptionalPostImport.isPresent());
+            final AppSecrets restoredSecrets = secretsOptionalPostImport.get();
 
-        assertEquals(restoredSecrets.getKey(),secrets.getKey());
-        assertEquals(restoredSecrets.getSecrets().size(),secrets.getSecrets().size());
-        for (final Entry<String, Secret> entry : secrets.getSecrets().entrySet()) {
-            final Secret originalSecret = entry.getValue();
-            final Secret restoredSecret = restoredSecrets.getSecrets().get(entry.getKey());
-            assertTrue(originalSecret.equals(restoredSecret));
+            assertEquals(restoredSecrets.getKey(), secrets.getKey());
+            assertEquals(restoredSecrets.getSecrets().size(), secrets.getSecrets().size());
+            for (final Entry<String, Secret> entry : secrets.getSecrets().entrySet()) {
+                final Secret originalSecret = entry.getValue();
+                final Secret restoredSecret = restoredSecrets.getSecrets().get(entry.getKey());
+                assertTrue(originalSecret.equals(restoredSecret));
+            }
+        } finally {
+            file.delete();
         }
+    }
+
+    @DataProvider
+    public static Object[] getTargetSitesTestCases() throws Exception {
+        return new Object[]{
+                new SiteDataGen().nextPersisted(),
+                APILocator.getHostAPI().findSystemHost()
+        };
     }
 
     /**
@@ -1156,37 +1202,42 @@ public class AppsAPIImplTest {
                 .withDescription("system-app")
                 .withExtraParameters(false);
         final File file = dataGen.nextPersistedDescriptor();
-        api.createAppDescriptor(file, admin);
+        try {
+            api.createAppDescriptor(file, admin);
 
-        final String appKey = dataGen.getKey();
-        //generate secrets
-        final AppSecrets secrets = builder1.withKey(appKey)
-                .withHiddenSecret("p1", "secret-1")
-                .withHiddenSecret("p2", "secret-2")
-                .build();
-        //Save it
-        api.saveSecrets(secrets, site, admin);
-        final Optional<AppSecrets> secretsOptional = api.getSecrets(appKey, site, admin);
-        Assert.assertTrue(secretsOptional.isPresent());
+            final String appKey = dataGen.getKey();
+            //generate secrets
+            final AppSecrets secrets = builder1.withKey(appKey)
+                    .withHiddenSecret("p1", "secret-1")
+                    .withHiddenSecret("p2", "secret-2")
+                    .build();
+            //Save it
+            api.saveSecrets(secrets, site, admin);
+            final Optional<AppSecrets> secretsOptional = api.getSecrets(appKey, site, admin);
+            Assert.assertTrue(secretsOptional.isPresent());
 
-        //AES only supports security Key of sizes of 16, 24 or 32 bytes.
-        final String password = RandomStringUtils.randomAlphanumeric(32);
-        final Key securityKey = AppsUtil.generateKey(password);
+            //AES only supports security Key of sizes of 16, 24 or 32 bytes.
+            final String password = RandomStringUtils.randomAlphanumeric(32);
+            final Key securityKey = AppsUtil.generateKey(password);
 
-        //Now that we have a valid key lets dump our selection of secrets
-        final Map<String,Set<String>> appKeysBySite = ImmutableMap.of(site.getIdentifier(), ImmutableSet.of(appKey));
-        final Path exportSecretsFile = api.exportSecrets(securityKey, false, appKeysBySite, admin);
-        assertTrue(exportSecretsFile.toFile().exists());
+            //Now that we have a valid key lets dump our selection of secrets
+            final Map<String, Set<String>> appKeysBySite = ImmutableMap
+                    .of(site.getIdentifier(), ImmutableSet.of(appKey));
+            final Path exportSecretsFile = api
+                    .exportSecrets(securityKey, false, appKeysBySite, admin);
+            assertTrue(exportSecretsFile.toFile().exists());
 
-        //Remove the secret we dumped we can re import it.
-        api.deleteSecrets(appKey, site, admin);
+            //Remove the secret we dumped we can re import it.
+            api.deleteSecrets(appKey, site, admin);
 
-        //Now we're gonna create an inconsistency removing the app descriptor and then try to import the secret.
-        api.removeApp(appKey,admin, true);
+            //Now we're gonna create an inconsistency removing the app descriptor and then try to import the secret.
+            api.removeApp(appKey, admin, true);
 
-        //and finally import it
-        api.importSecretsAndSave(exportSecretsFile, securityKey, admin);
-
+            //and finally import it
+            api.importSecretsAndSave(exportSecretsFile, securityKey, admin);
+        }finally {
+            file.delete();
+        }
     }
 
     /**
@@ -1215,39 +1266,143 @@ public class AppsAPIImplTest {
                 .withDescription("system-app")
                 .withExtraParameters(false);
         final File file = dataGen.nextPersistedDescriptor();
-        api.createAppDescriptor(file, admin);
+        try {
+            api.createAppDescriptor(file, admin);
 
-        final String appKey = dataGen.getKey();
-        //generate secrets
-        final AppSecrets secrets = builder1.withKey(appKey)
-                .withHiddenSecret("p1", "secret-1")
-                .withHiddenSecret("p2", "secret-2")
-                .build();
-        //Save it
-        api.saveSecrets(secrets, site, admin);
-        final Optional<AppSecrets> secretsOptional = api.getSecrets(appKey, site, admin);
-        Assert.assertTrue(secretsOptional.isPresent());
+            final String appKey = dataGen.getKey();
+            //generate secrets
+            final AppSecrets secrets = builder1.withKey(appKey)
+                    .withHiddenSecret("p1", "secret-1")
+                    .withHiddenSecret("p2", "secret-2")
+                    .build();
+            //Save it
+            api.saveSecrets(secrets, site, admin);
+            final Optional<AppSecrets> secretsOptional = api.getSecrets(appKey, site, admin);
+            Assert.assertTrue(secretsOptional.isPresent());
 
-        //AES only supports security Key of sizes of 16, 24 or 32 bytes.
-        final String password = RandomStringUtils.randomAlphanumeric(32);
-        final Key securityKey = AppsUtil.generateKey(password);
+            //AES only supports security Key of sizes of 16, 24 or 32 bytes.
+            final String password = RandomStringUtils.randomAlphanumeric(32);
+            final Key securityKey = AppsUtil.generateKey(password);
 
-        //Now that we have a valid key lets dump our selection of secrets
-        final Map<String,Set<String>> appKeysBySite = ImmutableMap.of(site.getIdentifier(), ImmutableSet.of(appKey));
-        final Path exportSecretsFile = api.exportSecrets(securityKey, false, appKeysBySite, admin);
-        assertTrue(exportSecretsFile.toFile().exists());
+            //Now that we have a valid key lets dump our selection of secrets
+            final Map<String, Set<String>> appKeysBySite = ImmutableMap
+                    .of(site.getIdentifier(), ImmutableSet.of(appKey));
+            final Path exportSecretsFile = api
+                    .exportSecrets(securityKey, false, appKeysBySite, admin);
+            assertTrue(exportSecretsFile.toFile().exists());
 
-        //Remove the secret we dumped we can re import it.
-        api.deleteSecrets(appKey, site, admin);
+            //Remove the secret we dumped we can re import it.
+            api.deleteSecrets(appKey, site, admin);
 
-        //Now we're gonna create an inconsistency removing the app descriptor and then try to import the secret.
-        final HostAPI hostAPI = APILocator.getHostAPI();
-        hostAPI.archive(site, admin, false);
-        hostAPI.delete(site, admin, false);
+            //Now we're gonna create an inconsistency removing the app descriptor and then try to import the secret.
+            final HostAPI hostAPI = APILocator.getHostAPI();
+            hostAPI.archive(site, admin, false);
+            hostAPI.delete(site, admin, false);
 
-        //and finally import it
-        api.importSecretsAndSave(exportSecretsFile, securityKey, admin);
+            //and finally import it
+            api.importSecretsAndSave(exportSecretsFile, securityKey, admin);
+        }finally {
+            file.delete();
+        }
+    }
 
+    /**
+     * Method to test {@link AppsAPIImpl#exportSecrets(Key, boolean, Map, User)} and {@link AppsAPIImpl#collectSecretsForExport(Map, User)}
+     * Given scenario: We're testing exporting secrets generated for different sites (one being SYSTEM_HOST)
+     * Expected results:  We should be able to recover everthing that initially got exported using the "exportAll" param regardless of site.
+     * @throws DotDataException
+     * @throws IOException
+     * @throws AlreadyExistException
+     * @throws DotSecurityException
+     * @throws EncryptorException
+     */
+    @Test
+    public void Test_Export_All_Secrets_For_System_Non_System_Sites()
+            throws DotDataException, IOException, AlreadyExistException, DotSecurityException, EncryptorException {
+        final User admin = TestUserUtils.getAdminUser();
+        final AppsAPI api = APILocator.getAppsAPI();
+        api.resetSecrets(admin);
+
+        final Host site = new SiteDataGen().nextPersisted();
+        final Host systemHost = APILocator.getHostAPI().findSystemHost();
+
+        //generate a descriptor
+        final AppSecrets.Builder builder1 = new AppSecrets.Builder();
+        final AppDescriptorDataGen dataGen = new AppDescriptorDataGen()
+                .stringParam("p1", false,  true)
+                .stringParam("p2", false,  true)
+                .withName("app-example")
+                .withDescription("app")
+                .withExtraParameters(false);
+        final File file = dataGen.nextPersistedDescriptor();
+        try {
+            api.createAppDescriptor(file, admin);
+
+            final String appKey = dataGen.getKey();
+            //generate secrets
+            final AppSecrets secrets = builder1.withKey(appKey)
+                    .withHiddenSecret("p1", "secret-1")
+                    .withHiddenSecret("p2", "secret-2")
+                    .build();
+
+            //Save it
+            api.saveSecrets(secrets, site, admin);
+            final Optional<AppSecrets> siteSecretsOptional = api.getSecrets(appKey, site, admin);
+
+            api.saveSecrets(secrets, systemHost, admin);
+            final Optional<AppSecrets> systemHostSecretsOptional = api
+                    .getSecrets(appKey, systemHost, admin);
+
+            //AES only supports security Key of sizes of 16, 24 or 32 bytes.
+            final String password = RandomStringUtils.randomAlphanumeric(32);
+            final Key securityKey = AppsUtil.generateKey(password);
+
+            //Now that we have a valid key lets dump all our secrets.
+            final Path exportSecretsFile = api.exportSecrets(securityKey, true, null, admin);
+            assertTrue(exportSecretsFile.toFile().exists());
+
+            assertTrue(exportSecretsFile.toFile().exists());
+
+            //Remove the secret we dumped we can re import it.
+            api.deleteSecrets(appKey, site, admin);
+            api.deleteSecrets(appKey, systemHost, admin);
+
+            //and finally import it
+            api.importSecretsAndSave(exportSecretsFile, securityKey, admin);
+
+            //verify
+            final Optional<AppSecrets> secretsOptionalPostImport1 = api.getSecrets(appKey, site, admin);
+            assertTrue(secretsOptionalPostImport1.isPresent());
+            final AppSecrets restoredSecrets1 = secretsOptionalPostImport1.get();
+
+            final Optional<AppSecrets> secretsOptionalPostImport2 = api.getSecrets(appKey, systemHost, admin);
+            assertTrue(secretsOptionalPostImport2.isPresent());
+            final AppSecrets restoredSecrets2 = secretsOptionalPostImport2.get();
+
+            assertEquals(restoredSecrets1.getKey(),appKey);
+            assertEquals(restoredSecrets2.getKey(),appKey);
+
+            assertTrue(restoredSecrets1.getSecrets().containsKey("p1"));
+            assertTrue(restoredSecrets2.getSecrets().containsKey("p2"));
+
+        }finally {
+           file.delete();
+        }
+
+    }
+
+    /**
+     * Method to test {@link ExportSecretForm#toString()}
+     * Given scenario: We feed the form with null and non null values
+     * Expected results: We expect the form to behave NPE Free when calling toString
+     */
+    @Test
+    public void Test_NPE_Free_ToString(){
+        final ExportSecretForm formAllNull = new ExportSecretForm(null, false, null);
+        assertNotNull(formAllNull.toString());
+
+        final ExportSecretForm formNotAllNull = new ExportSecretForm(null, false, ImmutableMap.of("1", ImmutableSet.of("1","2")));
+        assertNotNull(formNotAllNull.toString());
     }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecretsTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecretsTest.java
@@ -21,7 +21,6 @@ import com.dotmarketing.exception.AlreadyExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
-import com.dotmarketing.startup.runalways.Task00050LoadAppsSecrets;
 import com.dotmarketing.util.Config;
 import com.google.common.collect.ImmutableSet;
 import com.liferay.portal.model.User;

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecretsTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecretsTest.java
@@ -1,4 +1,4 @@
-package com.dotmarketing.startup.runonce;
+package com.dotmarketing.startup.runalways;
 
 import static com.dotcms.security.apps.AppsUtil.APPS_IMPORT_EXPORT_DEFAULT_PASSWORD;
 import static com.liferay.util.StringPool.BLANK;
@@ -21,6 +21,7 @@ import com.dotmarketing.exception.AlreadyExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
+import com.dotmarketing.startup.runalways.Task00050LoadAppsSecrets;
 import com.dotmarketing.util.Config;
 import com.google.common.collect.ImmutableSet;
 import com.liferay.portal.model.User;
@@ -36,7 +37,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class Task201008LoadAppsSecretsTest {
+public class Task00050LoadAppsSecretsTest {
 
     static AppsAPI api;
     static User admin;
@@ -117,7 +118,7 @@ public class Task201008LoadAppsSecretsTest {
         exportFile.renameTo(fileToImport);
         destroySecretsStore();
 
-        final Task201008LoadAppsSecrets task = new Task201008LoadAppsSecrets();
+        final Task00050LoadAppsSecrets task = new Task00050LoadAppsSecrets();
         Assert.assertTrue(task.forceRun());
         task.executeUpgrade();
         Assert.assertEquals(1, task.getImportCount());
@@ -154,7 +155,7 @@ public class Task201008LoadAppsSecretsTest {
         exportFile.renameTo(fileToImport);
         destroySecretsStore();
 
-        final Task201008LoadAppsSecrets task = new Task201008LoadAppsSecrets();
+        final Task00050LoadAppsSecrets task = new Task00050LoadAppsSecrets();
         Assert.assertTrue(task.forceRun());
         task.executeUpgrade();
         Assert.assertEquals(1, task.getImportCount());
@@ -189,7 +190,7 @@ public class Task201008LoadAppsSecretsTest {
         exportFile.renameTo(fileToImport);
         destroySecretsStore();
 
-        final Task201008LoadAppsSecrets task = new Task201008LoadAppsSecrets();
+        final Task00050LoadAppsSecrets task = new Task00050LoadAppsSecrets();
         Assert.assertTrue(task.forceRun());
         task.executeUpgrade();
         Assert.assertEquals(1, task.getImportCount());
@@ -209,7 +210,7 @@ public class Task201008LoadAppsSecretsTest {
         final String stringProperty = Config.getStringProperty(APPS_IMPORT_EXPORT_DEFAULT_PASSWORD);
        try{
            Config.setProperty(APPS_IMPORT_EXPORT_DEFAULT_PASSWORD, BLANK);
-           final Task201008LoadAppsSecrets task = new Task201008LoadAppsSecrets();
+           final Task00050LoadAppsSecrets task = new Task00050LoadAppsSecrets();
            Assert.assertFalse(task.forceRun());
        }finally {
            Config.setProperty(APPS_IMPORT_EXPORT_DEFAULT_PASSWORD, stringProperty);

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/ExportSecretForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/ExportSecretForm.java
@@ -3,6 +3,7 @@ package com.dotcms.rest.api.v1.apps;
 import com.dotcms.rest.api.Validated;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,10 +47,11 @@ public class ExportSecretForm extends Validated {
 
     @Override
     public String toString() {
-        final List<String> stringsList = appKeysBySite.entrySet().stream()
-                .map(entry -> "Site " + entry.getKey() + " keys: " + String
-                        .join(",", entry.getValue())).collect(
-                        Collectors.toList());
+        final List<String> stringsList =
+                appKeysBySite == null ? ImmutableList.of() : appKeysBySite.entrySet().stream()
+                        .map(entry -> "Site " + entry.getKey() + " keys: " + String
+                                .join(",", entry.getValue())).collect(
+                                Collectors.toList());
 
         return String.format("ExportSecretForm{ all={%s} {%s}}", exportAll,
                 String.join("\n", stringsList));

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -702,7 +702,7 @@ public class AppsAPIImpl implements AppsAPI {
             exportedSecrets = collectSecretsForExport(appKeysByHost(), user);
         } else {
            if(null == paramAppKeysBySite || paramAppKeysBySite.isEmpty()){
-              throw new IllegalArgumentException("No `AppKeysBySite` param wasn't specified.");
+              throw new IllegalArgumentException("No `AppKeysBySite` param was specified.");
            }
            exportedSecrets = collectSecretsForExport(paramAppKeysBySite, user);
         }
@@ -731,10 +731,10 @@ public class AppsAPIImpl implements AppsAPI {
         }
 
         for (final Entry<String, Set<String>> entry : paramAppKeysBySite.entrySet()) {
-            final String siteId = Host.SYSTEM_HOST.equalsIgnoreCase(entry.getKey()) ? Host.SYSTEM_HOST : entry.getKey();
-            final Host site = hostAPI.find(siteId, user, false);
+            final String siteId = entry.getKey();
+            final Host site = Host.SYSTEM_HOST.equalsIgnoreCase(siteId) ? hostAPI.findSystemHost() : hostAPI.find(siteId, user, false);
             if (null != site ) {
-                final Set<String> appKeysBySiteId = paramAppKeysBySite.get(siteId.toLowerCase());
+                final Set<String> appKeysBySiteId = paramAppKeysBySite.get(siteId);
                 if (isSet(appKeysBySiteId)) {
                     for (final String appKey : appKeysBySiteId) {
                         final Optional<AppSecrets> optional = getSecrets(appKey, site, user);

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -704,11 +704,7 @@ public class AppsAPIImpl implements AppsAPI {
            if(null == paramAppKeysBySite || paramAppKeysBySite.isEmpty()){
               throw new IllegalArgumentException("No `AppKeysBySite` param wasn't specified.");
            }
-            //This does transform all keys into their lowe case version
-            Map<String, Set<String>> paramAppKeysBySiteLC = paramAppKeysBySite.entrySet().stream()
-                    .collect(Collectors.toMap(entry -> entry.getKey().toLowerCase(),
-                            Entry::getValue));
-           exportedSecrets = collectSecretsForExport(paramAppKeysBySiteLC, user);
+           exportedSecrets = collectSecretsForExport(paramAppKeysBySite, user);
         }
 
         Logger.info(AppsAPIImpl.class," exporting : "+exportedSecrets);
@@ -735,9 +731,9 @@ public class AppsAPIImpl implements AppsAPI {
         }
 
         for (final Entry<String, Set<String>> entry : paramAppKeysBySite.entrySet()) {
-            final String siteId = entry.getKey();
+            final String siteId =  Host.SYSTEM_HOST.equalsIgnoreCase(entry.getKey()) ? Host.SYSTEM_HOST : entry.getKey();
             final Host site = hostAPI.find(siteId, user, false);
-            if (null != site) {
+            if (null != site ) {
                 final Set<String> appKeysBySiteId = paramAppKeysBySite.get(siteId);
                 if (isSet(appKeysBySiteId)) {
                     for (final String appKey : appKeysBySiteId) {

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -731,10 +731,10 @@ public class AppsAPIImpl implements AppsAPI {
         }
 
         for (final Entry<String, Set<String>> entry : paramAppKeysBySite.entrySet()) {
-            final String siteId =  Host.SYSTEM_HOST.equalsIgnoreCase(entry.getKey()) ? Host.SYSTEM_HOST : entry.getKey();
+            final String siteId = Host.SYSTEM_HOST.equalsIgnoreCase(entry.getKey()) ? Host.SYSTEM_HOST : entry.getKey();
             final Host site = hostAPI.find(siteId, user, false);
             if (null != site ) {
-                final Set<String> appKeysBySiteId = paramAppKeysBySite.get(siteId);
+                final Set<String> appKeysBySiteId = paramAppKeysBySite.get(siteId.toLowerCase());
                 if (isSet(appKeysBySiteId)) {
                     for (final String appKey : appKeysBySiteId) {
                         final Optional<AppSecrets> optional = getSecrets(appKey, site, user);
@@ -753,7 +753,7 @@ public class AppsAPIImpl implements AppsAPI {
             }
         }
         if(exportedSecrets.isEmpty()){
-            throw new IllegalArgumentException(String.format("Unable to collect any secrets for export with the given params `%s` ", paramAppKeysBySite));
+            throw new IllegalArgumentException("Unable to collect any secrets for the given params. The result would be an empty file.");
         }
         return new AppsSecretsImportExport(exportedSecrets);
     }

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecrets.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecrets.java
@@ -1,4 +1,4 @@
-package com.dotmarketing.startup.runonce;
+package com.dotmarketing.startup.runalways;
 
 import static com.dotcms.security.apps.AppsUtil.APPS_IMPORT_EXPORT_DEFAULT_PASSWORD;
 import static com.dotcms.security.apps.AppsUtil.generateKey;
@@ -40,7 +40,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-public class Task201008LoadAppsSecrets implements StartupTask {
+public class Task00050LoadAppsSecrets implements StartupTask {
 
     private static final Pattern importFilePattern = Pattern
             .compile("^dotSecrets-import\\.([a-zA-Z0-9-_]+)", Pattern.CASE_INSENSITIVE);

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.util;
 
+import com.dotmarketing.startup.runalways.Task00050LoadAppsSecrets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -288,7 +289,6 @@ public class TaskLocatorUtil {
     	.add(Task05390MakeRoomForLongerJobDetail.class)
 		.add(Task05395RemoveEndpointIdForeignKeyInIntegrityResolverTables.class)
 		//New task date-based naming convention starts here
-		.add(Task201008LoadAppsSecrets.class)
         .add(Task201013AddNewColumnsToIdentifierTable.class)
         .add(Task201014UpdateColumnsValuesInIdentifierTable.class)
         .build();
@@ -325,6 +325,7 @@ public class TaskLocatorUtil {
 		ret.add(Task00002LoadClusterLicenses.class);
 		//ret.add(Task00030ClusterInitialize.class);
 		ret.add(Task00040CheckAnonymousUser.class);
+		ret.add(Task00050LoadAppsSecrets.class);
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
This fixes: 
A bug loading appSecrets when staring dotcMS. The Task should be an always-run type of task.
A Null pointer exception when not sending a non-required param on the export request.
A Case sensitive problem when sending SYSTEM_HOST. It was initially working but after clearing the cache. No longer works.