### PR TITLE
#20733 adding the role.key.substitution functionality

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
@@ -228,6 +228,28 @@ public class SAMLHelperTest extends IntegrationTestBase {
     }
 
     @Test()
+    public void test_getRoleKeySubstitution_processReplacement_doing_null_substitution() throws DotDataException, DotSecurityException, IOException {
+
+        final SamlAuthenticationService samlAuthenticationService         = new MockSamlAuthenticationService();
+        final CompanyAPI companyAPI                                       = mock(CompanyAPI.class);
+        final Company    company                                          = new Company();
+        final SAMLHelper           		samlHelper                        = new SAMLHelper(samlAuthenticationService, companyAPI);
+
+        company.setAuthType(Company.AUTH_TYPE_EA);
+        when(companyAPI.getDefaultCompany()).thenReturn(company);
+
+        final String pattern      = null;
+        final Optional<Tuple2<String, String>> substitutionTokenOpt = samlHelper.getRoleKeySubstitution(pattern);
+
+        Assert.assertFalse(substitutionTokenOpt.isPresent());
+        final String expected     = "CMS Administrator";
+
+        final String roleResult   = samlHelper.processReplacement(expected, substitutionTokenOpt);
+
+        Assert.assertEquals(expected, roleResult);
+    }
+
+    @Test()
     public void test_getRoleKeySubstitution_processReplacement_doing_substitution() throws DotDataException, DotSecurityException, IOException {
 
         final SamlAuthenticationService samlAuthenticationService         = new MockSamlAuthenticationService();
@@ -248,8 +270,6 @@ public class SAMLHelperTest extends IntegrationTestBase {
         final String roleResult   = samlHelper.processReplacement(tokenRole, substitutionTokenOpt);
 
         Assert.assertEquals(expected, roleResult);
-
-        ;
     }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
@@ -12,8 +12,13 @@ import com.dotcms.saml.SamlName;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.util.RegEX;
+import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -24,6 +29,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -220,4 +226,30 @@ public class SAMLHelperTest extends IntegrationTestBase {
         Assert.assertNotEquals(nativeUser.getFirstName(),  recoveredNativeUser.getFirstName());
         Assert.assertEquals (nativeUser.getLastName(),     recoveredNativeUser.getLastName());
     }
+
+    @Test()
+    public void test_getRoleKeySubstitution_processReplacement_doing_substitution() throws DotDataException, DotSecurityException, IOException {
+
+        final SamlAuthenticationService samlAuthenticationService         = new MockSamlAuthenticationService();
+        final CompanyAPI companyAPI                                       = mock(CompanyAPI.class);
+        final Company    company                                          = new Company();
+        final SAMLHelper           		samlHelper                        = new SAMLHelper(samlAuthenticationService, companyAPI);
+
+        company.setAuthType(Company.AUTH_TYPE_EA);
+        when(companyAPI.getDefaultCompany()).thenReturn(company);
+
+        final String pattern      = "/_sepsep_/ /";
+        final Optional<Tuple2<String, String>> substitutionTokenOpt = samlHelper.getRoleKeySubstitution(pattern);
+
+        Assert.assertTrue(substitutionTokenOpt.isPresent());
+        final String tokenRole    = "CMS_sepsep_Administrator";
+        final String expected     = "CMS Administrator";
+
+        final String roleResult   = samlHelper.processReplacement(tokenRole, substitutionTokenOpt);
+
+        Assert.assertEquals(expected, roleResult);
+
+        ;
+    }
+
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
@@ -227,6 +227,12 @@ public class SAMLHelperTest extends IntegrationTestBase {
         Assert.assertEquals (nativeUser.getLastName(),     recoveredNativeUser.getLastName());
     }
 
+    /**
+     * Method to test: {@link SAMLHelper#getRoleKeySubstitution(String)}  {@link SAMLHelper#processReplacement(String, Optional)}
+     * Given Scenario: sending an null pattern should be doing nothing
+     * ExpectedResult: The role does not change
+     *
+     */
     @Test()
     public void test_getRoleKeySubstitution_processReplacement_doing_null_substitution() throws DotDataException, DotSecurityException, IOException {
 
@@ -249,6 +255,12 @@ public class SAMLHelperTest extends IntegrationTestBase {
         Assert.assertEquals(expected, roleResult);
     }
 
+    /**
+     * Method to test: {@link SAMLHelper#getRoleKeySubstitution(String)}  {@link SAMLHelper#processReplacement(String, Optional)}
+     * Given Scenario: sending an substitution pattern should be doing the replacement
+     * ExpectedResult: The role will be clean up
+     *
+     */
     @Test()
     public void test_getRoleKeySubstitution_processReplacement_doing_substitution() throws DotDataException, DotSecurityException, IOException {
 

--- a/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/SAMLHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/SAMLHelper.java
@@ -380,7 +380,7 @@ public class SAMLHelper {
                 + ", or roles have been not set from the IdP");
     }
 
-    private String processReplacement(final String role, final Optional<Tuple2<String, String>> roleKeySubstitutionOpt) {
+    protected String processReplacement(final String role, final Optional<Tuple2<String, String>> roleKeySubstitutionOpt) {
 
         if (roleKeySubstitutionOpt.isPresent()) {
 
@@ -396,6 +396,11 @@ public class SAMLHelper {
 
         final String roleKeySubstitution = this.getSamlConfigurationService().getConfigAsString(
                 identityProviderConfiguration, SamlName.DOT_SAML_ROLE_KEY_SUBSTITUTION);
+
+        return getRoleKeySubstitution(roleKeySubstitution);
+    }
+
+    protected Optional<Tuple2<String, String>> getRoleKeySubstitution(final String roleKeySubstitution) {
 
         if (UtilMethods.isSet(roleKeySubstitution) && roleKeySubstitution.startsWith(StringPool.FORWARD_SLASH)
                 && roleKeySubstitution.endsWith(StringPool.FORWARD_SLASH)) {

--- a/dotCMS/src/main/java/com/dotcms/saml/SamlName.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/SamlName.java
@@ -349,7 +349,14 @@ public enum SamlName {
 	/**
 	 * In case the session wants to be renew, should be true by default.
 	 */
-	DOT_RENEW_SESSION("renew.session");
+	DOT_RENEW_SESSION("renew.session"),
+
+	/**
+	 * In case want do a substitution on all roles:
+	 * role.key.substitution=/_sepsep_/ /
+	 * That substitution expression will replace the string _sepsep_ with white space before matching role name from IdP against role key from dotCMS.
+	 */
+	DOT_SAML_ROLE_KEY_SUBSTITUTION("role.key.substitution");
 
 	private final String propertyName;
 

--- a/dotCMS/src/test/java/com/dotmarketing/util/RegEXTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/RegEXTest.java
@@ -87,6 +87,12 @@ public class RegEXTest {
         Assert.assertTrue(RegEX.containsCaseInsensitive(text3, regex));
     }
 
+    /**
+     * Method to test: {@link RegEX#replace(String, String, String)}
+     * Given Scenario: Do a replace by white space
+     * ExpectedResult: The token is replaced with white space
+     *
+     */
     @Test
     public void test_replace_token_by_white_space () throws ParseException {
 
@@ -100,6 +106,12 @@ public class RegEXTest {
         Assert.assertEquals(expected, result);
     }
 
+    /**
+     * Method to test: {@link RegEX#replace(String, String, String)}
+     * Given Scenario: Do a parsing and replace
+     * ExpectedResult: The role will be clean up
+     *
+     */
     @Test
     public void test_replace_token_by_white_space_on_pattern () throws ParseException {
 

--- a/dotCMS/src/test/java/com/dotmarketing/util/RegEXTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/RegEXTest.java
@@ -1,9 +1,13 @@
 package com.dotmarketing.util;
 
+import com.liferay.util.StringPool;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.text.ParseException;
+import java.util.Optional;
 
 public class RegEXTest {
 
@@ -81,5 +85,43 @@ public class RegEXTest {
         Assert.assertTrue(RegEX.containsCaseInsensitive(text1, regex));
         Assert.assertTrue(RegEX.containsCaseInsensitive(text2, regex));
         Assert.assertTrue(RegEX.containsCaseInsensitive(text3, regex));
+    }
+
+    @Test
+    public void test_replace_token_by_white_space () throws ParseException {
+
+        final String replace      = "_sepsep_";
+        final String replacement  = " ";
+        final String token        = "CMS_sepsep_Administrator";
+        final String expected     = "CMS Administrator";
+
+        final String result = RegEX.replace(token, replacement, replace);
+
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void test_replace_token_by_white_space_on_pattern () throws ParseException {
+
+        final String pattern      = "/_sepsep_/ /";
+        Optional<Tuple2<String, String>> substitutionTokenOpt = Optional.empty();
+
+        if (UtilMethods.isSet(pattern) && pattern.startsWith(StringPool.FORWARD_SLASH)
+                && pattern.endsWith(StringPool.FORWARD_SLASH)) {
+
+            final String [] substitutionTokens = pattern.substring(1, pattern.length()-1).split(StringPool.FORWARD_SLASH);
+            substitutionTokenOpt = substitutionTokens.length == 2? Optional.ofNullable(Tuple.of(substitutionTokens[0], substitutionTokens[1])): Optional.empty();
+        }
+
+        Assert.assertTrue(substitutionTokenOpt.isPresent());
+
+        final String replace      = substitutionTokenOpt.get()._1();
+        final String replacement  = substitutionTokenOpt.get()._2();
+        final String token        = "CMS_sepsep_Administrator";
+        final String expected     = "CMS Administrator";
+
+        final String result = RegEX.replace(token, replacement, replace);
+
+        Assert.assertEquals(expected, result);
     }
 }


### PR DESCRIPTION
A new configuration property for the SAML plugin will allow adding a substitution expression to use when mapping dotCMS role keys. For example:

role.key.substitution=/_sepsep_/ /


That substitution expression will replace the string _sepsep_ with white space before matching role name from IdP against role key from dotCMS.