### PR TITLE
* Updated default access_log format

### DIFF
--- a/docker/dotcms/ROOT/srv/30-tomcat-config.sh
+++ b/docker/dotcms/ROOT/srv/30-tomcat-config.sh
@@ -7,3 +7,14 @@ source /srv/utils/config-defaults.sh
 echo "Tomcat config ...."
 echo "CMS_CONNECTOR_THREADS=${CMS_CONNECTOR_THREADS}" >>/srv/config/settings.ini
 echo "CMS_SMTP_HOST=${CMS_SMTP_HOST}" >>/srv/config/settings.ini
+
+echo "CMS_COMPRESSION=${CMS_COMPRESSION}" >>/srv/config/settings.ini
+echo "CMS_COMPRESSABLEMIMETYPE=${CMS_COMPRESSABLEMIMETYPE}" >>/srv/config/settings.ini
+
+echo "CMS_ACCESSLOG_PATTERN=${CMS_ACCESSLOG_PATTERN}" >>/srv/config/settings.ini
+echo "CMS_ACCESSLOG_FILEDATEFORMAT=${CMS_ACCESSLOG_FILEDATEFORMAT}" >>/srv/config/settings.ini
+echo "CMS_ACCESSLOG_MAXDAYS=${CMS_ACCESSLOG_MAXDAYS}" >>/srv/config/settings.ini
+
+echo "CMS_REMOTEIP_REMOTEIPHEADER=${CMS_REMOTEIP_REMOTEIPHEADER}" >>/srv/config/settings.ini
+echo "CMS_REMOTEIP_INTERNALPROXIES=${CMS_REMOTEIP_INTERNALPROXIES}" >>/srv/config/settings.ini
+

--- a/docker/dotcms/ROOT/srv/templates/tomcat/OVERRIDE/conf/server-8.5.32.xml
+++ b/docker/dotcms/ROOT/srv/templates/tomcat/OVERRIDE/conf/server-8.5.32.xml
@@ -32,20 +32,64 @@
         maxThreads="{{ .Env.CMS_CONNECTOR_THREADS }}" minSpareThreads="25"/>
 
     <!-- HTTP Connector from direct connect -->
-    <Connector executor="tomcatConnectorThreadPool" port="8080" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
-               connectionTimeout="3000" enableLookups="false" redirectPort="443" URIEncoding="UTF-8" bindOnInit="false"
-               scheme="http" />
+    <Connector 
+	    port="8080"
+	    scheme="http"
+	    redirectPort="443"
+	    executor="tomcatConnectorThreadPool"
+	    protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+	    connectionTimeout="3000"
+	    enableLookups="false"
+	    URIEncoding="UTF-8"
+	    bindOnInit="true"
+            compression="{{ .Env.CMS_COMPRESSION }}"
+	    compressableMimeType="{{ .Env.CMS_COMPRESSABLEMIMETYPE }}"
+            compressionMinSize="128"
+            useSendfile="false"
+    />
 
-    <!-- HTTP Connector from upstream proxy -->
-    <Connector executor="tomcatConnectorThreadPool" port="8081" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
-                connectionTimeout="3000" enableLookups="false" redirectPort="443" URIEncoding="UTF-8" bindOnInit="false"
-                scheme="http" proxyPort="80" />
 
