### PR TITLE
Removing unnecessary call to IdentifierAPI

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactoryImpl.java
@@ -271,25 +271,22 @@ public class IdentifierFactoryImpl extends IdentifierFactory {
 
 	@Override
 	protected Identifier createNewIdentifier(final Folder folder, final Folder parent, final String existingId) throws DotDataException {
-		final User systemUser = APILocator.getUserAPI().getSystemUser();
 		final Identifier identifier = new Identifier();
 
 		identifier.setId(existingId!=null?existingId:UUIDGenerator.generateUuid());
-
-		final Identifier parentId = APILocator.getIdentifierAPI().find(parent.getIdentifier());
 
 		identifier.setAssetType(Identifier.ASSET_TYPE_FOLDER);
 		identifier.setAssetName(folder.getName());
 		identifier.setOwner(folder.getOwner());
 
-		if (Host.SYSTEM_HOST.equals(parentId.getHostId())) {
+		if (Host.SYSTEM_HOST.equals(parent.getHostId())) {
 			Logger.error(this, "A folder cannot be saved on the system host.");
 			throw new DotStateException("A folder cannot be saved on the system host.");
 
 		}
 
-		identifier.setHostId(parentId.getHostId());
-		identifier.setParentPath(parentId.getPath());
+		identifier.setHostId(parent.getHostId());
+		identifier.setParentPath(parent.getPath());
 
 		identifier.setCreateDate(folder.getIDate()!=null? folder.getIDate():new Date());
 		saveIdentifier(identifier);
@@ -322,7 +319,6 @@ public class IdentifierFactoryImpl extends IdentifierFactory {
 
 	@Override
 	protected Identifier createNewIdentifier(final Versionable versionable, final Folder folder, final String existingId) throws DotDataException {
-		final User systemUser = APILocator.getUserAPI().getSystemUser();
 		final Identifier identifier = new Identifier();
 
 		identifier.setId(existingId!=null?existingId:UUIDGenerator.generateUuid());

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -683,26 +683,27 @@ public class FolderAPIImpl implements FolderAPI  {
 		while (st.hasMoreTokens()) {
 			final String name = st.nextToken();
 			sb.append(name + "/");
-			Folder f = findFolderByPath(sb.toString(), host, user, respectFrontEndPermissions);
-			if (f == null || !InodeUtils.isSet(f.getInode())) {
-				f= new Folder();
-				f.setName(name);
-				f.setTitle(name);
-				f.setShowOnMenu(false);
-				f.setSortOrder(0);
-				f.setFilesMasks("");
-				f.setHostId(host.getIdentifier());
-				f.setDefaultFileType((parent!=null && parent.getDefaultFileType() !=null) 
+			Folder folder = findFolderByPath(sb.toString(), host, user, respectFrontEndPermissions);
+			if (folder == null || !InodeUtils.isSet(folder.getInode())) {
+				folder= new Folder();
+				folder.setName(name);
+				folder.setTitle(name);
+				folder.setShowOnMenu(false);
+				folder.setSortOrder(0);
+				folder.setFilesMasks("");
+				folder.setHostId(host.getIdentifier());
+				folder.setDefaultFileType((parent!=null && parent.getDefaultFileType() !=null)
 				                ? parent.getDefaultFileType() 
 				                : defaultFileAssetType);
 				final Identifier newIdentifier = !UtilMethods.isSet(parent)?
-						APILocator.getIdentifierAPI().createNew(f, host):
-						APILocator.getIdentifierAPI().createNew(f, parent);
+						APILocator.getIdentifierAPI().createNew(folder, host):
+						APILocator.getIdentifierAPI().createNew(folder, parent);
 
-				f.setIdentifier(newIdentifier.getId());
-				save(f,  user,  respectFrontEndPermissions);
+				folder.setIdentifier(newIdentifier.getId());
+				folder.setPath(newIdentifier.getPath());
+				save(folder,  user,  respectFrontEndPermissions);
 			}
-			parent = f;
+			parent = folder;
 		}
 		return parent;
 	}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/model/Folder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/model/Folder.java
@@ -74,6 +74,8 @@ public class Folder implements Serializable, Permissionable, Treeable, Ruleable,
 
 	private String inode;
 
+	private String path;
+
 	@Override
 	public String getOwner() {
 		return owner;
@@ -359,6 +361,9 @@ public class Folder implements Serializable, Permissionable, Treeable, Ruleable,
 	}
 
 	public String getPath() {
+		if (null != this.path){
+			return this.path;
+		}
 
 		Identifier id = null;
 
@@ -370,7 +375,15 @@ public class Folder implements Serializable, Permissionable, Treeable, Ruleable,
 			Logger.debug(this, " This is usually not a problem as it is usually just the identifier not being found" +  e.getMessage(), e);
 		}
 
-		return id!=null?id.getPath():null;
+		if (null != id){
+			this.path = id.getPath();
+		}
+
+		return this.path;
+	}
+
+	public void setPath(final String path) {
+		this.path = path;
 	}
 	
 	public boolean equals(Object o){

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/model/Folder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/model/Folder.java
@@ -361,7 +361,7 @@ public class Folder implements Serializable, Permissionable, Treeable, Ruleable,
 	}
 
 	public String getPath() {
-		if (null != this.path){
+		if (UtilMethods.isSet(this.path)){
 			return this.path;
 		}
 


### PR DESCRIPTION
This change fixes a potential race condition in test `IdentifierConsistencyIntegrationTest. Test_Identifier_Create_Folder_Tree_Then_Update_Update_Identifier_Non_existing_Path`. 
We were calling IdentifierAPI.find to get the parentId, but we should do it only if it's required. Otherwise, if I already have the parentId, I should reuse it instead of searching for it again.