### PR TITLE
dotCMS/core#21827 fix add-a-fallback-flag-when-no-lang-exist

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/languagesmanager/view_languages.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/languagesmanager/view_languages.jsp
@@ -32,6 +32,10 @@ List<PublishingEndPoint> sendingEndpoints = pepAPI.getReceivingEndPoints();%>
 var sendingEndpoints = <%=UtilMethods.isSet(sendingEndpoints) && !sendingEndpoints.isEmpty()%>;
 
 var pushHandler = new dotcms.dojo.push.PushHandler('Push Publish');
+
+function replaceWithIcon(parentElement, iconName) {
+    parentElement.innerHTML = '<dot-contentlet-icon icon="' + iconName +'" size="48px" />'
+}
 </script>
 
 <liferay:box top="/html/common/box_top.jsp"
@@ -107,7 +111,7 @@ var pushHandler = new dotcms.dojo.push.PushHandler('Push Publish');
 				          title="<%=LanguageUtil.get(pageContext, "default-language")%>"
 						<% } %>
 				>
-					<img src="/html/images/languages/<%= langIcon %>.gif" border="0" />
+					<span><img src="/html/images/languages/<%= langIcon %>.gif" border="0" onError="replaceWithIcon(this.parentElement, 'emoji_flags')" /></span>
 					<%= strLanguage %>&nbsp;<%= (UtilMethods.isSet(strCountryCode) ? ("(" + strCountryCode + ")&nbsp;") : StringPool.BLANK) %>
 			    </a>
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/languagesmanager/view_languages.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/languagesmanager/view_languages.jsp
@@ -34,7 +34,7 @@ var sendingEndpoints = <%=UtilMethods.isSet(sendingEndpoints) && !sendingEndpoin
 var pushHandler = new dotcms.dojo.push.PushHandler('Push Publish');
 
 function replaceWithIcon(parentElement, iconName) {
-    parentElement.innerHTML = '<dot-contentlet-icon icon="' + iconName +'" size="48px" />'
+    parentElement.innerHTML = '<dot-contentlet-icon icon="' + iconName +'" size="16px" />'
 }
 </script>
 


### PR DESCRIPTION
if for any reason we are not able to show the flag, we need to select a default flag or icon for it.