### PR TITLE
#20821 Expiring Map 

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/business/expiring/ExpiringMap.java
+++ b/dotCMS/src/main/java/com/dotcms/business/expiring/ExpiringMap.java
@@ -50,6 +50,15 @@ public interface ExpiringMap<K, V> {
     V put(K key, V value, final long ttl, final TimeUnit unit);
 
     /**
+     * This allows expiration based on the default ttt used when built the caffeine cache.
+     * @param key K
+     * @param value V
+     * @param useCacheTtl {@link boolean} useCacheTtl if true, the entry will expire using the ttl specified when the the internal caffeine cache got built not the {@link ExpiringEntryStrategy}.
+     * @return
+     */
+    V put(final K key, final V value, final boolean useCacheTtl);
+
+    /**
      *  Put a value with a key, will use the {@link ExpiringEntryStrategy} in other to figure out the timeout for the entry
      * @param key    K
      * @param value  V

--- a/dotCMS/src/main/java/com/dotcms/business/expiring/ExpiringMapBuilder.java
+++ b/dotCMS/src/main/java/com/dotcms/business/expiring/ExpiringMapBuilder.java
@@ -97,10 +97,19 @@ public class ExpiringMapBuilder<K,V> {
         }
 
         @Override
-        public V put(final K key, final V value) {
+        public V put(final K key, final V value, final boolean useCacheTtl) {
+           if(useCacheTtl){
+               this.cache.put(key, value);
+               return value;
+           } else {
+              final Tuple2<Long, TimeUnit> expiring = this.strategy.getExpireTime(key, value);
+              return this.put(key, value, expiring._1, expiring._2);
+           }
+        }
 
-            final Tuple2<Long, TimeUnit> expiring = this.strategy.getExpireTime(key, value);
-            return this.put(key, value, expiring._1, expiring._2);
+        @Override
+        public V put(final K key, final V value) {
+            return this.put(key, value, false);
         }
 
         @Override

--- a/dotCMS/src/main/java/com/dotmarketing/util/Logger.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Logger.java
@@ -249,8 +249,7 @@ public class Logger {
         final Long expireWhen = logMap.get().get(hash);
 
         if (expireWhen == null || expireWhen < System.currentTimeMillis()) {
-            logMap.get().put(hash, System.currentTimeMillis() + warnEveryMillis, warnEveryMillis,
-                            TimeUnit.MILLISECONDS);
+            logMap.get().put(hash, System.currentTimeMillis() + warnEveryMillis, true);
             logger.warn(message + " (every " + warnEveryMillis + " millis)");
 
         }
@@ -273,12 +272,9 @@ public class Logger {
 
         final Long hash = new Long(Objects.hashCode(cl, message.substring(0, Math.min(message.length(), 10)), cl));
         final Long expireWhen = logMap.get().get(hash);
-
         if (expireWhen == null || expireWhen < System.currentTimeMillis()) {
-            logMap.get().put(hash, System.currentTimeMillis() + warnEveryMillis, warnEveryMillis,
-                            TimeUnit.MILLISECONDS);
+            logMap.get().put(hash, System.currentTimeMillis() + warnEveryMillis, true);
             logger.info(message + " (every " + warnEveryMillis + " millis)");
-
         }
         logger.debug(() -> message);
     }

--- a/dotCMS/src/test/java/com/dotcms/business/expiring/ExpiringMapTest.java
+++ b/dotCMS/src/test/java/com/dotcms/business/expiring/ExpiringMapTest.java
@@ -149,4 +149,23 @@ public class ExpiringMapTest extends UnitTestBase {
     }
 
 
+    @Test
+    public void Put_Using_Cache_TTL_No_Expiring_Strategy() {
+
+        // put a message with 10 seconds, for more messages repeat
+        final ExpiringMap<String, String> map = new ExpiringMapBuilder<>()
+                .size(10).ttl(DateUtil.FIVE_SECOND_MILLIS).build();
+
+        final String one = ONE;
+        try {
+            map.put(one, one, true);
+            IntStream.of(1, 2, 3).forEach(i -> Assert.assertTrue(map.containsKey(one)));
+            DateUtil.sleep(DateUtil.FIVE_SECOND_MILLIS);
+            IntStream.of(1, 2, 3).forEach(i -> Assert.assertFalse(map.containsKey(one)));
+        } finally {
+            map.remove(one);
+        }
+    }
+
+
 }


### PR DESCRIPTION
Expiring Map is built on top of a Caffeine cache impl. this cache implementation takes a ttl making entries expirable out of the box. However the expirable map queue up a new task every time we call put to invalidate the entry when the times is up.  
I'm introducing a method that simply puts the entry on the caffeine cache which is already auto-expirable no need to enqueue tasks. The enqueued task creates a race condition when called from the Index Thread 