### PR TITLE
Additional fix on 20786

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/business/VersionableAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/business/VersionableAPITest.java
@@ -3,11 +3,14 @@ package com.dotmarketing.business;
 import com.dotcms.datagen.ContainerDataGen;
 import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.datagen.HTMLPageDataGen;
+import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.datagen.StructureDataGen;
 import com.dotcms.datagen.TemplateDataGen;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
+import com.dotmarketing.common.reindex.ReindexQueueFactory;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.folders.model.Folder;
@@ -18,6 +21,7 @@ import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.util.Config;
 import com.liferay.portal.model.User;
 
+import java.util.Random;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -225,6 +229,51 @@ public class VersionableAPITest {
 		}finally {
         	StructureDataGen.remove(structure);
 		}
+	}
+
+	/**
+	 * Method to test: {@link VersionableAPI#isWorking(Versionable)}
+	 * Test Case: Invoking {@link VersionableAPI#isWorking(Versionable)} using a host with an invalid language
+	 * Expected Results: It should return the host because the language should be ignored
+	 * @throws DotDataException
+	 * @throws DotSecurityException
+	 */
+	@Test
+	public void testIsWorkingHost() throws DotDataException, DotSecurityException {
+		final Host host = new SiteDataGen().nextPersisted();
+		host.setLanguageId(new Random().nextLong());
+		assertTrue(APILocator.getVersionableAPI().isWorking(host));
+	}
+
+	/**
+	 * Method to test: {@link VersionableAPI#isLive(Versionable)}
+	 * Test Case: Invoking {@link VersionableAPI#isLive(Versionable)} using a host with an invalid language
+	 * Expected Results: It should return the host because the language should be ignored
+	 * @throws DotDataException
+	 * @throws DotSecurityException
+	 */
+	@Test
+	public void testIsLiveHost() throws DotDataException, DotSecurityException {
+		final Host host = new SiteDataGen().nextPersisted();
+		host.setLanguageId(new Random().nextLong());
+		assertTrue(APILocator.getVersionableAPI().isLive(host));
+	}
+
+	/**
+	 * Methods to test: {@link VersionableAPI#isLocked(Versionable)} and {@link VersionableAPI#setLocked(Versionable, boolean, User)}
+	 * Test Case: Invoking {@link VersionableAPI#isLive(Versionable)} and {@link VersionableAPI#setLocked(Versionable, boolean, User)}
+	 * using a host with an invalid language
+	 * Expected Results: They should return the host because the language should be ignored
+	 * @throws DotDataException
+	 * @throws DotSecurityException
+	 */
+	@Test
+	public void testSetLockedHost() throws DotDataException, DotSecurityException {
+		final Host host = new SiteDataGen().nextPersisted();
+		host.setLanguageId(new Random().nextLong());
+		assertFalse(APILocator.getVersionableAPI().isLocked(host));
+		APILocator.getVersionableAPI().setLocked(host, true, user);
+		assertTrue(APILocator.getVersionableAPI().isLocked(host));
 	}
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v2/languages/LanguagesResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v2/languages/LanguagesResource.java
@@ -2,6 +2,7 @@ package com.dotcms.rest.api.v2.languages;
 
 import static com.dotcms.rest.ResponseEntityView.OK;
 import static com.dotmarketing.util.UtilMethods.isNotSet;
+import static com.dotmarketing.util.WebKeys.*;
 
 import com.dotcms.keyvalue.model.KeyValue;
 import com.dotcms.rendering.velocity.viewtools.util.ConversionUtils;
@@ -421,6 +422,10 @@ public class LanguagesResource {
             DefaultLanguageTransferAssetJob
                     .triggerDefaultLanguageTransferAssetJob(oldDefaultLanguage.getId(), newDefault.getId());
         }
