### PR TITLE
#20358 New upgrade task to add hash_ref column in storage table

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -94,6 +94,7 @@ import com.dotmarketing.startup.runonce.Task201102UpdateColumnSitelicTableTest;
 import com.dotmarketing.startup.runonce.Task210218MigrateUserProxyTableTest;
 import com.dotmarketing.startup.runonce.Task210319CreateStorageTableTest;
 import com.dotmarketing.startup.runonce.Task210321RemoveOldMetadataFilesTest;
+import com.dotmarketing.startup.runonce.Task210506UpdateStorageTableTest;
 import com.dotmarketing.util.ConfigTest;
 import com.dotmarketing.util.HashBuilderTest;
 import com.dotmarketing.util.TestConfig;
@@ -409,7 +410,8 @@ import org.junit.runners.Suite.SuiteClasses;
         ContentHandlerTest.class,
         ESIndexAPITest.class,
         FileAssetTemplateUtilTest.class,
-        SiteSearchJobImplTest.class
+        SiteSearchJobImplTest.class,
+        Task210506UpdateStorageTableTest.class
 })
 public class MainSuite {
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task210506UpdateStorageTableTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task210506UpdateStorageTableTest.java
@@ -1,0 +1,36 @@
+package com.dotmarketing.startup.runonce;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import java.sql.SQLException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class Task210506UpdateStorageTableTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        // Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    @Test
+    public void testExecuteUpgrade() throws DotDataException, SQLException {
+        //Remove column if exists
+        final DotDatabaseMetaData dotDatabaseMetaData = new DotDatabaseMetaData();
+        if (dotDatabaseMetaData.hasColumn("storage", "hash_ref")) {
+            dotDatabaseMetaData
+                    .dropColumn(DbConnectionFactory.getConnection(), "storage", "hash_ref");
+        }
+
+        final Task210506UpdateStorageTable upgradeTask = new Task210506UpdateStorageTable();
+        assertTrue(upgradeTask.forceRun());
+        upgradeTask.executeUpgrade();
+        assertFalse(upgradeTask.forceRun());
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210506UpdateStorageTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210506UpdateStorageTable.java
@@ -1,0 +1,54 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.startup.AbstractJDBCStartupTask;
+import com.dotmarketing.util.Logger;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Upgrade task used to add column `hash_ref` in `storage` table if needed
+ */
+public class Task210506UpdateStorageTable extends AbstractJDBCStartupTask {
+
+    @Override
+    public boolean forceRun() {
+        try {
+            return !new DotDatabaseMetaData().hasColumn("storage", "hash_ref") ;
+        } catch (SQLException e) {
+            Logger.error(this, e.getMessage(),e);
+            return false;
+        }
+    }
+
+    @Override
+    public String getPostgresScript() {
+        return "ALTER TABLE storage ADD COLUMN hash_ref varchar(64);";
+    }
+
+    @Override
+    public String getMySQLScript() {
+        return "ALTER TABLE storage ADD hash_ref varchar(64);";
+    }
+
+    @Override
+    public String getOracleScript() {
+        return "ALTER TABLE storage ADD hash_ref varchar(64);";
+    }
+
+    @Override
+    public String getMSSQLScript() {
+        return "ALTER TABLE storage ADD hash_ref varchar(64);";
+    }
+
+    @Override
+    public String getH2Script() {
+        return null;
+    }
+
+    @Override
+    protected List<String> getTablesToDropConstraints() {
+        return null;
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -296,6 +296,7 @@ public class TaskLocatorUtil {
 		.add(Task210316UpdateLayoutIcons.class)
         .add(Task210319CreateStorageTable.class)
 		.add(Task210321RemoveOldMetadataFiles.class)
+        .add(Task210506UpdateStorageTable.class)
         .build();
         
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());


### PR DESCRIPTION
Including UT to add hash_ref column in storage table if it doesn't exist. An IT was implemented as well.

It works perfect for servers that upgrade from versions older than 21.04, but if you are using a database created in 21.04, it will fail. The reason is that the postgres.sql without the column was released in 21.04 and there isn’t an upgrade task for the alter table.

It only happens in postgres, however the alter table was included for all databases just in case.