### PR TITLE
#20452 user with BE & FE roles logged in FE now are able to see the contents

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityServlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityServlet.java
@@ -48,16 +48,14 @@ public class VelocityServlet extends HttpServlet {
         final String uri = CMSUrlUtil.getCurrentURI(request);
         final boolean comeFromSomeWhere = request.getHeader("referer") != null;
         
-        req.setAttribute(WebKeys.IS_LIVE_REQUEST, true);
-        
-        final User user = (userApi.getLoggedInUser(request)!=null) 
+        final User user = (userApi.getLoggedInUser(request)!=null)
                         ? userApi.getLoggedInUser(request) 
                         : userApi.getLoggedInFrontendUser(request) !=null
                            ? userApi.getLoggedInFrontendUser(request)
                            : userApi.getAnonymousUserNoThrow();
         
         request.setRequestUri(uri);
-        final PageMode mode = PageMode.getWithNavigateMode(request);
+        final PageMode mode = user.isFrontendUser()?  PageMode.setPageMode(request, PageMode.LIVE) : PageMode.getWithNavigateMode(request);
         
         // if you are hitting the servlet without running through the other filters
         if (uri == null) {

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityServlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityServlet.java
@@ -6,6 +6,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.dotmarketing.util.WebKeys;
 import org.apache.velocity.exception.ResourceNotFoundException;
 import com.dotcms.business.CloseDB;
 import com.dotcms.enterprise.LicenseUtil;
@@ -46,7 +48,7 @@ public class VelocityServlet extends HttpServlet {
         final String uri = CMSUrlUtil.getCurrentURI(request);
         final boolean comeFromSomeWhere = request.getHeader("referer") != null;
         
-
+        req.setAttribute(WebKeys.IS_LIVE_REQUEST, true);
         
         final User user = (userApi.getLoggedInUser(request)!=null) 
                         ? userApi.getLoggedInUser(request) 

--- a/dotCMS/src/main/java/com/dotmarketing/util/PageMode.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PageMode.java
@@ -4,8 +4,6 @@ import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.PortalUtil;
 import io.vavr.control.Try;
-import org.apache.commons.lang3.BooleanUtils;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -82,10 +80,7 @@ public enum PageMode {
         final User user = PortalUtil.getUser(request);
 
         // only backend users can see non-live assets
-        if (user == null  ||
-                // it is a velocity live request (FE) and the user is FE
-                (BooleanUtils.toBoolean((Boolean) request.getAttribute(WebKeys.IS_LIVE_REQUEST)) && user.isFrontendUser()) ||
-                !user.isBackendUser()) {
+        if (user == null || !user.isBackendUser()) {
             return DEFAULT_PAGE_MODE;
         }
 
@@ -127,6 +122,7 @@ public enum PageMode {
         return setPageMode(request,mode);
 
     }
+
 
     /**
      * Page mode can only be set for back end users, not for front end users (even logged in Front end users)

--- a/dotCMS/src/main/java/com/dotmarketing/util/PageMode.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PageMode.java
@@ -83,6 +83,7 @@ public enum PageMode {
 
         // only backend users can see non-live assets
         if (user == null  ||
+                // it is a velocity live request (FE) and the user is FE
                 (BooleanUtils.toBoolean((Boolean) request.getAttribute(WebKeys.IS_LIVE_REQUEST)) && user.isFrontendUser()) ||
                 !user.isBackendUser()) {
             return DEFAULT_PAGE_MODE;

--- a/dotCMS/src/main/java/com/dotmarketing/util/PageMode.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PageMode.java
@@ -4,6 +4,8 @@ import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.PortalUtil;
 import io.vavr.control.Try;
+import org.apache.commons.lang3.BooleanUtils;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -80,7 +82,9 @@ public enum PageMode {
         final User user = PortalUtil.getUser(request);
 
         // only backend users can see non-live assets
-        if (user == null || !user.isBackendUser()) {
+        if (user == null  ||
+                (BooleanUtils.toBoolean((Boolean) request.getAttribute(WebKeys.IS_LIVE_REQUEST)) && user.isFrontendUser()) ||
+                !user.isBackendUser()) {
             return DEFAULT_PAGE_MODE;
         }
 
@@ -122,7 +126,6 @@ public enum PageMode {
         return setPageMode(request,mode);
 
     }
-
 
     /**
      * Page mode can only be set for back end users, not for front end users (even logged in Front end users)

--- a/dotCMS/src/main/java/com/dotmarketing/util/WebKeys.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/WebKeys.java
@@ -724,8 +724,4 @@ public final class WebKeys {
 
     public static final String BACKEND_LANGUAGE_PARAMETER_NAME = "backend_language_id";
 
-    /**
-     * Set to true (otherwise null or false) when the request is coming from the VelocityServlet (Aka live request)
-     */
-    public static final String IS_LIVE_REQUEST = "live_request";
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/WebKeys.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/WebKeys.java
@@ -724,4 +724,8 @@ public final class WebKeys {
 
     public static final String BACKEND_LANGUAGE_PARAMETER_NAME = "backend_language_id";
 
+    /**
+     * Set to true (otherwise null or false) when the request is coming from the VelocityServlet (Aka live request)
+     */
+    public static final String IS_LIVE_REQUEST = "live_request";
 }


### PR DESCRIPTION
The page mode when the user is fe and be was always preview and users with both roles were not able to see any contentlet on live site when logged in, with this fix users with FE role on live mode still using page mode on LIVE, but on admin mode keeps the same previous logic, only velocity live mode works in this way'
the page mode when the user is fe and be was always preview and users with both roles were not able to see any contentlet on live site, with this fix users with FE role on live mode still using page mode on LIVE, but on admin mode keeps the same previous logic, only velocity live mode works in this way