### PR TITLE
Additional logging graphql schema generation

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
@@ -138,7 +138,7 @@ public enum ContentAPIGraphQLTypesProvider implements GraphQLTypesProvider {
         // let's log if we are including dupe types
         final Map<String, ContentType> localTypesMap = new HashMap<>();
         allTypes.forEach((type)-> {
-            if(localTypesMap.get(type.variable())!=null) {
+            if(localTypesMap.containsKey(type.variable())) {
                 Logger.warn(this, "Dupe Content Type detected!: " + type.variable());
             }
             localTypesMap.put(type.variable(), type);

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
@@ -40,6 +40,7 @@ import com.dotcms.graphql.util.TypeUtil;
 import com.dotcms.util.DotPreconditions;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
@@ -133,6 +134,16 @@ public enum ContentAPIGraphQLTypesProvider implements GraphQLTypesProvider {
 
         List<ContentType> allTypes = APILocator.getContentTypeAPI(APILocator.systemUser())
                 .search("", null, 100000, 0);
+
+        // try to detect dupes here and log it
+        // let's log if we are including dup types
+        final Map<String, ContentType> localTypesMap = new HashMap<>();
+        allTypes.forEach((type)-> {
+            if(localTypesMap.get(type.variable())!=null) {
+                Logger.warn(this, "Dupe Content Type detected!: " + type.variable());
+            }
+            localTypesMap.put(type.variable(), type);
+        });
 
         allTypes.forEach((type) -> {
             try {

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
@@ -135,8 +135,7 @@ public enum ContentAPIGraphQLTypesProvider implements GraphQLTypesProvider {
         List<ContentType> allTypes = APILocator.getContentTypeAPI(APILocator.systemUser())
                 .search("", null, 100000, 0);
 
-        // try to detect dupes here and log it
-        // let's log if we are including dup types
+        // let's log if we are including dupe types
         final Map<String, ContentType> localTypesMap = new HashMap<>();
         allTypes.forEach((type)-> {
             if(localTypesMap.get(type.variable())!=null) {

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
@@ -27,8 +27,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -144,6 +147,22 @@ public class GraphqlAPIImpl implements GraphqlAPI {
             }
         }
 
+        // let's log if we are including dupe types
+        final Map<String, GraphQLType> localTypesMap = new HashMap<>();
+        graphQLTypes.forEach((type)-> {
+            if(localTypesMap.get(type.getName())!=null) {
+                Logger.warn(this, "Dupe GraphQLType detected!: " + type.getName());
+                // removing dupes based on Config property
+                if(Config.getBooleanProperty("GRAPHQL_REMOVE_DUPLICATED_TYPES", false)) {
+                    return;
+                }
+            }
+            localTypesMap.put(type.getName(), type);
+        });
+
+        final Set<GraphQLType> finalTypesSet = new HashSet<>(localTypesMap.values());
+
+
         List<GraphQLFieldDefinition> fieldDefinitions = new ArrayList<>();
 
         for (GraphQLFieldsProvider fieldsProvider : fieldsProviders) {
@@ -157,7 +176,7 @@ public class GraphqlAPIImpl implements GraphqlAPI {
         // Root Type
         GraphQLObjectType.Builder rootTypeBuilder = createRootTypeBuilder().fields(fieldDefinitions);
 
-        return new GraphQLSchema.Builder().query(rootTypeBuilder.build()).additionalTypes(graphQLTypes).build();
+        return new GraphQLSchema.Builder().query(rootTypeBuilder.build()).additionalTypes(finalTypesSet).build();
     }
 
     private Builder createRootTypeBuilder() {

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/GraphqlAPIImpl.java
@@ -6,6 +6,7 @@ import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLList.list;
 import static graphql.schema.GraphQLNonNull.nonNull;
 import static graphql.schema.GraphQLObjectType.newObject;
+
 import com.dotcms.concurrent.Debouncer;
 import com.dotcms.graphql.InterfaceType;
 import com.dotcms.graphql.datafetcher.ContentletDataFetcher;
@@ -27,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -150,7 +150,7 @@ public class GraphqlAPIImpl implements GraphqlAPI {
         // let's log if we are including dupe types
         final Map<String, GraphQLType> localTypesMap = new HashMap<>();
         graphQLTypes.forEach((type)-> {
-            if(localTypesMap.get(type.getName())!=null) {
+            if(localTypesMap.containsKey(type.getName())) {
                 Logger.warn(this, "Dupe GraphQLType detected!: " + type.getName());
                 // removing dupes based on Config property
                 if(Config.getBooleanProperty("GRAPHQL_REMOVE_DUPLICATED_TYPES", false)) {


### PR DESCRIPTION
We need to determine if we are, sometimes, sending dupe types to the GraphQL Schema generation process. This is not currently reproducible on local dev environments. 