### PR TITLE
Issue 19956 allow user disable drag and drop on wysiwig v2

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -326,7 +326,7 @@
 
                 List<FieldVariable> fieldVariables=APILocator.getFieldAPI().getFieldVariablesForField(field.getInode(), user, true);
                     for(FieldVariable fv : fieldVariables){
-                        if (fv.getKey().equals("drag-and-drop")) {
+                        if (fv.getKey().equals("dragAndDrop")) {
                             dragAndDrop = !"false".equalsIgnoreCase(fv.getValue());
                         }
                     }


### PR DESCRIPTION
-  convert the variable to camel case, e.g. dragAndDrop instead of `drag-and-drop`