### PR TITLE
#20164 adding a fix when the json has new lines or spaces

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/JSONToolTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/JSONToolTest.java
@@ -27,6 +27,58 @@ public class JSONToolTest extends IntegrationTestBase {
         IntegrationTestInitService.getInstance().init();
     }
 
+    private static final String DIRTY_ARRAY_JSON = "     \n\n\n[\n" +
+            "      {\n" +
+            "         \"getBundleId\":0,\n" +
+            "         \"getLocation\":\"System Bundle\",\n" +
+            "         \"getState\":32,\n" +
+            "         \"getSymbolicName\":\"org.apache.felix.framework\",\n" +
+            "         \"getVersion\":{\n" +
+            "            \"major\":5,\n" +
+            "            \"micro\":10,\n" +
+            "            \"minor\":6,\n" +
+            "            \"qualifier\":\"\"\n" +
+            "         }\n" +
+            "      },\n" +
+            "      {\n" +
+            "         \"getBundleId\":1,\n" +
+            "         \"getLocation\":\"file:/srv/dotserver/tomcat-8.5.32/webapps/ROOT/WEB-INF/felix/bundle/com.dotcms.samlbundle-21.03.1.jar\",\n" +
+            "         \"getState\":32,\n" +
+            "         \"getSymbolicName\":\"com.dotcms.samlbundle\",\n" +
+            "         \"getVersion\":{\n" +
+            "            \"major\":21,\n" +
+            "            \"micro\":1,\n" +
+            "            \"minor\":3,\n" +
+            "            \"qualifier\":\"\"\n" +
+            "         }\n" +
+            "      }]    \n\n";
+
+    /**
+     * Method to test: {@link JSONTool#generate(String)}
+     * Given Scenario: Parsing an plain object with new lines and spaces
+     * ExpectedResult: Expected a list of map with the properties
+     * @throws DotSecurityException
+     * @throws DotDataException
+     */
+    @Test
+    public void test_Generate_dirty_Map() throws Exception {
+
+        final JSONTool jsonTool   = new JSONTool();
+        final String   stringJson = DIRTY_ARRAY_JSON;
+        final Object object = jsonTool.generate(stringJson);
+
+        assertNotNull(object);
+        assertTrue(object instanceof List);
+
+        final List<Map<String, Object>> list = (List<Map<String, Object>>)object;
+        assertTrue(list.size() > 0);
+        final Map<String, Object> map = list.get(0);
+        assertFalse(map.isEmpty());
+
+        assertTrue(map.containsKey("getBundleId"));
+        assertTrue(map.containsKey("getLocation"));
+    }
+
     /**
      * Method to test: {@link JSONTool#generate(String)}
      * Given Scenario: Parsing an plain object

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/JSONTool.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/JSONTool.java
@@ -269,11 +269,12 @@ public class JSONTool extends ImportSupport implements ViewTool {
 
     try {
 
+      final String trimmedString = s.trim();
       Logger.debug(this.getClass(), ()->"Json RESPONSE: " + s);
 
-      return s.startsWith("[") && s.endsWith("]")?
-              mapper.getDefaultObjectMapper().readValue(s, LIST_MAP_CLASS):
-              mapper.getDefaultObjectMapper().readValue(s, MAP_CLASS);
+      return trimmedString.startsWith("[") && trimmedString.endsWith("]")?
+              mapper.getDefaultObjectMapper().readValue(trimmedString, LIST_MAP_CLASS):
+              mapper.getDefaultObjectMapper().readValue(trimmedString, MAP_CLASS);
     } catch (Exception e) {
       Logger.error(this.getClass(), "Error on parsing the String: " + s + ", message: " + e.getMessage());
       Logger.warnAndDebug(this.getClass(), e);
@@ -285,10 +286,12 @@ public class JSONTool extends ImportSupport implements ViewTool {
     Object result;
 
     try {
-      if (s.startsWith("[") && s.endsWith("]")) {
-        result = new JSONArray(s);
+
+      final String trimmedString = s.trim();
+      if (trimmedString.startsWith("[") && trimmedString.endsWith("]")) {
+        result = new JSONArray(trimmedString);
       } else {
-        result = new JSONObject(s);
+        result = new JSONObject(trimmedString);
       }
     } catch (Exception e) {
       Logger.warn(this.getClass(), e.getMessage());


### PR DESCRIPTION
When the json is an array and contains spaces or new lines, the parsing does not work.
With this fix will work ok