### PR TITLE
dotCMS/core#21715 fix JS-error-shown-when-uploaded-img-on-content-type

### DIFF
--- a/dotCMS/src/main/webapp/html/js/messages.js
+++ b/dotCMS/src/main/webapp/html/js/messages.js
@@ -27,8 +27,9 @@ function showDotCMSSystemMessage(message, isError) {
         id: "systemMessages" + messagesCount,
         className: className
     }, holdingDiv);
-
-    systemMessages.innerHTML = message;
+    
+    var messageText = message instanceof Error ? message.message : message;
+    systemMessages.innerHTML = messageText;
 
     dojo.connect(dijit.byId("systemMessages"), "onClick", hideDotCMSSystemMessage);
 
@@ -41,7 +42,7 @@ function showDotCMSSystemMessage(message, isError) {
     var fadeIn = dojo.fadeIn({node: "systemMessages" + messagesCount, duration: 5000, onEnd: fadeOutFn});
     fadeIn.play();
 
-    var ttl = message.split(" ").length;
+    var ttl = messageText ? messageText.split(" ").length : 0;
     ttl = ttl * 200;
     if (ttl < 1000) {
         ttl = 1000;

--- a/dotCMS/src/main/webapp/html/portlet/ext/files/upload_multiple_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/files/upload_multiple_js_inc.jsp
@@ -111,7 +111,11 @@ function fillAvailableWorkflowActions(actions){
         items: items
     };
     actionStore = new dojo.data.ItemFileReadStore({data:actionData});
-    dijit.byId("wfActionId").attr('store', actionStore);
+    
+    var wfActionHiddenField = dijit.byId("wfActionId");
+    if (wfActionHiddenField) {
+        wfActionHiddenField.attr('store', actionStore);
+    }
 }
 loadWorkflowActions("<%=selectedStructure%>");
 </script>


### PR DESCRIPTION
When uploading an image via an image field, the following error displays when you select a folder and use the UPLOAD NEW FILE button.