### PR TITLE
#19679 A new SUCCESS_WITH_WARNINGS PP status was added to support silent failures

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/publisher/business/TestPushPublisher.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publisher/business/TestPushPublisher.java
@@ -1,6 +1,7 @@
 package com.dotcms.publisher.business;
 
 import com.dotcms.publisher.bundle.bean.Bundle;
+import com.dotcms.publisher.business.PublishAuditStatus.Status;
 import com.dotcms.publisher.endpoint.bean.PublishingEndPoint;
 import com.dotcms.publisher.endpoint.business.PublishingEndPointAPI;
 import com.dotcms.publisher.environment.bean.Environment;
@@ -90,6 +91,7 @@ public class TestPushPublisher extends PushPublisher {
                             if (PublisherConfig.DeliveryStrategy.ALL_ENDPOINTS.equals(this.config.getDeliveryStrategy())
                                     || (PublisherConfig.DeliveryStrategy.FAILED_ENDPOINTS.equals(this.config.getDeliveryStrategy())
                                     && PublishAuditStatus.Status.SUCCESS.getCode() != epDetail.getStatus()
+                                    && Status.SUCCESS_WITH_WARNINGS.getCode() != epDetail.getStatus()
                                     && PublishAuditStatus.Status.BUNDLE_SENT_SUCCESSFULLY.getCode() != epDetail.getStatus())) {
                                 endpoints.add(ep);
                             }

--- a/dotCMS/src/main/java/com/dotcms/publisher/ajax/RemotePublishAjaxAction.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/ajax/RemotePublishAjaxAction.java
@@ -331,7 +331,9 @@ public class RemotePublishAjaxAction extends AjaxAction {
             }
 
             //We will be able to retry failed and successfully bundles
-            if ( !(status.getStatus().equals( Status.FAILED_TO_PUBLISH ) || status.getStatus().equals( Status.SUCCESS )) ) {
+            if (!(status.getStatus().equals(Status.FAILED_TO_PUBLISH) || status.getStatus()
+                    .equals(Status.SUCCESS) || status.getStatus()
+                    .equals(Status.SUCCESS_WITH_WARNINGS))) {
                 appendMessage( responseMessage, "publisher_retry.error.only.failed.publish", bundleId, true );
                 continue;
             }
@@ -425,7 +427,8 @@ public class RemotePublishAjaxAction extends AjaxAction {
 					appendMessage(responseMessage, "publisher_retry.error.not.found", bundleId, true);
 					continue;
 				}
-				if (status.getStatus().equals(Status.SUCCESS)) {
+                if (status.getStatus().equals(Status.SUCCESS) || status.getStatus()
+                        .equals(Status.SUCCESS_WITH_WARNINGS)) {
 					bundle.setForcePush(Boolean.TRUE);
 				} else {
 					bundle.setForcePush(isForcePush);

--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditStatus.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditStatus.java
@@ -33,7 +33,9 @@ public class PublishAuditStatus implements Serializable {
 		BUNDLE_SAVED_SUCCESSFULLY(14),
 
 		INVALID_TOKEN(15),
-		LICENSE_REQUIRED(16);
+		LICENSE_REQUIRED(16),
+
+        SUCCESS_WITH_WARNINGS(17);
 
 		private int code;
 		private Status(int code) {

--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublisherQueueJob.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublisherQueueJob.java
@@ -383,7 +383,8 @@ public class PublisherQueueJob implements StatefulJob {
 		Logger.info(this, String.format("For bundle '%s':", auditedBundleId));
 		Logger.info(this, String.format("-> Status             : %s [%d]", bundleStatus.toString(), bundleStatus.getCode()));
 		if (!bundleStatus.equals(PublishAuditStatus.Status.PUBLISHING_BUNDLE) && !bundleStatus.equals
-				(PublishAuditStatus.Status.WAITING_FOR_PUBLISHING) && !bundleStatus.equals(Status.SUCCESS)) {
+                (PublishAuditStatus.Status.WAITING_FOR_PUBLISHING) && !bundleStatus
+                .equals(Status.SUCCESS) && !bundleStatus.equals(Status.SUCCESS_WITH_WARNINGS)) {
 			final int totalAttemptsFromHistory = localHistory.getNumTries();
 			Logger.info(this, String.format("-> Re-publish attempts: %d out of %d", totalAttemptsFromHistory,
 					MAX_NUM_TRIES));
@@ -476,7 +477,8 @@ public class PublisherQueueJob implements StatefulJob {
 			boolean isGroupFailed = false;
 			boolean isGroupSaved = false;
 			for (final EndpointDetail detail : group.values() ) {
-				if ( detail.getStatus() == Status.SUCCESS.getCode() ) {
+                if (detail.getStatus() == Status.SUCCESS.getCode()
+                        || detail.getStatus() == Status.SUCCESS_WITH_WARNINGS.getCode()) {
 					isGroupOk = true;
 				} else if ( detail.getStatus() == Status.PUBLISHING_BUNDLE
 						.getCode() ) {

--- a/dotCMS/src/main/java/com/dotcms/publisher/pusher/PushPublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/pusher/PushPublisher.java
@@ -22,6 +22,7 @@ import com.dotcms.enterprise.publishing.remote.bundler.UserBundler;
 import com.dotcms.enterprise.publishing.remote.bundler.WorkflowBundler;
 import com.dotcms.publisher.bundle.bean.Bundle;
 import com.dotcms.publisher.business.*;
+import com.dotcms.publisher.business.PublishAuditStatus.Status;
 import com.dotcms.publisher.endpoint.bean.PublishingEndPoint;
 import com.dotcms.publisher.endpoint.business.PublishingEndPointAPI;
 import com.dotcms.publisher.environment.bean.Environment;
@@ -198,6 +199,7 @@ public class PushPublisher extends Publisher {
 							if (DeliveryStrategy.ALL_ENDPOINTS.equals(this.config.getDeliveryStrategy())
 									|| (DeliveryStrategy.FAILED_ENDPOINTS.equals(this.config.getDeliveryStrategy())
 									&& PublishAuditStatus.Status.SUCCESS.getCode() != epDetail.getStatus()
+                                    && Status.SUCCESS_WITH_WARNINGS.getCode() != epDetail.getStatus()
 									&& PublishAuditStatus.Status.BUNDLE_SENT_SUCCESSFULLY.getCode() != epDetail.getStatus())) {
 								endpoints.add(ep);
 							}

--- a/dotCMS/src/main/java/com/dotcms/publisher/receiver/handler/IHandler.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/receiver/handler/IHandler.java
@@ -1,6 +1,8 @@
 package com.dotcms.publisher.receiver.handler;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
 
 
 public interface IHandler {
@@ -8,4 +10,8 @@ public interface IHandler {
 	public void handle(File bundleFolder) throws Exception;
 	
 	public String getName();
+
+	default List<String> getWarnings(){
+        return Collections.emptyList();
+    }
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/BundleResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/BundleResource.java
@@ -83,6 +83,7 @@ import static com.dotcms.publisher.business.PublishAuditStatus.Status.FAILED_TO_
 import static com.dotcms.publisher.business.PublishAuditStatus.Status.FAILED_TO_SEND_TO_SOME_GROUPS;
 import static com.dotcms.publisher.business.PublishAuditStatus.Status.FAILED_TO_SENT;
 import static com.dotcms.publisher.business.PublishAuditStatus.Status.SUCCESS;
+import static com.dotcms.publisher.business.PublishAuditStatus.Status.SUCCESS_WITH_WARNINGS;
 
 @Path("/bundle")
 public class BundleResource {
@@ -507,7 +508,7 @@ public class BundleResource {
                 final PublishAuditStatus.Status [] statuses = Config.getCustomArrayProperty("bundle.delete.all.statuses",
                         PublishAuditStatus.Status::valueOf, PublishAuditStatus.Status.class,
                         ()-> new PublishAuditStatus.Status[] {FAILED_TO_SEND_TO_ALL_GROUPS, FAILED_TO_SEND_TO_SOME_GROUPS,
-                                FAILED_TO_BUNDLE, FAILED_TO_SENT, FAILED_TO_PUBLISH, SUCCESS});
+                                FAILED_TO_BUNDLE, FAILED_TO_SENT, FAILED_TO_PUBLISH, SUCCESS, SUCCESS_WITH_WARNINGS});
 
                 final BundleDeleteResult bundleDeleteResult = this.bundleAPI.deleteAllBundles(initData.getUser(), statuses);
                 sendDeleteResultsMessage(initData, locale, bundleDeleteResult);
@@ -614,7 +615,7 @@ public class BundleResource {
 
                 final PublishAuditStatus.Status [] statuses = Config.getCustomArrayProperty("bundle.delete.success.statuses",
                         PublishAuditStatus.Status::valueOf, PublishAuditStatus.Status.class,
-                        ()-> new PublishAuditStatus.Status[] {SUCCESS});
+                        ()-> new PublishAuditStatus.Status[] {SUCCESS, SUCCESS_WITH_WARNINGS});
                 final BundleDeleteResult bundleDeleteResult = this.bundleAPI.deleteAllBundles(initData.getUser(), statuses);
                 sendDeleteResultsMessage(initData, locale, bundleDeleteResult);
             } catch (DotDataException e) {

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -3272,6 +3272,7 @@ publisher_status_PUBLISHING_BUNDLE = Publishing Bundle
 publisher_status_RECEIVED_BUNDLE = Bundle Received
 publisher_status_SENDING_TO_ENDPOINTS = Sending to all environments
 publisher_status_SUCCESS = Success
+publisher_status_SUCCESS_WITH_WARNINGS = Success with warnings
 publisher_status_WAITING_FOR_PUBLISHING = Waiting for Publishing
 publisher_status = Publishing Status
 publisher_Status = Status

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -4905,6 +4905,8 @@ push_publish.end_point.expired_token.message = the current token is expired you 
 
 bundle.named.success.notification = Bundle <strong>{0}</strong> successfully published
 bundle.title.success.notification = Bundle containing:<br/> {0} successfully published
+bundle.named.success_with_warnings.notification = Bundle <strong>{0}</strong> published with warnings
+bundle.title.success_with_warnings.notification = Bundle containing:<br/> {0} published with warnings
 bundle.named.fail.notification = Bundle <strong>{0}</strong> failed to publish.<br/>For more information, please <a href="#/c/publishing-queue">click here</a>
 bundle.title.fail.notification = Bundle containing:<br/> {0} failed to publish.<br/>For more information, please <a href="#/c/publishing-queue">click here</a>
 


### PR DESCRIPTION
With these changes PP handlers can keep warnings of the process without failing and send feedback to the user with the warnings even when the process finishes successfully.

This change was made because rules should fail silently, so in case the RuleHandler fails processing a rule, we should rollback only the rule being processed, but the whole process should continue.

This PR es part of this one: https://github.com/dotCMS/enterprise/pull/766