+
+        httpServletRequest.getSession().removeAttribute(LANGUAGE_SEARCHED);
+        httpServletRequest.getSession().removeAttribute(HTMLPAGE_LANGUAGE);
+        httpServletRequest.getSession().removeAttribute(CONTENT_SELECTED_LANGUAGE);
         return Response.ok(new ResponseEntityView(newDefault)).build(); // 200
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPIImpl.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.commons.beanutils.BeanUtils;
+import org.jetbrains.annotations.NotNull;
 
 public class VersionableAPIImpl implements VersionableAPI {
 
@@ -286,11 +287,8 @@ public class VersionableAPIImpl implements VersionableAPI {
         String liveInode;
         if(identifier.getAssetType().equals("contentlet")) {
             final Contentlet contentlet = (Contentlet)versionable;
-            final Optional<ContentletVersionInfo> info = versionableFactory
-                    .getContentletVersionInfo(contentlet.getIdentifier(), contentlet.getLanguageId());
-
-            if(!info.isPresent())
-                throw new DotStateException("No version info. Call setWorking first "+identifier.getId());
+            final Optional<ContentletVersionInfo> info = getContentletVersionInfo(identifier,
+                    contentlet);
 
             liveInode=info.get().getLiveInode();
         } else {
@@ -301,6 +299,22 @@ public class VersionableAPIImpl implements VersionableAPI {
             liveInode = info.getLiveInode();
         }
         return liveInode!=null && liveInode.equals(versionable.getInode());
+    }
+
+    private Optional<ContentletVersionInfo> getContentletVersionInfo(final Identifier identifier,
+            final Contentlet contentlet) throws DotDataException {
+        final Optional<ContentletVersionInfo> info;
+
+        if (contentlet.isHost()){
+            info = versionableFactory.findAnyContentletVersionInfo(contentlet.getIdentifier());
+        } else{
+            info = versionableFactory
+                    .getContentletVersionInfo(contentlet.getIdentifier(), contentlet.getLanguageId());
+        }
+
+        if(!info.isPresent())
+            throw new DotStateException("No version info. Call setWorking first "+identifier.getId());
+        return info;
     }
 
     @CloseDBIfOpened
@@ -317,10 +331,7 @@ public class VersionableAPIImpl implements VersionableAPI {
         }
         if("contentlet".equals(identifier.getAssetType())) {
             final Contentlet contentlet = (Contentlet)versionable;
-            final Optional<ContentletVersionInfo> info = versionableFactory.getContentletVersionInfo(contentlet.getIdentifier(),contentlet.getLanguageId());
-
-            if(!info.isPresent())
-                throw new DotStateException("No version info. Call setWorking first");
+            final Optional<ContentletVersionInfo> info = getContentletVersionInfo(identifier, contentlet);
 
             return info.get().isLocked();
         } else {
@@ -347,10 +358,7 @@ public class VersionableAPIImpl implements VersionableAPI {
         if(identifier.getAssetType().equals("contentlet")) {
 
             final Contentlet contentlet = (Contentlet)versionable;
-            final Optional<ContentletVersionInfo> info= versionableFactory
-                    .getContentletVersionInfo(contentlet.getIdentifier(), contentlet.getLanguageId());
-            if(!info.isPresent())
-                throw new DotStateException("No version info. Call setWorking first");
+            final Optional<ContentletVersionInfo> info = getContentletVersionInfo(identifier, contentlet);
 
             workingInode = info.get().getWorkingInode();
         } else {
@@ -437,11 +445,7 @@ public class VersionableAPIImpl implements VersionableAPI {
 
         if(identifier.getAssetType().equals("contentlet")) {
             final Contentlet contentlet      = (Contentlet)versionable;
-            final Optional<ContentletVersionInfo> info = versionableFactory
-                    .getContentletVersionInfo(contentlet.getIdentifier(),contentlet.getLanguageId());
-
-            if(!info.isPresent())
-                throw new DotStateException("No version info. Call setWorking first");
+            final Optional<ContentletVersionInfo> info = getContentletVersionInfo(identifier, contentlet);
             
             final ContentletVersionInfo newInfo = Sneaky.sneak(()-> (ContentletVersionInfo) BeanUtils.cloneBean(info.get())) ;
             newInfo.setDeleted(deleted);
@@ -469,12 +473,7 @@ public class VersionableAPIImpl implements VersionableAPI {
         if ( identifier.getAssetType().equals( "contentlet" ) ) {
 
             final Contentlet contentlet = (Contentlet) versionable;
-            final Optional<ContentletVersionInfo> info = versionableFactory
-                    .getContentletVersionInfo( contentlet.getIdentifier(), contentlet.getLanguageId() );
-
-            if (!info.isPresent()) {
-                throw new DotStateException( "No version info. Call setWorking first" );
-            }
+            final Optional<ContentletVersionInfo> info = getContentletVersionInfo(identifier, contentlet);
 
             //Get the structure for this contentlet
             final Structure structure = CacheLocator.getContentTypeCache().getStructureByInode( contentlet.getStructureInode() );
@@ -536,11 +535,8 @@ public class VersionableAPIImpl implements VersionableAPI {
         if(identifier.getAssetType().equals("contentlet")) {
 
             final Contentlet contentlet =(Contentlet)versionable;
-            final Optional<ContentletVersionInfo> info = versionableFactory
-                    .getContentletVersionInfo(contentlet.getIdentifier(),contentlet.getLanguageId());
-
-            if(!info.isPresent())
-                throw new DotStateException("No version info. Call setWorking first");
+            final Optional<ContentletVersionInfo> info = getContentletVersionInfo(identifier,
+                    contentlet);
             final ContentletVersionInfo newInfo = Sneaky.sneak(()-> (ContentletVersionInfo) BeanUtils.cloneBean(info.get())) ;
 
             if(locked) {

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactory.java
@@ -180,6 +180,8 @@ public abstract class VersionableFactory {
      */
     protected abstract VersionInfo findVersionInfoFromDb(Identifier identifier) throws DotDataException, DotStateException;
 
+    protected abstract Optional<ContentletVersionInfo> findAnyContentletVersionInfo(String identifier) throws DotDataException;
+
     protected abstract List<ContentletVersionInfo> findAllContentletVersionInfos(String identifier)
         throws DotDataException, DotStateException ;
 

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactoryImpl.java
@@ -355,25 +355,43 @@ public class VersionableFactoryImpl extends VersionableFactory {
 				.addParam(identifier)
 				.addParam(lang);
 
-		List<ContentletVersionInfo> versionInfos = TransformerLocator
+		final List<ContentletVersionInfo> versionInfos = TransformerLocator
 				.createContentletVersionInfoTransformer(dotConnect.loadObjectResults()).asList();
 
 		return !versionInfos.isEmpty() ? Optional.of(versionInfos.get(0)) : Optional.empty();
     }
-    @Override
-    protected List<ContentletVersionInfo> findAllContentletVersionInfos(final String identifier)throws DotDataException, DotStateException {
-        final DotConnect dotConnect = new DotConnect()
-                .setSQL("SELECT * FROM contentlet_version_info WHERE identifier=?")
-                .addParam(identifier);
 
-        List<ContentletVersionInfo> versionInfos = TransformerLocator
-                .createContentletVersionInfoTransformer(dotConnect.loadObjectResults()).asList();
+	@Override
+	public Optional<ContentletVersionInfo> findAnyContentletVersionInfo(final String identifier)
+			throws DotDataException {
+		final List<ContentletVersionInfo> result = findContentletVersionInfos(identifier, 1);
+		return !result.isEmpty() ? Optional.of(result.get(0)) : Optional.empty();
+	}
 
-		return versionInfos==null || versionInfos.isEmpty()
+	private List<ContentletVersionInfo> findContentletVersionInfos(final String identifier,
+			final int maxResults) throws DotDataException, DotStateException {
+		final DotConnect dotConnect = new DotConnect()
+				.setSQL("SELECT * FROM contentlet_version_info WHERE identifier=?")
+				.addParam(identifier);
+
+		if (maxResults > 0) {
+			dotConnect.setMaxRows(maxResults);
+		}
+
+		final List<ContentletVersionInfo> versionInfos = TransformerLocator
+				.createContentletVersionInfoTransformer(dotConnect.loadObjectResults()).asList();
+
+		return versionInfos == null || versionInfos.isEmpty()
 				? Collections.emptyList()
 				: versionInfos;
+	}
 
-    }
+	@Override
+	protected List<ContentletVersionInfo> findAllContentletVersionInfos(final String identifier)
+			throws DotDataException, DotStateException {
+		return findContentletVersionInfos(identifier, -1);
+	}
+
     @Override
     protected void saveContentletVersionInfo(ContentletVersionInfo cvInfo, boolean updateVersionTS) throws DotDataException, DotStateException {
 		boolean isNew = true;


### PR DESCRIPTION
Methods `VersionableAPI.isWorking`, `VersionableAPI.isLive`, `VersionableAPI.setLive`, `VersionableAPI.isLocked` and `VersionableAPI.setLocked` were modified to ignore languageId when a host is used. 

ITs were implemented.

Besides, the attributes that store the current language info were removed from session after changing the default language.