### PR TITLE
Issue 21079 widgets headless support

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
@@ -21,12 +21,10 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.factories.MultiTreeAPI;
-import com.dotmarketing.factories.PublishFactory;
 import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
-import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI;
 import com.dotmarketing.portlets.htmlpageasset.business.render.page.HTMLPageAssetRendered;
@@ -794,13 +792,13 @@ public class PageResourceTest {
         assertTrue(containers.size() > 0);
 
         for (ContainerRendered container : containers) {
-            final Map<String, String> rendered = container.getRendered();
-            final Collection<String> codes = rendered.values();
+            final Map<String, Object> rendered = container.getRendered();
+            final Collection<Object> codes = rendered.values();
             assertTrue(codes.size() > 0);
 
-            for (final String code : codes) {
-                assertTrue(code.indexOf("data-dot-object=\"container\"") != -1);
-                assertTrue(code.indexOf("data-dot-object=\"contentlet\"") != -1);
+            for (final Object code : codes) {
+                assertTrue(code.toString().indexOf("data-dot-object=\"container\"") != -1);
+                assertTrue(code.toString().indexOf("data-dot-object=\"contentlet\"") != -1);
             }
         }
         assertNull(pageView.getViewAs().getPersona());

--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/type/WidgetContentType.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/type/WidgetContentType.java
@@ -20,6 +20,8 @@ public abstract class WidgetContentType extends ContentType implements Expireabl
 	
 	public static final String WIDGET_CODE_FIELD_NAME = "Widget Code";
 	public static final String WIDGET_CODE_FIELD_VAR = "widgetCode";
+	public static final String WIDGET_CODE_JSON_FIELD_NAME = "Widget Code as JSON";
+	public static final String WIDGET_CODE_JSON_FIELD_VAR = "widgetCodeJSON";
 	public static final String WIDGET_USAGE_FIELD_NAME = "Widget Usage";
 	public static final String WIDGET_USAGE_FIELD_VAR = "widgetUsage";
 	public static final String WIDGET_TITLE_FIELD_NAME = "Widget Title";
@@ -55,7 +57,7 @@ public abstract class WidgetContentType extends ContentType implements Expireabl
 		Field preExecute = ImmutableConstantField.builder()
 				.name(WIDGET_PRE_EXECUTE_FIELD_NAME)
 				.variable(WIDGET_PRE_EXECUTE_FIELD_VAR)
-				.sortOrder(4)
+				.sortOrder(5)
 				.fixed(false)
 				.readOnly(false)
 				.searchable(true)
@@ -70,8 +72,17 @@ public abstract class WidgetContentType extends ContentType implements Expireabl
 				.readOnly(true)
 				.searchable(true)
 				.build();
+
+		Field codeJSONField = ImmutableConstantField.builder()
+				.name(WIDGET_CODE_JSON_FIELD_NAME)
+				.variable(WIDGET_CODE_JSON_FIELD_VAR)
+				.sortOrder(4)
+				.fixed(true)
+				.readOnly(true)
+				.searchable(true)
+				.build();
 		
-		Field usageField = ImmutableConstantField.builder()
+		Field usageField = ImmutableTextField.builder()
 				.name(WIDGET_USAGE_FIELD_NAME)
 				.variable(WIDGET_USAGE_FIELD_VAR)
 				.sortOrder(2)
@@ -79,12 +90,7 @@ public abstract class WidgetContentType extends ContentType implements Expireabl
 				.readOnly(false)
 				.searchable(true)
 				.build();
-		
 
-		
-		return ImmutableList.of(titleField,usageField,codeField,preExecute);
-		
-		
-		
+		return ImmutableList.of(titleField,usageField,codeField,codeJSONField,preExecute);
 	}
 }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/type/WidgetContentType.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/type/WidgetContentType.java
@@ -1,17 +1,15 @@
 package com.dotcms.contenttype.model.type;
 
-import java.util.List;
-
-import org.immutables.gson.Gson;
-import org.immutables.value.Value;
-
 import com.dotcms.contenttype.model.field.DataTypes;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.ImmutableConstantField;
 import com.dotcms.contenttype.model.field.ImmutableTextField;
-import com.google.common.collect.ImmutableList;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.immutables.gson.Gson;
+import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableWidgetContentType.class)
 @JsonDeserialize(as = ImmutableWidgetContentType.class)
 @Gson.TypeAdapters
@@ -73,15 +71,6 @@ public abstract class WidgetContentType extends ContentType implements Expireabl
 				.searchable(true)
 				.build();
 
-		Field codeJSONField = ImmutableConstantField.builder()
-				.name(WIDGET_CODE_JSON_FIELD_NAME)
-				.variable(WIDGET_CODE_JSON_FIELD_VAR)
-				.sortOrder(4)
-				.fixed(true)
-				.readOnly(true)
-				.searchable(true)
-				.build();
-		
 		Field usageField = ImmutableTextField.builder()
 				.name(WIDGET_USAGE_FIELD_NAME)
 				.variable(WIDGET_USAGE_FIELD_VAR)
