### PR TITLE
#19489 #19458 Unique fields and tag fields are mapped as keywords

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelperTest.java
@@ -24,6 +24,7 @@ import com.dotcms.contenttype.model.field.ImmutableFieldVariable;
 import com.dotcms.contenttype.model.field.RadioField;
 import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.SelectField;
+import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.datagen.ContentTypeDataGen;
@@ -146,47 +147,52 @@ public class ESMappingUtilHelperTest {
     public static Object[][] dataProviderAddMappingForFields() {
         return new Object[][] {
                 {  "strings_as_dates", DateField.class, DataTypes.DATE,
-                        new String[] {"originalstartdate", "recurrencestart", "recurrenceend"},  "date" },
+                        new String[] {"originalstartdate", "recurrencestart", "recurrenceend"},  "date", false },
 
                 {  "strings_as_date_times", DateTimeField.class, DataTypes.DATE,
-                        new String[] {"originalstartdate", "recurrencestart", "recurrenceend"},  "date" },
+                        new String[] {"originalstartdate", "recurrencestart", "recurrenceend"},  "date", false },
 
                 {  "dates_as_text", TextField.class, DataTypes.TEXT,
-                        new String[] {"originalstartdate", "recurrencestart", "recurrenceend"},  "text" },
+                        new String[] {"originalstartdate", "recurrencestart", "recurrenceend"},  "text", false },
 
                 {  "keywordmapping", TextField.class, DataTypes.TEXT,
                         new String[] {"categories", "tags", "conhost",
                                 "wfstep", "structurename", "contenttype", "parentpath",
-                                "path", "urlmap", "moduser", "owner"},  "text" },
+                                "path", "urlmap", "moduser", "owner"},  "text", false },
 
                 {  "geomapping", TextField.class, DataTypes.TEXT,
-                        new String[] {"mylatlong", "mylatlon"},  null },
+                        new String[] {"mylatlong", "mylatlon"},  null, false },
 
-                {  "permissions", TextField.class, DataTypes.TEXT, new String[] {"permissions"},  "text" },
+                {  "permissions", TextField.class, DataTypes.TEXT, new String[] {"permissions"},  "text", false },
 
                 {  "radio_as_boolean", RadioField.class, DataTypes.BOOL,
-                        new String[] {"MyRadioAsBoolean"},  "boolean" },
+                        new String[] {"MyRadioAsBoolean"},  "boolean", false },
 
                 {  "radio_as_float", RadioField.class, DataTypes.FLOAT,
-                        new String[] {"MyRadioAsFloat"},  "double" },
+                        new String[] {"MyRadioAsFloat"},  "double", false },
 
                 {  "radio_as_integer", RadioField.class, DataTypes.INTEGER,
-                        new String[] {"MyRadioAsInteger"},  "long" },
+                        new String[] {"MyRadioAsInteger"},  "long", false },
 
                 {  "select_as_boolean", SelectField.class, DataTypes.BOOL,
-                        new String[] {"MySelectAsBoolean"},  "boolean" },
+                        new String[] {"MySelectAsBoolean"},  "boolean", false },
 
                 {  "select_as_float", SelectField.class, DataTypes.FLOAT,
-                        new String[] {"MySelectAsFloat"},  "double" },
+                        new String[] {"MySelectAsFloat"},  "double", false },
 
                 {  "select_as_integer", SelectField.class, DataTypes.INTEGER,
-                        new String[] {"MySelectAsInteger"},  "long" },
+                        new String[] {"MySelectAsInteger"},  "long", false  },
 
                 {  "text_as_float", TextField.class, DataTypes.FLOAT,
-                        new String[] {"MyTextAsFloat"},  "double" },
+                        new String[] {"MyTextAsFloat"},  "double", false  },
 
                 {  "text_as_integer", TextField.class, DataTypes.INTEGER,
-                        new String[] {"MyTextAsInteger"},  "long" }
+                        new String[] {"MyTextAsInteger"},  "long", false  },
+
+                {  "tags", TagField.class, DataTypes.TEXT,
+                        new String[] {"MyTagField"},  "keyword", false },
+
+                {  "uniqueField", TextField.class, DataTypes.TEXT, new String[] {"MyUniqueField"},  "keyword", true },
         };
     }
 
