### PR TITLE
#21286 Fixing bug when try to add a contentlet in a page

### DIFF
--- a/dotCMS/src/curl-test/ContainerResource.postman_collection.json
+++ b/dotCMS/src/curl-test/ContainerResource.postman_collection.json
@@ -102,6 +102,8 @@
 							"    console.log(jsonData);",
 							"",
 							"    pm.expect(jsonData[\"entity\"]['render']).to.contains('dotPageContent object has the expected values');",
+							"",
+							"        pm.expect(jsonData[\"entity\"]['render']).to.not.contains('data-dot-object=\"container\"');",
 							"});"
 						],
 						"type": "text/javascript"

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/container/ContainerResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/container/ContainerResource.java
@@ -367,26 +367,29 @@ public class ContainerResource implements Serializable {
 
         final org.apache.velocity.context.Context context = velocityUtil.getContext(req, res);
 
+        if (UtilMethods.isSet(pageInode)) {
+            loadPageContext(user, pageInode, mode, context);
+        } else {
+            context.put("dotPageContent", Boolean.TRUE);
+        }
+
         context.put(ContainerLoader.SHOW_PRE_POST_LOOP, false);
         context.put("contentletList" + container.getIdentifier() + Container.LEGACY_RELATION_TYPE,
                 Lists.newArrayList(contentlet.getIdentifier()));
         context.put(mode.name(), Boolean.TRUE);
 
-        if (UtilMethods.isSet(pageInode)) {
-
-            final IHTMLPage htmlPage =  APILocator.getHTMLPageAssetAPI().findPage(pageInode, user, false);
-            final long languageId = htmlPage.getLanguageId();
-
-            final VelocityResourceKey pageKey = new VelocityResourceKey((HTMLPageAsset) htmlPage, mode, languageId);
-            velocityUtil.merge(pageKey.path, context);
-
-        } else {
-            context.put("dotPageContent", Boolean.TRUE);
-        }
-
         final VelocityResourceKey key = new VelocityResourceKey(container, Container.LEGACY_RELATION_TYPE, mode);
-
         return velocityUtil.merge(key.path, context);
+    }
+
+    private void loadPageContext(User user, String pageInode, PageMode mode,
+            org.apache.velocity.context.Context context)
+            throws DotDataException, DotSecurityException {
+        final IHTMLPage htmlPage =  APILocator.getHTMLPageAssetAPI().findPage(pageInode, user, false);
+        final long languageId = htmlPage.getLanguageId();
+
+        final VelocityResourceKey pageKey = new VelocityResourceKey((HTMLPageAsset) htmlPage, mode, languageId);
+        velocityUtil.merge(pageKey.path, context);
     }
 
 


### PR DESCRIPTION
When try to add a contenlet into a page, the render end point is returning the html with the `data-dot-object="container"'` div because we are overwriting some attributes in the velocity context.

