### PR TITLE
docker-compose examples

### DIFF
--- a/docker/docker-compose-examples/README.md
+++ b/docker/docker-compose-examples/README.md
@@ -1,0 +1,14 @@
+# Docker Compose Examples
+
+This directory contains docker-compose examples ready to use
+
+The following examples are provided:
+
+- **dotcms-cluster-mode:** dotcms instance with 2 nodes in a cluster
+- **dotcms-redis:** dotcms cluster with redis cache and pub/sub provider
+- **dotcms-single-node:** basic dotcms instance running with postgres database
+- **dotcms-with-kibana:** basic dotcms instance running with postgres database and kibana
+- **dotcms-with-oracle:** basic dotcms instance running with oracle database
+- **elasticsearch-with-kibana:** elasticsearch server with kibana
+- **oracle-database:** oracle database running on port 1521
+

--- a/docker/docker-compose-examples/dotcms-cluster-mode/README.md
+++ b/docker/docker-compose-examples/dotcms-cluster-mode/README.md
@@ -1,0 +1,54 @@
+# Dotcms Cluster Mode
+
+Cluster with 2 dotCMS instances running on ports 8080 and 8081 respectively. Database: postgres
+
+## Usage
+
+####Environment setup
+
+
+1) A local path to license pack must be set here:
+
+```
+- {license_local_path}/license.zip:/data/shared/assets/license.zip
+```
+
+The license pack must contain at least two licenses (one for each node in the cluster)
+
+
+2) A local path to access data in the instance can be set uncommenting this line: 
+
+```
+#- {local_data_path}:/data/shared
+```
+
+3) A custom starter can be set through this line (uncomment and change the starter url accordingly): 
+
+```
+#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+```
+
+####Deploying nodes:
+
+```bash
+docker-compose -f docker-compose-node-1.yml up
+
+```
+
+Once the node 1 is running, deploy node 2:
+```bash
+docker-compose -f docker-compose-node-2.yml up
+
+```
+
+
+####Undeploying nodes:
+
+```bash
+docker-compose -f docker-compose-node-2.yml down
+docker-compose -f docker-compose-node-1.yml down
+```
+
+**Important note:** `ctrl+c` does not destroy instances
+
+

--- a/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-1.yml
@@ -1,0 +1,62 @@
+version: '3.5'
+
+networks:
+  db_net:
+  es_net:
+
+volumes:
+  cms-shared:
+  dbdata:
+  esdata:
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    environment:
+      - cluster.name=elastic-cluster
+      - discovery.type=single-node
+      - data
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xmx1G "
+    ports:
+      - 9200:9200
+      - 9600:9600
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - es_net
+
+  dotcms-node-1:
+    image: dotcms/dotcms:latest
+    environment:
+      "CMS_HEAP_SIZE": '1g'
+      "PROVIDER_DB_DNSNAME": 'db'
+      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
+      "PROVIDER_DB_PASSWORD": "password"
+      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
+      "ES_ADMIN_PASSWORD": 'admin'
+      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+    depends_on:
+      - elasticsearch
+      - db
+    volumes:
+      #- {local_data_path}:/data/shared
+      - {license_local_path}/license.zip:/data/shared/assets/license.zip
+    networks:
+      - db_net
+      - es_net
+    ports:
+      - "8080:8081"
+      - "8443:8443"
+
+  db:
+    image: postgres:11
+    command: postgres -c 'max_connections=400' -c 'shared_buffers=128MB'
+    environment:
+        "POSTGRES_USER": 'dotcmsdbuser'
+        "POSTGRES_PASSWORD": 'password'
+        "POSTGRES_DB": 'dotcms'
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+    networks:
+      - db_net

