### PR TITLE
#21684 merge missed commit - we have dupe org.w3c.dom packages

### DIFF
--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -549,8 +549,6 @@ dependencies {
 
     implementation group: 'org.aspectj', name: 'aspectjrt', version:'1.9.2'
     implementation group: 'io.bit3', name: 'jsass', version: '5.10.3'
-    //XML Tool dependency
-    implementation group: 'jaxen', name: 'jaxen', version: '1.1.6'
 
     // https://github.com/lukas-krecan/ShedLock
     implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-core', version: '4.33.0'


### PR DESCRIPTION
We missed this commit when merging the gradle changes:

https://github.com/dotCMS/core/pull/21834/commits/4d94e55f80b92be6ea843f9f9a606af07dd41c37

This removes an old version of jaxen that also contains the `org.w3c.dom` packages which causes errors in java > 8