### PR TITLE
#19991 Avoid sen session expired notification after logout

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/api/system/event/SystemEvent.java
+++ b/dotCMS/src/main/java/com/dotcms/api/system/event/SystemEvent.java
@@ -160,7 +160,7 @@ public class SystemEvent implements Serializable {
 		}
 		SystemEvent other = (SystemEvent) obj;
 		if (!UtilMethods.isSet(other.id)) {
-			return false;
+			return this.event == other.event;
 		}
 		if (!this.id.equalsIgnoreCase(other.id)) {
 			return false;

--- a/dotCMS/src/main/java/com/dotcms/cms/login/LoginServiceAPIFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/cms/login/LoginServiceAPIFactory.java
@@ -62,9 +62,10 @@ import com.liferay.util.InstancePool;
  */
 public class LoginServiceAPIFactory implements Serializable {
 
-     private static final String BACKEND_LOGIN = "backendLogin";
+    private static final String BACKEND_LOGIN = "backendLogin";
+    public static final String LOG_OUT_ATTRIBUTE = "LOG_OUT";
 
-	/**
+    /**
 	 * Used to keep the instance of the {@link LoginServiceAPI}. Should be volatile
 	 * to avoid thread-caching
 	 */
@@ -207,6 +208,7 @@ public class LoginServiceAPIFactory implements Serializable {
                 }
 
                 log.debug("Logout - Invalidating http session...");
+                session.setAttribute(LOG_OUT_ATTRIBUTE, true);
                 session.invalidate();
 
                 log.debug("Logout - Events Processor Post Logout events.");

--- a/dotCMS/src/main/java/com/dotcms/listeners/SessionMonitor.java
+++ b/dotCMS/src/main/java/com/dotcms/listeners/SessionMonitor.java
@@ -16,6 +16,8 @@ import javax.servlet.http.HttpSessionBindingEvent;
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
 
+import static com.dotcms.cms.login.LoginServiceAPIFactory.LOG_OUT_ATTRIBUTE;
+
 /**
  * Listener that keeps track of logged in users by monitoring for USER_ID
  * session attribute addition.
@@ -115,8 +117,14 @@ public class SessionMonitor implements ServletRequestListener,
 
                 Logger.debug(this, "Triggering a session destroyed event");
 
-                this.systemEventsAPI.push(new SystemEvent
-                        (SystemEventType.SESSION_DESTROYED, UserSessionPayloadBuilder.build(userId, sessionId)));
+                final Boolean isLogout = event.getSession().getAttribute(LOG_OUT_ATTRIBUTE) != null ?
+                        Boolean.parseBoolean(event.getSession().getAttribute(LOG_OUT_ATTRIBUTE).toString()) :
+                        false;
+
+                if (!isLogout) {
+                    this.systemEventsAPI.push(new SystemEvent
+                            (SystemEventType.SESSION_DESTROYED, UserSessionPayloadBuilder.build(userId, sessionId)));
+                }
             } catch (DotDataException e) {
 
                 Logger.debug(this, "Could not sent the session destroyed event" + e.getMessage(), e);

--- a/dotCMS/src/test/java/com/dotcms/listeners/SessionMonitorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/listeners/SessionMonitorTest.java
@@ -1,0 +1,68 @@
+package com.dotcms.listeners;
+
+
+import com.dotcms.api.system.event.SystemEvent;
+import com.dotcms.api.system.event.SystemEventType;
+import com.dotcms.api.system.event.SystemEventsAPI;
+import com.dotcms.api.system.event.UserSessionPayloadBuilder;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.portlets.rules.model.ConditionGroup;
+import com.liferay.portal.model.User;
+import org.junit.Test;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+
+import static com.dotcms.cms.login.LoginServiceAPIFactory.LOG_OUT_ATTRIBUTE;
+import static org.mockito.Mockito.*;
+
+public class SessionMonitorTest {
+
+    /**
+     * Method to Test: {@link SessionMonitor#sessionDestroyed(HttpSessionEvent)}
+     * When: The session expired
+     * Should: Send a {@link SystemEventType#SESSION_DESTROYED} notification
+     */
+    @Test
+    public void testSessionDestroyedWithoutLogout() throws DotDataException {
+        final HttpSession httpSession = mock(HttpSession.class);
+        when(httpSession.getAttribute("USER_ID")).thenReturn("user_id");
+        when(httpSession.getId()).thenReturn("session_id");
+
+        final HttpSessionEvent event =  mock(HttpSessionEvent.class);
+        when(event.getSession()).thenReturn(httpSession);
+
+        final SystemEventsAPI systemEventsAPI = mock(SystemEventsAPI.class);
+
+        final SessionMonitor sessionMonitor =  new SessionMonitor(systemEventsAPI);
+        sessionMonitor.sessionDestroyed(event);
+
+        final SystemEvent systemEvent = new SystemEvent
+                (SystemEventType.SESSION_DESTROYED, UserSessionPayloadBuilder.build("user_id", "session_id"));
+        verify(systemEventsAPI).push(systemEvent);
+
+    }
+
+    /**
+     * Method to Test: {@link SessionMonitor#sessionDestroyed(HttpSessionEvent)}
+     * When: The session expired after call the logout
+     * Should: Not send a {@link SystemEventType#SESSION_DESTROYED} notification
+     */
+    @Test
+    public void testSessionDestroyedWithLogout() throws DotDataException {
+        final HttpSession httpSession = mock(HttpSession.class);
+        when(httpSession.getAttribute("USER_ID")).thenReturn("user_id");
+        when(httpSession.getId()).thenReturn("session_id");
+        when(httpSession.getAttribute(LOG_OUT_ATTRIBUTE)).thenReturn(true);
+
+        final HttpSessionEvent event =  mock(HttpSessionEvent.class);
+        when(event.getSession()).thenReturn(httpSession);
+
+        final SystemEventsAPI systemEventsAPI = mock(SystemEventsAPI.class);
+
+        final SessionMonitor sessionMonitor =  new SessionMonitor(systemEventsAPI);
+        sessionMonitor.sessionDestroyed(event);
+
+        verify(systemEventsAPI, never()).push(any());
+    }
+}


### PR DESCRIPTION
When a logout is done and a session is invalidate the the SessionMonitor send a notification to UI, this cause that the AutoLoginFilter try to login again, so with this change I am avoiding to  send a SystemEventType.SESSION_DESTROYED when the session if close after a Logout event.

The SystemEventType.SESSION_DESTROYED is going to be send just when the HttpSession expired by timeout