### PR TITLE
Issue 20557 site resource improvements

### DIFF
--- a/dotCMS/src/curl-test/GraphQLTests.json
+++ b/dotCMS/src/curl-test/GraphQLTests.json
@@ -1,10 +1,163 @@
 {
 	"info": {
-		"_postman_id": "f8e6f36f-0e13-4a74-8439-9cc82852be81",
+		"_postman_id": "997033b2-adeb-4476-8a5f-6833cfbf3794",
 		"name": "GraphQL",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
+		{
+			"name": "File Metadata",
+			"item": [
+				{
+					"name": "Create FileAsset Content",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"pm.collectionVariables.set(\"fileContentIdentifier\", jsonData.entity.identifier);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotCMS.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "json",
+									"value": "{\n    \"contentlet\": {\n       \"contentType\":\"FileAsset\",\n       \"title\":\"Legioss\", \n       \"hostFolder\":\"default\",\n       \"indexPolicy\":\"WAIT_FOR\",\n       \"showOnMenu\":\"true\",\n       \"sortOrder\":\"2\"\n    }\n}",
+									"type": "text"
+								},
+								{
+									"key": "file",
+									"type": "file",
+									"src": "resources/GraphQL/Test_GraphQL_Image_Field_fields/actn-legioss.jpg"
+								}
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"workflow",
+								"actions",
+								"default",
+								"fire",
+								"PUBLISH"
+							]
+						},
+						"description": "This is to fire the added default action\n\nhttp://localhost:8080/api/v1/workflow/actions/default/fire/PUBLISH\n\nIn this case I'm using the \"test\" content type that just have a name filed (text)"
+					},
+					"response": []
+				},
+				{
+					"name": "Request File Asset metada fields",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"var imageFieldVariable = pm.collectionVariables.get(\"imageFieldVariable\");",
+									"var fileFieldVariable = pm.collectionVariables.get(\"fileFieldVariable\");",
+									"",
+									"var contentIdentifier = pm.collectionVariables.get(\"contentIdentifier\")",
+									"",
+									"pm.test(\"FileAsset metadata attributes\", function () {",
+									"     ",
+									"    var metadataFields = jsonData.data[\"FileAssetCollection\"][0][\"fileAsset\"];",
+									"    ",
+									"    // metadata attributes",
+									"    pm.expect(metadataFields.name).to.eql(\"actn-legioss.jpg\");",
+									"    pm.expect(metadataFields.title).to.eql(\"actn-legioss.jpg\");",
+									"    pm.expect(metadataFields.isImage).to.eql(true);",
+									"    pm.expect(metadataFields.modDate).to.be.above(0);",
+									"    pm.expect(metadataFields.size).to.eql(215384);",
+									"    pm.expect(metadataFields.mime).to.eql(\"image/jpeg\");",
+									"    pm.expect(metadataFields.width).to.eql(1200);",
+									"    pm.expect(metadataFields.height).to.eql(900);",
+									"    pm.expect(metadataFields.sha256).to.eql(\"ffe7157a4b7c8dd772f57dc2de8694ea974b87653b5605f854924a43bbfbb0ce\");",
+									"    pm.expect(metadataFields.path).not.eql(null);",
+									"    pm.expect(metadataFields.versionPath).not.eql(null);",
+									"    pm.expect(metadataFields.focalPoint).to.eql(\"0.0\");",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "graphql",
+							"graphql": {
+								"query": "{\n  \nFileAssetCollection(limit:20){\n    fileAsset{\n      modDate\n      sha256\n      mime\n      title\n      versionPath\n      mime\n      focalPoint\n      path\n      name\n      versionPath\n      width\n      height\n      size\n      isImage\n    }   \n  }\n\n}\n\n\n\n\n",
+								"variables": ""
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/graphql",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"graphql"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
 		{
 			"name": "Page API",
 			"item": [
@@ -5159,159 +5312,6 @@
 							"mode": "graphql",
 							"graphql": {
 								"query": "{\n  MovieCollection(sortBy: \"Movie.title\") {\n    title\n    studio(query: \"+studio.name:\\\"Walt Disney Pictures\\\"\") {\n      name\n    }\n  }\n}\n",
-								"variables": ""
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/graphql",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"graphql"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "File Metadata",
-			"item": [
-				{
-					"name": "Create FileAsset Content",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"pm.collectionVariables.set(\"fileContentIdentifier\", jsonData.entity.identifier);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotCMS.com",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"type": "any"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "json",
-									"value": "{\n    \"contentlet\": {\n       \"contentType\":\"FileAsset\",\n       \"title\":\"Legioss\", \n       \"hostFolder\":\"default\",\n       \"indexPolicy\":\"WAIT_FOR\",\n       \"showOnMenu\":\"true\",\n       \"sortOrder\":\"2\"\n    }\n}",
-									"type": "text"
-								},
-								{
-									"key": "file",
-									"type": "file",
-									"src": "resources/GraphQL/Test_GraphQL_Image_Field_fields/actn-legioss.jpg"
-								}
-							],
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"workflow",
-								"actions",
-								"default",
-								"fire",
-								"PUBLISH"
-							]
-						},
-						"description": "This is to fire the added default action\n\nhttp://localhost:8080/api/v1/workflow/actions/default/fire/PUBLISH\n\nIn this case I'm using the \"test\" content type that just have a name filed (text)"
-					},
-					"response": []
-				},
-				{
-					"name": "Request File Asset metada fields",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"var imageFieldVariable = pm.collectionVariables.get(\"imageFieldVariable\");",
-									"var fileFieldVariable = pm.collectionVariables.get(\"fileFieldVariable\");",
-									"",
-									"var contentIdentifier = pm.collectionVariables.get(\"contentIdentifier\")",
-									"",
-									"pm.test(\"FileAsset metadata attributes\", function () {",
-									"     ",
-									"    var metadataFields = jsonData.data[\"FileAssetCollection\"][0][\"fileAsset\"];",
-									"    ",
-									"    // metadata attributes",
-									"    pm.expect(metadataFields.name).to.eql(\"actn-legioss.jpg\");",
-									"    pm.expect(metadataFields.title).to.eql(\"actn-legioss.jpg\");",
-									"    pm.expect(metadataFields.isImage).to.eql(true);",
-									"    pm.expect(metadataFields.modDate).to.be.above(0);",
-									"    pm.expect(metadataFields.size).to.eql(215384);",
-									"    pm.expect(metadataFields.mime).to.eql(\"image/jpeg\");",
-									"    pm.expect(metadataFields.width).to.eql(1200);",
-									"    pm.expect(metadataFields.height).to.eql(900);",
-									"    pm.expect(metadataFields.sha256).to.eql(\"ffe7157a4b7c8dd772f57dc2de8694ea974b87653b5605f854924a43bbfbb0ce\");",
-									"    pm.expect(metadataFields.path).not.eql(null);",
-									"    pm.expect(metadataFields.versionPath).not.eql(null);",
-									"    pm.expect(metadataFields.focalPoint).to.eql(\"0.0\");",
-									"",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "graphql",
-							"graphql": {
-								"query": "{\n  \nFileAssetCollection(limit:20){\n    fileAsset{\n      modDate\n      sha256\n      mime\n      title\n      versionPath\n      mime\n      focalPoint\n      path\n      name\n      versionPath\n      width\n      height\n      size\n      isImage\n    }   \n  }\n\n}\n\n\n\n\n",
 								"variables": ""
 							}
 						},

--- a/dotCMS/src/curl-test/GraphQLTests.json
+++ b/dotCMS/src/curl-test/GraphQLTests.json
@@ -1,163 +1,10 @@
 {
 	"info": {
-		"_postman_id": "997033b2-adeb-4476-8a5f-6833cfbf3794",
+		"_postman_id": "f8e6f36f-0e13-4a74-8439-9cc82852be81",
 		"name": "GraphQL",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
-		{
-			"name": "File Metadata",
-			"item": [
-				{
-					"name": "Create FileAsset Content",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"pm.collectionVariables.set(\"fileContentIdentifier\", jsonData.entity.identifier);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotCMS.com",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"type": "any"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "json",
-									"value": "{\n    \"contentlet\": {\n       \"contentType\":\"FileAsset\",\n       \"title\":\"Legioss\", \n       \"hostFolder\":\"default\",\n       \"indexPolicy\":\"WAIT_FOR\",\n       \"showOnMenu\":\"true\",\n       \"sortOrder\":\"2\"\n    }\n}",
-									"type": "text"
-								},
-								{
-									"key": "file",
-									"type": "file",
-									"src": "resources/GraphQL/Test_GraphQL_Image_Field_fields/actn-legioss.jpg"
-								}
-							],
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"workflow",
-								"actions",
-								"default",
-								"fire",
-								"PUBLISH"
-							]
-						},
-						"description": "This is to fire the added default action\n\nhttp://localhost:8080/api/v1/workflow/actions/default/fire/PUBLISH\n\nIn this case I'm using the \"test\" content type that just have a name filed (text)"
-					},
-					"response": []
-				},
-				{
-					"name": "Request File Asset metada fields",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"var imageFieldVariable = pm.collectionVariables.get(\"imageFieldVariable\");",
-									"var fileFieldVariable = pm.collectionVariables.get(\"fileFieldVariable\");",
-									"",
-									"var contentIdentifier = pm.collectionVariables.get(\"contentIdentifier\")",
-									"",
-									"pm.test(\"FileAsset metadata attributes\", function () {",
-									"     ",
-									"    var metadataFields = jsonData.data[\"FileAssetCollection\"][0][\"fileAsset\"];",
-									"    ",
-									"    // metadata attributes",
-									"    pm.expect(metadataFields.name).to.eql(\"actn-legioss.jpg\");",
-									"    pm.expect(metadataFields.title).to.eql(\"actn-legioss.jpg\");",
-									"    pm.expect(metadataFields.isImage).to.eql(true);",
-									"    pm.expect(metadataFields.modDate).to.be.above(0);",
-									"    pm.expect(metadataFields.size).to.eql(215384);",
-									"    pm.expect(metadataFields.mime).to.eql(\"image/jpeg\");",
-									"    pm.expect(metadataFields.width).to.eql(1200);",
-									"    pm.expect(metadataFields.height).to.eql(900);",
-									"    pm.expect(metadataFields.sha256).to.eql(\"ffe7157a4b7c8dd772f57dc2de8694ea974b87653b5605f854924a43bbfbb0ce\");",
-									"    pm.expect(metadataFields.path).not.eql(null);",
-									"    pm.expect(metadataFields.versionPath).not.eql(null);",
-									"    pm.expect(metadataFields.focalPoint).to.eql(\"0.0\");",
-									"",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "graphql",
-							"graphql": {
-								"query": "{\n  \nFileAssetCollection(limit:20){\n    fileAsset{\n      modDate\n      sha256\n      mime\n      title\n      versionPath\n      mime\n      focalPoint\n      path\n      name\n      versionPath\n      width\n      height\n      size\n      isImage\n    }   \n  }\n\n}\n\n\n\n\n",
-								"variables": ""
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/graphql",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"graphql"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
 		{
 			"name": "Page API",
 			"item": [
@@ -5312,6 +5159,159 @@
 							"mode": "graphql",
 							"graphql": {
 								"query": "{\n  MovieCollection(sortBy: \"Movie.title\") {\n    title\n    studio(query: \"+studio.name:\\\"Walt Disney Pictures\\\"\") {\n      name\n    }\n  }\n}\n",
+								"variables": ""
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/graphql",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"graphql"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "File Metadata",
+			"item": [
+				{
+					"name": "Create FileAsset Content",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"pm.collectionVariables.set(\"fileContentIdentifier\", jsonData.entity.identifier);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotCMS.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "json",
+									"value": "{\n    \"contentlet\": {\n       \"contentType\":\"FileAsset\",\n       \"title\":\"Legioss\", \n       \"hostFolder\":\"default\",\n       \"indexPolicy\":\"WAIT_FOR\",\n       \"showOnMenu\":\"true\",\n       \"sortOrder\":\"2\"\n    }\n}",
+									"type": "text"
+								},
+								{
+									"key": "file",
+									"type": "file",
+									"src": "resources/GraphQL/Test_GraphQL_Image_Field_fields/actn-legioss.jpg"
+								}
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"workflow",
+								"actions",
+								"default",
+								"fire",
+								"PUBLISH"
+							]
+						},
+						"description": "This is to fire the added default action\n\nhttp://localhost:8080/api/v1/workflow/actions/default/fire/PUBLISH\n\nIn this case I'm using the \"test\" content type that just have a name filed (text)"
+					},
+					"response": []
+				},
+				{
+					"name": "Request File Asset metada fields",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"var imageFieldVariable = pm.collectionVariables.get(\"imageFieldVariable\");",
+									"var fileFieldVariable = pm.collectionVariables.get(\"fileFieldVariable\");",
+									"",
+									"var contentIdentifier = pm.collectionVariables.get(\"contentIdentifier\")",
+									"",
+									"pm.test(\"FileAsset metadata attributes\", function () {",
+									"     ",
+									"    var metadataFields = jsonData.data[\"FileAssetCollection\"][0][\"fileAsset\"];",
+									"    ",
+									"    // metadata attributes",
+									"    pm.expect(metadataFields.name).to.eql(\"actn-legioss.jpg\");",
+									"    pm.expect(metadataFields.title).to.eql(\"actn-legioss.jpg\");",
+									"    pm.expect(metadataFields.isImage).to.eql(true);",
+									"    pm.expect(metadataFields.modDate).to.be.above(0);",
+									"    pm.expect(metadataFields.size).to.eql(215384);",
+									"    pm.expect(metadataFields.mime).to.eql(\"image/jpeg\");",
+									"    pm.expect(metadataFields.width).to.eql(1200);",
+									"    pm.expect(metadataFields.height).to.eql(900);",
+									"    pm.expect(metadataFields.sha256).to.eql(\"ffe7157a4b7c8dd772f57dc2de8694ea974b87653b5605f854924a43bbfbb0ce\");",
+									"    pm.expect(metadataFields.path).not.eql(null);",
+									"    pm.expect(metadataFields.versionPath).not.eql(null);",
+									"    pm.expect(metadataFields.focalPoint).to.eql(\"0.0\");",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "graphql",
+							"graphql": {
+								"query": "{\n  \nFileAssetCollection(limit:20){\n    fileAsset{\n      modDate\n      sha256\n      mime\n      title\n      versionPath\n      mime\n      focalPoint\n      path\n      name\n      versionPath\n      width\n      height\n      size\n      isImage\n    }   \n  }\n\n}\n\n\n\n\n",
 								"variables": ""
 							}
 						},

--- a/dotCMS/src/curl-test/Site Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Site Resource.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "90ad55aa-c2e7-4fc8-b56f-68e526c20695",
+		"_postman_id": "26eff347-1ce6-496e-bb5d-52901fedbe71",
 		"name": "Site Resource",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -370,7 +370,7 @@
 							"    pm.expect(jsonData.entity.siteThumbnail).to.include('250px-Bocas2.jpg');",
 							"});",
 							"",
-							"pm.collectionVariables.set(\"hostId\", jsonData.entity.identifier);",
+							"pm.collectionVariables.set(\"siteId\", jsonData.entity.identifier);",
 							""
 						],
 						"type": "text/javascript"
@@ -446,7 +446,7 @@
 							"    pm.expect(jsonData.entity.live).to.eql(true);",
 							"});",
 							"",
-							"pm.collectionVariables.set(\"hostId\", jsonData.entity.identifier);",
+							"pm.collectionVariables.set(\"siteId\", jsonData.entity.identifier);",
 							""
 						],
 						"type": "text/javascript"
