### PR TITLE
dotCMS/core#21307 fix personas-portlet-not-showing-require-license

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -667,6 +667,7 @@ com.dotcms.repackage.javax.portlet.title.link-checker = Link Checker
 com.dotcms.repackage.javax.portlet.title.links = Links
 com.dotcms.repackage.javax.portlet.title.maintenance = Maintenance
 com.dotcms.repackage.javax.portlet.title.NetworkPortlet = Network
+com.dotcms.repackage.javax.portlet.title.personas = Personas
 com.dotcms.repackage.javax.portlet.title.publishing-queue = Publishing Queue
 com.dotcms.repackage.javax.portlet.title.query-tool = Query Tool
 com.dotcms.repackage.javax.portlet.title.reports = Reports


### PR DESCRIPTION
We are unable to show the required license message when you are using the community edition and you try to access to the personas portlet, we are showing an error in the log and display a blank page.