### PR TITLE
#21782 : Use `velocity_var_name` column instead of `name` column.

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
@@ -389,7 +389,7 @@ public class HostAPIImpl implements HostAPI, Flushable<Host> {
         final List<Host> hosts = new ArrayList<Host>();
 
         final String sql = "select  c.title, c.inode from contentlet_version_info clvi, contentlet c, structure s  " +
-                " where c.structure_inode = s.inode and  s.name = 'Host' and c.identifier <> ? and clvi.working_inode = c.inode ";
+                " where c.structure_inode = s.inode and s.velocity_var_name = 'Host' and c.identifier <> ? and clvi.working_inode = c.inode ";
 
         final DotConnect dc = new DotConnect();
         dc.setSQL(sql);


### PR DESCRIPTION
NOTE TO DEVS: This PR is intended for ixing this issue in the LTS releases only, as new changes recently sent to master