### PR TITLE
#19527 - This comes to solve the 10K items count limitation on ES.

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
@@ -932,6 +932,7 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
                 .indexSearch(queryString, MAX_LIMIT, 0, null);
         assertEquals(searchHits.getHits().length, newContentTypeItems);
         assertEquals(searchHits.getTotalHits().value, newContentTypeItems);
+        assertEquals(newContentTypeItems, instance.indexCount(queryString));
 
         final String savedValue = Config.getStringProperty(ES_TRACK_TOTAL_HITS);
         try {
@@ -944,6 +945,9 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
                 searchHits = instance.indexSearch(queryString, MAX_LIMIT, 0, null);
                 assertEquals(searchHits.getHits().length, newContentTypeItems);
                 assertEquals(searchHits.getTotalHits().value, i);
+                //Regardless of the track_hits count flag. index count should always get you the accurate number.
+                // as it works independently from that flag.
+                assertEquals(newContentTypeItems, instance.indexCount(queryString));
             }
 
             Config.setProperty(ES_TRACK_TOTAL_HITS, "true");

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/ESQueryCache.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/ESQueryCache.java
@@ -38,7 +38,7 @@ public class ESQueryCache implements Cachable {
     }
 
 
-    final static String[] groups = new String[] {"esQueryCache","esQueryCountCache"};
+    final static String[] groups = new String[] {"esquerycache","esquerycountcache"};
 
     @Override
     public String getPrimaryGroup() {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -1549,6 +1549,8 @@ public class ESContentFactoryImpl extends ContentletFactory {
              if(null != trackTotalHitsBool){
                  searchSourceBuilder.trackTotalHits(trackTotalHitsBool);
              }
+        } else {
+            searchSourceBuilder.trackTotalHitsUpTo(MAX_LIMIT);
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -1433,30 +1433,6 @@ public class ESContentFactoryImpl extends ContentletFactory {
 	protected long indexCount(final String query) {
 	    final String qq = LuceneQueryDateTimeFormatter
                 .findAndReplaceQueryDates(translateQuery(query, null).getQuery());
-/*
-	    // we check the query to figure out wich indexes to hit
-        String indexToHit;
-        IndiciesInfo info;
-        try {
-            info = APILocator.getIndiciesAPI().loadIndicies();
-        }
-        catch(DotDataException ee) {
-            Logger.fatal(this, "Can't get indicies information",ee);
-            return 0;
-        }
-        if(query.contains("+live:true") && !query.contains("+deleted:true")) {
-            indexToHit = info.getLive();
-        } else {
-            indexToHit = info.getWorking();
-        }
-
-        SearchRequest searchRequest = getCountSearchRequest(qq);
-        searchRequest.indices(indexToHit);
-
-       final SearchHits hits = cachedIndexSearch(searchRequest);
-       return hits.getTotalHits().value;
-  */
-
         final CountRequest countRequest = getCountRequest(qq);
         return cachedIndexCount(countRequest);
     }
@@ -1465,28 +1441,6 @@ public class ESContentFactoryImpl extends ContentletFactory {
     @Override
     protected long indexCount(final String query,
                         final long timeoutMillis) {
-/*
-        final String queryStringQuery =
-                LuceneQueryDateTimeFormatter.findAndReplaceQueryDates(translateQuery(query, null).getQuery());
-
-        // we check the query to figure out which indexes to hit
-        IndiciesInfo info;
-
-        try {
-
-            info = this.indiciesAPI.loadIndicies();
-        } catch(DotDataException ee) {
-            Logger.fatal(this, "Can't get indicies information",ee);
-            return 0;
-        }
-
-        SearchRequest searchRequest = getCountSearchRequest(queryStringQuery);
-        searchRequest.indices(query.contains("+live:true") && !query.contains("+deleted:true")?
-                info.getLive(): info.getWorking());
-
-        final SearchHits hits = cachedIndexSearch(searchRequest);
-        return hits.getTotalHits().value;
-  */
        return indexCount(query);
     }
 
@@ -1499,44 +1453,7 @@ public class ESContentFactoryImpl extends ContentletFactory {
 
         final String queryStringQuery =
                 LuceneQueryDateTimeFormatter.findAndReplaceQueryDates(translateQuery(query, null).getQuery());
-/*
-        // we check the query to figure out wich indexes to hit
-        IndiciesInfo info;
 
-        try {
-
-            info=APILocator.getIndiciesAPI().loadIndicies();
-        } catch(DotDataException ee) {
-            Logger.fatal(this, "Can't get indices information",ee);
-            if (null != indexCountFailure) {
-
-                indexCountFailure.accept(ee);
-            }
-            return;
-        }
-
-        SearchRequest searchRequest = getCountSearchRequest(queryStringQuery);
-        searchRequest.indices(query.contains("+live:true") && !query.contains("+deleted:true")?
-                info.getLive(): info.getWorking());
-
-        RestHighLevelClientProvider.getInstance().getClient().searchAsync(searchRequest, RequestOptions.DEFAULT,
-                        new ActionListener<SearchResponse>() {
-            @Override
-            public void onResponse(SearchResponse searchResponse) {
-
-                indexCountSuccess.accept(searchResponse.getHits().getTotalHits().value);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-
-                if (null != indexCountFailure) {
-
-                    indexCountFailure.accept(e);
-                }
-            }
-        });
-*/
         try {
             final CountRequest countRequest = getCountRequest(queryStringQuery);
 
@@ -1590,17 +1507,6 @@ public class ESContentFactoryImpl extends ContentletFactory {
        }
        return indexToHit;
    }
-
-    @NotNull
-    private SearchRequest getCountSearchRequest(final String queryString) {
-        SearchRequest searchRequest = new SearchRequest();
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchSourceBuilder.query(QueryBuilders.queryStringQuery(queryString));
-        searchSourceBuilder.size(0);
-        searchSourceBuilder.timeout(TimeValue.timeValueMillis(INDEX_OPERATIONS_TIMEOUT_IN_MS));
-        searchRequest.source(searchSourceBuilder);
-        return searchRequest;
-    }
 
     /**
      * It will call createRequest with null as sortBy parameter

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -126,8 +126,10 @@ import io.vavr.control.Try;
  *
  */
 public class ESContentFactoryImpl extends ContentletFactory {
+
     private static final String[] ES_FIELDS = {"inode", "identifier"};
     public static final int ES_TRACK_TOTAL_HITS_DEFAULT = 10000000;
+    public static final String ES_TRACK_TOTAL_HITS = "ES_TRACK_TOTAL_HITS";
     private final ContentletCache contentletCache;
 	private final LanguageAPI languageAPI;
 	private final IndiciesAPI indiciesAPI;
@@ -1537,12 +1539,7 @@ public class ESContentFactoryImpl extends ContentletFactory {
      */
      @VisibleForTesting
      void setTrackHits(final SearchSourceBuilder searchSourceBuilder){
-        final boolean trackTotalHitsBool = Config.getBooleanProperty("ES_TRACK_TOTAL_HITS", false);
-        if(trackTotalHitsBool){
-            searchSourceBuilder.trackTotalHits(true);
-            return;
-        }
-        final int trackTotalHits = Config.getIntProperty("ES_TRACK_TOTAL_HITS", ES_TRACK_TOTAL_HITS_DEFAULT);
+        final int trackTotalHits = Config.getIntProperty(ES_TRACK_TOTAL_HITS, ES_TRACK_TOTAL_HITS_DEFAULT);
         searchSourceBuilder.trackTotalHitsUpTo(trackTotalHits);
     }
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -992,14 +992,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 catch(Exception e){
                     Logger.error(this,e.getMessage(),e);
                 }
-
-                if(searchHits.getTotalHits().value == MAX_LIMIT && searchHits.getTotalHits().relation == Relation.GREATER_THAN_OR_EQUAL_TO){
-                    //The total isn't accurate. It is telling us there is more. So Let's do a countRequest.
-                    final long count = contentFactory.indexCount(buffy.toString());
-                    if(count >= 0){
-                        list.setTotalResults(count);
-                    }
-                }
             }
             return list;
         } else {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -7787,14 +7787,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
     private boolean isInodeIndexedWithQuery(final String luceneQuery,
                                             final int milliSecondsToWait) {
 
-        final long indexTimeOut    = Config.getLongProperty("TIMEOUT_INDEX_COUNT", 1000);
         final long millistoWait    = Config.getLongProperty("IS_NODE_INDEXED_INDEX_MILLIS_WAIT", 100);
         final int limit            = - 1 != milliSecondsToWait?milliSecondsToWait: 300;
         boolean   found            = false;
         int       counter          = 0;
         int       fibonacciIndex   = 0;
 
-        if (this.contentFactory.indexCount(luceneQuery, indexTimeOut) > 0) {
+        if (this.contentFactory.indexCount(luceneQuery) > 0) {
 
             if (ConfigUtils.isDevMode()) {
                 Logger.info(this, ()-> "******>>>>>> Index count found in the fist hit for the query: " + luceneQuery);
@@ -7809,7 +7808,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                 try {
 
-                    found = this.contentFactory.indexCount(luceneQuery, indexTimeOut) > 0;
+                    found = this.contentFactory.indexCount(luceneQuery) > 0;
                 } catch (Exception e) {
                     Logger.error(this.getClass(), e.getMessage(), e);
                     return false;

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -163,8 +163,6 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.DomDriver;
 import io.vavr.control.Try;
 import org.apache.commons.lang.StringUtils;
-import org.apache.lucene.search.TotalHits;
-import org.apache.lucene.search.TotalHits.Relation;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.SearchHit;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
@@ -405,27 +405,6 @@ public abstract class ContentletFactory {
     
     protected abstract long indexCount(String query);
 
-	/**
-	 * This indexCount will use the thirdparty mechanism to async known when the query is returning something.
-	 * @param query          {@link String} query to test if get results
-	 * @param timeoutMillis  {@link Long}   time in millis to timeout
-	 */
-	protected abstract long indexCount(final String query,
-							  final long timeoutMillis);
-
-	/**
-	 * This indexCount will use the thirdparty mechanism to async known when the query is returning something.
-	 * this one use an async response, the indexCountSuccess will be called if the count is success, otherwise if the indexCountFailure is not null will be invoked.
-	 * @param query
-	 * @param timeoutMillis
-	 * @param indexCountSuccess
-	 * @param indexCountFailure
-	 */
-	protected abstract void indexCount(final String query,
-					final long timeoutMillis,
-					final Consumer<Long> indexCountSuccess,
-					final Consumer<Exception> indexCountFailure);
-    
     /**
      * Gets the top viewed contents identifier and numberOfViews for a particular structure for a specified date interval
      * 

--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -522,6 +522,14 @@ CACHE_INVALIDATION_TRANSPORT_CLASS=com.dotcms.cache.transport.HazelcastCacheTran
 ## Cache elasticsearch query results
 ES_CACHE_SEARCH_QUERIES=true
 
+# This Property can be set to a positive numeric value or a boolean value
+# if set to false ES will stop retrieving the hits Count. DO NOT SET IT TO FALSE.
+# IF set to true  ES will track all hits beyond the 10K items limit. This might imply an impact performance wise.
+# By default we're providing a max number.
+# If commented out ES will default to 10K again.
+# https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-your-data.html#track-total-hits
+ES_TRACK_TOTAL_HITS=1000000
+
 ## Default Caching Settings
 cache.default.size=1000
 

--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -514,6 +514,11 @@ cache.esquerycache.chain=com.dotmarketing.business.cache.provider.timedcache.Tim
 cache.esquerycache.seconds=3600
 cache.esquerycache.size=10000
 
+## Cache Elasticsearch Queries for an hour - this cache gets in validated whenever a contentlet is checked in
+cache.esquerycountcache.chain=com.dotmarketing.business.cache.provider.timedcache.TimedCacheProvider
+cache.esquerycountcache.seconds=3600
+cache.esquerycountcache.size=10000
+
 #cache.default.chain=com.dotmarketing.business.cache.provider.hazelcast.HazelcastCacheProviderEmbedded
 #cache.default.chain=com.dotmarketing.business.cache.provider.hazelcast.HazelcastCacheProviderClient
 
@@ -521,14 +526,6 @@ CACHE_INVALIDATION_TRANSPORT_CLASS=com.dotcms.cache.transport.HazelcastCacheTran
 
 ## Cache elasticsearch query results
 ES_CACHE_SEARCH_QUERIES=true
-
-# This Property can be set to a positive numeric value or a boolean value
-# if set to false ES will stop retrieving the hits Count. DO NOT SET IT TO FALSE.
-# IF set to true  ES will track all hits beyond the 10K items limit. This might imply an impact performance wise.
-# By default we're providing a max number.
-# If commented out ES will default to 10K again.
-# https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-your-data.html#track-total-hits
-ES_TRACK_TOTAL_HITS=1000000
 
 ## Default Caching Settings
 cache.default.size=1000


### PR DESCRIPTION
Our index count methods are executed via  ES's `SearchRequest` which is pretty much limited by the 10K items hard limit restriction. I am replacing the uses of `SearchRequest` with `CountRequest` which operates without the  10K items restriction.

 
