### PR TITLE
#20688 previously we do a find by id, the find by host is not valid a…

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/site/SiteHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/site/SiteHelper.java
@@ -137,9 +137,7 @@ public class SiteHelper implements Serializable {
 	 * @throws AlreadyExistException
 	 */
 	public Host update(final Host site, final User user, final boolean respectAnonPerms) throws DotSecurityException, DotDataException, DoesNotExistException {
-		if(null == hostAPI.findByName(site.getHostname(), user, respectAnonPerms)){
-			throw new DoesNotExistException(String.format("Invalid attempt to update a non existing site `%s` .",site.getHostname()));
-		}
+
 		return hostAPI.save(site, user, respectAnonPerms);
 	}
 


### PR DESCRIPTION
When updating a site, the host could be changed. Validated if that host exists is not necessary since previously we already validated the host by id