### PR TITLE
fix broken tests

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/enterprise/HTMLDiffUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/enterprise/HTMLDiffUtilTest.java
@@ -134,7 +134,7 @@ public class HTMLDiffUtilTest extends IntegrationTestBase {
         contentlet.setBoolProperty(Contentlet.IS_TEST_MODE, true);
         contentletAPI.publish(contentlet, systemUser, false);
 
-        HTMLPageAsset pageLive = new HTMLPageDataGen(folder, template).languageId(language.getId())
+        final HTMLPageAsset pageLive = new HTMLPageDataGen(folder, template).languageId(language.getId())
                 .pageURL(pageName)
                 .friendlyName(pageName)
                 .title(pageName).nextPersisted();
@@ -144,16 +144,15 @@ public class HTMLDiffUtilTest extends IntegrationTestBase {
                 getDotParserContainerUUID(uuid), 0);
         multiTreeAPI.saveMultiTree(multiTreeV1);
         HTMLPageDataGen.publish(pageLive);
-        pageLive = (HTMLPageAsset) APILocator.getHTMLPageAssetAPI().getLiveHTMLPages(folder,systemUser,false).get(0);
 
         final Contentlet workingPage = contentletAPI
                 .checkout(pageLive.getInode(), systemUser, false);
-        final Contentlet contentletCheckedOut = contentletAPI
+        final Contentlet checkedOut = contentletAPI
                 .checkout(contentlet.getInode(), systemUser, false);
-        contentletCheckedOut.setProperty("body", String.join(",", coneheads));
-        contentletCheckedOut.setIndexPolicy(IndexPolicy.FORCE);
-        contentletAPI.checkin(contentletCheckedOut, systemUser, false);
-        workingPage.setIndexPolicy(IndexPolicy.FORCE);
+        checkedOut.setProperty("body", String.join(",", coneheads));
+        checkedOut.setIndexPolicy(IndexPolicy.WAIT_FOR);
+        contentletAPI.checkin(checkedOut, systemUser, false);
+        workingPage.setIndexPolicy(IndexPolicy.WAIT_FOR);
         contentletAPI.checkin(workingPage, systemUser, false);
 
         final HttpServletRequest request = mock(HttpServletRequest.class);

--- a/dotCMS/src/integration-test/java/com/dotcms/enterprise/HTMLDiffUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/enterprise/HTMLDiffUtilTest.java
@@ -134,7 +134,7 @@ public class HTMLDiffUtilTest extends IntegrationTestBase {
         contentlet.setBoolProperty(Contentlet.IS_TEST_MODE, true);
         contentletAPI.publish(contentlet, systemUser, false);
 
-        final HTMLPageAsset pageLive = new HTMLPageDataGen(folder, template).languageId(language.getId())
+        HTMLPageAsset pageLive = new HTMLPageDataGen(folder, template).languageId(language.getId())
                 .pageURL(pageName)
                 .friendlyName(pageName)
                 .title(pageName).nextPersisted();
@@ -144,6 +144,7 @@ public class HTMLDiffUtilTest extends IntegrationTestBase {
                 getDotParserContainerUUID(uuid), 0);
         multiTreeAPI.saveMultiTree(multiTreeV1);
         HTMLPageDataGen.publish(pageLive);
+        pageLive = (HTMLPageAsset) APILocator.getHTMLPageAssetAPI().getLiveHTMLPages(folder,systemUser,false).get(0);
 
         final Contentlet workingPage = contentletAPI
                 .checkout(pageLive.getInode(), systemUser, false);

--- a/dotCMS/src/integration-test/java/com/dotcms/enterprise/HTMLDiffUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/enterprise/HTMLDiffUtilTest.java
@@ -147,12 +147,12 @@ public class HTMLDiffUtilTest extends IntegrationTestBase {
 
         final Contentlet workingPage = contentletAPI
                 .checkout(pageLive.getInode(), systemUser, false);
-        final Contentlet checkedOut = contentletAPI
+        final Contentlet contentletCheckedOut = contentletAPI
                 .checkout(contentlet.getInode(), systemUser, false);
-        checkedOut.setProperty("body", String.join(",", coneheads));
-        checkedOut.setIndexPolicy(IndexPolicy.WAIT_FOR);
-        contentletAPI.checkin(checkedOut, systemUser, false);
-        workingPage.setIndexPolicy(IndexPolicy.WAIT_FOR);
+        contentletCheckedOut.setProperty("body", String.join(",", coneheads));
+        contentletCheckedOut.setIndexPolicy(IndexPolicy.FORCE);
+        contentletAPI.checkin(contentletCheckedOut, systemUser, false);
+        workingPage.setIndexPolicy(IndexPolicy.FORCE);
         contentletAPI.checkin(workingPage, systemUser, false);
 
         final HttpServletRequest request = mock(HttpServletRequest.class);

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformerTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformerTest.java
@@ -447,14 +447,9 @@ public class ContentletTransformerTest extends BaseWorkflowIntegrationTest {
 
                 if(object1 instanceof File){
                     //Binaries are now formatted to their /dA/ path form.
-                    final File conBinary = (File)object1;
-
-                    final Identifier identifier = APILocator.getIdentifierAPI().find(original.getIdentifier());
-
-                    final String dAPath = "/dA/%s/%s/%s";
-                    final String binaryPath = String.format(dAPath, sourceMap.get("identifier"),propertyName,identifier.getAssetName());
-                    assertEquals(String.format(assertMessage,
-                            baseTypeName, original.getIdentifier(), propertyName), binaryPath, object2);
+                    final String dAPath = "/dA/%s/%s/";
+                    final String binaryPath = String.format(dAPath, sourceMap.get("identifier"),propertyName);
+                    assertTrue(String.format(assertMessage, baseTypeName, original.getIdentifier(), propertyName), object2.toString().contains(binaryPath));
                     continue;
                 }
 
@@ -489,12 +484,9 @@ public class ContentletTransformerTest extends BaseWorkflowIntegrationTest {
 
                 if(object1 instanceof File){
                     //Binaries are now formatted to their /dA/ path form.
-                    final File conBinary = (File)object1;
-                    final Identifier identifier = APILocator.getIdentifierAPI().find(contentlet1.getIdentifier());
-                    final String dAPath = "/dA/%s/%s/%s";
-                    final String binaryPath = String.format(dAPath, contentlet1.getMap().get("identifier"),propertyName,identifier.getAssetName());
-                    assertEquals(String.format(" contentType:`%s` , id: `%s` ,  key: `%s` ",
-                            baseTypeName, contentlet1.getIdentifier(), propertyName), binaryPath, object2);
+                    final String dAPath = "/dA/%s/%s/";
+                    final String binaryPath = String.format(dAPath, contentlet1.getMap().get("identifier"),propertyName);
+                    assertTrue(String.format(" contentType:`%s` , id: `%s` ,  key: `%s` ", baseTypeName, contentlet1.getIdentifier(), propertyName), object2.toString().contains(binaryPath));
                     continue;
                 }
 


### PR DESCRIPTION
This fixes the test **ContentletTransformerTest** that was broken a long time ago.
We were expecting that the FileName e.g `testfile.jpg` was the same as the `AssetName` which it's not true since a Content can have a Binary File and the AssetName on the identifier table could be something like `content.1e33....`

