### PR TITLE
Updating properties in docker compose examples

### DIFF
--- a/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-1.yml
@@ -29,13 +29,13 @@ services:
   dotcms-node-1:
     image: dotcms/dotcms:latest
     environment:
-      "CMS_HEAP_SIZE": '1g'
-      "PROVIDER_DB_DNSNAME": 'db'
-      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
-      "PROVIDER_DB_PASSWORD": "password"
-      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
-      "ES_ADMIN_PASSWORD": 'admin'
-      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
+        "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
+        "DB_USERNAME": 'dotcmsdbuser'
+        "DB_PASSWORD": 'password'
+        "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
     depends_on:
       - elasticsearch
       - db
@@ -46,7 +46,7 @@ services:
       - db_net
       - es_net
     ports:
-      - "8080:8081"
+      - "8080:8080"
       - "8443:8443"
 
   db:

--- a/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-2.yml
@@ -13,13 +13,13 @@ services:
   dotcms-node-2:
     image: dotcms/dotcms:latest
     environment:
-      "CMS_HEAP_SIZE": '1g'
-      "PROVIDER_DB_DNSNAME": 'db'
-      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
-      "PROVIDER_DB_PASSWORD": "password"
-      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
-      "ES_ADMIN_PASSWORD": 'admin'
-      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
+        "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
+        "DB_USERNAME": 'dotcmsdbuser'
+        "DB_PASSWORD": 'password'
+        "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
     volumes:
       #- {local_data_path}:/data/shared
       - {license_local_path}/license.zip:/data/shared/assets/license.zip
@@ -27,5 +27,5 @@ services:
       - dotcms-cluster-mode_db_net
       - dotcms-cluster-mode_es_net
     ports:
-      - "8081:8081"
+      - "8081:8080"
       - "8444:8443"

--- a/docker/docker-compose-examples/dotcms-push-publish/README.md
+++ b/docker/docker-compose-examples/dotcms-push-publish/README.md
@@ -1,0 +1,46 @@
+# Dotcms Push Publish
+
+Push publish environment where the sender runs on port 8080 and the receiver on 8081. Database: postgres
+
+## Usage
+
+####Environment setup
+
+
+1) A local path to license pack must be set here:
+
+```
+- {license_local_path}/license.zip:/data/shared/assets/license.zip
+```
+
+The license pack must contain at least two licenses (one for each node in the cluster)
+
+
+2) A local path to access data in the instance can be set uncommenting this line: 
+
+```
+#- {local_data_path}:/data/shared
+```
+
+3) A custom starter can be set through this line (uncomment and change the starter url accordingly): 
+
+```
+#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+```
+
+####Deploying nodes:
+
+```bash
+docker-compose -f docker-compose-node-sender.yml up
+docker-compose -f docker-compose-node-receiver.yml up
+
+```
+
+####Undeploying nodes:
+
+```bash
+docker-compose -f docker-compose-sender.yml down
+docker-compose -f docker-compose-receiver.yml down
+```
+
+**Important note:** `ctrl+c` does not destroy instances

--- a/docker/docker-compose-examples/dotcms-push-publish/README.md
+++ b/docker/docker-compose-examples/dotcms-push-publish/README.md
@@ -1,6 +1,8 @@
 # Dotcms Push Publish
 
-Push publish environment where the sender runs on port 8080 and the receiver on 8081. Database: postgres
+Push publish environment where the sender runs on port 8080 and the receiver on 8081. Database: postgres.
+
+**Important note:**  For the endpoint configuration, the local IP address must be used instead of `localhost` or `127.0.0.1`
 
 ## Usage
 
