### PR TITLE
#20267 Setting autocommit=false before creating additional_info column

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210218MigrateUserProxyTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210218MigrateUserProxyTable.java
@@ -29,8 +29,7 @@ public class Task210218MigrateUserProxyTable implements StartupTask {
 
     private static final String ORACLE_SCRIPT = "alter table user_ add additional_info NCLOB NULL;";
 
-    private static final String MSSQL_SCRIPT = "SET TRANSACTION ISOLATION LEVEL READ COMMITTED;\n"
-            + "alter table user_ add additional_info NVARCHAR(MAX) NULL;";
+    private static final String MSSQL_SCRIPT = "alter table user_ add additional_info NVARCHAR(MAX) NULL;";
 
     @Override
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
@@ -49,6 +48,7 @@ public class Task210218MigrateUserProxyTable implements StartupTask {
      * @throws DotDataException
      */
     private void migrateDataFromUserProxyToUser() throws DotDataException {
+
         DotConnect dotConnect = new DotConnect();
         // retrieves existing additional info from user_proxy table
         final List<Map<String, Object>> additionalInfoMaps = dotConnect.setSQL(
@@ -58,6 +58,8 @@ public class Task210218MigrateUserProxyTable implements StartupTask {
 
         Connection connection;
         try {
+
+            DbConnectionFactory.getConnection().setAutoCommit(false);
             connection = DbConnectionFactory.getDataSource().getConnection();
 
             if (DbConnectionFactory.isPostgres()){

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210218MigrateUserProxyTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210218MigrateUserProxyTable.java
@@ -10,6 +10,7 @@ import com.dotmarketing.startup.StartupTask;
 import com.dotmarketing.util.Logger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -22,22 +23,55 @@ public class Task210218MigrateUserProxyTable implements StartupTask {
     private static final ObjectMapper mapper = DotObjectMapperProvider.getInstance()
             .getDefaultObjectMapper();
 
+    private static final String POSTGRES_SCRIPT = "alter table user_ add additional_info JSONB NULL;";
+
+    private static final String MYSQL_SCRIPT = "alter table user_ add additional_info text NULL;";
+
+    private static final String ORACLE_SCRIPT = "alter table user_ add additional_info NCLOB NULL;";
+
+    private static final String MSSQL_SCRIPT = "SET TRANSACTION ISOLATION LEVEL READ COMMITTED;\n"
+            + "alter table user_ add additional_info NVARCHAR(MAX) NULL;";
+
     @Override
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
 
-        createAdditionalInfoColumn();
-        migrateDataFromUserProxyToUser();
+        try{
+            migrateDataFromUserProxyToUser();
+        } catch(Exception e){
+            Logger.error(this, "Unable to execute SQL upgrade", e);
+            throw e;
+        }
     }
 
+    /**
+     * Creates the `additional_info` column in the `user_` table and migrates existing data from `user_proxy`
+     * to `user_`. The migrated data will be stored in the new column
+     * @throws DotDataException
+     */
     private void migrateDataFromUserProxyToUser() throws DotDataException {
         DotConnect dotConnect = new DotConnect();
         // retrieves existing additional info from user_proxy table
         final List<Map<String, Object>> additionalInfoMaps = dotConnect.setSQL(
                 "select * from user_proxy").loadObjectResults();
 
-        if (null != additionalInfoMaps) {
+        dotConnect = new DotConnect();
 
-            try {
+        Connection connection;
+        try {
+            connection = DbConnectionFactory.getDataSource().getConnection();
+
+            if (DbConnectionFactory.isPostgres()){
+                dotConnect.executeStatement(POSTGRES_SCRIPT, connection);
+            }else if (DbConnectionFactory.isMySql()){
+                dotConnect.executeStatement(MYSQL_SCRIPT, connection);
+            }else if (DbConnectionFactory.isOracle()){
+                dotConnect.executeStatement(ORACLE_SCRIPT, connection);
+            }else{
+                dotConnect.executeStatement(MSSQL_SCRIPT, connection);
+            }
+
+            if (null != additionalInfoMaps) {
+
                 //migrates info from proxy_user table to user_
                 for (final Map<String, Object> additionalInfo : additionalInfoMaps) {
                     dotConnect = new DotConnect();
@@ -49,54 +83,15 @@ public class Task210218MigrateUserProxyTable implements StartupTask {
                                     DbConnectionFactory.isPostgres() ? "? ::jsonb" : "?")
                                     + " where userid = ? ")
                             .addParam(mapper.writeValueAsString(additionalInfo)).addParam(userId)
-                            .loadResult();
+                            .loadResult(connection);
                 }
-
-            } catch (JsonProcessingException e) {
-                throw new DotRuntimeException(e);
             }
-        }
-    }
 
-    private void createAdditionalInfoColumn() {
-        DotConnect dotConnect = new DotConnect();
-        final String sql;
-
-        if (DbConnectionFactory.isPostgres()){
-            sql = getPostgresScript();
-        }else if (DbConnectionFactory.isMySql()){
-            sql = getMySQLScript();
-        }else if (DbConnectionFactory.isOracle()){
-            sql = getOracleScript();
-        }else{
-            sql = getMSSQLScript();
+        } catch (JsonProcessingException | SQLException exception) {
+            throw new DotDataException(exception);
         }
 
-        try {
-            dotConnect.executeStatement(sql);
-        } catch (SQLException exception) {
-            throw new DotRuntimeException(exception);
-        }
-
-        Logger.info(this, "additional_info column created");
-    }
-
-    private String getPostgresScript() {
-        return "alter table user_ add additional_info JSONB NULL;";
-
-    }
-
-    private String getMySQLScript() {
-        return "alter table user_ add additional_info text NULL;";
-
-    }
-
-    private String getOracleScript() {
-        return "alter table user_ add additional_info NCLOB NULL;";
-    }
-
-    private String getMSSQLScript() {
-        return  "alter table user_ add additional_info NVARCHAR(MAX) NULL;";
+        Logger.info(this, "additional_info column created and user_proxy data migrated");
     }
 
     @Override


### PR DESCRIPTION
The `Task210218MigrateUserProxyTable` was refactored to set ~TRANSACTION ISOLATION LEVEL READ COMMITTED~ `autocommit=false` when the scripts are run. It will avoid an exception during an upgrade process.

For some reason, the IT created for this task doesn't fail, probably because the way we handle transactions in MSSQL for our ITs is different.