### PR TITLE
Issue 20494 error retrieving content references in multilang setup

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -209,6 +209,7 @@ import java.util.stream.Stream;
 import static com.dotcms.exception.ExceptionUtil.bubbleUpException;
 import static com.dotcms.exception.ExceptionUtil.getLocalizedMessageOrDefault;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.URL_MAP_FOR_CONTENT_KEY;
+import static com.dotmarketing.portlets.personas.business.PersonaAPI.DEFAULT_PERSONA_NAME_KEY;
 
 /**
  * Implementation class for the {@link ContentletAPI} interface.
@@ -1196,14 +1197,15 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     private String getPersonaNameByMultitree(final MultiTree tree) throws DotSecurityException, DotDataException {
+        final String defaultPersona = Try.of(()->LanguageUtil.get(DEFAULT_PERSONA_NAME_KEY)).getOrElse("Default Visitor");
         String personaTag = Try.of(()-> tree.getPersonalization()
                 .substring((Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON).length()))
-                .getOrElse("Default");
+                .getOrElse("");
         Optional<Persona> personaOpt = APILocator.getPersonaAPI()
                 .findPersonaByTag(personaTag,
                         APILocator.systemUser(), false);
 
-        return personaOpt.isPresent()? personaOpt.get().getName(): "Default";
+        return personaOpt.isPresent()? personaOpt.get().getName(): defaultPersona;
     }
 
     @CloseDBIfOpened

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -2909,6 +2909,7 @@ permissions-saved = Permissions Saved
 permissions = Permissions
 Permissions = Permissions
 PERSONAS-NOT-LICENSED = Personas are a <a href="https://dotcms.com/features" target="_blank">dotCMS Enterprise</a> only feature.  It allows you to:<ul><li> Create and Manage Personas</li><li> Personalize content based on assigned Personas</li></ul>
+Persona=Persona
 phone = Phone
 Phone = Phone
 Pick-HTML-page-to-view-statistics-on = Pick an HTML Page to view statistics for.

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_references.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_references.jsp
@@ -23,12 +23,14 @@
 		<th><%= LanguageUtil.get(pageContext, "Page") %></th>
 		<th><%= LanguageUtil.get(pageContext, "Container") %></th>
 		<th><%= LanguageUtil.get(pageContext, "Page-Owner") %></th>
+		<th><%= LanguageUtil.get(pageContext, "Persona") %></th>
 	</tr>
 <%
 	int Cmod=0;
    	for (Map<String, Object> reference : references) {
     	IHTMLPage htmlpageRef = (IHTMLPage)reference.get("page");
     	Container containerRef = (Container)reference.get("container");
+    	String persona = (String)reference.get("persona");
 		Host host = APILocator.getHTMLPageAssetAPI().getParentHost(htmlpageRef);
 		
 		String str_style2 = "";
@@ -48,6 +50,7 @@
 		</td>
 		<td><%= containerRef.getTitle() %></td>
 		<td><%= UtilMethods.getUserFullName(htmlpageRef.getModUser()) %></td>
+		<td><%= persona %></td>
 	</tr>
 	<%
 	}


### PR DESCRIPTION
* Avoids failing when a referenced page (from multitree) in the Content References tab can't be found in the contentlet's lang. 
* Added "Persona" column to the Contentlet References result list
* Integration tests for both changes 
