### PR TITLE
#19902 reordering the welcome list in order to take precedence to the…

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/web.xml
+++ b/dotCMS/src/main/webapp/WEB-INF/web.xml
@@ -572,8 +572,8 @@
 	</mime-mapping>
 	
 	<welcome-file-list>
-		<welcome-file>index.html</welcome-file>
 		<welcome-file>index.jsp</welcome-file>
+		<welcome-file>index.html</welcome-file>
 	</welcome-file-list>
 	
 	<error-page>


### PR DESCRIPTION
#19902 reordering the welcome list in order to take precedence to the index.jsp instead of the index.html, it is to be able to wrap html resources into a jsp resources and provide stuff such as cache invalidation headers

for instance
```
   <%
   response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
response.setHeader("Pragma", "no-cache");
response.setDateHeader("Expires", 0);
   %>
<%@ include file = "index.html" %>
```