### PR TITLE
#21772 Fixing after be broke by 21889

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -1258,9 +1258,8 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
         checkout.setHost(host_1.getIdentifier());
         checkout.setProperty(VanityUrlContentType.FORWARD_TO_FIELD_VAR, "/test-url_2.html");
 
-        ContentletDataGen.checkin(checkout);
-
         checkout.setProperty(Contentlet.TO_BE_PUBLISH, true);
+        ContentletDataGen.checkin(checkout);
         ContentletDataGen.publish(checkout);
 
         final VanityUrl vanityUrlUpdated = APILocator.getVanityUrlAPI().fromContentlet(checkout);

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -1256,11 +1256,11 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
 
         final Contentlet checkout = ContentletDataGen.checkout(vanityURL);
         checkout.setHost(host_1.getIdentifier());
-        checkout.setHost(host_1.getIdentifier());
         checkout.setProperty(VanityUrlContentType.FORWARD_TO_FIELD_VAR, "/test-url_2.html");
 
         ContentletDataGen.checkin(checkout);
 
+        checkout.setProperty(Contentlet.TO_BE_PUBLISH, true);
         ContentletDataGen.publish(checkout);
 
         final VanityUrl vanityUrlUpdated = APILocator.getVanityUrlAPI().fromContentlet(checkout);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -131,6 +131,8 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
   @VisibleForTesting
   public static final String IS_TEST_MODE = "_is_test_mode";
 
+  public static final String TO_BE_PUBLISH = "to_be_publish";
+
   /**
    * Flag to avoid to trigger the workflow again on the checkin when it is already in progress.
    */

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/SaveContentActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/SaveContentActionlet.java
@@ -67,6 +67,7 @@ public class SaveContentActionlet extends WorkFlowActionlet {
 			final Contentlet checkoutContentlet = this.checkout(contentlet, processor.getUser());
 
 			checkoutContentlet.setProperty(Contentlet.WORKFLOW_IN_PROGRESS, Boolean.TRUE);
+			checkoutContentlet.setProperty(Contentlet.TO_BE_PUBLISH, contentlet.getBoolProperty(Contentlet.TO_BE_PUBLISH));
 
 			final ContentletDependencies contentletDependencies = processor.getContentletDependencies();
 			final boolean respectFrontendPermission = contentletDependencies != null ?

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
@@ -2357,6 +2357,14 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 		}
 
 		final List<WorkflowActionClass> actionClasses = processor.getActionClasses();
+
+		final boolean isPublish = actionClasses.stream()
+				.anyMatch((WorkflowActionClass workflowActionClass) -> workflowActionClass.getClazz().equals(
+						PublishContentActionlet.class.getName()));
+
+		contentlet.setProperty(Contentlet.TO_BE_PUBLISH, isPublish);
+
+
 		if(actionClasses != null){
 			for(WorkflowActionClass actionClass : actionClasses){
 				final WorkFlowActionlet actionlet = actionClass.getActionlet();


### PR DESCRIPTION
Fixing issue:

https://github.com/dotCMS/core/issues/21772

it was broken after this one:

https://github.com/dotCMS/core/issues/21889

Now the site field is a "com.dotcms.contenttype.model.field.HostFolderField" this kind of field is saved in different way and time, the value for a HostFolderField is set in the Identifier so when you try to get the oldHost by the previous version here:

https://github.com/dotCMS/core/blob/master/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java#L886

it is already save in the identifier table so you really get the host already changed