### PR TITLE
dotCMS/core#21413 Frame Resize Bug submitted on behalf of Deutsche Bank/Sunny Metkar

### DIFF
--- a/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
+++ b/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
@@ -11674,13 +11674,6 @@ a.category_higlighted, a.tag_higlighted {
   text-align: center;
 }
 
-.file-selector-tree__main {
-  display: flex;
-  height: 84vh !important;
-  width: calc(100% - 200px) !important;
-  overflow: inherit;
-}
-
 .file-selector-tree__sidebar {
   padding: 16px 0 16px 16px;
 }

--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/FileBrowserDialog.jsp
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/FileBrowserDialog.jsp
@@ -5,8 +5,8 @@
     <div dojoAttachPoint="dialog" dojoType="dijit.Dialog" title="<%= LanguageUtil.get(pageContext, "Select-a-file")%>" class="file-selector-tree">
         <dot-asset-drop-zone dojoAttachPoint="dropzone">
         <form dojoAttachPoint="search_form" onsubmit="return false;">
-            <div dojotype="dijit.layout.BorderContainer" design="sidebar" gutters="false" livesplitters="false" class="file-selector-tree__container">
-                <div dojotype="dijit.layout.ContentPane" dojoAttachPoint="foldersContentPane" splitter="false" region="leading" title="<%= LanguageUtil.get(pageContext, "Folders")%>" class="portlet-sidebar-wrapper">
+            <div dojotype="dijit.layout.BorderContainer" design="sidebar" gutters="false" livesplitters="true" class="file-selector-tree__container">
+                <div dojotype="dijit.layout.ContentPane" dojoAttachPoint="foldersContentPane" splitter="true" region="leading" title="<%= LanguageUtil.get(pageContext, "Folders")%>" class="portlet-sidebar-wrapper">
                     <div dojoAttachPoint="foldersTreeWrapper" class="file-selector-tree__sidebar">
                         <div dojoAttachPoint="foldersTree"></div>
                     </div>


### PR DESCRIPTION
On a content having "image" field, clicking on Browse button opens "Select a file " popup showing project folder structure on left pane.

Client reported that there is no handle to resize the left pane and they have to rely on horizontal scrollbar which shows only when expanded folders are long enough for need of scrollbar. This is not user friendly for them or consistent with other screens.

All we need is existing functionality/handle which is available on Site > Browser to expand left pane to see the long folder names easily on Image field >browse menu.

![image](https://user-images.githubusercontent.com/37185433/146999673-d53d6e36-1379-4be6-ab41-24cc46452d2f.png)
