### PR TITLE
Fixing test

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/filters/VanityUrlFilterTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/filters/VanityUrlFilterTest.java
@@ -142,7 +142,7 @@ public class VanityUrlFilterTest {
 
     /**
      * this tests that the vanityURL proxies requests that are made to different hosts.
-     * In this case, we will request a url from dotcms and check to see that we get the results from dotcms.com
+     * In this case, we will request an url from dotcms and check to see that we get the results from dotcms.com
      */
     @Test
     public void test_that_vanity_url_filter_handles_proxy_requests() throws Exception {
@@ -176,7 +176,7 @@ public class VanityUrlFilterTest {
             String content = FileUtil.read(tmp);
             assert (content != null);
             assert (content.contains("All rights reserved"));
-            assert (content.contains("<meta property=\"og:url\" content=\"https://dotcms.com/\">"));
+            assert (content.contains("<meta property=\"og:url\" content=\"https://www.dotcms.com/\">"));
         }
     }
 


### PR DESCRIPTION
Fixing VanityUrlFilterTest#test_that_vanity_url_filter_handles_proxy_requests

this test create a VanityURl to foward to "https://dotcms.com' and the it assert the response content 

<meta property="og:url" content="https://dotcms.com">

for any reasons this line change by 

<meta property="og:url" content="https://www.dotcms.com">

