### PR TITLE
Bump up mysql connector version to be able to run in Java 11

### DIFF
--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -501,7 +501,7 @@ dependencies {
         transitive = false
     }
     //https://mvnrepository.com/artifact/mysql/mysql-connector-java
-    providedCompile (group: 'mysql', name: 'mysql-connector-java', version: '8.0.18') {
+    providedCompile (group: 'mysql', name: 'mysql-connector-java', version: '8.0.19') {
         transitive = false
     }
     //https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc


### PR DESCRIPTION
Automated tests were not running on MySQL and the db was logging a `Bad _handshake`. 

After reproducing locally against our mysql docker-compose (same one used for tests), it was determined that the error happens when running on java 11 only. 

Bumping up the version of the `mysql-connector-java` from `8.0.18` to `8.0.19` makes possible to run both in Java 8 and 11. 