### PR TITLE
dotCMS/core#21735 fix Content with 2 Relationship Fields of Same Type Also Shows Non-Available Languages

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp
@@ -241,7 +241,7 @@
         }
 
 		//Function used to render language id
-		function <%= relationJsName %>_lang(o) {
+		function <%= relationJsName %>_lang(o, preId) {
 			if (o !== null && dijit.byId("langcombo")) {
 			    var contentletLangCode = '<%= langAPI.getLanguageCodeAndCountry(contentlet.getLanguageId(),null)%>';
                 var currentLanguageIndex = getCurrentLanguageIndex(o);
@@ -250,7 +250,7 @@
                 var anchorValue = "";
                 var imgLangName = '';
 
-                result = '<div class="relationLanguageFlag" id="' + o.id + '"><div value="' + currentLanguageIndex + '" data-dojo-type="dijit/form/Select">';
+                result = '<div class="relationLanguageFlag" data-id="' + preId + '_' + o.id +'" id="' + o.id + '"><div value="' + currentLanguageIndex + '" data-dojo-type="dijit/form/Select">';
 
 				for(var sibIndex = 0; sibIndex < o['siblings'].length ; sibIndex++){
 					langImg = o['siblings'][sibIndex]['langCode'];
@@ -546,7 +546,7 @@
 
 		}
 
-        function createLangTd(row, item) {
+        function createLangTd(row, item, preId) {
             var langTD = document.createElement("td");
             row.appendChild(langTD);
             // displays the publish/unpublish/archive status of the content and language flag, if multiple languages exists.
@@ -554,8 +554,9 @@
                 if(dijit.byId("langcombo")){
                     langTD.style.whiteSpace="nowrap";
                     langTD.style.textAlign = 'right';
-                    langTD.innerHTML = <%= relationJsName %>_lang(item);
-                    setTimeout(function () { dojo.parser.parse(item.id); }, 0);
+                    langTD.innerHTML = <%= relationJsName %>_lang(item, preId);
+                    setTimeout(function () { dojo.parser.parse(document.querySelector('[data-id="' + preId + '_'+ item.id +'"]')
+); }, 0);
                 }
             <%}%>
         }
@@ -588,12 +589,12 @@
                 var titleCell = row.insertCell (row.cells.length);
                 titleCell.innerHTML = <%= relationJsName%>WriteLinkTitle (item);
 
-                createLangTd(row, item);
+                createLangTd(row, item, '<%= relationJsName %>');
             } else {
                 <%= relationJsName %>_showFields.forEach(function(fieldName) {
                     var fieldValue = '';
                     if (fieldName === 'languageId') {
-                        createLangTd(row, item);
+                        createLangTd(row, item, '<%= relationJsName %>');
                     } else if (fieldName === 'titleImage') {
                         createImageCell(row, item);
                     } else {


### PR DESCRIPTION
In the instance of a content type that has two relationship fields for the same content type, when relating the same content on each field the second relationship field shows both the language the content is in, as well as all languages that are available in the system as crossed out. This becomes a jarring UI experience when instances have a very large number of languages available.

![image](https://user-images.githubusercontent.com/37185433/162543671-82e6ea6b-f860-4582-914b-8eaefcb33954.png)
