### PR TITLE
#21801 Removing redundant IdentifierAPI.delete call

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactory.java
@@ -23,7 +23,15 @@ import java.util.TimeZone;
 public abstract class FolderFactory {
 
 
-	abstract void delete(Folder f) throws DotDataException;
+	/**
+	 * Deletes a folder.
+	 * The folder reference is not explicitly deleted from the identifier table because there is
+	 * a db trigger that executes the delete operation once the folder table is cleaned up.
+	 * Only the Identifier Cache is flushed.
+	 * @param folder
+	 * @throws DotDataException
+	 */
+	abstract void delete(final Folder folder) throws DotDataException;
 
 	abstract Folder find(String folderInode) throws  DotDataException;
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -89,7 +89,12 @@ public class FolderFactoryImpl extends FolderFactory {
 
            folderCache.removeFolder(folder, id);
 
-		   APILocator.getIdentifierAPI().delete(id);
+		   /*Folder reference is not explicitly deleted from the identifier table because there is
+		   a db trigger that executes the delete operation once the folder table is cleaned up.
+		   Only cache is flushed.
+		   Trigger name: folder_identifier_check_trigger
+		   */
+		   CacheLocator.getIdentifierCache().removeFromCacheByIdentifier(id.getId());
 	}
 
 
@@ -613,6 +618,7 @@ public class FolderFactoryImpl extends FolderFactory {
 					+ "' where inode_id = '" + oldFolderInode + "'");
 			dotConnect.executeStatement("update permission_reference set asset_id = '"
 					+ newFolderInode + "' where asset_id = '" + oldFolderInode + "'");
+
 
 		}catch (SQLException e){
 			Logger.error(FolderFactoryImpl.class, e.getMessage(), e);

--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
@@ -1328,17 +1328,15 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
     }
 
     function moveFolder (objId, parentId, referer) {
-        //top.location='<portlet:actionURL windowState="<%= WindowState.MAXIMIZED.toString() %>"><portlet:param name="struts_action" value="/ext/folders/edit_folder" /><portlet:param name="cmd" value="move" /></portlet:actionURL>&inode=' + objId + '&parent=' + parentId + '&referer=' + referer;
         BrowserAjax.moveFolder(objId, parentId, moveFolderCallback);
-        setTimeout('reloadContent()',500);
     }
 
     function moveFolderCallback (response) {
+        reloadContent();
         if(response == '<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Folder-moved")) %>'){
             BrowserAjax.getTree(null, initializeTree);
             showDotCMSSystemMessage(response);
         } else {
-            reloadContent ();
             showDotCMSErrorMessage(response);
         }
     }


### PR DESCRIPTION
The line `APILocator.getIdentifierAPI().delete(id);` was removed when a folder is deleted because there is a trigger that internally deletes the reference on the `identifier` table. Only the IdentifierCache is flushed.