### PR TITLE
Issue 20369 site resource adjustments

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/site/SiteResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/site/SiteResource.java
@@ -130,7 +130,6 @@ public class SiteResource implements Serializable {
               .requestAndResponse(httpServletRequest, httpServletResponse)
               .requiredBackendUser(true)
               .requiredFrontendUser(true)
-              .requiredPortlet("sites")
               .init().getUser();
           
             Host currentSite = siteHelper.getCurrentSite(httpServletRequest, user);
@@ -177,7 +176,6 @@ public class SiteResource implements Serializable {
             .requestAndResponse(httpServletRequest, httpServletResponse)
             .requiredBackendUser(true)
             .rejectWhenNoUser(true)
-            .requiredPortlet("sites")
             .init().getUser();
 
         String filter = (null != filterParam && filterParam.endsWith(NO_FILTER))?


### PR DESCRIPTION
Previously we had turned on requires-Portlet for sites to all the endpoints of the SitesResource.
Later on, @erickgonzalez figured out this was breaking the login for users. 
The required-Portlet option must be retracted from the following endpoint.

- sites
- current-site