### PR TITLE
#19951 Supporting the time zone when adding a contentlet

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -5917,11 +5917,23 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
     }
 
+    private static final String[] DEFAULT_DATE_FORMATS = new String[] {
+            // time zone
+            "yyyy-MM-dd HH:mm:ss z Z", "d-MMM-yy z Z", "dd-MMM-yyyy z Z", "MM/dd/yy HH:mm:ss z Z",
+            "MM/dd/yy hh:mm:ss z Z", "MMMM dd, yyyy z Z", "M/d/y z Z", "MM/dd/yyyy z Z", "yyyy-MM-dd z Z",
+
+            "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd HH:mm", "d-MMM-yy", "MMM-yy", "MMMM-yy", "d-MMM", "dd-MMM-yyyy",
+            "MM/dd/yyyy hh:mm:ss aa", "MM/dd/yyyy hh:mm aa", "MM/dd/yy HH:mm:ss", "MM/dd/yy HH:mm:ss", "MM/dd/yy HH:mm",
+            "MM/dd/yy hh:mm:ss aa", "MM/dd/yy hh:mm:ss", "MM/dd/yyyy HH:mm:ss", "MM/dd/yyyy HH:mm", "MMMM dd, yyyy",
+            "M/d/y", "M/d", "EEEE, MMMM dd, yyyy", "MM/dd/yyyy",
+            "hh:mm:ss aa", "hh:mm aa", "HH:mm:ss", "HH:mm", "yyyy-MM-dd"
+    };
+
     @Override
     public void setContentletProperty(Contentlet contentlet,Field field, Object value)throws DotContentletStateException {
-        String[] dateFormats = new String[] { "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd HH:mm", "d-MMM-yy", "MMM-yy", "MMMM-yy", "d-MMM", "dd-MMM-yyyy", "MM/dd/yyyy hh:mm:ss aa", "MM/dd/yyyy hh:mm aa", "MM/dd/yy HH:mm:ss", "MM/dd/yy HH:mm:ss", "MM/dd/yy HH:mm", "MM/dd/yy hh:mm:ss aa", "MM/dd/yy hh:mm:ss",
-                "MM/dd/yyyy HH:mm:ss", "MM/dd/yyyy HH:mm", "MMMM dd, yyyy", "M/d/y", "M/d", "EEEE, MMMM dd, yyyy", "MM/dd/yyyy",
-                "hh:mm:ss aa", "hh:mm aa", "HH:mm:ss", "HH:mm", "yyyy-MM-dd"};
+
+        final String[] dateFormats = Config.getStringArrayProperty("dotcontentlet_dateformats", DEFAULT_DATE_FORMATS);
+
         if(contentlet == null){
             throw new DotContentletValidationException("The contentlet must not be null");
         }

--- a/dotCMS/src/main/java/com/dotmarketing/util/DateUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/DateUtil.java
@@ -225,7 +225,7 @@ public class DateUtil {
 				break;
 			} catch (java.text.ParseException e) {
 				// quiet
-				e.printStackTrace();
+				//e.printStackTrace();
 			}
 		}
 

--- a/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
@@ -391,4 +391,70 @@ public class DateUtilTest extends UnitTestBase {
         assertEquals("Month should be Feb", Calendar.FEBRUARY, date1.getMonth());
         assertEquals("Day should be 4", 4, date1.getDate());
     }