@@ -208,7 +214,7 @@ public class ESMappingUtilHelperTest {
     @Test
     public void testAddMappingForFields(final String testCase, final Class fieldType,
             final DataTypes type,
-            final String[] fields, final String expectedResult)
+            final String[] fields, final String expectedResult, final boolean isUnique)
             throws IOException, DotIndexException, DotSecurityException, DotDataException {
 
         Logger.info(ESMappingUtilHelperTest.class,
@@ -224,7 +230,7 @@ public class ESMappingUtilHelperTest {
             for (final String field : fields) {
                 final Field newField = FieldBuilder.builder(fieldType)
                         .name(field).variable(field).dataType(type).contentTypeId(contentType.id())
-                        .indexed(true).build();
+                        .indexed(true).unique(isUnique).build();
                 fieldAPI.save(newField, user);
             }
 

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelperTest.java
@@ -264,6 +264,16 @@ public class ESMappingUtilHelperTest {
                     assertTrue(UtilMethods.isSet(mapping.get("type")));
                     assertEquals("keyword", mapping.get("type"));
 
+                    //validate _sha256 mapping for unique fields
+                    if (isUnique){
+                        mapping = (Map<String, String>) esMappingAPI
+                                .getFieldMappingAsMap(workingIndex,
+                                        (contentType.variable() + StringPool.PERIOD + field)
+                                                .toLowerCase() + ESUtils.SHA_256).get(field.toLowerCase() + ESUtils.SHA_256);
+                        assertTrue(UtilMethods.isSet(mapping.get("type")));
+                        assertEquals("keyword", mapping.get("type"));
+                    }
+
                     //validate _text fields
                     mapping = (Map<String, String>) esMappingAPI
                             .getFieldMappingAsMap(workingIndex,

--- a/dotCMS/src/integration-test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/util/ImportUtilTest.java
@@ -729,7 +729,7 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
             //Creating csv
             reader = createTempFile("languageCode, countryCode, testTitle, testHost" + "\r\n" +
                     "en, US, " + uniqueTitle + " , " + defaultSite.getIdentifier() + "\r\n" +
-                    "en, US," + uniqueTitle + " , " + defaultSite.getIdentifier() + "\r\n");
+                    "en, US, " + uniqueTitle + " , " + defaultSite.getIdentifier() + "\r\n");
             csvreader = new CsvReader(reader);
             csvreader.setSafetySwitch(false);
             csvHeaders = csvreader.getHeaders();

--- a/dotCMS/src/integration-test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/util/ImportUtilTest.java
@@ -5,14 +5,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.dotcms.content.elasticsearch.business.ContentletIndexAPI;
 import com.dotcms.contenttype.business.ContentTypeAPIImpl;
 import com.dotcms.contenttype.business.FieldAPI;
 import com.dotcms.contenttype.model.field.BinaryField;
 import com.dotcms.contenttype.model.field.DataTypes;
 import com.dotcms.contenttype.model.field.FieldBuilder;
 import com.dotcms.contenttype.model.field.HostFolderField;
-import com.dotcms.contenttype.model.field.ImmutableBinaryField;
 import com.dotcms.contenttype.model.field.ImmutableTextAreaField;
 import com.dotcms.contenttype.model.field.ImmutableTextField;
 import com.dotcms.contenttype.model.field.RelationshipField;
@@ -172,6 +170,14 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
                 //Importing relationships 2.0 using identifiers
                 new RelationshipTestCase(false, false)
         };
+    }
+
+    @DataProvider
+    public static String[] testCasesUniqueTextField() {
+        return new String[]{"UniqueTitle","A+ Student",
+                "aaa-bbb-ccc","valid - field","with \" quotes",
+                "with special characters + [ ] { } * ( ) : && ! | ^ ~ ?",
+                "CASEINSENSITIVE","with chinese characters 好 心 面"};
     }
 
     @BeforeClass
@@ -626,8 +632,14 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
         }
     }
 
