### PR TITLE
Fixing retry bundle

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -44,6 +44,7 @@ import com.dotcms.publishing.PushPublishFiltersInitializerTest;
 import com.dotcms.publishing.job.SiteSearchJobImplTest;
 import com.dotcms.publishing.manifest.CSVManifestBuilderTest;
 import com.dotcms.publishing.manifest.CSVManifestReaderTest;
+import com.dotcms.publishing.manifest.ManifestReaderFactoryTest;
 import com.dotcms.rendering.velocity.directive.DotParseTest;
 import com.dotcms.rendering.velocity.servlet.VelocityServletIntegrationTest;
 import com.dotcms.rendering.velocity.viewtools.DotTemplateToolTest;

--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -468,7 +468,8 @@ import org.junit.runners.Suite.SuiteClasses;
         DotObjectCodecTest.class,
         RedisClientTest.class,
         LettuceCacheTest.class,
-        RedisPubSubImplTest.class
+        RedisPubSubImplTest.class,
+        ManifestReaderFactoryTest.class
 })
 public class MainSuite {
 

--- a/dotCMS/src/integration-test/java/com/dotcms/publishing/manifest/CSVManifestReaderTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publishing/manifest/CSVManifestReaderTest.java
@@ -46,6 +46,8 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -298,6 +300,35 @@ public class CSVManifestReaderTest {
         }
 
         final ManifestReader manifestReader = new CSVManifestReader(manifestFile);
+        final Collection<ManifestInfo> includedAssets = manifestReader.getAssets(ManifestReason.INCLUDE_BY_USER);
+        assertEquals(1, includedAssets.size());
+
+        final ManifestInfo assetIncluded = includedAssets.iterator().next();
+        assertEquals(contentType1.getManifestInfo(), assetIncluded);
+    }
+
+    /**
+     * Method to test: {@link CSVManifestReader#getAssets(ManifestReason)}
+     * when: Create a Manifest File and include two asset with different reason
+     * should: Return just the asset with the reason requested
+     */
+    @Test
+    public void createCSVManifestReaderWithInputStream() throws FileNotFoundException {
+        final String includeReason1 = ManifestReason.INCLUDE_BY_USER.getMessage();
+        final String includeReason2 = ManifestReason.INCLUDE_AUTOMATIC_BY_DOTCMS.getMessage();
+
+        File manifestFile = null;
+
+        final ContentType contentType1 = new ContentTypeDataGen().nextPersisted();
+        final ContentType contentType2 = new ContentTypeDataGen().nextPersisted();
+
+        try(final CSVManifestBuilder manifestBuilder = new CSVManifestBuilder()) {
+            manifestBuilder.include(contentType1, includeReason1);
+            manifestBuilder.include(contentType2, includeReason2);
+            manifestFile = manifestBuilder.getManifestFile();
+        }
+
+        final ManifestReader manifestReader = new CSVManifestReader(new FileReader(manifestFile));
         final Collection<ManifestInfo> includedAssets = manifestReader.getAssets(ManifestReason.INCLUDE_BY_USER);
         assertEquals(1, includedAssets.size());
 

--- a/dotCMS/src/integration-test/java/com/dotcms/publishing/manifest/ManifestReaderFactoryTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publishing/manifest/ManifestReaderFactoryTest.java
@@ -1,0 +1,66 @@
+package com.dotcms.publishing.manifest;
+
+import static com.dotcms.util.CollectionsUtils.list;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.datagen.BundleDataGen;
+import com.dotcms.datagen.ContentTypeDataGen;
+import com.dotcms.datagen.FilterDescriptorDataGen;
+import com.dotcms.publisher.bundle.bean.Bundle;
+import com.dotcms.publisher.pusher.PushPublisherConfig;
+import com.dotcms.publishing.DotPublishingException;
+import com.dotcms.publishing.FilterDescriptor;
+import com.dotcms.publishing.GenerateBundlePublisher;
+import com.dotcms.publishing.PublishStatus;
+import com.dotcms.publishing.Publisher;
+import com.dotcms.publishing.PublisherConfig;
+import com.dotcms.publishing.manifest.ManifestItem.ManifestInfo;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import java.io.File;
+import java.util.Collection;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ManifestReaderFactoryTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    @Test
+    public void createCSVManifestReader() throws DotPublishingException {
+        final ContentType contentType = new ContentTypeDataGen().nextPersisted();
+
+        final PushPublisherConfig config = new PushPublisherConfig();
+        config.setPublishers(list(GenerateBundlePublisher.class));
+        config.setOperation(PublisherConfig.Operation.PUBLISH);
+        config.setLuceneQueries(list());
+        config.setId("PublisherAPIImplTest_" + System.currentTimeMillis());
+
+        final FilterDescriptor filterDescriptor = new FilterDescriptorDataGen().nextPersisted();
+
+        final Bundle bundle = new BundleDataGen()
+                .pushPublisherConfig(config)
+                .addAssets(list(contentType))
+                .filter(filterDescriptor)
+                .nextPersisted();
+
+        final PublishStatus publish = APILocator.getPublisherAPI().publish(config);
+
+        final CSVManifestReader csvManifestReader = ManifestReaderFactory.INSTANCE
+                .createCSVManifestReader(bundle.getId());
+
+        assertNotNull(csvManifestReader);
+        final Collection<ManifestInfo> assets = csvManifestReader
+                .getAssets(ManifestReason.INCLUDE_BY_USER);
+
+        assertEquals(1, assets.size());
+        assertEquals(contentType.id(), assets.iterator().next().id());;
+    }
+}

