### PR TITLE
#19597 Consider license when using routes to edit a piece of content

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeAPIImplTest.java
@@ -93,6 +93,7 @@ import java.io.ObjectOutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -2190,7 +2191,7 @@ public class ContentTypeAPIImplTest extends ContentTypeBaseTest {
 	}
 
 	/**
-	 * Method to rest: {@link ContentTypeAPI#findAllRespectingLicense()}
+	 * Method to test: {@link ContentTypeAPI#findAllRespectingLicense()}
 	 * Given scenario: No EE license
 	 * Expected result: {@link EnterpriseType}s not included in returned List
 	 */
@@ -2204,7 +2205,7 @@ public class ContentTypeAPIImplTest extends ContentTypeBaseTest {
 	}
 
 	/**
-	 * Method to rest: {@link ContentTypeAPI#findAllRespectingLicense()}
+	 * Method to test: {@link ContentTypeAPI#findAllRespectingLicense()}
 	 * Given scenario: Valid EE license
 	 * Expected result: {@link EnterpriseType}s included in returned List
 	 */
@@ -2214,4 +2215,44 @@ public class ContentTypeAPIImplTest extends ContentTypeBaseTest {
 				.stream().noneMatch((type) -> type instanceof EnterpriseType));
 
 	}
+
+    /**
+     * Method to test: {@link ContentTypeAPI#isContentTypeAllowed(ContentType)}
+     * Given scenario: The method is tested for each {@link BaseContentType} using an enterprise license
+     * Expected result: The method should return true
+     */
+	@Test
+	public void testIsContentTypeAllowedReturnsTrue(){
+        assertTrue(Arrays.asList(BaseContentType.values()).stream()
+                .filter(type -> type != BaseContentType.ANY).allMatch(
+                        type -> {
+                            try {
+                                return APILocator.getContentTypeAPI(APILocator.systemUser())
+                                        .isContentTypeAllowed(
+                                                new ContentTypeDataGen().baseContentType(type)
+                                                        .next());
+                            } catch (Exception e) {
+                                return false;
+                            }
+                        }));
+    }
+
+    /**
+     * Method to test: {@link ContentTypeAPI#isContentTypeAllowed(ContentType)}
+     * Given scenario: The method is invoked without license using {@link BaseContentType#FORM} and {@link BaseContentType#PERSONA}
+     * Expected result: The method should return false
+     * @throws Exception
+     */
+    @Test
+    public void testIsContentTypeAllowedReturnsFalse() throws Exception {
+        runNoLicense(() -> {
+            assertFalse(APILocator.getContentTypeAPI(APILocator.systemUser())
+                    .isContentTypeAllowed(new ContentTypeDataGen()
+                            .baseContentType(BaseContentType.PERSONA).nextPersisted()));
+
+            assertFalse(APILocator.getContentTypeAPI(APILocator.systemUser())
+                    .isContentTypeAllowed(new ContentTypeDataGen()
+                            .baseContentType(BaseContentType.FORM).nextPersisted()));
+        });
+    }
 }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPI.java
@@ -120,8 +120,7 @@ public interface ContentTypeAPI {
 
   /**
    * Finds all the Content Types in the system, orders it according the given column.
-   * 
-   * @param type Base Content Type that will be search
+   *
    * @param orderBy Specifies an order criteria for the results
    * @return List of Content Types Objects
    * @throws DotDataException Error occurred when performing the action.
@@ -307,4 +306,12 @@ public interface ContentTypeAPI {
    */
   void unlinkPageFromContentType(ContentType contentType)
           throws DotSecurityException, DotDataException;
+
+    /**
+     * Given a content type, verifies if the content type can be used considering the {@link LicenseLevel}.
+     * If the {@link LicenseLevel} is Community, only the content types that are not an {@link com.dotcms.contenttype.model.type.EnterpriseType} will be allowed
+     * @param contentType
+     * @return
+     */
+    boolean isContentTypeAllowed(ContentType contentType);
 }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPIImpl.java
@@ -6,7 +6,6 @@ import com.dotcms.api.system.event.SystemEventType;
 import com.dotcms.api.system.event.Visibility;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
-import com.dotcms.concurrent.DotConcurrentFactory;
 import com.dotcms.contenttype.exception.NotFoundInDbException;
 import com.dotcms.contenttype.model.event.ContentTypeDeletedEvent;
 import com.dotcms.contenttype.model.event.ContentTypeSavedEvent;
