### PR TITLE
#20905 only show parent folder if is requested

### DIFF
--- a/dotCMS/src/curl-test/FolderResource.postman_collection.json
+++ b/dotCMS/src/curl-test/FolderResource.postman_collection.json
@@ -445,11 +445,11 @@
 									"var jsonData = pm.response.json();",
 									"",
 									"pm.test(\"Folder Check\", function () {",
-									"    pm.expect(jsonData.entity[1].path).to.eql('/testfindfolder1/subfolder1/');",
+									"    pm.expect(jsonData.entity[0].path).to.eql('/testfindfolder1/subfolder1/');",
 									"});",
 									"",
 									"pm.test(\"Length Check\", function () {",
-									"    pm.expect(jsonData.entity.length).to.eql(3);",
+									"    pm.expect(jsonData.entity.length).to.eql(2);",
 									"});"
 								],
 								"type": "text/javascript"

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/FolderHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/FolderHelper.java
@@ -243,9 +243,14 @@ public class FolderHelper {
                 .findFolderByPath(lastValidPath, host, user, false);
         if (UtilMethods.isSet(lastValidFolder) && UtilMethods
                 .isSet(lastValidFolder.getInode())) {
-            subFolders.add(new FolderSearchResultView(lastValidFolder.getPath(),host.getHostname(),
-                    Try.of(() -> APILocator.getPermissionAPI().doesUserHavePermission(lastValidFolder,
-                    PermissionAPI.PERMISSION_CAN_ADD_CHILDREN,user)).getOrElse(false)));
+            if(pathToSearch.equals(lastValidPath) || pathToSearch.equals(lastValidPath+"/")) {
+                subFolders.add(new FolderSearchResultView(lastValidFolder.getPath(),
+                        host.getHostname(),
+                        Try.of(() -> APILocator.getPermissionAPI()
+                                .doesUserHavePermission(lastValidFolder,
+                                        PermissionAPI.PERMISSION_CAN_ADD_CHILDREN, user))
+                                .getOrElse(false)));
+            }
             final List<Folder> subFoldersOfLastValidPath = APILocator.getFolderAPI()
                     .findSubFolders(lastValidFolder, user, false);
             subFoldersOfLastValidPath.stream()


### PR DESCRIPTION
Before we were always adding the parent folder to the list, but now if what is requested is the subfolders we shouldn't add it.

E.g
`//demo.dotcms.com/activities/` -> should return the folder activities
`//demo.dotcms.com/activities` -> should return the folder activities
`//demo.dotcms.com/activities/t` -> shouldn't return the folder activities, since we are trying to get the subfolders that start with t