+    /**
+     * Method to test: {@link ImportUtil#importFile(Long, String, String, String[], boolean, boolean, User, long, String[], CsvReader, int, int, Reader, String, HttpServletRequest)}
+     * Test Case: Lines contain the same unique text key (testTitle) but different language
+     * Expected Results: The import process should success
+     */
+    @UseDataProvider("testCasesUniqueTextField")
     @Test
-    public void importFile_success_when_twoLinesHaveSameUniqueKeysButDifferentLanguage()
+    public void importFile_success_when_twoLinesHaveSameUniqueKeysButDifferentLanguage(final String uniqueTitle)
             throws DotSecurityException, DotDataException, IOException {
 
         CsvReader csvreader;
@@ -656,8 +668,8 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
 
         //Creating csv
         reader = createTempFile("languageCode, countryCode, testTitle, testHost" + "\r\n" +
-                "es, ES, UniqueTitle, " + defaultSite.getIdentifier() + "\r\n" +
-                "en, US, UniqueTitle, " + defaultSite.getIdentifier() + "\r\n");
+                "es, ES, " + uniqueTitle + " , " + defaultSite.getIdentifier() + "\r\n" +
+                "en, US, " + uniqueTitle + " , " + defaultSite.getIdentifier() + "\r\n");
         csvreader = new CsvReader(reader);
         csvreader.setSafetySwitch(false);
         csvHeaders = csvreader.getHeaders();
@@ -684,8 +696,9 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
      * Test Case: Lines contain the same unique text key (testTitle)
      * Expected Results: The import process should fail
      */
+    @UseDataProvider("testCasesUniqueTextField")
     @Test
