### PR TITLE
dotCMS/core#19562 fix to handle multiple keyValue fields with White List functionality

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -1192,10 +1192,10 @@
             }
         </style>
 
-        <dot-key-value></dot-key-value>
+        <dot-key-value id="<%=field.getVelocityVarName()%>KeyValue"></dot-key-value>
 
         <script>
-            var dotKeyValue = document.querySelector('dot-key-value');
+            var dotKeyValue = document.querySelector('#<%=field.getVelocityVarName()%>KeyValue');
             dotKeyValue.uniqueKeys = "true";
             dotKeyValue.value = '<%=dotKeyValueDataRaw.toString()%>';
             dotKeyValue.disabled = '<%=field.isReadOnly()%>';


### PR DESCRIPTION


Adding a second key-value field makes the first one lose its whiteList capabilities.