### PR TITLE
#20192 md generation wasnt working on the db when fp has been written

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/storage/FileMetadataAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/storage/FileMetadataAPITest.java
@@ -424,7 +424,7 @@ public class FileMetadataAPITest {
 
             Metadata fileAssetMeta = fileMetadataAPI
                     .getFullMetadataNoCache(fileAssetContent, FILE_ASSET);
-            //Expect No metadata it's generation until generateContentletMetadata is called
+            //Expect No metadata it's generated until generateContentletMetadata is called
             assertNull(fileAssetMeta);
 
             final ContentletMetadata metadata = fileMetadataAPI

--- a/dotCMS/src/integration-test/java/com/dotcms/storage/FileMetadataAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/storage/FileMetadataAPITest.java
@@ -12,6 +12,7 @@ import static com.dotcms.storage.StoragePersistenceProvider.DEFAULT_STORAGE_TYPE
 import static com.dotcms.storage.model.Metadata.CUSTOM_PROP_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -51,6 +52,7 @@ import java.util.SortedSet;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.io.FilenameUtils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -85,6 +87,7 @@ public class FileMetadataAPITest {
      * Expected Results: we should get full and basic md for every type. Basic metadata must be included within the fm
      * @throws IOException
      */
+    
     @Test
     @UseDataProvider("getFileAssetMetadataTestCases")
     public void Test_Generate_Metadata_From_FileAssets(final TestCase testCase) throws Exception {
@@ -134,6 +137,7 @@ public class FileMetadataAPITest {
      * @param testCase
      * @throws Exception
      */
+    
     @Test
     @UseDataProvider("getFileAssetMetadataTestCases")
     public void Test_Force_Set_Metadata(final TestCase testCase) throws Exception {
@@ -306,6 +310,7 @@ public class FileMetadataAPITest {
      * Expected Results:
      * @throws IOException
      */
+    
     @Test
     @UseDataProvider("getStorageType")
     public void Test_Generate_Metadata_From_ContentType_With_Multiple_Binary_Fields(final StorageType storageType) throws Exception {
@@ -372,6 +377,7 @@ public class FileMetadataAPITest {
      * Expected Results: After calling findBinaryFields I should get a tuple with one file
      * candidate for the full MD generation and the rest in the second component of the tuple
      */
+    
     @Test
     public void Test_Get_First_Indexed_Binary_Field() throws Exception {
         prepareIfNecessary();
@@ -402,6 +408,7 @@ public class FileMetadataAPITest {
      * @param storageType
      * @throws IOException
      */
+    
     @Test
     @UseDataProvider("getStorageType")
     public void Test_Get_Metadata_No_Cache(final StorageType storageType) throws Exception {
@@ -417,8 +424,8 @@ public class FileMetadataAPITest {
 
             Metadata fileAssetMeta = fileMetadataAPI
                     .getFullMetadataNoCache(fileAssetContent, FILE_ASSET);
-            //Expect metadata it's generation is forced in case it doesn't exist.
-            assertNotNull(fileAssetMeta);
+            //Expect No metadata it's generation until generateContentletMetadata is called
+            assertNull(fileAssetMeta);
 
             final ContentletMetadata metadata = fileMetadataAPI
                     .generateContentletMetadata(fileAssetContent);
@@ -453,6 +460,7 @@ public class FileMetadataAPITest {
      * @param storageType
      * @throws IOException
      */
+    
     @Test
     @UseDataProvider("getStorageType")
     public void Test_Get_Metadata_No_Cache_Force_Generate(final StorageType storageType) throws Exception {
@@ -468,8 +476,8 @@ public class FileMetadataAPITest {
 
             Metadata fileAssetMD = fileMetadataAPI
                     .getFullMetadataNoCache(fileAssetContent, FILE_ASSET);
-            //Expect metadata it has been generated right out of the box
-            assertNotNull(fileAssetMD);
+            //Expect No metadata it hasn't been generated right out of the box
+            assertNull(fileAssetMD);
 
             fileAssetMD = fileMetadataAPI
                     .getFullMetadataNoCacheForceGenerate(fileAssetContent, FILE_ASSET);
@@ -501,6 +509,7 @@ public class FileMetadataAPITest {
      * @param storageType
      * @throws IOException
      */
+    
     @Test
     @UseDataProvider("getStorageType")
     public void Test_GetMetadata(final StorageType storageType) throws Exception {
@@ -518,12 +527,15 @@ public class FileMetadataAPITest {
             final File file = (File) fileAssetContent.get(FILE_ASSET);
             removeAnyMetadata(file);
 
-            Metadata fileAssetMD = fileMetadataAPI
+            //So this returns the metadata only if it has been generated already.
+            final Metadata fileAssetMD = fileMetadataAPI
                     .getMetadata(fileAssetContent, FILE_ASSET);
+            assertNull(fileAssetMD);
 
+             //While this forces the generation if it hasn't occurred yet
             final Metadata meta = fileAssetContent.getBinaryMetadata(FILE_ASSET);
 
-            assertEquals(fileAssetMD, meta);
+            assertNotNull(meta);
 
             final Map<String, Serializable> metadataMap = meta.getFieldsMeta();
             assertNotNull(metadataMap);
@@ -547,6 +559,7 @@ public class FileMetadataAPITest {
      * @param storageType
      * @throws IOException
      */
+    
     @Test
     @UseDataProvider("getStorageType")
     public void Test_GetMetadata_ForceGenerate(final StorageType storageType) throws Exception {
@@ -564,10 +577,10 @@ public class FileMetadataAPITest {
             final File file = (File) fileAssetContent.get(FILE_ASSET);
             removeAnyMetadata(file);
 
-            Metadata fileAssetMD = fileMetadataAPI
-                    .getMetadata(fileAssetContent, FILE_ASSET);
-            assertNotNull(fileAssetMD);
-
+            //Once again this method does not force it's generation. it returns the md if it's already available
+            Metadata fileAssetMD = fileMetadataAPI.getMetadata(fileAssetContent, FILE_ASSET);
+            assertNull(fileAssetMD);
+            ///Now we should be getting the generated md
             final Metadata meta = fileMetadataAPI.getMetadataForceGenerate(fileAssetContent, FILE_ASSET);
             assertNotNull(meta);
 
@@ -594,6 +607,7 @@ public class FileMetadataAPITest {
      * @param storageType
      * @throws IOException
      */
+    
     @Test
     @UseDataProvider("getStorageType")
     public void Test_Add_Custom_Attributes_FileAssets(final StorageType storageType)
@@ -658,6 +672,7 @@ public class FileMetadataAPITest {
      * @param storageType
      * @throws Exception
      */
+    
     @Test
     @UseDataProvider("getStorageType")
     public void Test_Copy_Metadata(final StorageType storageType) throws Exception {
@@ -721,6 +736,7 @@ public class FileMetadataAPITest {
      * @param storageType
      * @throws Exception
      */
+    
     @Test
     @UseDataProvider("getStorageType")
     public void Test_Generate_Metadata_Should_Not_Override_Custom_Attributes(final StorageType storageType) throws Exception {
@@ -771,6 +787,53 @@ public class FileMetadataAPITest {
 
     }
 
+
+    @Test
+    @UseDataProvider("getStorageType")
+    public void Test_Write_Custom_Metadata_Then_Generate_Metadata_Expect_All_Metadata(final StorageType storageType) throws Exception {
+        prepareIfNecessary();
+        final String stringProperty = Config.getStringProperty(DEFAULT_STORAGE_TYPE);
+        //disconnect the MD generation on indexing so we can test directly here.
+        final boolean defaultValue = Config.getBooleanProperty(WRITE_METADATA_ON_REINDEX, true);
+        try {
+            Config.setProperty(WRITE_METADATA_ON_REINDEX, false);
+            Config.setProperty(DEFAULT_STORAGE_TYPE, storageType.name());
+            final long langId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+            final Contentlet source = getFileAssetContent(true, langId, TestFile.GIF);
+
+            assertNull(" Must not have metadata",
+                 fileMetadataAPI.getMetadata(source, FILE_ASSET)
+            );
+
+            fileMetadataAPI.putCustomMetadataAttributes(source, ImmutableMap
+                    .of(
+                       FILE_ASSET, ImmutableMap.of("foo", "bar", "bar", "foo")
+                    )
+            );
+
+            final ContentletMetadata contentletMetadata = fileMetadataAPI
+                    .generateContentletMetadata(source);
+            assertNotNull(contentletMetadata);
+
+            //Now verify that the MD has been really merged and stored in disk
+            final Metadata fullMetadataNoCache = fileMetadataAPI
+                    .getFullMetadataNoCache(source, FILE_ASSET);
+
+            assertNotNull(fullMetadataNoCache);
+
+            validateCustomMetadata(fullMetadataNoCache.getCustomMeta());
+
+            validateFull(fullMetadataNoCache);
+            validateBasic(fullMetadataNoCache);
+
+
+        } finally {
+            Config.setProperty(DEFAULT_STORAGE_TYPE, stringProperty);
+            Config.setProperty(WRITE_METADATA_ON_REINDEX, defaultValue);
+        }
+
+    }
+
     /**
      * This Method uses the file system to store metadata linked to a temp file.
      * Method to test: {@link FileMetadataAPIImpl#putCustomMetadataAttributes(String, Map)}
@@ -778,6 +841,7 @@ public class FileMetadataAPITest {
      * Expected result: When we request such info using the same id the results we get must match the originals
      * @throws Exception
      */
+    
     @Test
     public void Test_Add_Then_Recover_Temp_Resource_Metadata() throws Exception {
         prepareIfNecessary();
@@ -812,6 +876,7 @@ public class FileMetadataAPITest {
          StorageType.DB
         };
     }
+    
     @Test
     public void TestMetadataModel() {
 

--- a/dotCMS/src/integration-test/java/com/dotcms/storage/FileMetadataAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/storage/FileMetadataAPITest.java
@@ -787,7 +787,14 @@ public class FileMetadataAPITest {
 
     }
 
-
+    /**
+     * Method to test: {@link FileMetadataAPIImpl#putCustomMetadataAttributes(Contentlet, Map)}
+     * combined with {@link FileMetadataAPIImpl#generateContentletMetadata(Contentlet)}
+     * Given scenario: We have a file asset then we set custom attributes then we generate the file Metadata by calling {@link FileMetadataAPIImpl#generateContentletMetadata(Contentlet)}
+     * Expected Result: We must have the combined metadata straight from disk no cache.. this to ensure that both were saved.
+     * @param storageType
+     * @throws Exception
+     */
     @Test
     @UseDataProvider("getStorageType")
     public void Test_Write_Custom_Metadata_Then_Generate_Metadata_Expect_All_Metadata(final StorageType storageType) throws Exception {

--- a/dotCMS/src/integration-test/java/com/dotcms/storage/StoragePersistenceAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/storage/StoragePersistenceAPITest.java
@@ -220,6 +220,7 @@ public class StoragePersistenceAPITest {
         final StoragePersistenceAPI storage = persistenceProvider.getStorage(testCase.storageType);
         storage.deleteObjectAndReferences(testCase.groupName, testCase.path);
         assertTrue(storage.createGroup(testCase.groupName));
+
         final Object object = storage
                 .pushFile(testCase.groupName, testCase.path, testCase.file, ImmutableMap.of());
         assertNotNull(object);
@@ -229,6 +230,17 @@ public class StoragePersistenceAPITest {
         final Object object2 = storage
                 .pushFile(testCase.groupName, testCase.path, testCase.file, ImmutableMap.of());
         assertNotNull(object2);
+
+        //Same binary to a different group
+
+        final String groupVariant = testCase.groupName + "_2" ;
+
+        assertTrue(storage.createGroup(groupVariant));
+
+        final Object object3 = storage
+                .pushFile(groupVariant, testCase.path, testCase.file, ImmutableMap.of());
+        assertNotNull(object3);
+
     }
 
     @DataProvider

--- a/dotCMS/src/integration-test/java/com/dotcms/storage/StoragePersistenceAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/storage/StoragePersistenceAPITest.java
@@ -70,8 +70,8 @@ public class StoragePersistenceAPITest {
     }
 
     /**
-     * Given Scenario:
-     * Expected Result:
+     * Given Scenario: Given a configured property value we must be able to predict what implementation will be returned by the persistence provider
+     * Expected Result: We must be able to predict what implementation will be returned by the persistence provider
      */
     @Test
     public void Test_Get_Provider_By_StorageType() {
@@ -82,7 +82,12 @@ public class StoragePersistenceAPITest {
                 .getStorage(StorageType.DB) instanceof DataBaseStoragePersistenceAPIImpl);
     }
 
-
+    /**
+     * Given Scenario: We want to Test we can replace the contents of a file
+     * Expected Result: We push a file, then we push a different one. We verify it has been replaced.
+     * @param testCase
+     * @throws Exception
+     */
     @Test
     @UseDataProvider("getRandomTestCases")
     public void Test_Replace_Entry(final TestCase testCase) throws Exception {

--- a/dotCMS/src/integration-test/java/com/dotmarketing/util/HashBuilderTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/util/HashBuilderTest.java
@@ -2,6 +2,8 @@ package com.dotmarketing.util;
 
 import com.liferay.util.Encryptor;
 import com.liferay.util.HashBuilder;
+import java.io.File;
+import java.io.FileOutputStream;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,4 +32,23 @@ public class HashBuilderTest {
         Assert.assertEquals("both should be the same", hash3, hash2);
         Assert.assertEquals("both should be the same", hash1, hash3);
     }
+
+
+    @Test
+    public void Test_Identical_Files_Different_Name_Location_BuildUnixHash () throws Exception {
+        final File file1 = staticTestFile();
+        final File file2 = staticTestFile();
+        Assert.assertNotSame(file1, file2);
+        Assert.assertEquals(FileUtil.sha256toUnixHash(file1),FileUtil.sha256toUnixHash(file2));
+    }
+
+    private static File staticTestFile() throws Exception {
+        final String data = "{\"content\":\"this is the content of the file\\\\n\",\"contentType\":\"text/plain; charset=ISO-8859-1\",\"fileSize\":31,\"isImage\":false,\"length\":31,\"modDate\":1619466298000,\"name\":\"hello.txt\",\"path\":\"c/b/cb9340f6-324d-4766-b95d-1c78684d0618/fileAsset/hello.txt\",\"sha256\":\"3ab847baadfebc8ff1c36464ce67009e4a3e3092fe306c90bdb2a6a0c321a00b\",\"title\":\"hello.txt\"}";
+        final File temp = File.createTempFile("testFile", ".bin");
+        try (FileOutputStream output = new FileOutputStream(temp, true)) {
+            output.write(data.getBytes());
+        }
+        return temp;
+    }
+
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/util/HashBuilderTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/util/HashBuilderTest.java
@@ -4,6 +4,8 @@ import com.liferay.util.Encryptor;
 import com.liferay.util.HashBuilder;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -36,15 +38,17 @@ public class HashBuilderTest {
 
     @Test
     public void Test_Identical_Files_Different_Name_Location_BuildUnixHash () throws Exception {
-        final File file1 = staticTestFile();
-        final File file2 = staticTestFile();
+        final Path path1 = Files.createTempDirectory("t1_");
+        final File file1 = staticTestFile(path1);
+        final Path path2 = Files.createTempDirectory("t2_");
+        final File file2 = staticTestFile(path2);
         Assert.assertNotSame(file1, file2);
         Assert.assertEquals(FileUtil.sha256toUnixHash(file1),FileUtil.sha256toUnixHash(file2));
     }
 
-    private static File staticTestFile() throws Exception {
+    private static File staticTestFile(final Path dir) throws Exception {
         final String data = "{\"content\":\"this is the content of the file\\\\n\",\"contentType\":\"text/plain; charset=ISO-8859-1\",\"fileSize\":31,\"isImage\":false,\"length\":31,\"modDate\":1619466298000,\"name\":\"hello.txt\",\"path\":\"c/b/cb9340f6-324d-4766-b95d-1c78684d0618/fileAsset/hello.txt\",\"sha256\":\"3ab847baadfebc8ff1c36464ce67009e4a3e3092fe306c90bdb2a6a0c321a00b\",\"title\":\"hello.txt\"}";
-        final File temp = File.createTempFile("testFile", ".bin");
+        final File temp = File.createTempFile("testFile", ".bin", dir.toFile());
         try (FileOutputStream output = new FileOutputStream(temp, true)) {
             output.write(data.getBytes());
         }

--- a/dotCMS/src/main/java/com/dotcms/storage/DataBaseStoragePersistenceAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/DataBaseStoragePersistenceAPIImpl.java
@@ -3,6 +3,7 @@ package com.dotcms.storage;
 import static com.dotcms.storage.model.BasicMetadataFields.SHA256_META_KEY;
 
 import com.dotcms.concurrent.DotConcurrentFactory;
+import com.dotcms.concurrent.lock.DotKeyLockManagerBuilder;
 import com.dotcms.concurrent.lock.IdentifierStripedLock;
 import com.dotcms.util.CloseUtils;
 import com.dotcms.util.CollectionsUtils;
@@ -67,7 +68,8 @@ public class DataBaseStoragePersistenceAPIImpl implements StoragePersistenceAPI 
 
     private static final String DATABASE_STORAGE_JDBC_POOL_NAME = "DATABASE_STORAGE_JDBC_POOL_NAME";
 
-    private IdentifierStripedLock stripedLock = DotConcurrentFactory.getInstance().getIdentifierStripedLock();
+    private static final IdentifierStripedLock stripedLock =
+            new IdentifierStripedLock(DotKeyLockManagerBuilder.newLockManager("fileHashStripedLock"));
 
     /**
      * custom external connection provider method in case we want to store stuff outside our db

--- a/dotCMS/src/main/java/com/dotcms/storage/DataBaseStoragePersistenceAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/DataBaseStoragePersistenceAPIImpl.java
@@ -456,14 +456,13 @@ public class DataBaseStoragePersistenceAPIImpl implements StoragePersistenceAPI 
                                     ", does not exist.");
                         }
                         if (this.existsObject(groupName, path, connection)) {
+                            deleteObjectAndReferences(groupName, path);
                             Logger.warn(DataBaseStoragePersistenceAPIImpl.class,
-                                    String.format("Attempt to override entry `%s/%s` ", groupName,
-                                            path));
-                            return false;
+                            String.format("The existing entry `%s/%s` has been completely replaced.", groupName, path));
                         }
                         return existsHashReference(fileHash, connection) ?
-                                this.pushFileReference(groupName, path, metaData, fileHash, connection) :
-                                this.pushNewFile(groupName, path, file, metaData, connection);
+                                pushFileReference(groupName, path, metaData, fileHash, connection) :
+                                pushNewFile(groupName, path, file, metaData, connection);
                     }
                 });
     }
@@ -610,13 +609,18 @@ public class DataBaseStoragePersistenceAPIImpl implements StoragePersistenceAPI 
             final ObjectWriterDelegate writerDelegate,
             final Serializable object, final Map<String, Serializable> extraMeta)
             throws DotDataException {
+        File file = null;
         try {
-            final File file = FileUtil.createTemporaryFile("object-storage", ".tmp");
+            file = FileUtil.createTemporaryFile("object-storage", ".tmp");
             writeToFile(writerDelegate, object, file);
             return this.pushFile(groupName, path, file, extraMeta);
         } catch (Exception e) {
             Logger.error(DataBaseStoragePersistenceAPIImpl.class, e.getMessage(), e);
             throw new DotDataException(e);
+        } finally {
+            if(null != file){
+               file.delete();
+            }
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/storage/FileStorageAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileStorageAPIImpl.java
@@ -267,7 +267,7 @@ public class FileStorageAPIImpl implements FileStorageAPI {
                         }
 
                     } else {
-                        //Carry the custom metata
+                        //Carry the custom metadata
                         if(!onlyHasCustomMetadataMap.isEmpty()){
                             //This metadata is expected to have prefix that's fine.
                             //This is necessary since metadataMap is immutable.

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -1314,8 +1314,10 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 			// we simply return the the MD associated with the field `fileAsset`
 			if (isFileAsset()) {
 				final Metadata fileAssetMetadata = Try
-						.of(() -> //Access directly the binaryField
-							 getBinaryMetadata(FileAssetAPI.BINARY_FIELD)
+						.of(() -> //here we only return MD if it has been already generated NOT earlier
+						// That is why we're accessing the API method tha does not force it's generation
+						// otherwise we would loose control and API behavior would become a bit unpredictable
+								fileMetadataAPI.getMetadata(this, FileAssetAPI.BINARY_FIELD)
 						).getOrNull();
 				if (null != fileAssetMetadata) {
 					return fileAssetMetadata;


### PR DESCRIPTION
This basically fixes a problem generating  and storing the MD on the DB 
that had already been fixed for the File System implementation.  

The problem was that if the MD had been previously generated only with custom attributes the MD generator would skip the generation of the file MD attributes because it would think there was already MD for that binary.

Additionally to that. Another Erratic behavior on the API was corrected. Where a method that would force the MD generation was getting called from within the Content. The rule needs to be.. We Only generate metadata when indexing. If such mechanism is disconnected the generation of the metadata occurs when calling the API directly or calling `Contentl.getBinaryMetadata()` Method. Calling the method `fileMetadataAPI.getMetadata() `will serve the MD only when it is ready. This behavior helps us put in place an API that behaves predictably and more consistently   
 