-    <!-- HTTPS (SSL) Connector from upstream proxy -->
-    <Connector executor="tomcatConnectorThreadPool" port="8082" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
-                connectionTimeout="3000" enableLookups="false" redirectPort="443" URIEncoding="UTF-8" bindOnInit="false"
-                scheme="https" proxyPort="443" secure="true" />
-    
+    <!-- HTTP Connector from upstream proxy 
+         client <-HTTP-> proxy:80 <-HTTP-> dotCMS:8081
+    -->
+    <Connector 
+	    port="8081"
+	    proxyPort="80"
+	    scheme="http"
+	    redirectPort="443"
+	    executor="tomcatConnectorThreadPool" 
+	    protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+	    connectionTimeout="3000"
+	    enableLookups="false"
+	    URIEncoding="UTF-8"
+            bindOnInit="true"
+            compression="{{ .Env.CMS_COMPRESSION }}"
+	    compressableMimeType="{{ .Env.CMS_COMPRESSABLEMIMETYPE }}"
+            compressionMinSize="128"
+            useSendfile="false"
+    />
+
+    <!-- HTTPS (SSL) Connector from upstream proxy
+         client <-HTTPS-> proxy:443 <-HTTP-> dotCMS:8082
+     -->
+    <Connector 
+	    port="8082"
+	    proxyPort="443"
+	    scheme="https"
+	    redirectPort="443"
+	    executor="tomcatConnectorThreadPool"
+	    protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+	    connectionTimeout="3000"
+	    enableLookups="false"
+	    URIEncoding="UTF-8"
+	    bindOnInit="true"
+	    secure="true" 
+            compression="{{ .Env.CMS_COMPRESSION }}"
+	    compressableMimeType="{{ .Env.CMS_COMPRESSABLEMIMETYPE }}"
+            compressionMinSize="128"
+            useSendfile="false"
+    />
+
     <!-- An Engine represents the entry point (within Catalina) that processes
          every request.  The Engine implementation for Tomcat stand alone
          analyzes the HTTP headers included with the request, and passes them
@@ -53,20 +97,23 @@
          Documentation at /docs/config/engine.html -->
 
     <Engine name="Catalina" defaultHost="localhost">
-
-
-      <Host name="localhost"  appBase="webapps"
-            unpackWARs="true" autoDeploy="true">
-            
-       <Valve className="org.apache.catalina.valves.RemoteIpValve"   />
+      <Host name="localhost"  appBase="webapps" unpackWARs="true" autoDeploy="true">
+          <Valve 
+	       className="org.apache.catalina.valves.RemoteIpValve" 
+	       remoteIpHeader="{{ .Env.CMS_REMOTEIP_REMOTEIPHEADER }}" 
+	       internalProxies="{{ .Env.CMS_REMOTEIP_INTERNALPROXIES }}" 
+          />
         
-        <!-- Access log processes all example.
-             Documentation at: /docs/config/valve.html
-             Note: The pattern used is equivalent to using pattern="common" -->
-
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-               prefix="dotcms_access" suffix=".log"
-               pattern="%{org.apache.catalina.AccessLog.RemoteAddr}r {{ .Env.CMS_VALVE_IP }} %l %u %t %r %H %v%U%q %s %b %{Referer}i %{User-Agent}i" />
+           <!-- Access log processes all example.  Documentation at: /docs/config/valve.html -->
+	  <Valve 
+		 className="org.apache.catalina.valves.AccessLogValve" 
+                 directory="logs"
+                 prefix="dotcms_access" 
+                 suffix=".log"
+	         pattern="{{ .Env.CMS_ACCESSLOG_PATTERN }}" 
+	         fileDateFormat="{{ .Env.CMS_ACCESSLOG_FILEDATEFORMAT }}"
+	         maxDays="{{ .Env.CMS_ACCESSLOG_MAXDAYS }}"
+            />
  
       </Host>
     </Engine>

--- a/docker/dotcms/ROOT/srv/templates/tomcat/OVERRIDE/conf/server-9.0.41.xml
+++ b/docker/dotcms/ROOT/srv/templates/tomcat/OVERRIDE/conf/server-9.0.41.xml
@@ -14,53 +14,88 @@
             minSpareThreads="25"
     />
 
-    <!-- HTTP Connector -->
+    <!-- HTTP Connector, no proxy
+	 client <-HTTP-> dotCMS:8080
+    -->
     <Connector
-            executor="tomcatConnectorThreadPool"
             port="8080"
+            scheme="http"
+            redirectPort="8443"
+            executor="tomcatConnectorThreadPool"
             protocol="org.apache.coyote.http11.Http11Nio2Protocol"
             connectionTimeout="3000"
             enableLookups="false"
-            redirectPort="8443"
             URIEncoding="UTF-8"
             bindOnInit="true"
-            scheme="http"
-            compression="on"
+            compression="{{ .Env.CMS_COMPRESSION }}"
+	    compressableMimeType="{{ .Env.CMS_COMPRESSABLEMIMETYPE }}"
             compressionMinSize="128"
