### PR TITLE
dotCMS/core#21883 Add block field variable shortcut to container creation 

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/containers/add_variables.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/containers/add_variables.jsp
@@ -516,6 +516,28 @@
 					}
 				%>
 
+				<%
+					it = fields.iterator();
+					while (it.hasNext()) {
+						Field field = (Field)it.next();
+						if (field.getFieldType().equals(Field.FieldType.STORY_BLOCK_FIELD.toString())) {
+            	%>
+							<tr>
+								<td align="center">
+									<button dojoType="dijit.form.Button" onClick="addBlockEditor('<%= field.getVelocityVarName() %>')">
+									<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "add")) %>
+									</button>
+								</td>
+								<td>
+									<%=field.getFieldName()%>
+								</td>
+							</tr>
+
+            <%
+                    	}
+                	}
+            %>
+
 				
 					<tr>
 						<td align="center" nowrap colspan="2">

--- a/dotCMS/src/main/webapp/html/portlet/ext/containers/edit_container_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/containers/edit_container_js_inc.jsp
@@ -154,6 +154,12 @@
 		dijit.byId('variablesDialog').hide();
 	}
 
+	function addBlockEditor(velocityVarName){
+		var insert = `$dotContentMap.get('${velocityVarName}').toHtml()`;
+		insertAtCursor(insert, "codeMaskMulti");
+		dijit.byId('variablesDialog').hide();
+	}
+
 	function addImage(velocityVarName){
 		var insert = "#if ($UtilMethods.isSet($" + "{" + velocityVarName+"ImageURI})) \n   <img src=\"$!{"+velocityVarName+"ImageURI}\" alt=\"$!{"+velocityVarName+"ImageTitle}\"  /> \n#end \n";
 		insertAtCursor(insert, "codeMaskMulti");


### PR DESCRIPTION
add a shortcut, so the user can add the basic render of a block editor fields with one click.

https://github.com/dotCMS/core/issues/21883