### PR TITLE
dotCMS/core#22276 fix Replace Alert(...) to an Angular Component/Service to show successfully when the user edits info in My Account

### DIFF
--- a/ui/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.component.spec.ts
+++ b/ui/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.component.spec.ts
@@ -51,6 +51,7 @@ describe('DotMyAccountComponent', () => {
     let loginService: LoginService;
     let dotRouterService: DotRouterService;
     let dotMenuService: DotMenuService;
+    let dotAlertConfirmService: DotAlertConfirmService;
     let httpErrorManagerService: DotHttpErrorManagerService;
 
     const messageServiceMock = new MockDotMessageService({
@@ -113,6 +114,7 @@ describe('DotMyAccountComponent', () => {
             dotAccountService = TestBed.inject(DotAccountService);
             loginService = TestBed.inject(LoginService);
             dotRouterService = TestBed.inject(DotRouterService);
+            dotAlertConfirmService = TestBed.inject(DotAlertConfirmService);
             dotMenuService = TestBed.inject(DotMenuService);
             httpErrorManagerService = TestBed.inject(DotHttpErrorManagerService);
 
@@ -344,6 +346,7 @@ describe('DotMyAccountComponent', () => {
         spyOn<any>(dotAccountService, 'updateUser').and.returnValue(
             of({ entity: { reauthenticate: true } })
         );
+        spyOn(dotAlertConfirmService, 'alert');
         spyOn(comp.shutdown, 'emit');
 
         fixture.detectChanges();
@@ -369,6 +372,10 @@ describe('DotMyAccountComponent', () => {
         fixture.detectChanges();
         expect(comp.shutdown.emit).toHaveBeenCalledTimes(1);
         expect(dotAccountService.updateUser).toHaveBeenCalledWith(comp.dotAccountUser);
+        expect(dotAlertConfirmService.alert).toHaveBeenCalledWith({
+            header: messageServiceMock.get('my-account'),
+            message: messageServiceMock.get('message.createaccount.success')
+        });
         expect(dotRouterService.doLogOut).toHaveBeenCalledTimes(1);
     });
 

--- a/ui/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.component.ts
+++ b/ui/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.component.ts
@@ -18,6 +18,7 @@ import { DotRouterService } from '@services/dot-router/dot-router.service';
 import { DotMenuService } from '@services/dot-menu.service';
 import { DotAccountService, DotAccountUser } from '@services/dot-account-service';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
+import { DotAlertConfirmService } from '@dotcms/app/api/services/dot-alert-confirm/dot-alert-confirm.service';
 
 interface AccountUserForm extends DotAccountUser {
     confirmPassword?: string;
@@ -63,7 +64,8 @@ export class DotMyAccountComponent implements OnInit, OnDestroy {
         private loginService: LoginService,
         private dotRouterService: DotRouterService,
         private dotMenuService: DotMenuService,
-        private httpErrorManagerService: DotHttpErrorManagerService
+        private httpErrorManagerService: DotHttpErrorManagerService,
+        private dotAlertConfirmService: DotAlertConfirmService
     ) {
         this.passwordMatch = false;
         this.changePasswordOption = false;
@@ -152,8 +154,11 @@ export class DotMyAccountComponent implements OnInit, OnDestroy {
             .pipe(take(1))
             .subscribe(
                 (response) => {
-                    // TODO: replace the alert with a Angular components
-                    alert(this.dotMessageService.get('message.createaccount.success'));
+                    this.dotAlertConfirmService.alert({
+                        header: this.dotMessageService.get('my-account'),
+                        message: this.dotMessageService.get('message.createaccount.success')
+                    });
+
                     this.setShowStarter();
                     this.shutdown.emit();
 

--- a/ui/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.module.ts
+++ b/ui/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.module.ts
@@ -8,6 +8,7 @@ import { DotPipesModule } from '@pipes/dot-pipes.module';
 import { PasswordModule } from 'primeng/password';
 import { InputTextModule } from 'primeng/inputtext';
 import { CheckboxModule } from 'primeng/checkbox';
+import { DotAlertConfirmService } from '@dotcms/app/api/services/dot-alert-confirm/dot-alert-confirm.service';
 
 @NgModule({
     imports: [
@@ -21,6 +22,6 @@ import { CheckboxModule } from 'primeng/checkbox';
     ],
     exports: [DotMyAccountComponent],
     declarations: [DotMyAccountComponent],
-    providers: []
+    providers: [DotAlertConfirmService]
 })
 export class DotMyAccountModule {}


### PR DESCRIPTION
As a user, when I switch to My Account, passing all validations and saving the form successfully, I get a browser's native alert (...) to show that the form was saved successfully.

Replace Alert(...) to an Angular Component/Service to show successfully when the user edits info in My Account

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
