### PR TITLE
Process default language at last in static publish

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publishing/IBundler.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/IBundler.java
@@ -75,9 +75,9 @@ public interface IBundler {
 				if (o1.equals(defaultLangId) && o2.equals(defaultLangId)) {
 					return 0;
 				} else if (o1.equals(defaultLangId)) {
-					return -1;
-				} else if (o2.equals(defaultLangId)) {
 					return 1;
+				} else if (o2.equals(defaultLangId)) {
+					return -1;
 				} else {
 					return 0;
 				}


### PR DESCRIPTION
Generate default language at last in static publish.
in this way if you use a "static_publish_to" property that not use the language then the default language page is going to overwrite the others ones.

I am missing test with this change but we already have a issue to create test to static publish

https://github.com/dotCMS/core/issues/20297