### PR TITLE
#20317 another logging that needed to be slienced

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/storage/FileMetadataAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileMetadataAPIImpl.java
@@ -230,7 +230,7 @@ public class FileMetadataAPIImpl implements FileMetadataAPI {
 
                 builder.put(binaryFieldName, new Metadata(binaryFieldName, metadataMap));
             } else {
-                Logger.warn(FileMetadataAPIImpl.class,String.format("The Contentlet named `%s` references a binary field: `%s` that is null, does not exists or can not be access.", contentlet.getTitle(), binaryFieldName));
+                Logger.debug(FileMetadataAPIImpl.class,String.format("The Contentlet named `%s` references a binary field: `%s` that is null, does not exists or can not be access.", contentlet.getTitle(), binaryFieldName));
             }
         }
         return builder.build();


### PR DESCRIPTION
When you reindex a site that has content with binary fields without assets - which is a normal op - the log gets filled with messages like these:

```
age.FileMetadataAPIImpl: The Contentlet named `H22 Cache Provider` references a binary field: `videothumb2` that is null, does not exists or can not be access.
[29/04/21 15:30:36:410 GMT] WARN storage.FileMetadataAPIImpl: The Contentlet named `H22 Cache Provider` references a binary field: `videothumb3` that is null, does not exists or can not be access.
[29/04/21 15:30:36:410 GMT] WARN storage.FileMetadataAPIImpl: The Contentlet named `H22 Cache Provider` references a binary field: `videothumb4` that is null, does not exists or can not be access.
[29/04/21 15:30:36:410 GMT] WARN storage.FileMetadataAPIImpl: The Contentlet named `H22 Cache Provider` references a binary field: `videothumb5` that is null, does not exists or can not be access.
[29/04/21 15:30:36:429 GMT] WARN storage.FileMetadataAPIImpl: The Contentlet named `The Broken Link Checker (5.x)` references a binary field: `attachment1` that is null, does not exists or can not be access.
[29/04/21 15:30:36:429 GMT] WARN storage.FileMetadataAPIImpl: The Contentlet named `The Broken Link Checker (5.x)` references a binary field: `attachment2` that is null, does not exists or can not be access.
[29/04/21 15:30:36:429 GMT] WARN storage.FileMetadataAPIImpl: The Contentlet named `The Broken Link Checker (5.x)` references a binary field: `attachment3` that is null, does not exists or can not be access.
[29/04/21 15:30:36:429 GMT] WARN storage.FileMetadataAPIImpl: The Contentlet named `The Broken Link Checker (5.x)` references a binary field: `attachment4` that is null, does not exists or can not be access.
[29/04/21 15:30:36:483 GMT] WARN storage.FileMetadataAPIImpl: The Contentlet named `Logging Configuratio
```