### PR TITLE
#20342 : As per discussion with Freddy R, we noticed that the API is …

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/field/layout/FieldLayout.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/field/layout/FieldLayout.java
@@ -186,7 +186,8 @@ public class FieldLayout {
         try {
             strictFieldLayoutRowSyntaxValidator.validate();
             return true;
-        } catch (FieldLayoutValidationException e) {
+        } catch (final FieldLayoutValidationException e) {
+            Logger.error(FieldLayout.class, e.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
…trying to create relationships in any Relationship field even after simply deleting or moving other fields. The code in charge of moving and deleting fields is now setting the skip Relationship creation parameter to "true" so that this doesn't happen. Also, logging the error when the field layout is invalid, and adding Javadoc.