### PR TITLE
Issue 19916

### DIFF
--- a/dotCMS/src/curl-test/ForgotPasswordResource.postman_collection.json
+++ b/dotCMS/src/curl-test/ForgotPasswordResource.postman_collection.json
@@ -1,0 +1,91 @@
+{
+	"info": {
+		"_postman_id": "f8d834bf-8464-494d-9eb8-9a4ac98f93ed",
+		"name": "ForgotPasswordResource",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "ForgotPassword Email Not Valid BadRequest",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Email Not Valid\", function () {",
+							"    pm.response.to.have.status(400);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"userId\":\"1\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{serverURL}}/api/v1/forgotpassword",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"forgotpassword"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "ForgotPassword Success",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Send email to reset password sucessfully\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"userId\":\"user@user.com\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{serverURL}}/api/v1/forgotpassword",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"forgotpassword"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ForgotPasswordForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ForgotPasswordForm.java
@@ -10,7 +10,6 @@ import com.dotcms.rest.api.Validated;
 public class ForgotPasswordForm extends Validated {
 
     @NotNull
-    @Length(min = 2, max = 100)
     private final String userId;
 
     public String getUserId() {

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/authentication/ForgotPasswordResourceTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/authentication/ForgotPasswordResourceTest.java
@@ -62,19 +62,6 @@ public class ForgotPasswordResourceTest extends UnitTestBase {
     }
 
     @Test
-    public void testWrongParameter() throws JSONException{
-
-        try {
-            final ForgotPasswordForm forgotPasswordForm =
-                    new ForgotPasswordForm.Builder().userId("").build();
-
-            fail ("Should throw a ValidationException");
-        } catch (Exception e) {
-            // quiet
-        }
-    }
-
-    @Test
     public void testNoSuchUserExceptionExposingNoData() throws Exception {
 
         final HttpServletRequest request  = mock(HttpServletRequest.class);


### PR DESCRIPTION
Removing length validation b/c is throwing the error in a diff format for the UI to catch it.
Regardless of this, an error is thrown:

```
POST /api/v1/forgotpassword
{
    "userId":"1"
}

{
    "entity": "",
    "errors": [
        {
            "errorCode": "please-enter-a-valid-email-address",
            "fieldName": null,
            "message": "Please enter a valid Email Address."
        }
    ],
    "i18nMessagesMap": {},
    "messages": [],
    "permissions": []
}
```