### PR TITLE
#21699 : Single quote in content's title breaks JS code

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_audit_list.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_audit_list.jsp
@@ -436,7 +436,7 @@
 					assetTitleAsObject.toString() : StringPool.BLANK;
 		%>
 				addRow({
-					title: '<%=StringEscapeUtils.escapeHtml(assetTitle)%>',
+					title: '<%=StringEscapeUtils.escapeJavaScript(assetTitle)%>',
 					type: '<%=assetType%>',
 					bundleId: '<%=publishAuditStatus.getBundleId()%>',
 					isHtml: <%=asset.get(PublishQueueElementTransformer.HTML_PAGE_KEY)%>
@@ -461,28 +461,31 @@
 
 	function addShowMoreMessage(bundleId, nAssets){
 		let td = document.getElementById("td_assets_" + bundleId);
-
+		let MAX_ASSETS_TO_SHOW = <%= MAX_ASSETS_TO_SHOW %>;
 		let newRow = td.insertRow();
 		let newCell = newRow.insertCell();
-
-		newCell.innerHTML += nAssets + ' <%=LanguageUtil.get(pageContext, "publisher_audit_more_assets") %>&nbsp;' +
-				"<a href=\"javascript:requestAssets('" + bundleId + "')\">" +
+		var remaining = 0;
+		if (nAssets > MAX_ASSETS_TO_SHOW) {
+			remaining = nAssets - MAX_ASSETS_TO_SHOW;
+		}
+		newCell.innerHTML += remaining + ' <%=LanguageUtil.get(pageContext, "publisher_audit_more_assets") %>&nbsp;' +
+				"<a href=\"javascript:requestAssets('" + bundleId + "', -1, " + nAssets + ")\">" +
 				"<strong id='view_all_" + bundleId + "' class='view_link' style=\"text-decoration: underline;\"><%=LanguageUtil.get(pageContext, "bundles.view.all") %></strong>" +
 				"</a>";
 	}
 
 
-	function addShowLessMessage(bundleId){
+	function addShowLessMessage(bundleId, numberToShow){
 		let td = document.getElementById("td_assets_" + bundleId);
 		let newRow = td.insertRow();
 		let newCell = newRow.insertCell();
 		newCell.innerHTML +=  '<%=LanguageUtil.get(pageContext, "bundles.item.all.show") %>&nbsp;' +
-				"<a href=\"javascript:requestAssets('" + bundleId + "', 3)\">" +
+				"<a href=\"javascript:requestAssets('" + bundleId + "', <%= MAX_ASSETS_TO_SHOW %>, " + numberToShow + ")\">" +
 				"<strong id='view_less_" + bundleId + "' class='view_link' style=\"text-decoration: underline;\"><%=LanguageUtil.get(pageContext, "bundles.item.less.show")%></strong>" +
 				"</a>";
 	}
 
-	function requestAssets(bundleId, numberToShow = -1){
+	function requestAssets(bundleId, numberToShow = -1, totalAssets){
 		let viewAllNode = (numberToShow === -1) ? document.getElementById('view_all_' + bundleId) : document.getElementById('view_less_' + bundleId);
 
 		if (viewAllNode) {
@@ -496,10 +499,10 @@
 			}
 
 			if (numberToShow !== -1) {
-				addShowMoreMessage(bundleId, data.length);
+				addShowMoreMessage(bundleId, totalAssets);
 				data = data.slice(0, numberToShow);
 			} else {
-				addShowLessMessage(bundleId);
+				addShowLessMessage(bundleId, totalAssets);
 			}
 
 			data.forEach(asset => addRow({

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_unpushed_bundles.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_unpushed_bundles.jsp
@@ -157,12 +157,12 @@
 						for(Map<String, Object> asset : assetsTransformed){
 
 							final String title = UtilMethods.isSet(asset.get(PublishQueueElementTransformer.TITLE_KEY)) ?
-								StringEscapeUtils.escapeHtml(asset.get(PublishQueueElementTransformer.TITLE_KEY).toString()) : StringPool.BLANK;
+								StringEscapeUtils.escapeJavaScript(asset.get(PublishQueueElementTransformer.TITLE_KEY).toString()) : StringPool.BLANK;
 
 							if (!title.equals( "" ) ) {%>
 
 								addRow({
-									title:'<%=asset.get(PublishQueueElementTransformer.TITLE_KEY)%>',
+									title:'<%= title %>',
 									inode:'<%=asset.get(PublishQueueElementTransformer.INODE_KEY)%>',
 									type:'<%=asset.get(PublishQueueElementTransformer.TYPE_KEY)%>',
 									content_type_name:'<%= asset.get(PublishQueueElementTransformer.CONTENT_TYPE_NAME_KEY) %>',


### PR DESCRIPTION
The `StringEscapeUtils.escapeJavaScript` method is the one that must be used when escaping values that are meant to be handled by JS code. Beyond that, the total count of assets that are displayed/hidden when looking at a bundle was fixed as well.