### PR TITLE
#19646 Avoid Out of Memory with huge file

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publishing/output/BundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/BundleOutput.java
@@ -60,11 +60,15 @@ public abstract class BundleOutput implements Closeable {
     }
 
     /**
-     * Copy method to be override by sub clss if it need it
      *
-     * @param source
-     * @param destinationPath
-     * @throws IOException
+     * Copy {@code source } to {@code destinationPath}, this method use by
+     * {@link BundleOutput#copyFile(File, String)} when {@link BundleOutput#useHardLinkByDefault()}
+     * return false, the default implementacion use {@link FileUtil#copyFile(File, File, boolean)} method to
+     * copy the file but it can be override by subclases to have a custom implementation.
+     *
+     * @param source file to be copied
+     * @param destinationPath destiniton path to copy
+     * @throws IOException if any is wrong in the copy
      */
     protected void innerCopyFile(final File source, final String destinationPath) throws IOException {
         FileUtil.copyFile(source, getFile(destinationPath), useHardLinkByDefault());

--- a/dotCMS/src/main/java/com/dotcms/publishing/output/BundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/BundleOutput.java
@@ -55,13 +55,12 @@ public abstract class BundleOutput implements Closeable {
         if (userHardLink) {
             FileUtil.copyFile(source, getFile(destinationPath), true);
         } else {
-            try(final OutputStream outputStream = addFile(destinationPath)) {
-                FileUtil.copyFile(source, outputStream);
-            } catch(IOException e) {
-                Logger.error(FileUtil.class, e);
-                throw e;
-            }
+            innerCopyFile(source, destinationPath);
         }
+    }
+
+    protected void innerCopyFile(final File source, final String destinationPath) throws IOException {
+        FileUtil.copyFile(source, getFile(destinationPath), useHardLinkByDefault());
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/publishing/output/BundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/BundleOutput.java
@@ -47,7 +47,7 @@ public abstract class BundleOutput implements Closeable {
      * @param destinationPath destination path to copy into the output
      * @throws IOException
      */
-    public void copyFile(File source, String destinationPath) throws IOException {
+    public final void copyFile(File source, String destinationPath) throws IOException {
         final boolean userHardLink =
                 Config.getBooleanProperty("CONTENT_VERSION_HARD_LINK", true)
                         && this.useHardLinkByDefault();
@@ -59,6 +59,13 @@ public abstract class BundleOutput implements Closeable {
         }
     }
 
+    /**
+     * Copy method to be override by sub clss if it need it
+     *
+     * @param source
+     * @param destinationPath
+     * @throws IOException
+     */
     protected void innerCopyFile(final File source, final String destinationPath) throws IOException {
         FileUtil.copyFile(source, getFile(destinationPath), useHardLinkByDefault());
     }

--- a/dotCMS/src/main/java/com/dotcms/publishing/output/TarGzipBundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/TarGzipBundleOutput.java
@@ -97,11 +97,13 @@ public class TarGzipBundleOutput extends BundleOutput {
     public void mkdirs(final String path) {
         final TarArchiveEntry tarArchiveEntry = new TarArchiveEntry(path);
 
-        try {
-            tarArchiveOutputStream.putArchiveEntry(tarArchiveEntry);
-            tarArchiveOutputStream.closeArchiveEntry();
-        } catch (IOException e) {
-            throw new DotRuntimeException(e);
+        synchronized (tarArchiveOutputStream) {
+            try {
+                tarArchiveOutputStream.putArchiveEntry(tarArchiveEntry);
+                tarArchiveOutputStream.closeArchiveEntry();
+            } catch (IOException e) {
+                throw new DotRuntimeException(e);
+            }
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/publishing/output/TarGzipBundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/TarGzipBundleOutput.java
@@ -79,7 +79,8 @@ public class TarGzipBundleOutput extends BundleOutput {
     public void setLastModified(String myFile, long timeInMillis){
 
     }
-
+    
+    @Override
     public void innerCopyFile(final File source, final String destinationPath) throws IOException {
         synchronized (tarArchiveOutputStream) {
             try {

--- a/dotCMS/src/main/java/com/dotcms/publishing/output/TarGzipBundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/TarGzipBundleOutput.java
@@ -5,6 +5,7 @@ import com.dotcms.repackage.org.apache.commons.io.IOUtils;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.ConfigUtils;
+import com.liferay.util.FileUtil;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 
@@ -77,6 +78,20 @@ public class TarGzipBundleOutput extends BundleOutput {
     @Override
     public void setLastModified(String myFile, long timeInMillis){
 
+    }
+
+    public void innerCopyFile(final File source, final String destinationPath) throws IOException {
+        synchronized (tarArchiveOutputStream) {
+            try {
+                final TarArchiveEntry tarArchiveEntry = new TarArchiveEntry(destinationPath);
+                tarArchiveEntry.setSize(source.length());
+
+                tarArchiveOutputStream.putArchiveEntry(tarArchiveEntry);
+                IOUtils.copy(new FileInputStream(source), tarArchiveOutputStream);
+            } finally {
+                tarArchiveOutputStream.closeArchiveEntry();
+            }
+        }
     }
 
     public void mkdirs(final String path) {


### PR DESCRIPTION
Before all the files was store in memory before be added in the tar.gzip, so if the file was huge then you got a Out of Memory 