@@ -472,7 +472,7 @@
 				"method": "PUT",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}/_publish",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}/_publish",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -480,7 +480,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}",
+						"{{siteId}}",
 						"_publish"
 					]
 				}
@@ -526,7 +526,7 @@
 				"method": "PUT",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}/_makedefault",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}/_makedefault",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -534,7 +534,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}",
+						"{{siteId}}",
 						"_makedefault"
 					]
 				}
@@ -570,7 +570,7 @@
 							"    pm.expect(jsonData.entity.default).to.eql(true);",
 							"});",
 							"",
-							"pm.collectionVariables.set(\"hostId\", jsonData.entity.identifier);",
+							"pm.collectionVariables.set(\"siteId\", jsonData.entity.identifier);",
 							""
 						],
 						"type": "text/javascript"
@@ -596,7 +596,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -604,7 +604,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}"
+						"{{siteId}}"
 					]
 				}
 			},
@@ -629,7 +629,7 @@
 							"});",
 							"",
 							"pm.collectionVariables.set(\"hostInode\", jsonData.entity.inode);",
-							"pm.collectionVariables.set(\"hostdentifier\", jsonData.entity.identifier);",
+							"pm.collectionVariables.set(\"siteIdentifier\", jsonData.entity.identifier);",
 							""
 						],
 						"type": "text/javascript"
