### PR TITLE
dotCMS/core#22097 Velocity render for block editor doesn’t support links

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/marks-macro.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/marks-macro.vtl
@@ -14,8 +14,14 @@
             #if ($mark.type == "italic")
             <em>
             #end
+            #if ($mark.type == "strike")
+            <s>
+            #end
             #if ($mark.type == "underline")
             <u>
+            #end
+            #if ($mark.type == "link")
+            <a href="$mark.attrs.href" target="$mark.attrs.target">
             #end
         #end
     #end
@@ -32,8 +38,14 @@
             #if ($mark.type == "italic")
             </em>
             #end
+            #if ($mark.type == "strike")
+            </s>
+            #end
             #if ($mark.type == "underline")
             </u>
+            #end
+            #if($mark.type == "link")
+            </a>
             #end
         #end
     #end


### PR DESCRIPTION
Now, the velocity render for `block editor` works for `links`.

**Before**
![image](https://user-images.githubusercontent.com/72418962/165585840-d3a53330-a2bb-447e-81a7-45f6ed47ea10.png)

**After**
<img width="999" alt="Screen Shot 2022-04-27 at 1 33 33 PM" src="https://user-images.githubusercontent.com/72418962/165585744-d2961c42-4239-45da-b426-c6d77cb4c61d.png">
