### PR TITLE
#19564 vanity url redirects and forwards must support param merge

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/filters/FiltersTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/filters/FiltersTest.java
@@ -2,10 +2,13 @@ package com.dotmarketing.filters;
 
 import static com.dotcms.datagen.TestDataUtils.getNewsLikeContentType;
 import static com.dotcms.vanityurl.business.VanityUrlAPIImpl.LEGACY_CMS_HOME_PAGE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -14,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.servlet.FilterChain;
 import javax.servlet.RequestDispatcher;
@@ -207,8 +211,8 @@ public class FiltersTest {
         
         HttpServletRequest request = getMockRequest(site.getHostname(), "/" + uniqueUrl + "1");
         filter.doFilter(request, response, chain);
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE,
+        assertEquals(200, response.getStatus());
+        assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE,
                 request.getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
 
         Logger.info(this.getClass(),
@@ -216,8 +220,8 @@ public class FiltersTest {
         request = getMockRequest(site.getHostname(), "/" + uniqueUrl + "2");
         response = new MockResponseWrapper(Mockito.mock(HttpServletResponse.class));
         filter.doFilter(request, response, chain);
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE,
+        assertEquals(200, response.getStatus());
+        assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE,
                 request.getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
 
         Logger.info(this.getClass(),
@@ -226,8 +230,8 @@ public class FiltersTest {
         request = getMockRequest(site.getHostname(), "/" + uniqueUrl + "3");
         response = new MockResponseWrapper(Mockito.mock(HttpServletResponse.class));
         filter.doFilter(request, response, chain);
-        Assert.assertEquals(301, response.getStatus());
-        Assert.assertEquals("http://demo.dotcms.com/about-us/" + CMSFilter.CMS_INDEX_PAGE,
+        assertEquals(301, response.getStatus());
+        assertEquals("http://demo.dotcms.com/about-us/" + CMSFilter.CMS_INDEX_PAGE,
                 response.getRedirectLocation());
 
         Logger.info(this.getClass(),
@@ -236,8 +240,8 @@ public class FiltersTest {
         request = getMockRequest(site.getHostname(), "/" + uniqueUrl + "4");
         response = new MockResponseWrapper(Mockito.mock(HttpServletResponse.class));
         filter.doFilter(request, response, chain);
-        Assert.assertEquals(301, response.getStatus());
-        Assert.assertEquals("http://demo.dotcms.com/about-us/" + CMSFilter.CMS_INDEX_PAGE,
+        assertEquals(301, response.getStatus());
+        assertEquals("http://demo.dotcms.com/about-us/" + CMSFilter.CMS_INDEX_PAGE,
                 response.getRedirectLocation());
 
         Logger.info(this.getClass(),
@@ -245,7 +249,7 @@ public class FiltersTest {
         request = getMockRequest(site.getHostname(), "/forbidden");
         response = new MockResponseWrapper(Mockito.mock(HttpServletResponse.class));
         filter.doFilter(request, response, chain);
-        Assert.assertEquals(302, response.getStatus());
+        assertEquals(302, response.getStatus());
 
 
     }
@@ -300,8 +304,8 @@ public class FiltersTest {
         //assert that we have a new request wrapper
         assertTrue(request instanceof VanityUrlRequestWrapper);
         
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE, request.getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
+        assertEquals(200, response.getStatus());
+        assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE, request.getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
         
         
         assertTrue(VANITY.equals(request.getParameter("param1")));
@@ -319,8 +323,8 @@ public class FiltersTest {
         request =(HttpServletRequest) chain.request;
         
         
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE,
+        assertEquals(200, response.getStatus());
+        assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE,
                 request.getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
 
         // VANITY - from the VANITY takes priority
@@ -334,11 +338,41 @@ public class FiltersTest {
 
 
     }
-    
-    
-    
-    
-    
+
+    @Test
+    public void Test_VanityURL_Forward_Redirect_Params() throws Exception {
+
+        final List<Integer> actions = ImmutableList.of(200, 301, 302);
+        final VanityURLFilter filter = new VanityURLFilter();
+        final MockFilterChain chain = new MockFilterChain();
+        for (final Integer action : actions) {
+
+            final String uniqueUrl = UUIDGenerator.shorty();
+            final Contentlet vanityUrl1 = filtersUtil
+                    .createVanityUrl("Fwd", site.getIdentifier(), "/" + uniqueUrl + "fwd",
+                            "/about-us/" + CMSFilter.CMS_INDEX_PAGE + "?param1=" + VANITY + "&param2="+VANITY , action,
+                            1, defaultLanguageId);
+            filtersUtil.publishVanityUrl(vanityUrl1);
+
+            final HttpServletResponse response = new MockHttpStatusResponse(
+                    new MockHttpResponse().response()).response();
+            final HttpServletRequest request = new MockHttpRequest(site.getHostname(),
+                    "/" + uniqueUrl + "fwd?param1=" + URL).request();
+
+            final ServletOutputStream servletOutputStream = mock(ServletOutputStream.class);
+            final HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
+            when(res.getOutputStream()).thenReturn(servletOutputStream);
+
+            Logger.info(this.getClass(),
+                    "/" + uniqueUrl + "1 should forward to /about-us/" + CMSFilter.CMS_INDEX_PAGE);
+
+            filter.doFilter(request, response, chain);
+            final HttpServletRequest postFilterRequest = (HttpServletRequest) chain.request;
+            assertEquals(response.getStatus(), action.intValue());
+            assertEquals(VANITY, postFilterRequest.getParameter("param1"));//Vanity takes precedence
+            assertEquals(VANITY, postFilterRequest.getParameter("param2"));
+        }
+    }
     
     
     
@@ -374,11 +408,11 @@ public class FiltersTest {
                     Mockito.mock(HttpServletResponse.class));
             filter.doFilter(request, response, chain);
             Logger.info(this.getClass(), "looking for 200, got:" + response.getStatus());
-            Assert.assertEquals(200, response.getStatus());
+            assertEquals(200, response.getStatus());
             Logger.info(this.getClass(),
                     "looking for /about-us/" + CMSFilter.CMS_INDEX_PAGE + ", got:" + request
                             .getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
-            Assert.assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE,
+            assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE,
                     request.getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
             //Delete the test Vanity URL
             contentletAPI.archive(vanityURLContentlet, user, false);
@@ -396,11 +430,11 @@ public class FiltersTest {
             response = new MockResponseWrapper(Mockito.mock(HttpServletResponse.class));
             filter.doFilter(request, response, chain);
             Logger.info(this.getClass(), "looking for 200, got:" + response.getStatus());
-            Assert.assertEquals(200, response.getStatus());
+            assertEquals(200, response.getStatus());
             Logger.info(this.getClass(),
                     "looking for /about-us" + CMSFilter.CMS_INDEX_PAGE + ", got:" + request
                             .getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
-            Assert.assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE,
+            assertEquals("/about-us/" + CMSFilter.CMS_INDEX_PAGE,
                     request.getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
 
         } catch (Exception e) {
@@ -471,11 +505,11 @@ public class FiltersTest {
                     Mockito.mock(HttpServletResponse.class));
             filter.doFilter(request, response, chain);
             Logger.info(this.getClass(), "looking for 200, got:" + response.getStatus());
-            Assert.assertEquals(200, response.getStatus());
+            assertEquals(200, response.getStatus());
             Logger.info(this.getClass(),
                     "looking for " + forwardTo + ", got:" + request
                             .getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
-            Assert.assertEquals(forwardTo,
+            assertEquals(forwardTo,
                     request.getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
 
         } catch (Exception e) {
@@ -586,7 +620,7 @@ public class FiltersTest {
         try {
             new CMSFilter().doFilter(request, response, chain);
             Logger.info(this.getClass(), "looking for 200, got;" + response.getStatus());
-            Assert.assertEquals(200, response.getStatus());
+            assertEquals(200, response.getStatus());
             Mockito.verify(chain).doFilter(request, response);
         } catch (ServletException e) {
             Assert.fail();
@@ -614,7 +648,7 @@ public class FiltersTest {
         try {
             new CMSFilter().doFilter(request, response, chain);
             Logger.info(this.getClass(), "looking for 200, got;" + response.getStatus());
-            Assert.assertEquals(200, response.getStatus());
+            assertEquals(200, response.getStatus());
 
 
         } catch (ServletException e) {
@@ -642,7 +676,7 @@ public class FiltersTest {
         try {
             new CMSFilter().doFilter(request, response, chain);
             Logger.info(this.getClass(), "looking for 401, got;" + response.getStatus());
-            Assert.assertEquals(401, response.getStatus());
+            assertEquals(401, response.getStatus());
 
 
         } catch (ServletException e) {
@@ -668,9 +702,9 @@ public class FiltersTest {
         try {
             new CMSFilter().doFilter(request, response, chain);
 
-            Assert.assertEquals("/products/",
+            assertEquals("/products/",
                     response.getRedirectLocation());
-            Assert.assertEquals(301, response.getStatus());
+            assertEquals(301, response.getStatus());
         } catch (ServletException e) {
             Assert.fail();
         }
@@ -685,10 +719,10 @@ public class FiltersTest {
             Logger.info(this.getClass(),
                     "looking for /products/" + CMSFilter.CMS_INDEX_PAGE + " , got;" + request
                             .getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
-            Assert.assertEquals("/products/" + CMSFilter.CMS_INDEX_PAGE,
+            assertEquals("/products/" + CMSFilter.CMS_INDEX_PAGE,
                     request.getAttribute(Constants.CMS_FILTER_URI_OVERRIDE));
             Logger.info(this.getClass(), "looking for 200, got;" + response.getStatus());
-            Assert.assertEquals(200, response.getStatus());
+            assertEquals(200, response.getStatus());
 
 
 

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityURLFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityURLFilter.java
@@ -115,7 +115,7 @@ public class VanityURLFilter implements Filter {
             final HttpServletResponse response, final VanityUrlResult vanityUrlResult) {
         if (!response.isCommitted()) {
             final String uri = vanityUrlResult.getRewrite();
-            final String queryString = vanityUrlResult.getQueryString();
+            final String queryString = request.getQueryString();
             final int responseCode = request.getResponseCode();
 
             final String newUrl = uri + (queryString != null ? StringPool.QUESTION + queryString

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityUrlRequestWrapper.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityUrlRequestWrapper.java
@@ -2,7 +2,12 @@ package com.dotcms.vanityurl.filters;
 
 import static com.dotmarketing.filters.Constants.CMS_FILTER_QUERY_STRING_OVERRIDE;
 import static com.dotmarketing.filters.Constants.CMS_FILTER_URI_OVERRIDE;
-import java.nio.charset.Charset;
+
+import com.dotcms.vanityurl.model.VanityUrlResult;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
+import com.google.common.collect.ImmutableMap;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -12,9 +17,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
-import com.dotcms.vanityurl.model.VanityUrlResult;
-import com.dotmarketing.util.UtilMethods;
-import com.google.common.collect.ImmutableMap;
 
 
 /**
@@ -26,16 +28,14 @@ import com.google.common.collect.ImmutableMap;
  */
 public class VanityUrlRequestWrapper extends HttpServletRequestWrapper {
     
-    final Map<String, String[]> queryParamMap;
-    final String newQueryString;
-    final boolean vanityHasQueryString;
+    private final Map<String, String[]> queryParamMap;
+    private final String newQueryString;
+    private final int responseCode;
 
-
-    public VanityUrlRequestWrapper(HttpServletRequest request, VanityUrlResult vanityUrlResult) {
+    public VanityUrlRequestWrapper(final HttpServletRequest request, final VanityUrlResult vanityUrlResult) {
         super(request);
 
-        
-        this.vanityHasQueryString = UtilMethods.isSet(vanityUrlResult.getQueryString());
+        final boolean vanityHasQueryString = UtilMethods.isSet(vanityUrlResult.getQueryString());
         
         this.newQueryString = vanityHasQueryString && UtilMethods.isSet(request.getQueryString())
                         ? request.getQueryString() + "&" + vanityUrlResult.getQueryString()
@@ -47,7 +47,7 @@ public class VanityUrlRequestWrapper extends HttpServletRequestWrapper {
         // we create a new map here because it merges the 
         Map<String,String[]> tempMap = new HashMap<>(request.getParameterMap());
         if(vanityHasQueryString) {
-            List<NameValuePair> additional = URLEncodedUtils.parse(newQueryString, Charset.forName("UTF-8"));
+            List<NameValuePair> additional = URLEncodedUtils.parse(newQueryString, StandardCharsets.UTF_8);
             for(NameValuePair nvp : additional) {
                 tempMap.compute(nvp.getName(), (k, v) -> (v == null) ? new String[] {nvp.getValue()} : new String[]{nvp.getValue(),v[0]});
             }
@@ -56,7 +56,7 @@ public class VanityUrlRequestWrapper extends HttpServletRequestWrapper {
 
         this.queryParamMap = ImmutableMap.copyOf(tempMap);
 
-
+        this.responseCode = vanityUrlResult.getResponseCode();
 
         this.setAttribute(CMS_FILTER_URI_OVERRIDE, vanityUrlResult.getRewrite());
         this.setAttribute(CMS_FILTER_QUERY_STRING_OVERRIDE, this.newQueryString);
@@ -98,4 +98,11 @@ public class VanityUrlRequestWrapper extends HttpServletRequestWrapper {
        
     }
 
+    /**
+     * response code used to build the Vanity URL.
+     * @return
+     */
+    public int getResponseCode() {
+        return responseCode;
+    }
 }

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/model/CachedVanityUrl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/model/CachedVanityUrl.java
@@ -130,25 +130,7 @@ public class CachedVanityUrl implements Serializable, Comparable<CachedVanityUrl
         final Tuple2<String,String> rewritten = processForward(uriIn);
         final String rewrite = rewritten._1;
         final String queryString = rewritten._2;
-
-
-        // if the vanity is a redirect
-        if (this.response==301 || this.response==302 ) {
-            response.setStatus(this.response);
-            response.setHeader("Location", rewrite);
-            return new VanityUrlResult(rewrite, queryString, true);
-        }
-        
-        // if the vanity is a proxy request
-        if (this.response==200 && UtilMethods.isSet(rewrite) && rewrite.contains("//")) {
-            
-            final String proxyUrl  = rewrite + (queryString!=null ? "?" + queryString : "");
-            
-            Try.run(()-> new CircuitBreakerUrl(proxyUrl).doOut(response)).onFailure(DotRuntimeException::new);
-            return new VanityUrlResult(rewrite, queryString, true);
-        }
-
-        return new VanityUrlResult(rewrite, queryString, false);
+        return new VanityUrlResult(rewrite, queryString, this.response);
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/model/VanityUrlResult.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/model/VanityUrlResult.java
@@ -15,6 +15,7 @@ public class VanityUrlResult {
     private final String queryString;
     private final String rewrite;
     private final boolean resolved;
+    private final int responseCode;
 
     /**
      * Create a Vanity URL Object
@@ -26,6 +27,20 @@ public class VanityUrlResult {
         this.rewrite = rewrite;
         this.queryString = queryString;
         this.resolved = resolved;
+        this.responseCode = 200;
+    }
+
+    /**
+     * Create a Vanity Result that takes into account the responseCode of the vanity URL
+     * @param rewrite
+     * @param queryString
+     * @param responseCode
+     */
+    VanityUrlResult(final String rewrite, final String queryString, final int responseCode) {
+        this.rewrite = rewrite;
+        this.queryString = queryString;
+        this.resolved = false;
+        this.responseCode = responseCode;
     }
 
     /**
@@ -56,4 +71,11 @@ public class VanityUrlResult {
         return resolved;
     }
 
+    /**
+     * VanityURL response Code
+     * @return
+     */
+    public int getResponseCode() {
+        return responseCode;
+    }
 }


### PR DESCRIPTION
Per support request, we need to preserve the original query string passed on vanity URLs that get resolved with redirects