### PR TITLE
#19926 adding fix to avoid null type on the Nav Result and Wrappers

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResult.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResult.java
@@ -364,13 +364,23 @@ public class NavResult implements Iterable<NavResult>, Permissionable, Serializa
     }
 
     public String getEnclosingPermissionClassName() {
-        if (type.equals("htmlpage"))
+
+        // we can not use the this.type b/c the nav could be wrapping, so the getType will use the wrapper instead of the var
+        final  String internalType = this.getType();
+
+        if ("htmlpage".equals(internalType)) {
             return IHTMLPage.class.getCanonicalName();
-        if (type.equals("link"))
+        }
+
+        if ("link".equals(internalType)) {
             return Link.class.getCanonicalName();
-        if (type.equals("folder"))
+        }
+
+        if ("folder".equals(internalType)) {
             return Folder.class.getCanonicalName();
-        throw new IllegalStateException("unknow internal type " + type); // we shouldn't reach this
+        }
+
+        throw new IllegalStateException("unknown internal type " + type); // we shouldn't reach this
                                                                          // point
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResult.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResult.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.velocity.tools.view.tools.ViewRenderTool;
 
 import com.liferay.portal.model.User;
@@ -78,6 +79,22 @@ public class NavResult implements Iterable<NavResult>, Permissionable, Serializa
 
     
         sysuser = APILocator.systemUser();
+
+    }
+
+    @VisibleForTesting
+    protected NavResult(final String parent, final String hostId, final String folderId, final Long languageId, final User user) {
+        this.hostId = hostId;
+        this.folderId = folderId;
+        this.parent = parent;
+        this.languageId = languageId;
+
+
+        title = href = "";
+        order = 0;
+
+
+        sysuser = user;
 
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResultHydrated.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResultHydrated.java
@@ -32,6 +32,7 @@ public final class NavResultHydrated extends NavResult{
         super(navResult.getUnhydratedNavResult());
         this.navResult = navResult.getUnhydratedNavResult();
         this.context = context;
+        this.setType(navResult.getType());
     }
     @Override
     @JSONIgnore

--- a/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResultTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResultTest.java
@@ -31,7 +31,7 @@ public class NavResultTest extends UnitTestBase {
     public void getEnclosingPermissionClassName_on_unknown_type() throws DotDataException {
 
         final NavResult navResult = new NavResult("", "", "", 1l);
-        navResult.setType("unknown"); 
+        navResult.setType("unknown");
         navResult.getEnclosingPermissionClassName();
     }
 

--- a/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResultTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResultTest.java
@@ -19,7 +19,7 @@ public class NavResultTest extends UnitTestBase {
     @Test(expected = IllegalStateException.class)
     public void getEnclosingPermissionClassName_on_null_type() throws DotDataException {
 
-        new NavResult("", "", "", 1l).getEnclosingPermissionClassName();
+        new NavResult("", "", "", 1l, null).getEnclosingPermissionClassName();
     }
 
     /**
@@ -30,7 +30,7 @@ public class NavResultTest extends UnitTestBase {
     @Test(expected = IllegalStateException.class)
     public void getEnclosingPermissionClassName_on_unknown_type() throws DotDataException {
 
-        final NavResult navResult = new NavResult("", "", "", 1l);
+        final NavResult navResult = new NavResult("", "", "", 1l, null);
         navResult.setType("unknown");
         navResult.getEnclosingPermissionClassName();
     }
@@ -43,7 +43,7 @@ public class NavResultTest extends UnitTestBase {
     @Test()
     public void getEnclosingPermissionClassName_on_htmlpage_type() throws DotDataException {
 
-        final NavResult navResult = new NavResult("", "", "", 1l);
+        final NavResult navResult = new NavResult("", "", "", 1l, null);
         navResult.setType("htmlpage");
         Assert.assertEquals(IHTMLPage.class.getCanonicalName(), navResult.getEnclosingPermissionClassName());
     }
@@ -56,7 +56,7 @@ public class NavResultTest extends UnitTestBase {
     @Test()
     public void getEnclosingPermissionClassName_on_link_type() throws DotDataException {
 
-        final NavResult navResult = new NavResult("", "", "", 1l);
+        final NavResult navResult = new NavResult("", "", "", 1l, null);
         navResult.setType("link");
         Assert.assertEquals(Link.class.getCanonicalName(), navResult.getEnclosingPermissionClassName());
     }
@@ -69,7 +69,7 @@ public class NavResultTest extends UnitTestBase {
     @Test()
     public void getEnclosingPermissionClassName_on_folder_type() throws DotDataException {
 
-        final NavResult navResult = new NavResult("", "", "", 1l);
+        final NavResult navResult = new NavResult("", "", "", 1l, null);
         navResult.setType("folder");
         Assert.assertEquals(Folder.class.getCanonicalName(), navResult.getEnclosingPermissionClassName());
     }

--- a/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResultTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResultTest.java
@@ -1,0 +1,2 @@
+package com.dotcms.rendering.velocity.viewtools.navigation;public class NavResult {
+}

--- a/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResultTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/navigation/NavResultTest.java
@@ -1,2 +1,76 @@
-package com.dotcms.rendering.velocity.viewtools.navigation;public class NavResult {
+package com.dotcms.rendering.velocity.viewtools.navigation;
+
+import com.dotcms.UnitTestBase;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
+import com.dotmarketing.portlets.links.model.Link;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NavResultTest extends UnitTestBase {
+
+
+    /**
+     * Method to test: getEnclosingPermissionClassName
+     * Given Scenario: the type attribute is null
+     * ExpectedResult: should throw an IllegalStateException
+     */
+    @Test(expected = IllegalStateException.class)
+    public void getEnclosingPermissionClassName_on_null_type() throws DotDataException {
+
+        new NavResult("", "", "", 1l).getEnclosingPermissionClassName();
+    }
+
+    /**
+     * Method to test: getEnclosingPermissionClassName
+     * Given Scenario: the type attribute is unknown
+     * ExpectedResult: should throw an IllegalStateException
+     */
+    @Test(expected = IllegalStateException.class)
+    public void getEnclosingPermissionClassName_on_unknown_type() throws DotDataException {
+
+        final NavResult navResult = new NavResult("", "", "", 1l);
+        navResult.setType("unknown"); 
+        navResult.getEnclosingPermissionClassName();
+    }
+
+    /**
+     * Method to test: getEnclosingPermissionClassName
+     * Given Scenario: the type attribute is htmlpage
+     * ExpectedResult: should IHTMLPage.class.getCanonicalName()
+     */
+    @Test()
+    public void getEnclosingPermissionClassName_on_htmlpage_type() throws DotDataException {
+
+        final NavResult navResult = new NavResult("", "", "", 1l);
+        navResult.setType("htmlpage");
+        Assert.assertEquals(IHTMLPage.class.getCanonicalName(), navResult.getEnclosingPermissionClassName());
+    }
+
+    /**
+     * Method to test: getEnclosingPermissionClassName
+     * Given Scenario: the type attribute is link
+     * ExpectedResult: should IHTMLPage.class.getCanonicalName()
+     */
+    @Test()
+    public void getEnclosingPermissionClassName_on_link_type() throws DotDataException {
+
+        final NavResult navResult = new NavResult("", "", "", 1l);
+        navResult.setType("link");
+        Assert.assertEquals(Link.class.getCanonicalName(), navResult.getEnclosingPermissionClassName());
+    }
+
+    /**
+     * Method to test: getEnclosingPermissionClassName
+     * Given Scenario: the type attribute is folder
+     * ExpectedResult: should IHTMLPage.class.getCanonicalName()
+     */
+    @Test()
+    public void getEnclosingPermissionClassName_on_folder_type() throws DotDataException {
+
+        final NavResult navResult = new NavResult("", "", "", 1l);
+        navResult.setType("folder");
+        Assert.assertEquals(Folder.class.getCanonicalName(), navResult.getEnclosingPermissionClassName());
+    }
 }


### PR DESCRIPTION
Current the NavResultHydrated wraps the NavResult, but leaves the type on the NavResultHydrated as null.
Later a method uses the property directly instead using the getType method (which is the one that uses the wrapped object to return the type) finally it becomes to null throws a NPE
These changes avoid the issue