### PR TITLE
Issue 20725 error upgrading using a managed database

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task201014UpdateColumnsValuesInIdentifierTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task201014UpdateColumnsValuesInIdentifierTable.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.startup.AbstractJDBCStartupTask;
 import java.util.List;
 
@@ -13,24 +14,28 @@ public class Task201014UpdateColumnsValuesInIdentifierTable extends AbstractJDBC
         return true;
     }
 
-    @Override
-    public String getPostgresScript() {
-
+    /**
+     * Creates a string builder with the script to be executed in Postgres/MSSQL
+     * @return Script compatible with Postgres and MSSQL databases
+     */
+    private String getScript(){
         final StringBuilder query = new StringBuilder();
 
-        query.append("SET session_replication_role TO 'replica';\n");
+        //session_replication_role is used in Postgres
+        query.append(DbConnectionFactory.isMsSql() ? "ALTER TABLE identifier DISABLE TRIGGER ALL;"
+                : "SET session_replication_role TO 'replica';\n");
 
         //update templates
-        query.append(getQueryToUpdateNonContentletsPostgres("template"));
+        query.append(getQueryToUpdateNonContentlets("template"));
 
         //update containers
-        query.append(getQueryToUpdateNonContentletsPostgres("dot_containers"));
+        query.append(getQueryToUpdateNonContentlets("dot_containers"));
 
         //update links
-        query.append(getQueryToUpdateNonContentletsPostgres("links"));
+        query.append(getQueryToUpdateNonContentlets("links"));
 
         //update folders
-        query.append(getQueryToUpdateNonContentletsPostgres("folder"));
+        query.append(getQueryToUpdateNonContentlets("folder"));
 
         //update contentlets
         query.append("UPDATE identifier SET owner=mod_user, create_date=idate, asset_subtype=velocity_var_name from\n")
@@ -44,8 +49,15 @@ public class Task201014UpdateColumnsValuesInIdentifierTable extends AbstractJDBC
                 .append(" WHERE  id=myID;\n");
 
 
-        query.append("SET session_replication_role TO 'origin';\n");
+        //session_replication_role is used in Postgres
+        query.append(DbConnectionFactory.isMsSql() ? "ALTER TABLE identifier ENABLE TRIGGER ALL;"
+                : "SET session_replication_role TO 'origin';\n");
         return query.toString();
+    }
+
+    @Override
+    public String getPostgresScript() {
+        return getScript();
     }
 
     @Override
@@ -188,7 +200,7 @@ public class Task201014UpdateColumnsValuesInIdentifierTable extends AbstractJDBC
 
     @Override
     public String getMSSQLScript() {
-        return getPostgresScript();
+        return getScript();
     }
 
     @Override
@@ -224,7 +236,12 @@ public class Task201014UpdateColumnsValuesInIdentifierTable extends AbstractJDBC
 
     }
 
-    private String getQueryToUpdateNonContentletsPostgres(final String tableName){
+    /**
+     * Queries valid in Postgres/MSSQL
+     * @param tableName
+     * @return
+     */
+    private String getQueryToUpdateNonContentlets(final String tableName){
         final StringBuilder query = new StringBuilder();
         return query.append("UPDATE identifier SET owner=iowner, create_date=idate FROM\n")
                 .append("(SELECT DISTINCT temp.identifier myID, owner iowner, inode.idate idate from ")

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task201014UpdateColumnsValuesInIdentifierTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task201014UpdateColumnsValuesInIdentifierTable.java
@@ -18,7 +18,7 @@ public class Task201014UpdateColumnsValuesInIdentifierTable extends AbstractJDBC
 
         final StringBuilder query = new StringBuilder();
 
-        query.append("ALTER TABLE identifier DISABLE TRIGGER ALL;\n");
+        query.append("SET session_replication_role TO 'replica';\n");
 
         //update templates
         query.append(getQueryToUpdateNonContentletsPostgres("template"));
@@ -44,7 +44,7 @@ public class Task201014UpdateColumnsValuesInIdentifierTable extends AbstractJDBC
                 .append(" WHERE  id=myID;\n");
 
 
-        query.append("ALTER TABLE identifier ENABLE TRIGGER ALL;\n");
+        query.append("SET session_replication_role TO 'origin';\n");
         return query.toString();
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -183,7 +183,6 @@ public class TaskLocatorUtil {
 		.add(Task01096CreateContainerStructuresTable.class)
 		.add(Task03005CreateModDateForFieldIfNeeded.class)
 		.add(Task03010AddContentletIdentifierIndex.class)
-		.add(Task201102UpdateColumnSitelicTable.class)
 		.add(Task03015CreateClusterConfigModel.class)
 		.add(Task03020PostgresqlIndiciesFK.class)
 		.add(Task03025CreateFoundationForNotificationSystem.class)
@@ -292,6 +291,7 @@ public class TaskLocatorUtil {
 		//New task date-based naming convention starts here
         .add(Task201013AddNewColumnsToIdentifierTable.class)
         .add(Task201014UpdateColumnsValuesInIdentifierTable.class)
+        .add(Task201102UpdateColumnSitelicTable.class)
 		.add(Task210218MigrateUserProxyTable.class)
 		.add(Task210316UpdateLayoutIcons.class)
         .add(Task210319CreateStorageTable.class)


### PR DESCRIPTION
The way we disable triggers was modified in Postgres, as it failed when the database connection was established using a non-superuser. A `session_replication_role='replica'` ignores triggers temporarily.

Besides, the position of the task `Task201102UpdateColumnSitelicTable` was modified to avoid confusion when an upgrade process is executed.

**Note:** The UT already has an integration test.