-            compressableMimeType="text/html,text/xml,text/csv,text/css,text/javascript,text/json,application/javascript,application/json,application/xml,application/x-javascript"
             useSendfile="false"
     />
 
-    <!-- HTTP Connector from upstream proxy -->
-    <Connector executor="tomcatConnectorThreadPool" port="8081" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
-                connectionTimeout="3000" enableLookups="false" redirectPort="443" URIEncoding="UTF-8" bindOnInit="false"
-                scheme="http" proxyPort="80" />
+    <!-- HTTP Connector from upstream proxy 
+         client <-HTTP-> proxy:80 <-HTTP-> dotCMS:8081
+    -->
+    <Connector 
+	    port="8081"
+	    proxyPort="80"
+	    scheme="http"
+	    redirectPort="443"
+	    executor="tomcatConnectorThreadPool" 
+	    protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+	    connectionTimeout="3000"
+	    enableLookups="false"
+	    URIEncoding="UTF-8"
+            bindOnInit="true"
+            compression="{{ .Env.CMS_COMPRESSION }}"
+	    compressableMimeType="{{ .Env.CMS_COMPRESSABLEMIMETYPE }}"
+            compressionMinSize="128"
+            useSendfile="false"
+    />
 
-    <!-- HTTPS (SSL) Connector from upstream proxy -->
-    <Connector executor="tomcatConnectorThreadPool" port="8082" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
-                connectionTimeout="3000" enableLookups="false" redirectPort="443" URIEncoding="UTF-8" bindOnInit="false"
-                scheme="https" proxyPort="443" secure="true" />
+    <!-- HTTPS (SSL) Connector from upstream proxy
+         client <-HTTPS-> proxy:443 <-HTTP-> dotCMS:8082
+     -->
+    <Connector 
+	    port="8082"
+	    proxyPort="443"
+	    scheme="https"
+	    redirectPort="443"
+	    executor="tomcatConnectorThreadPool"
+	    protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+	    connectionTimeout="3000"
+	    enableLookups="false"
+	    URIEncoding="UTF-8"
+	    bindOnInit="true"
+	    secure="true" 
+            compression="{{ .Env.CMS_COMPRESSION }}"
+	    compressableMimeType="{{ .Env.CMS_COMPRESSABLEMIMETYPE }}"
+            compressionMinSize="128"
+            useSendfile="false"
+    />
 
 
     <!-- HTTPS (SSL) Connector
-      To use APR and native openssl for https, add:
-      sslImplementationName="org.apache.tomcat.util.net.openssl.OpenSSLImplementation"
+	 client <-HTTPS-> proxy:443 <-HTTPS-> dotCMS:8443
+
+         To use APR and native openssl for https, add:
+         sslImplementationName="org.apache.tomcat.util.net.openssl.OpenSSLImplementation"
     -->
     <Connector
-            executor="tomcatConnectorThreadPool"
             port="8443"
+            proxyPort="443"
+            scheme="https"
+            redirectPort="8443"
             protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+            executor="tomcatConnectorThreadPool"
             connectionTimeout="3000"
             enableLookups="false"
-            redirectPort="8443"
             URIEncoding="UTF-8"
             bindOnInit="true"
-            scheme="https"
-            proxyPort="443"
             secure="true"
-            compression="on"
+            compression="{{ .Env.CMS_COMPRESSION }}"
+	    compressableMimeType="{{ .Env.CMS_COMPRESSABLEMIMETYPE }}"
             compressionMinSize="128"
-            compressableMimeType="text/html,text/xml,text/csv,text/css,text/javascript,text/json,application/javascript,application/json,application/xml,application/x-javascript"
             useSendfile="false"
             SSLEnabled="true"
             keystoreFile="conf/server.keystore"
@@ -71,16 +106,25 @@
     <Engine name="Catalina" defaultHost="localhost">
 
       <Host name="localhost"  appBase="webapps">
