### PR TITLE
Fix user api delete test

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/business/UserAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/business/UserAPITest.java
@@ -572,6 +572,8 @@ public class UserAPITest extends IntegrationTestBase {
 		Logger.info(this, "ES query: " + luceneQuery.toString());
 		Logger.info(this, "contentlets.size: " + contentlets.size());
 
+		APILocator.getNotificationAPI().deleteNotifications(systemUser.getUserId());
+
 		userAPI.delete(userToDelete, replacementUser, systemUser,false);
 
 		waitForDeleteCompletedNotification(userToDelete);

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/versionable/VersionableHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/versionable/VersionableHelper.java
@@ -341,7 +341,7 @@ public class VersionableHelper {
                 this.checkPermission(user, container);
                 this.checkIsLiveOrIsWorking(container);
                 this.containerAPI.deleteContainerContentTypesByContainerInode(container);
-                WebAssetFactory.deleteAssetVersion(container);
+                this.containerAPI.deleteVersionByInode(inode);
             } else {
 
                 throw new DoesNotExistException("The container inode: " + inode + " does not exists");

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerAPI.java
@@ -282,6 +282,12 @@ public interface ContainerAPI {
 	Container save(Container container, List<ContainerStructure> containerStructureList, Host host, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException;
 
 	/**
+	 * Deletes the template version by inode
+	 * @param inode String
+	 */
+	void deleteVersionByInode(String inode);
+
+	/**
 	 * Delete the specified container
 	 *
 	 * @param container

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerAPIImpl.java
@@ -30,6 +30,7 @@ import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.util.Constants;
 import com.dotmarketing.util.HostUtil;
+import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
@@ -681,6 +682,13 @@ public class ContainerAPIImpl extends BaseWebAssetAPI implements ContainerAPI {
 		new ContainerLoader().invalidate(container);
 
 		return container;
+	}
+
+	@Override
+	@WrapInTransaction
+	public void deleteVersionByInode(final String inode) {
+		Logger.debug(this, ()-> "Deleting container inode: " + inode);
+		Try.run(()->containerFactory.deleteContainerByInode(inode)).onFailure(e -> new RuntimeException(e));
 	}
 
 	@WrapInTransaction

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactory.java
@@ -161,4 +161,12 @@ public interface ContainerFactory {
      * @throws DotSecurityException
      */
 	Container find(String inode) throws DotDataException, DotSecurityException;
+
+	/**
+	 * Deletes a container by inode
+	 * @param containerInode containerInode to be deleted
+	 * @throws DotDataException
+	 */
+	void deleteContainerByInode(final String containerInode) throws DotDataException;
+
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactoryImpl.java
@@ -177,6 +177,26 @@ public class ContainerFactoryImpl implements ContainerFactory {
     }
 
 	@Override
+	public void deleteContainerByInode(String containerInode) throws DotDataException {
+		deleteContainerInDB(containerInode);
+		deleteInodeInDB(containerInode);
+	}
+
+	private void deleteInodeInDB(final String inode) throws DotDataException{
+		DotConnect dc = new DotConnect();
+		dc.setSQL("delete from inode where inode = ? and type='containers'");
+		dc.addParam(inode);
+		dc.loadResult();
+	}
+
+	private void deleteContainerInDB(final String inode) throws DotDataException{
+		DotConnect dc = new DotConnect();
+		dc.setSQL("delete from " + Type.CONTAINERS.getTableName() + " where inode = ?");
+		dc.addParam(inode);
+		dc.loadResult();
+	}
+
+	@Override
 	public Container getLiveContainerByFolderPath(final String path, final Host host, final User user,
 												  final boolean respectFrontEndPermissions) throws DotSecurityException, DotDataException {
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactoryImpl.java
@@ -159,14 +159,12 @@ public class ContainerFactoryImpl implements ContainerFactory {
 		  final StringBuilder sql = new StringBuilder()
 				  .append("SELECT ")
 				  .append(tableName)
-				  .append(".*, dot_containers_1_.* from ")
+				  .append(".*, inode.* from ")
 				  .append(tableName)
-				  .append(", inode dot_containers_1_, container_version_info vv where vv.working_inode= ")
+				  .append(", inode inode where ")
 				  .append(tableName)
-				  .append(".inode and ")
-				  .append(tableName)
-				  .append(".inode = dot_containers_1_.inode and dot_containers_1_.type='containers'")
-				  .append(" and dot_containers_1_.inode = ?");
+				  .append(".inode = inode.inode and inode.type='containers'")
+				  .append(" and inode.inode = ?");
 
 		  container = TransformerLocator.createContainerTransformer
 				  (new DotConnect().setSQL(sql.toString()).addParam(inode).loadObjectResults())

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactoryImpl.java
@@ -924,10 +924,8 @@ public class ContainerFactoryImpl implements ContainerFactory {
            dc.addParam(userId);
            dc.loadResult();
 
-           Logger.info(this, "containers to update: " + containers);
            for(HashMap<String, String> ident:containers){
                String identifier = ident.get("identifier");
-               Logger.info(this, "Updating container: " + identifier);
                if (UtilMethods.isSet(identifier)) {
         			   final VersionInfo info =APILocator.getVersionableAPI().getVersionInfo(identifier);
         			   CacheLocator.getContainerCache().remove(info);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/transform/ContainerTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/transform/ContainerTransformer.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * DBTransformer that converts DB objects into Container instances
  */
-public class ContainerTransformer implements DBTransformer {
+public class ContainerTransformer implements DBTransformer<Container> {
     final List<Container> list;
 
 


### PR DESCRIPTION
During the integration tests run, hibernate was loading an old version of a Container via the ContainerFactory.find, making the test to fail, even though the record in the DB had the updated values. Migrating the ContainerFactory.find to DotConnect-Transformers fixes the issue.  

**Additional changes** : a new method for deleting a version (inode) of a container was added to the API/factory and it's now used instead of hibernate to avoid hibernate errors.  