### PR TITLE
Adding user_preference to the list of tables with identity

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportStarterUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportStarterUtil.java
@@ -122,9 +122,11 @@ public class ImportStarterUtil {
 
         classesWithIdentity.add("Permission");
         classesWithIdentity.add("UsersToDelete");
+        classesWithIdentity.add("UserPreference");
         tableNames = new HashMap<String, String>();
         tableNames.put("Permission", "permission");
         tableNames.put("UsersToDelete", "users_to_delete");
+        tableNames.put("UserPreference", "user_preferences");
 
         if (DbConnectionFactory.isPostgres() || DbConnectionFactory.isOracle()) {
             sequences = new HashMap<String, String>();


### PR DESCRIPTION
`user_preferences` was added to the list of tables with identity to avoid exception thrown in MSSQL when the starter is being imported