### PR TITLE
#21786 : Stop sending the "rendered" property in the JSON response fo…

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ema/EMAWebInterceptor.java
+++ b/dotCMS/src/main/java/com/dotcms/ema/EMAWebInterceptor.java
@@ -1,39 +1,30 @@
 package com.dotcms.ema;
 
-import com.dotcms.security.apps.AppSecrets;
-import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.exception.DotSecurityException;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-
-import org.apache.http.Header;
-
-import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.ema.proxy.MockHttpCaptureResponse;
 import com.dotcms.ema.proxy.ProxyResponse;
 import com.dotcms.ema.proxy.ProxyTool;
 import com.dotcms.filters.interceptor.Result;
 import com.dotcms.filters.interceptor.WebInterceptor;
+import com.dotcms.security.apps.AppSecrets;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.web.UserWebAPI;
 import com.dotmarketing.business.web.WebAPILocator;
-import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
-import com.dotmarketing.util.WebKeys;
 import com.dotmarketing.util.json.JSONObject;
 import com.google.common.collect.ImmutableMap;
-import com.liferay.portal.model.User;
+import org.apache.http.Header;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Intercepts a content managers's request to dotCMS EDIT_MODE in the admin of dotCMS,
@@ -43,13 +34,14 @@ import com.liferay.portal.model.User;
  *
  * More info on how EMA works https://github.com/dotcms-plugins/com.dotcms.ema#dotcms-edit-mode-anywhere---ema
  */
