### PR TITLE
(#18301): ignoring scss resources that lives in the same directory as the main scss file

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/csspreproc/DotCSSCompiler.java
+++ b/dotCMS/src/main/java/com/dotcms/csspreproc/DotCSSCompiler.java
@@ -224,6 +224,9 @@ abstract class DotCSSCompiler {
         if (f.exists())
           continue;
         String assetUri = asset.getURI();
+        if (assetUri.endsWith(".scss") && areSiblings(uri, assetUri)) {
+          continue;
+        }
         getAllImportedURI().add(assetUri);
         f.getParentFile().mkdirs();
         FileUtil.copyFile(asset.getFileAsset(), f);
@@ -232,6 +235,10 @@ abstract class DotCSSCompiler {
     }
 
     return compDir;
+  }
+
+  private boolean areSiblings(final String uri, final String otherUri) {
+    return uri.substring(0, uri.lastIndexOf("/")).equals(otherUri.substring(0, otherUri.lastIndexOf("/")));
   }
 
   private String addImportUnderscore(String url) {

--- a/dotCMS/src/main/java/com/dotcms/csspreproc/DotCSSCompiler.java
+++ b/dotCMS/src/main/java/com/dotcms/csspreproc/DotCSSCompiler.java
@@ -26,6 +26,7 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.fileassets.business.FileAsset;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
 import com.dotmarketing.util.InodeUtils;
+import com.dotmarketing.util.StringUtils;
 import com.dotmarketing.util.UUIDGenerator;
 import com.liferay.util.FileUtil;
 
@@ -224,7 +225,7 @@ abstract class DotCSSCompiler {
         if (f.exists())
           continue;
         String assetUri = asset.getURI();
-        if (assetUri.endsWith(".scss") && areSiblings(uri, assetUri)) {
+        if (assetUri.endsWith(".scss") && StringUtils.shareSamePath(uri, assetUri)) {
           continue;
         }
         getAllImportedURI().add(assetUri);
@@ -235,10 +236,6 @@ abstract class DotCSSCompiler {
     }
 
     return compDir;
-  }
-
-  private boolean areSiblings(final String uri, final String otherUri) {
-    return uri.substring(0, uri.lastIndexOf("/")).equals(otherUri.substring(0, otherUri.lastIndexOf("/")));
   }
 
   private String addImportUnderscore(String url) {

--- a/dotCMS/src/main/java/com/dotmarketing/util/StringUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/StringUtils.java
@@ -10,6 +10,7 @@ import com.dotcms.rest.api.v1.temp.TempFileAPI;
 import com.dotcms.uuid.shorty.ShortyException;
 import com.liferay.util.StringPool;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class StringUtils {
 
@@ -368,11 +370,29 @@ public class StringUtils {
                   + minLength + " alphanumeric chars in length", se);
       }
     }
-    
-    
-    
 
+    /**
+     * Given a SLASH delimited string extract the base path
+     *
+     * @param path path
+     * @return base path
+     */
+    public static String getBasePath(final String path) {
+        final List<String> parts = Arrays.asList(getOrDefault(path, () -> "").split(StringPool.SLASH));
+        return String.join(StringPool.SLASH, parts.isEmpty() ? parts : parts.subList(0, parts.size() - 1));
+    }
 
+    /**
+     * Returns true if provided paths share the same base path.
+     * AKA: if they are siblings.
+     *
+     * @param path one path to compare
+     * @param otherPath other path to compare
+     * @return tru if they are siblings, otherwise false
+     */
+    public static boolean shareSamePath(final String path, final String otherPath) {
+        return getBasePath(path).equals(getBasePath(otherPath));
+    }
 
    private static final Pattern pattern = Pattern.compile("\\s");
 

--- a/dotCMS/src/test/java/com/dotmarketing/util/StringUtilsTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/StringUtilsTest.java
@@ -355,4 +355,19 @@ public class StringUtilsTest {
         assertFalse(StringUtils.hasWhiteSpaces("lol"));
     }
 
+    @Test
+    public void test_getBasePath() {
+        assertEquals("/a/b/c", StringUtils.getBasePath("/a/b/c/d.ext"));
+        assertEquals("", StringUtils.getBasePath(""));
+        assertEquals("", StringUtils.getBasePath(null));
+    }
+
+    @Test
+    public void test_shareSamePath() {
+        assertTrue(StringUtils.shareSamePath("/a/b/c/d.ext", "/a/b/c/z.ext"));
+        assertTrue(StringUtils.shareSamePath("", ""));
+        assertTrue(StringUtils.shareSamePath(null, null));
+        assertFalse(StringUtils.shareSamePath("/a/b/c/d.ext", "/g/f/e/d.ext"));
+    }
+
 }


### PR DESCRIPTION
Since they will have a shot with the `CssPreProcessServlet`. This way we will avoid recursively process each other as they were included in the compiler's `allImportedURI` attribute.