### PR TITLE
Renaming Task210702UpdateStructureTable to Task210802UpdateStructureTable

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -109,7 +109,7 @@ import com.dotmarketing.startup.runonce.Task210506UpdateStorageTableTest;
 import com.dotmarketing.startup.runonce.Task210527DropReviewFieldsFromContentletTableTest;
 import com.dotmarketing.startup.runonce.Task210520UpdateAnonymousEmailTest;
 import com.dotmarketing.startup.runonce.Task210510UpdateStorageTableDropMetadataColumnTest;
-import com.dotmarketing.startup.runonce.Task210702UpdateStructureTableTest;
+import com.dotmarketing.startup.runonce.Task210802UpdateStructureTableTest;
 import com.dotmarketing.util.ConfigTest;
 import com.dotmarketing.util.HashBuilderTest;
 import com.dotmarketing.util.MaintenanceUtilTest;
@@ -442,7 +442,7 @@ import org.junit.runners.Suite.SuiteClasses;
         Task210527DropReviewFieldsFromContentletTableTest.class,
         ContentletCacheImplTest.class,
         HostTest.class,
-        Task210702UpdateStructureTableTest.class,
+        Task210802UpdateStructureTableTest.class,
         MaintenanceUtilTest.class,
         TestBundlePublisher.class,
         CategoryFactoryTest.class

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task210802UpdateStructureTableTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task210802UpdateStructureTableTest.java
@@ -11,7 +11,7 @@ import java.sql.SQLException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class Task210702UpdateStructureTableTest {
+public class Task210802UpdateStructureTableTest {
 
     @BeforeClass
     public static void prepare() throws Exception {
@@ -32,7 +32,7 @@ public class Task210702UpdateStructureTableTest {
                     .dropColumn(DbConnectionFactory.getConnection(), "structure", "sort_order");
         }
 
-        final Task210702UpdateStructureTable upgradeTask = new Task210702UpdateStructureTable();
+        final Task210802UpdateStructureTable upgradeTask = new Task210802UpdateStructureTable();
         assertTrue(upgradeTask.forceRun());
         upgradeTask.executeUpgrade();
         assertFalse(upgradeTask.forceRun());//columns were created

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210802UpdateStructureTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210802UpdateStructureTable.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * Upgrade task used to add columns `icon` and `sort_order` in `structure` table if needed
  */
-public class Task210702UpdateStructureTable extends AbstractJDBCStartupTask {
+public class Task210802UpdateStructureTable extends AbstractJDBCStartupTask {
 
     private final DotDatabaseMetaData dotDatabaseMetaData = new DotDatabaseMetaData();
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -300,7 +300,7 @@ public class TaskLocatorUtil {
 		.add(Task210510UpdateStorageTableDropMetadataColumn.class)
 		.add(Task210520UpdateAnonymousEmail.class)
         .add(Task210527DropReviewFieldsFromContentletTable.class)
-		.add(Task210702UpdateStructureTable.class)
+		.add(Task210802UpdateStructureTable.class)
         .build();
         
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());


### PR DESCRIPTION
It's required to rename it because there is an UT with date 210719 in 21.07