### PR TITLE
Issue 21440 docker uid

### DIFF
--- a/docker/dotcms/Dockerfile
+++ b/docker/dotcms/Dockerfile
@@ -87,8 +87,8 @@ LABEL com.dotcms.contact "support@dotcms.com"
 LABEL com.dotcms.vendor "dotCMS LLC"
 LABEL com.dotcms.description "dotCMS Content Management System"
 
-ARG USER_UID="1000000000"
-ARG USER_GID="1000000000"
+ARG USER_UID="65001"
+ARG USER_GID="65001"
 
 COPY --from=container-base / /
 

--- a/docker/dotcms/ROOT/srv/05-setup-app-storage.sh
+++ b/docker/dotcms/ROOT/srv/05-setup-app-storage.sh
@@ -11,6 +11,3 @@ source /srv/utils/config-defaults.sh
 [[ ! -d /data/shared/felix/undeployed ]] && mkdir -p /data/shared/felix/undeployed
 
 
-
-
-mkdir -p /srv/home

--- a/docker/dotcms/ROOT/srv/05-setup-app-storage.sh
+++ b/docker/dotcms/ROOT/srv/05-setup-app-storage.sh
@@ -10,23 +10,6 @@ source /srv/utils/config-defaults.sh
 [[ ! -d /data/shared/felix/load ]] && mkdir -p /data/shared/felix/load
 [[ ! -d /data/shared/felix/undeployed ]] && mkdir -p /data/shared/felix/undeployed
 
-ASSET_USER_ID=$( stat -c %u /data/shared/assets )
-FELIX_USER_ID=$( stat -c %u /data/shared/felix/load )
-
-
-
-echo "found /data/shared/assets directory owner: $ASSET_USER_ID"
-if [[ ! "$CMS_RUNAS_UID" -eq $ASSET_USER_ID ]]; then
-    echo "Updating asset directory owner to $CMS_RUNAS_UID:$CMS_RUNAS_GID"
-    chown $CMS_RUNAS_UID:$CMS_RUNAS_GID /data/shared/assets &
-fi
-
-
-if [[ ! "$CMS_RUNAS_UID" -eq $FELIX_USER_ID ]]; then
-    echo "Updating felix directory owner to $CMS_RUNAS_UID:$CMS_RUNAS_GID"
-    chown $CMS_RUNAS_UID:$CMS_RUNAS_GID /data/shared/felix/load &
-    chown $CMS_RUNAS_UID:$CMS_RUNAS_GID /data/shared/felix/undeployed &
-fi
 
 
 

--- a/docker/dotcms/ROOT/srv/utils/config-defaults.sh
+++ b/docker/dotcms/ROOT/srv/utils/config-defaults.sh
@@ -26,12 +26,6 @@ TOMCAT_HOME=/srv/dotserver/tomcat-${TOMCAT_VERSION}
 # SMTP hostname for CMS
 : ${CMS_SMTP_HOST:="smtp"}
 
-# dotCMS runas user UID
-: ${CMS_RUNAS_UID:="1000000000"}
-
-# dotCMS runas group GID
-: ${CMS_RUNAS_GID:="1000000000"}
-
 ## Plugins init (not implemented yet!!)
 : ${CMS_PLUGINS_OSGI_OVERWRITE_SHARED:="false"}
 : ${CMS_PLUGINS_OSGI_FIX_OWNER:="true"}


### PR DESCRIPTION
This updates the uid/gid used to run dotCMS to a manageable `65001`