### PR TITLE
#19854 : The Page Mode instance being passed down when a limited user…

### DIFF
--- a/dotCMS/src/main/java/com/liferay/portal/struts/PortletRequestProcessor.java
+++ b/dotCMS/src/main/java/com/liferay/portal/struts/PortletRequestProcessor.java
@@ -332,7 +332,7 @@ public class PortletRequestProcessor extends StxxTilesRequestProcessor {
 		PortletRequestDispatcherImpl prd = (PortletRequestDispatcherImpl)
 			portletConfig.getPortletContext().getRequestDispatcher(
 				Constants.TEXT_HTML_DIR + uri);
-		final User user = WebAPILocator.getUserWebAPI().getLoggedInUser(req);
+		final User user = PortalUtil.getUser(req);
 		if (null != user && user.isBackendUser()) {
 			PageMode.setPageMode(req, PageMode.NAVIGATE_EDIT_MODE);
 		}

--- a/dotCMS/src/main/java/com/liferay/portal/struts/PortletRequestProcessor.java
+++ b/dotCMS/src/main/java/com/liferay/portal/struts/PortletRequestProcessor.java
@@ -38,7 +38,9 @@ import com.dotcms.repackage.org.apache.struts.action.ActionServlet;
 import com.dotcms.repackage.org.apache.struts.config.ForwardConfig;
 import com.dotcms.repackage.org.apache.struts.config.ModuleConfig;
 import com.dotcms.util.SecurityUtils;
+import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.PageMode;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.Constants;
@@ -330,7 +332,10 @@ public class PortletRequestProcessor extends StxxTilesRequestProcessor {
 		PortletRequestDispatcherImpl prd = (PortletRequestDispatcherImpl)
 			portletConfig.getPortletContext().getRequestDispatcher(
 				Constants.TEXT_HTML_DIR + uri);
-
+		final User user = WebAPILocator.getUserWebAPI().getLoggedInUser(req);
+		if (null != user && user.isBackendUser()) {
+			PageMode.setPageMode(req, PageMode.NAVIGATE_EDIT_MODE);
+		}
 		try {
 			if (prd == null) {
 				_log.error(uri + " is not a valid include");

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
@@ -10,6 +10,7 @@
 <%@page import="java.util.Map"%>
 <%@ page import="com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo" %>
 <%@ page import="com.dotmarketing.util.Logger" %>
+<%@ page import="com.dotmarketing.util.PageMode" %>
 <%
 
 if(user == null){
@@ -103,7 +104,7 @@ function editPage(url, languageId) {
 <%}%>
 
 <%--check permissions to display the save and publish button or not--%>
-<%boolean canUserWriteToContentlet = conPerAPI.doesUserHavePermission(contentlet,PermissionAPI.PERMISSION_WRITE,user);%>
+<%boolean canUserWriteToContentlet = conPerAPI.doesUserHavePermission(contentlet,PermissionAPI.PERMISSION_WRITE,user, PageMode.get(request).respectAnonPerms);%>
 
 <%if(!"edit-page".equals(request.getParameter("angularCurrentPortlet")) && contentlet.isHTMLPage() && contentlet.getIdentifier() != "" && (canUserWriteToContentlet)) {%>
    <div class="content-edit-actions" >

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet.jsp
@@ -81,10 +81,10 @@
 
 	}
 
-	boolean canUserPublishContentlet = conPerAPI.doesUserHavePermission(contentlet,PermissionAPI.PERMISSION_PUBLISH,user);
+	boolean canUserPublishContentlet = conPerAPI.doesUserHavePermission(contentlet,PermissionAPI.PERMISSION_PUBLISH,user, PageMode.get(request).respectAnonPerms);
 
 	if(!InodeUtils.isSet(contentlet.getInode())) {
-		canUserPublishContentlet = conPerAPI.doesUserHavePermission(structure,PermissionAPI.PERMISSION_PUBLISH,user);
+		canUserPublishContentlet = conPerAPI.doesUserHavePermission(structure,PermissionAPI.PERMISSION_PUBLISH,user, PageMode.get(request).respectAnonPerms);
 		//Set roles = conPerAPI.getPublishRoles();
 		if(!canUserPublishContentlet){
 			canUserPublishContentlet = conPerAPI.doesRoleHavePermission(structure, PermissionAPI.PERMISSION_PUBLISH,com.dotmarketing.business.APILocator.getRoleAPI().loadCMSOwnerRole());
@@ -176,15 +176,15 @@
 		}
 	}
 
-	boolean canEditAsset = conPerAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT_PERMISSIONS, user);
+	boolean canEditAsset = conPerAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT_PERMISSIONS, user, PageMode.get(request).respectAnonPerms);
 	final LayoutAPI layoutAPI = APILocator.getLayoutAPI();
     boolean canSeeRules = layoutAPI.doesUserHaveAccessToPortlet("rules", user)
             && conPerAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_USE, user, PageMode.get(request).respectAnonPerms)
-            && conPerAPI.doesUserHavePermissions(contentlet.getParentPermissionable(), "RULES: " + PermissionAPI.PERMISSION_USE, user);
+            && conPerAPI.doesUserHavePermissions(contentlet.getParentPermissionable(), "RULES: " + PermissionAPI.PERMISSION_USE, user, PageMode.get(request).respectAnonPerms);
     
     boolean hasViewPermision = layoutAPI.doesUserHaveAccessToPortlet("permissions", user)
             && conPerAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_USE, user, PageMode.get(request).respectAnonPerms)
-            && conPerAPI.doesUserHavePermissions(contentlet.getParentPermissionable(), "PERMISSIONS: " + PermissionAPI.PERMISSION_USE, user);
+            && conPerAPI.doesUserHavePermissions(contentlet.getParentPermissionable(), "PERMISSIONS: " + PermissionAPI.PERMISSION_USE, user, PageMode.get(request).respectAnonPerms);
 
     Boolean isContentEditable = (Boolean) request.getAttribute(com.dotmarketing.util.WebKeys.CONTENT_EDITABLE);
 	isContentEditable = isContentEditable != null ? isContentEditable : false;
@@ -431,7 +431,7 @@
                                 Host host = APILocator.getHostAPI().findSystemHost();
 
                                 String hostId = host.getIdentifier();
-                                if (!conPerAPI.doesUserHavePermission(host, PermissionAPI.PERMISSION_READ, user)) {
+                                if (!conPerAPI.doesUserHavePermission(host, PermissionAPI.PERMISSION_READ, user, PageMode.get(request).respectAnonPerms)) {
                                     hostId = (String) session.getAttribute(com.dotmarketing.util.WebKeys.CMS_SELECTED_HOST_ID);
                                 }
 


### PR DESCRIPTION
… creates a contentlet in a non-default language returns `true` for the `respectFrontendRoles` flag, which is not correct. Jonathan and I went through the code and compared it with the `PortalRequestProcessor` class which explictly sets the Page Mode. We believe that's required in this case as well. Also, several calls to the Permission API were missing their `PageMode.get(request).respectAnonPerms)` flag.