### PR TITLE
#22055 now the bundle fragments are moved to undeploy folder

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/ResourceCollectorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ResourceCollectorUtil.java
@@ -23,6 +23,28 @@ import java.util.zip.ZipFile;
 public class ResourceCollectorUtil {
 
     /**
+     * Returns true if the file is a fragment
+     * @param file {@link File}
+     * @return boolean if it is a fragment
+     */
+    public static boolean isFragmentJar (final File file) {
+
+        boolean isFragment = false;
+        try (final JarFile jarFile     = new JarFile(file)){
+
+            final Manifest manifest    = jarFile.getManifest();
+            final String fragmentHost  = manifest.getMainAttributes().getValue("Fragment-Host");
+            isFragment =  UtilMethods.isSet(fragmentHost) &&
+                    "system.bundle; extension:=framework".equals(fragmentHost.trim());
+        }  catch (Exception e) {
+
+            Logger.error(ResourceCollectorUtil.class, e.getMessage(), e);
+        }
+
+        return isFragment;
+    }
+
+    /**
      * Get the packages for a jar file, if the file is a fragment will return the Export packages
      * If the file is a bundle will return the Import packages
      * @param file File

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -360,16 +360,23 @@ public class OSGIUtil {
 
     private void moveNewBundlesToFelixLoadFolder(final File uploadFolderFile, final String[] pathnames) {
 
-        final File deployDirectory = new File(this.getFelixDeployPath());
+        final File deployDirectory   = new File(this.getFelixDeployPath());
+        final File undeployDirectory = new File(this.getFelixUndeployPath());
         try {
 
             if (deployDirectory.exists() && deployDirectory.canWrite()) {
 
                 for (final String pathname : pathnames) {
 
-                    final File bundle = new File(uploadFolderFile, pathname);
+                    final File bundle      = new File(uploadFolderFile, pathname);
+                    File bundleDestination = new File(deployDirectory, bundle.getName());
+                    if (ResourceCollectorUtil.isFragmentJar(bundle)) {
+
+                        bundleDestination = new File(undeployDirectory, bundle.getName());
+                    }
+
                     Logger.debug(this, "Moving the bundle: " + bundle + " to " + deployDirectory);
-                    final File bundleDestination = new File(deployDirectory, bundle.getName());
+
                     if (FileUtil.move(bundle, bundleDestination)) {
 
                         Try.run(()->APILocator.getSystemEventsAPI()					    // CLUSTER WIDE


### PR DESCRIPTION
We have done several improvements to OSGI, one of them to read the packages imported on the jar + fragments, but we want to avoid to move the fragments from the upload folder to the load b/c it forces the restart and eventually causes issues on classpath, so this code still reading the packages but instead of moving to load, moves the fragments to undeploy folder