### PR TITLE
#21632 adding test when not attrs only name id

### DIFF
--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     felix group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.25'
     felix group: 'com.dotcms.tika', name: 'com.dotcms.tika', version: '0.2'
 
-    felix group: 'com.dotcms.samlbundle', name: 'com.dotcms.samlbundle', version: '21.04'
+    felix group: 'com.dotcms.samlbundle', name: 'com.dotcms.samlbundle', version: '22.03'
     /**** And now the libs we pull in from internal company sources - libs stored in ./plugins, ./bin, ./libs, the starter site, etc. ****/
     compile fileTree("src/main/plugins/com.dotcms.config/build/jar").include('plugin-com.dotcms.config.jar')
 

--- a/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
@@ -313,7 +313,7 @@ public class SAMLHelperTest extends IntegrationTestBase {
 
     /**
      * Method to test: {@link SAMLHelper#createNewUser(User, Attributes, IdentityProviderConfiguration)}
-     * Given Scenario: creates an user only with name id
+     * Given Scenario: creates an user with all properties
      * ExpectedResult: The user is created successfully with random values
      *
      */

--- a/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
@@ -10,6 +10,7 @@ import com.dotcms.saml.SamlAuthenticationService;
 import com.dotcms.saml.SamlConfigurationService;
 import com.dotcms.saml.SamlName;
 import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.RegEX;
@@ -27,6 +28,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Writer;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -282,6 +284,31 @@ public class SAMLHelperTest extends IntegrationTestBase {
         final String roleResult   = samlHelper.processReplacement(tokenRole, substitutionTokenOpt);
 
         Assert.assertEquals(expected, roleResult);
+    }
+
+    /**
+     * Method to test: {@link SAMLHelper#createNewUser(User, Attributes, IdentityProviderConfiguration)}
+     * Given Scenario: creates an user only with name id
+     * ExpectedResult: The user is created successfully with random values
+     *
+     */
+    @Test()
+    public void test_createNewUser_non_Attrs() throws NoSuchAlgorithmException {
+
+        final SamlAuthenticationService samlAuthenticationService         = new MockSamlAuthenticationService();
+        final CompanyAPI companyAPI                                       = mock(CompanyAPI.class);
+        final Company    company                                          = new Company();
+        final SAMLHelper           		samlHelper                        = new SAMLHelper(samlAuthenticationService, companyAPI);
+
+        company.setAuthType(Company.AUTH_TYPE_EA);
+        when(companyAPI.getDefaultCompany()).thenReturn(company);
+        final IdentityProviderConfiguration identityProviderConfiguration = mock(IdentityProviderConfiguration.class);
+        final Attributes attrs = new Attributes.Builder().nameID(UUID.randomUUID()).build();
+
+        final User user = samlHelper.createNewUser(APILocator.systemUser(), attrs, identityProviderConfiguration);
+
+        Assert.assertNotNull(user);
+        Assert.assertEquals(samlHelper.hashIt(attrs.getNameID().toString()), user.getUserId());
     }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
@@ -311,4 +311,34 @@ public class SAMLHelperTest extends IntegrationTestBase {
         Assert.assertEquals(samlHelper.hashIt(attrs.getNameID().toString()), user.getUserId());
     }
 
+    /**
+     * Method to test: {@link SAMLHelper#createNewUser(User, Attributes, IdentityProviderConfiguration)}
+     * Given Scenario: creates an user only with name id
+     * ExpectedResult: The user is created successfully with random values
+     *
+     */
+    @Test()
+    public void test_createNewUser_known_Attrs() throws NoSuchAlgorithmException {
+
+        final SamlAuthenticationService samlAuthenticationService         = new MockSamlAuthenticationService();
+        final CompanyAPI companyAPI                                       = mock(CompanyAPI.class);
+        final Company    company                                          = new Company();
+        final SAMLHelper           		samlHelper                        = new SAMLHelper(samlAuthenticationService, companyAPI);
+
+        company.setAuthType(Company.AUTH_TYPE_EA);
+        when(companyAPI.getDefaultCompany()).thenReturn(company);
+        final IdentityProviderConfiguration identityProviderConfiguration = mock(IdentityProviderConfiguration.class);
+        final String uuid = UUID.randomUUID().toString();
+        final Attributes attrs = new Attributes.Builder().nameID(uuid).email(uuid+"@dotcms.com.cr").firstName("John").lastName("Sn").build();
+
+        final User user = samlHelper.createNewUser(APILocator.systemUser(), attrs, identityProviderConfiguration);
+
+        Assert.assertNotNull(user);
+        Assert.assertEquals(samlHelper.hashIt(attrs.getNameID().toString()), user.getUserId());
+        Assert.assertEquals(uuid+"@dotcms.com.cr", attrs.getEmail());
+        Assert.assertEquals("John", attrs.getFirstName());
+        Assert.assertEquals("Sn", attrs.getLastName());
+    }
+
+
 }

--- a/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/SAMLHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/SAMLHelper.java
@@ -485,7 +485,8 @@ public class SAMLHelper {
         return null == rolePatterns ? DotSamlConstants.NULL : Arrays.asList(rolePatterns).toString();
     }
 
-    private String hashIt (final String token) throws NoSuchAlgorithmException {
+    @VisibleForTesting
+    protected String hashIt (final String token) throws NoSuchAlgorithmException {
 
         final String hashed = Encryptor.Hashing.sha256().append(token.getBytes(StandardCharsets.UTF_8)).buildUnixHash();
         return org.apache.commons.lang3.StringUtils.abbreviate(hashed, Config.getIntProperty("dotcms.user.id.maxlength", 100));

--- a/dotCMS/src/main/java/com/dotcms/saml/Attributes.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/Attributes.java
@@ -1,5 +1,8 @@
 package com.dotcms.saml;
 
+import com.dotmarketing.util.UUIDUtil;
+import com.dotmarketing.util.UtilMethods;
+
 import java.io.Serializable;
 
 /**
@@ -34,9 +37,10 @@ public class Attributes implements Serializable {
 
 	private Attributes(final Builder builder) {
 
-		this.email        = builder.email;
-		this.lastName     = builder.lastName;
-		this.firstName    = builder.firstName;
+		final String uuid = UUIDUtil.uuid();
+		this.email        = UtilMethods.isSet(builder.email)?     builder.email:     uuid+"@dotcms.com";
+		this.lastName     = UtilMethods.isSet(builder.lastName)?  builder.lastName:  uuid+"lastName";
+		this.firstName    = UtilMethods.isSet(builder.firstName)? builder.firstName: uuid+"firstName";
 		this.addRoles     = builder.addRoles;
 		this.roles        = builder.roles;
 		this.nameID       = builder.nameID;


### PR DESCRIPTION
This PR allows the creation of the user without email, lastname or name from the SAML  attributes