### PR TITLE
Issue 19042 enter key needs to work for adding content to bundle

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/AddToBundleDialog.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/AddToBundleDialog.js
@@ -40,6 +40,13 @@ dojo.declare("dotcms.dijit.AddToBundleDialog", null, {
             dojo.connect(dijit.byId("addToBundleSaveButton"), "onClick", function(){
                 container.addToBundle();
             });
+
+            document.querySelector('#bundleSelect').addEventListener('keypress', function (e) {
+                debugger
+                if (e.keyCode == 13) {
+                    container.addToBundle();
+                }
+            });
         });
 
         dojo.connect(dia, "onDownloadEnd", function () {
@@ -52,12 +59,6 @@ dojo.declare("dotcms.dijit.AddToBundleDialog", null, {
                 }
                 
                 dijit.byId('bundleSelect').set('value', lastSelectedBundle.name);
-                document.querySelector('#bundleSelect').addEventListener('keypress', function (e) {
-                    if (e.keyCode == 13) {
-                        container.addToBundle();
-                    }
-                });
-
             }
         });
 


### PR DESCRIPTION
When you try to add some piece of content to a bundle and you type any new name for the bundle and hit the Intro key, we need to recognize this as accept and create the bundle