### PR TITLE
#20452 the issue is that the host when the user has FE is not true fo…

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/web/HostWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/web/HostWebAPIImpl.java
@@ -78,7 +78,7 @@ public class HostWebAPIImpl extends HostAPIImpl implements HostWebAPI {
 
         final UserWebAPI userWebAPI = WebAPILocator.getUserWebAPI();
         final User user       = userParam != null ? userParam : userWebAPI.getSystemUser();
-        final boolean respectAnonPerms = user == null || !user.isBackendUser();
+        final boolean respectAnonPerms = user == null || user.isFrontendUser() || !user.isBackendUser();
 
         Optional<Host> optionalHost = this.getCurrentHostFromRequest(request, user, respectAnonPerms);
 
@@ -112,7 +112,7 @@ public class HostWebAPIImpl extends HostAPIImpl implements HostWebAPI {
             final String userId = (user != null) ? user.getUserId() : null;
 
             final String message = "User " + userId + " does not have permission to host:" + host.getHostname();
-            Logger.error(HostAPIImpl.class, message);
+            Logger.error(HostWebAPIImpl.class, message);
             throw new DotSecurityException(message);
         }
     }


### PR DESCRIPTION
Before this change when asking for host permissions, if the user has FE and BE roles, the FE was not been taking in consideration and consequently sets the respect front end roles in false.
This change takes in consideration if the user is FE, if it is respect front end roles should be true.

With that change user with FE and BE are able to see FE pages, now user with BE role but not FE role still not able to see pages on FE