### PR TITLE
dotCMS/core#Add backdrop-filter to our popup overlay background

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dojo/custom-build/dijit/themes/dijit.css
+++ b/dotCMS/src/main/webapp/html/js/dojo/custom-build/dijit/themes/dijit.css
@@ -1615,6 +1615,7 @@ div.dijitTabDisabled, .dj_ie div.dijitTabDisabled {
 	cursor: pointer;
 }
 .dijitDialogUnderlayWrapper {
+	backdrop-filter: blur(5px);
 	position: absolute;
 	left: 0;
 	top: 0;


### PR DESCRIPTION
We want to make the app looks more "appy" (Jason's words) so for the overlay of the dialogs we want to add:

    backdrop-filter: blur(5px);