### PR TITLE
Issue 21488 support smtps in mailer class

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -36,6 +36,7 @@ import com.dotcms.enterprise.rules.RulesAPIImplIntegrationTest;
 import com.dotcms.graphql.DotGraphQLHttpServletTest;
 import com.dotcms.integritycheckers.HostIntegrityCheckerTest;
 import com.dotcms.junit.MainBaseSuite;
+import com.dotcms.mail.MailAPIImplTest;
 import com.dotcms.mock.request.CachedParameterDecoratorTest;
 import com.dotcms.publisher.bundle.business.BundleAPITest;
 import com.dotcms.publisher.bundle.business.BundleFactoryTest;
@@ -508,7 +509,8 @@ import org.junit.runners.Suite.SuiteClasses;
         ContentSecurityPolicyUtilTest.class,
         MessageToolTest.class,
         XmlToolTest.class,
-        LanguageFolderTest.class
+        LanguageFolderTest.class,
+        MailAPIImplTest.class
 })
 public class MainSuite {
 

--- a/dotCMS/src/integration-test/java/com/dotcms/mail/MailAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/mail/MailAPIImplTest.java
@@ -90,19 +90,37 @@ public class MailAPIImplTest {
         properties.setProperty("mail.smtp.auth", "false");
         authenticator = new MailAPIImpl(properties).createAuthenticator();
         assert(authenticator ==null);
-        
-        
-        // Test no password
-        properties.setProperty("mail.smtp.auth", "true");
-        properties.setProperty("mail.smtp.user", "test");
+
+        // test smtps.auth=false
+        properties.setProperty("mail.smtps.auth", "false");
         authenticator = new MailAPIImpl(properties).createAuthenticator();
         assert(authenticator ==null);
         
         
-        // Test password
+        // Test no password (smtp)
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.user", "test");
+        authenticator = new MailAPIImpl(properties).createAuthenticator();
+        assert(authenticator ==null);
+
+
+        // Test no password (smtps)
+        properties.setProperty("mail.smtps.auth", "true");
+        properties.setProperty("mail.smtps.user", "test");
+        authenticator = new MailAPIImpl(properties).createAuthenticator();
+        assert(authenticator ==null);
+
+        // Test password (smtp)
         properties.setProperty("mail.smtp.auth", "true");
         properties.setProperty("mail.smtp.user", "test");
         properties.setProperty("mail.smtp.password", "test");
+        authenticator = new MailAPIImpl(properties).createAuthenticator();
+        assert(authenticator !=null);
+
+        // Test password (smtps)
+        properties.setProperty("mail.smtps.auth", "true");
+        properties.setProperty("mail.smtps.user", "test");
+        properties.setProperty("mail.smtps.password", "test");
         authenticator = new MailAPIImpl(properties).createAuthenticator();
         assert(authenticator !=null);
     }

--- a/dotCMS/src/main/java/com/dotcms/mail/MailAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/mail/MailAPI.java
@@ -18,15 +18,9 @@ public interface MailAPI {
      */
     enum Keys {
 
-        HOST("mail.smtp.host"),
-        PORT("mail.smtp.port"),
-        TIMEOUT("mail.smtp.connectiontimeout"),
-        ENABLED("mail.smtp.auth"),
-        EHLO("mail.smtp.ehlo"),
+        TRANSPORT_PROTOCOL("mail.transport.protocol"),
         USER("mail.user"),
-        SMTP_USER("mail.smtp.user"),
-        PASSWORD("mail.password"),
-        SMTP_PASSWORD("mail.smtp.password");
+        PASSWORD("mail.password");
 
         private final String value;
 

--- a/dotCMS/src/main/java/com/dotcms/mail/MailAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/mail/MailAPI.java
@@ -38,6 +38,9 @@ public interface MailAPI {
         }
     }
 
+    int DEFAULT_MAIL_PORT = 25;
+    String DEFAULT_MAIL_PROTOCOL = "smtp";
+
     /**
      * Default JNDI dir for the mail session
      */

--- a/dotCMS/src/main/java/com/dotcms/mail/MailAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/mail/MailAPI.java
@@ -49,6 +49,10 @@ public interface MailAPI {
      */
     Optional<Session> loadMailSessionFromContext();
 
+    int getConnectionPort();
+
+    String getConnectionHost();
+
     /**
      * True if has a mail session in the context
      * @return Boolean

--- a/dotCMS/src/main/java/com/dotcms/mail/MailAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/mail/MailAPIImpl.java
@@ -41,13 +41,13 @@ public class MailAPIImpl implements MailAPI {
 
     private String getProtocol(){
         return this.properties.containsKey(Keys.TRANSPORT_PROTOCOL.getValue())
-                ? this.properties.getProperty(Keys.TRANSPORT_PROTOCOL.getValue()) : "smtp";
+                ? this.properties.getProperty(Keys.TRANSPORT_PROTOCOL.getValue()) : DEFAULT_MAIL_PROTOCOL;
     }
 
     @Override
     public int getConnectionPort(){
         return this.properties.containsKey("mail." + protocol.get() + ".port")?
-                Integer.parseInt(this.properties.getProperty("mail." + protocol.get() + ".port")):25;
+                Integer.parseInt(this.properties.getProperty("mail." + protocol.get() + ".port")): DEFAULT_MAIL_PORT;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/mail/MailAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/mail/MailAPIImpl.java
@@ -21,6 +21,8 @@ public class MailAPIImpl implements MailAPI {
             new MailAPIImpl().loadMailSessionFromContext()
                     .orElse(new MailAPIImpl().createNewMailContext()));
 
+    private static Lazy<String> protocol = Lazy.of(() -> new MailAPIImpl().getProtocol());
+
     private final Properties properties;
 
     public MailAPIImpl() {
@@ -35,6 +37,23 @@ public class MailAPIImpl implements MailAPI {
     @Override
     public Session getMailSession() {
         return mailSessionHolder.get();
+    }
+
+    private String getProtocol(){
+        return this.properties.containsKey(Keys.TRANSPORT_PROTOCOL.getValue())
+                ? this.properties.getProperty(Keys.TRANSPORT_PROTOCOL.getValue()) : "smtp";
+    }
+
+    @Override
+    public int getConnectionPort(){
+        return this.properties.containsKey("mail." + protocol.get() + ".port")?
+                Integer.parseInt(this.properties.getProperty("mail." + protocol.get() + ".port")):25;
+    }
+
+    @Override
+    public String getConnectionHost(){
+        return this.properties.containsKey("mail." + protocol.get() + ".host")?
+                this.properties.getProperty("mail." + protocol.get() + ".host"):"localhost";
     }
 
     @Override
@@ -74,18 +93,15 @@ public class MailAPIImpl implements MailAPI {
     @VisibleForTesting
     Authenticator createAuthenticator() {
 
-        final String protocol = this.properties.containsKey(Keys.TRANSPORT_PROTOCOL.getValue())
-                ? this.properties.getProperty(Keys.TRANSPORT_PROTOCOL.getValue()) : "smtp";
-
-        final boolean enabled = "true".equalsIgnoreCase(this.properties.getProperty("mail." + protocol + ".auth"));
+        final boolean enabled = "true".equalsIgnoreCase(this.properties.getProperty("mail." + protocol.get() + ".auth"));
 
         if (!enabled) {
 
             return null;
         }
 
-        final String userKey = "mail." + protocol + ".user";
-        final String passwordKey = "mail." + protocol + ".password";
+        final String userKey = "mail." + protocol.get() + ".user";
+        final String passwordKey = "mail." + protocol.get() + ".password";
 
         final String user = this.properties.containsKey(userKey)?
                                 this.properties.getProperty(userKey):

--- a/dotCMS/src/main/java/com/dotcms/mail/MailAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/mail/MailAPIImpl.java
@@ -62,7 +62,6 @@ public class MailAPIImpl implements MailAPI {
     private Session createNewMailContext() {
 
         final Session session = Session.getInstance(this.properties, createAuthenticator());
-
         // bind session if not already there
         if (!hasMailInContext()) {
             Try.run(() -> new InitialContext().bind(MAIL_JNDI_NAME, session))
@@ -75,19 +74,25 @@ public class MailAPIImpl implements MailAPI {
     @VisibleForTesting
     Authenticator createAuthenticator() {
 
-        final boolean enabled = "true".equalsIgnoreCase(this.properties.getProperty(Keys.ENABLED.getValue()));
+        final String protocol = this.properties.containsKey(Keys.TRANSPORT_PROTOCOL.getValue())
+                ? this.properties.getProperty(Keys.TRANSPORT_PROTOCOL.getValue()) : "smtp";
+
+        final boolean enabled = "true".equalsIgnoreCase(this.properties.getProperty("mail." + protocol + ".auth"));
 
         if (!enabled) {
 
             return null;
         }
 
-        final String user = this.properties.containsKey(Keys.SMTP_USER.getValue())?
-                                this.properties.getProperty(Keys.SMTP_USER.getValue()):
+        final String userKey = "mail." + protocol + ".user";
+        final String passwordKey = "mail." + protocol + ".password";
+
+        final String user = this.properties.containsKey(userKey)?
+                                this.properties.getProperty(userKey):
                                 this.properties.getProperty(Keys.USER.getValue());
 
-        final String password = this.properties.containsKey(Keys.SMTP_PASSWORD.getValue())?
-                                this.properties.getProperty(Keys.SMTP_PASSWORD.getValue()):
+        final String password = this.properties.containsKey(passwordKey)?
+                                this.properties.getProperty(passwordKey):
                                 this.properties.getProperty(Keys.PASSWORD.getValue());
 
         if(user==null || password==null) {

--- a/dotCMS/src/main/java/com/dotcms/mail/MailConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/mail/MailConfig.java
@@ -1,5 +1,6 @@
 package com.dotcms.mail;
 
+import com.dotcms.mail.MailAPI.Keys;
 import java.util.Properties;
 import com.dotmarketing.util.Config;
 import io.vavr.Lazy;
@@ -27,8 +28,11 @@ class MailConfig {
 
         final Properties properties = new Properties();
 
-        properties.setProperty(MailAPI.Keys.HOST.getValue(),       "localhost");
-        properties.setProperty(MailAPI.Keys.SMTP_USER.getValue(), "dotCMS");
+        final String protocol = properties.containsKey(Keys.TRANSPORT_PROTOCOL.getValue())
+                ? properties.getProperty(Keys.TRANSPORT_PROTOCOL.getValue()) : "smtp";
+
+        properties.setProperty("mail." + protocol + ".host", "localhost");
+        properties.setProperty("mail." + protocol + ".user", "dotCMS");
 
         Config.getKeys().forEachRemaining(origKey -> {
             final String lowerKey = origKey.toLowerCase();

--- a/dotCMS/src/main/java/com/dotcms/mail/MailConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/mail/MailConfig.java
@@ -1,5 +1,7 @@
 package com.dotcms.mail;
 
+import static com.dotcms.mail.MailAPI.DEFAULT_MAIL_PROTOCOL;
+
 import com.dotcms.mail.MailAPI.Keys;
 import java.util.Properties;
 import com.dotmarketing.util.Config;
@@ -29,7 +31,7 @@ class MailConfig {
         final Properties properties = new Properties();
 
         final String protocol = properties.containsKey(Keys.TRANSPORT_PROTOCOL.getValue())
-                ? properties.getProperty(Keys.TRANSPORT_PROTOCOL.getValue()) : "smtp";
+                ? properties.getProperty(Keys.TRANSPORT_PROTOCOL.getValue()) : DEFAULT_MAIL_PROTOCOL;
 
         properties.setProperty("mail." + protocol + ".host", "localhost");
         properties.setProperty("mail." + protocol + ".user", "dotCMS");

--- a/dotCMS/src/main/java/com/dotmarketing/util/Mailer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Mailer.java
@@ -356,7 +356,9 @@ public class Mailer {
 			}
 			message.setSubject(subject, encoding);
 			message.setContent(mp);
-			session.getTransport().sendMessage(message, message.getAllRecipients());
+			Transport transport = session.getTransport();
+			transport.connect();
+			transport.sendMessage(message, message.getAllRecipients());
 			result = "Send Ok";
 			return true;
 		} catch (javax.mail.SendFailedException f) {

--- a/dotCMS/src/main/java/com/dotmarketing/util/Mailer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Mailer.java
@@ -356,7 +356,7 @@ public class Mailer {
 			}
 			message.setSubject(subject, encoding);
 			message.setContent(mp);
-			Transport.send(message);
+			session.getTransport().sendMessage(message, message.getAllRecipients());
 			result = "Send Ok";
 			return true;
 		} catch (javax.mail.SendFailedException f) {

--- a/dotCMS/src/main/java/com/dotmarketing/util/Mailer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Mailer.java
@@ -356,8 +356,10 @@ public class Mailer {
 			}
 			message.setSubject(subject, encoding);
 			message.setContent(mp);
-			Transport transport = session.getTransport();
-			transport.connect();
+
+			final Transport transport = session.getTransport();
+			transport.connect(APILocator.getMailApi().getConnectionHost(),
+					APILocator.getMailApi().getConnectionPort(), null, null);
 			transport.sendMessage(message, message.getAllRecipients());
 			result = "Send Ok";
 			return true;


### PR DESCRIPTION
They way we used to send emails was changed in Mailer.java to support `smtps` because the method `Transport.send()` uses `smtp` by default.

Besides, MailAPIImpl.java was modified to be able to initialize the authenticator using smtps. 

Other than that, some cleanup was applied.