### PR TITLE
#20669 Replacing cast to Long by ConversionUtils.toLong

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -50,11 +50,14 @@ import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 
 import com.rainerhahnekamp.sneakythrow.Sneaky;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
@@ -701,6 +704,27 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
             }
         }
 
+    }
+
+    /**
+     * Method to test: {@link ESContentletAPIImpl#copyProperties(Contentlet, Map)}<br>
+     * Given Scenario: {@link Long} properties set as {@link BigDecimal} are copied to the {@link Contentlet} object <br>
+     * ExpectedResult: should success
+     *
+     * @throws DotSecurityException
+     * @throws DotDataException
+     */
+    @Test
+    public void testCopyProperties() throws DotSecurityException {
+        final Contentlet contentlet = TestDataUtils
+                .getPageContent(true, APILocator.getLanguageAPI().getDefaultLanguage().getId());
+        final Map<String, Object> propertiesToCopy = new HashMap<>();
+        propertiesToCopy.put(Contentlet.LANGUAGEID_KEY, new BigDecimal(1));
+        propertiesToCopy.put(Contentlet.SORT_ORDER_KEY, new BigDecimal(2));
+        contentletAPI.copyProperties(contentlet, propertiesToCopy);
+
+        assertEquals(1, contentlet.getLanguageId());
+        assertEquals(2, contentlet.getSortOrder());
     }
 
     private void addPermission(

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -5758,7 +5758,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 if(conVariable.equals(Contentlet.INODE_KEY)){
                     contentlet.setInode((String)value);
                 }else if(conVariable.equals(Contentlet.LANGUAGEID_KEY)){
-                    contentlet.setLanguageId((Long)value);
+                    contentlet.setLanguageId(ConversionUtils.toLong(value, 0L));
                 }else if(conVariable.equals(Contentlet.STRUCTURE_INODE_KEY)){
                     contentlet.setStructureInode((String)value);
                 }else if(conVariable.equals(Contentlet.DISABLED_WYSIWYG_KEY)){
@@ -5772,7 +5772,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 }else if(conVariable.equals(Contentlet.IDENTIFIER_KEY)){
                     contentlet.setIdentifier((String)value);
                 }else if(conVariable.equals(Contentlet.SORT_ORDER_KEY)){
-                    contentlet.setSortOrder((Long)value);
+                    contentlet.setSortOrder(ConversionUtils.toLong(value, 0L));
                 }else if(conVariable.equals(Contentlet.HOST_KEY)){
                     contentlet.setHost((String)value);
                 }else if(conVariable.equals(Contentlet.FOLDER_KEY)){


### PR DESCRIPTION
The cast to `Long` was replaced by `ConversionUtils.toLong` to support BigDecimal values