### PR TITLE
Issue 20098 send page mimetype if is page

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/web.xml
+++ b/dotCMS/src/main/webapp/WEB-INF/web.xml
@@ -28,6 +28,23 @@
 		<filter-class>com.dotmarketing.filters.InterceptorFilter</filter-class>
 		<async-supported>true</async-supported>
 	</filter>
+    <filter>
+        <filter-name>HttpHeaderSecurityFilter</filter-name>
+        <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
+        <async-supported>true</async-supported>
+        <init-param>
+            <param-name>hstsMaxAgeSeconds</param-name>
+            <param-value>3600</param-value>
+        </init-param>
+        <init-param>
+            <param-name>hstsIncludeSubDomains</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <init-param>
+            <param-name>antiClickJackingOption</param-name>
+            <param-value>SAMEORIGIN</param-value>
+        </init-param>
+    </filter>
 	<filter>
 		<filter-name>CookiesFilter</filter-name>
 		<filter-class>com.dotmarketing.filters.CookiesFilter</filter-class>
@@ -102,10 +119,15 @@
 		<filter-name>NormalizationFilter</filter-name>
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
+    <filter-mapping>
+        <filter-name>HttpHeaderSecurityFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 	<filter-mapping>
 		<filter-name>InterceptorFilter</filter-name>
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
+    
 	<filter-mapping>
 		<filter-name>CharsetEncodingFilter</filter-name>
 		<url-pattern>/*</url-pattern>


### PR DESCRIPTION
If the time machine is unable to parse the mimetype from a URI - which happens because we have pages with no extensions like : `/index` and `/destinations/index`, then we check if the asset is a page in the CMS and if so, send `text/html`.