@@ -714,7 +714,7 @@
 				"method": "PUT",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostdentifier}}/_makedefault",
+					"raw": "{{serverURL}}/api/v1/site/{{siteIdentifier}}/_makedefault",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -722,7 +722,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostdentifier}}",
+						"{{siteIdentifier}}",
 						"_makedefault"
 					]
 				}
@@ -758,7 +758,7 @@
 							"    pm.expect(jsonData.entity.default).to.eql(false);",
 							"});",
 							"",
-							"pm.collectionVariables.set(\"hostId\", jsonData.entity.identifier);",
+							"pm.collectionVariables.set(\"siteId\", jsonData.entity.identifier);",
 							""
 						],
 						"type": "text/javascript"
@@ -769,7 +769,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -777,7 +777,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}"
+						"{{siteId}}"
 					]
 				}
 			},
@@ -812,7 +812,7 @@
 							"    pm.expect(jsonData.entity.default).to.eql(false);",
 							"});",
 							"",
-							"pm.collectionVariables.set(\"hostId\", jsonData.entity.identifier);",
+							"pm.collectionVariables.set(\"siteId\", jsonData.entity.identifier);",
 							""
 						],
 						"type": "text/javascript"
@@ -838,7 +838,7 @@
 				"method": "PUT",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}/_unpublish",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}/_unpublish",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -846,7 +846,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}",
