### PR TITLE
Issue 21267 Make ReindexThread more Robust

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -639,7 +639,6 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         builder.setBulkActions(numberToReindexInRequest)
                         .setBulkSize(new ByteSizeValue(ReindexThread.ELASTICSEARCH_BULK_SIZE, ByteSizeUnit.MB))
                         .setConcurrentRequests(ELASTICSEARCH_CONCURRENT_REQUESTS)
-                        //.setFlushInterval(new TimeValue(ReindexThread.ELASTICSEARCH_BULK_FLUSH_INTERVAL))
                         .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(200), 5));
 
         return builder.build();

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -639,7 +639,7 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
                         .setBulkSize(new ByteSizeValue(ReindexThread.ELASTICSEARCH_BULK_SIZE, ByteSizeUnit.MB))
                         .setConcurrentRequests(ELASTICSEARCH_CONCURRENT_REQUESTS)
                         .setFlushInterval(new TimeValue(ReindexThread.ELASTICSEARCH_BULK_FLUSH_INTERVAL))
-                        .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(1000), 5));
+                        .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(200), 5));
 
         return builder.build();
     }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -638,7 +638,7 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         builder.setBulkActions(numberToReindexInRequest)
                         .setBulkSize(new ByteSizeValue(ReindexThread.ELASTICSEARCH_BULK_SIZE, ByteSizeUnit.MB))
                         .setConcurrentRequests(ELASTICSEARCH_CONCURRENT_REQUESTS)
-                        .setFlushInterval(new TimeValue(ReindexThread.ELASTICSEARCH_BULK_FLUSH_INTERVAL))
+                        //.setFlushInterval(new TimeValue(ReindexThread.ELASTICSEARCH_BULK_FLUSH_INTERVAL))
                         .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(200), 5));
 
         return builder.build();

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1,6 +1,7 @@
 package com.dotcms.content.elasticsearch.business;
 
 import static com.dotcms.content.elasticsearch.business.ESIndexAPI.INDEX_OPERATIONS_TIMEOUT_IN_MS;
+import static com.dotmarketing.common.reindex.ReindexThread.BACKOFF_POLICY_TIME_IN_MILLIS;
 import static com.dotmarketing.common.reindex.ReindexThread.ELASTICSEARCH_CONCURRENT_REQUESTS;
 import static com.dotmarketing.util.StringUtils.builder;
 import com.dotcms.api.system.event.message.MessageSeverity;
@@ -639,7 +640,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         builder.setBulkActions(numberToReindexInRequest)
                         .setBulkSize(new ByteSizeValue(ReindexThread.ELASTICSEARCH_BULK_SIZE, ByteSizeUnit.MB))
                         .setConcurrentRequests(ELASTICSEARCH_CONCURRENT_REQUESTS)
-                        .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(200), 5));
+                        .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(
+                                BACKOFF_POLICY_TIME_IN_MILLIS), 5));
 
         return builder.build();
     }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -358,6 +358,7 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
                 if (!luckyServer.equals(ConfigUtils.getServerId())) {
                     logSwitchover(oldInfo, luckyServer);
                     DateUtil.sleep(5000);
+                    CacheLocator.getIndiciesCache().clearCache();
                     return false;
                 }
             }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -639,7 +639,7 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         builder.setBulkActions(numberToReindexInRequest)
                         .setBulkSize(new ByteSizeValue(ReindexThread.ELASTICSEARCH_BULK_SIZE, ByteSizeUnit.MB))
                         .setConcurrentRequests(ELASTICSEARCH_CONCURRENT_REQUESTS)
