### PR TITLE
Issue 21351 es contentlet api impl internal checkin fails when mix of absolute and relative path

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -17,6 +17,7 @@ import com.dotcms.IntegrationTestBase;
 import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.FieldAPI;
+import com.dotcms.contenttype.model.field.BinaryField;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.FieldBuilder;
 import com.dotcms.contenttype.model.field.RelationshipField;
@@ -26,7 +27,9 @@ import com.dotcms.contenttype.model.type.ImmutableSimpleContentType;
 import com.dotcms.contenttype.model.type.SimpleContentType;
 import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotcms.datagen.*;
+import com.dotcms.test.util.FileTestUtil;
 import com.dotcms.util.CollectionsUtils;
+import com.dotcms.util.ConfigTestHelper;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Permission;
@@ -49,9 +52,13 @@ import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
+import com.google.common.io.Files;
 import com.liferay.portal.model.User;
+import com.liferay.util.FileUtil;
 import com.liferay.util.StringPool;
 
+import java.io.File;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Date;
@@ -398,6 +405,86 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
         esContentletAPI.lock(contentletSaved, user, false);
 
         checkLock(user, contentletSaved);
+    }
+
+    /**
+     * Method to test: {@link ESContentletAPIImpl#checkin(Contentlet, User, boolean)}
+     * When: You have a {@link ContentType} with a {@link BinaryField}, First save it, and later Update it
+     * with a different file
+     * Should: Save contentlet with the right file's path and should copy the file to
+     * <pre>
+     *     [Abdolute asset root path]/[inode first character]/[inode second character]/[inode]/[field variable name]/[file_name]
+     * </pre>
+     *
+     * @throws IOException
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    @Test
+    public void saveAndUpdateContentletWithBynaryField() throws IOException, DotDataException, DotSecurityException {
+        final Field binaryField = new FieldDataGen()
+                .name("binary")
+                .velocityVarName("binary")
+                .type(BinaryField.class)
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .fields(list(binaryField))
+                .nextPersisted();
+
+        final File testFile = createFile("images/test.jpg", ".jpg");
+        final Contentlet contentlet = new ContentletDataGen(contentType.id())
+                .setProperty(binaryField.variable(), testFile)
+                .next();
+
+        final ESContentletAPIImpl esContentletAPI = new ESContentletAPIImpl();
+        esContentletAPI.checkin(contentlet, APILocator.systemUser(), false);
+
+        Contentlet contentletFromDataBase = APILocator.getContentletAPI()
+                .find(contentlet.getInode(), APILocator.systemUser(), false);
+
+        assertFiles(binaryField, testFile, contentletFromDataBase);
+
+        final File testFile_2 = createFile("images/test.png", "v");
+
+        final Contentlet checkout = ContentletDataGen.checkout(contentletFromDataBase);
+        checkout.setProperty(binaryField.variable(), testFile_2);
+
+        esContentletAPI.checkin(checkout, APILocator.systemUser(), false);
+
+        Contentlet contentletFromDataBase_2 = APILocator.getContentletAPI()
+                .find(checkout.getInode(), APILocator.systemUser(), false);
+
+        assertFiles(binaryField, testFile_2, contentletFromDataBase_2);
+    }
+
+    private void assertFiles(Field binaryField, File testFile, Contentlet contentletFromDataBase)
+            throws IOException {
+        final String inode = contentletFromDataBase.getInode();
+        File newDir = new File(APILocator.getFileAssetAPI().getRealAssetsRootPath() + File.separator
+                + inode.charAt(0)
+                + File.separator
+                + inode.charAt(1) + File.separator + inode);
+
+        final String expectedPath =
+                newDir.getAbsolutePath() + File.separator + binaryField.variable()
+                        + File.separator + testFile.getName();
+        assertEquals(expectedPath,
+                contentletFromDataBase.getStringProperty(binaryField.variable()));
+
+        final File newFile = new File(expectedPath);
+        FileTestUtil.compare(testFile, newFile);
+    }
+
+    private static File createFile(final String path, final String suffix) throws IOException {
+        final File originalFile = new File(Thread.currentThread()
+                .getContextClassLoader().getResource(path).getFile());
+
+        final String fileName = "test_" + System.currentTimeMillis() + suffix;
+        final File testFile = new File(Files.createTempDir(), fileName);
+        FileUtil.copyFile(originalFile, testFile);
+
+        return testFile;
     }
 
     private void checkLock(final User user, final Contentlet contentletSaved) throws DotDataException {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -5069,7 +5069,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             binaryFieldFolder.mkdirs();
 
                             // we move files that have been newly uploaded or edited
-                            if(oldFile==null || !oldFile.equals(incomingFile)){
+                            if(oldFile==null || !oldFile.getAbsolutePath().equals(incomingFile.getAbsolutePath())){
                                 if(!createNewVersion){
                                     // If we're calling a checkinWithoutVersioning method,
                                     // then folder needs to be cleaned up in order to add the new file in it.


### PR DESCRIPTION
Really this file always are created using the absolute path, how we can see here:

https://github.com/dotCMS/core/blob/7e8c24964a30a0935dc3677d62995d2933c86ef3/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java#L5058

...and...

https://github.com/dotCMS/core/blob/8ce2849d2cd00a24b5fac3776bef06cbf4391600/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java#L1152

but to avoid future bug is better to compare with the absolute path