+						"{{siteId}}",
 						"_unpublish"
 					]
 				}
@@ -883,7 +883,7 @@
 							"    pm.expect(jsonData.entity.default).to.eql(false);",
 							"});",
 							"",
-							"pm.collectionVariables.set(\"hostId\", jsonData.entity.identifier);",
+							"pm.collectionVariables.set(\"siteId\", jsonData.entity.identifier);",
 							""
 						],
 						"type": "text/javascript"
@@ -909,7 +909,7 @@
 				"method": "PUT",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}/_archive",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}/_archive",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -917,7 +917,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}",
+						"{{siteId}}",
 						"_archive"
 					]
 				}
@@ -954,7 +954,7 @@
 							"    pm.expect(jsonData.entity.default).to.eql(false);",
 							"});",
 							"",
-							"pm.collectionVariables.set(\"hostId\", jsonData.entity.identifier);",
+							"pm.collectionVariables.set(\"siteId\", jsonData.entity.identifier);",
 							""
 						],
 						"type": "text/javascript"
@@ -980,7 +980,7 @@
 				"method": "PUT",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}/_unarchive",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}/_unarchive",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -988,7 +988,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}",
+						"{{siteId}}",
 						"_unarchive"
 					]
 				}
@@ -1094,7 +1094,7 @@
 				"method": "DELETE",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -1102,7 +1102,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}"
