### PR TITLE
dotCMS/core#21120 fix Time machine looks miss-aligned when you are using the system in spanish

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/timemachine/settings.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/timemachine/settings.jsp
@@ -298,11 +298,6 @@
             </dl>
         </div>
         <div style="text-align: center;">
-            <span class="showScheduler">
-                <button dojoType="dijit.form.Button" class="dijitButtonFlat" id="disableButton" onClick="disableJob();" iconClass="deleteIcon">
-                    <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "TIMEMACHINE-DISABLE")) %>
-                </button>
-            </span>
             <span class="showRunNow">
                 <button dojoType="dijit.form.Button" id="runButton" onClick="runNow();" iconClass="republishIcon">
                     <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "TIMEMACHINE-RUN")) %>
@@ -314,7 +309,13 @@
                 </button>
             </span>
         </div>
-
+        <div style="text-align: center;">
+            <span class="showScheduler">
+                <button dojoType="dijit.form.Button" class="dijitButtonFlat" id="disableButton" onClick="disableJob();" iconClass="deleteIcon">
+                    <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "TIMEMACHINE-DISABLE")) %>
+                </button>
+            </span>
+        </div>
     </form>
 </div>
 <%@include file="/html/common/bottom_inc.jsp"%>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37185433/150214429-2607cfe4-d0dc-4fef-a390-eac6a929f217.png)