### PR TITLE
#19471 Use proper value when discarding conflicts

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/IntegrityResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/IntegrityResource.java
@@ -811,9 +811,10 @@ public class IntegrityResource {
 
         JSONObject jsonResponse = new JSONObject();
         IntegrityUtil integrityUtil = new IntegrityUtil();
+        String key = null;
 
         try {
-            final String key = pushPublishAuthenticationToken.isJWTTokenWay() ?
+             key = pushPublishAuthenticationToken.isJWTTokenWay() ?
                     pushPublishAuthenticationToken.getToken().getId() :
                     pushPublishAuthenticationToken.getPublishingEndPoint().getId();
             integrityUtil.fixConflicts(dataToFix, key,
@@ -824,18 +825,15 @@ public class IntegrityResource {
             Logger.error( this.getClass(), "Error fixing "+type+" conflicts from remote", e );
             return response( "Error fixing "+type+" conflicts from remote" , true );
         } finally {
-            final String remoteIp = RestEndPointIPUtil.resolveRemoteIp(request);
-
             try {
-                if (remoteIp != null) {
+                if (key != null) {
                     // Discard conflicts if successful or failed
-                    integrityUtil.discardConflicts(remoteIp,
-                            IntegrityType.valueOf(type.toUpperCase()));
+                    integrityUtil.discardConflicts(key, IntegrityType.valueOf(type.toUpperCase()));
                 }
             } catch (DotDataException e) {
                 Logger.error(this.getClass(), "ERROR: Table "
                         + IntegrityType.valueOf(type.toUpperCase()).getResultsTableName()
-                        + " could not be cleared on request id [" + remoteIp
+                        + " could not be cleared on request id [" + key
                         + "]. Please truncate the table data manually.", e);
             }
         }


### PR DESCRIPTION
The integrity checker tables were tried be cleaned up using always the `endpoint_id` which only works when using the secret, but doesn't work when using a JWT. Now the proper value is used to clean the Integrity db tables. 