### PR TITLE
#17569 this adds-up alias validation to the jobs scheduler

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -564,7 +564,7 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 
 			final Map<String, Object> readOnlyMetadata = (Map<String, Object>) contentlet.get(FileAssetAPI.META_DATA_FIELD);
             if(readOnlyMetadata.isEmpty()){
-            	Logger.warn(ESMappingAPIImpl.class,String.format("No pre-calculated metadata available to populate keyValue field on contentlet with id `%s`.",contentlet.getIdentifier()));
+            	Logger.debug(ESMappingAPIImpl.class,String.format("No pre-calculated metadata available to populate keyValue field on contentlet with id `%s`.",contentlet.getIdentifier()));
             	return;
 			}
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/sitesearch/site_search.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/sitesearch/site_search.jsp
@@ -569,7 +569,10 @@ function submitSchedule() {
 	//Based on the error invalid_alias_name_exception returned by the ES
 	//Alias must not contain the following characters [ , \", *, \\, <, |, ,, >, /, ?]"}]
 	let indexAlias = dojo.byId("indexAlias").value;
-	if( !indexAlias || indexAlias === "" || /[^a-zA-Z0-9-_]/.test(indexAlias.split(/\b\s+/)[0].trim())) {
+
+	let aliasTestResult = /^(?=.{3,60}$)^(?![-_])[a-zA-Z0-9_-]+$/.test(indexAlias);
+
+	if(!aliasTestResult) {
 		showDotCMSErrorMessage("<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Invalid-Index-Alias")) %>");
         return;
 	}


### PR DESCRIPTION
This PR does two things 

- Adds the same validation that we had applied for the site-search alias creation to the site search job scheduler
- And also lowers some noise on the logs coming from the reindex that I found while testing