### PR TITLE
#20648 support new content type ids

### DIFF
--- a/dotCMS/src/main/webapp/html/js/uuidUtils.js
+++ b/dotCMS/src/main/webapp/html/js/uuidUtils.js
@@ -7,7 +7,7 @@ function isInodeSet(inode){
 	   
 	    inode = inode + "";
 		
-		var validUUIDRegex = "^([a-f0-9]{8,8})\-([a-f0-9]{4,4})\-([a-f0-9]{4,4})\-([a-f0-9]{4,4})\-([a-f0-9]{12,12})$";
+		var validUUIDRegex = "^([a-f0-9]{8,8})\-?([a-f0-9]{4,4})\-?([a-f0-9]{4,4})\-?([a-f0-9]{4,4})\-?([a-f0-9]{12,12})$";
 		var olderInodeRegex = "^[0-9]+$";
 
 		if(inode.match(validUUIDRegex)){


### PR DESCRIPTION
Ids for new content types now don't include a hyphen. There's a validation for inodes of content types that was expecting the hyphens, thus breaking searching/filtering by new content types. 

This makes supporting old and new ids for content types. 