### PR TITLE
Issue 21356 defaults on text fields

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/business/ContentletJsonAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/business/ContentletJsonAPITest.java
@@ -25,6 +25,7 @@ import com.dotmarketing.portlets.categories.model.Category;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.Logger;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Date;
@@ -118,6 +119,12 @@ public class ContentletJsonAPITest extends IntegrationTestBase {
      */
     @Test
     public void Create_Content_Then_Find_It_Then_Create_Json_Content_Then_Recover_And_Compare() throws Exception {
+
+        //TODO: Once we have json capabilities enabled on all the supported dbs we must remove this condition. Currently we only support them on Postgres
+        if(!APILocator.getContentletJsonAPI().isPersistContentAsJson()){
+            Logger.info(ContentletJsonAPITest.class, ()->"Test Should only run on databases with enabled json capabilities.");
+            return;
+        }
 
         final String hostName = "my.custom" + System.currentTimeMillis() + ".dotcms.com";
         final Host site = new SiteDataGen().name(hostName).nextPersisted(true);

--- a/dotCMS/src/integration-test/java/com/dotcms/content/business/ContentletJsonAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/business/ContentletJsonAPITest.java
@@ -281,7 +281,7 @@ public class ContentletJsonAPITest extends IntegrationTestBase {
             assertNotNull(filledWithNulls);
             filledWithNulls.getMap().put("textFieldNumeric",null);
             filledWithNulls.getMap().put("textFieldFloat",null);
-
+            Config.setProperty(JSON_NUMERIC_FIELD_DEFAULT_TO_ZERO, false);
             final String json2 = impl.toJson(filledWithNulls);
             assertNotNull(json2);
 
@@ -292,7 +292,7 @@ public class ContentletJsonAPITest extends IntegrationTestBase {
 
         } finally {
             Config.setProperty(SAVE_CONTENTLET_AS_JSON, defaultValue);
-            Config.setProperty("json.field.number.init", initNumericTextFields);
+            Config.setProperty(JSON_NUMERIC_FIELD_DEFAULT_TO_ZERO, initNumericTextFields);
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/content/business/ContentletJsonAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/content/business/ContentletJsonAPI.java
@@ -20,6 +20,8 @@ public interface ContentletJsonAPI {
 
     String SAVE_CONTENTLET_AS_COLUMNS =  "persist.contentlet.as.columns";
 
+    String JSON_NUMERIC_FIELD_DEFAULT_TO_ZERO = "json.numeric.field.default.to.zero";
+
     String CONTENTLET_AS_JSON = "contentlet_as_json";
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/content/business/ContentletJsonAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/business/ContentletJsonAPIImpl.java
@@ -181,14 +181,14 @@ public class ContentletJsonAPIImpl implements ContentletJsonAPI {
             if (null != value) {
                 final Optional<FieldValue<?>> fieldValue = getFieldValue(value, field);
                 if (!fieldValue.isPresent()) {
-                    Logger.debug(ContentletJsonAPIImpl.class,
+                    Logger.debug(ContentletJsonAPIImpl.class,()->
                             String.format("Unable to set field `%s` with the given value %s.",
                                     field.name(), value));
                 } else {
                     builder.putFields(field.variable(), fieldValue.get());
                 }
             } else {
-                Logger.debug(ContentletJsonAPIImpl.class,
+                Logger.debug(ContentletJsonAPIImpl.class,()->
                         String.format("Unable to set field `%s` as it wasn't set on the source contentlet", field.name()));
 
                 if(Config.getBooleanProperty(JSON_NUMERIC_FIELD_DEFAULT_TO_ZERO, true)) {


### PR DESCRIPTION
Originally when we saved a numeric text field (Float, Integer) if there were not explicitly set with a value. They ended up with the value of 0. This comes mimic that behavior