### PR TITLE
 (#21658): Increasing publishing_pushed_assets.asset_id capacity to 2…

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -152,6 +152,7 @@ import com.dotmarketing.startup.runonce.Task220215MigrateDataFromInodeToFolderTe
 import com.dotmarketing.startup.runonce.Task220330ChangeVanityURLSiteFieldTypeTest;
 import com.dotmarketing.startup.runonce.Task220331UpdateDateTimezonesTest;
 import com.dotmarketing.startup.runonce.Task220404RemoveCalendarReminderTest;
+import com.dotmarketing.startup.runonce.Task220413IncreasePublishedPushedAssetIdColTest;
 import com.dotmarketing.util.ConfigTest;
 import com.dotmarketing.util.HashBuilderTest;
 import com.dotmarketing.util.MaintenanceUtilTest;
@@ -533,7 +534,8 @@ import org.junit.runners.Suite.SuiteClasses;
         Task220215MigrateDataFromInodeToFolderTest.class,
         Task220330ChangeVanityURLSiteFieldTypeTest.class,
         Task220331UpdateDateTimezonesTest.class,
-        Task220404RemoveCalendarReminderTest.class
+        Task220404RemoveCalendarReminderTest.class,
+        Task220413IncreasePublishedPushedAssetIdColTest.class
 })
 public class MainSuite {
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task220413IncreasePublishedPushedAssetIdColTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task220413IncreasePublishedPushedAssetIdColTest.java
@@ -1,0 +1,93 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.junit.Assert.assertTrue;
+
+public class Task220413IncreasePublishedPushedAssetIdColTest {
+
+    private static final String ASSET_ID = "this-is-an-assetid-which-is-longer-than-expected";
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Tests Task220413IncreasePublishedPushedAssetIdCol by inserting to published_pushed_assets with an assetId with
+     * greater capacity that it can hold.
+     * An exception is expected to be thrown.
+     *
+     * @throws DotDataException
+     */
+    @Test(expected = DotDataException.class)
+    public void test_upgradeTask_noCapacity() throws DotDataException {
+        rollbackToOriginal();
+        insertPublishedAsset(ASSET_ID);
+    }
+
+    /**
+     * Tests Task220413IncreasePublishedPushedAssetIdCol by inserting to published_pushed_assets with an assetId with
+     * greater capacity that it used to hold.
+     *
+     * @throws DotDataException
+     */
+    @Test
+    public void test_upgradeTask() throws DotDataException {
+        final Task220413IncreasePublishedPushedAssetIdCol task = new Task220413IncreasePublishedPushedAssetIdCol();
+        assertTrue(task.forceRun());
+
+        task.executeUpgrade();
+
+        try {
+            insertPublishedAsset(ASSET_ID);
+        } catch (DotDataException e) {
+            Assert.fail();
+        }
+    }
+
+    private void rollbackToOriginal() throws DotDataException {
+        try {
+            DbConnectionFactory.getConnection().setAutoCommit(true);
+        } catch (SQLException e) {
+            throw new DotDataException(e.getMessage(), e);
+        }
+
+        final DotConnect dotConnect = new DotConnect();
+        try {
+            dotConnect
+                    .setSQL("DELETE FROM publishing_pushed_assets")
+                    .loadResult();
+            dotConnect
+                    .setSQL(Task220413IncreasePublishedPushedAssetIdCol.resolveAlterCommand(36))
+                    .loadResult();
+        } catch (DotDataException e){
+            //Nah.
+        }
+    }
+
+    private void insertPublishedAsset(final String assetId) throws DotDataException {
+        new DotConnect().setSQL("INSERT INTO public.publishing_pushed_assets(" +
+                        "bundle_id, asset_id, asset_type, push_date, environment_id, endpoint_ids, publisher)" +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?)")
+                .addParam(UUID.randomUUID())
+                .addParam(assetId)
+                .addParam("OSGI")
+                .addParam(new Date())
+                .addParam(UUID.randomUUID())
+                .addParam(UUID.randomUUID())
+                .addParam("com.dotcms.publisher.pusher.PushPublisher")
+                .loadResult();
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220413IncreasePublishedPushedAssetIdCol.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220413IncreasePublishedPushedAssetIdCol.java
@@ -1,0 +1,39 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.startup.StartupTask;
+
+/**
+ * Increase the PUBLISHING_PUSHED_ASSETS.ASSET_ID column capacity to 255 since after pushing plugins we can have long
+ * names stored in this column.
+ */
+public class Task220413IncreasePublishedPushedAssetIdCol implements StartupTask {
+
+    static final String PG_INCREASE_COL_CAPACITY_SQL =
+            "ALTER TABLE publishing_pushed_assets ALTER COLUMN asset_id TYPE VARCHAR(%d)";
+    static final String MSSQL_INCREASE_COL_CAPACITY_SQL =
+            "ALTER TABLE publishing_pushed_assets ALTER COLUMN asset_id NVARCHAR(%d) NOT NULL";
+
+    @Override
+    public boolean forceRun() {
+        return true;
+    }
+
+    @Override
+    public void executeUpgrade() throws DotDataException {
+        new DotConnect()
+                .setSQL(resolveAlterCommand(255))
+                .loadResult();
+    }
+
+    static String resolveAlterCommand(int capacity) {
+        return String.format(
+                (DbConnectionFactory.isMsSql()
+                        ? MSSQL_INCREASE_COL_CAPACITY_SQL
+                        : PG_INCREASE_COL_CAPACITY_SQL),
+                capacity);
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -317,6 +317,7 @@ public class TaskLocatorUtil {
 		.add(Task220330ChangeVanityURLSiteFieldType.class)
 		.add(Task220331UpdateDateTimezones.class)
 		.add(Task220404RemoveCalendarReminder.class)
+		.add(Task220413IncreasePublishedPushedAssetIdCol.class)
 		.build();
         
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());

--- a/dotCMS/src/main/resources/mssql.sql
+++ b/dotCMS/src/main/resources/mssql.sql
@@ -2534,7 +2534,7 @@ alter table publishing_bundle_environment add constraint FK_environment_id forei
 
 create table publishing_pushed_assets(
     bundle_id NVARCHAR(36) NOT NULL,
-    asset_id NVARCHAR(36) NOT NULL,
+    asset_id NVARCHAR(255) NOT NULL,
     asset_type NVARCHAR(255) NOT NULL,
     push_date datetimeoffset(3),
     environment_id NVARCHAR(36) NOT NULL,

--- a/dotCMS/src/main/resources/postgres.sql
+++ b/dotCMS/src/main/resources/postgres.sql
@@ -2312,7 +2312,7 @@ alter table publishing_bundle_environment add constraint FK_environment_id forei
 
 create table publishing_pushed_assets(
 	bundle_id varchar(36) NOT NULL,
-	asset_id varchar(36) NOT NULL,
+	asset_id varchar(255) NOT NULL,
 	asset_type varchar(255) NOT NULL,
 	push_date timestamptz,
 	environment_id varchar(36) NOT NULL,


### PR DESCRIPTION
…55. Upgrade task and tests added.

Same as https://github.com/dotCMS/core/pull/22028 but against master.