### PR TITLE
issue-21051-svg-imgs-looking-bad-on-ImgEditor

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/image/ImageEditor.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/image/ImageEditor.js
@@ -61,7 +61,7 @@ dojo.declare("dotcms.dijit.image.ImageEditor", dijit._Widget,{
 
 
         this.thumbnailImage = dojo.create("img" , {
-            style:"max-width:100%;"},this.thumbnailDiv);
+            style:{ "max-width":"100%", "max-height":"100%" }},this.thumbnailDiv);
 
 
 


### PR DESCRIPTION
fix preview img expanding more than container

![image](https://user-images.githubusercontent.com/37185433/136861667-13488351-a056-4d9c-8346-324eedc06e36.png)
