### PR TITLE
#21882 adding first draft of the osgi cluste wide restart

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/OSGIResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/OSGIResource.java
@@ -188,7 +188,6 @@ public class OSGIResource  {
                 .filter(file -> file.getName().endsWith(".jar"))
                 .collect(Collectors.toList()));
 
-        // todo: use the second part to would be to take jar from the temp api
         final String felixUploadFolder = OSGIUtil.getInstance().getFelixUploadPath();
         final File felixFolder = new File(felixUploadFolder);
         if (!felixFolder.exists() || !felixFolder.canWrite()) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/osgi/AJAX/OSGIAJAX.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/osgi/AJAX/OSGIAJAX.java
@@ -212,15 +212,8 @@ public class OSGIAJAX extends OSGIBaseAJAX {
 
     public void restart ( HttpServletRequest request, HttpServletResponse response ) throws ServletException, IOException {
 
-        //Remove portlets and actionlets references that were removed directly from the file system
-        remove();
-
-        //First we need to stop the framework
-        OSGIUtil.getInstance().stopFramework();
-
-        //Now we need to initialize it
-        OSGIUtil.getInstance().initializeFramework();
-
+        // restart the framework at notify to all nodes to do the same
+        OSGIUtil.getInstance().restartOsgiClusterWide();
         //Send a respose
         writeSuccess( response, "OSGI Framework Restarted" );
     }

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -381,8 +381,10 @@ public class OSGIUtil {
             Logger.info(this, "Portlets Removed: " + this.portletIDsStopped.toString());
 
             //Remove Actionlets in the list
-            this.actionletsStopped.stream().forEach(this.workflowOsgiService::removeActionlet);
-            Logger.info(this, "Actionlets Removed: " + this.actionletsStopped.toString());
+            if (null  != this.workflowOsgiService) {
+                this.actionletsStopped.stream().forEach(this.workflowOsgiService::removeActionlet);
+                Logger.info(this, "Actionlets Removed: " + this.actionletsStopped.toString());
+            }
 
             //Cleanup lists
             this.portletIDsStopped.clear();

--- a/dotCMS/src/main/java/org/apache/felix/framework/OsgiRestartTopic.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OsgiRestartTopic.java
@@ -1,0 +1,175 @@
+package org.apache.felix.framework;
+
+import com.dotcms.dotpubsub.DotPubSubEvent;
+import com.dotcms.dotpubsub.DotPubSubProvider;
+import com.dotcms.dotpubsub.DotPubSubProviderLocator;
+import com.dotcms.dotpubsub.DotPubSubTopic;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.StringUtils;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * This topic alerts the other nodes that one of the nodes has restarted the OSGI Framework and
+ * all of them needs to do the restart too.
+ * @author jsanca
+ */
+public class OsgiRestartTopic implements DotPubSubTopic {
+
+    final static String OSGI_RESTART_TOPIC = "osgi_restart_topic";
+
+    static long bytesSent, bytesRecieved, messagesSent, messagesRecieved = 0;
+
+    private final Map<String, Serializable> serverResponses = new ConcurrentHashMap<>();
+
+    public HashMap<String, Serializable> readResponses() {
+        return new HashMap<>(serverResponses);
+
+    }
+
+    public void resetResponses() {
+        serverResponses.clear();
+    }
+
+    @VisibleForTesting
+    private final String serverId;
+
+    private final DotPubSubProvider provider;
+
+    /**
+     * Events types to handle
+     * request: made on the content api
+     * response: handle by the Pub/Sub
+     * unknown
+     */
+    public enum EventType {
+
+        OGSI_RESTART_REQUEST, OGSI_RESTART_RESPONSE, UNKNOWN;
+
+        private static final EventType [] types = values();
+
+        public static  EventType from(final Serializable name) {
+
+            for (final EventType type : types) {
+                if (type.name().equals(name)) {
+                    return type;
+                }
+            }
+
+            return UNKNOWN;
+        }
+    }
+
+    final Map<String, Consumer<DotPubSubEvent>> consumerMap =
+            new ImmutableMap.Builder<String, Consumer<DotPubSubEvent>>()
+                    .put(EventType.OGSI_RESTART_REQUEST.name(),  (event) -> {
+
+                        Logger.info(this.getClass(), () -> "Got OGSI_RESTART_REQUEST from server:" + event.getOrigin() + ". sending response");
+
+                        OsgiRestartTopic.this.provider.publish(new DotPubSubEvent.Builder(event)
+                                // we set response b/c the nodes subscribed will wait this kind of msg
+                                .withType(EventType.OGSI_RESTART_RESPONSE.name()).withTopic(OsgiRestartTopic.this)
+                                .build());
+                    })
+                    .put(EventType.OGSI_RESTART_RESPONSE.name(), (event) -> {
+
+                        Logger.info(this.getClass(),
+                                () -> "Got PUBLISH_CONTENT_RESPONSE from server:" + event.getOrigin() + ". Saving response");
+
+                        final String origin = (String) event.getPayload().get("serverId");
+                        Logger.info(this, "Event received: " + event.toString());
+
+                        // Restart the current instance
+                        OSGIUtil.getInstance().restartOsgiOnlyLocal();
+                    }).build();
+
+
+    public OsgiRestartTopic() {
+        this(APILocator.getServerAPI().readServerId());
+    }
+
+    @VisibleForTesting
+    public OsgiRestartTopic(String serverId) {
+        this(serverId, DotPubSubProviderLocator.provider.get());
+    }
+
+    @VisibleForTesting
+    public OsgiRestartTopic(String serverId, DotPubSubProvider provider) {
+        this.serverId = StringUtils.shortify(serverId, 10);
+        this.provider = provider;
+    }
+
+    @Override
+    public String getInstanceId () {
+        return serverId;
+    }
+
+    public enum CacheEventType {
+        CLUSTER_REQ, CLUSTER_RES, UKN;
+
+        static public CacheEventType from(Serializable name) {
+            for (CacheEventType type : CacheEventType.values()) {
+                if (type.name().equals(name)) {
+                    return type;
+                }
+            }
+            return UKN;
+        }
+    }
+
+    @Override
+    public Comparable getKey() {
+        return OSGI_RESTART_TOPIC;
+    }
+
+    @Override
+    public void notify(final DotPubSubEvent event) {
+
+        Logger.info(this.getClass(), () -> "Got CLUSTER_REQ from server:" + event.getOrigin() + ". sending response");
+
+        this.consumerMap.getOrDefault(event.getType(), doNothing).accept(event);
+    }
+
+    final private Consumer<DotPubSubEvent> doNothing = (event) -> {
+        Logger.debug(getClass(), () -> "got an non-event:" + event);
+    };
+
+    @Override
+    public long messagesSent() {
+        return messagesSent;
+    }
+
+    @Override
+    public long bytesSent() {
+        return bytesSent;
+    }
+
+    @Override
+    public long messagesReceived() {
+        return messagesRecieved;
+    }
+
+    @Override
+    public long bytesReceived() {
+        return bytesRecieved;
+    }
+
+    @Override
+    public void incrementSentCounters(final DotPubSubEvent event) {
+        bytesSent += event.toString().getBytes().length;
+        messagesSent++;
+    }
+
+    @Override
+    public void incrementReceivedCounters(final DotPubSubEvent event) {
+        bytesRecieved += event.toString().getBytes().length;
+        messagesRecieved++;
+    }
+}

--- a/dotCMS/src/main/java/org/apache/felix/framework/OsgiRestartTopic.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OsgiRestartTopic.java
@@ -56,7 +56,7 @@ public class OsgiRestartTopic implements DotPubSubTopic {
 
     @VisibleForTesting
     public OsgiRestartTopic(final String serverId, final DotPubSubProvider provider) {
-        
+
         this.serverId = StringUtils.shortify(serverId, 10);
         this.provider = provider;
         this.consumerMap =
@@ -75,11 +75,12 @@ public class OsgiRestartTopic implements DotPubSubTopic {
                             Logger.info(this.getClass(),
                                     () -> "Got OGSI_RESTART_RESPONSE from server:" + event.getOrigin());
 
-                            final String origin = (String) event.getPayload().get("sourceNode");
+                            final String origin       = (String) event.getPayload().get("sourceNode");
+                            final String shortyOrigin = StringUtils.shortify(origin, 10);
                             Logger.info(this, "Event received: " + event + ", origin node: " + origin);
 
                             // just in case we double check the origin is not itself to avoid double osgi restart
-                            if (!OsgiRestartTopic.this.serverId.equals(origin)) {
+                            if (!OsgiRestartTopic.this.serverId.equals(shortyOrigin)) {
                                 // Restart the current instance
                                 OSGIUtil.getInstance().restartOsgiOnlyLocal();
                             }

--- a/dotCMS/src/main/java/org/apache/felix/framework/OsgiRestartTopic.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OsgiRestartTopic.java
@@ -81,10 +81,10 @@ public class OsgiRestartTopic implements DotPubSubTopic {
                     .put(EventType.OGSI_RESTART_RESPONSE.name(), (event) -> {
 
                         Logger.info(this.getClass(),
-                                () -> "Got OGSI_RESTART_RESPONSE from server:" + event.getOrigin() + ". Saving response");
+                                () -> "Got OGSI_RESTART_RESPONSE from server:" + event.getOrigin());
 
                         final String origin = (String) event.getPayload().get("sourceNode");
-                        Logger.info(this, "Event received: " + event.toString() + ", origin node: " + origin);
+                        Logger.info(this, "Event received: " + event + ", origin node: " + origin);
 
                         // just in case we double check the origin is not itself to avoid double osgi restart
                         if (!OsgiRestartTopic.this.serverId.equals(origin)) {

--- a/dotCMS/src/main/java/org/apache/felix/framework/OsgiRestartTopic.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OsgiRestartTopic.java
@@ -81,13 +81,16 @@ public class OsgiRestartTopic implements DotPubSubTopic {
                     .put(EventType.OGSI_RESTART_RESPONSE.name(), (event) -> {
 
                         Logger.info(this.getClass(),
-                                () -> "Got PUBLISH_CONTENT_RESPONSE from server:" + event.getOrigin() + ". Saving response");
+                                () -> "Got OGSI_RESTART_RESPONSE from server:" + event.getOrigin() + ". Saving response");
 
-                        final String origin = (String) event.getPayload().get("serverId");
-                        Logger.info(this, "Event received: " + event.toString());
+                        final String origin = (String) event.getPayload().get("sourceNode");
+                        Logger.info(this, "Event received: " + event.toString() + ", origin node: " + origin);
 
-                        // Restart the current instance
-                        OSGIUtil.getInstance().restartOsgiOnlyLocal();
+                        // just in case we double check the origin is not itself to avoid double osgi restart
+                        if (!OsgiRestartTopic.this.serverId.equals(origin)) {
+                            // Restart the current instance
+                            OSGIUtil.getInstance().restartOsgiOnlyLocal();
+                        }
                     }).build();
 
 


### PR DESCRIPTION
when dotcms is on cluster context and one of the nodes restarts their OSGI framework, the rest of the nodes in the cluster should restart their own OSGI frameworks too