### PR TITLE
Issue 20707 advance image transformations and sass compilation not working on static publish and time machine

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/mock/request/DotCMSMockRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/mock/request/DotCMSMockRequest.java
@@ -38,7 +38,7 @@ public class DotCMSMockRequest implements HttpServletRequest {
     private Map<String, String[]> paramMap = new HashMap<>();
     private Map<String, String> headers = new HashMap<>();
     private String servletPath;
-    private Map<String, Object> attributes;
+    private Map<String, Object> attributes = new HashMap<>();
 
     @Override
     public String getRequestURI() {

--- a/dotCMS/src/main/java/com/dotcms/publishing/IBundler.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/IBundler.java
@@ -75,9 +75,9 @@ public interface IBundler {
 				if (o1.equals(defaultLangId) && o2.equals(defaultLangId)) {
 					return 0;
 				} else if (o1.equals(defaultLangId)) {
-					return 1;
-				} else if (o2.equals(defaultLangId)) {
 					return -1;
+				} else if (o2.equals(defaultLangId)) {
+					return 1;
 				} else {
 					return 0;
 				}


### PR DESCRIPTION
Avoid NullpointerException when try to add a Attribute

Also revert this change 

https://github.com/dotCMS/core/commit/7b5813dd17f47bc0d9f54a25a6124d162ef6e488

because it really not solve the issue

https://github.com/dotCMS/core/issues/20469

static publish not have any issue but we already have a issue to create them

https://github.com/dotCMS/core/issues/20297