### PR TITLE
#19916 change response to forbidden

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/authentication/ResetPasswordResourceIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/authentication/ResetPasswordResourceIntegrationTest.java
@@ -113,7 +113,7 @@ public class ResetPasswordResourceIntegrationTest{
         //Call Resource
         final Response responseResource = resource.resetPassword(getHttpRequest(),getResetPasswordForm("n3wPa$$w0rD",token));
         //Check that the response is 401
-        Assert.assertEquals(Status.UNAUTHORIZED.getStatusCode(),responseResource.getStatus());
+        Assert.assertEquals(Status.FORBIDDEN.getStatusCode(),responseResource.getStatus());
         final ResponseEntityView responseEntityView = ResponseEntityView.class.cast(responseResource.getEntity());
         Assert.assertEquals("reset-password-token-expired",responseEntityView.getErrors().get(0).getErrorCode());
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ResetPasswordResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ResetPasswordResource.java
@@ -1,7 +1,6 @@
 package com.dotcms.rest.api.v1.authentication;
 
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.util.UtilMethods;
 import java.util.Locale;
 
 import java.util.Optional;
@@ -14,6 +13,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import org.glassfish.jersey.server.JSONP;
 import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.annotation.InitRequestRequired;
@@ -91,7 +91,7 @@ public class ResetPasswordResource {
             	SecurityLogger.logInfo(ResetPasswordResource.class,
             			"Error resetting password. "
             	        + this.responseUtil.getFormattedMessage(null,"reset-password-token-expired"));
-                res = this.responseUtil.getErrorResponse(request, Response.Status.UNAUTHORIZED, locale, null,
+                res = this.responseUtil.getErrorResponse(request, Status.FORBIDDEN, locale, null,
                         "reset-password-token-expired");
             }else{
             	SecurityLogger.logInfo(ResetPasswordResource.class,


### PR DESCRIPTION
Change the response to FORBIDDEN instead of UNAUTHORIZED b/c UI has an auto-redirect to the login screen if the response is 401, so the user is unable to see the error in the UI.