### PR TITLE
Improved typing on base Field Type List

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeAPIImplTest.java
@@ -630,7 +630,7 @@ public class ContentTypeAPIImplTest extends ContentTypeBaseTest {
 		String TEST_VAR_PREFIX = "testField";
 
 		int numFields = 0;
-		for (Class clazz : APILocator.getContentTypeFieldAPI().fieldTypes()) {
+		for (Class<? extends Field> clazz : APILocator.getContentTypeFieldAPI().fieldTypes()) {
 			Field fakeField = FieldBuilder.builder(clazz).name("fake").variable("fake").contentTypeId(type.id()).build();
 			boolean save = true;
 			if (fakeField instanceof OnePerContentType) {

--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/ContentTypeFactoryImplTest.java
@@ -468,7 +468,7 @@ public class ContentTypeFactoryImplTest extends ContentTypeBaseTest {
 		String TEST_VAR_PREFIX = "testField";
 
 		int numFields = 0;
-		for(Class clazz : APILocator.getContentTypeFieldAPI().fieldTypes()){
+		for(Class<? extends Field> clazz : APILocator.getContentTypeFieldAPI().fieldTypes()){
 			Field fakeField = FieldBuilder.builder(clazz).name("fake").variable("fake").contentTypeId(type.id()).build();
 			boolean save = true;
 			if(fakeField instanceof OnePerContentType){

--- a/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/FieldFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/contenttype/test/FieldFactoryImplTest.java
@@ -608,7 +608,7 @@ public class FieldFactoryImplTest extends ContentTypeBaseTest {
 	@Test
 	public void testFieldImplClasses() throws Exception {
 
-		for (Class clazz : APILocator.getContentTypeFieldAPI().fieldTypes()) {
+		for (Class<? extends Field> clazz : APILocator.getContentTypeFieldAPI().fieldTypes()) {
 			Field newField = FieldBuilder.builder(clazz).contentTypeId("test")
 					.name("test" + clazz.getSimpleName())
 					.variable(TEST_VAR_PREFIX + clazz.getSimpleName()).build();

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldAPI.java
@@ -47,7 +47,7 @@ public interface FieldAPI {
 	 * 
 	 * @return List of baseFieldTypes
 	 */
-	List<Class> fieldTypes();
+	List<Class<? extends Field>> fieldTypes();
 	
 	/**
 	 * Register a field type to the list of field types. Still not implemented.

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldAPIImpl.java
@@ -90,7 +90,7 @@ import org.apache.commons.lang.StringUtils;
 
 public class FieldAPIImpl implements FieldAPI {
 
-  private final List<Class> baseFieldTypes = ImmutableList.of(BinaryField.class, StoryBlockField.class,
+  private final List<Class<? extends Field>> baseFieldTypes = ImmutableList.of(BinaryField.class, StoryBlockField.class,
           CategoryField.class, ConstantField.class, CheckboxField.class, CustomField.class, DateField.class,
       DateTimeField.class, FileField.class, HiddenField.class, HostFolderField.class,
       ImageField.class, KeyValueField.class, LineDividerField.class, MultiSelectField.class,
@@ -777,7 +777,7 @@ public class FieldAPIImpl implements FieldAPI {
   }
 
   @Override
-  public List<Class> fieldTypes() {
+  public List<Class<? extends Field>> fieldTypes() {
     return baseFieldTypes;
   }
 


### PR DESCRIPTION
A small improvement on the typing of the list of available Field classes. 
When specified this way we can take advantage of the methods already contained under the Field class without having to use a lot code to cast them 