### PR TITLE
Issue 19443 deterministic id fields

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPIImpl.java
@@ -421,9 +421,9 @@ public class ContentTypeAPIImpl implements ContentTypeAPI {
     // Sets the host:
     try {
       if (contentType.host() == null || contentType.fixed()) {
-        final List<Field> existinFields = contentType.fields();
+        final List<Field> existingFields = contentType.fields();
         contentType = ContentTypeBuilder.builder(contentType).host(Host.SYSTEM_HOST).build();
-        contentType.constructWithFields(existinFields);
+        contentType.constructWithFields(existingFields);
       }
       if (!UUIDUtil.isUUID(contentType.host()) && !Host.SYSTEM_HOST.equalsIgnoreCase(contentType.host())) {
         HostAPI hapi = APILocator.getHostAPI();

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldFactoryImpl.java
@@ -234,15 +234,11 @@ public class FieldFactoryImpl implements FieldFactory {
 
     } catch (NotFoundInDbException e) {
       List<Field> fieldsAlreadyAdded = byContentTypeId(throwAwayField.contentTypeId());
-      // assign an inode and db column if needed
-      if (throwAwayField.id() == null) {
-        builder.id(UUID.randomUUID().toString());
-      }
 
       if (throwAwayField.sortOrder() < 0) {
         // move to the end of the line
     	builder.sortOrder(
-    		fieldsAlreadyAdded.stream().map(f -> f.sortOrder()).max(Integer::compare).orElse(-1) + 1
+    		fieldsAlreadyAdded.stream().map(Field::sortOrder).max(Integer::compare).orElse(-1) + 1
     	);
       }
 
@@ -253,6 +249,12 @@ public class FieldFactoryImpl implements FieldFactory {
       String tryVar = getFieldVariable(throwAwayField, takenFieldVars);
 
       builder.variable(tryVar);
+
+      // assign an inode and db column if needed
+      if (throwAwayField.id() == null) {
+          builder.id(APILocator.getDeterministicIdentifierAPI().generateDeterministicIdBestEffort(throwAwayField, ()->tryVar));
+      }
+
     }
     builder = FieldBuilder.builder(normalizeData(builder.build()));
 

--- a/dotCMS/src/main/java/com/dotmarketing/business/DeterministicIdentifierAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/DeterministicIdentifierAPI.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.business;
 
+import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import java.util.function.Supplier;
@@ -28,6 +29,13 @@ public interface DeterministicIdentifierAPI {
      * @return generated deterministic id
      */
     String generateDeterministicIdBestEffort(ContentType contentType, Supplier<String> contentTypeVarName);
+
+    /**
+     * Entry point for Fields
+     * @param throwAwayField sometimes the var-name isn't set on the Field
+     * @return
+     */
+    String generateDeterministicIdBestEffort(Field throwAwayField, Supplier<String> fieldVarName);
 
     /**
      * Given a Language this will evaluate the code and country code if any then generate a sha256 and finally will hash it out into a long val

--- a/dotCMS/src/main/java/com/dotmarketing/business/DeterministicIdentifierAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/DeterministicIdentifierAPIImpl.java
@@ -3,7 +3,9 @@ package com.dotmarketing.business;
 import static com.dotmarketing.util.UUIDUtil.isUUID;
 
 import com.dotcms.business.CloseDBIfOpened;
+import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.model.field.BinaryField;
+import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotmarketing.beans.Host;
@@ -23,6 +25,7 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
 import java.util.Iterator;
@@ -44,19 +47,23 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
 
     private final FolderAPI folderAPI;
     private final HostAPI hostAPI;
+    private final ContentTypeAPI contentTypeAPI;
     private final Supplier<String> uuidSupplier;
     private final Function<String, String> hashFunction;
 
     DeterministicIdentifierAPIImpl() {
-        this(APILocator.getFolderAPI(), APILocator.getHostAPI(),
+        this(APILocator.getFolderAPI(),
+             APILocator.getHostAPI(),
+             APILocator.getContentTypeAPI(APILocator.systemUser()),
              UUIDGenerator::generateUuid,
              DigestUtils::sha256Hex);
     }
 
     @VisibleForTesting
-    DeterministicIdentifierAPIImpl(final FolderAPI folderAPI, final HostAPI hostAPI, final Supplier<String> uuidSupplier, final Function<String, String> hashFunction) {
+    DeterministicIdentifierAPIImpl(final FolderAPI folderAPI, final HostAPI hostAPI, final ContentTypeAPI contentTypeAPI,final Supplier<String> uuidSupplier, final Function<String, String> hashFunction) {
         this.folderAPI = folderAPI;
         this.hostAPI = hostAPI;
+        this.contentTypeAPI = contentTypeAPI;
         this.uuidSupplier = uuidSupplier;
         this.hashFunction = hashFunction;
     }
@@ -171,11 +178,17 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
         return baseContentType.getAlternateName();
     }
 
+    /**
+     * This method is used by ContentTypes if the CT does not have a predefined variable-name installed on it we rely on the supplier.
+     * @param contentType
+     * @param varName
+     * @return
+     */
     @VisibleForTesting
-    String resolveName(final ContentType contentType, final Supplier<String>contentTypeVarName) {
+    String resolveName(final ContentType contentType, final Supplier<String> varName) {
         String name = contentType.variable();
         if(UtilMethods.isNotSet(name)){
-           name = contentTypeVarName.get();
+            name = varName.get();
         }
         return name;
     }
@@ -183,16 +196,40 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
     /**
      * Generates the seed to the deterministic id
      * @param contentType
-     * @param contentTypeVarName
+     * @param variableName
      * @return
      */
-    private String deterministicIdSeed(final ContentType contentType, final Supplier<String>contentTypeVarName) {
+    private String deterministicIdSeed(final ContentType contentType, final Supplier<String>variableName) {
        final String assetType = resolveAssetType(contentType);
-       final String name = resolveName(contentType, contentTypeVarName);
+       final String name = resolveName(contentType, variableName);
        final String seedId = String.format("%s:%s",assetType, name).toLowerCase();
 
        Logger.debug(DeterministicIdentifierAPIImpl.class, String.format(" contentType: %s, assetName: %s,  seedId: %s", assetType, name, seedId));
        return seedId;
+    }
+
+    /**
+     * This method is used by Fields if the Field does not have a predefined variable-name installed on it we rely on the supplier.
+     * @param field
+     * @param varName
+     * @return
+     */
+    @VisibleForTesting
+    String resolveName(final Field field, final Supplier<String> varName) {
+        String name = varName.get();
+        if(UtilMethods.isNotSet(name)){
+            name = field.variable();
+        }
+        return name;
+    }
+
+    private String deterministicIdSeed(final ContentType contentType, final Field field, final Supplier<String>fieldVariableName) {
+        final String assetType = deterministicIdSeed(contentType, contentType::variable);
+        final String name = resolveName(field, fieldVariableName);
+        final String seedId = String.format("%s:%s", assetType, name).toLowerCase();
+
+        Logger.debug(DeterministicIdentifierAPIImpl.class, String.format(" contentType: %s, assetName: %s,  seedId: %s", assetType, name, seedId));
+        return seedId;
     }
 
     /**
@@ -217,50 +254,29 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
         return hashed;
     }
 
-    @CloseDBIfOpened
-    private String bestEffortDeterministicId(final String hash) {
-
-        final IdentifierFactory identifierFactory = FactoryLocator.getIdentifierFactory();
-        String candidateId = hash;
-
-        for (int i = 1; i <= MAX_ATTEMPTS; i++) {
-            if (!identifierFactory.isIdentifier(candidateId)) {
-                return candidateId;
-            }
-            candidateId = uuidSupplier.get();
-        }
-        Logger.warn(DeterministicIdentifierAPIImpl.class,String.format("Attempt to generate id has failed instead a non deterministic id (%s) was returned.",candidateId));
-        return candidateId;
-    }
-
-    @CloseDBIfOpened
-    private String bestEffortDeterministicContentId(final String hash) {
-
-        String candidateId = hash;
-
-        for (int i = 1; i <= MAX_ATTEMPTS; i++) {
-            if (!isContentTypeInode(candidateId)) {
-                return candidateId;
-            }
-            candidateId = uuidSupplier.get();
-        }
-        Logger.warn(DeterministicIdentifierAPIImpl.class,String.format("Attempt to generate content-type id has failed instead a non deterministic id (%s) was returned.",candidateId));
-        return candidateId;
-    }
-
     /**
-     * Test if the calculated hash has already been used
+     * best effort means we Test the generated identifier against a table to see if it already has been taken previously
+     * if not we use it as the next identifier but if it has been already taken then we rely on the fallback function.
+     * The fallback function basically does what it was done before the introduction of the deterministic identifier api.
      * @param hash
+     * @param testIdentifierFunction
+     * @param fallbackIdentifier
+     * @param <T>
      * @return
      */
     @CloseDBIfOpened
-    private boolean isContentTypeInode(final String hash){
-            return new DotConnect()
-                    .setSQL("select count(*) as test from structure s join inode i on s.inode = i.inode where s.inode =?")
-                    .addParam(hash)
-                    .getInt("test")>0;
-
+    private <T> T bestEffortDeterministicId(final T hash, final Function<T,Boolean> testIdentifierFunction, final Supplier<T> fallbackIdentifier) {
+        T candidateId = hash;
+        for (int i = 1; i <= MAX_ATTEMPTS; i++) {
+            if (!testIdentifierFunction.apply(candidateId)) {
+                return candidateId;
+            }
+            candidateId = fallbackIdentifier.get();
+        }
+        Logger.warn(DeterministicIdentifierAPIImpl.class,String.format("Attempt to generate id has failed instead a non deterministic id (%s) was returned. ",candidateId));
+        return candidateId;
     }
+
 
     /**
      * Entry point for (Contentlets, Host, Persona, Templates, Folders, FileAsset)
@@ -271,8 +287,11 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
     @Override
     public String generateDeterministicIdBestEffort(final Versionable asset,
             final Treeable parent) {
-        return isEnabled() ? bestEffortDeterministicId(hash(deterministicIdSeed(asset, parent)))
-                : uuidSupplier.get();
+
+        final IdentifierFactory identifierFactory = FactoryLocator.getIdentifierFactory();
+        final Function<String, Boolean> testIdentifierFunction = identifierFactory::isIdentifier;
+        return isEnabled() ? bestEffortDeterministicId(hash(deterministicIdSeed(asset, parent)),
+                testIdentifierFunction, uuidSupplier) : uuidSupplier.get();
     }
 
     /**
@@ -285,9 +304,34 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
     @Override
     public String generateDeterministicIdBestEffort(final ContentType contentType,
             final Supplier<String> contentTypeVarName) {
-        return isEnabled() ? bestEffortDeterministicContentId(
-                hash(deterministicIdSeed(contentType, contentTypeVarName)))
-                : uuidSupplier.get();
+
+        return isEnabled() ? bestEffortDeterministicId(
+                hash(deterministicIdSeed(contentType, contentTypeVarName)),
+                this::isContentTypeInode, uuidSupplier) : uuidSupplier.get();
+    }
+
+    /**
+     *
+     * @param throwAwayField
+     * @return
+     */
+    public String generateDeterministicIdBestEffort(final Field throwAwayField,
+            final Supplier<String> fieldVarName) {
+        Preconditions.checkNotNull(throwAwayField.contentTypeId(), "contentTypeRequired");
+        Preconditions.checkNotNull(fieldVarName.get(), "contentTypeVariableRequired");
+
+        if(isEnabled()){
+            final ContentType contentType = Try
+                    .of(() -> contentTypeAPI.find(throwAwayField.contentTypeId()))
+                    .getOrElseThrow(DotRuntimeException::new);
+
+            return bestEffortDeterministicId(
+                    hash(deterministicIdSeed(contentType, throwAwayField, fieldVarName)),
+                    this::isFieldInode, uuidSupplier);
+
+        }
+        return uuidSupplier.get();
+
     }
 
     /**
@@ -297,26 +341,28 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
      */
     @Override
     public long generateDeterministicIdBestEffort(final Language lang) {
-        return isEnabled() ? bestEffortDeterministicLanguageId(
-                simpleHash(hash(deterministicIdSeed(lang)))) : nextLangId();
+
+        return isEnabled() ? bestEffortDeterministicId(simpleHash(hash(deterministicIdSeed(lang))),
+                this::isLanguageId,
+                this::nextLangId) : nextLangId();
     }
 
-    @CloseDBIfOpened
-    private long bestEffortDeterministicLanguageId(final long hash) {
-
-        long candidateId = hash;
-        for (int i = 1; i <= MAX_ATTEMPTS; i++) {
-            if (!isLanguageId(candidateId)) {
-                return candidateId;
-            }
-            candidateId = nextLangId();
-        }
-        Logger.warn(DeterministicIdentifierAPIImpl.class,String.format("Attempt to generate language id has failed instead a non deterministic id (%s) was returned.",candidateId));
-        return candidateId;
-    }
 
     private synchronized long nextLangId(){
         return System.currentTimeMillis();
+    }
+
+    /**
+     * Test if the calculated hash has already been used as a language identifier
+     * @param hash
+     * @return
+     */
+    @CloseDBIfOpened
+    private boolean isLanguageId(final long hash){
+        return new DotConnect()
+                .setSQL("select count(*) as test from language where id =?")
+                .addParam(hash)
+                .getInt("test")>0;
     }
 
     /**
@@ -325,9 +371,23 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
      * @return
      */
     @CloseDBIfOpened
-    private boolean isLanguageId(final long hash){
+    private boolean isContentTypeInode(final String hash){
         return new DotConnect()
-                .setSQL("select count(*) as test from language where id =?")
+                .setSQL("select count(*) as test from structure s join inode i on s.inode = i.inode where s.inode =?")
+                .addParam(hash)
+                .getInt("test")>0;
+
+    }
+
+    /**
+     * Test the calculated hash has already been used as a field identifier or inode
+     * @param hash
+     * @return
+     */
+    @CloseDBIfOpened
+    private boolean isFieldInode(final String hash){
+        return new DotConnect()
+                .setSQL("select count(*) as test from field f join inode i on f.inode = i.inode where i.inode =?")
                 .addParam(hash)
                 .getInt("test")>0;
     }
@@ -345,7 +405,7 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
         final int len = string.length();
         long hash = 0;
         for (int i = 0; i < len; i++) {
-            hash += 131 * (i + 1) * string.charAt(i);
+            hash += 131L * (i + 1) * string.charAt(i);
         }
         return hash;
     }

--- a/dotCMS/src/main/java/com/dotmarketing/business/DeterministicIdentifierAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/DeterministicIdentifierAPIImpl.java
@@ -68,6 +68,11 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
         this.hashFunction = hashFunction;
     }
 
+    /**
+     * Resolves the name used to generate a seed for the given params
+     * @param asset
+     * @return
+     */
     @VisibleForTesting
     String resolveAssetName(final Versionable asset) {
 
@@ -133,6 +138,11 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
 
     }
 
+    /**
+     * Resolves the name used to generate a seed for the given params
+     * @param asset
+     * @return
+     */
     @VisibleForTesting
     String resolveAssetType(final Versionable asset) {
 
@@ -145,6 +155,12 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
 
     }
 
+    /**
+     * Generates the seed to the deterministic id for the given set of params
+     * @param asset
+     * @param parent
+     * @return
+     */
     private String deterministicIdSeed(final Versionable asset, final Treeable parent) {
 
         final Host parentHost = (parent instanceof Host) ? (Host) parent : Try.of(
@@ -199,7 +215,7 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
     }
 
     /**
-     * Generates the seed to the deterministic id
+     * Generates the seed to the deterministic id for the given set of params
      * @param contentType
      * @param contentTypeVarName
      * @return
@@ -228,6 +244,13 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
         return name;
     }
 
+    /**
+     * Generates the seed to the deterministic id for the given set of params
+     * @param contentType
+     * @param field
+     * @param fieldVarName
+     * @return
+     */
     private String deterministicIdSeed(final ContentType contentType, final Field field, final Supplier<String>fieldVarName) {
         final String assetType = deterministicIdSeed(contentType, contentType::variable);
         final String name = resolveName(field, fieldVarName);

--- a/dotCMS/src/main/java/com/dotmarketing/business/DeterministicIdentifierAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/DeterministicIdentifierAPIImpl.java
@@ -292,7 +292,6 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
      * @param <T> hash data-type
      * @return the new identifier ready to be inserted on a db
      */
-    @CloseDBIfOpened
     private <T> T bestEffortDeterministicId(final T hash, final Function<T,Boolean> testIdentifierFunction, final Supplier<T> fallbackIdentifier) {
         T candidateId = hash;
         for (int i = 1; i <= MAX_ATTEMPTS; i++) {
@@ -312,6 +311,7 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
      * @param parent
      * @return
      */
+    @CloseDBIfOpened
     @Override
     public String generateDeterministicIdBestEffort(final Versionable asset,
             final Treeable parent) {
@@ -329,6 +329,7 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
      * which is immutable in such cases we need to rely on this supplier.
      * @return generated deterministic id
      */
+    @CloseDBIfOpened
     @Override
     public String generateDeterministicIdBestEffort(final ContentType contentType,
             final Supplier<String> contentTypeVarName) {
@@ -343,6 +344,8 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
      * @param throwAwayField a field that might or might not has been initialized
      * @return generated deterministic id
      */
+    @CloseDBIfOpened
+    @Override
     public String generateDeterministicIdBestEffort(final Field throwAwayField,
             final Supplier<String> fieldVarName) {
         Preconditions.checkNotNull(throwAwayField.contentTypeId(), "contentTypeRequired");
@@ -367,6 +370,7 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
      * @param lang
      * @return generated deterministic id
      */
+    @CloseDBIfOpened
     @Override
     public long generateDeterministicIdBestEffort(final Language lang) {
 
@@ -385,7 +389,6 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
      * @param hash
      * @return
      */
-    @CloseDBIfOpened
     private boolean isLanguageId(final long hash){
         return new DotConnect()
                 .setSQL("select count(*) as test from language where id =?")
@@ -398,7 +401,6 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
      * @param hash
      * @return
      */
-    @CloseDBIfOpened
     private boolean isContentTypeInode(final String hash){
         return new DotConnect()
                 .setSQL("select count(*) as test from structure s join inode i on s.inode = i.inode where s.inode =?")
@@ -412,7 +414,6 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
      * @param hash
      * @return
      */
-    @CloseDBIfOpened
     private boolean isFieldInode(final String hash){
         return new DotConnect()
                 .setSQL("select count(*) as test from field f join inode i on f.inode = i.inode where i.inode =?")


### PR DESCRIPTION
This PR brings support for deterministic identifiers to Fields
The original formula proposed to generate a field identifier was {contentType_velocity_var}:{field_velocity_var}
But I introduce a small variant that allows me to re-use the code already used to fulfill the seed used for content-types 
So it should look like: {baseType}:{contentType_velocity_var}:{field_velocity_var}

Besides that, I did a bit of refactoring that allows me one single-function `bestEffortDeterministicId` to resolve if the candidate id is being used or not. Before there were three different versions. 
