### PR TITLE
dotCMS/core#22037 Support field variables to add customization to block editor

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -155,9 +155,31 @@
             
             // The extra single quotes indicate that it will return an empty string -> "''"
             String textValue = UtilMethods.isSet(value) ? value.toString() : (UtilMethods.isSet(defaultValue) ? defaultValue : "''");
+            String customStyles = "";
+            String customClassName = "";
+
+            List<FieldVariable> acceptTypes=APILocator.getFieldAPI().getFieldVariablesForField(field.getInode(), user, false);
+            for(FieldVariable fv : acceptTypes){
+                if("styles".equalsIgnoreCase(fv.getKey())){
+                    customStyles = fv.getValue();
+                    customClassName = "block-custom-styles";
+                }
+            }
             %>
+            <style type="text/css">
+                dotcms-block-editor {
+                    width: 100%; 
+                    height: 500px; 
+                    display: block;   
+                }
+
+                dotcms-block-editor.block-custom-styles {
+                    <%=customStyles%>
+                }
+            </style>
+
             <script src="/html/dotcms-block-editor.js"></script>
-            <dotcms-block-editor style="width: 100%; height: 500px; display: block;"></dotcms-block-editor>
+            <dotcms-block-editor class="<%=customClassName%>"></dotcms-block-editor>
             <input type="hidden" name="<%=field.getFieldContentlet()%>" id="<%=field.getVelocityVarName()%>"/>
 
             <script>


### PR DESCRIPTION
Users will add a field variable called `styles` add valid css styles as string to eventually be added to a custom class called `dotcms-block-editor.block-custom-styles` that will overwrite the default block editor styles.