-public class EMAWebInterceptor  implements WebInterceptor{
+public class EMAWebInterceptor  implements WebInterceptor {
 
     public  static final String      PROXY_EDIT_MODE_URL_VAR = "proxyEditModeURL";
     private static final String      API_CALL                = "/api/v1/page/render";
     public static final String EMA_APP_CONFIG_KEY = "dotema-config";
     private static final ProxyTool   proxy                   = new ProxyTool();
 
+    public static final String EMA_REQUEST_ATTR = "EMA_REQUEST";
 
     @Override
     public String[] getFilters() {
@@ -62,7 +54,7 @@ public class EMAWebInterceptor  implements WebInterceptor{
     public Result intercept(final HttpServletRequest request, final HttpServletResponse response) {
 
         final Host currentHost = WebAPILocator.getHostWebAPI().getCurrentHostNoThrow(request);
-
+        request.setAttribute(EMA_REQUEST_ATTR, true);
         if (!this.existsConfiguration(currentHost.getIdentifier())) {
             return Result.NEXT;
         }

--- a/dotCMS/src/main/java/com/dotcms/ema/EMAWebInterceptor.java
+++ b/dotCMS/src/main/java/com/dotcms/ema/EMAWebInterceptor.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 public class EMAWebInterceptor  implements WebInterceptor {
 
     public  static final String      PROXY_EDIT_MODE_URL_VAR = "proxyEditModeURL";
+    public  static final String      INCLUDE_RENDERED_VAR = "includeRendered";
     private static final String      API_CALL                = "/api/v1/page/render";
     public static final String EMA_APP_CONFIG_KEY = "dotema-config";
     private static final ProxyTool   proxy                   = new ProxyTool();

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -789,7 +789,7 @@ public class PageResource {
             }
         } catch (final DotDataException | DotSecurityException | SystemException | PortalException e) {
             final String siteName = null != currentSite ? currentSite.getHostname() : "N/A";
-            Logger.warn(this, String.format("An error occurred when checking the 'rendered' attribute in site '%s' for URI '%s': %s", siteName, uri, e.getMessage()));
+            Logger.debug(this, String.format("An error occurred when checking the 'rendered' attribute in site '%s' for URI '%s': %s", siteName, uri, e.getMessage()));
         }
         return includeRenderedAttr;
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -13,6 +13,8 @@ import com.dotcms.rest.api.v1.personalization.PersonalizationPersonaPageViewPagi
 import com.dotcms.rest.exception.BadRequestException;
 import com.dotcms.rest.exception.ForbiddenException;
 import com.dotcms.rest.exception.mapper.ExceptionMapperUtil;
+import com.dotcms.security.apps.AppSecrets;
+import com.dotcms.security.apps.AppsAPI;
 import com.dotcms.util.ConversionUtils;
 import com.dotcms.util.HttpRequestDataUtil;
 import com.dotcms.util.PaginationUtil;
@@ -221,9 +223,11 @@ public class PageResource {
             @QueryParam(WebKeys.PAGE_MODE_PARAMETER) final String modeParam,
             @QueryParam(WebKeys.CMS_PERSONA_PARAMETER) final String personaId,
             @QueryParam(WebKeys.LANGUAGE_ID_PARAMETER) final String languageId,
-            @QueryParam("device_inode") final String deviceInode) throws DotSecurityException, DotDataException {
+            @QueryParam("device_inode") final String deviceInode) throws DotSecurityException, DotDataException, SystemException, PortalException {
         if (HttpRequestDataUtil.getAttribute(originalRequest, EMAWebInterceptor.EMA_REQUEST_ATTR, Boolean.FALSE)) {
-            return loadJson(originalRequest, response, uri, modeParam, personaId, languageId, deviceInode);
+            if (!includeRenderedAttrFromEMA(originalRequest, uri)) {
+                return loadJson(originalRequest, response, uri, modeParam, personaId, languageId, deviceInode);
+            }
         }
         Logger.debug(this, ()->String.format(
                 "Rendering page: uri -> %s mode-> %s language -> persona -> %s device_inode -> %s live -> %b",
@@ -754,4 +758,40 @@ public class PageResource {
 
         return result.values();
     }
+
+    /**
+     * Checks whether the {@code rendered} attribute in the JSON data must be posted to the EMA service or not.
+     * <p>
+     * When dotCMS executes a POST to the EMA Service, it is sending the {@code page.rendered} property as part of the
+     * JSON payload. This is not required, and dotCMS should not do it. However, if the user needs it anyway, it can be
+     * re-added to the JSON data via UI in the {@code Include 'rendered' attribute?} box in the EMA APP configuration
+     * portlet.
+     * </p>
+     *
+     * @param request The current instance of the {@link HttpServletRequest} object.
+     * @param uri     The URI to the HTML Page that will be sent to the EMA Service.
+     * @return If the {@code rendered} attribute must be added to the JSON data, return {@code true}. Otherwise, return {@code false}.
+     */
+    private boolean includeRenderedAttrFromEMA(final HttpServletRequest request, final String uri) {
+        final AppsAPI appsAPI = APILocator.getAppsAPI();
+        boolean includeRenderedAttr = Boolean.FALSE;
+        Host currentSite = null;
+        try {
+            currentSite = WebAPILocator.getHostWebAPI().getCurrentHost(request);
+            final Optional<AppSecrets> secretsOpt = appsAPI.getSecrets(EMAWebInterceptor.EMA_APP_CONFIG_KEY, true, currentSite, APILocator.systemUser());
+            if (secretsOpt.isPresent()) {
+                AppSecrets secrets = secretsOpt.get();
+                Optional<Boolean> renderedOpt = secrets.getSecrets().containsKey(EMAWebInterceptor.INCLUDE_RENDERED_VAR) ?
+                        Optional.ofNullable(secrets.getSecrets().get(EMAWebInterceptor.INCLUDE_RENDERED_VAR).getBoolean()) : Optional.empty();
+                if (renderedOpt.isPresent() && renderedOpt.get()) {
+                    includeRenderedAttr = Boolean.TRUE;
+                }
+            }
+        } catch (final DotDataException | DotSecurityException | SystemException | PortalException e) {
+            final String siteName = null != currentSite ? currentSite.getHostname() : "N/A";
+            Logger.warn(this, String.format("An error occurred when checking the 'rendered' attribute in site '%s' for URI '%s': %s", siteName, uri, e.getMessage()));
+        }
+        return includeRenderedAttr;
+    }
+
 }

--- a/dotCMS/src/main/java/com/dotcms/util/HttpRequestDataUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/HttpRequestDataUtil.java
@@ -4,25 +4,22 @@ import com.dotcms.repackage.org.apache.commons.net.util.SubnetUtils;
 import com.dotcms.repackage.org.apache.commons.net.util.SubnetUtils.SubnetInfo;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
+import org.apache.commons.lang.StringUtils;
+
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.Query;
+import javax.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.lang.management.ManagementFactory;
-import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.net.UnknownHostException;
+import java.net.*;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-import javax.management.Query;
-import javax.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Provides quick access to information that can be obtained from the HTTP
@@ -238,6 +235,21 @@ public class HttpRequestDataUtil {
 			return null;
 		}
     }
+
+	/**
+	 * Returns the value of a given attribute in the HTTP Request object, or the default value if not present.
+	 *
+	 * @param request       An instance of the {@link HttpServletRequest} object.
+	 * @param attributeName The name of the attribute that should be present in the request.
+	 * @param defaultValue  The default value that will be returned in case the expected one is NOT present.
+	 * @return The value of the specified request attribute.
+	 */
+	public static <T> T getAttribute(final HttpServletRequest request, final String attributeName, final T defaultValue) {
+		if (null != request.getAttribute(attributeName)) {
+			return (T) request.getAttribute(attributeName);
+		}
+		return defaultValue;
+	}
 
 	/**
 	 * Convenience method to get the server port and cache it to use it must likely in logs.

--- a/dotCMS/src/main/resources/apps/dotema-config.yml
+++ b/dotCMS/src/main/resources/apps/dotema-config.yml
@@ -3,6 +3,13 @@ iconUrl: "https://static.dotcms.com/assets/icons/apps/ema-icon.png"
 allowExtraParameters: false
 description: "EMA - or Edit Mode Anywhere, allows you to proxy your edit mode requests to a 3rd party server or web site.  If that site is configured to use the dotCMS Page API then EMA enables remote content management of content, layouts and pages that are hosted remotely."
 params:
+  includeRendered:
+    value: false
+    hidden: false
+    type: "BOOL"
+    label: "Include 'rendered' attribute?"
+    hint: "If enabled, the information that dotCMS sends to the EMA Service via POST will include the 'rendered' attribute. This 'rendered' attribute is NOT sent by default."
+    required: true
   proxyEditModeURL:
     value: ""
     hidden: false


### PR DESCRIPTION
…r EMA Sites.

As discussed with Will and the Lunik Team, the `EMAWebInterceptor` class will add the "EMA_REQUEST" attribute when when a request goes through it. Then, the `/api/v1/page/render` method will check for that and if it is set, pass the args to the `/api/v1/page/json` method instead, and return its result.