-    public void importFile_fails_when_twoLinesHaveSameUniqueKeys()
+    public void importFile_fails_when_twoLinesHaveSameUniqueKeys(final String uniqueTitle)
             throws DotSecurityException, DotDataException, IOException {
 
         CsvReader csvreader;
@@ -715,8 +728,8 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
 
             //Creating csv
             reader = createTempFile("languageCode, countryCode, testTitle, testHost" + "\r\n" +
-                    "en, US, UniqueTitle, " + defaultSite.getIdentifier() + "\r\n" +
-                    "en, US, UniqueTitle, " + defaultSite.getIdentifier() + "\r\n");
+                    "en, US, " + uniqueTitle + " , " + defaultSite.getIdentifier() + "\r\n" +
+                    "en, US," + uniqueTitle + " , " + defaultSite.getIdentifier() + "\r\n");
             csvreader = new CsvReader(reader);
             csvreader.setSafetySwitch(false);
             csvHeaders = csvreader.getHeaders();

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -4979,14 +4979,17 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     @DataProvider
-    public static Object[] testCasesUniqueTextField() throws Exception{
+    public static Object[] testCasesUniqueTextField() {
         return new Object[]{
                 new testCaseUniqueTextField("diffLang"),//test for same value diff lang
-                //test for special chars (as unique fields are saved as keywords, quotation marks should not be used to escape special chars)
                 new testCaseUniqueTextField("A+ Student"),
+                new testCaseUniqueTextField("\"A+” student"),
                 new testCaseUniqueTextField("aaa-bbb-ccc"),
                 new testCaseUniqueTextField("valid - field"),
-                new testCaseUniqueTextField("CASEINSENSITIVE")//test for case insensitive
+                new testCaseUniqueTextField("with \" quotes"),
+                new testCaseUniqueTextField("with special characters + [ ] { } * ( ) : && ! | ^ ~ ?"),
+                new testCaseUniqueTextField("CASEINSENSITIVE"),
+                new testCaseUniqueTextField("with chinese characters 好 心 面")
         };
     }
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -4982,7 +4982,10 @@ public class ContentletAPITest extends ContentletBaseTest {
     public static Object[] testCasesUniqueTextField() throws Exception{
         return new Object[]{
                 new testCaseUniqueTextField("diffLang"),//test for same value diff lang
-                new testCaseUniqueTextField("\"A+\" Student"),//test for special chars
+                //test for special chars (as unique fields are saved as keywords, quotation marks should not be used to escape special chars)
+                new testCaseUniqueTextField("A+ Student"),
+                new testCaseUniqueTextField("aaa-bbb-ccc"),
+                new testCaseUniqueTextField("valid - field"),
                 new testCaseUniqueTextField("CASEINSENSITIVE")//test for case insensitive
         };
     }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -6302,6 +6302,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             // validate unique
             if(field.isUnique()){
+                final boolean isDataTypeNumber = field.getDataType().contains(DataTypes.INTEGER.toString())
+                        || field.getDataType().contains(DataTypes.FLOAT.toString());
                 try{
                     StringBuilder buffy = new StringBuilder(UUIDGenerator.generateUuid());
                     buffy.append(" +structureInode:" + contentlet.getStructureInode());
@@ -6312,9 +6314,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     buffy.append(" +languageId:" + contentlet.getLanguageId());
 
                     buffy.append(" +" + contentlet.getContentType().variable()).append(StringPool.PERIOD)
-                            .append(field.getVelocityVarName()).append("_dotraw").append(StringPool.COLON)
-                            .append("\"").append(getFieldValue(contentlet, new LegacyFieldTransformer(field).from()))
-                            .append("\"");
+                            .append(field.getVelocityVarName());
+
+                    if (isDataTypeNumber){
+                        buffy.append(StringPool.COLON).append("\"").append(getFieldValue(contentlet,
+                                new LegacyFieldTransformer(field).from())).append("\"");
+                    }else{
+                        buffy.append("_dotraw").append(StringPool.COLON).append("\"")
+                                .append(getFieldValue(contentlet,
+                                        new LegacyFieldTransformer(field).from()))
+                                .append("\"");
+                    }
 
                     List<ContentletSearch> contentlets = new ArrayList<ContentletSearch>();
                     try {
@@ -6333,9 +6343,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             Contentlet c = contentFactory.find(contentletSearch.getInode());
                             Map<String, Object> cMap = c.getMap();
                             Object obj = cMap.get(field.getVelocityVarName());
-
-                            boolean isDataTypeNumber = field.getDataType().contains(DataTypes.INTEGER.toString())
-                                    || field.getDataType().contains(DataTypes.FLOAT.toString());
 
                             if ( ( isDataTypeNumber && fieldValue.equals(obj) ) ||
                                     ( !isDataTypeNumber && ((String) obj).equalsIgnoreCase(((String) fieldValue)) ) )  {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -6311,9 +6311,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                     buffy.append(" +languageId:" + contentlet.getLanguageId());
 
-                    buffy.append(" +" + contentlet.getContentType().variable() + StringPool.PERIOD + field
-                            .getVelocityVarName() + StringPool.COLON);
-                    buffy.append(getFieldValue(contentlet, new LegacyFieldTransformer(field).from()));
+                    buffy.append(" +" + contentlet.getContentType().variable()).append(StringPool.PERIOD)
+                            .append(field.getVelocityVarName()).append("_dotraw").append(StringPool.COLON)
+                            .append("\"").append(getFieldValue(contentlet, new LegacyFieldTransformer(field).from()))
+                            .append("\"");
 
                     List<ContentletSearch> contentlets = new ArrayList<ContentletSearch>();
                     try {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -13,6 +13,7 @@ import com.dotcms.content.elasticsearch.business.event.ContentletCheckinEvent;
 import com.dotcms.content.elasticsearch.business.event.ContentletDeletedEvent;
 import com.dotcms.content.elasticsearch.business.event.ContentletPublishEvent;
 import com.dotcms.content.elasticsearch.constants.ESMappingConstants;
+import com.dotcms.content.elasticsearch.util.ESUtils;
 import com.dotcms.contenttype.business.BaseTypeToContentTypeStrategy;
 import com.dotcms.contenttype.business.BaseTypeToContentTypeStrategyResolver;
 import com.dotcms.contenttype.business.ContentTypeAPI;
@@ -6040,21 +6041,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
     }
 
-    private static final String[] SPECIAL_CHARS = new String[] { "+", "-", "&&", "||", "!", "(", ")", "{", "}", "[",
-            "]", "^", "\"", "?", ":", "\\" };
-
-    /**
-     *
-     * @param text
-     * @return
-     */
-    private static String escape(String text) {
-        for (int i = SPECIAL_CHARS.length - 1; i >= 0; i--) {
-            text = StringUtils.replace(text, SPECIAL_CHARS[i], "\\" + SPECIAL_CHARS[i]);
-        }
-
-        return text;
-    }
 
     /**
      * This method takes the incoming contentlet and determines if the new fileName we're receiving
@@ -6313,20 +6299,14 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                     buffy.append(" +languageId:" + contentlet.getLanguageId());
 
-                    buffy.append(" +" + contentlet.getContentType().variable()).append(StringPool.PERIOD)
-                            .append(field.getVelocityVarName());
+                    buffy.append(" +").append(contentlet.getContentType().variable()).append(StringPool.PERIOD)
+                            .append(field.getVelocityVarName()).append(ESUtils.SHA_256)
+                            .append(StringPool.COLON)
+                            .append(ESUtils.sha256(contentlet.getContentType().variable()
+                                    + StringPool.PERIOD + field.getVelocityVarName(), fieldValue,
+                            contentlet.getLanguageId()));
 
-                    if (isDataTypeNumber){
-                        buffy.append(StringPool.COLON).append("\"").append(getFieldValue(contentlet,
-                                new LegacyFieldTransformer(field).from())).append("\"");
-                    }else{
-                        buffy.append("_dotraw").append(StringPool.COLON).append("\"")
-                                .append(getFieldValue(contentlet,
-                                        new LegacyFieldTransformer(field).from()))
-                                .append("\"");
-                    }
-
-                    List<ContentletSearch> contentlets = new ArrayList<ContentletSearch>();
+                    List<ContentletSearch> contentlets = new ArrayList<>();
                     try {
                         contentlets.addAll(searchIndex(buffy.toString() + " +working:true", -1, 0, "inode", APILocator.getUserAPI().getSystemUser(), false));
                         contentlets.addAll(searchIndex(buffy.toString() + " +live:true", -1, 0, "inode", APILocator.getUserAPI().getSystemUser(), false));

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelper.java
@@ -13,9 +13,11 @@ import com.dotcms.contenttype.model.field.DateField;
 import com.dotcms.contenttype.model.field.DateTimeField;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.FieldVariable;
+import com.dotcms.contenttype.model.field.MultiSelectField;
 import com.dotcms.contenttype.model.field.RadioField;
 import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.SelectField;
+import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.field.TextAreaField;
 import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.field.TimeField;
@@ -361,20 +363,30 @@ public class ESMappingUtilHelper {
                 .of(DataTypes.BOOL, "boolean", DataTypes.FLOAT, "double", DataTypes.INTEGER,
                         "long");
         String mappingForField = null;
-        if (field instanceof DateField || field instanceof DateTimeField
-                || field instanceof TimeField) {
-            mappingForField = "{\n\"type\":\"date\",\n";
-            mappingForField += "\"format\": \"yyyy-MM-dd't'HH:mm:ss||MMM d, yyyy h:mm:ss a||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis\"\n}";
-        } else if (field instanceof TextField || field instanceof TextAreaField
-                || field instanceof WysiwygField || field instanceof RadioField
-                || field instanceof SelectField) {
-            if (dataTypesMap.containsKey(field.dataType())) {
-                mappingForField = String.format("{\n\"type\":\"%s\"\n}", dataTypesMap.get(field.dataType()));
-            } else if (!matchesExclusions(fieldVariableName)){
-                mappingForField = "{\n"
-                        + "\"type\":\"text\",\n"
-                        + "\"analyzer\":\"my_analyzer\""
-                        + "\n}";
+
+        if (!matchesExclusions(fieldVariableName)) {
+            if (field instanceof DateField || field instanceof DateTimeField
+                    || field instanceof TimeField) {
+                mappingForField = "{\n\"type\":\"date\",\n";
+                mappingForField += "\"format\": \"yyyy-MM-dd't'HH:mm:ss||MMM d, yyyy h:mm:ss a||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis\"\n}";
+            } else if (field instanceof TextField || field instanceof TextAreaField
+                    || field instanceof WysiwygField || field instanceof RadioField
+                    || field instanceof SelectField || field instanceof MultiSelectField
+                    || field instanceof TagField) {
+                if (field.unique() || field instanceof TagField) {
+                    mappingForField = "{\n\"type\":\"keyword\"\n}";
+                } else {
+                    if (dataTypesMap.containsKey(field.dataType())) {
+                        mappingForField = String
+                                .format("{\n\"type\":\"%s\"\n}",
+                                        dataTypesMap.get(field.dataType()));
+                    } else {
+                        mappingForField = "{\n"
+                                + ("\"type\":\"text\",\n")
+                                + "\"analyzer\":\"my_analyzer\""
+                                + "\n}";
+                    }
+                }
             }
         }
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelper.java
@@ -373,13 +373,14 @@ public class ESMappingUtilHelper {
                     || field instanceof WysiwygField || field instanceof RadioField
                     || field instanceof SelectField || field instanceof MultiSelectField
                     || field instanceof TagField) {
-                if (field.unique() || field instanceof TagField) {
-                    mappingForField = "{\n\"type\":\"keyword\"\n}";
+
+                if (dataTypesMap.containsKey(field.dataType())) {
+                    mappingForField = String
+                            .format("{\n\"type\":\"%s\"\n}",
+                                    dataTypesMap.get(field.dataType()));
                 } else {
-                    if (dataTypesMap.containsKey(field.dataType())) {
-                        mappingForField = String
-                                .format("{\n\"type\":\"%s\"\n}",
-                                        dataTypesMap.get(field.dataType()));
+                    if (field.unique() || field instanceof TagField) {
+                        mappingForField = "{\n\"type\":\"keyword\"\n}";
                     } else {
                         mappingForField = "{\n"
                                 + ("\"type\":\"text\",\n")

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESMappingUtilHelper.java
@@ -396,12 +396,19 @@ public class ESMappingUtilHelper {
             mappingList.add(Tuple.of(field.variable().toLowerCase(),
                     new JSONObject(mappingForField)));
 
-            //Put mapping for _dotraw fields and _text if needed
+            //Put mapping for _dotraw, _sha256 and _text fields if needed
             mappingList.add(Tuple.of(field.variable().toLowerCase() + "_dotraw",
                     new JSONObject("{\n"
                             + "\"type\":\"keyword\",\n"
                             + "\"ignore_above\": 8191"
                             + "\n}")));
+
+            mappingList.add(Tuple.of(field.variable().toLowerCase() + ESUtils.SHA_256,
+                    new JSONObject("{\n"
+                            + "\"type\":\"keyword\",\n"
+                            + "\"ignore_above\": 8191"
+                            + "\n}")));
+
             if (Config
                     .getBooleanProperty("CREATE_TEXT_INDEX_FIELD_FOR_NON_TEXT_FIELDS", false)) {
                 mappingList.add(Tuple.of(field.variable().toLowerCase() + ESMappingAPIImpl.TEXT,

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/util/ESUtils.java
@@ -37,7 +37,7 @@ public class ESUtils {
 	public static String sha256(final String fieldName, final Object fieldValue,
 			final long languageId) {
 		return Hashing.sha256().hashString(fieldName + "_"
-				+ (fieldValue == null ? "" : fieldValue.toString()) + "_"
+				+ (fieldValue == null ? "" : fieldValue.toString().toLowerCase()) + "_"
 				+ languageId, Charset.forName("UTF-8")).toString();
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -951,7 +951,7 @@ public class ImportUtil {
                                     .append(text).append(")");
                         } else {
                             buffy.append(" +").append(contentType.getVelocityVarName()).append(".")
-                                    .append(field.getVelocityVarName()).append(":")
+                                    .append(field.getVelocityVarName()).append("_dotraw").append(StringPool.COLON)
                                     .append(escapeLuceneSpecialCharacter(text).contains(" ") ? "\""
                                             + escapeLuceneSpecialCharacter(text) + "\""
                                             : escapeLuceneSpecialCharacter(text));

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.util;
 
 import com.dotcms.contenttype.model.field.BinaryField;
+import com.dotcms.contenttype.model.field.DataTypes;
 import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotcms.contenttype.transform.field.LegacyFieldTransformer;
 import com.dotcms.repackage.com.csvreader.CsvReader;
@@ -950,11 +951,18 @@ public class ImportUtil {
                             buffy.append(" +(conhost:").append(text).append(" conFolder:")
                                     .append(text).append(")");
                         } else {
-                            buffy.append(" +").append(contentType.getVelocityVarName()).append(".")
-                                    .append(field.getVelocityVarName()).append("_dotraw").append(StringPool.COLON)
-                                    .append(escapeLuceneSpecialCharacter(text).contains(" ") ? "\""
-                                            + escapeLuceneSpecialCharacter(text) + "\""
-                                            : escapeLuceneSpecialCharacter(text));
+                            final boolean isDataTypeNumber = field.getDataType().contains(DataTypes.INTEGER.toString())
+                                    || field.getDataType().contains(DataTypes.FLOAT.toString());
+
+                            if (isDataTypeNumber){
+                                buffy.append(" +").append(contentType.getVelocityVarName()).append(".")
+                                        .append(field.getVelocityVarName()).append(StringPool.COLON).append("\"").append(text).append("\"");
+                            } else{
+                                buffy.append(" +").append(contentType.getVelocityVarName()).append(".")
+                                        .append(field.getVelocityVarName()).append("_dotraw").append(StringPool.COLON)
+                                        .append("\"").append(text).append("\"");
+                            }
+
                         }
                         conditionValues += conditionValues + value + "-";
                     }

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.util;
 
+import com.dotcms.content.elasticsearch.util.ESUtils;
 import com.dotcms.contenttype.model.field.BinaryField;
 import com.dotcms.contenttype.model.field.DataTypes;
 import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
@@ -951,17 +952,12 @@ public class ImportUtil {
                             buffy.append(" +(conhost:").append(text).append(" conFolder:")
                                     .append(text).append(")");
                         } else {
-                            final boolean isDataTypeNumber = field.getDataType().contains(DataTypes.INTEGER.toString())
-                                    || field.getDataType().contains(DataTypes.FLOAT.toString());
-
-                            if (isDataTypeNumber){
-                                buffy.append(" +").append(contentType.getVelocityVarName()).append(".")
-                                        .append(field.getVelocityVarName()).append(StringPool.COLON).append("\"").append(text).append("\"");
-                            } else{
-                                buffy.append(" +").append(contentType.getVelocityVarName()).append(".")
-                                        .append(field.getVelocityVarName()).append("_dotraw").append(StringPool.COLON)
-                                        .append("\"").append(text).append("\"");
-                            }
+                            buffy.append(" +").append(contentType.getVelocityVarName()).append(StringPool.PERIOD)
+                                    .append(field.getVelocityVarName()).append(ESUtils.SHA_256)
+                                    .append(StringPool.COLON)
+                                    .append(ESUtils.sha256(contentType.getVelocityVarName()
+                                                    + StringPool.PERIOD + field.getVelocityVarName(), text,
+                                            language));
 
                         }
                         conditionValues += conditionValues + value + "-";
@@ -1753,26 +1749,6 @@ public class ImportUtil {
         }
         ret.append(" ] ");
         return ret.toString();
-    }
-
-	/**
-	 * Escape lucene reserved characters
-	 * 
-	 * @param text
-	 * @return String
-	 */
-    private static String escapeLuceneSpecialCharacter(String text){
-        text = text.replaceAll("\\[","\\\\[").replaceAll("\\]","\\\\]");
-        text = text.replaceAll("\\{","\\\\{").replaceAll("\\}","\\\\}");
-        text = text.replaceAll("\\+","\\\\+").replaceAll(":","\\\\:");
-        text = text.replaceAll("\\*","\\\\*").replaceAll("\\?","\\\\?");
-        text = text.replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)");
-        text = text.replaceAll("&&","\\\\&&").replaceAll("\\|\\|","\\\\||");
-        text = text.replaceAll("!","\\\\!").replaceAll("\\^","\\\\^");
-        text = text.replaceAll("-","\\\\-").replaceAll("~","\\\\~");
-        text = text.replaceAll("\"","\\\"");
-
-        return text;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -953,11 +953,13 @@ public class ImportUtil {
                                     .append(text).append(")");
                         } else {
                             buffy.append(" +").append(contentType.getVelocityVarName()).append(StringPool.PERIOD)
-                                    .append(field.getVelocityVarName()).append(ESUtils.SHA_256)
+                                    .append(field.getVelocityVarName()).append(field.isUnique()? ESUtils.SHA_256: "_dotraw")
                                     .append(StringPool.COLON)
-                                    .append(ESUtils.sha256(contentType.getVelocityVarName()
+                                    .append(field.isUnique()? ESUtils.sha256(contentType.getVelocityVarName()
                                                     + StringPool.PERIOD + field.getVelocityVarName(), text,
-                                            language));
+                                            language): escapeLuceneSpecialCharacter(text).contains(" ") ? "\""
+                                            + escapeLuceneSpecialCharacter(text) + "\""
+                                            : escapeLuceneSpecialCharacter(text));
 
                         }
                         conditionValues += conditionValues + value + "-";
@@ -1750,6 +1752,27 @@ public class ImportUtil {
         ret.append(" ] ");
         return ret.toString();
     }
+
+    /**
+     * Escape lucene reserved characters
+     *
+     * @param text
+     * @return String
+     */
+    private static String escapeLuceneSpecialCharacter(String text){
+        text = text.replaceAll("\\[","\\\\[").replaceAll("\\]","\\\\]");
+        text = text.replaceAll("\\{","\\\\{").replaceAll("\\}","\\\\}");
+        text = text.replaceAll("\\+","\\\\+").replaceAll(":","\\\\:");
+        text = text.replaceAll("\\*","\\\\*").replaceAll("\\?","\\\\?");
+        text = text.replaceAll("\\(","\\\\(").replaceAll("\\)","\\\\)");
+        text = text.replaceAll("&&","\\\\&&").replaceAll("\\|\\|","\\\\||");
+        text = text.replaceAll("!","\\\\!").replaceAll("\\^","\\\\^");
+        text = text.replaceAll("-","\\\\-").replaceAll("~","\\\\~");
+        text = text.replaceAll("\"","\\\"");
+
+        return text;
+    }
+
 
     /**
      * 


### PR DESCRIPTION
With these changes, unique text fields are mapped in ES as keywords. 
On the other hand, lucene queries used to validate fields uniqueness use _dotraw fields except for unique numbers (integer and float fields), as numeric datatypes behave like keywords in searches.