### PR TITLE
get Identifier in case inode belongs to a fileAssetTemplate

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/DotTemplateTool.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/DotTemplateTool.java
@@ -2,6 +2,7 @@ package com.dotcms.rendering.velocity.viewtools;
 
 import com.dotmarketing.business.FactoryLocator;
 import com.dotmarketing.business.Theme;
+import com.dotmarketing.portlets.templates.business.FileAssetTemplateUtil;
 import com.dotmarketing.portlets.templates.design.bean.ContainerUUID;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -136,10 +137,10 @@ public class DotTemplateTool implements ViewTool {
     private static DrawedBody getDrawedBody(String templateInodeOrId, User user) throws DotDataException, DotSecurityException {
         final boolean isIdentifier = APILocator.getIdentifierAPI().isIdentifier(templateInodeOrId);
         String identifier = templateInodeOrId;
-        if(!isIdentifier){
+        if(!isIdentifier && !FileAssetTemplateUtil.getInstance().isFolderAssetTemplateId(templateInodeOrId)){
             final Template template = FactoryLocator.getTemplateFactory().find(templateInodeOrId);
             identifier = template!=null ? template.getIdentifier() :
-                    APILocator.getIdentifierAPI().findFromInode(templateInodeOrId).getId();//this is for fileAssetTemplates
+                    APILocator.getIdentifierAPI().findFromInode(templateInodeOrId).getId();//this is for find the id of fileAssetTemplates by inode
         }
         final Template workingTemplate = APILocator.getTemplateAPI().findWorkingTemplate(identifier, user, false);
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/DotTemplateTool.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/DotTemplateTool.java
@@ -133,13 +133,19 @@ public class DotTemplateTool implements ViewTool {
         layoutCache.invalidate(templateInode + true);
     }
 
-    private static DrawedBody getDrawedBody(String themeInodeOrId, User user) throws DotDataException, DotSecurityException {
-        final Template template = FactoryLocator.getTemplateFactory().find(themeInodeOrId);//If null themeInodeOrId is a Id
-        final String identifier = template!=null ? template.getIdentifier() : themeInodeOrId;
+    private static DrawedBody getDrawedBody(String templateInodeOrId, User user) throws DotDataException, DotSecurityException {
+        final boolean isIdentifier = APILocator.getIdentifierAPI().isIdentifier(templateInodeOrId);
+        String identifier = templateInodeOrId;
+        if(!isIdentifier){
+            final Template template = FactoryLocator.getTemplateFactory().find(templateInodeOrId);
+            identifier = template!=null ? template.getIdentifier() :
+                    APILocator.getIdentifierAPI().findFromInode(templateInodeOrId).getId();//this is for fileAssetTemplates
+        }
         final Template workingTemplate = APILocator.getTemplateAPI().findWorkingTemplate(identifier, user, false);
 
+
         if (!workingTemplate.isDrawed()){
-            throw new RuntimeException("Template with inode: " + themeInodeOrId + " is not drawed");
+            throw new RuntimeException("Template with inode: " + templateInodeOrId + " is not drawed");
         }
 
         return new DrawedBody(workingTemplate.getTitle(), workingTemplate.getDrawedBody());


### PR DESCRIPTION
With the changes made here https://github.com/dotCMS/core/pull/20530/files now the cache is not used if is in a Transaction. And for the FileAssetTemplates that since they do not live in the template table were never returning.