### PR TITLE
#20827 fix postman

### DIFF
--- a/dotCMS/src/curl-test/System.postman_collection.json
+++ b/dotCMS/src/curl-test/System.postman_collection.json
@@ -161,8 +161,7 @@
 									"pm.test(\"Status code should be 200\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
-									"",
-									"var jsonData = pm.response.json();"
+									""
 								],
 								"type": "text/javascript"
 							}
@@ -295,9 +294,7 @@
 								"exec": [
 									"pm.test(\"Status code should be 200\", function () {",
 									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"var jsonData = pm.response.json();"
+									"});"
 								],
 								"type": "text/javascript"
 							}

--- a/dotCMS/src/curl-test/System.postman_collection.json
+++ b/dotCMS/src/curl-test/System.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cf588f1e-77f4-40dc-a0ac-fdf73748f6b9",
+		"_postman_id": "040258c6-4e99-4f42-a9f4-cdf4b6334562",
 		"name": "System",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -224,10 +224,8 @@
 									"",
 									"pm.test(\"System-Status check\", function () {",
 									"",
-									"    pm.expect(jsonData.backendHealthy).to.be.eql(true);",
-									"    pm.expect(jsonData.clusterID).to.not.eql(\"\");",
-									"    pm.expect(jsonData.backendHealthy).to.be.eql(true);",
-									"    pm.expect(jsonData.serverID).to.not.eql(\"\");",
+									"    pm.expect(jsonData.backendHealthy).to.be.eql(true);    ",
+									"    pm.expect(jsonData.frontendHealthy).to.be.eql(true);",
 									"",
 									"    pm.expect(jsonData.subsystems.assetFSHealthy).to.be.eql(true);",
 									"    pm.expect(jsonData.subsystems.cacheHealthy).to.be.eql(true);",


### PR DESCRIPTION
No server-id nor cluster-id are coming back from the test instance. So this excludes them from the test.
{
  "backendHealthy": true,
  "clusterID": "",
  "dotCMSHealthy": true,
  "frontendHealthy": true,
  "serverID": "",
  "subsystems": {
    "assetFSHealthy": true,
    "cacheHealthy": true,
    "dbSelectHealthy": true,
    "indexLiveHealthy": true,
    "indexWorkingHealthy": true,
    "localFSHealthy": true
  }
}