-        <!-- The remote IP valve picks up the X-FORWARDED-FOR header and uses it as the source ip -->
-        <Valve className="org.apache.catalina.valves.RemoteIpValve" remoteIpHeader="x-forwarded-for" proxiesHeader="x-forwarded-by" protocolHeader="x-forwarded-proto" />
+      <!-- The remote IP valve picks up the X-FORWARDED-FOR header (by default) and uses it as the source ip 
+           remoteIpHeader and internalProxies may need to change when behind some WAF or proxy servers
+      -->
+	      <Valve 
+		     className="org.apache.catalina.valves.RemoteIpValve" 
+		     remoteIpHeader="{{ .Env.CMS_REMOTEIP_REMOTEIPHEADER }}" 
+		     internalProxies="{{ .Env.CMS_REMOTEIP_INTERNALPROXIES }}" 
+	      />
 
-        <!-- Access log processes all example.
-              Documentation at: /docs/config/valve.html
-              Note: The pattern used is equivalent to using pattern="common" -->
-
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-               prefix="dotcms_access" suffix=".log"
-               pattern="%{org.apache.catalina.AccessLog.RemoteAddr}r {{ .Env.CMS_VALVE_IP }} %l %u %t %r %H %v%U%q %s %b %{Referer}i %{User-Agent}i" />
+        <!-- Access log processes all example.  Documentation at: /docs/config/valve.html -->
+        <Valve
+               className="org.apache.catalina.valves.AccessLogValve" 
+               directory="logs"
+               prefix="dotcms_access" 
+               suffix=".log"
+	       pattern="{{ .Env.CMS_ACCESSLOG_PATTERN }}" 
+	       fileDateFormat="{{ .Env.CMS_ACCESSLOG_FILEDATEFORMAT }}"
+	       maxDays="{{ .Env.CMS_ACCESSLOG_MAXDAYS }}"
+        />
 
       </Host>
     </Engine>

--- a/docker/dotcms/ROOT/srv/utils/config-defaults.sh
+++ b/docker/dotcms/ROOT/srv/utils/config-defaults.sh
@@ -32,9 +32,22 @@ TOMCAT_HOME=/srv/dotserver/tomcat-${TOMCAT_VERSION}
 # dotCMS runas group GID
 : ${CMS_RUNAS_GID:="1000000000"}
 
+# gzip compression
+: ${CMS_COMPRESSION:="on"}
+: ${CMS_COMPRESSABLEMIMETYPE:="text/html,text/xml,text/csv,text/css,text/javascript,text/json,application/javascript,application/json,application/xml,application/x-javascript,font/eot,font/otf,font/ttf,image/svg+xml"}
+
+# Access Log and Remote IP Valve
+: ${CMS_ACCESSLOG_PATTERN:="%{Host}i %{org.apache.catalina.AccessLog.RemoteAddr}r %l %u %t &quot;%r&quot; %s %b %D %{Referer}i %{User-Agent}i"}
+: ${CMS_ACCESSLOG_FILEDATEFORMAT:=".yyyy-MM-dd"}
+: ${CMS_ACCESSLOG_MAXDAYS:="-1"}
+
+: ${CMS_REMOTEIP_REMOTEIPHEADER:="x-forwarded-for"}
+: ${CMS_REMOTEIP_INTERNALPROXIES:="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1"}
+
 ## Plugins init (not implemented yet!!)
 : ${CMS_PLUGINS_OSGI_OVERWRITE_SHARED:="false"}
 : ${CMS_PLUGINS_OSGI_FIX_OWNER:="true"}
+
 
 ## Database config
 
@@ -107,8 +120,4 @@ TOMCAT_HOME=/srv/dotserver/tomcat-${TOMCAT_VERSION}
 : ${PROVIDER_LOADBALANCER_SVC_DELAY_MIN:="${SERVICE_DELAY_DEFAULT_MIN}"}
 : ${PROVIDER_LOADBALANCER_SVC_DELAY_STEP:="${SERVICE_DELAY_DEFAULT_STEP}"}
 : ${PROVIDER_LOADBALANCER_SVC_DELAY_MAX:="${SERVICE_DELAY_DEFAULT_MAX}"}
-
-
-
-
 


### PR DESCRIPTION
* Closes issues #20892 #21110 
* Enables gzip compression by default
* Adds CMS_* env vars to config-defaults.sh for compression and log
  settings