### PR TITLE
(#19993): Defaulting site host for contentlet when sending email at subaction before executing contente save subaction.

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPI.java
@@ -9,6 +9,7 @@ import com.dotmarketing.beans.WebAsset;
 import com.dotmarketing.business.Treeable;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.PaginatedArrayList;
 import com.liferay.portal.model.User;
@@ -102,6 +103,13 @@ public interface HostAPI {
 	 * Retrieves a host given its id
 	 */
 	public Host find(String id, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException;
+
+	/**
+	 * Retrieves a host given a {@link Contentlet} to resolve from there the actual host id
+	 */
+	Host find(Contentlet contentlet,
+			  User user,
+			  boolean respectFrontendRoles) throws DotDataException, DotSecurityException;
 
 	/**
 	 * Retrieves the list of all hosts in the system, that the given user has permissions to see

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
@@ -318,6 +318,19 @@ public class HostAPIImpl implements HostAPI {
         return host;
     }
 
+    @Override
+    @CloseDBIfOpened
+    public Host find(final Contentlet contentlet,
+                     final User user,
+                     final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+        return find(
+                org.apache.commons.lang3.StringUtils.defaultIfBlank(
+                        contentlet.getHost(),
+                        contentlet.getContentType().host()),
+                user,
+                respectFrontendRoles);
+    }
+
     /**
      * Retrieves the list of all hosts in the system
      * @throws DotSecurityException

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/EmailActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/EmailActionlet.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 
 import java.util.Optional;
-import javax.mail.internet.InternetAddress;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -29,6 +28,7 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.Mailer;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.VelocityUtil;
+import org.apache.commons.lang3.StringUtils;
 
 public class EmailActionlet extends WorkFlowActionlet {
 
@@ -101,8 +101,12 @@ public class EmailActionlet extends WorkFlowActionlet {
 
         try {
             // get the host of the content
-            Host host = APILocator.getHostAPI().find(processor.getContentlet().getHost(),
-                    APILocator.getUserAPI().getSystemUser(), false);
+            Host host = APILocator.getHostAPI().find(
+                    StringUtils.defaultIfBlank(
+                            processor.getContentlet().getHost(),
+                            processor.getContentlet().getContentType().host()),
+                    APILocator.getUserAPI().getSystemUser(),
+                    false);
             if (host.isSystemHost()) {
                 host = APILocator.getHostAPI().findDefaultHost(APILocator.getUserAPI().getSystemUser(), false);
             }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/EmailActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/EmailActionlet.java
@@ -102,9 +102,7 @@ public class EmailActionlet extends WorkFlowActionlet {
         try {
             // get the host of the content
             Host host = APILocator.getHostAPI().find(
-                    StringUtils.defaultIfBlank(
-                            processor.getContentlet().getHost(),
-                            processor.getContentlet().getContentType().host()),
+                    processor.getContentlet(),
                     APILocator.getUserAPI().getSystemUser(),
                     false);
             if (host.isSystemHost()) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/util/WorkflowEmailUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/util/WorkflowEmailUtil.java
@@ -61,8 +61,9 @@ public class WorkflowEmailUtil {
             }
 
             // get the host of the content
-            Host host = APILocator.getHostAPI().find(processor.getContentlet().getHost(),
-                    APILocator.getUserAPI().getSystemUser(), false);
+            Host host = APILocator
+                    .getHostAPI()
+                    .find(processor.getContentlet(), APILocator.getUserAPI().getSystemUser(), false);
             if (host.isSystemHost()) {
                 host = APILocator.getHostAPI().findDefaultHost(APILocator.getUserAPI().getSystemUser(), false);
             }


### PR DESCRIPTION
When worflow with "Send email" subaction just before "Save Content" action the contentlet has no host associated therefore throws a NPE when sending the email.
This is just some NPE checking.