### PR TITLE
#21583 make MimeTypeUtils more robust

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/util/MimeTypeUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/util/MimeTypeUtils.java
@@ -1,19 +1,15 @@
 package com.dotcms.util;
 
-import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.tika.TikaUtils;
 import com.dotmarketing.portlets.fileassets.business.FileAsset;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
-import com.rainerhahnekamp.sneakythrow.Sneaky;
 import io.vavr.control.Try;
-
-import java.util.function.Supplier;
-import javax.activation.MimeType;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import javax.activation.MimeType;
 
 /**
  * Mime Type Utils
@@ -33,11 +29,11 @@ public class MimeTypeUtils {
             return FileAsset.UNKNOWN_MIME_TYPE;
         }
         final Path path = binary.toPath();
-        String mimeType = Sneaky.sneak(() -> Files.probeContentType(path));
+        String mimeType = Try.of(() -> Files.probeContentType(path)).getOrNull();
 
         if  (!UtilMethods.isSet(mimeType)) {
 
-            mimeType    = Config.CONTEXT.getMimeType(binary.getAbsolutePath());
+            mimeType = Try.of(()->Config.CONTEXT.getMimeType(binary.getAbsolutePath())).getOrNull();
 
             if( !UtilMethods.isSet(mimeType)){
                 try {

--- a/dotCMS/src/main/java/com/dotcms/util/MimeTypeUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/util/MimeTypeUtils.java
@@ -25,13 +25,9 @@ public class MimeTypeUtils {
 
     /**
      * Gets the mime type of a file.
-     * @deprecated This is no longer the way to recover the mimeType instead use
-     *   {@link com.dotmarketing.portlets.contentlet.model.Contentlet#getBinaryMetadata(Field)} or
-     *   {@link com.dotcms.storage.FileMetadataAPI#getFullMetadataNoCache(File, Supplier)}
      * @param binary {@link File}
      * @return String
      */
-    @Deprecated
     public static String getMimeType (final File binary) {
         if(binary==null) {
             return FileAsset.UNKNOWN_MIME_TYPE;
@@ -46,8 +42,9 @@ public class MimeTypeUtils {
             if( !UtilMethods.isSet(mimeType)){
                 try {
                     mimeType = new TikaUtils().detect(binary);
-                } catch(Exception e) {
-                    Logger.warn(MimeTypeUtils.class, e.getMessage() +  e.getStackTrace()[0]);
+                } catch(Throwable e) {
+                    Logger.warn(MimeTypeUtils.class, "Unable to parse Mime type for : " + binary);
+                    Logger.warn(MimeTypeUtils.class, e.getMessage() + e.getStackTrace()[0]);
                 }
 
                 if(!UtilMethods.isSet(mimeType)) {


### PR DESCRIPTION
for some reason, the Tika Bundle somehow's missing. Classes should have been loaded via OSGI from whatever path is instructed in the Felix install-dir /bundle 
Whenever that happens we must be prepared for failure and catch Throwables 