### PR TITLE
dotCMS/core#18073 Save of checkbox field fails if Velocity var name of field is `properties`

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -823,7 +823,7 @@
     <%
         }
     %>
-    <input type="hidden" name="<%=fieldName%>" id="<%=field.getVelocityVarName()%>"
+    <input type="hidden" name="<%=fieldName%>" id="<%=field.getVelocityVarName()%>Checkbox"
            value="<%=value%>">
 
     <script type="text/javascript">
@@ -834,7 +834,7 @@
             checkedInputs.forEach(function(checkedInput) {
                 valuesList.push(checkedInput.value);
             });
-            $("<%=field.getVelocityVarName()%>").value = valuesList.join(",");
+            $("<%=field.getVelocityVarName()%>Checkbox").value = valuesList.join(",");
         }
 
         update<%=field.getVelocityVarName()%>Checkbox();


### PR DESCRIPTION
If you create a checkbox field in a content type, and name it so that the Velocity variable name of the field is properties, then when you make changes to the field in the content editing screen and then save the content, your changes to that field will not be saved.