### PR TITLE
21779: Adding javascript support for javadoc

### DIFF
--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -613,6 +613,7 @@ javadoc {
     options.charSet 'utf-8'
     options.linkSource false
     options.links 'https://docs.oracle.com/javase/8/docs/api/'
+    options.addBooleanOption("-allow-script-in-comments", true)
 }
 
 //Task meant to be use from a distribution structure using the buildwar.sh script.


### PR DESCRIPTION
Issue: https://github.com/dotCMS/core/issues/21779