--- a/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-2.yml
@@ -1,0 +1,31 @@
+version: '3.5'
+
+networks:
+  dotcms-cluster-mode_db_net:
+    external: true
+  dotcms-cluster-mode_es_net:
+    external: true
+
+volumes:
+  cms-shared:
+
+services:
+  dotcms-node-2:
+    image: dotcms/dotcms:latest
+    environment:
+      "CMS_HEAP_SIZE": '1g'
+      "PROVIDER_DB_DNSNAME": 'db'
+      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
+      "PROVIDER_DB_PASSWORD": "password"
+      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
+      "ES_ADMIN_PASSWORD": 'admin'
+      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+    volumes:
+      #- {local_data_path}:/data/shared
+      - {license_local_path}/license.zip:/data/shared/assets/license.zip
+    networks:
+      - dotcms-cluster-mode_db_net
+      - dotcms-cluster-mode_es_net
+    ports:
+      - "8081:8081"
+      - "8444:8443"

--- a/docker/docker-compose-examples/dotcms-redis/README.md
+++ b/docker/docker-compose-examples/dotcms-redis/README.md
@@ -1,0 +1,56 @@
+# Dotcms Cluster Mode with Redis
+
+Cluster with 2 dotCMS instances running on ports 8080 and 8081 respectively. Database: postgres.
+
+This environment uses Redis Pub/Sub and Cache. Redis runs on port 6379 with password `MY_SECRET_P4SS`
+
+## Usage
+
+####Environment setup
+
+
+1) A local path to license pack must be set here:
+
+```
+- {license_local_path}/license.zip:/data/shared/assets/license.zip
+```
+
+The license pack must contain at least two licenses (one for each node in the cluster)
+
+
+2) A local path to access data in the instance can be set uncommenting this line: 
+
+```
+#- {local_data_path}:/data/shared
+```
+
+3) A custom starter can be set through this line (uncomment and change the starter url accordingly): 
+
+```
+#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+```
+
+####Deploying nodes:
+
+```bash
+docker-compose -f docker-compose-node-1.yml up
+
+```
+
+Once the node 1 is running, deploy node 2:
+```bash
+docker-compose -f docker-compose-node-2.yml up
+
+```
+
+
+####Undeploying nodes:
+
+```bash
+docker-compose -f docker-compose-node-2.yml down
+docker-compose -f docker-compose-node-1.yml down
+```
+
+**Important note:** `ctrl+c` does not destroy instances
+
+

--- a/docker/docker-compose-examples/dotcms-redis/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/dotcms-redis/docker-compose-node-1.yml
@@ -1,0 +1,76 @@
+version: '3.5'
+
+networks:
+  db_net:
+  es_net:
+  redis_net:
+
+volumes:
+  cms-shared:
+  dbdata:
+  esdata:
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    environment:
+      - cluster.name=elastic-cluster
+      - discovery.type=single-node
+      - data
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xmx1G "
+    ports:
+      - 9200:9200
+      - 9600:9600
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - es_net
+
+  dotcms-node-1:
+    image: dotcms/dotcms:latest
+    environment:
+      "CMS_HEAP_SIZE": '1g'
+      "PROVIDER_DB_DNSNAME": 'db'
+      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
+      "PROVIDER_DB_PASSWORD": "password"
+      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
+      "ES_ADMIN_PASSWORD": 'admin'
+      "DOT_DOT_PUBSUB_PROVIDER_OVERRIDE": 'com.dotcms.dotpubsub.RedisPubSubImpl'
+      "DOT_REDIS_LETTUCECLIENT_URLS": 'redis://MY_SECRET_P4SS@redis'
+      "DOT_CACHE_DEFAULT_CHAIN": 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
+      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+    depends_on:
+      - elasticsearch
+      - db
+      - redis
+    volumes:
+      #- {local_data_path}:/data/shared
+      - {license_local_path}/license.zip:/data/shared/assets/license.zip
+    networks:
+      - db_net
+      - es_net
+      - redis_net
+    ports:
+      - "8080:8081"
+      - "8443:8443"
+      
+  redis:
+    image: "redis:latest"
+    command: redis-server --requirepass MY_SECRET_P4SS
+    ports:
+      - "6379:6379"
+    networks:
+      - redis_net
+
+  db:
+    image: postgres:11
+    command: postgres -c 'max_connections=400' -c 'shared_buffers=128MB'
+    environment:
+        "POSTGRES_USER": 'dotcmsdbuser'
+        "POSTGRES_PASSWORD": 'password'
+        "POSTGRES_DB": 'dotcms'
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+    networks:
+      - db_net

