### PR TITLE
Issue 21313 multi do not keep tree order

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -29,6 +29,7 @@ import com.dotcms.enterprise.publishing.remote.bundler.RuleBundlerTest;
 import com.dotcms.enterprise.publishing.remote.bundler.TemplateBundlerTest;
 import com.dotcms.enterprise.publishing.remote.bundler.WorkflowBundlerTest;
 import com.dotcms.enterprise.publishing.remote.handler.ContentHandlerTest;
+import com.dotcms.enterprise.publishing.remote.handler.HandlerUtilTest;
 import com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTest;
 import com.dotcms.enterprise.rules.RulesAPIImplIntegrationTest;
 import com.dotcms.graphql.DotGraphQLHttpServletTest;
@@ -496,6 +497,7 @@ import org.junit.runners.Suite.SuiteClasses;
         ContentletJsonAPITest.class,
         VelocityScriptActionletAbortTest.class,
         ContentletJsonAPITest.class,
+        HandlerUtilTest.class,
         Task211103RenameHostNameLabelTest.class
 })
 public class MainSuite {

--- a/dotCMS/src/integration-test/java/com/dotcms/enterprise/publishing/remote/handler/HandlerUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/enterprise/publishing/remote/handler/HandlerUtilTest.java
@@ -1,0 +1,156 @@
+package com.dotcms.enterprise.publishing.remote.handler;
+
+import com.dotcms.util.CollectionsUtils;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.MultiTree;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class HandlerUtilTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+
+        //Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    @Test
+    public void setMultiTree_on_diff_orders_should_not_reorder() throws IOException, DotSecurityException, DotDataException {
+
+        final String pageIdentifier = "e65ce6c5-6b03-45f8-b2a8-90ee80d17987";
+        final String pageInode = "001";
+        final Long pageLanguage = 1l;
+        final List<Map<String, Object>> wrapperMultiTree = new ArrayList<>();
+        this.populateMultitree(pageIdentifier, wrapperMultiTree);
+        final String modUser = "dotcms.org1";
+        HandlerUtil.setMultiTree(pageIdentifier, pageInode, pageLanguage, wrapperMultiTree, modUser);
+
+        //Identifier htmlPage, Identifier container, Identifier childContent, String containerInstance
+        final List<MultiTree>  multiTrees = APILocator.getMultiTreeAPI().getMultiTrees(pageIdentifier);
+
+        assertNotNull(multiTrees);
+        assertEquals(21, multiTrees.size());
+        assertEquals(0, multiTrees.get(0).getTreeOrder());
+        assertEquals(0, multiTrees.get(1).getTreeOrder());
+        assertEquals(1, multiTrees.get(2).getTreeOrder());
+        assertEquals(2, multiTrees.get(3).getTreeOrder());
+        assertEquals(3, multiTrees.get(4).getTreeOrder());
+        assertEquals(3, multiTrees.get(5).getTreeOrder());
+        assertEquals(4, multiTrees.get(6).getTreeOrder());
+        assertEquals(5, multiTrees.get(7).getTreeOrder());
+        assertEquals(5, multiTrees.get(8).getTreeOrder());
+        assertEquals(6, multiTrees.get(9).getTreeOrder());
+        assertEquals(6, multiTrees.get(10).getTreeOrder());
+        assertEquals(7, multiTrees.get(11).getTreeOrder());
+        assertEquals(7, multiTrees.get(12).getTreeOrder());
+        assertEquals(8, multiTrees.get(13).getTreeOrder());
+        assertEquals(9, multiTrees.get(14).getTreeOrder());
+        assertEquals(10, multiTrees.get(15).getTreeOrder());
+        assertEquals(10, multiTrees.get(16).getTreeOrder());
+        assertEquals(11, multiTrees.get(17).getTreeOrder());
+        assertEquals(12, multiTrees.get(18).getTreeOrder());
+        assertEquals(13, multiTrees.get(19).getTreeOrder());
+        assertEquals(14, multiTrees.get(20).getTreeOrder());
+
+
+    }
+
+    private void populateMultitree(String pageIdentifier, List<Map<String, Object>> wrapperMultiTree) {
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "3b538995-b85c-4de6-9c63-cf44acca89d2",
+                "relation_type", "1617389333051", "tree_order", 0));  // 1
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "d469e5bf-209c-4a80-99ab-fe92510a87c2",
+                "relation_type", "1617389333051", "tree_order", 0));  // 2
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "ded6029f-e7af-4acc-b57f-bae252407d30",
+                "relation_type", "1617389333051", "tree_order", 1));  // 3
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "469c77fe-ac29-4e90-932a-2668f455ae0a",
+                "relation_type", "1617389333051", "tree_order", 2)); // 4
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "cfe9c5d2-3518-4e56-bd5b-78cd4af9c70c",
+                "relation_type", "1617389333051", "tree_order", 3)); // 5
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "51104ac9-7b67-48aa-8ffd-0e2b8efb68d7",
+                "relation_type", "1617389333051", "tree_order", 3)); // 6
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "2fdd4348-1237-4532-9dd3-6f1358502bfd",
+                "relation_type", "1617389333051", "tree_order", 4)); // 7
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "1ea68733-a725-4c13-84d1-49b01cf08de7",
+                "relation_type", "1617389333051", "tree_order", 5)); // 8
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "cc433dcc-35af-4da3-8fc6-54aeb413e292",
+                "relation_type", "1617389333051", "tree_order", 5)); // 9
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "696fb981-0e19-41c0-9a90-209437127771",
+                "relation_type", "1617389333051", "tree_order", 6)); // 10
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "cfad3ddd-5812-419f-af96-27532f2b619e",
+                "relation_type", "1617389333051", "tree_order", 6)); // 11
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "3f6ced25-3205-4202-944a-422e176d57a5",
+                "relation_type", "1617389333051", "tree_order", 7)); // 12
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "ef12756b-c875-4b3f-94a9-25b92353ee95",
+                "relation_type", "1617389333051", "tree_order", 7)); // 13
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "7c0a1775-dff2-4221-88df-18b0dd010746",
+                "relation_type", "1617389333051", "tree_order", 8   )); // 14
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "f4089d2d-fc92-44bb-b9cf-c6bb92176cd8",
+                "relation_type", "1617389333051", "tree_order", 9)); // 15
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "0c2b2cac-ac3c-4d7d-90f3-1abb70aaec04",
+                "relation_type", "1617389333051", "tree_order", 10)); // 16
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "81b132ec-b48d-4838-82da-656acd29d176",
+                "relation_type", "1617389333051", "tree_order", 10)); // 17
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "b85fda79-12b6-4046-96aa-ba9b6acebd93",
+                "relation_type", "1617389333051", "tree_order", 11)); // 18
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "304993aa-2a66-4931-afe8-797bf3f7c0dd",
+                "relation_type", "1617389333051", "tree_order", 12)); // 19
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "1020cfa0-9f80-42d7-8baa-2e2e17733e45",
+                "relation_type", "1617389333051", "tree_order", 13)); // 20
+        wrapperMultiTree.add(CollectionsUtils.map("parent1", pageIdentifier,
+                "parent2", "77907283-a246-4688-bc93-033b5d683057",
+                "child", "f863ff25-2ee0-43de-aeba-faa7d74edeae",
+                "relation_type", "1617389333051", "tree_order", 14)); // 21
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentMap.java
@@ -125,7 +125,7 @@ public class ContentMap {
 		return get(fieldVariableName, false);
 	}
 
