### PR TITLE
Avoid Out of Memory with huge file

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publishing/output/BundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/BundleOutput.java
@@ -59,13 +59,23 @@ public abstract class BundleOutput implements Closeable {
         if (userHardLink) {
             FileUtil.copyFile(source, getFile(destinationPath), true);
         } else {
-            try(final OutputStream outputStream = addFile(destinationPath)) {
-                FileUtil.copyFile(source, outputStream);
-            } catch(IOException e) {
-                Logger.error(FileUtil.class, e);
-                throw e;
-            }
+            innerCopyFile(source, destinationPath);
         }
+    }
+
+    /**
+     *
+     * Copy {@code source } to {@code destinationPath}, this method use by
+     * {@link BundleOutput#copyFile(File, String)} when {@link BundleOutput#useHardLinkByDefault()}
+     * return false, the default implementacion use {@link FileUtil#copyFile(File, File, boolean)} method to
+     * copy the file but it can be override by subclases to have a custom implementation.
+     *
+     * @param source file to be copied
+     * @param destinationPath destiniton path to copy
+     * @throws IOException if any is wrong in the copy
+     */
+    protected void innerCopyFile(final File source, final String destinationPath) throws IOException {
+        FileUtil.copyFile(source, getFile(destinationPath), useHardLinkByDefault());
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/publishing/output/TarGzipBundleOutput.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/output/TarGzipBundleOutput.java
@@ -79,14 +79,31 @@ public class TarGzipBundleOutput extends BundleOutput {
 
     }
 
+    @Override
+    public void innerCopyFile(final File source, final String destinationPath) throws IOException {
+        synchronized (tarArchiveOutputStream) {
+            try {
+                final TarArchiveEntry tarArchiveEntry = new TarArchiveEntry(destinationPath);
+                tarArchiveEntry.setSize(source.length());
+
+                tarArchiveOutputStream.putArchiveEntry(tarArchiveEntry);
+                IOUtils.copy(new FileInputStream(source), tarArchiveOutputStream);
+            } finally {
+                tarArchiveOutputStream.closeArchiveEntry();
+            }
+        }
+    }
+
     public void mkdirs(final String path) {
         final TarArchiveEntry tarArchiveEntry = new TarArchiveEntry(path);
 
-        try {
-            tarArchiveOutputStream.putArchiveEntry(tarArchiveEntry);
-            tarArchiveOutputStream.closeArchiveEntry();
-        } catch (IOException e) {
-            throw new DotRuntimeException(e);
+        synchronized (tarArchiveOutputStream) {
+            try {
+                tarArchiveOutputStream.putArchiveEntry(tarArchiveEntry);
+                tarArchiveOutputStream.closeArchiveEntry();
+            } catch (IOException e) {
+                throw new DotRuntimeException(e);
+            }
         }
     }
 


### PR DESCRIPTION
Before all the files was store in memory before be added in the tar.gzip, so if the file was huge then you got a Out of Memory