### PR TITLE
#20358 earlier releases had a metadata column which isn't used anymore…

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -95,6 +95,7 @@ import com.dotmarketing.startup.runonce.Task210218MigrateUserProxyTableTest;
 import com.dotmarketing.startup.runonce.Task210319CreateStorageTableTest;
 import com.dotmarketing.startup.runonce.Task210321RemoveOldMetadataFilesTest;
 import com.dotmarketing.startup.runonce.Task210506UpdateStorageTableTest;
+import com.dotmarketing.startup.runonce.Task210510UpdateStorageTableDropMetadataColumnTest;
 import com.dotmarketing.util.ConfigTest;
 import com.dotmarketing.util.HashBuilderTest;
 import com.dotmarketing.util.TestConfig;
@@ -411,7 +412,8 @@ import org.junit.runners.Suite.SuiteClasses;
         ESIndexAPITest.class,
         FileAssetTemplateUtilTest.class,
         SiteSearchJobImplTest.class,
-        Task210506UpdateStorageTableTest.class
+        Task210506UpdateStorageTableTest.class,
+        Task210510UpdateStorageTableDropMetadataColumnTest.class
 })
 public class MainSuite {
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task210510UpdateStorageTableDropMetadataColumnTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task210510UpdateStorageTableDropMetadataColumnTest.java
@@ -1,0 +1,85 @@
+package com.dotmarketing.startup.runonce;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class Task210510UpdateStorageTableDropMetadataColumnTest {
+    @BeforeClass
+    public static void prepare() throws Exception {
+        // Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+
+    private String getPostgresScript() {
+        return "ALTER TABLE storage ADD COLUMN metadata text;";
+    }
+
+    private String getMyScript() {
+        return "ALTER TABLE storage ADD COLUMN metadata text;";
+    }
+
+    private String getMSSQLScript() {
+        return "ALTER TABLE storage ADD metadata text;";
+    }
+
+    private String getOracleScript() {
+        return "ALTER TABLE storage ADD metadata NCLOB ";
+    }
+
+
+    private String getScript() {
+        if(DbConnectionFactory.isPostgres()){
+            return getPostgresScript();
+        }
+        if(DbConnectionFactory.isMySql()){
+            return getMyScript();
+        }
+        if(DbConnectionFactory.isMsSql()){
+            return getMSSQLScript();
+        }
+        if(DbConnectionFactory.isOracle()){
+            return getOracleScript();
+        }
+        throw new DotRuntimeException("Oh snap! dunno what database I'm running on.");
+    }
+
+    /**
+     * Given scenario:
+     * Expected result:
+     * @throws DotDataException
+     * @throws SQLException
+     */
+    @Test
+    public void testExecuteUpgrade() throws DotDataException, SQLException {
+        //First Recreate the old column situation
+        //add column if it does not exist
+        final Connection connection = DbConnectionFactory.getConnection();
+        final boolean autoCommit = connection.getAutoCommit();
+        connection.setAutoCommit(true);
+        try{
+          final DotDatabaseMetaData dotDatabaseMetaData = new DotDatabaseMetaData();
+          if (!dotDatabaseMetaData.hasColumn("storage", "metadata")) {
+            new DotConnect().executeStatement(getScript(), connection);
+          }
+
+         final Task210510UpdateStorageTableDropMetadataColumn upgradeTask = new Task210510UpdateStorageTableDropMetadataColumn();
+         assertTrue(upgradeTask.forceRun());
+         upgradeTask.executeUpgrade();
+         assertFalse(upgradeTask.forceRun());
+        }finally {
+            connection.setAutoCommit(autoCommit);
+        }
+    }
+}

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task210510UpdateStorageTableDropMetadataColumnTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task210510UpdateStorageTableDropMetadataColumnTest.java
@@ -38,7 +38,10 @@ public class Task210510UpdateStorageTableDropMetadataColumnTest {
         return "ALTER TABLE storage ADD metadata NCLOB ";
     }
 
-
+    /**
+     * Returns the SQL Script depending on the db 
+     * @return
+     */
     private String getScript() {
         if(DbConnectionFactory.isPostgres()){
             return getPostgresScript();

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task210510UpdateStorageTableDropMetadataColumnTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task210510UpdateStorageTableDropMetadataColumnTest.java
@@ -56,8 +56,8 @@ public class Task210510UpdateStorageTableDropMetadataColumnTest {
     }
 
     /**
-     * Given scenario:
-     * Expected result:
+     * Given scenario: We intend to test the upgrade task that drops the column if it exist
+     * Expected result: If the column does not exist it gets added. Once added we test it can be removed and the task wont run again.
      * @throws DotDataException
      * @throws SQLException
      */

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210510UpdateStorageTableDropMetadataColumn.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210510UpdateStorageTableDropMetadataColumn.java
@@ -1,0 +1,54 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.startup.AbstractJDBCStartupTask;
+import com.dotmarketing.util.Logger;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Apparently the table storage went out on the last releases with an old column named metadata which is no longer used
+ */
+public class Task210510UpdateStorageTableDropMetadataColumn extends AbstractJDBCStartupTask {
+
+    @Override
+    public boolean forceRun() {
+        try {
+            return new DotDatabaseMetaData().hasColumn("storage", "metadata") ;
+        } catch (SQLException e) {
+            Logger.error(this, e.getMessage(),e);
+            return false;
+        }
+    }
+
+    @Override
+    public String getPostgresScript() {
+        return "ALTER TABLE storage DROP COLUMN metadata;";
+    }
+
+    @Override
+    public String getMySQLScript() {
+        return "ALTER TABLE storage DROP COLUMN metadata;";
+    }
+
+    @Override
+    public String getOracleScript() {
+        return "ALTER TABLE storage DROP COLUMN metadata;";
+    }
+
+    @Override
+    public String getMSSQLScript() {
+        return "ALTER TABLE storage DROP COLUMN metadata;";
+    }
+
+    @Override
+    public String getH2Script() {
+        return null;
+    }
+
+    @Override
+    protected List<String> getTablesToDropConstraints() {
+        return null;
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -297,6 +297,7 @@ public class TaskLocatorUtil {
         .add(Task210319CreateStorageTable.class)
 		.add(Task210321RemoveOldMetadataFiles.class)
         .add(Task210506UpdateStorageTable.class)
+		.add(Task210510UpdateStorageTableDropMetadataColumn.class)
         .build();
         
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());


### PR DESCRIPTION
earlier releases had a metadata column that isn't used anymore and it needs to be removed.
Yeah when we shipped the first version of the storage table they had column metadata which is no longer supported nor needed 