### PR TITLE
#19555 updateUserReferences on Identifier Table

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/IdentifierAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/IdentifierAPI.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.business;
 
+import com.dotmarketing.exception.DotSecurityException;
 import java.util.List;
 
 import com.dotmarketing.beans.Host;
@@ -163,5 +164,16 @@ public interface IdentifierAPI {
 	 * @throws DotDataException
 	 */
 	public String getAssetTypeFromDB(String identifier) throws DotDataException;
+
+	/**
+	 * Method will change user references of the given userId in Identifier
+	 * with the replacement user Id
+	 * @param userId User Identifier
+	 * @param replacementUserId The user id of the replacement user
+	 * @throws DotDataException There is a data inconsistency
+	 * @throws DotStateException There is a data inconsistency
+	 * @throws DotSecurityException
+	 */
+	public void updateUserReferences(final String userId, final String replacementUserId)throws DotDataException, DotSecurityException;
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/IdentifierAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/IdentifierAPIImpl.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.business;
 
+import com.dotmarketing.exception.DotSecurityException;
 import java.util.List;
 
 import com.dotcms.business.CloseDBIfOpened;
@@ -176,6 +177,13 @@ public class IdentifierAPIImpl implements IdentifierAPI {
 	public String getAssetTypeFromDB(final String identifier) throws DotDataException {
 
 		return identifierFactory.getAssetTypeFromDB(identifier);
+	}
+
+	@Override
+	@WrapInTransaction
+	public void updateUserReferences(final String userId, final String replacementUserId)
+			throws DotDataException, DotSecurityException {
+		identifierFactory.updateUserReferences(userId,replacementUserId);
 	}
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactory.java
@@ -3,6 +3,7 @@ package com.dotmarketing.business;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.folders.model.Folder;
 import java.util.List;
 
@@ -248,5 +249,16 @@ public abstract class IdentifierFactory {
 	 * @throws DotDataException
 	 */
 	abstract protected String getAssetTypeFromDB(String identifier) throws DotDataException;
+
+	/**
+	 * Method will change user references of the given userId in Identifier
+	 * with the replacement user Id
+	 * @param userId User Identifier
+	 * @param replacementUserId The user id of the replacement user
+	 * @throws DotDataException There is a data inconsistency
+	 * @throws DotStateException There is a data inconsistency
+	 * @throws DotSecurityException
+	 */
+	abstract protected void updateUserReferences(final String userId, final String replacementUserId)throws DotDataException, DotSecurityException;
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactoryImpl.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.business;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.util.transform.TransformerLocator;
 import com.dotmarketing.beans.Host;
@@ -32,6 +33,7 @@ import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -616,4 +618,24 @@ public class IdentifierFactoryImpl extends IdentifierFactory {
 		return assetType;
 	}
 
+	@Override
+	protected void updateUserReferences(final String userId, final String replacementUserId)throws DotDataException, DotSecurityException{
+		DotConnect dc = new DotConnect();
+
+		//Get all ids that will be updated, to remove it from cache
+		dc.setSQL("select id from identifier where owner = ?");
+		dc.addParam(userId);
+		final List<HashMap<String, String>> identifiers = dc.loadResults();
+
+		//Update owner
+		dc.setSQL("update identifier set owner = ? where owner = ?");
+		dc.addParam(replacementUserId);
+		dc.addParam(userId);
+		dc.loadResult();
+
+		//Remove all identifier that were updated from cache
+		for(final HashMap<String,String> id : identifiers){
+			ic.removeFromCacheByIdentifier(id.get("id"));
+		}
+	}
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/UserAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/UserAPIImpl.java
@@ -438,6 +438,13 @@ public class UserAPIImpl implements UserAPI {
 
         logDelete(DeletionStage.END, userToDelete, user, "Inodes");
 
+        //replace the user reference in Identifier
+        logDelete(DeletionStage.BEGINNING, userToDelete, user, "Identifier");
+
+        APILocator.getIdentifierAPI().updateUserReferences(userToDelete.getUserId(), replacementUser.getUserId());
+
+        logDelete(DeletionStage.END, userToDelete, user, "Identifier");
+
         //replace the user references in contentlets
         logDelete(DeletionStage.BEGINNING, userToDelete, user, "Contentlets");
 
@@ -458,9 +465,6 @@ public class UserAPIImpl implements UserAPI {
         logDelete(DeletionStage.BEGINNING, userToDelete, user, "HostVariables");
         APILocator.getHostVariableAPI().updateUserReferences(userToDelete.getUserId(), replacementUser.getUserId());
         logDelete(DeletionStage.END, userToDelete, user, "HostVariables");
-
-
-
 
         //replace user references in containers
         logDelete(DeletionStage.BEGINNING, userToDelete, user, "Containers");


### PR DESCRIPTION
Since we add an `owner` column to the Identifier table, we need to update the user reference it there when deleting a user.

The `UserAPITest.delete` was failing in master because of this.