### PR TITLE
#20312 multi thread proofing db storage

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/storage/FileMetadataAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileMetadataAPIImpl.java
@@ -2,6 +2,7 @@ package com.dotcms.storage;
 
 import static com.dotmarketing.util.UtilMethods.isSet;
 
+import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.contenttype.model.field.BinaryField;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.FieldVariable;
@@ -243,6 +244,7 @@ public class FileMetadataAPIImpl implements FileMetadataAPI {
      * @return
      */
     @VisibleForTesting
+    @CloseDBIfOpened
     Set<String> getMetadataFields (final String fieldIdentifier) {
 
         final Optional<FieldVariable> customIndexMetaDataFieldsOpt =


### PR DESCRIPTION
This fixes two things 
1.  A small connection leak derived from using FieldsFactory in FileMetadataAPIImpl.java
2. Typically the MD gets generated once the new contentlet gets indexed. As far as I can tell the indexing process might get called from different thread contexts.  Look at this piece of code from `ContentletIndexAPIImpl.java` 

```
    public void addContentToIndex(final Contentlet parentContenlet, final boolean includeDependencies)
            throws DotDataException {
        ....
        if(parentContenlet.getIndexPolicy()==IndexPolicy.DEFER) {
            queueApi.addContentletsReindex(contentToIndex);
        }  else if (!DbConnectionFactory.inTransaction()) {
            addContentToIndex(contentToIndex);
        } else {
            HibernateUtil.addSyncCommitListener(() -> addContentToIndex(contentToIndex));
        }
    }
```

So I'm basically adding a bit of synchronization to the save process.