### PR TITLE
Issue 21966 fix npe loading field

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -318,18 +318,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     public Object loadField(final String inode, final com.dotcms.contenttype.model.field.Field field) throws DotDataException{
-        final ContentletJsonAPI contentletJsonAPI = APILocator.getContentletJsonAPI();
         if(APILocator.getContentletJsonAPI().isPersistContentAsJson()){
           final Object value = contentFactory.loadJsonField(inode, field);
           if(null != value){
               return value;
           }
-          //If nothing was fetched from the json-column
-          //We check if we explicitly indicated that no values should be written into the columns
-          if(!contentletJsonAPI.isPersistContentletInColumns()){
-             return null;
-          }
-          //But if passed this check then we should also give a try fetching the field from the columns.
         }
         return contentFactory.loadField(inode, field.dbColumn());
     }


### PR DESCRIPTION
When requesting a field from a contentlet through an inode there was an incorrect condition causing to return null
The strategy should be we either load from Jason or the columns 
if we have explicitly indicated that we do not support JSON we should go again to the column 