+						"{{siteId}}"
 					]
 				}
 			},
@@ -1137,7 +1137,7 @@
 							"    pm.expect(jsonData.entity.default).to.eql(false);",
 							"});",
 							"",
-							"pm.collectionVariables.set(\"hostId\", jsonData.entity.identifier);",
+							"pm.collectionVariables.set(\"siteId\", jsonData.entity.identifier);",
 							""
 						],
 						"type": "text/javascript"
@@ -1163,7 +1163,7 @@
 				"method": "PUT",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}/_archive",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}/_archive",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -1171,7 +1171,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}",
+						"{{siteId}}",
 						"_archive"
 					]
 				}
@@ -1214,7 +1214,7 @@
 				"method": "DELETE",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -1222,7 +1222,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}"
+						"{{siteId}}"
 					]
 				}
 			},
@@ -1245,7 +1245,7 @@
 							"    pm.expect(jsonData.entity.siteName).to.eql('postman.copy.host.com');",
 							"});",
 							"",
-							"pm.collectionVariables.set(\"hostId\", jsonData.entity.identifier);",
+							"pm.collectionVariables.set(\"siteId\", jsonData.entity.identifier);",
 							""
 						],
 						"type": "text/javascript"
@@ -1272,7 +1272,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"copyFromSiteId\":\"{{hostdentifier}}\",\n    \"copyAll\":true,\n    \"copyTemplatesContainers\":true,\n    \"copyContentOnPages\":true,\n    \"copyFolders\":true,\n    \"copyContentOnSite\":true,\n    \"copyLinks\":true,\n    \"copySiteVariables\":true,\n    \"site\": {\n        \"siteName\":\"postman.copy.host.com\"\n    }\n}",
+					"raw": "{\n    \"copyFromSiteId\":\"{{siteIdentifier}}\",\n    \"copyAll\":true,\n    \"copyTemplatesContainers\":true,\n    \"copyContentOnPages\":true,\n    \"copyFolders\":true,\n    \"copyContentOnSite\":true,\n    \"copyLinks\":true,\n    \"copySiteVariables\":true,\n    \"site\": {\n        \"siteName\":\"postman.copy.host.com\"\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -1330,7 +1330,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostId}}/setup_progress",
+					"raw": "{{serverURL}}/api/v1/site/{{siteId}}/setup_progress",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -1338,7 +1338,7 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostId}}",
+						"{{siteId}}",
 						"setup_progress"
 					]
 				}
