### PR TITLE
dotCMS/core#19708 fix - Rules-push-options-not-visible-on-edit-page

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_js_inc.jsp
@@ -742,9 +742,6 @@
             dojo.empty(myDiv);
         }
         var hideRulePushOptions = false
-        <%if(contentlet.getStructure().isHTMLPageAsset()){%>
-        hideRulePushOptions=true;
-        <%}%>
         myCp = new dojox.layout.ContentPane({
             id : "contentletRulezDivCp",
             style: "height:100%",


### PR DESCRIPTION
If you add a rule to a page, you cannot see the "Add to Bundle" & "Delete Rule" options under the elipsis - it does work on a host and in the rules portlet