### PR TITLE
fix for IT :  RulesAPIImplIntegrationTest.shouldGetRulesFromPageId

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
@@ -721,7 +721,7 @@ public class HostAPIImpl implements HostAPI, Flushable<Host> {
         if (!UtilMethods.isSet(id)) {
             return null;
         }
-        return this.getHostFactory().DBSearch(id, user, respectFrontendRoles);
+        return this.getHostFactory().DBSearch(id, respectFrontendRoles);
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactory.java
@@ -113,7 +113,6 @@ public interface HostFactory {
      * Searches for a Site that matches the specified ID.
      *
      * @param id                   The Identifier of the Site
-     * @param user                 The {@link User} performing this action.
      * @param respectFrontendRoles If the User's front-end roles need to be taken into account in order to perform this
      *                             operation, set to {@code true}. Otherwise, set to {@code false}.
      *
@@ -123,7 +122,7 @@ public interface HostFactory {
      * @throws DotSecurityException The specified User does not have the required permissions to perform this
      *                              operation.
      */
-    Host DBSearch(final String id, final User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException;
+    Host DBSearch(final String id, boolean respectFrontendRoles) throws DotDataException, DotSecurityException;
 
     /**
      * <b>NOTE: Use with caution.</b> This method deletes the specified Site plus all assets under it. It has the

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactoryImpl.java
@@ -312,7 +312,7 @@ public class HostFactoryImpl implements HostFactory {
             return systemHost;
         }
         final String systemHostId = dbResults.get(0).get("id");
-        systemHost = DBSearch(systemHostId, user, respectFrontendRoles);
+        systemHost = DBSearch(systemHostId, respectFrontendRoles);
         if (dbResults.size() > 1) {
             Logger.fatal(this, "ERROR: There's more than one working version of the System Host!!");
         }
@@ -346,13 +346,13 @@ public class HostFactoryImpl implements HostFactory {
             this.getContentletFactory().save(systemHost);
             APILocator.getVersionableAPI().setWorking(systemHost);
         } else {
-            systemHost = DBSearch(dbResults.get(0).get("id"), systemUser, false);
+            systemHost = DBSearch(dbResults.get(0).get("id"), false);
         }
         return systemHost;
     }
 
     @Override
-    public Host DBSearch(final String id, final User user, final boolean respectFrontendRoles) throws
+    public Host DBSearch(final String id, final boolean respectFrontendRoles) throws
             DotDataException, DotSecurityException {
         Host site = null;
         final List<ContentletVersionInfo> versionInfos = APILocator.getVersionableAPI().findContentletVersionInfos(id);
@@ -366,10 +366,10 @@ public class HostFactoryImpl implements HostFactory {
                                 .getId()));
                         return versionInfos.get(0);
                     });
+            final User systemUser = APILocator.systemUser();
             final String siteInode = versionInfo.getWorkingInode();
-            final Contentlet siteAsContentlet = this.getContentletAPI().find(siteInode, user, respectFrontendRoles);
-            final ContentType hostContentType = APILocator.getContentTypeAPI(APILocator.systemUser(),
-                    respectFrontendRoles).find(Host.HOST_VELOCITY_VAR_NAME);
+            final Contentlet siteAsContentlet = this.getContentletAPI().find(siteInode, systemUser, respectFrontendRoles);
+            final ContentType hostContentType = APILocator.getContentTypeAPI(systemUser, respectFrontendRoles).find(Host.HOST_VELOCITY_VAR_NAME);
             if (siteAsContentlet.getContentType().id().equals(hostContentType.inode())) {
                 site = new Host(siteAsContentlet);
                 this.siteCache.add(site);


### PR DESCRIPTION
When finding a site at the factory level we always need to use SystemUser otherwise things break. 
Since this is a new Factory that recently was introduced a product of a refactoring effort. 
I'm removing the param from the DBSearch method 
Another potential improvement that I see fit here is removing the use of APIs. replacing those uses with straight SQL calls. But that type of work escapes the scope of this PR.