### PR TITLE
#21079 Use proper method when requesting only json

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -148,7 +148,7 @@ public class PageResource {
                 request.getSession().setAttribute(WebKeys.CURRENT_DEVICE, deviceInode);
             }
 
-            final PageView pageRendered = this.htmlPageAssetRenderedAPI.getPageRendered(
+            final PageView pageRendered = this.htmlPageAssetRenderedAPI.getPageMetadata(
                       PageContextBuilder.builder()
                             .setUser(user)
                             .setPageUri(uri)


### PR DESCRIPTION
Use proper method when requesting only json, to avoid including the "rendered" in the response. 