### PR TITLE
#21419 surrounding the code with a try catch in case of messed up json

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformer.java
@@ -24,6 +24,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -290,7 +291,7 @@ public class ContentletTransformer implements DBTransformer {
                 Logger.warn(ContentletTransformer.class, () -> String
                         .format("Failed to convert keyValue field `%s` to an actual json. An Empty will be returned instead. ",
                                 field.getVelocityVarName()));
-                value = new HashMap<>();
+                value = Collections.emptyMap();
             }
         }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformer.java
@@ -22,6 +22,7 @@ import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.util.StringPool;
+import io.vavr.control.Try;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -265,7 +266,7 @@ public class ContentletTransformer implements DBTransformer {
         APILocator.getContentletAPI().copyProperties(contentlet, fieldsMap);
     }
 
-    private static Object getObjectValue(Map<String, Object> originalMap, Field field) {
+    private static Object getObjectValue(final Map<String, Object> originalMap, final Field field) {
         Object value;
         if (field.getFieldContentlet().startsWith("float") && originalMap
                 .get(field.getFieldContentlet()) instanceof Double) {
@@ -278,9 +279,19 @@ public class ContentletTransformer implements DBTransformer {
             value = originalMap.get(field.getFieldContentlet());
         }
 
-        //KeyValue objects must be returned as Maps
-        if(LegacyFieldTypes.KEY_VALUE.legacyValue().equals(field.getFieldType()) && value instanceof String ){
-            value = com.dotmarketing.portlets.structure.model.KeyValueFieldUtil.JSONValueToHashMap((String)value);
+        //KeyValue Fields must be returned as Maps
+        if (LegacyFieldTypes.KEY_VALUE.legacyValue().equals(field.getFieldType())
+                && value instanceof String) {
+            final String asString = value.toString();
+            try {
+                value = com.dotmarketing.portlets.structure.model.KeyValueFieldUtil
+                        .JSONValueToHashMap(asString);
+            } catch (Throwable e) {
+                Logger.warn(ContentletTransformer.class, () -> String
+                        .format("Failed to convert keyValue field `%s` to an actual json. An Empty will be returned instead. ",
+                                field.getVelocityVarName()));
+                value = new HashMap<>();
+            }
         }
 
         return value;


### PR DESCRIPTION
On 21.12 we're introducing a change that converts KeyValues into Map
So the corresponding keyValue JSON is returned in the contentlet as a Map
This change prevents that any messed-up JSON breaks the app.