### PR TITLE
remove exception findSystemFolder, encapsulate findSubFolders in a new method

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/publishing/PublisherAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publishing/PublisherAPIImplTest.java
@@ -264,7 +264,7 @@ public class PublisherAPIImplTest {
                         folder, list(folderContentType)
                     ),
                     "/bundlers-test/host/host.host.xml");
-        } catch (DotDataException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/folders/business/FolderAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/folders/business/FolderAPITest.java
@@ -53,6 +53,7 @@ import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
+import com.liferay.util.StringPool;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -844,6 +845,55 @@ public class FolderAPITest {//24 contentlets
 
 		Assert.assertNotNull(folders);
 		Assert.assertFalse(folders.isEmpty());
+	}
+
+	/**
+	 * Method to test: findSubFoldersByParent
+	 * Given Scenario: Create a host and folder under it, get the folders living directly under the host.
+	 * ExpectedResult: the folder created.
+	 *
+	 */
+	@Test
+	public void testFindSubFoldersByParent_parentIsHost() throws DotDataException, DotSecurityException {
+		final Host newHost = new SiteDataGen().nextPersisted();
+		final String folderPath = "/folder"+System.currentTimeMillis();
+
+		final Folder folder = folderAPI.createFolders(folderPath, newHost, user, false);
+		folder.setOwner("folder's owner");
+
+		folderAPI.save(folder, user, false);
+
+		final List<Folder> folders = folderAPI.findSubFoldersByParent(newHost, user,false);
+
+		Assert.assertNotNull(folders);
+		Assert.assertFalse(folders.isEmpty());
+		Assert.assertEquals(folder.getPath(),folders.get(0).getPath());
+	}
+
+	/**
+	 * Method to test: findSubFoldersByParent
+	 * Given Scenario: Create a host, folder and a subfolder under it, get the folders living directly under the folder.
+	 * ExpectedResult: the subfolder created.
+	 *
+	 */
+	@Test
+	public void testFindSubFoldersByParent_parentIsFolder() throws DotDataException, DotSecurityException {
+		final Host newHost = new SiteDataGen().nextPersisted();
+		final String folder1Path = "/folder"+System.currentTimeMillis();
+		final String folder2Path = "/subfolder"+System.currentTimeMillis();
+
+		final Folder folder = folderAPI.createFolders(folder1Path, newHost, user, false);
+		folder.setOwner("folder's owner");
+		final Folder subfolder = folderAPI.createFolders(folder1Path+folder2Path, newHost, user, false);
+		subfolder.setOwner("folder's owner");
+
+		folderAPI.save(folder, user, false);
+
+		final List<Folder> folders = folderAPI.findSubFoldersByParent(folder, user,false);
+
+		Assert.assertNotNull(folders);
+		Assert.assertFalse(folders.isEmpty());
+		Assert.assertTrue(folder2Path.contains(folders.get(0).getTitle()));
 	}
 
 	@Test

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPI.java
@@ -309,7 +309,7 @@ import java.util.function.Predicate;
 	DotSecurityException, DotDataException;
 
 	// http://jira.dotmarketing.net/browse/DOTCMS-3232
-	Folder findSystemFolder() throws DotDataException;
+	Folder findSystemFolder() ;
 
 	/**
 	 * This method returns a new folder or the folder on the path you have

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPI.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.portlets.folders.business;
 
+import com.dotcms.api.tree.Parentable;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Inode;
 import com.dotmarketing.business.DotIdentifierStateException;
@@ -549,5 +550,15 @@ import java.util.function.Predicate;
 	 * @param childNameFilter {@link Predicate} filter
 	 */
 	void subscribeFolderListener (final Folder folder, final FolderListener folderListener, final Predicate<String> childNameFilter);
+
+    /**
+     *
+     * @param parent (host or folder)
+     * @return List of sub folders for passed in folder regardless the show on menu boolean
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    List<Folder> findSubFoldersByParent(Parentable parent, User user, boolean respectFrontEndPermissions)
+            throws DotDataException, DotSecurityException;
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -11,6 +11,7 @@ import com.dotcms.api.system.event.SystemEventsAPI;
 import com.dotcms.api.system.event.Visibility;
 import com.dotcms.api.system.event.VisibilityRoles;
 import com.dotcms.api.system.event.verifier.ExcludeOwnerVerifierBean;
+import com.dotcms.api.tree.Parentable;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.content.elasticsearch.business.event.ContentletArchiveEvent;
@@ -1181,5 +1182,23 @@ public class FolderAPIImpl implements FolderAPI  {
 			}
 		}
 	}
+
+	/**
+	 *
+	 * @param parent (host or folder)
+	 * @return List of sub folders for passed in folder regardless the show on menu boolean
+	 * @throws DotDataException
+	 * @throws DotSecurityException
+	 */
+	@Override
+	@CloseDBIfOpened
+	public List<Folder> findSubFoldersByParent(final Parentable parent, final User user,
+			final boolean respectFrontEndPermissions) throws DotDataException,
+			DotSecurityException {
+
+		return (parent instanceof Folder )
+				? findSubFolders((Folder)parent, user, respectFrontEndPermissions)
+				: findSubFolders((Host)parent, user, respectFrontEndPermissions);
+	} // findSubFolders.
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -613,7 +613,7 @@ public class FolderAPIImpl implements FolderAPI  {
 	
 	
 	@CloseDBIfOpened
-	public Folder findSystemFolder() throws DotDataException {
+	public Folder findSystemFolder()  {
 		return loadSystemFolder.get();
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/InitServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/InitServlet.java
@@ -190,13 +190,7 @@ public class InitServlet extends HttpServlet {
             Logger.fatal(InitServlet.class, e.getMessage(), e);
             throw new ServletException("Unable to initialize system host", e);
         }
-
-        try {
-            APILocator.getFolderAPI().findSystemFolder();
-        } catch (DotDataException e1) {
-            Logger.error(InitServlet.class, e1.getMessage(), e1);
-            throw new ServletException("Unable to initialize system folder", e1);
-        }
+        APILocator.getFolderAPI().findSystemFolder();
 
         // Create the GeoIP2 database reader on startup since it takes around 2
         // seconds to load the file. If the prop is not set, just move on


### PR DESCRIPTION
Remove unnecessary exception from findSystemFolder method.
Create a new method that encapsulates both findSubFolders methods (by host or by folder).