### PR TITLE
#19646 Improvment heap scape consumption generating a bundle

### DIFF
--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -3,7 +3,8 @@ dependencies {
 
     def eeType = dotcmsReleaseVersion.equals("master") ? '-SNAPSHOT' : ''
 
-    compile group: 'com.dotcms.enterprise', name: 'ee', version: dotcmsReleaseVersion + eeType, changing: true
+    compile group: 'com.dotcms.enterprise', name: 'ee', version: 'issue-19646-improvment-memory-space-consumption-SNAPSHOT', changing: true
+    //compile fileTree(dir: 'src/main/enterprise/build/libs', include: ['ee_clean.jar'])
 
     compile group: 'com.dotcms', name: 'ant-tooling', version: '1.3.2'
     compile ('io.jsonwebtoken:jjwt:0.6.0'){

--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -3,8 +3,7 @@ dependencies {
 
     def eeType = dotcmsReleaseVersion.equals("master") ? '-SNAPSHOT' : ''
 
-    compile group: 'com.dotcms.enterprise', name: 'ee', version: 'issue-19646-improvment-memory-space-consumption-SNAPSHOT', changing: true
-    //compile fileTree(dir: 'src/main/enterprise/build/libs', include: ['ee_clean.jar'])
+    compile group: 'com.dotcms.enterprise', name: 'ee', version: dotcmsReleaseVersion + eeType, changing: true
 
     compile group: 'com.dotcms', name: 'ant-tooling', version: '1.3.2'
     compile ('io.jsonwebtoken:jjwt:0.6.0'){

--- a/dotCMS/src/main/java/com/dotcms/concurrent/DotConcurrentFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/concurrent/DotConcurrentFactory.java
@@ -737,6 +737,13 @@ public class DotConcurrentFactory implements DotConcurrentFactoryMBean, Serializ
         }
 
         @Override
+        public void waitForAll() throws ExecutionException {
+            while(executorService.isTerminated()) {
+                waitForAll(10, TimeUnit.MINUTES);
+            }
+        }
+
+        @Override
         public long getTaskCount() {
             throw new UnsupportedOperationException("Submit Delay not supported on single submitter, name: " + this.name);
         }
@@ -945,6 +952,13 @@ public class DotConcurrentFactory implements DotConcurrentFactoryMBean, Serializ
                 threadPoolExecutor.awaitTermination(timeout, unit);
             } catch (InterruptedException e) {
                 throw new DotRuntimeException(e);
+            }
+        }
+
+        @Override
+        public void waitForAll(){
+            while(!threadPoolExecutor.isTerminated()) {
+                waitForAll(10, TimeUnit.MINUTES);
             }
         }
 

--- a/dotCMS/src/main/java/com/dotcms/concurrent/DotSubmitter.java
+++ b/dotCMS/src/main/java/com/dotcms/concurrent/DotSubmitter.java
@@ -106,19 +106,7 @@ public interface DotSubmitter extends Executor, Serializable {
      */
     void waitForAll(final long timeout, final TimeUnit unit) throws ExecutionException;
 
-    default void waitForAll(final Collection<Future<Void>> futures) throws ExecutionException {
-        for(final Future future : futures) {
-            try {
-                future.get();
-            } catch(ExecutionException e) {
-                Logger.error(DotSubmitter.class, e);
-                throw e;
-            } catch(InterruptedException e) {
-                Logger.error(DotSubmitter.class, e);
-                continue;
-            }
-        }
-    }
+    void waitForAll() throws ExecutionException;
 
     long getTaskCount();
 } // E:O:F:DotExecutor.

--- a/dotCMS/src/main/java/com/dotcms/concurrent/DotSubmitter.java
+++ b/dotCMS/src/main/java/com/dotcms/concurrent/DotSubmitter.java
@@ -108,5 +108,19 @@ public interface DotSubmitter extends Executor, Serializable {
 
     void waitForAll() throws ExecutionException;
 
+    default void waitForAll(final Collection<Future<Void>> futures) throws ExecutionException {
+        for(final Future future : futures) {
+            try {
+                future.get();
+            } catch(ExecutionException e) {
+                Logger.error(DotSubmitter.class, e);
+                throw e;
+            } catch(InterruptedException e) {
+                Logger.error(DotSubmitter.class, e);
+                continue;
+            }
+        }
+    }
+
     long getTaskCount();
 } // E:O:F:DotExecutor.

--- a/dotCMS/src/main/java/com/dotcms/publishing/output/BundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/BundleOutput.java
@@ -1,5 +1,7 @@
 package com.dotcms.publishing.output;
 
+import static com.liferay.util.FileUtil.validateEmptyFile;
+
 import com.dotcms.publishing.PublisherConfig;
 import com.dotmarketing.util.Config;
 
@@ -51,6 +53,8 @@ public abstract class BundleOutput implements Closeable {
         final boolean userHardLink =
                 Config.getBooleanProperty("CONTENT_VERSION_HARD_LINK", true)
                         && this.useHardLinkByDefault();
+
+        validateEmptyFile(source);
 
         if (userHardLink) {
             FileUtil.copyFile(source, getFile(destinationPath), true);

--- a/dotCMS/src/main/java/com/dotcms/publishing/output/TarGzipBundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/TarGzipBundleOutput.java
@@ -116,9 +116,12 @@ public class TarGzipBundleOutput extends BundleOutput {
 
         private void putEntry(byte[] bytes, TarArchiveEntry tarArchiveEntry) throws IOException {
             synchronized (tarArchiveOutputStream) {
-                tarArchiveOutputStream.putArchiveEntry(tarArchiveEntry);
-                IOUtils.copy(new ByteArrayInputStream(bytes), tarArchiveOutputStream);
-                tarArchiveOutputStream.closeArchiveEntry();
+                try {
+                    tarArchiveOutputStream.putArchiveEntry(tarArchiveEntry);
+                    IOUtils.copy(new ByteArrayInputStream(bytes), tarArchiveOutputStream);
+                } finally {
+                    tarArchiveOutputStream.closeArchiveEntry();
+                }
             }
         }
 

--- a/dotCMS/src/main/java/com/liferay/util/FileUtil.java
+++ b/dotCMS/src/main/java/com/liferay/util/FileUtil.java
@@ -150,7 +150,7 @@ public class FileUtil {
 		copyFile(source, destination, Config.getBooleanProperty("CONTENT_VERSION_HARD_LINK", true));
 	}
 	
-	private static void validateEmptyFile(File source) throws IOException{
+	public static void validateEmptyFile(File source) throws IOException{
 		final String metaDataPath = "metaData" + File.separator + "content";
         final String languagePropertyPath = "messages" + File.separator + "cms_language";
         


### PR DESCRIPTION
Create a new waitForAll method to improve the before implementation, now it not need to keep in memory a Future Collection.

https://github.com/dotCMS/core/pull/20345/files#diff-eb86bd7229e6b229dd5fbcab201c7948ceeb9b17f90a6bc501e71b4e7dd9f2a5R740

Also create the getSessionIfOpened to use in the evict method, this new 'getSessionIfOpened' just return a session if exists one already opened and it never open a new session (this change avoid a leak connection error that we was gottinh before)

https://github.com/dotCMS/core/pull/20345/files#diff-97d93998d67c9cb195bdae899f747d17ddcfcc3d3a71392dfd74b2df40648f4aR721

Finally just in case I closed the Entry in the finally section

https://github.com/dotCMS/core/pull/20345/files#diff-ad30c1685bed7089a0808e5fb617e74e6f11f5e2c73ed0a7fb395293997caa8bR123

All this methods are really util and it are used here:

https://github.com/dotCMS/enterprise/pull/796