### PR TITLE
dotCMS/core#20915 fix set-change-password-flag-to-enable-form-saving

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
@@ -511,6 +511,7 @@
 
         dijit.byId('password').attr('value', data.password);
         dijit.byId('passwordCheck').attr('value', data.password);
+        userPasswordChanged();
     }
 
 	//Handler from when the user info has changed


### PR DESCRIPTION
Admin users need an easier way to generate a secure password.

in the user's form when the password is changed manually a flag that indicates that change is done by calling the function `userPasswordChanged()`, so that call was missing in the autogenerate password function.