-                        .setBackoffPolicy(BackoffPolicy.constantBackoff(TimeValue.timeValueMillis(
+                        .setBackoffPolicy(BackoffPolicy.constantBackoff(TimeValue.timeValueSeconds(
                                         ReindexThread.BACKOFF_POLICY_TIME_IN_SECONDS), ReindexThread.BACKOFF_POLICY_MAX_RETRYS));
 
         return builder.build();

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1,7 +1,6 @@
 package com.dotcms.content.elasticsearch.business;
 
 import static com.dotcms.content.elasticsearch.business.ESIndexAPI.INDEX_OPERATIONS_TIMEOUT_IN_MS;
-import static com.dotmarketing.common.reindex.ReindexThread.BACKOFF_POLICY_TIME_IN_MILLIS;
 import static com.dotmarketing.common.reindex.ReindexThread.ELASTICSEARCH_CONCURRENT_REQUESTS;
 import static com.dotmarketing.util.StringUtils.builder;
 import com.dotcms.api.system.event.message.MessageSeverity;
@@ -640,8 +639,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         builder.setBulkActions(numberToReindexInRequest)
                         .setBulkSize(new ByteSizeValue(ReindexThread.ELASTICSEARCH_BULK_SIZE, ByteSizeUnit.MB))
                         .setConcurrentRequests(ELASTICSEARCH_CONCURRENT_REQUESTS)
-                        .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(
-                                BACKOFF_POLICY_TIME_IN_MILLIS), 5));
+                        .setBackoffPolicy(BackoffPolicy.constantBackoff(TimeValue.timeValueMillis(
+                                        ReindexThread.BACKOFF_POLICY_TIME_IN_SECONDS), ReindexThread.BACKOFF_POLICY_MAX_RETRYS));
 
         return builder.build();
     }

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.common.reindex;
 
 
+import com.dotmarketing.db.DbConnectionFactory;
 import com.google.common.collect.ImmutableList;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
