### PR TITLE
Issue 22013 graph ql is not working on release 22.04

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldType.java
@@ -3,6 +3,7 @@ package com.dotmarketing.startup.runonce;
 import static java.util.stream.Collectors.toMap;
 
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.db.Params;
 import com.dotmarketing.exception.DotDataException;
@@ -63,6 +64,8 @@ public class Task220330ChangeVanityURLSiteFieldType implements StartupTask {
 
             updateHost(contentlets);
             updateFieldType();
+
+            CacheLocator.getContentTypeCache2().clearCache();
         } catch (JsonProcessingException | DotSecurityException e) {
             Logger.error(Task220330ChangeVanityURLSiteFieldType.class, e.getMessage());
         }

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldType.java
@@ -3,7 +3,6 @@ package com.dotmarketing.startup.runonce;
 import static java.util.stream.Collectors.toMap;
 
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.db.Params;
 import com.dotmarketing.exception.DotDataException;
@@ -64,8 +63,6 @@ public class Task220330ChangeVanityURLSiteFieldType implements StartupTask {
 
             updateHost(contentlets);
             updateFieldType();
-
-            CacheLocator.getContentTypeCache2().clearCache();
         } catch (JsonProcessingException | DotSecurityException e) {
             Logger.error(Task220330ChangeVanityURLSiteFieldType.class, e.getMessage());
         }


### PR DESCRIPTION
For some reasons (Maybe because another TU is using the ContentTypeAPI) we need to flush the ContentType Cache after run this TU, if we don't do it the site field is taking as a CustomField from the cache and when it try to create the GraphQL scheme throw a Exception because the types no math.