### PR TITLE
#20063 sending cookies httponly and secure

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/filters/CookieServletResponse.java
+++ b/dotCMS/src/main/java/com/dotmarketing/filters/CookieServletResponse.java
@@ -8,35 +8,51 @@ package com.dotmarketing.filters;
 
 import static com.liferay.util.CookieUtil.COOKIES_HTTP_ONLY;
 import static com.liferay.util.CookieUtil.COOKIES_SECURE_FLAG;
-
-import com.dotmarketing.util.Config;
-import com.dotmarketing.util.CookieUtil;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.CookieUtil;
 
 
 public class CookieServletResponse extends HttpServletResponseWrapper {
 
-    public CookieServletResponse(final HttpServletResponse response) {
+    
+    
+    
+    final boolean requestIsSecure;
+    
+    public CookieServletResponse(final HttpServletResponse response, final boolean secure) {
         super(response);
+        this.requestIsSecure=secure;
+    }
+    
+    public CookieServletResponse(final ServletResponse response, final boolean secure) {
+        this((HttpServletResponse) response, secure);
     }
 
-    public CookieServletResponse(final ServletResponse response) {
-        this((HttpServletResponse) response);
-    }
 
+    // prevent repeated lookups
+    final static boolean COOKIES_HTTP_ONLY_FLAG = Config.getBooleanProperty(COOKIES_HTTP_ONLY, true);
+    
+    final static boolean SEND_COOKIES_SECURE_ALWAYS = CookieUtil.ALWAYS.equals(Config.getStringProperty(COOKIES_SECURE_FLAG, CookieUtil.ALWAYS));
+    
+    final static boolean SEND_COOKIES_SECURE_WHEN_HTTPS = CookieUtil.HTTPS.equals(Config.getStringProperty(COOKIES_SECURE_FLAG, CookieUtil.HTTPS));
+    
+   
+    
     @Override
     public void addCookie(final Cookie cookie) {
 
-        if (Config.getBooleanProperty(COOKIES_HTTP_ONLY, false)) {
+        if (COOKIES_HTTP_ONLY_FLAG) {
             cookie.setHttpOnly(true);
         }
-        if ( CookieUtil.ALWAYS.equals(Config.getStringProperty(COOKIES_SECURE_FLAG, CookieUtil.HTTPS))
-                || CookieUtil.HTTPS.equals(Config.getStringProperty(COOKIES_SECURE_FLAG, CookieUtil.HTTPS)) ){
+        
+        if ( SEND_COOKIES_SECURE_ALWAYS || this.requestIsSecure && SEND_COOKIES_SECURE_WHEN_HTTPS){
             cookie.setSecure(true);
         }
+        
 
         super.addCookie(cookie);
     }

--- a/dotCMS/src/main/java/com/dotmarketing/filters/CookiesFilter.java
+++ b/dotCMS/src/main/java/com/dotmarketing/filters/CookiesFilter.java
@@ -42,7 +42,9 @@ public class CookiesFilter implements Filter {
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
 
     HttpServletRequest req = (HttpServletRequest) request;
-    HttpServletResponse res = new CookieServletResponse(response);
+    
+    boolean isSecure = req.isSecure();
+    HttpServletResponse res = new CookieServletResponse(response, isSecure);
     CookieUtil.setCookiesSecurityHeaders(req, res);
     try {
       filterChain.doFilter(req, res);

--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -709,9 +709,9 @@ PUSH_PUBLISHING_PAGE_LIMIT=25
 ## In order to set the httpOnly flag of the JSESSIONID cookie, you need to add the attribute useHttpOnly="true" 
 ## to the Context tag of the tomcat/conf/context.xml. If using different app servers/containers you can consult their documentation. 
 ## For reference see https://www.owasp.org/index.php/HttpOnly
-COOKIES_HTTP_ONLY=false
+COOKIES_HTTP_ONLY=true
 # values: never|always|https
-COOKIES_SECURE_FLAG=never
+COOKIES_SECURE_FLAG=https
 COOKIES_SESSION_COOKIE_FLAGS_MODIFIABLE=true
 
 ########################################


### PR DESCRIPTION
Correctly sets the secure cookie and also sets our default to HttpOnly