### PR TITLE
Additional fix on 21801

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/api/system/event/verifier/PermissionVerifier.java
+++ b/dotCMS/src/main/java/com/dotcms/api/system/event/verifier/PermissionVerifier.java
@@ -10,6 +10,8 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.business.Permissionable;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import java.util.Map;
 
 /**
  * Verifies if the sessionUser has read permission (against the payload visibilityValue) and over the payload data.
@@ -30,7 +32,14 @@ public class PermissionVerifier implements PayloadVerifier{
     @Override
     public boolean verified(final Payload payload, final WebSocketUserSessionData userSessionData) {
         try {
-            return permissionAPI.doesUserHavePermission((Permissionable) payload.getData(),
+            Permissionable permissionable;
+            if (payload.getData() instanceof Map){
+                permissionable = new Contentlet((Map) payload.getData());
+            }else{
+                permissionable = (Permissionable) payload.getData();
+            }
+
+            return permissionAPI.doesUserHavePermission(permissionable,
                     ConversionUtils.toInt(payload.getVisibilityValue(), PermissionAPI.PERMISSION_READ),
                     userSessionData.getUser(), false);
         } catch (DotDataException e) {

--- a/dotCMS/src/main/java/com/dotmarketing/factories/WebAssetFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/WebAssetFactory.java
@@ -137,7 +137,7 @@ public class WebAssetFactory {
 		HibernateUtil.saveOrUpdate(webasset);
         APILocator.getVersionableAPI().setWorking(webasset);
 
-		systemEventsAPI.pushAsync(SystemEventType.SAVE_LINK, new Payload(webasset, Visibility.EXCLUDE_OWNER,
+		systemEventsAPI.pushAsync(SystemEventType.SAVE_LINK, new Payload(webasset.getMap(), Visibility.EXCLUDE_OWNER,
 				new ExcludeOwnerVerifierBean(userId, PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 	}
 
@@ -158,7 +158,7 @@ public class WebAssetFactory {
 
 		APILocator.getVersionableAPI().setWorking(webasset);
 
-		systemEventsAPI.pushAsync(SystemEventType.SAVE_LINK, new Payload(webasset, Visibility.EXCLUDE_OWNER,
+		systemEventsAPI.pushAsync(SystemEventType.SAVE_LINK, new Payload(webasset.getMap(), Visibility.EXCLUDE_OWNER,
 				new ExcludeOwnerVerifierBean(userId, PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 	}
 
@@ -505,7 +505,7 @@ public class WebAssetFactory {
 		}
 
 
-		systemEventsAPI.pushAsync(SystemEventType.PUBLISH_LINK, new Payload(currWebAsset, Visibility.EXCLUDE_OWNER,
+		systemEventsAPI.pushAsync(SystemEventType.PUBLISH_LINK, new Payload(currWebAsset.getMap(), Visibility.EXCLUDE_OWNER,
 				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 
 		return livewebasset;
@@ -578,7 +578,7 @@ public class WebAssetFactory {
 				HibernateUtil.saveOrUpdate(workingwebasset);
 			}
 
-			systemEventsAPI.pushAsync(SystemEventType.ARCHIVE_LINK, new Payload(currWebAsset, Visibility.EXCLUDE_OWNER,
+			systemEventsAPI.pushAsync(SystemEventType.ARCHIVE_LINK, new Payload(currWebAsset.getMap(), Visibility.EXCLUDE_OWNER,
 					new ExcludeOwnerVerifierBean(userId, PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 
 			return true;
@@ -1000,7 +1000,7 @@ public class WebAssetFactory {
 			//### Delete the Identifier ###
 			returnValue = true;
 
-			systemEventsAPI.pushAsync(SystemEventType.DELETE_LINK, new Payload(currWebAsset, Visibility.EXCLUDE_OWNER,
+			systemEventsAPI.pushAsync(SystemEventType.DELETE_LINK, new Payload(currWebAsset.getMap(), Visibility.EXCLUDE_OWNER,
 					new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 		}
 		else

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
@@ -765,7 +765,7 @@ public class BrowserAjax {
 		try {
 			children = folderAPI.findSubFolders(parent,userAPI.getSystemUser(),false);
 		} catch (Exception e) {
-			Logger.error(this, "Could not load folders : ",e);
+			Logger.error(this, "Could not load subfolders for folder with ID: " + parent.getIdentifier(),e);
 		}
         return getFoldersTree(parent.getIdentifier(), children, roles);
     }
@@ -795,7 +795,7 @@ public class BrowserAjax {
         	try {
         		permissions = permissionAPI.getPermissionIdsFromRoles(folder, roles, usr);
         	} catch (DotDataException e) {
-        		Logger.error(this, "Could not load permissions : ",e);
+        		Logger.error(this, "Could not load permissions for folder with ID: " + folder.getIdentifier(),e);
         	}
 
         	folderMap.put("permissions", permissions);
@@ -1947,7 +1947,7 @@ public class BrowserAjax {
 						try {
 							permissions = permissionAPI.getPermissionIdsFromRoles(folder, roles, user);
 						} catch (DotDataException e) {
-							Logger.error(this, "Could not load permissions : ",e);
+							Logger.error(this, "Could not load permissions for folder with ID: " + folder.getIdentifier(),e);
 						}
 						if(permissions.contains(PERMISSION_READ)){
 							Map<String, Object> folderMap = new HashMap<String, Object>();

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotFolderTransformerImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotFolderTransformerImpl.java
@@ -124,7 +124,7 @@ public class DotFolderTransformerImpl implements DotMapViewTransformer {
 
         final Map<String, Object> map = new HashMap<>(folder.getMap());
         map.put("permissions", permissions);
-        map.put("parent", folder.getInode());
+        map.put("parent", folder.getIdentifier());
         map.put("mimeType", StringPool.BLANK);
         map.put("name", folder.getName());
         map.put("title", folder.getName());

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/action/EditFolderAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/action/EditFolderAction.java
@@ -365,7 +365,7 @@ public class EditFolderAction extends DotPortletAction {
 			}
 
 			if (parentFolder instanceof Folder){
-				if(folder.getName().equalsIgnoreCase("admin")){
+				if("admin".equalsIgnoreCase(folder.getName())){
 
 				SessionMessages.add(req, "message",
 				"message.folder.admin.doesnotallow");

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPI.java
@@ -2,6 +2,7 @@ package com.dotmarketing.portlets.folders.business;
 
 import com.dotcms.api.tree.Parentable;
 import com.dotcms.business.CloseDBIfOpened;
+import com.dotcms.util.CollectionsUtils;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Inode;
 import com.dotmarketing.business.DotIdentifierStateException;
@@ -15,11 +16,16 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.links.model.Link;
 import com.dotmarketing.portlets.structure.model.Structure;
+import com.dotmarketing.util.Config;
+import com.google.common.annotations.VisibleForTesting;
 import com.liferay.portal.model.User;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -29,11 +35,10 @@ import java.util.function.Predicate;
  */
  public interface FolderAPI   {
 
-	public static final String SYSTEM_FOLDER = "SYSTEM_FOLDER";
-	public static final String SYSTEM_FOLDER_ID = "bc9a1d37-dd2d-4d49-a29d-0c9be740bfaf";
-	public static final String SYSTEM_FOLDER_ASSET_NAME = "system folder";
-	public static final String SYSTEM_FOLDER_PARENT_PATH = "/System folder";
-
+	String SYSTEM_FOLDER = "SYSTEM_FOLDER";
+	String SYSTEM_FOLDER_ID = "bc9a1d37-dd2d-4d49-a29d-0c9be740bfaf";
+	String SYSTEM_FOLDER_ASSET_NAME = "system folder";
+	String SYSTEM_FOLDER_PARENT_PATH = "/System folder";
 
 	/**
 	 * Find a folder by a Host and a path
@@ -188,7 +193,7 @@ import java.util.function.Predicate;
 	/**
 	 * Does a folder already exist?
 	 *
-	 * @param folderInode
+	 * @param folderInode or folderID
 	 * @return boolean
 	 * @throws DotDataException
 	 */
@@ -289,6 +294,13 @@ import java.util.function.Predicate;
 	 */
 	Folder find(String id, User user, boolean respectFrontEndPermissions) throws
 			DotSecurityException, DotDataException;
+
+	/**
+	 * Validates that the folder name is not a reserved word
+	 * @param folder folder whose name will be validated
+	 * @throws DotDataException
+	 */
+	void validateFolderName(final Folder folder) throws DotDataException;
 
 	/**
 	 * Saves a folder. The folder needs to have been created from the

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -22,6 +22,7 @@ import com.dotcms.contenttype.model.type.FileAssetContentType;
 import com.dotcms.publisher.business.PublisherAPI;
 import com.dotcms.system.event.local.business.LocalSystemEventsAPI;
 import com.dotcms.system.event.local.model.EventSubscriber;
+import com.dotcms.util.CollectionsUtils;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.beans.Inode;
@@ -43,7 +44,6 @@ import com.dotmarketing.db.HibernateUtil;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.menubuilders.RefreshMenus;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.fileassets.business.IFileAsset;
@@ -53,10 +53,12 @@ import com.dotmarketing.portlets.links.model.Link;
 import com.dotmarketing.portlets.structure.factories.StructureFactory;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.util.AdminLogger;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
+import com.google.common.annotations.VisibleForTesting;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import com.rainerhahnekamp.sneakythrow.Sneaky;
@@ -65,8 +67,10 @@ import io.vavr.control.Try;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -83,6 +87,18 @@ public class FolderAPIImpl implements FolderAPI  {
 	private final SystemEventsAPI systemEventsAPI = APILocator.getSystemEventsAPI();
 	private final LocalSystemEventsAPI localSystemEventsAPI = APILocator.getLocalSystemEventsAPI();
 	private final ContentletAPI contentletAPI = APILocator.getContentletAPI();
+
+	@VisibleForTesting
+	protected static final Set<String> reservedFolderNames =
+			Collections.unmodifiableSet(
+					new HashSet<>(CollectionsUtils
+							.set(Config.getStringArrayProperty("RESERVEDFOLDERNAMES",
+									new String[]{"WEB-INF", "META-INF", "assets", "dotcms", "html",
+											"portal",
+											"email_backups",
+											"DOTLESS", "DOTSASS", "dotAdmin", "custom_elements"})
+							))
+			);
 
 	/**
 	 * Will get a folder on a given path for a particular host.
@@ -139,6 +155,7 @@ public class FolderAPIImpl implements FolderAPI  {
 		}
 
 		try {
+			validateFolderName(folder, newName);
 			renamed = folderFactory.renameFolder(folder, newName, user, respectFrontEndPermissions);
 			CacheLocator.getNavToolCache().removeNav(folder.getHostId(), folder.getInode());
 			Identifier folderId = APILocator.getIdentifierAPI().find(folder.getIdentifier());
@@ -333,6 +350,7 @@ public class FolderAPIImpl implements FolderAPI  {
 			throw new DotSecurityException("User " + (user.getUserId() != null?user.getUserId():BLANK) + " does not have permission to add to Host " + newParentHost.getHostname());
 		}
 
+		validateFolderName(folderToCopy);
 		folderFactory.copy(folderToCopy, newParentHost);
 
 		this.systemEventsAPI.pushAsync(SystemEventType.COPY_FOLDER, new Payload(folderToCopy, Visibility.EXCLUDE_OWNER,
@@ -553,6 +571,20 @@ public class FolderAPIImpl implements FolderAPI  {
 		return folder;
 	} // find.
 
+	@Override
+	public void validateFolderName(final Folder folder) throws DotDataException {
+		validateFolderName(folder, folder.getName());
+	}
+
+	private void validateFolderName(final Folder folder, final String folderName) throws DotDataException {
+		if (UtilMethods.isSet(folder.getParentPermissionable())
+				&& folder.getParentPermissionable() instanceof Host
+				&& UtilMethods.isSet(folderName)
+				&& reservedFolderNames.stream()
+				.anyMatch((name)->name.equalsIgnoreCase(folderName))) {
+			throw new InvalidFolderNameException("Folder can't be saved. You entered a reserved folder name: " + folder.getName());
+		}
+	}
 
 	/**
 	 * Saves a folder
@@ -565,17 +597,24 @@ public class FolderAPIImpl implements FolderAPI  {
 	public void save(final Folder folder, final String existingId,
 					 final User user, final boolean respectFrontEndPermissions) throws DotDataException, DotStateException, DotSecurityException {
 
-		Identifier id = APILocator.getIdentifierAPI().find(folder.getIdentifier());
-		if(id ==null || !UtilMethods.isSet(id.getId())){
+		Identifier existingID = APILocator.getIdentifierAPI().find(folder.getIdentifier());
+		if(existingID ==null || !UtilMethods.isSet(existingID.getId())){
 			throw new DotStateException("Folder must already have an identifier before saving");
 		}
 
+		if (SYSTEM_FOLDER.equals(folder.getInode()) && !Host.SYSTEM_HOST.equals(folder.getHostId())) {
+			throw new DotRuntimeException(String.format("Host ID for SYSTEM_FOLDER must always be SYSTEM_HOST. Value " +
+					"'%s' was set.", folder.getHostId()));
+		}
+
+		validateFolderName(folder);
+
 		Host host = APILocator.getHostAPI().find(folder.getHostId(), user, respectFrontEndPermissions);
-		Folder parentFolder = findFolderByPath(id.getParentPath(), id.getHostId(), user, respectFrontEndPermissions);
-		Permissionable parent = id.getParentPath().equals("/")?host:parentFolder;
+		Folder parentFolder = findFolderByPath(existingID.getParentPath(), existingID.getHostId(), user, respectFrontEndPermissions);
+		Permissionable parent = existingID.getParentPath().equals("/")?host:parentFolder;
 
 		if(parent ==null){
-			throw new DotStateException("No Folder Found for id: " + id.getParentPath());
+			throw new DotStateException("No Folder Found for id: " + existingID.getParentPath());
 		}
 		if (!permissionAPI.doesUserHavePermission(parent, PermissionAPI.PERMISSION_CAN_ADD_CHILDREN, user,respectFrontEndPermissions)
 				|| !permissionAPI.doesUserHavePermissions(PermissionableType.FOLDERS, PermissionAPI.PERMISSION_EDIT, user)) {
@@ -584,13 +623,19 @@ public class FolderAPIImpl implements FolderAPI  {
 		}
 
 		boolean isNew = folder.getInode() == null;
-		folder.setModDate(new Date());
-		folder.setName(folder.getName());
-		folderFactory.save(folder);
+
+
+		//if the folder was renamed, we will need to create a new identifier
+		if (!folder.getName().equals(existingID.getAssetName())){
+			folderFactory.renameFolder(folder, folder.getName(), user, respectFrontEndPermissions);
+		} else{
+			folder.setModDate(new Date());
+			folderFactory.save(folder);
+		}
 
         // remove folder and parent from navigation cache
         CacheLocator.getNavToolCache().removeNav(folder.getHostId(), folder.getInode());
-        CacheLocator.getNavToolCache().removeNavByPath(id.getHostId(), id.getParentPath());
+        CacheLocator.getNavToolCache().removeNavByPath(existingID.getHostId(), existingID.getParentPath());
 
         SystemEventType systemEventType = isNew ? SystemEventType.SAVE_FOLDER : SystemEventType.UPDATE_FOLDER;
 		systemEventsAPI.pushAsync(systemEventType, new Payload(folder, Visibility.EXCLUDE_OWNER,

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactory.java
@@ -137,13 +137,6 @@ public abstract class FolderFactory {
     }
 
 	/**
-	 * Validates that the folder name is not a reserved word
-	 * @param folder folder whose name will be validated
-	 * @throws DotDataException
-	 */
-	abstract public void validateFolderName(final Folder folder) throws DotDataException;
-
-	/**
 	 * Updates folder's owner when a user is replaced by another
 	 * @param userId ID of the user to be replace
 	 * @param replacementUserId ID of the new folder's owner

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/links/factories/LinkFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/links/factories/LinkFactory.java
@@ -268,7 +268,7 @@ public class LinkFactory {
         //Copy permissions
         permissionAPI.copyPermissions( currentLink, newLink );
 
-		systemEventsAPI.pushAsync(SystemEventType.COPY_LINK, new Payload(currentLink, Visibility.EXCLUDE_OWNER,
+		systemEventsAPI.pushAsync(SystemEventType.COPY_LINK, new Payload(currentLink.getMap(), Visibility.EXCLUDE_OWNER,
 				new ExcludeOwnerVerifierBean(currentLink.getModUser(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 
         return newLink;


### PR DESCRIPTION
On this PR: 
* FolderAPI.exists(String) can filter by folderId or folderInode. A test was implemented.
* Fixing JS exception in SiteBrowser when you double click on a folder created on a previous dotCMS version.
* Fixing ClassCastException when a folder containing a FileAsset is moved.
* Copying/Renaming a folder must generate a new identifier. Tests were updated to support the new logic.
* Serialization exception when a MenuLink is added to a folder.
* Method `validateFolderName` was moved from `FolderFactoryImpl` to `FolderAPI`.