### PR TITLE
dotCMS/core#21492 Fix Toggle to Code in WYSIWYG Makes UI Jump

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -370,6 +370,11 @@
             <div id="acheck<%=field.getVelocityVarName()%>"></div>
 
         </div>
+        <style>
+            .editWYSIWYGField.aceText.aceTall {
+                height: 400px;
+            }
+        </style>
         <script type="text/javascript">
             dojo.addOnLoad(function () {
                 <% if (!wysiwygDisabled) { %>

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp
@@ -443,6 +443,7 @@ var cmsfile=null;
 			  // Init instance callback to fix the pointer-events issue.
 			  tinyConf = {
 			    ...tinyConf,
+                height: 332,
 			    init_instance_callback: (editor) => {
 			      let dropZone = document.getElementById(
 			        `dot-asset-drop-zone-${textAreaId}`


### PR DESCRIPTION
This is present only for content types where a contentlet requires scrolling to view all fields. When creating a new or editing an existing contentlet of this nature with a WYSIWYG field, when toggling to code the UI "jumps" to the next field which can hide the previous field from view. This has been reported as confusing to end users