### PR TITLE
#21476 : Ability to include System Host in results was being ignored.

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
@@ -805,8 +805,9 @@ public class HostAPIImpl implements HostAPI, Flushable<Host> {
     public PaginatedArrayList<Host> searchByStopped(final String filter, final boolean showStopped, final boolean
             showSystemHost, final int limit, final int offset, final User user, final boolean respectFrontendRoles) {
         PaginatedArrayList<Host> paginatedSiteList = new PaginatedArrayList<>();
-        final Optional<List<Host>> siteListOpt = showStopped ? this.getHostFactory().findStoppedSites(filter, true, limit, offset, user,
-                respectFrontendRoles) : this.getHostFactory().findLiveSites(filter, limit, offset, user, respectFrontendRoles);
+        final Optional<List<Host>> siteListOpt = showStopped ? this.getHostFactory()
+                .findStoppedSites(filter, true, limit, offset, showSystemHost, user, respectFrontendRoles) :
+                this.getHostFactory().findLiveSites(filter, limit, offset, showSystemHost, user, respectFrontendRoles);
         if (siteListOpt.isPresent()) {
             if (showStopped) {
                 return convertToSitePaginatedList(siteListOpt.get());
@@ -836,7 +837,8 @@ public class HostAPIImpl implements HostAPI, Flushable<Host> {
         Optional<List<Host>> siteListOpt;
         if (!showStopped && !showArchived) {
             // Return live Sites
-            siteListOpt = this.getHostFactory().findLiveSites(filter, limit, offset, user, respectFrontendRoles);
+            siteListOpt = this.getHostFactory()
+                    .findLiveSites(filter, limit, offset, showSystemHost, user, respectFrontendRoles);
             if (siteListOpt.isPresent()) {
                 try {
                     // Permissions can only be checked on LIVE contents
@@ -855,14 +857,16 @@ public class HostAPIImpl implements HostAPI, Flushable<Host> {
         }
         if (showStopped && !showArchived) {
             // Return stopped Sites
-            siteListOpt = this.getHostFactory().findStoppedSites(filter, false, limit, offset, user, respectFrontendRoles);
+            siteListOpt = this.getHostFactory()
+                    .findStoppedSites(filter, false, limit, offset, showSystemHost, user, respectFrontendRoles);
             if (siteListOpt.isPresent()) {
                 paginatedSiteList = convertToSitePaginatedList(siteListOpt.get());
             }
         }
         if (showStopped && showArchived) {
             // Return archived Sites
-            siteListOpt = this.getHostFactory().findArchivedSites(filter, limit, offset, user, respectFrontendRoles);
+            siteListOpt = this.getHostFactory()
+                    .findArchivedSites(filter, limit, offset, showSystemHost, user, respectFrontendRoles);
             if (siteListOpt.isPresent()) {
                 paginatedSiteList = convertToSitePaginatedList(siteListOpt.get());
             }
@@ -874,7 +878,8 @@ public class HostAPIImpl implements HostAPI, Flushable<Host> {
     @Override
     public PaginatedArrayList<Host> search(String filter, boolean showSystemHost, int limit, int offset, User user, boolean respectFrontendRoles){
         PaginatedArrayList<Host> paginatedSiteList = new PaginatedArrayList<>();
-        final Optional<List<Host>> siteListOpt = this.getHostFactory().findLiveSites(filter, limit, offset, user, respectFrontendRoles);
+        final Optional<List<Host>> siteListOpt =
+                this.getHostFactory().findLiveSites(filter, limit, offset, showSystemHost, user, respectFrontendRoles);
         if (siteListOpt.isPresent()) {
             try {
                 List<Host> filteredSiteList = APILocator.getPermissionAPI().filterCollection(siteListOpt.get(), PermissionAPI
@@ -896,8 +901,9 @@ public class HostAPIImpl implements HostAPI, Flushable<Host> {
     public PaginatedArrayList<Host> search(final String filter, boolean showArchived, boolean showSystemHost, int
             limit, int offset, User user, boolean respectFrontendRoles) {
         PaginatedArrayList<Host> paginatedSiteList = new PaginatedArrayList<>();
-        final Optional<List<Host>> siteListOpt = showArchived ? this.getHostFactory().findArchivedSites(filter, limit, offset, user,
-                respectFrontendRoles) : this.getHostFactory().findLiveSites(filter, limit, offset, user, respectFrontendRoles);
+        final Optional<List<Host>> siteListOpt = showArchived ? this.getHostFactory()
+                .findArchivedSites(filter, limit, offset, showSystemHost, user, respectFrontendRoles) :
+                this.getHostFactory().findLiveSites(filter, limit, offset, showSystemHost, user, respectFrontendRoles);
         if (siteListOpt.isPresent()) {
             if (showArchived) {
                 return convertToSitePaginatedList(siteListOpt.get());

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactory.java
@@ -161,18 +161,21 @@ public interface HostFactory {
      * Returns all live Sites in dotCMS.
      *
      * @param siteNameFilter       Optional parameter used to filter by Site name.
-     * @param limit                Limit of results returned in the response, for pagination purposes. If set equal or
-     *                             lower than zero, this parameter will be ignored.
+     * @param limit                Limit of results being returned as part of the response, for pagination purposes. If
+     *                             set equal or lower than zero, this parameter will be ignored.
      * @param offset               Expected offset of results in the response, for pagination purposes. If set equal or
      *                             lower than zero, this parameter will be ignored.
+     * @param showSystemHost       If the System Host must be included in the results, set to {@code true}. Otherwise,
+     *                             set to {@code false}.
      * @param user                 The {@link User} performing this action.
      * @param respectFrontendRoles If the User's front-end roles need to be taken into account in order to perform this
      *                             operation, set to {@code true}. Otherwise, set to {@code false}.
      *
      * @return The resulting list of {@link Host} objects.
      */
-    Optional<List<Host>> findLiveSites(final String siteNameFilter, final int limit, final int offset, final User
-            user, final boolean respectFrontendRoles);
+    Optional<List<Host>> findLiveSites(final String siteNameFilter, final int limit, final int offset,
+                                       final boolean showSystemHost, final User user,
+                                       final boolean respectFrontendRoles);
 
     /**
      * Returns all stopped/un-published Sites in dotCMS.
@@ -180,10 +183,12 @@ public interface HostFactory {
      * @param siteNameFilter       Optional parameter used to filter by Site name.
      * @param includeArchivedSites If archived Sites must be returned, set to {@code true}. Otherwise, set to {@code
      *                             false}.
-     * @param limit                Limit of results returned in the response, for pagination purposes. If set equal or
-     *                             lower than zero, this parameter will be ignored.
+     * @param limit                Limit of results being returned as part of the response, for pagination purposes. If
+     *                             set equal or lower than zero, this parameter will be ignored.
      * @param offset               Expected offset of results in the response, for pagination purposes. If set equal or
      *                             lower than zero, this parameter will be ignored.
+     * @param showSystemHost       If the System Host must be included in the results, set to {@code true}. Otherwise,
+     *                             set to {@code false}.
      * @param user                 The {@link User} performing this action.
      * @param respectFrontendRoles If the User's front-end roles need to be taken into account in order to perform this
      *                             operation, set to {@code true}. Otherwise, set to {@code false}.
@@ -191,24 +196,27 @@ public interface HostFactory {
      * @return The resulting list of {@link Host} objects.
      */
     Optional<List<Host>> findStoppedSites(final String siteNameFilter, boolean includeArchivedSites, final int limit,
-                                          final int offset, final User user, final boolean respectFrontendRoles);
+                                          final int offset, boolean showSystemHost, final User user,
+                                          final boolean respectFrontendRoles);
 
     /**
      * Returns all stopped/un-published Sites in dotCMS.
      *
      * @param siteNameFilter       Optional parameter used to filter by Site name.
-     * @param limit                Limit of results returned in the response, for pagination purposes. If set equal or
-     *                             lower than zero, this parameter will be ignored.
+     * @param limit                Limit of results being returned as part of the response, for pagination purposes. If
+     *                             set equal or lower than zero, this parameter will be ignored.
      * @param offset               Expected offset of results in the response, for pagination purposes. If set equal or
      *                             lower than zero, this parameter will be ignored.
+     * @param showSystemHost       If the System Host must be included in the results, set to {@code true}. Otherwise,
+     *                             set to {@code false}.
      * @param user                 The {@link User} performing this action.
      * @param respectFrontendRoles If the User's front-end roles need to be taken into account in order to perform this
      *                             operation, set to {@code true}. Otherwise, set to {@code false}.
      *
      * @return The resulting list of {@link Host} objects.
      */
-    Optional<List<Host>> findArchivedSites(final String siteNameFilter, final int limit, final int offset, final User
-            user, final boolean respectFrontendRoles);
+    Optional<List<Host>> findArchivedSites(final String siteNameFilter, final int limit, final int offset,
+                                           boolean showSystemHost, final User user, final boolean respectFrontendRoles);
 
     /**
      * Returns the total number of Sites that exist in your content repository.

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactoryImpl.java
@@ -1,6 +1,5 @@
 package com.dotmarketing.portlets.contentlet.business;
 
-import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.concurrent.DotConcurrentFactory;
 import com.dotcms.content.business.json.ContentletJsonAPI;
@@ -622,21 +621,27 @@ public class HostFactoryImpl implements HostFactory {
     }
 
     @Override
-    public Optional<List<Host>> findLiveSites(final String siteNameFilter, int limit, int offset, final User user, boolean
-            respectFrontendRoles) {
-        return search(siteNameFilter, SITE_IS_LIVE.toString(), false, limit, offset, user, respectFrontendRoles);
+    public Optional<List<Host>> findLiveSites(final String siteNameFilter, final int limit, final int offset,
+                                              final boolean showSystemHost, final User user, final boolean respectFrontendRoles) {
+        return search(siteNameFilter, SITE_IS_LIVE.toString(), showSystemHost, limit, offset, user,
+                respectFrontendRoles);
     }
 
     @Override
-    public Optional<List<Host>> findStoppedSites(final String siteNameFilter, boolean includeArchivedSites, int limit, int offset, final User user, boolean respectFrontendRoles) {
-        final String condition = includeArchivedSites ? SITE_IS_STOPPED_OR_ARCHIVED.toString() : SITE_IS_STOPPED.toString();
-        return search(siteNameFilter, condition, false, limit, offset, user, respectFrontendRoles);
+    public Optional<List<Host>> findStoppedSites(final String siteNameFilter, final boolean includeArchivedSites,
+                                                 final int limit, final int offset, final boolean showSystemHost,
+                                                 final User user, final boolean respectFrontendRoles) {
+        final String condition =
+                includeArchivedSites ? SITE_IS_STOPPED_OR_ARCHIVED.toString() : SITE_IS_STOPPED.toString();
+        return search(siteNameFilter, condition, showSystemHost, limit, offset, user, respectFrontendRoles);
     }
 
     @Override
-    public Optional<List<Host>> findArchivedSites(final String siteNameFilter, int limit, int offset, final User user, boolean
-            respectFrontendRoles) {
-        return search(siteNameFilter, SITE_IS_ARCHIVED.toString(), false, limit, offset, user, respectFrontendRoles);
+    public Optional<List<Host>> findArchivedSites(final String siteNameFilter, final int limit, final int offset,
+                                                  final boolean showSystemHost, final User user,
+                                                  final boolean respectFrontendRoles) {
+        return search(siteNameFilter, SITE_IS_ARCHIVED.toString(), showSystemHost, limit, offset, user,
+                respectFrontendRoles);
     }
 
     @Override


### PR DESCRIPTION
The 'includeSystemHost' flag was being ignored, which was causing that services who required the System Host reference were not getting it.