+
+    /**
+     * Method to test: convert Date
+     * Given Scenario: Passing a Date with a specific time zone.
+     * ExpectedResult: The date is converted using the desired time zone.
+     *
+     */
+    @Test()
+    public void test_time_zone() throws ParseException {
+
+        final String   easternUSTimeZone = "US/Eastern";
+        final String   westernUSTimeZone = "US/Western";
+        final TimeZone timeZone      = TimeZone.getTimeZone(easternUSTimeZone);
+        final TimeZone defaultTimeZone =  TimeZone.getDefault();
+
+        final Date date1 = DateUtil.convertDate("2015-02-04 11", timeZone, "yyyy-MM-dd HH");
+
+        assertNotNull(date1);
+        assertEquals("Year should be 2015", 115,date1.getYear());
+        assertEquals("Month should be Feb", Calendar.FEBRUARY, date1.getMonth());
+        assertEquals("Day should be 4", 4, date1.getDate());
+
+        if (timeZone.getRawOffset() != date1.getTimezoneOffset()) {
+            assertNotEquals("If the date is not in the same time zone, hour should be diff",
+                    11, date1.getHours());
+            assertEquals("If the date is not in the same time zone, hour should be diff",
+                    11, date1.toInstant().atZone(timeZone.toZoneId()).getHour());
+
+            final GregorianCalendar calendar = new GregorianCalendar();
+            calendar.setTime(date1);
+            assertEquals("Default time zone and date time zome should be the same",
+                    defaultTimeZone.getRawOffset(), calendar.getTimeZone().getRawOffset());
+        }
+    }
+
+    /**
+     * Method to test: convert Date
+     * Given Scenario: Passing a Date with a specific time zone into the pattern
+     * ExpectedResult: The date is converted using the desired time zone.
+     *
+     */
+    @Test()
+    public void test_time_zone_string() throws ParseException {
+
+        final String   gmt12TimeZone   = "GMT+1400";
+        final TimeZone timeZone        = TimeZone.getTimeZone(gmt12TimeZone);
+        final TimeZone defaultTimeZone =  TimeZone.getDefault();
+
+        final Date date1 = DateUtil.convertDate("2015-02-04 11 GMT +1400", defaultTimeZone, "yyyy-MM-dd HH z Z");
+
+        assertNotNull(date1);
+        assertEquals("Year should be 2015", 115,date1.getYear());
+        assertEquals("Month should be Feb", Calendar.FEBRUARY, date1.getMonth());
+
+        if (timeZone.getRawOffset() != date1.getTimezoneOffset()) {
+            assertNotEquals("If the date is not in the same time zone, hour should be diff",
+                    11, date1.getHours());
+            assertEquals("If the date is not in the same time zone, hour should be diff",
+                    11, date1.toInstant().atZone(timeZone.toZoneId()).getHour());
+
+            final GregorianCalendar calendar = new GregorianCalendar();
+            calendar.setTime(date1);
+            assertEquals("Default time zone and date time zome should be the same",
+                    defaultTimeZone.getRawOffset(), calendar.getTimeZone().getRawOffset());
+        }
+    }
 }

--- a/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
@@ -416,7 +416,7 @@ public class DateUtilTest extends UnitTestBase {
         if (timeZone.getRawOffset() != date1.getTimezoneOffset()) {
             assertNotEquals("If the date is not in the same time zone, hour should be diff",
                     11, date1.getHours());
-            assertEquals("If the date is not in the same time zone, hour should be diff",
+            assertEquals("If the date is in the same time zone, hour should be the same",
                     11, date1.toInstant().atZone(timeZone.toZoneId()).getHour());
 
             final GregorianCalendar calendar = new GregorianCalendar();
@@ -448,7 +448,7 @@ public class DateUtilTest extends UnitTestBase {
         if (timeZone.getRawOffset() != date1.getTimezoneOffset()) {
             assertNotEquals("If the date is not in the same time zone, hour should be diff",
                     11, date1.getHours());
-            assertEquals("If the date is not in the same time zone, hour should be diff",
+            assertEquals("If the date is in the same time zone, hour should be same",
                     11, date1.toInstant().atZone(timeZone.toZoneId()).getHour());
 
             final GregorianCalendar calendar = new GregorianCalendar();


### PR DESCRIPTION
Before this change if a clients PUT a contentlet to the rest api with Time Zone such as 

```
<publishDate>2021-02-10 13:17:36 GMT +1400</publishDate>
```

Won't work.

Also, adding to the formatter the company default time zone, if not time zone set in the pattern