### PR TITLE
dotCMS/core#1807 Save of Multi Select field fails if Velocity var name of field is `properties`

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -763,8 +763,8 @@
         }
     %>
     </select>
-    <input type="hidden" name="<%=field.getFieldContentlet()%>" id="<%=field.getVelocityVarName()%>MultiSelect" value="<%= value %>"/>
-    <script type="text/javascript">
+    <input type="hidden" name="<%=field.getFieldContentlet()%>" id="<%=field.getVelocityVarName()%>MultiSelectHF" value="<%= value %>"/>
+        <script type="text/javascript">
         function update<%=field.getVelocityVarName()%>MultiSelect() {
             var valuesList = "";
             var multiselect = $('<%=field.getVelocityVarName()%>MultiSelect');
@@ -776,7 +776,7 @@
                     valuesList += multiselect.options[i].value;
                 }
             }
-            $('<%=field.getVelocityVarName()%>MultiSelect').value = valuesList;
+            $('<%=field.getVelocityVarName()%>MultiSelectHF').value = valuesList;
         }
 
         update<%=field.getVelocityVarName()%>MultiSelect();


### PR DESCRIPTION
If you create a MULTI Select field in a content type, and name it so that the Velocity variable name of the field is properties, then when you make changes to the field in the content editing screen and then save the content, your changes to that field will not be saved.

dotCMS/core#18073 fix