### PR TITLE
Fixing:  loading of a large bundle summary at Status/History is takin…

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publishing/BundlerUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/BundlerUtil.java
@@ -107,7 +107,7 @@ public class BundlerUtil {
     public static boolean isRetryable(final String bundleId) {
         try {
             final PublishAuditStatus publishAuditStatus = PublishAuditAPI.getInstance()
-                    .getPublishAuditStatus(bundleId);
+                    .getPublishAuditStatus(bundleId, 0);
 
             return isRetryable(publishAuditStatus) && !isInPublishQueue(bundleId)
                     && bundleExists(bundleId);


### PR DESCRIPTION
Not need load the assets to know if a asset is retryable