@@ -31,8 +33,8 @@ The license pack must contain at least two licenses (one for each node in the cl
 ####Deploying nodes:
 
 ```bash
-docker-compose -f docker-compose-node-sender.yml up
-docker-compose -f docker-compose-node-receiver.yml up
+docker-compose -f docker-compose-sender.yml up
+docker-compose -f docker-compose-receiver.yml up
 
 ```
 

--- a/docker/docker-compose-examples/dotcms-push-publish/docker-compose-receiver.yml
+++ b/docker/docker-compose-examples/dotcms-push-publish/docker-compose-receiver.yml
@@ -1,16 +1,15 @@
 version: '3.5'
 
 networks:
-  db_net:
-  es_net:
+  db_net_receiver:
+  es_net_receiver:
 
 volumes:
-  cms-shared:
-  dbdata:
-  esdata:
+  dbdata_receiver:
+  esdata_receiver:
 
 services:
-  elasticsearch:
+  elasticsearch-receiver:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
     environment:
       - cluster.name=elastic-cluster
@@ -22,34 +21,34 @@ services:
       - 9201:9200
       - 9601:9600
     volumes:
-      - esdata:/usr/share/elasticsearch/data
+      - esdata_receiver:/usr/share/elasticsearch/data
     networks:
-      - es_net
+      - es_net_receiver
 
-  dotcms:
+  dotcms-receiver:
     image: dotcms/dotcms:latest
     environment:
         "CATALINA_OPTS": ' -Xms1g -Xmx1g '
-        "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
+        "DB_BASE_URL": "jdbc:postgresql://db-receiver/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'
         "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
-        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch-receiver:9200'
         #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
     depends_on:
-      - elasticsearch
-      - db
+      - elasticsearch-receiver
+      - db-receiver
     volumes:
       #- {local_data_path}:/data/shared
       - {license_local_path}/license.zip:/data/shared/assets/license.zip
     networks:
-      - db_net
-      - es_net
+      - db_net_receiver
+      - es_net_receiver
     ports:
       - "8081:8080"
       - "8444:8443"
 
-  db:
+  db-receiver:
     image: postgres:11
     command: postgres -c 'max_connections=400' -c 'shared_buffers=128MB'
     environment:
@@ -57,6 +56,6 @@ services:
         "POSTGRES_PASSWORD": 'password'
         "POSTGRES_DB": 'dotcms'
     volumes:
-      - dbdata:/var/lib/postgresql/data
+      - dbdata_receiver:/var/lib/postgresql/data
     networks:
-      - db_net
+      - db_net_receiver

--- a/docker/docker-compose-examples/dotcms-push-publish/docker-compose-receiver.yml
+++ b/docker/docker-compose-examples/dotcms-push-publish/docker-compose-receiver.yml
@@ -1,0 +1,62 @@
+version: '3.5'
+
+networks:
+  db_net:
+  es_net:
+
+volumes:
+  cms-shared:
+  dbdata:
+  esdata:
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    environment:
+      - cluster.name=elastic-cluster
+      - discovery.type=single-node
+      - data
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xmx1G "
+    ports:
+      - 9201:9200
+      - 9601:9600
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - es_net
+
+  dotcms:
+    image: dotcms/dotcms:latest
+    environment:
+        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
+        "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
+        "DB_USERNAME": 'dotcmsdbuser'
+        "DB_PASSWORD": 'password'
+        "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
+    depends_on:
+      - elasticsearch
+      - db
+    volumes:
+      #- {local_data_path}:/data/shared
+      - {license_local_path}/license.zip:/data/shared/assets/license.zip
+    networks:
+      - db_net
+      - es_net
+    ports:
+      - "8081:8080"
+      - "8444:8443"
+
+  db:
+    image: postgres:11
+    command: postgres -c 'max_connections=400' -c 'shared_buffers=128MB'
+    environment:
+        "POSTGRES_USER": 'dotcmsdbuser'
+        "POSTGRES_PASSWORD": 'password'
+        "POSTGRES_DB": 'dotcms'
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+    networks:
+      - db_net

--- a/docker/docker-compose-examples/dotcms-push-publish/docker-compose-sender.yml
+++ b/docker/docker-compose-examples/dotcms-push-publish/docker-compose-sender.yml
@@ -1,0 +1,62 @@
+version: '3.5'
+
+networks:
+  db_net:
+  es_net:
+
+volumes:
+  cms-shared:
+  dbdata:
+  esdata:
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    environment:
+      - cluster.name=elastic-cluster
+      - discovery.type=single-node
+      - data
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xmx1G "
+    ports:
+      - 9200:9200
+      - 9600:9600
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - es_net
+
+  dotcms:
+    image: dotcms/dotcms:latest
+    environment:
+        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
+        "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
+        "DB_USERNAME": 'dotcmsdbuser'
+        "DB_PASSWORD": 'password'
+        "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
+    depends_on:
+      - elasticsearch
+      - db
+    volumes:
+      #- {local_data_path}:/data/shared
+      - {license_local_path}/license.zip:/data/shared/assets/license.zip
+    networks:
+      - db_net
+      - es_net
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+
+  db:
+    image: postgres:11
+    command: postgres -c 'max_connections=400' -c 'shared_buffers=128MB'
+    environment:
+        "POSTGRES_USER": 'dotcmsdbuser'
+        "POSTGRES_PASSWORD": 'password'
+        "POSTGRES_DB": 'dotcms'
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+    networks:
+      - db_net

--- a/docker/docker-compose-examples/dotcms-push-publish/docker-compose-sender.yml
+++ b/docker/docker-compose-examples/dotcms-push-publish/docker-compose-sender.yml
@@ -1,16 +1,15 @@
 version: '3.5'
 
 networks:
-  db_net:
-  es_net:
+  db_net_sender:
+  es_net_sender:
 
 volumes:
-  cms-shared:
-  dbdata:
-  esdata:
+  dbdata_sender:
+  esdata_sender:
 
 services:
-  elasticsearch:
+  elasticsearch-sender:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
     environment:
       - cluster.name=elastic-cluster
@@ -22,34 +21,34 @@ services:
       - 9200:9200
       - 9600:9600
     volumes:
-      - esdata:/usr/share/elasticsearch/data
+      - esdata_sender:/usr/share/elasticsearch/data
     networks:
-      - es_net
+      - es_net_sender
 
-  dotcms:
+  dotcms-sender:
     image: dotcms/dotcms:latest
     environment:
         "CATALINA_OPTS": ' -Xms1g -Xmx1g '
-        "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
+        "DB_BASE_URL": "jdbc:postgresql://db-sender/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'
         "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
-        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch-sender:9200'
         #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
     depends_on:
-      - elasticsearch
-      - db
+      - elasticsearch-sender
+      - db-sender
     volumes:
       #- {local_data_path}:/data/shared
       - {license_local_path}/license.zip:/data/shared/assets/license.zip
     networks:
-      - db_net
-      - es_net
+      - db_net_sender
+      - es_net_sender
     ports:
       - "8080:8080"
       - "8443:8443"
 
-  db:
+  db-sender:
     image: postgres:11
     command: postgres -c 'max_connections=400' -c 'shared_buffers=128MB'
     environment:
@@ -57,6 +56,6 @@ services:
         "POSTGRES_PASSWORD": 'password'
         "POSTGRES_DB": 'dotcms'
     volumes:
-      - dbdata:/var/lib/postgresql/data
+      - dbdata_sender:/var/lib/postgresql/data
     networks:
-      - db_net
+      - db_net_sender

--- a/docker/docker-compose-examples/dotcms-redis/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/dotcms-redis/docker-compose-node-1.yml
@@ -30,16 +30,16 @@ services:
   dotcms-node-1:
     image: dotcms/dotcms:latest
     environment:
-      "CMS_HEAP_SIZE": '1g'
-      "PROVIDER_DB_DNSNAME": 'db'
-      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
-      "PROVIDER_DB_PASSWORD": "password"
-      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
-      "ES_ADMIN_PASSWORD": 'admin'
-      "DOT_DOT_PUBSUB_PROVIDER_OVERRIDE": 'com.dotcms.dotpubsub.RedisPubSubImpl'
-      "DOT_REDIS_LETTUCECLIENT_URLS": 'redis://MY_SECRET_P4SS@redis'
-      "DOT_CACHE_DEFAULT_CHAIN": 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
-      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
+        "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
+        "DB_USERNAME": 'dotcmsdbuser'
+        "DB_PASSWORD": 'password'
+        "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        "DOT_DOT_PUBSUB_PROVIDER_OVERRIDE": 'com.dotcms.dotpubsub.RedisPubSubImpl'
+        "DOT_REDIS_LETTUCECLIENT_URLS": 'redis://MY_SECRET_P4SS@redis'
+        "DOT_CACHE_DEFAULT_CHAIN": 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
+        #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
     depends_on:
       - elasticsearch
       - db
@@ -52,7 +52,7 @@ services:
       - es_net
       - redis_net
     ports:
-      - "8080:8081"
+      - "8080:8080"
       - "8443:8443"
       
   redis:

--- a/docker/docker-compose-examples/dotcms-redis/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/dotcms-redis/docker-compose-node-2.yml
@@ -15,16 +15,16 @@ services:
   dotcms-node-2:
     image: dotcms/dotcms:latest
     environment:
-      "CMS_HEAP_SIZE": '1g'
-      "PROVIDER_DB_DNSNAME": 'db'
-      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
-      "PROVIDER_DB_PASSWORD": "password"
-      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
-      "ES_ADMIN_PASSWORD": 'admin'
-      "DOT_DOT_PUBSUB_PROVIDER_OVERRIDE": 'com.dotcms.dotpubsub.RedisPubSubImpl'
-      "DOT_REDIS_LETTUCECLIENT_URLS": 'redis://MY_SECRET_P4SS@redis'
-      "DOT_CACHE_DEFAULT_CHAIN": 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
-      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
+        "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
+        "DB_USERNAME": 'dotcmsdbuser'
+        "DB_PASSWORD": 'password'
+        "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        "DOT_DOT_PUBSUB_PROVIDER_OVERRIDE": 'com.dotcms.dotpubsub.RedisPubSubImpl'
+        "DOT_REDIS_LETTUCECLIENT_URLS": 'redis://MY_SECRET_P4SS@redis'
+        "DOT_CACHE_DEFAULT_CHAIN": 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
+        #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
     volumes:
       #- {local_data_path}:/data/shared
       - {license_local_path}/license.zip:/data/shared/assets/license.zip
@@ -33,5 +33,5 @@ services:
       - dotcms-redis_es_net
       - dotcms-redis_redis_net
     ports:
-      - "8081:8081"
+      - "8081:8080"
       - "8444:8443"

--- a/docker/docker-compose-examples/dotcms-single-node/docker-compose.yml
+++ b/docker/docker-compose-examples/dotcms-single-node/docker-compose.yml
@@ -29,13 +29,13 @@ services:
   dotcms:
     image: dotcms/dotcms:latest
     environment:
-      "CMS_HEAP_SIZE": '1g'
-      "PROVIDER_DB_DNSNAME": 'db'
-      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
-      "PROVIDER_DB_PASSWORD": "password"
-      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
-      "ES_ADMIN_PASSWORD": 'admin'
-      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
+        "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
+        "DB_USERNAME": 'dotcmsdbuser'
+        "DB_PASSWORD": 'password'
+        "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
     depends_on:
       - elasticsearch
       - db
@@ -46,7 +46,7 @@ services:
       - db_net
       - es_net
     ports:
-      - "8080:8081"
+      - "8080:8080"
       - "8443:8443"
 
   db:

--- a/docker/docker-compose-examples/dotcms-with-kibana/docker-compose.yml
+++ b/docker/docker-compose-examples/dotcms-with-kibana/docker-compose.yml
@@ -38,13 +38,13 @@ services:
   dotcms:
     image: dotcms/dotcms:latest
     environment:
-      "CMS_HEAP_SIZE": '1g'
-      "PROVIDER_DB_DNSNAME": 'db'
-      "PROVIDER_DB_USERNAME": "dotcmsdbuser"
-      "PROVIDER_DB_PASSWORD": "password"
-      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
-      "ES_ADMIN_PASSWORD": 'admin'
-      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
+        "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
+        "DB_USERNAME": 'dotcmsdbuser'
+        "DB_PASSWORD": 'password'
+        "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
     depends_on:
       - elasticsearch
       - db
@@ -55,7 +55,7 @@ services:
       - db_net
       - es_net
     ports:
-      - "8080:8081"
+      - "8080:8080"
       - "8443:8443"
 
   db:

--- a/docker/docker-compose-examples/dotcms-with-oracle/docker-compose.yml
+++ b/docker/docker-compose-examples/dotcms-with-oracle/docker-compose.yml
@@ -29,16 +29,16 @@ services:
   dotcms:
     image: dotcms/dotcms:latest
     environment:
-      "CMS_HEAP_SIZE": '1g'
-      "PROVIDER_DB_DNSNAME": '{ip_address}'
-      "PROVIDER_DB_URL": 'jdbc:oracle:thin:@{ip_address}:1521:XE'
-      "PROVIDER_DB_DRIVER": 'ORACLE'
-      "PROVIDER_DB_USERNAME": "oracle"
-      "PROVIDER_DB_PASSWORD": "oracle"
-      "PROVIDER_ELASTICSEARCH_ENDPOINTS": 'http://elasticsearch:9200'
-      "ES_ADMIN_PASSWORD": 'admin'
-      "TZ": UTC
-      #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20210920/starter-20210920.zip'
+        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
+        "DB_BASE_URL": "jdbc:oracle:thin:@{ip_address}:1521:XE"
+        "DB_USERNAME": 'oracle'
+        "DB_PASSWORD": 'oracle'
+        "DOT_ES_AUTH_BASIC_PASSWORD": 'admin'
+        "DOT_ES_ENDPOINTS": 'http://elasticsearch:9200'
+        "DB_DRIVER": 'oracle.jdbc.OracleDriver'
+        "ES_ADMIN_PASSWORD": 'admin'
+        "TZ": UTC
+        #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
     depends_on:
       - elasticsearch
     volumes:


### PR DESCRIPTION
The docker compose examples were updated to make them compatible with the new dotCMS docker image.

Besides, a new example was included to deploy a PP environment.