### PR TITLE
#22137 Fixing Navigation Menu Order

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/action/OrderMenuAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/action/OrderMenuAction.java
@@ -649,21 +649,21 @@ public class OrderMenuAction extends DotPortletAction {
 						}
 					}
 				} else {
-					if(item instanceof FileAsset){
-						FileAsset fa =(FileAsset)item;
-						title = fa.getTitle();
+					if(item instanceof Contentlet && ((Contentlet) item).isFileAsset()){
+						final FileAsset fileAsset = APILocator.getFileAssetAPI().fromContentlet(Contentlet.class.cast(item));
+						title = fileAsset.getTitle();
 						title = retrieveTitle(title, user);
-						inode = fa.getInode();
-						if (fa.isShowOnMenu()) {
-							if (!APILocator.getPermissionAPI().doesUserHavePermission(fa, PermissionAPI.PERMISSION_PUBLISH, user, false)) {
+						inode = fileAsset.getInode();
+						if (fileAsset.isShowOnMenu()) {
+							if (!APILocator.getPermissionAPI().doesUserHavePermission(fileAsset, PermissionAPI.PERMISSION_PUBLISH, user, false)) {
 								show = false;
 							}
-							if (APILocator.getPermissionAPI().doesUserHavePermission(fa, PermissionAPI.PERMISSION_READ, user, false)) {
+							if (APILocator.getPermissionAPI().doesUserHavePermission(fileAsset, PermissionAPI.PERMISSION_READ, user, false)) {
 								sb.append("<li class=\"" + className + "\" id=\"inode_" + inode + "\" >" + title + "</li>\n");
 							}
 						}
-					}else if(item instanceof IHTMLPage){
-						IHTMLPage asset = ((IHTMLPage) item);
+					}else if(item instanceof Contentlet && ((Contentlet) item).isHTMLPage()){
+						IHTMLPage asset = APILocator.getHTMLPageAssetAPI().fromContentlet(Contentlet.class.cast(item));
 						title = asset.getTitle();
 						title = retrieveTitle(title, user);
 						inode = asset.getInode();
@@ -771,21 +771,21 @@ public class OrderMenuAction extends DotPortletAction {
 					}
 				}
 			} else {
-				if(item instanceof FileAsset){
-					FileAsset fa =(FileAsset)item;
-					title = fa.getTitle();
+				if(item instanceof Contentlet && ((Contentlet) item).isFileAsset()){
+					final FileAsset fileAsset = APILocator.getFileAssetAPI().fromContentlet(Contentlet.class.cast(item));
+					title = fileAsset.getTitle();
 					title = retrieveTitle(title, user);
-					inode = fa.getInode();
-					if (fa.isShowOnMenu()) {
-						if (!APILocator.getPermissionAPI().doesUserHavePermission(fa, PermissionAPI.PERMISSION_PUBLISH, user, false)) {
+					inode = fileAsset.getInode();
+					if (fileAsset.isShowOnMenu()) {
+						if (!APILocator.getPermissionAPI().doesUserHavePermission(fileAsset, PermissionAPI.PERMISSION_PUBLISH, user, false)) {
 							show = false;
 						}
-						if (APILocator.getPermissionAPI().doesUserHavePermission(fa, PermissionAPI.PERMISSION_READ, user, false)) {
+						if (APILocator.getPermissionAPI().doesUserHavePermission(fileAsset, PermissionAPI.PERMISSION_READ, user, false)) {
 							sb.append("<li class=\"" + className + "\" id=\"inode_" + inode + "\" >" + title + "</li>\n");
 						}
 					}
-				}else if(item instanceof IHTMLPage){
-					IHTMLPage asset = ((IHTMLPage) item);
+				}else if(item instanceof Contentlet && ((Contentlet) item).isHTMLPage()){
+					final IHTMLPage asset = APILocator.getHTMLPageAssetAPI().fromContentlet(Contentlet.class.cast(item));
 					title = asset.getTitle();
 					title = retrieveTitle(title, user);
 					inode = asset.getInode();

--- a/dotCMS/src/main/java/com/dotmarketing/util/AssetsComparator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/AssetsComparator.java
@@ -6,7 +6,6 @@ import com.dotmarketing.beans.WebAsset;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.fileassets.business.FileAsset;
 import com.dotmarketing.portlets.folders.model.Folder;
-import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 
 
 
@@ -29,7 +28,7 @@ public class AssetsComparator implements Comparator {
 	    if(obj instanceof WebAsset) return ((WebAsset)obj).getSortOrder();
 	    if(obj instanceof Folder) return ((Folder)obj).getSortOrder();
 	    if(obj instanceof FileAsset) return ((FileAsset)obj).getSortOrder();
-	    if(obj instanceof HTMLPageAsset) return ((Contentlet)obj).getSortOrder();
+	    if(obj instanceof Contentlet) return ((Contentlet)obj).getSortOrder();
 	    return 0;
 	}
 


### PR DESCRIPTION
After a recent refactoring, html pages weren't being returned as IHTMLPage objects but as Contentlet. A similar case occurred for FileAssets. It was causing a ClassCastException and an odd behavior when menu items were sorted.

With this change we are casting to Contentlet and using isFileAsset() and isHTMLPage() accordingly.

