### PR TITLE
#21801 A move should not generate a new contentlet version

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -673,25 +673,16 @@ public class FolderFactoryImpl extends FolderFactory {
 									  final User systemUser,
 									  final List<Contentlet> contentlets) throws DotDataException, DotSecurityException {
 
-		final ContentletAPI contentletAPI = APILocator.getContentletAPI();
-		final FileAssetAPI  fileAssetAPI  = APILocator.getFileAssetAPI();
-
 		for(final Contentlet contentlet : contentlets) {
-
 			if (contentlet.isFileAsset()) {
+				final FileAssetAPI  fileAssetAPI  = APILocator.getFileAssetAPI();
 				fileAssetAPI.moveFile(contentlet, folder, systemUser, false);
 		    } else if (contentlet.isHTMLPage()) {
 				HTMLPageAssetAPI pageAssetAPI = APILocator.getHTMLPageAssetAPI();
 				pageAssetAPI.move(pageAssetAPI.fromContentlet(contentlet), folder, systemUser);
 			} else {
-    			final boolean isLive = contentlet.isLive();
-				Contentlet newContentlet  = contentletAPI.checkout(contentlet.getInode(), systemUser, false);
-				newContentlet.setFolder(folder.getInode());
-				newContentlet = contentletAPI.checkin(newContentlet, systemUser, false);
-    			if(isLive) {
-
-					contentletAPI.publish(newContentlet, systemUser, false);
-    			}
+				final ContentletAPI contentletAPI = APILocator.getContentletAPI();
+				contentletAPI.move(contentlet, systemUser, folder.getHost(), folder, false);
 		    }
 		}
 	}

--- a/dotCMS/src/main/webapp/html/portlet/ext/folders/edit_folder.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/folders/edit_folder.jsp
@@ -39,7 +39,7 @@ dojo.require("dotcms.dojo.data.StructureReadStore");
 
 	var formName;
 	function save(formName) {
-
+        dijit.byId('processingDialog').show();
 		this.formName = formName;
 
 		var form = document.getElementById(this.formName);
@@ -266,6 +266,10 @@ dojo.require("dotcms.dojo.data.StructureReadStore");
 	%>
 	<!-- END permissions -->
 	</div>
+</div>
+
+<div id="processingDialog" dojoType="dijit.Dialog" disableCloseButton="true" title="<%=LanguageUtil.get(pageContext,"Processing")%>" style="display: none;">
+    <div dojoType="dijit.ProgressBar" style="width:200px;text-align:center;" indeterminate="true" jsId="processingLoading" id="processingLoading"></div>
 </div>
 
 </liferay:box>


### PR DESCRIPTION
When a piece of content is moved from a folder or host, only the identifier should be updated. It does not require a new contentlet version