### PR TITLE
#19646 Fixing error in static publish

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/publisher/business/PublisherTestUtil.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publisher/business/PublisherTestUtil.java
@@ -365,9 +365,7 @@ public class PublisherTestUtil {
         PublishStatus         publishStatus   = null;
 
         try {
-            final DirectoryBundleOutput directoryBundleOutput = new DirectoryBundleOutput(
-                    publisherConfig);
-            publishStatus = APILocator.getPublisherAPI().publish(publisherConfig, directoryBundleOutput);
+            publishStatus = APILocator.getPublisherAPI().publish(publisherConfig);
         } catch (DotPublishingException e) {
 
             publishAuditAPI.updatePublishAuditStatus(publisherConfig.getId(), PublishAuditStatus.Status.FAILED_TO_BUNDLE, historyPojo);

--- a/dotCMS/src/integration-test/java/com/dotcms/publishing/PublisherAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publishing/PublisherAPIImplTest.java
@@ -109,7 +109,7 @@ public class PublisherAPIImplTest {
 
 
     /**
-     * Method to Test: {@link PublisherAPIImpl#publish(PublisherConfig, BundleOutput)}
+     * Method to Test: {@link PublisherAPIImpl#publish(PublisherConfig)}
      * When: Add a {@link Container} in a bundle
      * Should:
      * - The file should be create in:
@@ -142,8 +142,8 @@ public class PublisherAPIImplTest {
 
         for (final Class<? extends Publisher> publisher : publishers) {
             for (TestAsset asset : assets) {
-                cases.add(new TestCase(publisher, asset, true));
-                cases.add(new TestCase(publisher, asset, false));
+                cases.add(new TestCase(publisher, asset));
+                cases.add(new TestCase(publisher, asset));
             }
         }
 
@@ -377,8 +377,6 @@ public class PublisherAPIImplTest {
         config.setLuceneQueries(list());
         config.setId("PublisherAPIImplTest_" + System.currentTimeMillis());
 
-        final BundleOutput output = testCase.useTarGzipOutput ? new TarGzipBundleOutput(config) :
-                new DirectoryBundleOutput(config);
 
         new BundleDataGen()
                 .pushPublisherConfig(config)
@@ -386,12 +384,10 @@ public class PublisherAPIImplTest {
                 .filter(filterDescriptor)
                 .nextPersisted();
 
-        publisherAPI.publish(config);
-        output.close();
+        final PublishStatus publish = publisherAPI.publish(config);
+        File bundleRoot = publish.getOutputFiles().get(0);
 
-        File bundleRoot = output.getFile();
-
-        if (TarGzipBundleOutput.class.isInstance(output)) {
+        if (GenerateBundlePublisher.class.equals(publisher)) {
             final File extractHere = new File(bundleRoot.getParent() + File.separator + config.getName());
             extractTarArchive(bundleRoot, extractHere);
             bundleRoot = extractHere;
@@ -461,14 +457,13 @@ public class PublisherAPIImplTest {
     private static class TestCase {
         Class<? extends Publisher> publisher;
         TestAsset asset;
-        boolean useTarGzipOutput;
+
         public TestCase(
                 final Class<? extends Publisher> publisher,
-                TestAsset asset, final boolean useTarGzipOutput) {
+                TestAsset asset) {
 
             this.publisher = publisher;
             this.asset = asset;
-            this.useTarGzipOutput =useTarGzipOutput;
         }
     }
 

--- a/dotCMS/src/integration-test/java/com/dotcms/publishing/PublisherAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publishing/PublisherAPIImplTest.java
@@ -386,7 +386,7 @@ public class PublisherAPIImplTest {
                 .filter(filterDescriptor)
                 .nextPersisted();
 
-        publisherAPI.publish(config, output);
+        publisherAPI.publish(config);
         output.close();
 
         File bundleRoot = output.getFile();

--- a/dotCMS/src/integration-test/java/com/dotcms/publishing/PublisherAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publishing/PublisherAPITest.java
@@ -216,10 +216,8 @@ public class PublisherAPITest extends IntegrationTestBase {
             publisherConfig.setStartDate(new Date(new Date().getTime() - 24*3600*1000));
             publisherConfig.setPublishers(Lists.newArrayList(PushPublisher.class));
 
-            DirectoryBundleOutput directoryBundleOutput = new DirectoryBundleOutput(
-                    publisherConfig);
             // Push Publish.
-            publisherAPI.publish(publisherConfig, directoryBundleOutput);
+            publisherAPI.publish(publisherConfig);
             /* Get the date of a file. */
             final String bundlePath =
                     ConfigUtils.getBundlePath() + File.separator + publisherConfig.getName();
@@ -256,8 +254,7 @@ public class PublisherAPITest extends IntegrationTestBase {
             publisherConfig.setStartDate(new Date());
             publisherConfig.setPublishers(Lists.newArrayList(PushPublisher.class));
 
-            directoryBundleOutput = new DirectoryBundleOutput(publisherConfig);
-            publisherAPI.publish(publisherConfig, directoryBundleOutput);
+            publisherAPI.publish(publisherConfig);
 
             /* Check the file dates */
             final long bundleTarGzSecondDate = bundleTarGz.lastModified();

--- a/dotCMS/src/main/java/com/dotcms/publisher/bundle/business/BundleAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/bundle/business/BundleAPIImpl.java
@@ -7,6 +7,7 @@ import com.dotcms.publisher.business.DotPublisherException;
 import com.dotcms.publisher.business.PublishAuditAPI;
 import com.dotcms.publisher.business.PublishAuditStatus;
 import com.dotcms.publisher.business.PublishAuditStatus.Status;
+import com.dotcms.publishing.PublishStatus;
 import com.dotcms.publishing.output.TarGzipBundleOutput;
 import com.dotcms.util.DotPreconditions;
 
@@ -407,9 +408,10 @@ public class BundleAPIImpl implements BundleAPI {
         final PushPublisherConfig pushPublisherConfig = new PushPublisherConfig(bundle);
         pushPublisherConfig.setPublishers(Arrays.asList(GenerateBundlePublisher.class));
 
-        try (final TarGzipBundleOutput tarGzipPublisherOutput = new TarGzipBundleOutput(pushPublisherConfig)) {
-			APILocator.getPublisherAPI().publish(pushPublisherConfig, tarGzipPublisherOutput);
-            return tarGzipPublisherOutput.getFile();
+        try {
+			final PublishStatus publishStatus =
+					APILocator.getPublisherAPI().publish(pushPublisherConfig);
+			return publishStatus.getOutputFiles().get(0);
         }
         catch(final Exception e) {
         	Logger.error(this,e.getMessage(),e);

--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublisherQueueJob.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublisherQueueJob.java
@@ -183,8 +183,8 @@ public class PublisherQueueJob implements StatefulJob {
 						pconf = setUpConfigForPublisher(pconf);
 						PushPublishLogger.log(this.getClass(), "Pre-publish work complete.");
 
-						try (final DirectoryBundleOutput bundlerOutput = new DirectoryBundleOutput(pconf)){
-							APILocator.getPublisherAPI().publish(pconf, bundlerOutput);
+						try {
+							APILocator.getPublisherAPI().publish(pconf);
 						} catch (final DotPublishingException e) {
 							/*
 							If we are getting errors creating the bundle we should stop trying to publish it, this is not just a connection error,

--- a/dotCMS/src/main/java/com/dotcms/publishing/GenerateBundlePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/GenerateBundlePublisher.java
@@ -1,8 +1,12 @@
 package com.dotcms.publishing;
 
+import com.dotcms.publishing.output.BundleOutput;
+import com.dotcms.publishing.output.DirectoryBundleOutput;
+import com.dotcms.publishing.output.TarGzipBundleOutput;
 import java.io.File;
 import com.dotcms.publisher.pusher.PushPublisher;
 import com.dotmarketing.util.Logger;
+import java.io.IOException;
 
 /**
  * This GenerateBundlePublisher uses the same config/bundlers as the PushPublisher - the only
@@ -21,7 +25,9 @@ public class GenerateBundlePublisher extends PushPublisher {
         Logger.info(this.getClass(), "Bundling Complete: " + bundleRoot);
         return this.config;
     }
-    
-    
+
+    public BundleOutput createBundleOutput() throws IOException {
+        return new TarGzipBundleOutput(config);
+    }
     
 }

--- a/dotCMS/src/main/java/com/dotcms/publishing/PublishStatus.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/PublishStatus.java
@@ -1,16 +1,25 @@
 package com.dotcms.publishing;
 
+import com.dotcms.api.system.event.SystemEventsFactory;
+import com.dotcms.publishing.output.BundleOutput;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 
 import com.dotmarketing.quartz.TaskRuntimeValues;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class PublishStatus extends TaskRuntimeValues {
 
-	
+
+	private List<BundleOutput> outputs;
+
 	public PublishStatus() {
 		super();
+		outputs = new ArrayList<>();
 
 	}
 	List<BundlerStatus> bundlerStatuses = new ArrayList<BundlerStatus>();
@@ -62,5 +71,13 @@ public class PublishStatus extends TaskRuntimeValues {
 		}
 
 		return x;
+	}
+
+	public void addOutput(BundleOutput output) {
+		outputs.add(output);
+	}
+
+	public List<File> getOutputFiles() {
+		return outputs.stream().map(output -> output.getFile()).collect(Collectors.toList());
 	}
 }

--- a/dotCMS/src/main/java/com/dotcms/publishing/Publisher.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/Publisher.java
@@ -2,6 +2,8 @@ package com.dotcms.publishing;
 
 import com.dotcms.publisher.endpoint.bean.PublishingEndPoint;
 import com.dotcms.publisher.pusher.PushUtils;
+import com.dotcms.publishing.output.BundleOutput;
+import com.dotcms.publishing.output.DirectoryBundleOutput;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.cms.factories.PublicEncryptionFactory;
@@ -346,4 +348,7 @@ public abstract class Publisher implements IPublisher {
         return config;
     } // getContextMap.
 
+    public BundleOutput createBundleOutput() throws IOException {
+        return new DirectoryBundleOutput(config);
+    }
 }

--- a/dotCMS/src/main/java/com/dotcms/publishing/PublisherAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/PublisherAPI.java
@@ -1,6 +1,5 @@
 package com.dotcms.publishing;
 
-import com.dotcms.publishing.output.BundleOutput;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.liferay.portal.model.User;
@@ -24,7 +23,7 @@ public interface PublisherAPI {
      * @see Publisher
      * @see com.dotcms.publisher.environment.bean.Environment
      */
-    public PublishStatus publish ( PublisherConfig config , BundleOutput output) throws DotPublishingException;
+    public PublishStatus publish ( PublisherConfig config) throws DotPublishingException;
 
     /**
      * This method call will create and send to an specified Environments a Bundle, in order to do that it will follow this main steps:<br/>
@@ -43,7 +42,7 @@ public interface PublisherAPI {
      * @see Publisher
      * @see com.dotcms.publisher.environment.bean.Environment
      */
-    public PublishStatus publish ( PublisherConfig config, PublishStatus status, BundleOutput output) throws DotPublishingException;
+    public PublishStatus publish ( PublisherConfig config, PublishStatus status) throws DotPublishingException;
 
     /**
      * Adds a filter to the map of filters, using the filterDescriptor.Key as the key

--- a/dotCMS/src/main/java/com/dotcms/publishing/PublisherAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/PublisherAPIImpl.java
@@ -33,14 +33,14 @@ public class PublisherAPIImpl implements PublisherAPI {
 
 
     @Override
-    final public PublishStatus publish ( PublisherConfig config , BundleOutput output) throws DotPublishingException {
+    final public PublishStatus publish ( PublisherConfig config) throws DotPublishingException {
 
-        return publish( config, new PublishStatus(), output );
+        return publish( config, new PublishStatus() );
     }
 
     @CloseDBIfOpened
     @Override
-    final public PublishStatus publish ( PublisherConfig config, PublishStatus status, BundleOutput output) throws DotPublishingException {
+    final public PublishStatus publish ( PublisherConfig config, PublishStatus status) throws DotPublishingException {
 
         PushPublishLogger.log( this.getClass(), "Started Publishing Task", config.getId() );
 
@@ -56,22 +56,23 @@ public class PublisherAPIImpl implements PublisherAPI {
             for ( Class<Publisher> c : config.getPublishers() ) {
                 // Process config
                 Publisher publisher = c.newInstance();
-                config = publisher.init( config );
+                config = publisher.init(config);
 
-                if ( config.isIncremental() && config.getEndDate() == null && config.getStartDate() == null ) {
+                if (config.isIncremental() && config.getEndDate() == null
+                        && config.getStartDate() == null) {
                     // if its incremental and start/end dates aren't se we take it from latest bundle
-                    if ( BundlerUtil.bundleExists( config ) ) {
-                        PublisherConfig pc = BundlerUtil.readBundleXml( config );
-                        if ( pc.getEndDate() != null ) {
-                            config.setStartDate( pc.getEndDate() );
-                            config.setEndDate( new Date() );
+                    if (BundlerUtil.bundleExists(config)) {
+                        PublisherConfig pc = BundlerUtil.readBundleXml(config);
+                        if (pc.getEndDate() != null) {
+                            config.setStartDate(pc.getEndDate());
+                            config.setEndDate(new Date());
                         } else {
-                            config.setStartDate( null );
-                            config.setEndDate( new Date() );
+                            config.setStartDate(null);
+                            config.setEndDate(new Date());
                         }
                     } else {
-                        config.setStartDate( null );
-                        config.setEndDate( new Date() );
+                        config.setStartDate(null);
+                        config.setEndDate(new Date());
                     }
                 }
 
@@ -81,70 +82,73 @@ public class PublisherAPIImpl implements PublisherAPI {
                 // will return true after that always.
                 final boolean bundleExists = BundlerUtil.bundleExists(config);
 
-                // Run bundlers
+                try (BundleOutput output = publisher.createBundleOutput()){
+                    status.addOutput(output);
+                    // Run bundlers
 
-                if (config.isStatic()) {
-                    //If static we just want to save the things that we need,
-                    // at this point only the id, static and operation.
-                	PublisherConfig pcClone = new PublisherConfig();
-                	pcClone.setId(config.getId());
-                	pcClone.setStatic(true);
-                	pcClone.setOperation(config.getOperation());
-                    Logger.info(this, "Writing bundle.xml file");
-                	BundlerUtil.writeBundleXML( pcClone, output );
-                } else {
-                    Logger.info(this, "Writing bundle.xml file");
-                    BundlerUtil.writeBundleXML( config, output );
-                }
+                    if (config.isStatic()) {
+                        //If static we just want to save the things that we need,
+                        // at this point only the id, static and operation.
+                        PublisherConfig pcClone = new PublisherConfig();
+                        pcClone.setId(config.getId());
+                        pcClone.setStatic(true);
+                        pcClone.setOperation(config.getOperation());
+                        Logger.info(this, "Writing bundle.xml file");
+                        BundlerUtil.writeBundleXML(pcClone, output);
+                    } else {
+                        Logger.info(this, "Writing bundle.xml file");
+                        BundlerUtil.writeBundleXML(config, output);
+                    }
 
-                // If the bundle exists and we are retrying to push the bundle
-                // there is no need to run all the bundlers again.
-                if (!bundleExists || !publishAuditAPI.isPublishRetry(config.getId())) {
-                    PublishAuditStatus currentStatus = publishAuditAPI
-                            .getPublishAuditStatus(config.getId());
-                    PublishAuditHistory currentStatusHistory = null;
-                    if(currentStatus != null) {
-                        currentStatusHistory = currentStatus.getStatusPojo();
-                        if(currentStatusHistory != null) {
-                            currentStatusHistory.setBundleStart(new Date());
+                    // If the bundle exists and we are retrying to push the bundle
+                    // there is no need to run all the bundlers again.
+                    if (!bundleExists || !publishAuditAPI.isPublishRetry(config.getId())) {
+                        PublishAuditStatus currentStatus = publishAuditAPI
+                                .getPublishAuditStatus(config.getId());
+                        PublishAuditHistory currentStatusHistory = null;
+                        if (currentStatus != null) {
+                            currentStatusHistory = currentStatus.getStatusPojo();
+                            if (currentStatusHistory != null) {
+                                currentStatusHistory.setBundleStart(new Date());
+                            }
                         }
+
+                        for (Class<IBundler> clazz : publisher.getBundlers()) {
+                            IBundler bundler = clazz.newInstance();
+                            confBundlers.add(bundler);
+                            bundler.setConfig(config);
+                            bundler.setPublisher(publisher);
+                            BundlerStatus bs = new BundlerStatus(bundler.getClass().getName());
+                            status.addToBs(bs);
+                            //Generate the bundler
+                            Logger.info(this, "Start of Bundler: " + clazz.getSimpleName());
+                            bundler.generate(output, bs);
+                            Logger.info(this, "End of Bundler: " + clazz.getSimpleName());
+                        }
+
+                        if (currentStatusHistory != null) {
+                            currentStatusHistory.setBundleEnd(new Date());
+                            publishAuditAPI
+                                    .updatePublishAuditStatus(config.getId(),
+                                            PublishAuditStatus.Status.BUNDLING,
+                                            currentStatusHistory);
+                        }
+                    } else {
+                        Logger.info(this, "Retrying bundle: " + config.getId()
+                                + ", we don't need to run bundlers again");
                     }
 
-                    for ( Class<IBundler> clazz : publisher.getBundlers() ) {
-                        IBundler bundler = clazz.newInstance();
-                        confBundlers.add( bundler );
-                        bundler.setConfig( config );
-                        bundler.setPublisher(publisher);
-                        BundlerStatus bs = new BundlerStatus( bundler.getClass().getName() );
-                        status.addToBs( bs );
-                        //Generate the bundler
-                        Logger.info(this, "Start of Bundler: " + clazz.getSimpleName());
-                        bundler.generate(output, bs );
-                        Logger.info(this, "End of Bundler: " + clazz.getSimpleName());
-                    }
-
-                    if(currentStatusHistory != null) {
-                        currentStatusHistory.setBundleEnd(new Date());
-                        publishAuditAPI
-                                .updatePublishAuditStatus(config.getId(),
-                                        PublishAuditStatus.Status.BUNDLING,
-                                        currentStatusHistory);
-                    }
-                } else {
-                    Logger.info(this, "Retrying bundle: " + config.getId()
-                            + ", we don't need to run bundlers again");
+                    publisher.process(status);
                 }
 
-                publisher.process( status );
+                config.setBundlers(confBundlers);
+
+                //Triggering event listener when the publishing process ends
+                localSystemEventsAPI.asyncNotify(new PushPublishEndEvent(config.getAssets()));
+                localSystemEventsAPI.asyncNotify(new StaticPublishEndEvent(config.getAssets()));
+
+                PushPublishLogger.log(this.getClass(), "Completed Publishing Task", config.getId());
             }
-
-            config.setBundlers( confBundlers );
-
-            //Triggering event listener when the publishing process ends
-            localSystemEventsAPI.asyncNotify(new PushPublishEndEvent(config.getAssets()));
-            localSystemEventsAPI.asyncNotify(new StaticPublishEndEvent(config.getAssets()));
-
-            PushPublishLogger.log( this.getClass(), "Completed Publishing Task", config.getId() );
         } catch ( Exception e ) {
             Logger.error( PublisherAPIImpl.class, e.getMessage(), e );
             throw new DotPublishingException( e.getMessage(), e );

--- a/dotCMS/src/main/java/com/dotcms/publishing/job/SiteSearchJobImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/job/SiteSearchJobImpl.java
@@ -147,11 +147,7 @@ public class SiteSearchJobImpl {
             final PreparedJobContext preparedJobContext = prepareJob(jobContext);
             synchronized (preparedJobContext.lockKey()) {
                 for (final SiteSearchConfig config : preparedJobContext.getConfigs()) {
-                    try(final DirectoryBundleOutput directoryPublisherOutput = new DirectoryBundleOutput(config)) {
-                        publisherAPI.publish(config, status, directoryPublisherOutput);
-                    }catch(Exception e) {
-                        throw e;
-                    }
+                    publisherAPI.publish(config, status);
                 }
 
                 try {

--- a/dotCMS/src/main/java/com/dotcms/publishing/output/DirectoryBundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/DirectoryBundleOutput.java
@@ -2,8 +2,12 @@ package com.dotcms.publishing.output;
 
 import com.dotcms.publishing.BundlerUtil;
 import com.dotcms.publishing.PublisherConfig;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.util.WebKeys;
 import com.google.common.annotations.VisibleForTesting;
 import com.liferay.util.FileUtil;
+import io.vavr.Lazy;
+import io.vavr.control.Try;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -23,7 +27,7 @@ public class DirectoryBundleOutput extends BundleOutput {
 
     public DirectoryBundleOutput(final PublisherConfig publisherConfig) {
         super(publisherConfig);
-        directoryRootPath = BundlerUtil.getBundleRoot( publisherConfig );
+        directoryRootPath = BundlerUtil.getBundleRoot(publisherConfig);
     }
 
     @VisibleForTesting

--- a/dotCMS/src/main/java/com/dotcms/timemachine/business/TimeMachineAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/timemachine/business/TimeMachineAPIImpl.java
@@ -53,11 +53,7 @@ public class TimeMachineAPIImpl implements TimeMachineAPI {
                 	timeMachineConfig.setId("timeMachineBundle_" +currentDate.getTime() + "_" + language.getId());
                 }
 
-                try(final DirectoryBundleOutput directoryPublisherOutput = new DirectoryBundleOutput(timeMachineConfig)) {
-                    publishStatusList.add(APILocator.getPublisherAPI().publish(timeMachineConfig, directoryPublisherOutput));
-                } catch (Exception e) {
-                    throw e;
-                }
+                publishStatusList.add(APILocator.getPublisherAPI().publish(timeMachineConfig));
             }
             catch(Exception ex) {
                 Logger.error(this, ex.getMessage(), ex);


### PR DESCRIPTION
Fixing error in static publish after performance changes.
After the performance changes two folders was created after a static publish one with the _static suffix and the another one without it, the _static folder was created but empty and all the files was added into the not suffix folder.
We need just the _static folder with all the bundles's files

Static publish not have any test so I create a new issue for it

https://github.com/dotCMS/core/issues/20297