### PR TITLE
#19972 Fixing bug when the Upload file button is not showing

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/FileBrowserDialog.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/FileBrowserDialog.js
@@ -209,7 +209,8 @@ dojo.declare("dotcms.dijit.FileBrowserDialog", [dijit._Widget, dijit._Templated]
 		this.tree.set('path',this.selectFolder);
 		this._selectFolder({
 			id: this.selectFolder[this.selectFolder.length - 1],
-			identifier: "SYSTEM_HOST"
+			identifier: "SYSTEM_HOST",
+			type: this.selectFolder.length == 2 ? 'host' : 'folder'
 		})
 	},
 
@@ -249,6 +250,7 @@ dojo.declare("dotcms.dijit.FileBrowserDialog", [dijit._Widget, dijit._Templated]
     },
 
 	_selectFolder: function(item) {
+		console.log('item', item);
         this.dropzone.folder = item.id;
 
 		this.currentFolder = item;

--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/FileBrowserDialog.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/FileBrowserDialog.js
@@ -250,7 +250,6 @@ dojo.declare("dotcms.dijit.FileBrowserDialog", [dijit._Widget, dijit._Templated]
     },
 
 	_selectFolder: function(item) {
-		console.log('item', item);
         this.dropzone.folder = item.id;
 
 		this.currentFolder = item;

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet.jsp
@@ -225,7 +225,6 @@
 	<input name="wfFilterKey" id="wfFilterKey" type="hidden" value="">
 
 
-	<!-- HERE -->
 	<div dojoAttachPoint="cmsFileBrowserImage" currentView="thumbnails" jsId="cmsFileBrowserImage" onFileSelected="addFileImageCallback" mimeTypes="image" sortBy="modDate" sortByDesc="true" dojoType="dotcms.dijit.FileBrowserDialog"></div>
 	<div dojoAttachPoint="cmsFileBrowserFile" currentView="list" jsId="cmsFileBrowserFile" onFileSelected="addFileCallback" dojoType="dotcms.dijit.FileBrowserDialog"></div>
 


### PR DESCRIPTION
Fixing this bug:

"Also, when you set a defaultPath to some specific folder, the upload new file button is appearing disabled, we need to click in the folder to refresh and enable this button."

mention here:

https://github.com/dotCMS/core/issues/19972#issuecomment-1004385086
