### PR TITLE
dotCMS/core#21818 Reload contentlet on edit using #editContentlet macro 

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_js_inc.jsp
@@ -653,7 +653,9 @@
 
         if (data["contentletIdentifier"]) {
             if (ngEditContentletEvents) {
-                ngEditContentletEvents.next({
+                // This is needed to wait for re-index on update, since we are saving with ContentletAjax.saveContent
+                setTimeout(()=>{
+                    ngEditContentletEvents.next({
                     name: 'save',
                     data: {
                         identifier: data.contentletIdentifier,
@@ -661,6 +663,7 @@
                         type: null
                     }
                 });
+                },3000);
             }
 
             if((data["referer"] != null && data["referer"] != '' && !data["contentletLocked"])) {


### PR DESCRIPTION
Delay the fire of Angular event, to wait for content re-index when updating with ContentletAjax.saveContent