-	
+
 	private Object get(String fieldVariableName, Boolean parseVelocity) {
 		try {
 			final boolean respectFrontEndRoles = PageMode.get(Try.of(()->(HttpServletRequest)context.get("request")).getOrNull()).respectAnonPerms;

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/Renderable.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/Renderable.java
@@ -1,0 +1,23 @@
+package com.dotcms.rendering.velocity.viewtools.content;
+
+/**
+ * A renderable is an object that can transform it self to HTML.
+ * It can use their own way (usually using a convention velocity templates structure) or use a different path to overrided the
+ * default rendering of one or more elements.
+ * @author jsanca
+ */
+public interface Renderable {
+
+    /**
+     * Renders it to html
+     * @return String
+     */
+    String toHtml();
+
+    /**
+     * Renders to html using the base template path to override the default markup templates
+     * @param baseTemplatePath String folder path, could be have or not the host (starting by //)
+     * @return String
+     */
+    String toHtml(String baseTemplatePath);
+}

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMap.java
@@ -7,6 +7,7 @@ import com.dotcms.repackage.org.codehaus.jettison.json.JSONArray;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONException;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONObject;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.util.Logger;
@@ -72,9 +73,14 @@ public class StoryBlockMap implements Renderable {
             final JSONArray items = this.jsonContFieldValue.getJSONArray("content");
             for (int i = 0; i < items.length(); ++i) {
 
-                final JSONObject jsonObjectItem = items.getJSONObject(i);
-                this.defaultRenderableItem
+                try {
+                    final JSONObject jsonObjectItem = items.getJSONObject(i);
+                    this.defaultRenderableItem
                         .toHtml(jsonObjectItem, this.processType(jsonObjectItem));
+                } catch (JSONException | DotRuntimeException e) {
+                    Logger.error(this, e.getMessage(), e);
+                    this.addError (DEFAULT_TEMPLATE_STOCK_BLOCK_PATH, builder, e);
+                }
             }
         } catch (JSONException e) {
             Logger.error(this, e.getMessage(), e);
@@ -91,15 +97,20 @@ public class StoryBlockMap implements Renderable {
 
         try {
             final JSONArray items = this.jsonContFieldValue.getJSONArray("content");
-            for (int i = 0; i < items.length(); ++i) {
 
-                final JSONObject jsonObjectItem = items.getJSONObject(i);
-                this.defaultRenderableItem
+            for (int i = 0; i < items.length(); ++i) {
+                try {
+                    final JSONObject jsonObjectItem = items.getJSONObject(i);
+                    this.defaultRenderableItem
                         .toHtml(baseTemplatePath, jsonObjectItem, this.processType(jsonObjectItem));
+                } catch (JSONException | DotRuntimeException e) {
+                    Logger.error(this, e.getMessage(), e);
+                    this.addError (baseTemplatePath, builder, e);
+                }
             }
         } catch (JSONException e) {
             Logger.error(this, e.getMessage(), e);
-            this.addError (DEFAULT_TEMPLATE_STOCK_BLOCK_PATH, builder, e);
+            this.addError (baseTemplatePath, builder, e);
         }
 
         return builder.toString();

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMap.java
@@ -2,13 +2,20 @@ package com.dotcms.rendering.velocity.viewtools.content;
 
 
 import com.dotcms.contenttype.transform.field.LegacyFieldTransformer;
+import com.dotcms.rendering.velocity.viewtools.content.util.GenericRenderableItem;
+import com.dotcms.repackage.org.codehaus.jettison.json.JSONArray;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONException;
 import com.dotcms.repackage.org.codehaus.jettison.json.JSONObject;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.structure.model.Field;
+import com.dotmarketing.util.Logger;
+import com.google.common.collect.ImmutableSet;
 import com.liferay.util.StringPool;
 import org.apache.commons.lang.builder.ToStringBuilder;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 /**
  * Converts the json into a map and gets returned when it is requested like this $contentlet.storyBlock (var name of the field is storyBlock).
@@ -16,18 +23,24 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * $contentlet.storyBlock.type
  * $contentlet.storyBlock.render
  * $contentlet.storyBlock.content
+ * $contentlet.storyBlock.toHtml
  */
+public class StoryBlockMap implements Renderable {
 
-public class StoryBlockMap {
-
-    private String type = StringPool.BLANK;
-    private String render = StringPool.BLANK;
-    private String content = StringPool.BLANK;
+    final static String DEFAULT_TEMPLATE_STOCK_BLOCK_PATH = "static/storyblock/";
+    private final String type;
+    private final String render;
+    private final String content;
+    private final JSONObject jsonContFieldValue;
+    private final GenericRenderableItem defaultRenderableItem =
+            new GenericRenderableItem(DEFAULT_TEMPLATE_STOCK_BLOCK_PATH, "default.vtl",
+                    ImmutableSet.of("heading1","heading2","heading3","paragraph","dotContent","bulletList","orderedList"));
 
     public StoryBlockMap(final Field field,final Contentlet contentlet) throws JSONException {
+
         final com.dotcms.contenttype.model.field.Field fieldTransformed = new LegacyFieldTransformer(field).from();
         final Object contFieldValue = APILocator.getContentletAPI().getFieldValue(contentlet,fieldTransformed);
-        final JSONObject jsonContFieldValue = new JSONObject(contFieldValue.toString());
+        this.jsonContFieldValue = new JSONObject(contFieldValue.toString());
         type = jsonContFieldValue.get("type").toString();
         render = jsonContFieldValue.get("render").toString();
         content = jsonContFieldValue.get("content").toString();
@@ -48,5 +61,69 @@ public class StoryBlockMap {
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public String toHtml() {
+
+        final StringBuilder builder = new StringBuilder();
+
+        try {
+            final JSONArray items = this.jsonContFieldValue.getJSONArray("content");
+            for (int i = 0; i < items.length(); ++i) {
+
+                final JSONObject jsonObjectItem = items.getJSONObject(i);
+                this.defaultRenderableItem
+                        .toHtml(jsonObjectItem, this.processType(jsonObjectItem));
+            }
+        } catch (JSONException e) {
+            Logger.error(this, e.getMessage(), e);
+            this.addError (DEFAULT_TEMPLATE_STOCK_BLOCK_PATH, builder, e);
+        }
+
+        return builder.toString();
+    }
+
+    @Override
+    public String toHtml(final String baseTemplatePath) {
+
+        final StringBuilder builder = new StringBuilder();
+
+        try {
+            final JSONArray items = this.jsonContFieldValue.getJSONArray("content");
+            for (int i = 0; i < items.length(); ++i) {
+
+                final JSONObject jsonObjectItem = items.getJSONObject(i);
+                this.defaultRenderableItem
+                        .toHtml(baseTemplatePath, jsonObjectItem, this.processType(jsonObjectItem));
+            }
+        } catch (JSONException e) {
+            Logger.error(this, e.getMessage(), e);
+            this.addError (DEFAULT_TEMPLATE_STOCK_BLOCK_PATH, builder, e);
+        }
+
+        return builder.toString();
+    }
+
+    private String processType(final JSONObject jsonObjectItem) throws JSONException {
+        // heading is a special composite case, type + level
+        final String type = jsonObjectItem.get("type").toString();
+
+        return type + ("heading".equalsIgnoreCase(type)?
+                jsonObjectItem.getJSONObject("attrs").get("level").toString(): StringPool.BLANK);
+    }
+
+    private void addError(final String path, final StringBuilder builder, final Exception e) {
+
+        // todo: this could be a generic rendereable too, for errors
+        final StringWriter stringWriter = new StringWriter();
+        e.printStackTrace(new PrintWriter(stringWriter, true));
+        builder.append("<pre>")
+                .append("<code>")
+                .append("\tpath: ").append(path).append("\n")
+                .append("\terror message: ").append(e.getMessage()).append("\n")
+                .append("\terror stacktrace: ").append(stringWriter.toString()).append("\n")
+                .append("</code>")
+                .append("</pre>");
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/GenericRenderableItem.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/GenericRenderableItem.java
@@ -1,0 +1,118 @@
+package com.dotcms.rendering.velocity.viewtools.content.util;
+
+import com.dotcms.api.web.HttpServletRequestThreadLocal;
+import com.dotcms.mock.request.FakeHttpRequest;
+import com.dotcms.mock.response.BaseResponse;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.DotStateException;
+import com.dotmarketing.business.web.WebAPILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.util.HostUtil;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.VelocityUtil;
+import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.control.Try;
+import org.apache.velocity.context.Context;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Generic render for items based on a type.
+ * It is controlled by convention, basically the component has base default template, it concat the type as a vtl in order to find the resource
+ * Also, users can pass their own base path, in case the item render velocity template does not exists will fallbacks to the default one.
+ * @author jsanca
+ */
+public class GenericRenderableItem {
+
+    private final String defaultPath;
+    private final String templateName;
+    private final Set<String> allowedTypeSet;
+
+    public GenericRenderableItem(final String defaultPath, final String templateName,
+                                 final Set<String> allowedTypeSet) {
+
+        this.defaultPath    = defaultPath;
+        this.templateName   = templateName;
+        this.allowedTypeSet = allowedTypeSet;
+    }
+
+    public String toHtml(final Object item, final String type) {
+
+        try {
+            final Host host = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
+            final HttpServletRequest  requestProxy  = new FakeHttpRequest(host.getHostname(), null).request();
+            final HttpServletResponse responseProxy = new BaseResponse().response();
+            final Context context = VelocityUtil.getInstance().getContext(requestProxy, responseProxy);
+            context.put("item", item);
+
+            return VelocityUtil.getInstance().mergeTemplate(allowedTypeSet.contains(type)?
+                    this.defaultPath + type + ".vtl": this.defaultPath + templateName, context);
+        } catch (Exception e) {
+
+            Logger.error(this, e.getMessage(), e);
+            throw new DotRuntimeException(e);
+        }
+    }
+
+    public String toHtml(final String baseTemplatePath, final Object item, final String type) {
+
+        try {
+
+            if (this.allowedTypeSet.contains(type)) {
+
+                final Optional<User> userOpt = this.resolveUser();
+                final User user = userOpt.orElse(APILocator.systemUser());
+                final Tuple2<String, Host> hostPathTuple = resolveHost(baseTemplatePath, user);
+                final Host host = hostPathTuple._2();
+                final String relativePath = hostPathTuple._1();
+                final Folder folder = APILocator.getFolderAPI().findFolderByPath(relativePath, host, user, false);
+                if (APILocator.getFileAssetAPI().fileNameExists(host, folder, type + ".vtl")) {
+
+                    final HttpServletRequest requestProxy   = new FakeHttpRequest(host.getHostname(), null).request();
+                    final HttpServletResponse responseProxy = new BaseResponse().response();
+                    final Context context = VelocityUtil.getInstance().getContext(requestProxy, responseProxy);
+                    context.put("item", item);
+
+                    return VelocityUtil.getInstance().merge(baseTemplatePath + type + ".vtl", context);
+                }
+            }
+
+            return this.toHtml(item, type);
+        } catch (DotStateException | DotDataException | DotSecurityException e) {
+
+            Logger.error(this, e.getMessage(), e);
+            return this.toHtml(item, type);
+        } catch (Exception e) {
+
+            Logger.error(this, e.getMessage(), e);
+            throw new DotRuntimeException(e);
+        }
+    }
+
+    private Tuple2<String, Host>  resolveHost(final String baseTemplatePath, final User user) throws DotSecurityException, DotDataException {
+
+        final Tuple2<String, Host> hostPathTuple = Try.of(()-> HostUtil.splitPathHost(baseTemplatePath, user,
+                StringPool.FORWARD_SLASH)).get();
+        return hostPathTuple._2() == null?
+                Tuple.of(hostPathTuple._1(), APILocator.getHostAPI().findDefaultHost(user, false)):
+                hostPathTuple;
+    }
+
+    private Optional<User> resolveUser() {
+
+        final HttpServletRequest request = HttpServletRequestThreadLocal.INSTANCE.getRequest();
+        return null != request?
+                Optional.ofNullable(Try.of(()-> WebAPILocator.getUserWebAPI().getUser(request)).getOrNull()):
+                Optional.empty();
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPI.java
@@ -27,6 +27,15 @@ public interface MultiTreeAPI {
     void saveMultiTrees(String pageId, List<MultiTree> mTrees) throws DotDataException;
 
     /**
+     * Saves MultiTrees for a given page, keeping the tree order on the MultiTree
+     * Do not clean any previous multi tree for the page, assumes the clean up was already done
+     *
+     * @param mTrees
+     * @throws DotDataException
+     */
+    void saveMultiTreesKeepTreeOrder(String pageId, List<MultiTree> mTrees) throws DotDataException;
+
+    /**
      * Saves a specific MultiTree
      * 
      * @param multiTree

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/bulletList.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/bulletList.vtl
@@ -1,0 +1,14 @@
+<ul>
+    #foreach($listItem in $item.content)
+        #if ($listItem.type == "listItem")
+            <li>
+                #foreach($listItemContent in $listItem.content)
+                            #foreach($listItemContentContent in $listItemContent.content)
+                    $listItemContentContent.text
+                #end
+                        #end
+            </li>
+        #end
+
+    #end
+</ul>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/bulletList.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/bulletList.vtl
@@ -1,12 +1,13 @@
+#parse( "marks-macro.vtl" )
 <ul>
     #foreach($listItem in $item.content)
         #if ($listItem.type == "listItem")
             <li>
                 #foreach($listItemContent in $listItem.content)
-                            #foreach($listItemContentContent in $listItemContent.content)
-                    $listItemContentContent.text
+                    #foreach($listItemContentContent in $listItemContent.content)
+                        #renderText($listItemContentContent.text)
+                     #end
                 #end
-                        #end
             </li>
         #end
 

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotContent.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotContent.vtl
@@ -1,0 +1,1 @@
+<h2>$item.attrs.data.title</h2>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading1.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading1.vtl
@@ -1,0 +1,5 @@
+<h1>
+    #foreach($content in $item.content)
+        $content.text
+    #end
+</h1>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading1.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading1.vtl
@@ -1,5 +1,6 @@
+#parse( "marks-macro.vtl" )
 <h1>
     #foreach($content in $item.content)
-        $content.text
+        #renderText($content.text)
     #end
 </h1>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading2.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading2.vtl
@@ -1,0 +1,5 @@
+<h2>
+    #foreach($content in $item.content)
+        $content.text
+    #end
+</h2>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading2.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading2.vtl
@@ -1,5 +1,6 @@
+#parse( "marks-macro.vtl" )
 <h2>
     #foreach($content in $item.content)
-        $content.text
+        #renderText($content.text)
     #end
 </h2>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading3.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading3.vtl
@@ -1,0 +1,5 @@
+<h3>
+    #foreach($content in $item.content)
+        $content.text
+    #end
+</h3>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading3.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading3.vtl
@@ -1,5 +1,6 @@
+#parse( "marks-macro.vtl" )
 <h3>
     #foreach($content in $item.content)
-        $content.text
+        #renderText($content.text)
     #end
 </h3>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/marks-macro.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/marks-macro.vtl
@@ -1,0 +1,29 @@
+#macro(renderText $content)
+    #foreach($item in $content)
+        #foreach ($mark in $item.marks)
+            #if ($mark.type == "bold")
+            <strong>
+            #end
+            #if ($mark.type == "italic")
+            <em>
+            #end
+            #if ($mark.type == "underline")
+            <u>
+            #end
+        #end
+
+        $item.text
+
+        #foreach ($mark in $item.marks)
+            #if ($mark.type == "bold")
+            </strong>
+            #end
+            #if ($mark.type == "italic")
+            </em>
+            #end
+            #if ($mark.type == "underline")
+            </u>
+            #end
+        #end
+    #end
+#end

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/orderedList.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/orderedList.vtl
@@ -1,0 +1,14 @@
+<ol>
+    #foreach($listItem in $item.content)
+        #if ($listItem.type == "listItem")
+            <li>
+                #foreach($listItemContent in $listItem.content)
+                            #foreach($listItemContentContent in $listItemContent.content)
+                    $listItemContentContent.text
+                #end
+                        #end
+            </li>
+        #end
+
+    #end
+</ol>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/orderedList.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/orderedList.vtl
@@ -1,12 +1,13 @@
+#parse( "marks-macro.vtl" )
 <ol>
     #foreach($listItem in $item.content)
         #if ($listItem.type == "listItem")
             <li>
                 #foreach($listItemContent in $listItem.content)
-                            #foreach($listItemContentContent in $listItemContent.content)
-                    $listItemContentContent.text
+                    #foreach($listItemContentContent in $listItemContent.content)
+                        #renderText($listItemContentContent.text)
+                    #end
                 #end
-                        #end
             </li>
         #end
 

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/paragraph.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/paragraph.vtl
@@ -1,0 +1,5 @@
+<p>
+    #foreach($content in $item.content)
+        $content.text
+    #end
+</p>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/paragraph.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/paragraph.vtl
@@ -1,5 +1,6 @@
+#parse( "marks-macro.vtl" )
 <p>
     #foreach($content in $item.content)
-        $content.text
+        #renderText($content.text)
     #end
 </p>


### PR DESCRIPTION
Before this change, on the content handler when the multi tree comes with a specific tree order: the tree order was overridden. The changes introduced allows to keep the multi tree order as it comes from the xml.