### PR TITLE
core#18241 fix Can-not-use-a-content-type-name-with-quotes

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
@@ -94,6 +94,7 @@ dojo.declare("dotcms.dijit.form.ContentSelector", [dijit._Widget, dijit._Templat
     useRelateContentOnSelect: false,
 
 	postCreate: function () {
+        this.containerStructures = this._decodeQuoteChars(this.containerStructures);
         var structuresParam = this.containerStructures.toString();
         this.containerStructures = structuresParam.length ? JSON.parse(structuresParam) : [];
 
@@ -131,7 +132,11 @@ dojo.declare("dotcms.dijit.form.ContentSelector", [dijit._Widget, dijit._Templat
 	hide: function () {
 		this._clearSearch();
 		!isNg && this.dialog.hide();
-	},
+    },
+    
+    _decodeQuoteChars: function (structures) {
+        return structures.map(chunk => chunk.replace(/%27/g, "'").replace(/%22/g, '&quot;'))
+    },
 
 	_structureDetailsCallback: function (structure) {
 

--- a/dotCMS/src/main/webapp/html/ng-contentlet-selector.jsp
+++ b/dotCMS/src/main/webapp/html/ng-contentlet-selector.jsp
@@ -72,7 +72,7 @@
     for (ContentType contentType: contentTypes) {
         containerStructures = containerStructures + "{";
         containerStructures = containerStructures + "\"inode\":" + "\"" + contentType.id() + "\",";
-        containerStructures = containerStructures + "\"name\":" + "\"" + contentType.name() + "\",";
+        containerStructures = containerStructures + "\"name\":" + "\"" + contentType.name().replace("'", "%27").replace("\"", "%22") + "\",";
         containerStructures = containerStructures + "\"baseType\":" + "\"" + contentType.baseType() + "\",";
         containerStructures = containerStructures + "\"variable\":" + "\"" + contentType.variable() + "\"";
         containerStructures = containerStructures + "}";


### PR DESCRIPTION
When you have a content type/structure with a single quote in its name ten dotCMS starts to function incorrectly. The content will not be displayed any more in a container and you can't add content to a container which handles that type. The add/edit content window will be empty.