### PR TITLE
(#21568): adding support for PPing plugins

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/integritycheckers/HostIntegrityChecker.java
+++ b/dotCMS/src/main/java/com/dotcms/integritycheckers/HostIntegrityChecker.java
@@ -323,7 +323,7 @@ public class HostIntegrityChecker extends AbstractIntegrityChecker {
 
     /**
      * Perform actual fix in real tables based on hosts_ir table record.
-     *1
+     *
      * @param row map representing a row from hosts_ir table
      * @param isLastConflict flag telling  if this is the last conflict
      * @throws DotDataException

--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditHistory.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditHistory.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class PublishAuditHistory implements Serializable {
 	private static final long serialVersionUID = 1L;
 	
-	//This map contains the enpoints group
+	//This map contains the endpoints group
 	//each group can have one or more endpoints
 	private Map<String, Map<String, EndpointDetail>> endpointsMap;
 	
@@ -115,8 +115,8 @@ public class PublishAuditHistory implements Serializable {
 	
 	static XStream xstream=new XStream(new DomDriver());
 	public String getSerialized() {
-		
-	       
+
+
         String xml=xstream.toXML(this);
         return xml;
 	}

--- a/dotCMS/src/main/java/com/dotcms/publisher/pusher/wrapper/OSGIWrapper.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/pusher/wrapper/OSGIWrapper.java
@@ -1,6 +1,9 @@
 package com.dotcms.publisher.pusher.wrapper;
 
 import com.dotcms.publishing.PublisherConfig.Operation;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 
 /**
  * @author Jonathan Gamba
@@ -11,7 +14,8 @@ public class OSGIWrapper {
     private Operation operation;
     private String jarName;
 
-    public OSGIWrapper ( String jarName, Operation operation ) {
+    @JsonCreator
+    public OSGIWrapper (@JsonProperty("jarName") String jarName, @JsonProperty("operation") Operation operation ) {
         this.operation = operation;
         this.jarName = jarName;
     }

--- a/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/DependencyManager.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/DependencyManager.java
@@ -3,16 +3,12 @@ package com.dotcms.publisher.util.dependencies;
 import static com.dotcms.util.CollectionsUtils.set;
 
 import com.dotcms.contenttype.model.type.ContentType;
-import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotcms.exception.ExceptionUtil;
-import com.dotcms.languagevariable.business.LanguageVariableAPI;
 import com.dotcms.publisher.business.PublishQueueElement;
-import com.dotcms.publisher.environment.bean.Environment;
 import com.dotcms.publisher.pusher.PushPublisherConfig;
 import com.dotcms.publisher.util.PublisherUtil;
 import com.dotcms.publisher.util.PusheableAsset;
 import com.dotcms.publishing.DotBundleException;
-import com.dotcms.publishing.PublisherConfig.Operation;
 import com.dotcms.publishing.PublisherFilter;
 import com.dotcms.publishing.manifest.CSVManifestBuilder;
 import com.dotcms.publishing.manifest.ManifestReason;
@@ -20,50 +16,34 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
-import com.dotmarketing.business.DotIdentifierStateException;
-import com.dotmarketing.business.DotStateException;
-import com.dotmarketing.business.IdentifierAPI;
-import com.dotmarketing.business.PermissionAPI;
-import com.dotmarketing.cache.FieldsCache;
 import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.factories.PersonalizedContentlet;
+import com.dotmarketing.plugin.model.Plugin;
 import com.dotmarketing.portlets.categories.model.Category;
 import com.dotmarketing.portlets.containers.model.Container;
-import com.dotmarketing.portlets.containers.model.FileAssetContainer;
-import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
-import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
-import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.links.model.Link;
 import com.dotmarketing.portlets.rules.model.Rule;
-import com.dotmarketing.portlets.structure.factories.StructureFactory;
-import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.portlets.templates.model.FileAssetTemplate;
 import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.portlets.workflows.model.WorkflowScheme;
-import com.dotmarketing.util.Config;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Table;
 import com.liferay.portal.model.User;
-import com.liferay.util.StringPool;
-import io.vavr.control.Try;
+
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
 import org.apache.commons.lang.StringUtils;
+import org.apache.felix.framework.OSGIUtil;
 
 /**
  * The main purpose of this class is to determine all possible content
@@ -312,6 +292,21 @@ public class DependencyManager {
 							: "N/A")
 							+ " is not present in the database, not Pushed.");
 				}
+			} else if (asset.getType().equals(PusheableAsset.OSGI.getType())) {
+				final String felixLoadFolder = OSGIUtil.getInstance().getFelixDeployPath();
+				final File bundleJar = Paths.get(felixLoadFolder, asset.getAsset()).toFile();
+
+				if (bundleJar.exists()) {
+					final Plugin plugin = new Plugin();
+					plugin.setId(asset.getAsset());
+					add(plugin, PusheableAsset.OSGI);
+				} else {
+					Logger.warn(
+							this,
+							String.format(
+									"Plugin id: %s is not present as a jar, not pushed.",
+									asset.getAsset() != null ? asset.getAsset() : "N/A"));
+				}
 			}
 		}
 
@@ -423,7 +418,10 @@ public class DependencyManager {
 		} else if (Language.class.isInstance(asset)) {
 			final Language languege = Language.class.cast(asset);
 			return String.valueOf(languege.getId());
-		} else {
+		} else if (Plugin.class.isInstance(asset)) {
+			final Plugin plugin = Plugin.class.cast(asset);
+			return plugin.getId();
+		}else {
 			throw new IllegalArgumentException("Not allowed: " + asset.getClass().getName());
 		}
 	}

--- a/dotCMS/src/main/java/com/dotcms/publishing/XMLSerializerUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/XMLSerializerUtil.java
@@ -5,8 +5,8 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.XStreamException;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.io.xml.DomDriver;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * Util for serialize object to XML file
@@ -14,7 +14,7 @@ import java.io.OutputStreamWriter;
 public class XMLSerializerUtil {
 
     private static final XMLSerializerUtil instance= new XMLSerializerUtil();
-    private XStream xmlSerializer = null;
+    private XStream xmlSerializer;
 
 
     /**
@@ -28,7 +28,11 @@ public class XMLSerializerUtil {
     }
 
     private XMLSerializerUtil(){
-        xmlSerializer = new XStream(new DomDriver("UTF-8"));
+        xmlSerializer = new XStream(new DomDriver(StandardCharsets.UTF_8.name()));
+    }
+
+    public XStream getXmlSerializer() {
+        return xmlSerializer;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/plugin/model/Plugin.java
+++ b/dotCMS/src/main/java/com/dotmarketing/plugin/model/Plugin.java
@@ -1,5 +1,8 @@
 package com.dotmarketing.plugin.model;
 
+import com.dotcms.publisher.util.PusheableAsset;
+import com.dotcms.publishing.manifest.ManifestItem;
+
 import java.io.Serializable;
 import java.util.Date;
 
@@ -9,7 +12,7 @@ import java.util.Date;
  * A simple POJO for dotCMS plugins
  */
 
-public class Plugin implements Serializable{
+public class Plugin implements Serializable, ManifestItem {
 
 	/**
 	 * 
@@ -98,5 +101,13 @@ public class Plugin implements Serializable{
 	public void setLastDeployedDate(Date lastDeployedDate) {
 		this.lastDeployedDate = lastDeployedDate;
 	}
-	
+
+	@Override
+	public ManifestInfo getManifestInfo() {
+		return new ManifestInfoBuilder()
+				.id(id)
+				.title(pluginName)
+				.objectType(PusheableAsset.OSGI.getType())
+				.build();
+	}
 }


### PR DESCRIPTION
Adding manifest file for plugin PP to avoid XML bundle writing, centralizing ObjectMapper and XStream instances to one and adding plugin case to Dependency manager.

Sibling PRs:
https://github.com/dotCMS/enterprise/pull/854
