### PR TITLE
Find getting started layout by name instead of id

### DIFF
--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -171,10 +171,10 @@ dependencies {
     /**** And now the libs we pull in from internal company sources - libs stored in ./plugins, ./bin, ./libs, the starter site, etc. ****/
     compile fileTree("src/main/plugins/com.dotcms.config/build/jar").include('plugin-com.dotcms.config.jar')
 
-    starter group: 'com.dotcms', name: 'starter', version: 'empty_20210305', ext: 'zip'
+    starter group: 'com.dotcms', name: 'starter', version: 'empty_20210312', ext: 'zip'
     //Uncomment this line if you want to download the starter that comes with data
-    //starter group: 'com.dotcms', name: 'starter', version: '20210305', ext: 'zip'
-    testsStarter group: 'com.dotcms', name: 'starter', version: 'empty_20210305', ext: 'zip'
+    //starter group: 'com.dotcms', name: 'starter', version: '20210312', ext: 'zip'
+    testsStarter group: 'com.dotcms', name: 'starter', version: 'empty_20210312', ext: 'zip'
 
     profiler group: 'glowroot-custom', name: 'glowroot-agent', version: '0.13.1'
     profilerDependencies group: 'glowroot-custom', name: 'collector-https-linux', version: '0.13.1'

--- a/dotCMS/src/main/java/com/dotmarketing/business/LayoutAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/LayoutAPIImpl.java
@@ -210,7 +210,7 @@ public class LayoutAPIImpl implements LayoutAPI {
 	@CloseDBIfOpened
 	@Override
     public Layout findGettingStartedLayout() {
-	    final Layout layout = Try.of(() -> findLayout(GETTING_STARTED_LAYOUT_ID)).getOrElseThrow(e->new DotRuntimeException(e));
+	    final Layout layout = Try.of(() -> findLayoutByName(GETTING_STARTED_LAYOUT_NAME)).getOrElseThrow(e->new DotRuntimeException(e));
 	    return layout.getPortletIds().isEmpty()  ? this.createGettingStartedLayout() : layout ;
     }
 	


### PR DESCRIPTION
This change fixes this issue: https://github.com/dotCMS/core/issues/19582#issuecomment-797036680

This logic has already tests coverage: https://github.com/dotCMS/core/blob/release-21.03/dotCMS/src/integration-test/java/com/dotmarketing/business/LayoutAPITest.java#L154