### PR TITLE
#20457 fix contentlet metaData attribute via vtl

### DIFF
--- a/.github/workflows/core-cicd-tests.yml
+++ b/.github/workflows/core-cicd-tests.yml
@@ -127,14 +127,7 @@ jobs:
         run: |
           sh -c "$(curl -fsSL https://raw.githubusercontent.com/dotCMS/dot-cicd/${DOT_CICD_BRANCH}/seed/install-dot-cicd.sh)"
         if: env.jobRun == 'true'
-      - name: Check Provider
-        run: |
-          dotcicd/library/checkProvider.sh github
-        if: env.jobRun == 'true'
-      - name: Fail provider
-        run: |
-          echo "jobRun=false" >> $GITHUB_ENV
-        if: env.jobRun == 'true' && failure()
+      
       - name: Build DotCMS Image
         run: |
           dotcicd/library/pipeline.sh buildBase

--- a/dotCMS/src/integration-test/java/com/dotcms/storage/FileMetadataAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/storage/FileMetadataAPITest.java
@@ -82,6 +82,19 @@ public class FileMetadataAPITest {
     }
 
     /**
+     * Simple test to verify that what we're getting via the contentlet map property is actually a map
+     * @throws Exception
+     */
+    @Test
+    public void Test_Get_Metadata_Property() throws Exception {
+        prepareIfNecessary();
+
+            final Contentlet fileAssetContent = getFileAssetContent(true, 1, TestFile.PDF);
+            assertTrue(fileAssetContent.get(FileAssetAPI.META_DATA_FIELD) instanceof Map);
+    }
+
+
+    /**
      * This test evaluates both basic vs full MD
      * Given scenarios: We're testing metadata api against different types of asset-files
      * Expected Results: we should get full and basic md for every type. Basic metadata must be included within the fm

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -865,10 +865,7 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 	    if(valueObj instanceof Map){
 	       return new HashMap<>((Map<String,Object>)valueObj);
 	    }
-		if(valueObj instanceof Metadata){
-			final Metadata metadata = (Metadata)valueObj;
-			return new HashMap<>(metadata.getFieldsMeta());
-		}
+
 		return KeyValueFieldUtil.JSONValueToHashMap((String) valueObj);
 	}
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentMap.java
@@ -277,21 +277,35 @@ public class ContentMap {
 			}else if(f != null && f.getFieldType().equals(Field.FieldType.CHECKBOX.toString())){
 				return new CheckboxMap(f, content);
 			}else if(f != null && f.getFieldType().equals(Field.FieldType.KEY_VALUE.toString())){
-			    final String jsonData=(String)conAPI.getFieldValue(content, f);
-				Map<String,Object> keyValueMap = KeyValueFieldUtil.JSONValueToHashMap(jsonData);
-				//needs to be ordered
-				Map<String,Object> retMap = new java.util.LinkedHashMap<String,Object>() {
-				    @Override
-				    public String toString() {
-				        return jsonData;
-				    }
-				};
-				for(String key :keyValueMap.keySet()){
-					retMap.put(key.replaceAll("\\W",""), keyValueMap.get(key));
+
+				Map<String, Object> keyValueMap = new HashMap<>();
+				Map<String, Object> retMap = new HashMap<>();
+
+				final Object object = conAPI.getFieldValue(content, f);
+
+				if(object instanceof Map){
+					keyValueMap=(Map)object;
+				}
+
+				if (object instanceof String) {
+					final String jsonData = (String) object;
+					keyValueMap = KeyValueFieldUtil.JSONValueToHashMap(jsonData);
+					//needs to be ordered
+					retMap = new java.util.LinkedHashMap<String, Object>() {
+						@Override
+						public String toString() {
+							return jsonData;
+						}
+					};
+				}
+
+				for (String key : keyValueMap.keySet()) {
+					retMap.put(key.replaceAll("\\W", ""), keyValueMap.get(key));
 				}
 				retMap.put("keys", retMap.keySet());
 				retMap.put("map", keyValueMap);
 				return retMap;
+
 			} else if(f != null && f.getFieldType().equals(FieldType.RELATIONSHIP.toString())){
 				return getRelationshipInfo(f);
 			}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -1320,7 +1320,7 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 								fileMetadataAPI.getMetadata(this, FileAssetAPI.BINARY_FIELD)
 						).getOrNull();
 				if (null != fileAssetMetadata) {
-					return fileAssetMetadata;
+					return fileAssetMetadata.getFieldsMeta();
 				}
 			} else {
 			    //Otherwise this will look the first indexed binary


### PR DESCRIPTION
This fixes an issue accessing metadata from vtl files
like this: 

```
#foreach($file in $dotcontent.pull("+contentType:FileAsset +metaData:image/jpeg",2,"modDate desc"))
   
    <h3>MetaData:</h3>
    <p>$file.metaData</p>
  
    <p>Content type: $file.metaData.contentType</p>
    <p>File Size: $file.metaData.fileSize</p>
#end

```