### PR TITLE
#19527 changing es index.max_result_window to 100000

### DIFF
--- a/dotCMS/src/main/resources/es-content-settings.json
+++ b/dotCMS/src/main/resources/es-content-settings.json
@@ -28,5 +28,7 @@
 
     "index.mapping.total_fields.limit" : "10000",
 
-    "index.mapping.nested_fields.limit" : "10000"
+    "index.mapping.nested_fields.limit" : "10000",
+
+	"index.max_result_window": "100000"
 }


### PR DESCRIPTION
This change should lift the 10000 items limitation established by default on ES