@@ -91,6 +80,6 @@ public abstract class WidgetContentType extends ContentType implements Expireabl
 				.searchable(true)
 				.build();
 
-		return ImmutableList.of(titleField,usageField,codeField,codeJSONField,preExecute);
+		return ImmutableList.of(titleField,usageField,codeField,preExecute);
 	}
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
@@ -104,10 +104,6 @@ public enum InterfaceType {
         addBaseTypeFields(widgetFields, ImmutableWidgetContentType.builder().name("dummy")
                 .build().requiredFields());
 
-        // add widgetCodeJSON field
-//        widgetFields.put("widgetCodeJSON",
-//                new TypeFetcher(ExtendedScalars.Json, new DotJSONDataFetcher()));
-
         interfaceTypes.put("WIDGET", createInterfaceType(WIDGET_INTERFACE_NAME, widgetFields, new ContentResolver()));
 
         final Map<String, TypeFetcher> vanityUrlFields = new HashMap<>(contentFields);

--- a/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/InterfaceType.java
@@ -27,8 +27,10 @@ import com.dotcms.contenttype.model.type.WidgetContentType;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.graphql.business.ContentAPIGraphQLTypesProvider;
+import com.dotcms.graphql.datafetcher.DotJSONDataFetcher;
 import com.dotcms.graphql.resolver.ContentResolver;
 import com.dotmarketing.util.Logger;
+import graphql.scalars.ExtendedScalars;
 import graphql.schema.GraphQLInterfaceType;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -101,6 +103,11 @@ public enum InterfaceType {
         final Map<String, TypeFetcher> widgetFields = new HashMap<>(contentFields);
         addBaseTypeFields(widgetFields, ImmutableWidgetContentType.builder().name("dummy")
                 .build().requiredFields());
+
+        // add widgetCodeJSON field
+//        widgetFields.put("widgetCodeJSON",
+//                new TypeFetcher(ExtendedScalars.Json, new DotJSONDataFetcher()));
+
         interfaceTypes.put("WIDGET", createInterfaceType(WIDGET_INTERFACE_NAME, widgetFields, new ContentResolver()));
 
         final Map<String, TypeFetcher> vanityUrlFields = new HashMap<>(contentFields);

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
@@ -232,7 +232,7 @@ public enum ContentAPIGraphQLTypesProvider implements GraphQLTypesProvider {
     public GraphQLOutputType getGraphqlTypeForFieldClass(final Class<? extends Field> fieldClass,
             final Field field) {
 
-        if(field.variable().equals(WIDGET_CODE_JSON_FIELD_VAR)) {
+        if(UtilMethods.isSet(field.variable()) && field.variable().equals(WIDGET_CODE_JSON_FIELD_VAR)) {
             return ExtendedScalars.Json;
         }
 

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
@@ -199,28 +199,15 @@ public enum ContentAPIGraphQLTypesProvider implements GraphQLTypesProvider {
             }
         });
 
-        final boolean alreadyExists = fieldDefinitions.stream()
-                .anyMatch((def)->def.getName().equals(WIDGET_CODE_JSON_FIELD_VAR));
-
-//        if(!alreadyExists) {
-            fieldDefinitions.add(newFieldDefinition()
-                    .name(WIDGET_CODE_JSON_FIELD_VAR)
-                    .argument(GraphQLArgument.newArgument()
-                            .name("render")
-                            .type(GraphQLBoolean)
-                            .defaultValue(null)
-                            .build())
-                    .type(ExtendedScalars.Json)
-                    .dataFetcher(new DotJSONDataFetcher()).build());
-//        }
-//        else {
-//            final Optional<GraphQLFieldDefinition> existingDefinition = fieldDefinitions.stream()
-//                    .filter((def)->def.getName().equals(WIDGET_CODE_JSON_FIELD_VAR)).findAny();
-//.
-//            if(existingDefinition.isPresent()) {
-//
-//            }
-//        }
+        fieldDefinitions.add(newFieldDefinition()
+                .name(WIDGET_CODE_JSON_FIELD_VAR)
+                .argument(GraphQLArgument.newArgument()
+                        .name("render")
+                        .type(GraphQLBoolean)
+                        .defaultValue(null)
+                        .build())
+                .type(ExtendedScalars.Json)
+                .dataFetcher(new DotJSONDataFetcher()).build());
 
         // add CONTENT interface fields
         fieldDefinitions.addAll(TypeUtil

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLTypesProvider.java
@@ -9,7 +9,6 @@ import static graphql.Scalars.GraphQLInt;
 import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLList.list;
-import static graphql.schema.GraphQLNonNull.nonNull;
 
 import com.dotcms.contenttype.model.field.BinaryField;
 import com.dotcms.contenttype.model.field.CategoryField;
@@ -60,6 +59,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -199,17 +199,28 @@ public enum ContentAPIGraphQLTypesProvider implements GraphQLTypesProvider {
             }
         });
 
-        // TODO crear widgetCodeJSON si no existe
+        final boolean alreadyExists = fieldDefinitions.stream()
+                .anyMatch((def)->def.getName().equals(WIDGET_CODE_JSON_FIELD_VAR));
 
-        fieldDefinitions.add(newFieldDefinition()
-                .name(WIDGET_CODE_JSON_FIELD_VAR)
-                .argument(GraphQLArgument.newArgument()
-                        .name("render")
-                        .type(GraphQLBoolean)
-                        .defaultValue(null)
-                        .build())
-                .type(ExtendedScalars.Json)
-                .dataFetcher(new DotJSONDataFetcher()).build());
+//        if(!alreadyExists) {
+            fieldDefinitions.add(newFieldDefinition()
+                    .name(WIDGET_CODE_JSON_FIELD_VAR)
+                    .argument(GraphQLArgument.newArgument()
+                            .name("render")
+                            .type(GraphQLBoolean)
+                            .defaultValue(null)
+                            .build())
+                    .type(ExtendedScalars.Json)
+                    .dataFetcher(new DotJSONDataFetcher()).build());
+//        }
+//        else {
+//            final Optional<GraphQLFieldDefinition> existingDefinition = fieldDefinitions.stream()
+//                    .filter((def)->def.getName().equals(WIDGET_CODE_JSON_FIELD_VAR)).findAny();
+//.
+//            if(existingDefinition.isPresent()) {
+//
+//            }
+//        }
 
         // add CONTENT interface fields
         fieldDefinitions.addAll(TypeUtil

--- a/dotCMS/src/main/java/com/dotcms/graphql/business/RegularContentFieldGenerator.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/RegularContentFieldGenerator.java
@@ -24,7 +24,7 @@ class RegularContentFieldGenerator implements GraphQLFieldGenerator {
                 .argument(GraphQLArgument.newArgument()
                         .name("render")
                         .type(GraphQLBoolean)
-                        .defaultValue(false)
+                        .defaultValue(null)
                         .build())
                 .type(field.required()
                         ? nonNull(typesProvider.getGraphqlTypeForFieldClass(field.type(), field))

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -107,6 +107,6 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             return contentlet.get(key);
         }
 
-        return renderFieldValue(request, response, contentlet.get(key), contentlet, field);
+        return renderFieldValue(request, response, (String) contentlet.get(key), contentlet, field);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/DotJSONDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/DotJSONDataFetcher.java
@@ -1,6 +1,8 @@
 package com.dotcms.graphql.datafetcher;
 
+import static com.dotcms.contenttype.model.type.WidgetContentType.WIDGET_CODE_FIELD_VAR;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.isFieldRenderable;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.parseAsJSON;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.renderFieldValue;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.RENDER_FIELDS;
 
@@ -37,15 +39,13 @@ import javax.servlet.http.HttpServletResponse;
  * </ul>
  */
 
-public class ContentMapDataFetcher implements DataFetcher<Object> {
+public class DotJSONDataFetcher implements DataFetcher<Object> {
 
     @Override
     public Object get(final DataFetchingEnvironment environment) throws Exception {
         try {
             final Contentlet contentlet = environment.getSource();
-            final String key = environment.getArgument("key");
-            final int depth = environment.getArgument("depth");
-            Boolean render = environment.getArgument("render");
+            final Boolean render = environment.getArgument("render");
 
             final HttpServletRequest request = ((DotGraphQLContext) environment.getContext())
                     .getHttpServletRequest();
@@ -53,61 +53,16 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             final HttpServletResponse response = ((DotGraphQLContext) environment.getContext())
                     .getHttpServletResponse();
 
-            if(UtilMethods.isSet(key)) {
-                Object fieldValue;
-                if(UtilMethods.isSet(render) && render) {
-                    fieldValue = getRenderedFieldValue(request, response, contentlet, key);
-                } else {
-                    fieldValue = contentlet.get(key);
-                }
-                return fieldValue;
-            }
+            final String fieldValue = (String) contentlet.get(WIDGET_CODE_FIELD_VAR);
 
-            final User user = ((DotGraphQLContext) environment.getContext()).getUser();
+            final String renderedValue = (String) parseAsJSON(request, response, fieldValue,
+                    contentlet, WIDGET_CODE_FIELD_VAR);
 
-            final DotTransformerBuilder transformerBuilder = new DotTransformerBuilder();
-
-            if(UtilMethods.isSet(render) && render) {
-                transformerBuilder.hydratedContentMapTransformer(RENDER_FIELDS);
-            } else {
-                render = false;
-                transformerBuilder.hydratedContentMapTransformer();
-            }
-
-            final DotContentletTransformer myTransformer = transformerBuilder.content(contentlet).build();
-
-            final Map<String, Object> hydratedMap =  myTransformer.toMaps().get(0);
-            final JSONObject contentMapInJSON = new JSONObject();
-
-            // this only adds relationships to any json. We would need to return them with the transformations already
-
-            final JSONObject jsonWithRels = ContentResource.addRelationshipsToJSON(request, response,
-                    render.toString(), user, depth, false, contentlet,
-                    contentMapInJSON, null, 1, true, false,
-                    true);
-
-            HashMap<String,Object> result = new ObjectMapper().readValue(jsonWithRels.toString(), HashMap.class);
-            hydratedMap.putAll(result);
-
-            return hydratedMap;
+            return new ObjectMapper().readValue(renderedValue, HashMap.class);
 
         } catch (Exception e) {
             Logger.error(this, e.getMessage(), e);
             throw e;
         }
-    }
-
-    private Object getRenderedFieldValue(final HttpServletRequest request,
-            final HttpServletResponse response, final Contentlet contentlet,
-            final String key) {
-        final Field field = Try.of(()-> contentlet.getContentType().fields()
-                .stream().filter((myField)->myField.variable().equals(key)).collect(
-                Collectors.toList()).get(0)).getOrNull();
-
-        if(!isFieldRenderable(field)) {
-            return contentlet.get(key);
-        }
-
-        return renderFieldValue(request, response, (String) contentlet.get(key), contentlet, field.variable());
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/DotJSONDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/DotJSONDataFetcher.java
@@ -1,29 +1,16 @@
 package com.dotcms.graphql.datafetcher;
 
 import static com.dotcms.contenttype.model.type.WidgetContentType.WIDGET_CODE_FIELD_VAR;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.isFieldRenderable;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.parseAsJSON;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.renderFieldValue;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.RENDER_FIELDS;
 
-import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.graphql.DotGraphQLContext;
-import com.dotcms.repackage.org.codehaus.jettison.json.JSONObject;
-import com.dotcms.rest.ContentResource;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.portlets.contentlet.transform.DotContentletTransformer;
-import com.dotmarketing.portlets.contentlet.transform.DotTransformerBuilder;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.liferay.portal.model.User;
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.vavr.control.Try;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -54,12 +41,10 @@ public class DotJSONDataFetcher implements DataFetcher<Object> {
             final String fieldValue = (String) contentlet.get(WIDGET_CODE_FIELD_VAR);
 
             if(render) {
-                final Object renderedValue = parseAsJSON(request, response, fieldValue,
+                final Object renderedValue = renderFieldValue(request, response, fieldValue,
                         contentlet, WIDGET_CODE_FIELD_VAR);
 
-                return UtilMethods.isSet(renderedValue)
-                        ? renderedValue
-                        : new HashMap<>();
+                return UtilMethods.isSet(renderedValue) ? renderedValue : new HashMap<>();
             } else {
                 return fieldValue;
             }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/FieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/FieldDataFetcher.java
@@ -51,7 +51,7 @@ public class FieldDataFetcher implements DataFetcher<Object> {
                     .getHttpServletResponse();
 
             return renderField && isFieldRenderable(field)
-                    ? renderFieldValue(request, response, fieldValue, contentlet, field)
+                    ? renderFieldValue(request, response, (String) fieldValue, contentlet, field)
                     : fieldValue;
         } catch (Exception e) {
             Logger.error(this, e.getMessage(), e);

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/FieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/FieldDataFetcher.java
@@ -41,8 +41,9 @@ public class FieldDataFetcher implements DataFetcher<Object> {
                 }
             }
 
+
             final boolean renderField = Try.of(()-> (boolean) environment.getArgument("render"))
-                    .getOrElse(false);
+                    .getOrElse(false) || shouldParseDotJson((String) fieldValue, environment);
 
             final HttpServletRequest request = ((DotGraphQLContext) environment.getContext())
                     .getHttpServletRequest();
@@ -57,5 +58,11 @@ public class FieldDataFetcher implements DataFetcher<Object> {
             Logger.error(this, e.getMessage(), e);
             throw e;
         }
+    }
+
+    private boolean shouldParseDotJson(final String fieldValue, final DataFetchingEnvironment environment) {
+          return (!UtilMethods.isSet((Object) environment.getArgument("render")) ||
+                        ((Boolean) environment.getArgument("render")))
+                  && fieldValue.contains("dotJSON") ;
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/FieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/FieldDataFetcher.java
@@ -41,10 +41,8 @@ public class FieldDataFetcher implements DataFetcher<Object> {
                 }
             }
 
-
             final boolean renderField = Try.of(()-> (boolean) environment.getArgument("render"))
-                    .getOrElse(false) || (fieldValue instanceof String &&
-                    shouldParseDotJson((String) fieldValue, environment));
+                    .getOrElse(false);
 
             final HttpServletRequest request = ((DotGraphQLContext) environment.getContext())
                     .getHttpServletRequest();
@@ -53,17 +51,11 @@ public class FieldDataFetcher implements DataFetcher<Object> {
                     .getHttpServletResponse();
 
             return renderField && isFieldRenderable(field)
-                    ? renderFieldValue(request, response, (String) fieldValue, contentlet, field)
+                    ? renderFieldValue(request, response, (String) fieldValue, contentlet, field.variable())
                     : fieldValue;
         } catch (Exception e) {
             Logger.error(this, e.getMessage(), e);
             throw e;
         }
-    }
-
-    private boolean shouldParseDotJson(final String fieldValue, final DataFetchingEnvironment environment) {
-          return (!UtilMethods.isSet((Object) environment.getArgument("render")) ||
-                        ((Boolean) environment.getArgument("render")))
-                  && fieldValue.contains("dotJSON") ;
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/FieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/FieldDataFetcher.java
@@ -43,7 +43,8 @@ public class FieldDataFetcher implements DataFetcher<Object> {
 
 
             final boolean renderField = Try.of(()-> (boolean) environment.getArgument("render"))
-                    .getOrElse(false) || shouldParseDotJson((String) fieldValue, environment);
+                    .getOrElse(false) || (fieldValue instanceof String &&
+                    shouldParseDotJson((String) fieldValue, environment));
 
             final HttpServletRequest request = ((DotGraphQLContext) environment.getContext())
                     .getHttpServletRequest();

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/page/RenderedContainersDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/page/RenderedContainersDataFetcher.java
@@ -21,9 +21,9 @@ import org.apache.velocity.context.Context;
 /**
  * This DataFetcher returns the {@link TemplateLayout} associated to the requested {@link HTMLPageAsset}.
  */
-public class RenderedContainersDataFetcher implements DataFetcher<Set<Entry<String, String>>> {
+public class RenderedContainersDataFetcher implements DataFetcher<Set<Entry<String, Object>>> {
     @Override
-    public Set<Entry<String, String>> get(final DataFetchingEnvironment environment) throws Exception {
+    public Set<Entry<String, Object>> get(final DataFetchingEnvironment environment) throws Exception {
         try {
             final DotGraphQLContext context = environment.getContext();
             final ContainerRaw containerRaw = environment.getSource();
@@ -38,7 +38,7 @@ public class RenderedContainersDataFetcher implements DataFetcher<Set<Entry<Stri
             final Context velocityContext  = pageRenderUtil
                     .addAll(VelocityUtil.getInstance().getContext(request, response));
 
-            final Map<String, String> uuidsRendered = ContainerRenderedBuilder.
+            final Map<String, Object> uuidsRendered = ContainerRenderedBuilder.
                     render(velocityContext, mode, containerRaw);
 
             return uuidsRendered.entrySet();

--- a/dotCMS/src/main/java/com/dotcms/graphql/util/TypeUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/util/TypeUtil.java
@@ -84,7 +84,7 @@ public class TypeUtil {
                 fieldDefinitionBuilder.argument(GraphQLArgument.newArgument()
                         .name("render")
                         .type(GraphQLBoolean)
-                        .defaultValue(false));
+                        .defaultValue(null));
 
                 fieldDefinitionList.add(fieldDefinitionBuilder.build());
             } catch (GraphQLException e) {
@@ -118,7 +118,7 @@ public class TypeUtil {
             fieldDefinitionBuilder.argument(GraphQLArgument.newArgument()
                     .name("render")
                     .type(GraphQLBoolean)
-                    .defaultValue(false));
+                    .defaultValue(null));
 
             builder.field(fieldDefinitionBuilder.build());
         });

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -148,15 +148,17 @@ public class PageResource {
                 request.getSession().setAttribute(WebKeys.CURRENT_DEVICE, deviceInode);
             }
 
-            final PageView pageRendered = this.htmlPageAssetRenderedAPI.getPageMetadata(
+            final PageView pageRendered = this.htmlPageAssetRenderedAPI.getPageRendered(
                       PageContextBuilder.builder()
                             .setUser(user)
                             .setPageUri(uri)
                             .setPageMode(mode)
+                            .setParseJSON(true)
                             .build(),
                     request,
                     response
             );
+
             final Response.ResponseBuilder responseBuilder = Response.ok(new ResponseEntityView(pageRendered));
 
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/RenderFieldStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/RenderFieldStrategy.java
@@ -95,7 +95,12 @@ public class RenderFieldStrategy extends AbstractTransformStrategy<Contentlet> {
                 || field instanceof ConstantField;
     }
 
-    public static Object parseAsJSON(final HttpServletRequest request,
+    /**
+     * Tries to render as velocity unless there's a put in the $dotJSON object, which will make it
+     * being parsed as JSON
+     */
+
+    public static Object renderFieldValue(final HttpServletRequest request,
             final HttpServletResponse response, final String fieldValue,
             final Contentlet contentlet, final String fieldVar) {
         if(!UtilMethods.isSet(fieldValue)) return null;
@@ -124,30 +129,4 @@ public class RenderFieldStrategy extends AbstractTransformStrategy<Contentlet> {
                     ? dotJSON.getMap() : evalResult.toString()
                 : fieldValue;
     }
-
-    public static Object renderFieldValue(final HttpServletRequest request,
-            final HttpServletResponse response, final String fieldValue,
-            final Contentlet contentlet, final String fieldVar) {
-        if(!UtilMethods.isSet(fieldValue)) return null;
-
-        final org.apache.velocity.context.Context context = (request!=null && response!=null)
-                ? VelocityUtil.getInstance().getContext(request, response)
-                : VelocityUtil.getBasicContext();
-
-        context.put("content", contentlet);
-        context.put("contentlet", contentlet);
-        context.put("dotJSON", new DotJSON());
-
-        final StringWriter evalResult = new StringWriter();
-
-        Try.runRunnable(()-> com.dotmarketing.util.VelocityUtil
-                .getEngine()
-                .evaluate(context, evalResult, "", fieldValue)).onFailure((error)->
-                Logger.warnAndDebug(RenderFieldStrategy.class, "Unable to render velocity in field: "
-                        + fieldVar, error)
-        );
-
-        return UtilMethods.isSet(evalResult.toString()) ? evalResult.toString() : fieldValue;
-    }
-
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/RenderFieldStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/RenderFieldStrategy.java
@@ -126,9 +126,9 @@ public class RenderFieldStrategy extends AbstractTransformStrategy<Contentlet> {
     }
 
     public static Object renderFieldValue(final HttpServletRequest request,
-            final HttpServletResponse response, final String incomingFieldValue,
+            final HttpServletResponse response, final String fieldValue,
             final Contentlet contentlet, final String fieldVar) {
-        if(!UtilMethods.isSet(incomingFieldValue)) return null;
+        if(!UtilMethods.isSet(fieldValue)) return null;
 
         final org.apache.velocity.context.Context context = (request!=null && response!=null)
                 ? VelocityUtil.getInstance().getContext(request, response)
@@ -137,11 +137,6 @@ public class RenderFieldStrategy extends AbstractTransformStrategy<Contentlet> {
         context.put("content", contentlet);
         context.put("contentlet", contentlet);
         context.put("dotJSON", new DotJSON());
-
-        final boolean returnAsJSON = incomingFieldValue.contains("dotJSON");
-
-        final String fieldValue = returnAsJSON ? prepareJSON(incomingFieldValue)
-                : incomingFieldValue;
 
         final StringWriter evalResult = new StringWriter();
 
@@ -153,33 +148,6 @@ public class RenderFieldStrategy extends AbstractTransformStrategy<Contentlet> {
         );
 
         return UtilMethods.isSet(evalResult.toString()) ? evalResult.toString() : fieldValue;
-    }
-
-    private static String prepareJSON(final String incomingFieldValue) {
-        final String valueWithOnlyVelocity = removeNonVelocityLines(incomingFieldValue);
-
-        return valueWithOnlyVelocity + System.lineSeparator()
-                + "#set($resultDotJSON = $json.generate($dotJSON.map))"
-                + System.lineSeparator()
-                + "$resultDotJSON";
-    }
-
-    private static String removeNonVelocityLines(final String incomingFieldValue) {
-        StringBuilder returnValue = new StringBuilder();
-
-        try(final Scanner scanner = new Scanner(incomingFieldValue)) {
-            while (scanner.hasNextLine()) {
-                final String line = scanner.nextLine().trim();
-                if (line.trim().startsWith("$") || line.trim().startsWith("#")) {
-                    returnValue.append(line);
-
-                    if(scanner.hasNextLine()) {
-                        returnValue.append(System.lineSeparator());
-                    }
-                }
-            }
-        }
-        return returnValue.toString();
     }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/RenderFieldStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/RenderFieldStrategy.java
@@ -96,9 +96,9 @@ public class RenderFieldStrategy extends AbstractTransformStrategy<Contentlet> {
     }
 
     public static Object parseAsJSON(final HttpServletRequest request,
-            final HttpServletResponse response, final String incomingFieldValue,
+            final HttpServletResponse response, final String fieldValue,
             final Contentlet contentlet, final String fieldVar) {
-        if(!UtilMethods.isSet(incomingFieldValue)) return null;
+        if(!UtilMethods.isSet(fieldValue)) return null;
 
         final org.apache.velocity.context.Context context = (request!=null && response!=null)
                 ? VelocityUtil.getInstance().getContext(request, response)
@@ -107,8 +107,6 @@ public class RenderFieldStrategy extends AbstractTransformStrategy<Contentlet> {
         context.put("content", contentlet);
         context.put("contentlet", contentlet);
         context.put("dotJSON", new DotJSON());
-
-        final String fieldValue = prepareJSON(incomingFieldValue);
 
         final StringWriter evalResult = new StringWriter();
 
@@ -119,7 +117,12 @@ public class RenderFieldStrategy extends AbstractTransformStrategy<Contentlet> {
                         + fieldVar, error)
         );
 
-        return UtilMethods.isSet(evalResult.toString()) ? evalResult.toString() : fieldValue;
+        final DotJSON dotJSON = (DotJSON) context.get("dotJSON");
+
+        return UtilMethods.isSet(evalResult.toString())
+                ? dotJSON.size() > 0
+                    ? dotJSON.getMap() : evalResult.toString()
+                : fieldValue;
     }
 
     public static Object renderFieldValue(final HttpServletRequest request,

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/ContainerRendered.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/ContainerRendered.java
@@ -22,7 +22,7 @@ public class ContainerRendered extends ContainerRaw {
     private static final long serialVersionUID = 1572918359580445566L;
 
 
-    private final Map<String, String> rendered;
+    private final Map<String, Object> rendered;
 
 
     /**
@@ -33,7 +33,7 @@ public class ContainerRendered extends ContainerRaw {
      *                           the browser.
      */
     public ContainerRendered(final Container container, final List<ContainerStructure> containerStructures,
-                             final Map<String, String> rendered, final Map<String,List<Contentlet>> contentlets) {
+                             final Map<String, Object> rendered, final Map<String,List<Contentlet>> contentlets) {
         super(container, containerStructures, contentlets);
 
         this.rendered = rendered;
@@ -47,7 +47,7 @@ public class ContainerRendered extends ContainerRaw {
      * @param containerStructures The list of {@link ContainerStructure} relationships.
      *                           the browser.
      */
-    public ContainerRendered(final ContainerRaw containerRaw, final Map<String, String> rendered) {
+    public ContainerRendered(final ContainerRaw containerRaw, final Map<String, Object> rendered) {
         this(containerRaw.getContainer(), containerRaw.getContainerStructures(), rendered, containerRaw.getContentlets());
 
     }
@@ -57,7 +57,7 @@ public class ContainerRendered extends ContainerRaw {
      *
      * @return The HTML representation of the container.
      */
-    public Map<String, String> getRendered() {
+    public Map<String, Object> getRendered() {
         return rendered;
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/ContainerRenderedBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/ContainerRenderedBuilder.java
@@ -13,6 +13,7 @@ import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.VelocityUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
+import io.vavr.control.Try;
 import org.apache.velocity.context.Context;
 
 import java.util.Collection;
@@ -76,7 +77,8 @@ public class ContainerRenderedBuilder {
                 final String renderedContainer = VelocityUtil.getInstance()
                         .mergeTemplate(key.path, velocityContext);
                 final DotJSON dotJSON = (DotJSON) velocityContext.get("dotJSON");
-                final boolean parseJSON = (boolean) velocityContext.get("parseJSON");
+                final boolean parseJSON = Try.of(()->(boolean) velocityContext.get("parseJSON"))
+                        .getOrElse(false);
 
                 if(dotJSON.size()>0 && parseJSON) {
                     rendered.put(uuid, dotJSON.getMap());

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/ContainerRenderedBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/ContainerRenderedBuilder.java
@@ -76,8 +76,9 @@ public class ContainerRenderedBuilder {
                 final String renderedContainer = VelocityUtil.getInstance()
                         .mergeTemplate(key.path, velocityContext);
                 final DotJSON dotJSON = (DotJSON) velocityContext.get("dotJSON");
+                final boolean parseJSON = (boolean) velocityContext.get("parseJSON");
 
-                if(dotJSON.size()>0) {
+                if(dotJSON.size()>0 && parseJSON) {
                     rendered.put(uuid, dotJSON.getMap());
                 } else {
                     rendered.put(uuid, renderedContainer);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/ContainerRenderedBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/ContainerRenderedBuilder.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.portlets.htmlpageasset.business.render;
 
 
+import com.dotcms.api.vtl.model.DotJSON;
 import com.dotcms.rendering.velocity.services.PageRenderUtil;
 import com.dotcms.rendering.velocity.services.VelocityResourceKey;
 import com.dotmarketing.business.APILocator;
@@ -10,6 +11,7 @@ import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.VelocityUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import org.apache.velocity.context.Context;
 
@@ -50,7 +52,7 @@ public class ContainerRenderedBuilder {
 
         return this.containerRaws.stream().map(containerRaw -> {
             try {
-                final Map<String, String> uuidsRendered = render(velocityContext, mode, containerRaw);
+                final Map<String, Object> uuidsRendered = render(velocityContext, mode, containerRaw);
                 return new ContainerRendered(containerRaw, uuidsRendered);
             } catch (Exception e) {
                 // if the container does not exists or is not valid for the mode, returns null to be filtrated
@@ -63,13 +65,24 @@ public class ContainerRenderedBuilder {
     }
 
 
-    public static Map<String, String> render(final Context velocityContext, final PageMode mode, final ContainerRaw containerRaw) {
+    public static Map<String, Object> render(final Context velocityContext, final PageMode mode, final ContainerRaw containerRaw) {
 
-        final Map<String, String> rendered = Maps.newHashMap();
+        final Map<String, Object> rendered = Maps.newHashMap();
         for (final String uuid : containerRaw.getContentlets().keySet()) {
-            final VelocityResourceKey key = new VelocityResourceKey(containerRaw.getContainer(), uuid.replace("uuid-", ""), mode);
+            final VelocityResourceKey key = new VelocityResourceKey(containerRaw.getContainer(),
+                    uuid.replace("uuid-", ""), mode);
             try {
-                rendered.put(uuid, VelocityUtil.getInstance().mergeTemplate(key.path, velocityContext));
+                velocityContext.put("dotJSON", new DotJSON());
+                final String renderedContainer = VelocityUtil.getInstance()
+                        .mergeTemplate(key.path, velocityContext);
+                final DotJSON dotJSON = (DotJSON) velocityContext.get("dotJSON");
+
+                if(dotJSON.size()>0) {
+                    rendered.put(uuid, dotJSON.getMap());
+                } else {
+                    rendered.put(uuid, renderedContainer);
+                }
+
             } catch (Exception e) {
                 Logger.warn(ContainerRenderedBuilder.class, e.getMessage());
             }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPI.java
@@ -122,6 +122,7 @@ public interface HTMLPageAssetRenderedAPI {
             final HttpServletResponse response)
             throws DotDataException, DotSecurityException;
 
+
     /**
      * Return the Page's html string
      * @param request The {@link HttpServletRequest} object.

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java
@@ -189,6 +189,7 @@ public class HTMLPageAssetRenderedAPIImpl implements HTMLPageAssetRenderedAPI {
                 .setSite(host)
                 .setURLMapper(htmlPageUrl.getPageUrlMapper())
                 .setLive(htmlPageUrl.hasLive())
+                .setParseJSON(context.isParseJSON())
                 .build(true, mode);
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/PageContext.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/PageContext.java
@@ -14,6 +14,7 @@ public class PageContext {
     private final PageMode pageMode;
     private final HTMLPageAsset page;
     private final boolean graphQL;
+    private final boolean parseJSON;
 
     public PageContext(
             final User user,
@@ -31,11 +32,23 @@ public class PageContext {
             final HTMLPageAsset page,
             final boolean graphQL) {
 
+        this(user, pageUri, pageMode, page, graphQL, false);
+    }
+
+    public PageContext(
+            final User user,
+            final String pageUri,
+            final PageMode pageMode,
+            final HTMLPageAsset page,
+            final boolean graphQL,
+            final boolean parseJSON) {
+
         this.user = user;
         this.pageUri = pageUri;
         this.pageMode = pageMode;
         this.page = page;
         this.graphQL = graphQL;
+        this.parseJSON = parseJSON;
     }
 
 
@@ -57,5 +70,9 @@ public class PageContext {
 
     public boolean isGraphQL() {
         return graphQL;
+    }
+
+    public boolean isParseJSON() {
+        return parseJSON;
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/PageContextBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/PageContextBuilder.java
@@ -14,6 +14,7 @@ public class PageContextBuilder {
     private PageMode pageMode;
     private HTMLPageAsset page;
     private boolean graphQL;
+    private boolean parseJSON;
 
     private PageContextBuilder() {}
 
@@ -46,7 +47,12 @@ public class PageContextBuilder {
         return this;
     }
 
+    public PageContextBuilder setParseJSON(final boolean parseJSON) {
+        this.parseJSON = parseJSON;
+        return this;
+    }
+
     public PageContext build() {
-        return new PageContext(user, pageUri, pageMode, page, graphQL);
+        return new PageContext(user, pageUri, pageMode, page, graphQL, parseJSON);
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/HTMLPageAssetRenderedBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/HTMLPageAssetRenderedBuilder.java
@@ -65,6 +65,7 @@ public class HTMLPageAssetRenderedBuilder {
     private final HTMLPageAssetRenderedAPI htmlPageAssetRenderedAPI;
     private String pageUrlMapper;
     private boolean live;
+    private boolean parseJSON;
 
     public HTMLPageAssetRenderedBuilder() {
 
@@ -112,6 +113,11 @@ public class HTMLPageAssetRenderedBuilder {
         return this;
     }
 
+    public HTMLPageAssetRenderedBuilder setParseJSON(final boolean parseJSON) {
+        this.parseJSON = parseJSON;
+        return this;
+    }
+
     @CloseDBIfOpened
     public PageView build(final boolean rendered, final PageMode mode) throws DotDataException, DotSecurityException {
         final Template template = getTemplate(mode);
@@ -154,8 +160,10 @@ public class HTMLPageAssetRenderedBuilder {
 
             final Context velocityContext  = pageRenderUtil
                     .addAll(VelocityUtil.getInstance().getContext(request, response));
+            velocityContext.put("parseJSON", parseJSON);
             final Collection<? extends ContainerRaw> containers = new ContainerRenderedBuilder(
-                    pageRenderUtil.getContainersRaw(), velocityContext, mode).build();
+                    pageRenderUtil.getContainersRaw(), velocityContext, mode)
+                    .build();
             final String pageHTML = this.getPageHTML();
 
             final HTMLPageAssetRendered.RenderedBuilder pageViewBuilder = new HTMLPageAssetRendered.RenderedBuilder().html(pageHTML);


### PR DESCRIPTION
These changes make possible rendering container and widget code as JSON in APIs (GraphQL, Page REST). 
Includes:
* New GraphQL widget field `widgetCodeJSON` 
* New DataFetcher for JSON (DotJSONDataFetcher) for widgetCode
* Update failing tests
* New parameter `parseJSON` to tell Page render API to do so.
 