### PR TITLE
#19241 point to tomcat9 branch

### DIFF
--- a/.cicd/seed.source
+++ b/.cicd/seed.source
@@ -1,2 +1,2 @@
 # Override values
-#export DOT_CICD_BRANCH="master"
+#export DOT_CICD_BRANCH="19241-ship-with-latest-tomcat"

--- a/.github/workflows/core-cicd-tests.yml
+++ b/.github/workflows/core-cicd-tests.yml
@@ -303,4 +303,3 @@ jobs:
         with:
           github-user: ${{ github.actor }}
           branch: ${{ env.CURRENT_BRANCH }}
-

--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -413,7 +413,7 @@ dependencies {
     }
     testCompile "org.powermock:powermock-module-junit4:1.6.5"
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
-    testCompile group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '8.5.32'
+    testCompile group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '9.0.41'
 
     /**
      * Order matters here: OSGI-Core must come after felix.

--- a/dotCMS/gradle.properties
+++ b/dotCMS/gradle.properties
@@ -6,7 +6,7 @@ webComponentsReleaseVersion=latest
 tomcatInstallRepo=https://github.com/dotCMS/tomcat.git
 tomcatInstallBranch=9.0.41
 tomcatInstallVersion=9.0.41
-tomcatInstallLocation=../../tomcat9
+tomcatInstallLocation=../../tomcat8
 
 jboss7InstallVersion=7.1.1
 jboss7InstallLocation=../../jboss7

--- a/dotCMS/gradle.properties
+++ b/dotCMS/gradle.properties
@@ -4,9 +4,9 @@ webComponentsReleaseVersion=latest
 
 
 tomcatInstallRepo=https://github.com/dotCMS/tomcat.git
-tomcatInstallBranch=8.5.32-dotCMS-5.3.0
-tomcatInstallVersion=8.5.32
-tomcatInstallLocation=../../tomcat8
+tomcatInstallBranch=9.0.41
+tomcatInstallVersion=9.0.41
+tomcatInstallLocation=../../tomcat9
 
 jboss7InstallVersion=7.1.1
 jboss7InstallLocation=../../jboss7

--- a/dotCMS/gradle.properties
+++ b/dotCMS/gradle.properties
@@ -6,7 +6,7 @@ webComponentsReleaseVersion=latest
 tomcatInstallRepo=https://github.com/dotCMS/tomcat.git
 tomcatInstallBranch=9.0.41
 tomcatInstallVersion=9.0.41
-tomcatInstallLocation=../../tomcat8
+tomcatInstallLocation=../../tomcat9
 
 jboss7InstallVersion=7.1.1
 jboss7InstallLocation=../../jboss7


### PR DESCRIPTION
Use the new branch with Tomcat 9 (9.0.41) instead of 8. 