### PR TITLE
dotCMS/core#21270 fix Broken style when opening a VTL file in file br…

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -82,7 +82,7 @@
 		<% } %>
     </div>
 
-    <div class="fieldValue field__<%=field.getFieldType()%>" style="display:flex" id="<%=field.getVelocityVarName()%>_field">
+    <div class="fieldValue field__<%=field.getFieldType()%>" id="<%=field.getVelocityVarName()%>_field">
         <%
             //TEXT kind of field rendering
             if (field.getFieldType().equals(Field.FieldType.TEXT.toString())) {
@@ -105,6 +105,12 @@
                     isReadOnly = true;
                 }
 
+                if (isHostNameField && textValue != "") {
+        %>
+            <%---  Renders wrapper to style INPUT and Edit Button for Site name --%>
+            <div style="display: flex;">
+        <%
+                }
         %>
         <%---  Renders the field it self --%>
         <input type="text" name="<%=field.getFieldContentlet()%>" id="<%=field.getVelocityVarName()%>"
@@ -133,6 +139,7 @@
                     </button>
                 </div>
             </div>
+        </div>
         <%
             }
 
@@ -581,7 +588,7 @@
            </div>
        </div>
 
-    <%}else{ %>
+    <% }else{ %>
 
         <%
          final Optional<FocalPoint> focalPoint =new FocalPointAPIImpl().readFocalPoint(binInode, field.getVelocityVarName());


### PR DESCRIPTION
when a VTL file is open on the file browser the VTL content style is broken on the dialog

![image](https://user-images.githubusercontent.com/37185433/142081990-04831fb5-1769-444f-b660-20ce851c199b.png)