--- a/dotCMS/src/integration-test/java/com/dotcms/publishing/manifest/ManifestReaderFactoryTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publishing/manifest/ManifestReaderFactoryTest.java
@@ -33,6 +33,14 @@ public class ManifestReaderFactoryTest {
         IntegrationTestInitService.getInstance().init();
     }
 
+    /***
+     * Method to test: {@link CSVManifestReader#getAssets(ManifestReason)}
+     * when: A Manifest is created and a {@link ContentType} is added
+     * should: the method {@link CSVManifestReader#getAssets(ManifestReason)} called with
+     * {@link ManifestReason#INCLUDE_BY_USER} should return the content tupe added
+     *
+     * @throws DotPublishingException
+     */
     @Test
     public void createCSVManifestReader() throws DotPublishingException {
         final ContentType contentType = new ContentTypeDataGen().nextPersisted();

--- a/dotCMS/src/main/java/com/dotcms/publisher/ajax/RemotePublishAjaxAction.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/ajax/RemotePublishAjaxAction.java
@@ -443,7 +443,7 @@ public class RemotePublishAjaxAction extends AjaxAction {
 				if (null == bundle) {
 					Logger.error(this.getClass(), "No Bundle with id: " + bundleId + " found.");
 					appendMessage(responseMessage, "publisher_retry.error.not.found", bundleId, true);
-					continue;o
+					continue;
 				}
                 if (status.getStatus().equals(Status.SUCCESS) || status.getStatus()
                         .equals(Status.SUCCESS_WITH_WARNINGS)) {

--- a/dotCMS/src/main/java/com/dotcms/publishing/BundlerUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/BundlerUtil.java
@@ -1,7 +1,15 @@
 package com.dotcms.publishing;
 
+import static com.dotcms.util.CollectionsUtils.list;
+
 import com.dotcms.content.elasticsearch.business.ESMappingAPIImpl;
 import com.dotcms.publisher.business.DotPublisherException;
+import com.dotcms.publisher.business.PublishAuditAPI;
+import com.dotcms.publisher.business.PublishAuditStatus;
+import com.dotcms.publisher.business.PublishAuditStatus.Status;
+import com.dotcms.publisher.business.PublishQueueElement;
+import com.dotcms.publisher.business.PublisherAPI;
+import com.dotcms.publishing.manifest.ManifestUtil;
 import com.dotcms.publishing.output.BundleOutput;
 import com.dotcms.publishing.output.TarGzipBundleOutput;
 import com.dotcms.rest.api.v1.DotObjectMapperProvider;
@@ -21,25 +29,40 @@ import java.io.*;
 import java.nio.file.Files;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 public class BundlerUtil {
 
     static XStream xmlSerializer = null;
+    public static final List<Status> STATUS_TO_RETRY = list(
+            Status.FAILED_TO_PUBLISH, Status.SUCCESS, Status.SUCCESS_WITH_WARNINGS,
+            Status.FAILED_TO_SEND_TO_ALL_GROUPS, Status.FAILED_TO_SEND_TO_SOME_GROUPS, Status.FAILED_TO_SENT
+    );
 
 	/**
 	 * does bundle exist
 	 * @param config
 	 * @return
 	 */
-	public static boolean bundleExists(PublisherConfig config){
+	public static boolean bundleExists(final PublisherConfig config){
 		if(config.getId() ==null){
 			throw new DotStateException("publishing config.id is null.  Please set an id before publishing (it will be the folder name under which the bundle will be created)");
 		}
 
-		String bundlePath = ConfigUtils.getBundlePath()+ File.separator + config.getName();
-		bundlePath += File.separator + "bundle.xml";
+		if (config.isStatic()) {
+            String bundlePath = ConfigUtils.getBundlePath()+ File.separator + config.getName();
+            bundlePath += File.separator + "bundle.xml";
 
-		return new File(bundlePath).exists();
+            return new File(bundlePath).exists();
+        } else {
+            try {
+                return ManifestUtil.manifestExists(config.getId());
+            } catch (IOException e) {
+                Logger.warn(BundlerUtil.class, () -> e.getMessage());
+                return false;
+            }
+        }
+
 	}
 
     public static File getBundleRoot(String name) {
@@ -66,6 +89,54 @@ public class BundlerUtil {
             dir.mkdirs();
         }
         return dir;
+    }
+
+    public static boolean isRetryable(final PublishAuditStatus status) {
+        return UtilMethods.isSet(status) && isRetryable(status.getStatus());
+    }
+
+    public static boolean isRetryable(final String bundleId) {
+        try {
+            final PublishAuditStatus publishAuditStatus = PublishAuditAPI.getInstance()
+                    .getPublishAuditStatus(bundleId);
+
+            return isRetryable(publishAuditStatus) && !isInPublishQueue(bundleId)
+                    && bundleExists(bundleId);
+        } catch (DotPublisherException e) {
+            Logger.error(BundlerUtil.class, e.getMessage());
+            return false;
+        }
+    }
+
+    private static boolean bundleExists(String bundleId) {
+        final PublisherConfig basicConfig = new PublisherConfig();
+        basicConfig.setId(bundleId);
+        final File bundleRoot = BundlerUtil.getBundleRoot( basicConfig.getName(), false );
+
+        final File bundleStaticFile = new File(bundleRoot.getAbsolutePath() + PublisherConfig.STATIC_SUFFIX);
+        if ( !bundleStaticFile.exists() ) {
+            return true;
+        }
+
+        final File bundleFile = new File( ConfigUtils.getBundlePath() + File.separator + basicConfig.getId() + ".tar.gz" );
+        if ( !bundleFile.exists() ) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isInPublishQueue(String bundleId) throws DotPublisherException {
+        List<PublishQueueElement> foundBundles = PublisherAPI.getInstance()
+                .getQueueElementsByBundleId(bundleId);
+
+        if ( foundBundles != null && !foundBundles.isEmpty() ) {
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isRetryable(final PublishAuditStatus.Status status) {
+        return UtilMethods.isSet(status) && STATUS_TO_RETRY.contains(status);
     }
 
 	/**

--- a/dotCMS/src/main/java/com/dotcms/publishing/BundlerUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/BundlerUtil.java
@@ -95,6 +95,20 @@ public class BundlerUtil {
         return UtilMethods.isSet(status) && isRetryable(status.getStatus());
     }
 
+    /**
+     * Return true if a bundle ca ne retry.
+     * A bundle cab be retry if:
+     *
+     * - If the method {@link BundlerUtil#isRetryable(Status)} return true
+     * - And The Bundle is not in the Publish Queue, it meean that the
+     * {@link PublisherAPI#getQueueElementsByBundleId(String)}  return a empty list
+     * - If the bundle's file exists, it mean:
+     *      - The bundle's tar.gzip file exists if it no a static bundle.
+     *      - The bundle's root folder exists if it a static bundle.
+     *
+     * @param bundleId
+     * @return
+     */
     public static boolean isRetryable(final String bundleId) {
         try {
             final PublishAuditStatus publishAuditStatus = PublishAuditAPI.getInstance()
@@ -135,6 +149,19 @@ public class BundlerUtil {
         return false;
     }
 
+    /**
+     * Return true if <code>status</code> is one of the follow {@link PublishAuditStatus.Status}:
+     *
+     * - {@link PublishAuditStatus#Status#FAILED_TO_PUBLISH}
+     * - {@link PublishAuditStatus#Status#SUCCESS}
+     * - {@link PublishAuditStatus#Status#SUCCESS_WITH_WARNINGS}
+     * - {@link PublishAuditStatus#Status#FAILED_TO_SEND_TO_ALL_GROUPS}
+     * - {@link PublishAuditStatus#Status#FAILED_TO_SEND_TO_SOME_GROUPS}
+     * - {@link PublishAuditStatus#Status#FAILED_TO_SENT}
+     *
+     * @param status
+     * @return
+     */
     public static boolean isRetryable(final PublishAuditStatus.Status status) {
         return UtilMethods.isSet(status) && STATUS_TO_RETRY.contains(status);
     }

--- a/dotCMS/src/main/java/com/dotcms/publishing/BundlerUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/BundlerUtil.java
@@ -97,7 +97,7 @@ public class BundlerUtil {
 
     /**
      * Return true if a bundle ca ne retry.
-     * A bundle cab be retry if:
+     * A bundle can be retry if:
      *
      * - If the method {@link BundlerUtil#isRetryable(Status)} return true
      * - And The Bundle is not in the Publish Queue, it meean that the

--- a/dotCMS/src/main/java/com/dotcms/publishing/manifest/CSVManifestReader.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/manifest/CSVManifestReader.java
@@ -11,7 +11,11 @@ import com.dotmarketing.util.FileUtil;
 import com.google.common.collect.ImmutableList;
 import com.liferay.util.StringPool;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -25,27 +29,44 @@ import java.util.stream.Stream;
 import jersey.repackaged.com.google.common.collect.ImmutableSet;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 
 /**
  * Util class to read a CSV Manifest file
  */
 public class CSVManifestReader implements ManifestReader{
 
-    final Collection<CSVManifestItem> manifestItemsIncluded;
-    final Collection<CSVManifestItem> manifestItemsExcluded;
-    final Map<String, String> metaData;
+    private Collection<CSVManifestItem> manifestItemsIncluded;
+    private Collection<CSVManifestItem> manifestItemsExcluded;
+    private Map<String, String> metaData;
 
     final static String COMMENTED_LINE_START = "#";
 
+    public CSVManifestReader(final Reader manifestReader){
+        init(manifestReader);
+    }
+
     public CSVManifestReader(final File csvManifestFile){
+        init(csvManifestFile);
+    }
+
+    private void init(final File csvManifestFile){
+        try{
+            init(new FileReader(csvManifestFile));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Not valid " + csvManifestFile.getAbsolutePath(), e);
+        }
+    }
+
+    private void init(final Reader manifestReader){
         try {
-            final List<String> lines = FileUtils.readLines(csvManifestFile, StandardCharsets.UTF_8);
+            final List<String> lines = IOUtils.readLines(manifestReader);
 
             this.manifestItemsIncluded = getManifestInfos(lines, "INCLUDED");
             this.manifestItemsExcluded = getManifestInfos(lines, "EXCLUDED");
             this.metaData = getAllMetaData(lines);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Not valid " + csvManifestFile.getAbsolutePath(), e);
+            throw new IllegalArgumentException("Not valid InputStream manifest: " + e.getMessage(), e);
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/publishing/manifest/ManifestReader.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/manifest/ManifestReader.java
@@ -7,6 +7,8 @@ import com.dotmarketing.util.UtilMethods;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import com.dotcms.publishing.PublisherConfig;
+import com.dotcms.publishing.PublisherConfig.Operation;
 
 /**
  * Util class to read a Manifest file
@@ -20,13 +22,14 @@ public interface ManifestReader {
     String getMetadata(final String name);
 
     default List<PublishQueueElement> getPublishQueueElement(){
-        final IntegrityType integrityType = IntegrityType.valueOf(getMetadata(CSVManifestBuilder.OPERATION_METADATA_NAME));
+        final Operation operation = Operation
+                .valueOf(getMetadata(CSVManifestBuilder.OPERATION_METADATA_NAME));
 
         return getAssets().stream()
                 .map(manifestInfo -> {
                     final PublishQueueElement publishQueueElement = new PublishQueueElement();
                     publishQueueElement.setAsset(UtilMethods.isSet(manifestInfo.inode()) ? manifestInfo.inode() : manifestInfo.id());
-                    publishQueueElement.setOperation(integrityType.ordinal());
+                    publishQueueElement.setOperation(operation.ordinal());
                     publishQueueElement.setBundleId(
                             getMetadata(CSVManifestBuilder.BUNDLE_ID_METADATA_NAME));
                     publishQueueElement.setType(manifestInfo.objectType());

--- a/dotCMS/src/main/java/com/dotcms/publishing/manifest/ManifestReader.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/manifest/ManifestReader.java
@@ -7,8 +7,6 @@ import com.dotmarketing.util.UtilMethods;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import com.dotcms.publishing.PublisherConfig;
-import com.dotcms.publishing.PublisherConfig.Operation;
 
 /**
  * Util class to read a Manifest file
@@ -22,14 +20,13 @@ public interface ManifestReader {
     String getMetadata(final String name);
 
     default List<PublishQueueElement> getPublishQueueElement(){
-        final Operation operation = Operation
-                .valueOf(getMetadata(CSVManifestBuilder.OPERATION_METADATA_NAME));
+        final IntegrityType integrityType = IntegrityType.valueOf(getMetadata(CSVManifestBuilder.OPERATION_METADATA_NAME));
 
         return getAssets().stream()
                 .map(manifestInfo -> {
                     final PublishQueueElement publishQueueElement = new PublishQueueElement();
                     publishQueueElement.setAsset(UtilMethods.isSet(manifestInfo.inode()) ? manifestInfo.inode() : manifestInfo.id());
-                    publishQueueElement.setOperation(operation.ordinal());
+                    publishQueueElement.setOperation(integrityType.ordinal());
                     publishQueueElement.setBundleId(
                             getMetadata(CSVManifestBuilder.BUNDLE_ID_METADATA_NAME));
                     publishQueueElement.setType(manifestInfo.objectType());

--- a/dotCMS/src/main/java/com/dotcms/publishing/manifest/ManifestReaderFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/manifest/ManifestReaderFactory.java
@@ -1,0 +1,30 @@
+package com.dotcms.publishing.manifest;
+
+import com.dotcms.publishing.output.TarGzipBundleOutput;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.util.ConfigUtils;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Optional;
+
+public enum ManifestReaderFactory {
+    INSTANCE;
+
+    public CSVManifestReader createCSVManifestReader(final String bundleID){
+        final File bundleTarGzipFile = TarGzipBundleOutput.getBundleTarGzipFile(bundleID);
+        try {
+            final Optional<Reader> manifestInputStream = ManifestUtil
+                    .getManifestInputStream(bundleTarGzipFile);
+
+            if (!manifestInputStream.isPresent()){
+                throw new IllegalArgumentException("Manifest not found for: " + bundleID);
+            }
+
+            return new CSVManifestReader(manifestInputStream.get());
+        } catch (IOException e) {
+            throw new DotRuntimeException(e);
+        }
+
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/publishing/manifest/ManifestReaderFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/manifest/ManifestReaderFactory.java
@@ -8,6 +8,9 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.Optional;
 
+/**
+ * Factory for {@link CSVManifestReader}
+ */
 public enum ManifestReaderFactory {
     INSTANCE;
 

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/BinaryCleanupJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/BinaryCleanupJob.java
@@ -56,9 +56,9 @@ public class BinaryCleanupJob implements StatefulJob {
 
     // also delete bundles older than 2 days
     if (Config.getBooleanProperty("bundles.delete.enabled", true)) {
-      
-      Logger.info(this.getClass(), "Deleting bundle files older than " + olderThan + " from " + APILocator.getFileAssetAPI().getRealAssetPathTmpBinary());
+
       olderThan =  Date.from(Instant.now().minus(Duration.ofMillis(Config.getIntProperty("bundles.delete.older.than.milliseconds", 1000 * 60 * 60 * 24 * 2))));
+      Logger.info(this.getClass(), "Deleting bundle files older than " + olderThan + " from " + APILocator.getFileAssetAPI().getRealAssetPathTmpBinary());
       final File bundleFolder = new File(ConfigUtils.getBundlePath());
       FileUtil.cleanTree(bundleFolder, olderThan);
     }

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_audit_detail.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_audit_detail.jsp
@@ -92,8 +92,10 @@
             <option value="1">All End-points</option>
             <option value="2">Failed End-points Only</option>
         </select> &nbsp;&nbsp;
-        &nbsp;&nbsp;
-        <button id="retryButton" dojoType="dijit.form.Button" onClick="retryBundles('<%=bundleId%>')" iconClass="repeatIcon"><%= LanguageUtil.get(pageContext, "publisher_retry") %></button>
+
+        <%if (BundlerUtil.isRetryable(bundle.getId())){%>&nbsp;&nbsp;
+            <button id="retryButton" dojoType="dijit.form.Button" onClick="retryBundles('<%=bundleId%>')" iconClass="repeatIcon"><%= LanguageUtil.get(pageContext, "publisher_retry") %></button>
+        <%}%>
     </div>
 </div>
 


### PR DESCRIPTION
Broke from 21.05

The retry fail because it not found the bundle folder (we are not creating the folder anymore now we are creating the tar.gzip file directly) and it was looking for the bundle.xml file to get the operation, now that value is get from the manifest file.

Also we was deleting the tar.gzip file after a retry, no matter if it was success or failed, now we are keeping the bundle's file until the BinaryCleanupJob delete it.

Also now we are not showing the retry button in the "view_publish_audit_detail.jsp" unless the bundle can b retryed

