### PR TITLE
#20257 js issue fix and small improvements on the logging

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/storage/FileMetadataAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileMetadataAPIImpl.java
@@ -104,7 +104,7 @@ public class FileMetadataAPIImpl implements FileMetadataAPI {
         final boolean alwaysRegenerateMetadata = Config
                 .getBooleanProperty(ALWAYS_REGENERATE_METADATA_ON_REINDEX, false);
 
-        Logger.info(this, ()-> "Generating the metadata for contentlet, id = " + contentlet.getIdentifier());
+        Logger.debug(this, ()-> "Generating the metadata for contentlet, id = " + contentlet.getIdentifier());
 
         // Full MD is stored in disc (FS or DB)
         final Map<String, Metadata> fullMetadata = generateFullMetadata(contentlet,

--- a/dotCMS/src/main/java/com/dotmarketing/image/focalpoint/FocalPointAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/image/focalpoint/FocalPointAPIImpl.java
@@ -123,7 +123,7 @@ public class FocalPointAPIImpl implements FocalPointAPI {
            return parseFocalPoint(
                    (String) metadata.getCustomMeta().get(FOCAL_POINT));
        }catch (Exception e){
-          Logger.error (FocalPointAPIImpl.class, "Metadata Error retrieving focal point from custom metadata", e);
+          Logger.debug (FocalPointAPIImpl.class, "Metadata Error retrieving focal point from custom metadata", e);
        }
         return Optional.empty();
     }
@@ -135,7 +135,7 @@ public class FocalPointAPIImpl implements FocalPointAPI {
             final String[] value = fpPattern.split(focalPoint);
             return Optional.of(new FocalPoint(Float.valueOf(value[0]), Float.valueOf(value[1])));
         } catch (Exception e) {
-            Logger.error(FocalPointAPIImpl.class, "Error parsing FP Metadata ", e);
+            Logger.debug(FocalPointAPIImpl.class, "Error parsing FP Metadata ", e);
             return Optional.empty();
         }
     }

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -489,8 +489,10 @@
 
     <%}else{ %>
 
-        <% Optional<FocalPoint> focalPoint =new FocalPointAPIImpl().readFocalPoint(binInode, field.getVelocityVarName()); %>
-        <% String fpStr = focalPoint.isPresent() ? focalPoint.get().x + "," + focalPoint.get().y :".0,.0"; %>
+        <%
+         final Optional<FocalPoint> focalPoint =new FocalPointAPIImpl().readFocalPoint(binInode, field.getVelocityVarName());
+         final String fpStr = focalPoint.isPresent() ? focalPoint.get().x + "," + focalPoint.get().y :"0.0,0.0";
+        %>
 
 
        <div id="thumbnailParent<%=field.getVelocityVarName()%>">

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp
@@ -9,6 +9,7 @@
 <%@ page import="com.liferay.portal.language.LanguageUtil"%>
 <%@page import="com.dotmarketing.util.UtilMethods"%>
 <%@page import="com.liferay.portal.model.User"%>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
 
 <script type='text/javascript' src='/dwr/interface/StructureAjax.js'></script>
 <script type='text/javascript' src='/dwr/interface/CategoryAjax.js'></script>
@@ -399,10 +400,17 @@ var cmsfile=null;
 					     var <%=field.variable()%>tinyPropOverride={};
 					     try{
 					    	   <%ctx.put("field", field);%>
-					    	  <%=field.variable()%>tinyPropOverride =  <%= com.dotcms.rendering.velocity.util.VelocityUtil.getInstance().parseVelocity(field.fieldVariablesMap().get("tinymceprops").value(),ctx) %>;
+					    	   <%
+					    	     String propsOverride = com.dotcms.rendering.velocity.util.VelocityUtil.getInstance().parseVelocity(field.fieldVariablesMap().get("tinymceprops").value(),ctx);
+					    	     if(StringUtils.isEmpty(propsOverride) || StringUtils.isBlank(propsOverride) ){
+					    	        propsOverride = "{}";
+					    	        //This is here to prevent a javascript syntax err
+					    	     }
+					    	   %>
+					    	   <%=field.variable()%>tinyPropOverride =  <%=propsOverride%>;
 					     }
 					     catch(e){
-					    	 showDotCMSErrorMessage("Enable to initialize WYSIWYG " + e.message);
+					    	 showDotCMSErrorMessage("unable to initialize WYSIWYG " + e.message);
 					     }
 
 					 <%}else{%>


### PR DESCRIPTION
This prevents a rare issue that breaks the javascript on the contentlet edit window.
More specifically on function named enableWYSIWYG(textAreaId, confirmChange) 
Where a js prop is created based on the evaluation of a velocity script. When the evaluation returns an empty string the javascript breaks and the dialog loads blank. 

Additionally to that, there are a couple of small log improvements 