### PR TITLE
Avoid reindexing before executing upgrade tasks

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -296,6 +296,17 @@ public class ReindexThread {
     }
 
     /**
+     * Gets the running thread if any, and cancels it.
+     */
+
+    public static void cancelThread(){
+        if (instance != null && instance.threadRunning != null) {
+            instance.threadRunning.cancel(true);
+            instance = null;
+        }
+    }
+
+    /**
      * This instance is intended to already be started. It will try to restart the thread if instance is
      * null.
      */

--- a/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
@@ -180,6 +180,7 @@ public class StartupTasksExecutor {
         String name = null;
 
 
+        ReindexThread.cancelThread();
         for (Class<?> c : TaskLocatorUtil.getStartupRunOnceTaskClasses()) {
             name = c.getCanonicalName();
             name = name.substring(name.lastIndexOf(".") + 1);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
@@ -180,7 +180,6 @@ public class StartupTasksExecutor {
         String name = null;
 
 
-        ReindexThread.pause();
         for (Class<?> c : TaskLocatorUtil.getStartupRunOnceTaskClasses()) {
             name = c.getCanonicalName();
             name = name.substring(name.lastIndexOf(".") + 1);


### PR DESCRIPTION
Right before running the upgrade tasks, there was a call to `ReindexThread.pause();` which was having the unintended consequences of firing the Reindex thread, which internally executed some db query sorted by a column that didn't exist at that point of the execution (the column is created in one of the upgrade tasks). This was due to the reason that the `pause` internally calls the `getInstance()` which in case that the instance is null, creates one and then starts the thread. 

The new `cancelThread` method neither creates a new instance of ReindexThread if null, nor starts the thread, it just cancels it if it's running.