### PR TITLE
#20714 NPE caused by an invalid attempt to fix a conflict over the same…

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/integritycheckers/FolderIntegrityChecker.java
+++ b/dotCMS/src/main/java/com/dotcms/integritycheckers/FolderIntegrityChecker.java
@@ -256,7 +256,7 @@ public class FolderIntegrityChecker extends AbstractIntegrityChecker {
                     String existingFolderNewIdentifier = UUIDGenerator.generateUuid();
                     String existingFolderNewInode = UUIDGenerator.generateUuid();
                     //Since we're now using deterministic or contextual ids which are generated in a predictable way
-                    //Finding two folders with identical identifier point at the exact on the exact location is now a case we need to consider.
+                    //Finding two folders with identical identifiers at the exact same time and at the exact same location is now a case we need to consider.
                     //Therefore now we need to take into account we're not looking at the same folder when attempting to change an identifier. Prior to applying the fix.
                     if(!fullFolderPath.equals(folder)){
                       //If the identifier already exist on another location we need to change it first before applying the real fix

--- a/dotCMS/src/main/java/com/dotcms/integritycheckers/IntegrityUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/integritycheckers/IntegrityUtil.java
@@ -16,6 +16,7 @@ import com.dotmarketing.util.ConfigUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.MaintenanceUtil;
 import com.dotmarketing.util.UtilMethods;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.*;
@@ -97,7 +98,7 @@ public class IntegrityUtil {
                     break;
             	case FOLDERS:
             		sbSelectTempTable.append(
-            			"select remote_inode, local_inode, remote_identifier, local_identifier from "
+            			"select folder, remote_inode, local_inode, remote_identifier, local_identifier from "
             		);
             		break;
             	case CMS_ROLES:
@@ -146,6 +147,7 @@ public class IntegrityUtil {
                     if (type == IntegrityType.FOLDERS) {
                         writer.write(rs.getString("remote_identifier"));
                         writer.write(rs.getString("local_identifier"));
+                        writer.write(rs.getString("folder"));
                     }
 
                     writer.endRecord();
@@ -614,7 +616,7 @@ public class IntegrityUtil {
         try {
             final CsvReader csvFile = new CsvReader(ConfigUtils.getIntegrityPath() + File.separator
                     + key + File.separator + type.getDataToFixCSVName(), '|',
-                    Charset.forName("UTF-8"));
+                    StandardCharsets.UTF_8);
 
             final String resultsTable = type.getResultsTableName();
             if (!type.hasResultsTable()) {
@@ -632,7 +634,7 @@ public class IntegrityUtil {
 	                ).append(type.getFirstDisplayColumnLabel()).append(", endpoint_id, language_id) values(?,?,?,?,?,?,?,?,?)");
 	                break;
             	case FOLDERS:
-                    sbInsertTempTable.append(" (local_inode, remote_inode, local_identifier, remote_identifier, endpoint_id) values(?,?,?,?,?)");
+                    sbInsertTempTable.append(" (local_inode, remote_inode, local_identifier, remote_identifier, folder, endpoint_id) values(?,?,?,?,?,?)");
                     break;
             	case CMS_ROLES:
             		sbInsertTempTable.append(" (name, role_key, local_role_id, remote_role_id, local_role_fqn, remote_role_fqn, endpoint_id) values(?,?,?,?,?,?,?)");
@@ -668,6 +670,7 @@ public class IntegrityUtil {
 	                } else if (type == IntegrityType.FOLDERS) {
 	                    dc.addParam(csvFile.get(2)); // localIdentifier
 	                    dc.addParam(csvFile.get(3)); // remoteIdentifier
+                        dc.addParam(csvFile.get(4)); // folder
 	                }
                 }
 


### PR DESCRIPTION
We had an NPE caused by an invalid attempt to fix a conflict between two folders. 
The old logic had a safeguard in place to look up the incoming identifier.  
(Meaning another folder in a different location already had that id taken). That code was there to prevent a collision when fixing the conflict. The safeguard is only valid if we're looking at folders in different locations. And Since now we have deterministic (or contextual) identifiers which are generated in a predictable fashion. finding two folders with the exact same identifier at the same location is a common situation now that we need to be able to identify. At least to prevent this NPE. However further work is required. Since the conflict is not caused by the 2 folders sharing different ids. But different inodes. We need to be able to set deterministic identifiers also as the inode of the folder. which currently isn't possible since hibernate takes care of that job automatically. We need to separate folders from hibernate and set the deterministic identifier as the new inode. This fix is solid since allows the distinction of the case by using the folder path passed from the sender to the receiver.   

See https://github.com/dotCMS/core/issues/20742