--- a/docker/docker-compose-examples/dotcms-redis/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/dotcms-redis/docker-compose-node-2.yml
@@ -1,0 +1,37 @@
+version: '3.5'
+
+networks:
+  dotcms-redis_db_net:
+    external: true
+  dotcms-redis_es_net:
+    external: true
+  dotcms-redis_redis_net:
+    external: true
+
+volumes:
+  cms-shared:
+
+services:
+  dotcms-node-2:
+    image: dotcms/dotcms:latest
+    environment:
+      "CMS_HEAP_SIZE": '1g'
+      "PROVIDER_DB_DNSNAME": 'db'
+      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
+      "PROVIDER_DB_PASSWORD": "password"
+      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
+      "ES_ADMIN_PASSWORD": 'admin'
+      "DOT_DOT_PUBSUB_PROVIDER_OVERRIDE": 'com.dotcms.dotpubsub.RedisPubSubImpl'
+      "DOT_REDIS_LETTUCECLIENT_URLS": 'redis://MY_SECRET_P4SS@redis'
+      "DOT_CACHE_DEFAULT_CHAIN": 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
+      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+    volumes:
+      #- {local_data_path}:/data/shared
+      - {license_local_path}/license.zip:/data/shared/assets/license.zip
+    networks:
+      - dotcms-redis_db_net
+      - dotcms-redis_es_net
+      - dotcms-redis_redis_net
+    ports:
+      - "8081:8081"
+      - "8444:8443"

--- a/docker/docker-compose-examples/dotcms-single-node/README.md
+++ b/docker/docker-compose-examples/dotcms-single-node/README.md
@@ -1,0 +1,40 @@
+# Dotcms Single Node
+
+A single instance of dotcms running on port 8080. Database: postgres
+
+## Usage
+
+####Environment setup
+
+
+1) A local path to license pack must be set here:
+
+```
+- {license_local_path}/license.zip:/data/shared/assets/license.zip
+```
+
+2) A local path to access data in the instance can be set uncommenting this line: 
+
+```
+#- {local_data_path}:/data/shared
+```
+
+3) A custom starter can be set through this line (uncomment and change the starter url accordingly): 
+
+```
+#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+```
+
+####Run an example:
+
+```bash
+docker-compose up```
+
+####Shut down instances:
+
+```bash
+docker-compose down```
+
+**Important note:** `ctrl+c` does not destroy instances
+
+

--- a/docker/docker-compose-examples/dotcms-single-node/docker-compose.yml
+++ b/docker/docker-compose-examples/dotcms-single-node/docker-compose.yml
@@ -1,0 +1,62 @@
+version: '3.5'
+
+networks:
+  db_net:
+  es_net:
+
+volumes:
+  cms-shared:
+  dbdata:
+  esdata:
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    environment:
+      - cluster.name=elastic-cluster
+      - discovery.type=single-node
+      - data
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xmx1G "
+    ports:
+      - 9200:9200
+      - 9600:9600
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - es_net
+
+  dotcms:
+    image: dotcms/dotcms:latest
+    environment:
+      "CMS_HEAP_SIZE": '1g'
+      "PROVIDER_DB_DNSNAME": 'db'
+      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
+      "PROVIDER_DB_PASSWORD": "password"
+      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
+      "ES_ADMIN_PASSWORD": 'admin'
+      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+    depends_on:
+      - elasticsearch
+      - db
+    volumes:
+      #- {local_data_path}:/data/shared
+      - {license_local_path}/license.zip:/data/shared/assets/license.zip
+    networks:
+      - db_net
+      - es_net
+    ports:
+      - "8080:8081"
+      - "8443:8443"
+
+  db:
+    image: postgres:11
+    command: postgres -c 'max_connections=400' -c 'shared_buffers=128MB'
+    environment:
+        "POSTGRES_USER": 'dotcmsdbuser'
+        "POSTGRES_PASSWORD": 'password'
+        "POSTGRES_DB": 'dotcms'
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+    networks:
+      - db_net