@@ -20,6 +19,7 @@ import com.dotcms.contenttype.model.type.EnterpriseType;
 import com.dotcms.contenttype.model.type.UrlMapable;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
+import com.dotcms.enterprise.license.LicenseManager;
 import com.dotcms.exception.BaseRuntimeInternationalizationException;
 import com.google.common.collect.ImmutableList;
 import com.dotcms.system.event.local.business.LocalSystemEventsAPI;
@@ -612,4 +612,10 @@ public class ContentTypeAPIImpl implements ContentTypeAPI {
             ContentTypeBuilder.builder(contentType).urlMapPattern(null).detailPage(null);
     save(builder.build());
   }
+
+    @Override
+    public boolean isContentTypeAllowed(ContentType contentType) {
+        return LicenseManager.getInstance().isEnterprise() || !BaseContentType
+                .getEnterpriseBaseTypes().contains(contentType.baseType());
+    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/EditContentletAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/EditContentletAction.java
@@ -15,6 +15,7 @@ import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.field.TimeField;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.transform.contenttype.ContentTypeTransformer;
 import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotcms.enterprise.license.LicenseManager;
 import com.dotcms.notifications.bean.NotificationLevel;
@@ -1948,10 +1949,9 @@ public class EditContentletAction extends DotPortletAction implements DotPortlet
 
 			//Add the structure to the collection if not exists.
             //In case of PERSONA AND FORM, the structure will be included only if the license is enterprise
-			if(!structures.contains(structure) &&
-                    ((!structure.isPersona() && !structure.isForm()) || (
-                        LicenseManager.getInstance().isEnterprise() && (structure.isPersona()
-                                || structure.isForm())))) {
+            if (!structures.contains(structure) &&
+                    APILocator.getContentTypeAPI(user)
+                            .isContentTypeAllowed(new StructureTransformer(structure).from())) {
                     //avoid exception if the list is immutable
                     structures = new ArrayList<>(structures);
                     structures.add(structure);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
@@ -4,8 +4,10 @@ import com.dotcms.api.system.event.ContentletSystemEventUtil;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.exception.NotFoundInDbException;
+import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
+import com.dotcms.enterprise.license.LicenseManager;
 import com.dotcms.publisher.environment.bean.Environment;
 import com.dotcms.repackage.javax.portlet.WindowState;
 import com.dotcms.repackage.org.directwebremoting.WebContextFactory;
@@ -317,6 +319,13 @@ public class ContentletWebAPIImpl implements ContentletWebAPI {
 
 		// Getting the contentlets variables to work
 		Contentlet currentContentlet = (Contentlet) contentletFormData.get(WebKeys.CONTENTLET_EDIT);
+
+        if (!LicenseManager.getInstance().isEnterprise() && (BaseContentType.FORM
+                == currentContentlet.getContentType().baseType()
+                || BaseContentType.PERSONA == currentContentlet.getContentType().baseType())) {
+            SessionMessages.add(request, "message", "An enterprise license is required to perform this operation");
+            throw new DotSecurityException("An enterprise license is required to perform this operation");
+        }
 		final Map<String, Object> oldContentletMap = currentContentlet.getMap();
 		//Form doesn't always contain this value upfront. And since populateContentlet sets 0 we better set it upfront
 		contentletFormData.put(Contentlet.IDENTIFIER_KEY, currentContentlet.getIdentifier());

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
@@ -320,9 +320,7 @@ public class ContentletWebAPIImpl implements ContentletWebAPI {
 		// Getting the contentlets variables to work
 		Contentlet currentContentlet = (Contentlet) contentletFormData.get(WebKeys.CONTENTLET_EDIT);
 
-        if (!LicenseManager.getInstance().isEnterprise() && (BaseContentType.FORM
-                == currentContentlet.getContentType().baseType()
-                || BaseContentType.PERSONA == currentContentlet.getContentType().baseType())) {
+        if (!APILocator.getContentTypeAPI(user).isContentTypeAllowed(currentContentlet.getContentType())) {
             SessionMessages.add(request, "message", "An enterprise license is required to perform this operation");
             throw new DotSecurityException("An enterprise license is required to perform this operation");
         }


### PR DESCRIPTION
A validation was included to avoid saving pieces of content if the license is not set properly. It applies for Personas and Forms.