### PR TITLE
#20280 adding fix for looping on vanity urls

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/mock/response/MockHttpStatusAndHeadersResponse.java
+++ b/dotCMS/src/main/java/com/dotcms/mock/response/MockHttpStatusAndHeadersResponse.java
@@ -1,0 +1,37 @@
+package com.dotcms.mock.response;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Response mock to collect the response status and headers.
+ * @author jsanca
+ */
+public class MockHttpStatusAndHeadersResponse extends MockHttpStatusResponse {
+
+    private final Map<String, String> headerMap = new HashMap<>();
+    public MockHttpStatusAndHeadersResponse(final HttpServletResponse response) {
+        super(response);
+    }
+
+    @Override
+    public HttpServletResponse response() {
+        return this;
+    }
+
+    @Override
+    public void addHeader(String name, String value) {
+        headerMap.put(name, value);
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return headerMap.get(name);
+    }
+
+    @Override
+    public void setHeader(String name, String value) {
+        headerMap.put(name, value);
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityURLFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityURLFilter.java
@@ -83,7 +83,10 @@ public class VanityURLFilter implements Filter {
           final Language language = this.languageWebAPI.getLanguage(request);
           final Optional<CachedVanityUrl> cachedVanity = vanityApi.resolveVanityUrl(uri, host, language);
           
-          if (cachedVanity.isPresent()) {
+          if (cachedVanity.isPresent()&&
+                  // checks if the current destiny is not exactly the forward of the vanity
+                  // we do this to avoid infinite loop
+                  this.forwardToIsnotTheSameOfUri(cachedVanity.get(), uri)) {
               request.setAttribute(VANITY_URL_OBJECT, cachedVanity.get());
               final VanityUrlResult vanityUrlResult = cachedVanity.get().handle( uri, response);
               final VanityUrlRequestWrapper vanityUrlRequestWrapper = new VanityUrlRequestWrapper(request, vanityUrlResult);
@@ -99,6 +102,13 @@ public class VanityURLFilter implements Filter {
 
       filterChain.doFilter(request, response);
   } // doFilter.
+
+    private boolean forwardToIsnotTheSameOfUri(final CachedVanityUrl cachedVanityUrl, final String uri) {
+
+        // if the forward to is not actually the same of uri, is ok
+        return null != cachedVanityUrl && null != cachedVanityUrl.forwardTo && null != uri?
+                !cachedVanityUrl.forwardTo.equals(uri): false;
+    }
 
   @Override
   public void destroy() {


### PR DESCRIPTION
When Create a new Vanity URL with trailing at the end such as:
Uri: /redirect-me/
Action: 301
Forward to: /redirect-me

The redirecting was on loop b/c the trail at the end is converter by #16433
to (/)*

The fix basically ask if the current request uri, is the same of the forward, if it is shouldn't be necessary to do the vanity logic and continue with the page