### PR TITLE
dotCMS/core#20097 Upload button applying a license on Safari does not working

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsconfig/license.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsconfig/license.jsp
@@ -304,21 +304,17 @@
                 return;
             }
 
-            dojo.io.iframe.send({
-
-                form: dojo.byId("uploadPackForm"),
-                load: function(message, ioArgs) {
-                    console.log(message);
-                    licenseAdmin.refreshLayout('<%= UtilMethods.javaScriptify(LanguageUtil.get(pageContext, "licenses-uploaded") )%>');
-                },
-                error: function(error){
-                    //showDotCMSSystemMessage("ERROR:" + error,true);
-                licenseAdmin.refreshLayout('<%= UtilMethods.javaScriptify(LanguageUtil.get(pageContext, "licenses-uploaded") )%>');
-                
-                }
-            });
+            var xhr = new XMLHttpRequest();
             
-            //dojo.byId('uploadPackForm').submit();
+            xhr.open("POST", "/api/license/upload/"); 
+            
+            xhr.onload = function(event){ 	
+                console.log(event);
+                licenseAdmin.refreshLayout('<%= UtilMethods.javaScriptify(LanguageUtil.get(pageContext, "licenses-uploaded") )%>');
+            }; 
+            var formData = new FormData(document.getElementById("uploadPackForm")); 
+            xhr.send(formData);
+            
             return false;
         }
     });


### PR DESCRIPTION
When you are navigating using Safari and try to apply a EE license, the upload button is not working, is downoading the file and you are unable to apply the license.