### PR TITLE
#21434 the code was expecting always a String, but the value could be…

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
@@ -1912,7 +1912,7 @@ public class ContentletAjax {
 						if(!vars.isEmpty()){
 							String[] refererVars =referer.split("/");
 							for(String var: vars.keySet()){
-								String contVar = contentlet.get(var)!=null?(String)contentlet.get(var):"";
+								String contVar = contentlet.get(var)!=null?contentlet.get(var).toString():"";
 								String refererVar = refererVars[vars.get(var)];
 								if(UtilMethods.isSet(contVar) && !contVar.equals(refererVar)){
 									refererVars[vars.get(var)] = contVar;


### PR DESCRIPTION
The code was expecting always a String, but the value could be a number in case the type of the text is mark as a whole number or so on the content type, the toString handles both cases
