### PR TITLE
#19639  Sometimes a contentlet is pushed back into the transformers pipeline

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DotAssetViewStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DotAssetViewStrategy.java
@@ -15,6 +15,7 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ResourceLink;
 import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
+import io.vavr.control.Try;
 import java.io.File;
 import java.util.Map;
 import java.util.Set;
@@ -25,6 +26,7 @@ import java.util.Set;
 public class DotAssetViewStrategy extends WebAssetStrategy<Contentlet> {
 
     private static final String ASSET = "asset";
+    private static final String UNKNOWN = "unknown";
 
     /**
      * Main constructor
@@ -50,16 +52,26 @@ public class DotAssetViewStrategy extends WebAssetStrategy<Contentlet> {
             final Set<TransformOptions> options, final User user)
             throws DotDataException, DotSecurityException {
 
-        String fileName = "unknown";
-        long fileSize = 0L;
-        try {
+        String fileName;
+        long fileSize;
             //TODO: in a near future this must be read from a pre-cached metadata.
-            final File asset = dotAsset.getBinary(ASSET);
-            fileName = asset.getName();
-            fileSize = asset.length();
-        }catch (Exception e){
-            Logger.warn(DotAssetViewStrategy.class, "dotAsset does not have a binary ", e);
-        }
+            final Object asset = dotAsset.get(ASSET);
+            if(asset instanceof File ){
+                final File file = (File)asset;
+                fileName = file.getName();
+                fileSize = file.length();
+            } else {
+                //There are scenarios on which a contentlet is pushed back into the transformers pipeline to add extra stuff etc..
+                //We're probably looking at contantlet that has already been transformed
+                //so we still have an "asset" but it's not java.io.File it's a string
+                //So lets try to get these attributes from the already transformed contentlet
+
+                //unknown is a fallback.
+                //if we're seeing it something has gone wrong.
+                fileName = Try.of(() -> (String)dotAsset.get("name")).getOrElse(UNKNOWN);
+                fileSize = Try.of(() -> (long)dotAsset.get("size")).getOrElse(0L);
+            }
+
         map.put(MIMETYPE_FIELD, toolBox.fileAssetAPI.getMimeType(fileName));
         map.put("isContentlet", true);
         map.put(TITLE_FIELD, fileName);


### PR DESCRIPTION
#19639  we need to look for clues to identify if a contentlet that has been already transformed is coming back into the transformers pipeline.

In this case, transformers are instructed to remove attributes of type File and replace them by the relative path which is a string. In certain cases, the content is pushed back into the pipeline to add additional stuff for example categories, etc.. 
In this case, the transformer strategy must be smart enough to  identify such situations