### PR TITLE
#21886 Validating potential NPE when an outdated folder reference is sent

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -5076,8 +5076,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
             if(UtilMethods.isSet(contentletRaw.getFolder()) && !contentletRaw.getFolder().equals(FolderAPI.SYSTEM_FOLDER)){
                 final Folder folder = folderAPI.find(contentletRaw.getFolder(), systemUser, false);
-                Identifier folderIdent = identifierAPI.find(folder.getIdentifier());
-                identifier.setParentPath(folderIdent.getPath());
+                if (null != folder) {
+                    Identifier folderIdent = identifierAPI.find(folder.getIdentifier());
+                    identifier.setParentPath(folderIdent.getPath());
+                }
             } else {
                 identifier.setParentPath(StringPool.FORWARD_SLASH);
             }


### PR DESCRIPTION
A contentlet with an outdated folderId might generate a NPE, for example: after uploading an old bundle with a renamed a folder, the piece of content in the bundle keeps the old folder identifier because in older dotCMS versions, folder ids weren't updated after a rename.

This PR is linked to some changes in [EE](https://github.com/dotCMS/enterprise/pull/862).