--- a/docker/docker-compose-examples/dotcms-with-kibana/README.md
+++ b/docker/docker-compose-examples/dotcms-with-kibana/README.md
@@ -1,0 +1,40 @@
+# Dotcms with Kibana
+
+A single instance of dotcms running on port 8080. Kibana was included for torubleshooting and runs on port 5601. Database: postgres.
+
+## Usage
+
+####Environment setup
+
+
+1) A local path to license pack must be set here:
+
+```
+- {license_local_path}/license.zip:/data/shared/assets/license.zip
+```
+
+2) A local path to access data in the instance can be set uncommenting this line: 
+
+```
+#- {local_data_path}:/data/shared
+```
+
+3) A custom starter can be set through this line (uncomment and change the starter url accordingly): 
+
+```
+#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+```
+
+####Run an example:
+
+```bash
+docker-compose up```
+
+####Shut down instances:
+
+```bash
+docker-compose down```
+
+**Important note:** `ctrl+c` does not destroy instances
+
+

--- a/docker/docker-compose-examples/dotcms-with-kibana/docker-compose.yml
+++ b/docker/docker-compose-examples/dotcms-with-kibana/docker-compose.yml
@@ -1,0 +1,71 @@
+version: '3.5'
+
+networks:
+  db_net:
+  es_net:
+
+volumes:
+  cms-shared:
+  dbdata:
+  esdata:
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    environment:
+      - cluster.name=elastic-cluster
+      - discovery.type=single-node
+      - data
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xmx1G "
+    ports:
+      - 9200:9200
+      - 9600:9600
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - es_net
+      
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.9.1
+    environment:
+      ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
+    ports:
+      - "5601:5601"
+    networks:
+      - es_net
+
+  dotcms:
+    image: dotcms/dotcms:latest
+    environment:
+      "CMS_HEAP_SIZE": '1g'
+      "PROVIDER_DB_DNSNAME": 'db'
+      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
+      "PROVIDER_DB_PASSWORD": "password"
+      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
+      "ES_ADMIN_PASSWORD": 'admin'
+      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+    depends_on:
+      - elasticsearch
+      - db
+    volumes:
+      #- {local_data_path}:/data/shared
+      - {license_local_path}/license.zip:/data/shared/assets/license.zip
+    networks:
+      - db_net
+      - es_net
+    ports:
+      - "8080:8081"
+      - "8443:8443"
+
+  db:
+    image: postgres:11
+    command: postgres -c 'max_connections=400' -c 'shared_buffers=128MB'
+    environment:
+        "POSTGRES_USER": 'dotcmsdbuser'
+        "POSTGRES_PASSWORD": 'password'
+        "POSTGRES_DB": 'dotcms'
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+    networks:
+      - db_net

--- a/docker/docker-compose-examples/dotcms-with-oracle/README.md
+++ b/docker/docker-compose-examples/dotcms-with-oracle/README.md
@@ -1,0 +1,49 @@
+# Dotcms Single Node (Oracle Database)
+
+A single instance of dotcms running on port 8080. Database: oracle
+
+## Usage
+
+####Environment setup
+
+1) Start the Oracle database using the example provided on this repo (view directory ***oracle-database***)
+
+2) Set your IP address accordingly. It could be a local or a public ip (not localhost nor 127.0.0.1):
+
+```
+      "PROVIDER_DB_DNSNAME": '{ip_address}'
+      "PROVIDER_DB_URL": 'jdbc:oracle:thin:@{ip_address}:1521:XE'
+```
+
+3) A local path to license pack must be set here:
+
+```
+- {license_local_path}/license.zip:/data/shared/assets/license.zip
+```
+
+4) A local path to access data in the instance can be set uncommenting this line: 
+
+```
+#- {local_data_path}:/data/shared
+```
+
+5) A custom starter can be set through this line (uncomment and change the starter url accordingly): 
+
+```
+#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+```
+
+
+####Run an example:
+
+```bash
+docker-compose up```
+
+####Shut down instances:
+
+```bash
+docker-compose down```
+
+**Important note:** `ctrl+c` does not destroy instances
+
+

