### PR TITLE
Issue 19290 select all files broken in content search

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
@@ -1680,8 +1680,12 @@
         function checkUncheckAll() {
                 var checkAll = dijit.byId("checkAll");
                 var check;
+	            var viewCard = getViewCardEl();
 
-	            getViewCardEl().value = ''
+                if (viewCard) {
+	                viewCard.value = '';
+                }
+                
                 for (var i = 0; i < cbContentInodeList.length; ++i) {
                         check = dijit.byId("checkbox" + i);
                         if(check) {


### PR DESCRIPTION
Select all files is broken in Content Search if you try to use it before loading the card view.
https://user-images.githubusercontent.com/934364/129929355-07eae87a-a768-4ffc-9189-f035c980c847.png