### PR TITLE
Fix for test ESSearchProxyTest.ESSearchProxyTest

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/enterprise/priv/ESSearchProxyTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/enterprise/priv/ESSearchProxyTest.java
@@ -79,7 +79,7 @@ public class ESSearchProxyTest extends IntegrationTestBase {
         }
         final String query = "{\"query\":{\"query_string\":{\"query\":\"+contenttype:" + blogContentType.variable()
                 + " +conhost:"+ newHost.getIdentifier()
-                +" +" + blogContentType.variable() + ".sysPublishDate:[2021-01-01t00\\:00\\:00 TO 2121-12-01t00\\:00\\:00]\""
+                +" +" + blogContentType.variable() + ".sysPublishDate:[2021-01-01t00\\\\:00\\\\:00 TO 2121-12-01t00\\\\:00\\\\:00]\""
                 +"}}}";
         final List<ESSearchResults> resultsList = getEsSearchResults(query, false);
         Assert.assertFalse(resultsList.isEmpty());


### PR DESCRIPTION
After the JSON lib refactoring (https://github.com/dotCMS/enterprise/pull/870), the way `\\` were escaped changed