### PR TITLE
Removing unnecessary code

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldTypeTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldTypeTest.java
@@ -45,8 +45,8 @@ public class Task220330ChangeVanityURLSiteFieldTypeTest {
 
     /**
      * Method to test: {@link Task220330ChangeVanityURLSiteFieldType#executeUpgrade}
-     * When: you hace a Vanity URl COntent Type with the site field as a {@link CustomField}
-     * Should: CHange the field type to {@link HostFolderField}
+     * When: you have a Vanity URl Content Type with the site field as a {@link CustomField}
+     * Should: Change the field type to {@link HostFolderField}
      *
      * @throws DotDataException
      * @throws DotSecurityException
@@ -90,6 +90,7 @@ public class Task220330ChangeVanityURLSiteFieldTypeTest {
                     .setProperty(ACTION_FIELD_VAR, 301)
                     .setProperty(ORDER_FIELD_VAR, 0)
                     .setProperty("site", host.getIdentifier())
+                    .host(host)
                     .nextPersistedAndPublish();
 
             Config.setProperty(SAVE_CONTENTLET_AS_JSON, true);
@@ -100,6 +101,7 @@ public class Task220330ChangeVanityURLSiteFieldTypeTest {
                     .setProperty(ACTION_FIELD_VAR, 301)
                     .setProperty(ORDER_FIELD_VAR, 0)
                     .setProperty("site", host.getIdentifier())
+                    .host(host)
                     .nextPersistedAndPublish();
 
             final Task220330ChangeVanityURLSiteFieldType task = new Task220330ChangeVanityURLSiteFieldType();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220330ChangeVanityURLSiteFieldType.java
@@ -50,8 +50,6 @@ public class Task220330ChangeVanityURLSiteFieldType implements StartupTask {
    final String GET_FIELD_CONTENTLET = "SELECT structure_inode,field_contentlet FROM field "
             + "WHERE velocity_var_name ='site' AND field_contentlet <> 'system_field' AND structure_inode in (SELECT inode FROM structure WHERE structuretype = 7)";
 
-   final String UPDATE_HOST_INODE = "UPDATE identifier SET host_inode = ? WHERE id = ?";
-
     @Override
     public boolean forceRun() {
         return true;
@@ -59,27 +57,9 @@ public class Task220330ChangeVanityURLSiteFieldType implements StartupTask {
 
     @Override
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
-        try {
-            final List<ContentletHost> contentlets = getContentlets();
+        updateFieldType();
 
-            updateHost(contentlets);
-            updateFieldType();
-
-            CacheLocator.getContentTypeCache2().clearCache();
-        } catch (JsonProcessingException | DotSecurityException e) {
-            Logger.error(Task220330ChangeVanityURLSiteFieldType.class, e.getMessage());
-        }
-    }
-
-    private List<ContentletHost> getContentlets()
-            throws DotDataException, DotSecurityException, JsonProcessingException {
-
-        final List<ContentletHost> result = new ArrayList<>();
-
-        addNotJsonContentlet(result);
-        addJsonContentlet(result);
-
-        return result;
+        CacheLocator.getContentTypeCache2().clearCache();
     }
 
     private void addJsonContentlet(final List<ContentletHost> result)
@@ -117,16 +97,6 @@ public class Task220330ChangeVanityURLSiteFieldType implements StartupTask {
         final DotConnect dotConnect = new DotConnect();
         dotConnect.setSQL(UPDATE_FIELD_TYPE);
         dotConnect.loadResult();
-    }
-
-    private void updateHost(final List<ContentletHost> contentlets) throws DotDataException {
-        final DotConnect dotConnect = new DotConnect();
-
-        final List<Params> batchParams = contentlets.stream()
-                .map(contentletHost -> new Params(contentletHost.hostInode, contentletHost.contentletIdentifier))
-                .collect(Collectors.toList());
-
-        dotConnect.executeBatch(UPDATE_HOST_INODE, batchParams);
     }
 
     private List<Map<String, Object>> getFromQuery(final  String contentletQuery)


### PR DESCRIPTION
The host_inode is storage in the Host_inode field in the identifier table already before this UT, so really we not need to do this update 


https://github.com/dotCMS/core/compare/release-22.06...issue-22282-removing-unnecessary-code?expand=1#diff-4bd5dd255e1c1e4d03c7d75875f7a9b5c1910a709dab1fe46bd97c5d9a873044L53