### PR TITLE
dotCMS/core#22131 fix show-or-hide-ViewStatistics-button-based-on-dotmarketing-property

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_menus_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_menus_js_inc.jsp
@@ -27,6 +27,7 @@
 <%@ page import="com.dotcms.publisher.endpoint.bean.PublishingEndPoint"%>
 <%@ page import="com.dotcms.publisher.endpoint.business.PublishingEndPointAPI"%>
 
+<% boolean enableClickStreamTracking = Config.getBooleanProperty("ENABLE_CLICKSTREAM_TRACKING", false); %>
 
 <script src="/dwr/interface/UserAjax.js" type="text/javascript"></script>
 <script language="JavaScript"><!--
@@ -50,7 +51,6 @@
 	String frameName = (String)request.getSession().getAttribute(WebKeys.FRAME);
 
 	%>
-
 
 
 
@@ -634,6 +634,7 @@
 		var read = hasReadPermissions(page.permissions);
 		var write = hasWritePermissions(page.permissions);
 		var publish = hasPublishPermissions(page.permissions);
+        var enableClickStreamTracking = <%= enableClickStreamTracking %>;
 		var live = page.live;
 		var working = page.working;
 		var archived = page.deleted;
@@ -660,7 +661,7 @@
 			}
 		}
 
-        if (!archived) {
+        if (!archived && enableClickStreamTracking) {
 	      strHTML += '<a href="javascript: viewHTMLPageStatistics(\'' + objId + '\', \'' + referer + '\');" class="context-menu__item">';
 		      strHTML += '<span class="statisticsIcon"></span>';
 		      strHTML += '<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "View-Statistics")) %>';

--- a/dotCMS/src/main/webapp/html/portlet/ext/folders/context_menus_js.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/folders/context_menus_js.jsp
@@ -1,6 +1,7 @@
 <%@page import="com.dotcms.repackage.javax.portlet.WindowState"%>
 <%@ include file="/html/portlet/ext/folders/init.jsp" %>
 <%@page import="com.dotmarketing.util.UtilMethods"%>
+<%@ page import="com.dotmarketing.util.Config" %>
 <%@page import="com.dotcms.enterprise.LicenseUtil"%>
 <%@page import="com.dotcms.enterprise.license.LicenseLevel"%>
 <%@ page import="com.dotcms.publisher.endpoint.bean.PublishingEndPoint"%>
@@ -11,6 +12,7 @@
 
 <%
 	String r = String.valueOf(System.currentTimeMillis());
+    boolean enableClickStreamTracking = Config.getBooleanProperty("ENABLE_CLICKSTREAM_TRACKING", false);
 %>
 <script language="JavaScript">
 
@@ -361,7 +363,8 @@ function getTemplatePopUp(i,ctxPath, objId, objIden, openNodes, referer,live,wor
 
 // HTML Page Flyout
 function getHTMLPagePopUp(i,ctxPath, objId, objIden, parentId, openNodes, referer,live,working,deleted,locked,read,write,publish,userId,isLegacyPage) {
-	var strHTML = '';
+	var enableClickStreamTracking = <%= enableClickStreamTracking %>;
+    var strHTML = '';
 		strHTML += '<div dojoType="dijit.Menu" class="dotContextMenu" id="popupTr' + i + '" style="display: none;" targetNodeIds="tr' + i + '">';
 
 		if (((live=="1") || (working=="1")) && (read=="1") && (deleted!="1")) {
@@ -398,7 +401,7 @@ function getHTMLPagePopUp(i,ctxPath, objId, objIden, parentId, openNodes, refere
 			}
 
 		}
-		if (deleted!="1") {
+		if (deleted!="1" && enableClickStreamTracking) {
 	      strHTML += '<div dojoType="dijit.MenuItem" iconClass="statisticsIcon" onClick="<%=locationMode%>=\'<portlet:renderURL windowState="<%= WindowState.MAXIMIZED.toString() %>"><portlet:param name="struts_action" value="/ext/htmlpageviews/view_htmlpage_views" /></portlet:renderURL>&htmlpage=' + objId + '&userId=' + userId + '&r=<%=r%>&referer=' + referer + openNodes + '\';">';
 	      strHTML += '<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "View-Statistics")) %>';
 	      strHTML += '</div>';


### PR DESCRIPTION
When right clicking on a page asset within the "site browser" portlet, there is an option to "view statistics" of the page. Currently, when you try to access that functionality, a loading bar shows up and the page never loads.