### PR TITLE
Reinstate CMS_JAVA_OPTS

### DIFF
--- a/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-1.yml
@@ -29,7 +29,6 @@ services:
   dotcms-node-1:
     image: dotcms/dotcms:latest
     environment:
-        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/dotcms-cluster-mode/docker-compose-node-2.yml
@@ -13,7 +13,6 @@ services:
   dotcms-node-2:
     image: dotcms/dotcms:latest
     environment:
-        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/dotcms-push-publish/docker-compose-receiver.yml
+++ b/docker/docker-compose-examples/dotcms-push-publish/docker-compose-receiver.yml
@@ -28,7 +28,6 @@ services:
   dotcms-receiver:
     image: dotcms/dotcms:latest
     environment:
-        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
         "DB_BASE_URL": "jdbc:postgresql://db-receiver/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/dotcms-push-publish/docker-compose-sender.yml
+++ b/docker/docker-compose-examples/dotcms-push-publish/docker-compose-sender.yml
@@ -28,7 +28,6 @@ services:
   dotcms-sender:
     image: dotcms/dotcms:latest
     environment:
-        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
         "DB_BASE_URL": "jdbc:postgresql://db-sender/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/dotcms-redis/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/dotcms-redis/docker-compose-node-1.yml
@@ -30,7 +30,6 @@ services:
   dotcms-node-1:
     image: dotcms/dotcms:latest
     environment:
-        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/dotcms-redis/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/dotcms-redis/docker-compose-node-2.yml
@@ -15,7 +15,6 @@ services:
   dotcms-node-2:
     image: dotcms/dotcms:latest
     environment:
-        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/dotcms-single-node/docker-compose.yml
+++ b/docker/docker-compose-examples/dotcms-single-node/docker-compose.yml
@@ -29,7 +29,6 @@ services:
   dotcms:
     image: dotcms/dotcms:latest
     environment:
-        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/dotcms-with-kibana/docker-compose.yml
+++ b/docker/docker-compose-examples/dotcms-with-kibana/docker-compose.yml
@@ -38,7 +38,6 @@ services:
   dotcms:
     image: dotcms/dotcms:latest
     environment:
-        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/dotcms-with-oracle/docker-compose.yml
+++ b/docker/docker-compose-examples/dotcms-with-oracle/docker-compose.yml
@@ -29,7 +29,6 @@ services:
   dotcms:
     image: dotcms/dotcms:latest
     environment:
-        "CATALINA_OPTS": ' -Xms1g -Xmx1g '
         "DB_BASE_URL": "jdbc:oracle:thin:@{ip_address}:1521:XE"
         "DB_USERNAME": 'oracle'
         "DB_PASSWORD": 'oracle'

--- a/docker/dotcms/ROOT/srv/00-config-defaults.sh
+++ b/docker/dotcms/ROOT/srv/00-config-defaults.sh
@@ -26,7 +26,7 @@ export JAVA_OPTS=${JAVA_OPTS:-"$JAVA_OPTS_BASE $JAVA_OPTS_AGENT $JAVA_OPTS_MEMOR
 export CMS_CONNECTOR_THREADS=${CMS_CONNECTOR_THREADS:-"600"}
 
 # SMTP hostname for CMS
-export CMS_SMTP_HOST=${CMS_SMTP_HOST:-"smtp.dotcms.site"}
+export DOT_MAIL_SMTP_HOST=${DOT_MAIL_SMTP_HOST:-"smtp.dotcms.site"}
 export DOT_MAIL_SMTP_SSL_PROTOCOLS=${DOT_MAIL_SMTP_SSL_PROTOCOLS:-"TLSv1.2"}
 
 # tomcat gzip compression

--- a/docker/dotcms/ROOT/srv/00-config-defaults.sh
+++ b/docker/dotcms/ROOT/srv/00-config-defaults.sh
@@ -17,7 +17,9 @@ export TOMCAT_HOME=$( find /srv/dotserver/ -type d -name "tomcat-*" )
 export JAVA_OPTS_BASE=${JAVA_OPTS_BASE:-"-Djava.awt.headless=true -Xverify:none -Dfile.encoding=UTF8 -server -XX:+DisableExplicitGC -Dpdfbox.fontcache=/data/local/dotsecure -Dlog4j2.formatMsgNoLookups=true -Djava.library.path=/usr/lib/x86_64-linux-gnu/"}
 export JAVA_OPTS_AGENT=${JAVA_OPTS_AGENT:-"-javaagent:${TOMCAT_HOME}/webapps/ROOT/WEB-INF/lib/byte-buddy-agent-1.9.0.jar"}
 export JAVA_OPTS_MEMORY=${JAVA_OPTS_MEMORY:-"-Xmx1G"}
-export JAVA_OPTS=${JAVA_OPTS:-"$JAVA_OPTS_BASE $JAVA_OPTS_AGENT $JAVA_OPTS_MEMORY"}
+
+# $CMS_JAVA_OPTS is last so it trumps them all
+export JAVA_OPTS=${JAVA_OPTS:-"$JAVA_OPTS_BASE $JAVA_OPTS_AGENT $JAVA_OPTS_MEMORY $CMS_JAVA_OPTS"}
 
 
 # Maximum number of Tomcat Connector threadpool threads (shared across Connectors)


### PR DESCRIPTION
We removed the `CMS_JAVA_OPTS` setting which was added last to the java options and allowed a user to override anything that was set before it.

Besides, the docker-compose-examples were updated and the property used to configure smtp host was renamed