@@ -1480,7 +1480,7 @@
 				"method": "PUT",
 				"header": [],
 				"url": {
-					"raw": "{{serverURL}}/api/v1/site/{{hostdentifier}}/_archive",
+					"raw": "{{serverURL}}/api/v1/site/{{siteIdentifier}}/_archive",
 					"host": [
 						"{{serverURL}}"
 					],
@@ -1488,8 +1488,57 @@
 						"api",
 						"v1",
 						"site",
-						"{{hostdentifier}}",
+						"{{siteIdentifier}}",
 						"_archive"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Test Delete Default Site  - Fail expected",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code should be 400\", function () {",
+							"    pm.response.to.have.status(400);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin@dotcms.com",
+							"type": "string"
+						}
+					]
+				},
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "{{serverURL}}/api/v1/site/{{siteIdentifier}}",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"site",
+						"{{siteIdentifier}}"
 					]
 				}
 			},
@@ -1546,7 +1595,7 @@
 			"response": []
 		},
 		{
-			"name": "Delete Site wrong site Id Copy",
+			"name": "Delete Site wrong site Id",
 			"event": [
 				{
 					"listen": "test",
@@ -1699,8 +1748,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test(\"Status code should be 400\", function () {",
-							"    pm.response.to.have.status(400);",
+							"pm.test(\"Status code should be 404\", function () {",
+							"    pm.response.to.have.status(404);",
 							"});",
 							""
 						],
@@ -1728,7 +1777,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"sitename\":\"xxxx.com\"\n}",
+					"raw": "{\n    \"siteName\":\"xxxx.com\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -1813,8 +1862,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test(\"Status code should be 400\", function () {",
-							"    pm.response.to.have.status(400);",
+							"pm.test(\"Status code should be 404\", function () {",
+							"    pm.response.to.have.status(404);",
 							"});",
 							""
 						],
@@ -1842,7 +1891,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"copyFromHostId\":\"xxxxx\",\n    \"copyAll\":true,\n    \"copyTemplatesContainers\":true,\n    \"copyContentOnPages\":true,\n    \"copyFolders\":true,\n    \"copyContentOnHost\":true,\n    \"copyLinks\":true,\n    \"copyHostVariables\":true,\n    \"host\": {\n        \"hostName\":\"postman.copy.host.com\"\n    }\n}",
+					"raw": "{\n    \"copyFromSiteId\":\"xxxxx\",\n    \"copyAll\":true,\n    \"copyTemplatesContainers\":true,\n    \"copyContentOnPages\":true,\n    \"copyFolders\":true,\n    \"copyContentOnSite\":true,\n    \"copyLinks\":true,\n    \"copySiteVariables\":true,\n    \"site\": {\n        \"siteName\":\"postman.copy.host.com\"\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -1879,19 +1928,19 @@
 			"value": ""
 		},
 		{
-			"key": "hostId",
-			"value": ""
-		},
-		{
-			"key": "hostInode",
-			"value": ""
-		},
-		{
-			"key": "hostdentifier",
+			"key": "siteInode",
 			"value": ""
 		},
 		{
 			"key": "siteId",
+			"value": ""
+		},
+		{
+			"key": "siteIdentifier",
+			"value": ""
+		},
+		{
+			"key": "hostInode",
 			"value": ""
 		}
 	]

