### PR TITLE
dotCMS/core#20566 ui-fixes-for-content-and-edit-page

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
@@ -175,7 +175,7 @@ dojo.declare("dotcms.dijit.form.ContentSelector", [dijit._Widget, dijit._Templat
     },
 
 	_fillStructures: function() {
-		this.structures_select.innerHTML = "";
+		this.content_type_select.innerHTML = "";
 		var htmlstr = "<dl class='vertical'>";
 		htmlstr += "<dt><label><b>Content Type:</b></label></dt>";
 		htmlstr += "<dd>";
@@ -199,8 +199,8 @@ dojo.declare("dotcms.dijit.form.ContentSelector", [dijit._Widget, dijit._Templat
 		this.displayStructureFields(this.containerStructures[0].inode);
 		htmlstr += "</dd>";
 		htmlstr += "</dl>";
-		dojo.place(htmlstr,this.structures_select);
-		dojo.parser.parse(this.structures_select);
+		dojo.place(htmlstr,this.content_type_select);
+		dojo.parser.parse(this.content_type_select);
 	},
 
 	_fillLanguages: function(data) {

--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelectorContent.jsp
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelectorContent.jsp
@@ -34,6 +34,7 @@
                 value="strInode"
             />
             <div class="sideMenuWrapper">
+                <div dojoAttachPoint="structures_select"></div>
                 <div dojoAttachPoint="search_general">
                     <dl class="vertical">
                         <dt>
@@ -54,7 +55,6 @@
                     </dl>
                 </div>
                 <div dojoAttachPoint="search_languages_table"></div>
-                <div dojoAttachPoint="structures_select"></div>
                 <div dojoAttachPoint="search_fields_table"></div>
                 <div dojoAttachPoint="search_categories_table">
                     <dl

--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelectorContent.jsp
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelectorContent.jsp
@@ -34,7 +34,7 @@
                 value="strInode"
             />
             <div class="sideMenuWrapper">
-                <div dojoAttachPoint="structures_select"></div>
+                <div dojoAttachPoint="content_type_select"></div>
                 <div dojoAttachPoint="search_general">
                     <dl class="vertical">
                         <dt>

--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_menus_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_menus_js_inc.jsp
@@ -915,7 +915,7 @@
 
 		if (menuOptions) {
 			var htmlCode = '';
-			htmlCode += '<div data-dojo-type="dijit/form/DropDownButton" data-dojo-props=\'iconClass:"actionIcon", class:"dijitDropDownActionButton"\'>';
+			htmlCode += '<div data-dojo-type="dijit/form/DropDownButton" data-dojo-props=\'iconClass:"fa-plus", class:"dijitDropDownActionButton"\'>';
 			htmlCode += '<span></span>';
 			htmlCode += '<div data-dojo-type="dijit/Menu" class="contentlet-menu-actions">';
 			htmlCode += menuOptions;


### PR DESCRIPTION
- The add button on the content search screen has the 3 dot menu but should be using the + icon
- In the Content Search dialog "Content Type" should be first like its in the normal content search screen