@@ -101,7 +102,8 @@ public class BulkProcessorListener implements BulkProcessor.Listener {
     }
 
     private void handleSuccess(final List<ReindexEntry> successful) {
-
+        Logger.info(this, "Connection exists: " + DbConnectionFactory.connectionExists());
+        Logger.info(this, "Is in transaction: " + DbConnectionFactory.inTransaction());
         try {
             if (!successful.isEmpty()) {
                 APILocator.getReindexQueueAPI().deleteReindexEntry(successful);

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
@@ -1,7 +1,6 @@
 package com.dotmarketing.common.reindex;
 
 
-import com.dotmarketing.db.DbConnectionFactory;
 import com.google.common.collect.ImmutableList;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
@@ -102,8 +101,7 @@ public class BulkProcessorListener implements BulkProcessor.Listener {
     }
 
     private void handleSuccess(final List<ReindexEntry> successful) {
-        Logger.info(this, "Connection exists: " + DbConnectionFactory.connectionExists());
-        Logger.info(this, "Is in transaction: " + DbConnectionFactory.inTransaction());
+
         try {
             if (!successful.isEmpty()) {
                 APILocator.getReindexQueueAPI().deleteReindexEntry(successful);

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -3,9 +3,6 @@ package com.dotmarketing.common.reindex;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,7 +30,6 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.ThreadUtils;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.liferay.portal.language.LanguageException;
 import com.liferay.portal.model.User;
 import io.vavr.Lazy;
@@ -268,7 +264,7 @@ public class ReindexThread {
     }
 
     private void state(ThreadState state) {
-        getInstance().STATE.set(ThreadState.RUNNING);
+        getInstance().STATE.set(state);
     }
     /**
      * Tells the thread to stop processing. Doesn't shut down the thread.

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -106,6 +106,8 @@ public class ReindexThread {
 
     // Time (in seconds) to wait before closing bulk processor in a full reindex
     private static final int BULK_PROCESSOR_AWAIT_TIMEOUT = Config.getIntProperty("BULK_PROCESSOR_AWAIT_TIMEOUT", 20);
+
+    public static final int BACKOFF_POLICY_TIME_IN_MILLIS = Config.getIntProperty("BACKOFF_POLICY_TIME_IN_MILLIS", 200);
     
     private AtomicReference<ThreadState> STATE = new AtomicReference<>(ThreadState.RUNNING);
     

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -107,7 +107,10 @@ public class ReindexThread {
     // Time (in seconds) to wait before closing bulk processor in a full reindex
     private static final int BULK_PROCESSOR_AWAIT_TIMEOUT = Config.getIntProperty("BULK_PROCESSOR_AWAIT_TIMEOUT", 20);
 
-    public static final int BACKOFF_POLICY_TIME_IN_MILLIS = Config.getIntProperty("BACKOFF_POLICY_TIME_IN_MILLIS", 200);
+    public static final int BACKOFF_POLICY_TIME_IN_SECONDS = Config.getIntProperty("BACKOFF_POLICY_TIME_IN_SECONDS", 20);
+    
+    public static final int BACKOFF_POLICY_MAX_RETRYS = Config.getIntProperty("BACKOFF_POLICY_TIME_IN_MILLIS", 10);
+    
     
     private AtomicReference<ThreadState> STATE = new AtomicReference<>(ThreadState.RUNNING);
     

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -109,7 +109,7 @@ public class ReindexThread {
 
     public static final int BACKOFF_POLICY_TIME_IN_SECONDS = Config.getIntProperty("BACKOFF_POLICY_TIME_IN_SECONDS", 20);
     
-    public static final int BACKOFF_POLICY_MAX_RETRYS = Config.getIntProperty("BACKOFF_POLICY_TIME_IN_MILLIS", 10);
+    public static final int BACKOFF_POLICY_MAX_RETRYS = Config.getIntProperty("BACKOFF_POLICY_MAX_RETRYS", 10);
     
     
     private AtomicReference<ThreadState> STATE = new AtomicReference<>(ThreadState.RUNNING);

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -114,14 +114,7 @@ public class ReindexThread {
     private AtomicReference<ThreadState> STATE = new AtomicReference<>(ThreadState.RUNNING);
     
 
-    final DotSubmitter submitter = DotConcurrentFactory.getInstance().getSubmitter("ReindexThreadSubmitter_" + System.currentTimeMillis(),
-                    new DotConcurrentFactory.SubmitterConfigBuilder()
-                            .poolSize(1)
-                            .maxPoolSize(1)
-                            .queueCapacity(2)
-                            .rejectedExecutionHandler(new ThreadPoolExecutor.DiscardOldestPolicy())
-                            .build()
-            );
+
     
     
     
@@ -318,7 +311,18 @@ public class ReindexThread {
         Logger.infoEvery(ReindexThread.class, "--- ReindexThread Running", 60000);
         cache.get().remove(REINDEX_THREAD_PAUSED);
         final Thread thread = new Thread(getInstance().ReindexThreadRunnable, "ReindexThreadRunnable");
-        getInstance().submitter.submit(thread);
+        
+        final DotSubmitter submitter = DotConcurrentFactory.getInstance().getSubmitter("ReindexThreadSubmitter",
+                        new DotConcurrentFactory.SubmitterConfigBuilder()
+                                .poolSize(1)
+                                .maxPoolSize(1)
+                                .queueCapacity(2)
+                                .rejectedExecutionHandler(new ThreadPoolExecutor.DiscardOldestPolicy())
+                                .build()
+                );
+        
+        
+       submitter.submit(thread);
         getInstance().state(ThreadState.RUNNING);
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
@@ -178,9 +178,7 @@ public class StartupTasksExecutor {
         Logger.info(this, "Database version: " + Config.DB_VERSION);
 
         String name = null;
-
-
-        ReindexThread.pauseExistingInstance();
+        
         for (Class<?> c : TaskLocatorUtil.getStartupRunOnceTaskClasses()) {
             name = c.getCanonicalName();
             name = name.substring(name.lastIndexOf(".") + 1);


### PR DESCRIPTION
This PR includes:
- Some refactoring in the ReindexThread
- The initialDelay in the BackoffPolicy was decreased and the flush interval used by the BulkProcessor was removed; now, the flush policy is set just by size. It was causing timeouts, blocking the reindex process  and killing the ReindexThread in a cluster environment. 
- The IndiciesCache is invalidated in the non-lucky node to avoid infinite checks to attempt a switchover. 