### PR TITLE
 small improvement that prevents breakage of the content edit dialog w…

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/tiny_mce_config.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/tiny_mce_config.jsp
@@ -17,10 +17,14 @@ if(!hasDefaultConfig){
 boolean dotCMSHasLicense = LicenseUtil.getLevel() > 100;
 
 if (hasDefaultConfig) {%>
-    <% Context ctx = VelocityUtil.getWebContext(request, response);%>
+    <%
+        Context ctx = VelocityUtil.getWebContext(request, response);
+        String props = VelocityUtil.eval("#set($dontShowIcon=true)#dotParse('//" + myHost.getHostname() + "/application/wysiwyg/tinymceprops.vtl')", ctx);
+        props = UtilMethods.isNotSet(props) ? "{}" : props;
+    %>
   
     var dotCMSHasLicense = <%=dotCMSHasLicense%>;
-    var tinyMCEProps = <%=VelocityUtil.eval("#set($dontShowIcon=true)#dotParse('//" + myHost.getHostname() + "/application/wysiwyg/tinymceprops.vtl')", ctx)%>
+    var tinyMCEProps = <%=props%>
 
 <%} else if (UtilMethods.isSet(Config.getStringProperty("TINY_MCE_CONFIG_LOCATION", null))) {%>
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/tiny_mce_config.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/tiny_mce_config.jsp
@@ -4,6 +4,7 @@
 <%@page import="com.dotcms.rendering.velocity.util.VelocityUtil"%>
 <%@page import="com.dotmarketing.util.Config"%>
 <%@page import="com.dotmarketing.util.UtilMethods"%>
+<%@ page import="com.dotmarketing.util.Logger" %>
 <%
 Host myHost =  WebAPILocator.getHostWebAPI().getCurrentHost(request); 
 Identifier id = APILocator.getIdentifierAPI().find(myHost, "/application/wysiwyg/tinymceprops.vtl");
@@ -20,7 +21,10 @@ if (hasDefaultConfig) {%>
     <%
         Context ctx = VelocityUtil.getWebContext(request, response);
         String props = VelocityUtil.eval("#set($dontShowIcon=true)#dotParse('//" + myHost.getHostname() + "/application/wysiwyg/tinymceprops.vtl')", ctx);
-        props = UtilMethods.isNotSet(props) ? "{}" : props;
+        if(UtilMethods.isNotSet(props)){
+            props = "{}";
+            Logger.warn(this.getClass()," Unable to set props on TinyMCE! No tinyMCE default props were loaded. check that the following file exist on your site.`/application/wysiwyg/tinymceprops.vtl`.");
+        }
     %>
   
     var dotCMSHasLicense = <%=dotCMSHasLicense%>;


### PR DESCRIPTION
The other day I was given a database but no assets. Suddenly my content edit dialog was not loading. 
I initially thought it was because of the issue I was researching. 
it turned out to be tinyMCE that had a dependency on a vtl that did not exist. 
It took me a while to figure it out before I could focus on the real problem.
This simply prevents the javascript from breaking on missing vtl. 
 