### PR TITLE
dotCMS/core#20868 reorder window issues

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/folders/order_menu.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/folders/order_menu.jsp
@@ -36,7 +36,8 @@ function submitfm() {
 	form.action = '<portlet:actionURL><portlet:param name="struts_action" value="/ext/folders/order_menu" /></portlet:actionURL>';
 	submitForm(form);
 }
-function savechanges() {
+function savechanges(btn) {
+    btn.setDisabled(true);
 	form = document.getElementById('fm');
 	form.cmd.value = "generatemenu";
 	form.action = '<portlet:actionURL><portlet:param name="struts_action" value="/ext/folders/order_menu" /></portlet:actionURL>';
@@ -160,7 +161,7 @@ pagePath=<%=pagePath%>
     
                             <div class="buttonRow">
                                 <% if(showSaveButton){%>
-                                    <button dojoType="dijit.form.Button" onClick="savechanges()" iconClass="saveIcon">
+                                    <button dojoType="dijit.form.Button" onClick="savechanges(this)" iconClass="saveIcon">
                                 <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "save-changes")) %>
                                     </button>       
                                 <%} %>


### PR DESCRIPTION
If you are reordering the menu in a page we have some problems in this screen:

The cancel button does not working
The save changes takes some time, then you can click multiple times and this cause the page reload multiple times too