### PR TITLE
dotCMS/core#21848 fix log-viewer-unsync-when-typed-fast

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log.jsp
@@ -212,11 +212,11 @@
         }
 
         function filterLog(event) {
+            dataLogPrintedElem.innerHTML = dataLogSourceElem.innerHTML;
             if (event.key === 'Enter') {
-                performMark(excludeNoMatchingRows);
                 excludeLogRowsActive = true;
+                performMark(excludeNoMatchingRows);
             } else {
-                dataLogPrintedElem.innerHTML = dataLogSourceElem.innerHTML;
                 excludeLogRowsActive = false;
                 performMark();
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37185433/171653234-c445eff3-c3d0-4e2d-945f-3e366ddbba5e.png)
