### PR TITLE
DotCMS/core#18073 Save of select component field fails if Velocity var name of field is `properties`

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -698,7 +698,7 @@
     //SELECT kind of field rendering
 } else if (field.getFieldType().equals(Field.FieldType.SELECT.toString())) {
 %>
-    <select dojoType="dijit.form.FilteringSelect"   onChange="emmitFieldDataChange(true)" autocomplete="true" id="<%=field.getVelocityVarName()%>" name="<%=field.getFieldContentlet()%>" <%=field.isReadOnly()?"readonly=\"\"":""%>>
+    <select dojoType="dijit.form.FilteringSelect"   onChange="emmitFieldDataChange(true)" autocomplete="true" id="<%=field.getVelocityVarName()%>Select" name="<%=field.getFieldContentlet()%>" <%=field.isReadOnly()?"readonly=\"\"":""%>>
         <%
             String[] pairs = fieldValues.contains("\r\n") ? fieldValues.split("\r\n") : fieldValues.split("\n");
             for (int j = 0; j < pairs.length; j++)
@@ -763,7 +763,7 @@
         }
     %>
     </select>
-    <input type="hidden" name="<%=field.getFieldContentlet()%>" id="<%=field.getVelocityVarName()%>" value="<%= value %>"/>
+    <input type="hidden" name="<%=field.getFieldContentlet()%>" id="<%=field.getVelocityVarName()%>MultiSelect" value="<%= value %>"/>
     <script type="text/javascript">
         function update<%=field.getVelocityVarName()%>MultiSelect() {
             var valuesList = "";
@@ -776,7 +776,7 @@
                     valuesList += multiselect.options[i].value;
                 }
             }
-            $('<%=field.getVelocityVarName()%>').value = valuesList;
+            $('<%=field.getVelocityVarName()%>MultiSelect').value = valuesList;
         }
 
         update<%=field.getVelocityVarName()%>MultiSelect();


### PR DESCRIPTION
If you create a select field in a content type, and name it so that the Velocity variable name of the field is properties, then when you make changes to the field in the content editing screen and then save the content, your changes to that field will not be saved.