### PR TITLE
dotCMS/core#21120 fix Time machine looks miss-aligned when you are using the system in spanish

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/timemachine/settings.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/timemachine/settings.jsp
@@ -202,7 +202,7 @@
 
 </script>
 <span dojoType="dotcms.dojo.data.HostReadStore" jsId="HostStore"></span>
-<div style="height:auto; width:580px; overflow:auto;">
+<div style="height:auto; overflow:auto;">
     <form id="settingform" dojoType="dijit.form.Form">
         <div class="form-horizontal">
             <dl>
@@ -297,7 +297,7 @@
                 </dd>
             </dl>
         </div>
-        <div class="buttonRow-right">
+        <div style="text-align: center;">
             <span class="showScheduler">
                 <button dojoType="dijit.form.Button" class="dijitButtonFlat" id="disableButton" onClick="disableJob();" iconClass="deleteIcon">
                     <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "TIMEMACHINE-DISABLE")) %>

--- a/dotCMS/src/main/webapp/html/portlet/ext/timemachine/timemachine_select.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/timemachine/timemachine_select.jsp
@@ -150,7 +150,7 @@ function showSettings() {
 	var dialog = new dijit.Dialog({
 		id: 'settingsDialog',
         title: "<%= LanguageUtil.get(pageContext, "TIMEMACHINE-SETTINGS")%>",
-        style: "width: 600px;height: auto;",
+        style: "width: 680px;height: auto;",
         content: new dojox.layout.ContentPane({
         	style: "height:auto; width: 580px;",
             href: "/html/portlet/ext/timemachine/settings.jsp?random="+r


### PR DESCRIPTION

When you are using Spanish as language and you try to create a time machine snapshot, we have some UI problems in the time machine modal

![image](https://user-images.githubusercontent.com/37185433/149382822-2544d6e9-db68-4d27-bbf6-cb2883f41bc3.png)
