### PR TITLE
Validate if exists a Vanity URL Content Type with a site Custom field

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldTypeTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldTypeTest.java
@@ -134,6 +134,21 @@ public class Task220330ChangeVanityURLSiteFieldTypeTest {
         }
     }
 
+    /**
+     * Method to test: {@link Task220330ChangeVanityURLSiteFieldType#executeUpgrade()}
+     * When: The {@link Task220330ChangeVanityURLSiteFieldType} is ru twice the second time is fail because the
+     * {@link Task220330ChangeVanityURLSiteFieldType#GET_CONTENTLET_NOT_JSON} has a wrong sintax
+     * Should: Should not fail and not execute the SQL query
+     *
+     * @throws DotDataException
+     */
+    @Test
+    public void runTUTwice() throws DotDataException {
+        final Task220330ChangeVanityURLSiteFieldType task = new Task220330ChangeVanityURLSiteFieldType();
+        task.executeUpgrade();
+        task.executeUpgrade();
+    }
+
     private void assertContentlet(Host host, Contentlet vanityURL_1) {
         final Optional<Contentlet> inDb = APILocator.getContentletAPI()
                 .findInDb(vanityURL_1.getInode());

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldType.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -99,16 +100,20 @@ public class Task220330ChangeVanityURLSiteFieldType implements StartupTask {
     private void addNotJsonContentlet(final List<ContentletHost> result) throws DotDataException {
         final List<Map<String, Object>> fieldContentlets = getFromQuery(GET_FIELD_CONTENTLET);
         final Map<String, String> fieldContentletsMap = sortByStructure(fieldContentlets);
-        final List<Map<String, Object>> contentletsFromQuery = getFromQuery(
-                getContentletQuery(fieldContentlets));
+        final Optional<String> contentletQueryOptional = getContentletQuery(fieldContentlets);
 
-        for (final Map<String, Object> contentlet : contentletsFromQuery) {
-            final String fieldContentlet = fieldContentletsMap.get(
-                    contentlet.get("structure_inode"));
+        if (contentletQueryOptional.isPresent()) {
+            final List<Map<String, Object>> contentletsFromQuery = getFromQuery(
+                    contentletQueryOptional.get());
 
-            if (UtilMethods.isSet(fieldContentlet)) {
-                result.add(new ContentletHost(contentlet.get("identifier").toString(),
-                        contentlet.get(fieldContentlet).toString()));
+            for (final Map<String, Object> contentlet : contentletsFromQuery) {
+                final String fieldContentlet = fieldContentletsMap.get(
+                        contentlet.get("structure_inode"));
+
+                if (UtilMethods.isSet(fieldContentlet)) {
+                    result.add(new ContentletHost(contentlet.get("identifier").toString(),
+                            contentlet.get(fieldContentlet).toString()));
+                }
             }
         }
     }
@@ -138,14 +143,16 @@ public class Task220330ChangeVanityURLSiteFieldType implements StartupTask {
         return (List<Map<String, Object>>) dotConnect.loadResults();
     }
 
-    private String getContentletQuery(final List<Map<String, Object>> fieldContentlets) {
+    private Optional<String> getContentletQuery(final List<Map<String, Object>> fieldContentlets) {
         final String fieldContentletsString = fieldContentlets.stream()
                 .map(fields -> fields.get("field_contentlet").toString())
                 .collect(Collectors.toSet())
                 .stream()
                 .collect(Collectors.joining(","));
 
-        return String.format(GET_CONTENTLET_NOT_JSON, fieldContentletsString);
+        return UtilMethods.isSet(fieldContentletsString) ?
+                Optional.of(String.format(GET_CONTENTLET_NOT_JSON, fieldContentletsString)) :
+                Optional.empty();
     }
 
     private Map<String, String> sortByStructure(final  List<Map<String, Object>> fieldContentlets) {


### PR DESCRIPTION
Really it is not possible reproduce the bug, but even so I am validating that this method is not returning a empty String

https://github.com/dotCMS/core/compare/release-22.06...issue-22199-Validate-if-exists-any-vanity-url-content-type-with-site-custom-field?expand=1#diff-4bd5dd255e1c1e4d03c7d75875f7a9b5c1910a709dab1fe46bd97c5d9a873044R146

Change the base branch From this: https://github.com/dotCMS/core/pull/22206