--- a/dotCMS/src/curl-test/ThemeResource.postman_collection.json
+++ b/dotCMS/src/curl-test/ThemeResource.postman_collection.json
@@ -9,7 +9,7 @@
 			"name": "findThemes",
 			"item": [
 				{
-					"name": "FindThemes HostId Not Exists NotFound",
+					"name": "FindThemes siteId Not Exists NotFound",
 					"event": [
 						{
 							"listen": "test",
@@ -72,7 +72,7 @@
 					"response": []
 				},
 				{
-					"name": "FindThemes HostId Not Sent BadRequest",
+					"name": "FindThemes SiteId Not Sent BadRequest",
 					"event": [
 						{
 							"listen": "test",
@@ -129,7 +129,7 @@
 					"response": []
 				},
 				{
-					"name": "FindThemes HostId is System Host Success",
+					"name": "FindThemes SiteId is System Host Success",
 					"event": [
 						{
 							"listen": "test",

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/site/SiteHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/site/SiteHelper.java
@@ -4,6 +4,8 @@ import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.web.WebAPILocator;
+import com.dotmarketing.exception.AlreadyExistException;
+import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -109,7 +111,7 @@ public class SiteHelper implements Serializable {
 	}
 
 	/**
-	 * Save a new or existing site
+	 * Saves a new. Validates if it already exist
 	 * @param site
 	 * @param user
 	 * @param respectAnonPerms
@@ -117,9 +119,28 @@ public class SiteHelper implements Serializable {
 	 * @throws DotSecurityException
 	 * @throws DotDataException
 	 */
-	public Host save(final Host site, final User user, final boolean respectAnonPerms) throws DotSecurityException, DotDataException {
+	public Host save(final Host site, final User user, final boolean respectAnonPerms) throws DotSecurityException, DotDataException, AlreadyExistException {
+		if(null != hostAPI.findByName(site.getHostname(), user, respectAnonPerms)){
+		   throw new AlreadyExistException(String.format("A site named `%s` already exists.",site.getHostname()));
+		}
+		return hostAPI.save(site, user, respectAnonPerms);
+	}
 
-		return APILocator.getHostAPI().save(site, user, respectAnonPerms);
+	/**
+	 * Saves an existing site
+	 * @param site
+	 * @param user
+	 * @param respectAnonPerms
+	 * @return
+	 * @throws DotSecurityException
+	 * @throws DotDataException
+	 * @throws AlreadyExistException
+	 */
+	public Host update(final Host site, final User user, final boolean respectAnonPerms) throws DotSecurityException, DotDataException, DoesNotExistException {
+		if(null == hostAPI.findByName(site.getHostname(), user, respectAnonPerms)){
+			throw new DoesNotExistException(String.format("Invalid attempt to update a non existing site `%s` .",site.getHostname()));
+		}
+		return hostAPI.save(site, user, respectAnonPerms);
 	}
 
 	/**
@@ -134,7 +155,7 @@ public class SiteHelper implements Serializable {
 	public Future<Boolean> delete(final Host site, final User user, final boolean respectAnonPerms) throws DotSecurityException, DotDataException {
 
 		final Optional<Future<Boolean>> hostDeleteResultOpt = hostAPI.delete(site, user, respectAnonPerms, true);
-		return hostDeleteResultOpt.isPresent()?hostDeleteResultOpt.get():null;
+		return hostDeleteResultOpt.orElse(null);
 	}
 
 	/**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/site/SiteResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/site/SiteResource.java
@@ -24,6 +24,7 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.UserAPI;
 import com.dotmarketing.business.util.HostNameComparator;
+import com.dotmarketing.exception.AlreadyExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
@@ -773,7 +774,7 @@ public class SiteResource implements Serializable {
     public Response createNewSite(@Context final HttpServletRequest httpServletRequest,
                                   @Context final HttpServletResponse httpServletResponse,
                                   final SiteForm newSiteForm)
-            throws DotDataException, DotSecurityException{
+            throws DotDataException, DotSecurityException, AlreadyExistException {
 
         final User user = new WebResource.InitBuilder(this.webResource)
                 .requestAndResponse(httpServletRequest, httpServletResponse)
@@ -961,7 +962,7 @@ public class SiteResource implements Serializable {
         Logger.debug(this, ()-> "Creating new Host: " + newSiteForm);
 
         return Response.ok(new ResponseEntityView(
-                this.toView(this.siteHelper.save(site, user, pageMode.respectAnonPerms)))).build();
+                this.toView(this.siteHelper.update(site, user, pageMode.respectAnonPerms)))).build();
     }
 
     /**
@@ -988,7 +989,7 @@ public class SiteResource implements Serializable {
     public Response copySite(@Context final HttpServletRequest httpServletRequest,
                                   @Context final HttpServletResponse httpServletResponse,
                                   final CopySiteForm copySiteForm)
-            throws DotDataException, DotSecurityException, PortalException, SystemException, ParseException, SchedulerException, ClassNotFoundException {
+            throws DotDataException, DotSecurityException, PortalException, SystemException, ParseException, SchedulerException, ClassNotFoundException, AlreadyExistException {
 
         final User user = new WebResource.InitBuilder(this.webResource)
                 .requestAndResponse(httpServletRequest, httpServletResponse)


### PR DESCRIPTION
This should bring...

1.  A better error handling when trying to create a site using a name that has already been taken. 
2. Whenever possible. Renaming occurrences of the keyword `hostId` or `hostIdentifier` to siteId or siteIdentifier
3. Moving up in the GraphQL postman code The File Metadata set of tests to avoid a tika issue
