### PR TITLE
dotCMS/core#19042 Need to recognize the 'Enter' key when created bundle

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/AddToBundleDialog.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/AddToBundleDialog.js
@@ -52,6 +52,12 @@ dojo.declare("dotcms.dijit.AddToBundleDialog", null, {
                 }
                 
                 dijit.byId('bundleSelect').set('value', lastSelectedBundle.name);
+                document.querySelector('#bundleSelect').addEventListener('keypress', function (e) {
+                    if (e.keyCode == 13) {
+                        container.addToBundle();
+                    }
+                });
+
             }
         });
 


### PR DESCRIPTION
When you try to add some piece of content to a bundle and you type any new name for the bundle and hit the Intro key, we need to recognize this as accept and create the bundle