--- a/docker/docker-compose-examples/dotcms-with-oracle/docker-compose.yml
+++ b/docker/docker-compose-examples/dotcms-with-oracle/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3.5'
+
+networks:
+  es_net:
+  oracle_net:
+    external: true
+
+volumes:
+  cms-shared:
+  esdata:
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    environment:
+      - cluster.name=elastic-cluster
+      - discovery.type=single-node
+      - data
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xmx1G "
+    ports:
+      - 9200:9200
+      - 9600:9600
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - es_net
+
+  dotcms:
+    image: dotcms/dotcms:latest
+    environment:
+      "CMS_HEAP_SIZE": '1g'
+      "PROVIDER_DB_DNSNAME": '{ip_address}'
+      "PROVIDER_DB_URL": 'jdbc:oracle:thin:@{ip_address}:1521:XE'
+      "PROVIDER_DB_DRIVER": 'ORACLE'
+      "PROVIDER_DB_USERNAME": "oracle"
+      "PROVIDER_DB_PASSWORD": "oracle"
+      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
+      "ES_ADMIN_PASSWORD": 'admin'
+      "TZ": UTC
+      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+    depends_on:
+      - elasticsearch
+    volumes:
+      #- {local_data_path}:/data/shared
+      - {license_local_path}/license.zip:/data/shared/assets/license.zip
+    networks:
+      - oracle_net
+      - es_net
+    ports:
+      - "8080:8081"
+      - "8443:8443"

--- a/docker/docker-compose-examples/elasticsearch-with-kibana/README.md
+++ b/docker/docker-compose-examples/elasticsearch-with-kibana/README.md
@@ -1,0 +1,19 @@
+# Elasticsearch with Kibana
+
+Elasticsearch runs on port 9200 and Kibana on 5601
+
+## Usage
+
+####Run an example:
+
+```bash
+docker-compose up```
+
+####Shut down instances:
+
+```bash
+docker-compose down```
+
+**Important note:** `ctrl+c` does not destroy instances
+
+

--- a/docker/docker-compose-examples/elasticsearch-with-kibana/docker-compose.yml
+++ b/docker/docker-compose-examples/elasticsearch-with-kibana/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.5'
+
+networks:
+  es_net:
+
+volumes:
+  esdata:
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    environment:
+      - cluster.name=elastic-cluster
+      - discovery.type=single-node
+      - data
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xmx1G "
+    ports:
+      - 9200:9200
+      - 9600:9600
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - es_net
+      
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.9.1
+    environment:
+      ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
+    ports:
+      - 5601:5601
+    networks:
+      - es_net

--- a/docker/docker-compose-examples/oracle-database/README.md
+++ b/docker/docker-compose-examples/oracle-database/README.md
@@ -1,0 +1,23 @@
+# Oracle Database
+
+oracle 11g express edition running on port 1521
+
+**User:** oracle
+
+**Password:** oracle
+
+## Usage
+
+####Run an example:
+
+```bash
+docker-compose up```
+
+####Shut down instances:
+
+```bash
+docker-compose down```
+
+**Important note:** `ctrl+c` does not destroy instances
+
+

--- a/docker/docker-compose-examples/oracle-database/docker-compose.yml
+++ b/docker/docker-compose-examples/oracle-database/docker-compose.yml
@@ -1,0 +1,22 @@
+# https://docs.docker.com/compose/compose-file/compose-versioning/
+version: "3.7"
+
+# https://docs.docker.com/compose/compose-file/
+networks:
+  default:
+    name: oracle_net
+
+services:
+
+  database:
+    image: "dotcms/oracle-xe-11g:latest"
+    shm_size: '2gb'
+    environment:
+      processes: 200
+      DATABASES: oracle
+      ORACLE_PWD: oracle
+    ports:
+      - "${SERVICE_HOST_PORT_PREFIX}1521:1521"
+      - "15080:8080"
+    volumes:
+      - ./setup/db/oracle:/u01/app/oracle


### PR DESCRIPTION
New directory with examples to deploy: 
- An oracle database
- Elasticsearch with kibana
- A basic dotCMS instance using postgres
- A basic dotCMS instance using postgres and kibana
- A basic dotCMS instance using oracle
- A dotCMS cluster with two nodes
- A dotCMS cluster with two nodes using Redis Pub/Sub and cache