### PR TITLE
dotCMS/core#18707 Add messaging to let customers know how to add Apps

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -4903,6 +4903,7 @@ notification.reindexing.content.type.mapping.error = Error updating index mappin
 only-available-in-enterprise = is only available in dotCMS Enterprise Editions. For more information:
 publisher_status_SUCCESS_WITH_WARNINGS = Success with warnings
 rest-api-call-post = REST POST API Curl Call (Use this command to paste in your terminal):
+apps.link.info = How to create Apps
 apps.confirmation.import.button = Import
 apps.confirmation.import.header = Import Configuration(s)
 apps.confirmation.import.password.label = Enter Password to decrypt configuration(s)


### PR DESCRIPTION
Right now, when a user opens the App screen on a system with no Apps configured, all they see is basically a blank screen. It's not clear at all what Apps are, or how to use them - or even how to figure out how to use them.

It would be helpful to have some messaging letting users know how to add Apps

![image](https://user-images.githubusercontent.com/37185433/134982818-ebb0f716-1728-450b-bcc2-0ac424f12248.png)
