### PR TITLE
#22144 fix invalid path coming from starter

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -176,6 +176,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(MainBaseSuite.class)
 @SuiteClasses({
+        /*
         PublishAuditAPITest.class,
         FolderCacheImplIntegrationTest.class,
         StaticPublisherIntegrationTest.class,
@@ -550,6 +551,7 @@ import org.junit.runners.Suite.SuiteClasses;
         AWSS3PublisherTest.class,
         ContentWorkflowHandlerTest.class,
         Task220512UpdateNoHTMLRegexValueTest.class,
+         */
         MetadataDelegateTest.class
 
 })

--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -176,7 +176,6 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(MainBaseSuite.class)
 @SuiteClasses({
-        /*
         PublishAuditAPITest.class,
         FolderCacheImplIntegrationTest.class,
         StaticPublisherIntegrationTest.class,
@@ -551,7 +550,6 @@ import org.junit.runners.Suite.SuiteClasses;
         AWSS3PublisherTest.class,
         ContentWorkflowHandlerTest.class,
         Task220512UpdateNoHTMLRegexValueTest.class,
-         */
         MetadataDelegateTest.class
 
 })

--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -11,6 +11,7 @@ import com.dotcms.content.elasticsearch.business.ESContentletAPIImplTest;
 import com.dotcms.content.elasticsearch.business.ESIndexAPITest;
 import com.dotcms.content.elasticsearch.business.ElasticsearchUtilTest;
 import com.dotcms.content.elasticsearch.util.ESMappingUtilHelperTest;
+import com.dotcms.content.model.hydration.MetadataDelegateTest;
 import com.dotcms.contenttype.business.DotAssetBaseTypeToContentTypeStrategyImplTest;
 import com.dotcms.contenttype.test.DotAssetAPITest;
 import com.dotcms.csspreproc.CSSCacheTest;
@@ -548,7 +549,8 @@ import org.junit.runners.Suite.SuiteClasses;
         BoundedBufferedReaderTest.class,
         AWSS3PublisherTest.class,
         ContentWorkflowHandlerTest.class,
-        Task220512UpdateNoHTMLRegexValueTest.class
+        Task220512UpdateNoHTMLRegexValueTest.class,
+        MetadataDelegateTest.class
 
 })
 public class MainSuite {

--- a/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
@@ -62,7 +62,7 @@ public class MetadataDelegateTest {
         //Drop the relative part and prepend a route like the one that typically has a file packed in the starter
         final String assetPath = path.substring(index + rootPath.length() );
         //The route is slightly different, so we don't get an unwanted match when running tests in cloud
-        final Path absoluteNoneExistingPath = Path.of("/data/shared2/" + assetPath).normalize();
+        final Path absoluteNoneExistingPath = Path.of("/data/shared2/" + assetPath);
         //Since we're mimicking an invalid file scenario. The file must not exist.
         Assert.assertFalse(absoluteNoneExistingPath.toFile().exists());
         //Moment of truth the file should be fixed and converted into the local equivalent file

--- a/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
@@ -67,7 +67,10 @@ public class MetadataDelegateTest {
         Assert.assertFalse(absoluteNoneExistingPath.toFile().exists());
         //Moment of truth the file should be fixed and converted into the local equivalent file
         final File normalizedExistingPath = delegate.normalize(absoluteNoneExistingPath.toFile());
-        Assert.assertTrue(String.format("Path %s is expected to exist.",normalizedExistingPath.getPath()) ,normalizedExistingPath.exists());
+        Assert.assertTrue(
+                String.format("Path %s is expected to exist. binary path is %s. Root path %s. ",
+                        normalizedExistingPath.getPath(), path, rootPath),
+                normalizedExistingPath.exists());
     }
 
 

--- a/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
@@ -65,7 +65,7 @@ public class MetadataDelegateTest {
         Assert.assertFalse(absoluteNoneExistingPath.toFile().exists());
         //Moment of truth the file should be fixed and converted into the local equivalent file
         final File normalizedExistingPath = delegate.normalize(absoluteNoneExistingPath.toFile());
-        Assert.assertTrue(normalizedExistingPath.exists());
+        Assert.assertTrue(String.format("Path %s is expected to exist.",normalizedExistingPath.getPath()) ,normalizedExistingPath.exists());
     }
 
 

--- a/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
@@ -18,6 +18,7 @@ import com.dotmarketing.util.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import javax.validation.constraints.AssertTrue;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -67,6 +68,10 @@ public class MetadataDelegateTest {
         Assert.assertFalse(absoluteNoneExistingPath.toFile().exists());
         //Moment of truth the file should be fixed and converted into the local equivalent file
         final File normalizedExistingPath = delegate.normalize(absoluteNoneExistingPath.toFile());
+
+        Assert.assertEquals("We expect the normalized path to be the same as the binary",
+                binary.getPath(), normalizedExistingPath.getPath());
+
         Assert.assertTrue(
                 String.format("Path %s is expected to exist. binary path is %s. Root path %s. ",
                         normalizedExistingPath.getPath(), path, rootPath),

--- a/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
@@ -55,9 +55,8 @@ public class MetadataDelegateTest {
         final Folder folder = new FolderDataGen().name("testFolder").site(host).nextPersisted();
         final Contentlet contentlet = new FileAssetDataGen(file).host(host).folder(folder).setPolicy(IndexPolicy.WAIT_FOR).nextPersisted();
         final File binary = (File)contentlet.get(FileAssetAPI.BINARY_FIELD);
-        final String rootPath = ConfigUtils.getRelativeAssetPath();
+        final String rootPath = ConfigUtils.getAbsoluteAssetsRootPath();
         final String path = binary.getPath();
-        Logger.info(MetadataDelegateTest.class, "Binary path ::: " +  path);
         final int index = path.indexOf(rootPath);
         //Drop the relative part and prepend a route like the one that typically has a file packed in the starter
         final String assetPath = path.substring(index + rootPath.length() );

--- a/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
@@ -14,6 +14,7 @@ import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.ConfigUtils;
 import com.dotmarketing.util.FileUtil;
+import com.dotmarketing.util.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -56,6 +57,7 @@ public class MetadataDelegateTest {
         final File binary = (File)contentlet.get(FileAssetAPI.BINARY_FIELD);
         final String rootPath = ConfigUtils.getRelativeAssetPath();
         final String path = binary.getPath();
+        Logger.info(MetadataDelegateTest.class, "Binary path ::: " +  path);
         final int index = path.indexOf(rootPath);
         //Drop the relative part and prepend a route like the one that typically has a file packed in the starter
         final String assetPath = path.substring(index + rootPath.length() );

--- a/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
@@ -1,0 +1,72 @@
+package com.dotcms.content.model.hydration;
+
+import com.dotcms.datagen.FileAssetDataGen;
+import com.dotcms.datagen.FolderDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.security.apps.SecretsStore;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
+import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
+import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.util.ConfigUtils;
+import com.dotmarketing.util.FileUtil;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MetadataDelegateTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+        SecretsStore.INSTANCE.get().deleteAll();
+    }
+
+    /**
+     * Tested method {@link MetadataDelegate#normalize(File)}
+     * The problem this method intends to fix is basically matching invalid paths coming from a starter that was generated and exported with an absolute route that does not exist locally.
+     * Given scenario: We want to test that given both a valid and an invalid file we still get a normalized file
+     * Expected Result: If the file we pass can be matched with a local file the returned file should exist. If it does not then the returned file should not exist
+     * @throws IOException
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    @Test
+    public void Test_File_Asset_Path_Normalized() throws IOException, DotDataException, DotSecurityException {
+        //Let's instantiate the class we want to test
+        final MetadataDelegate delegate = new MetadataDelegate();
+        //Now let's create a file
+        final File file = FileUtil.createTemporaryFile("test", ".txt", "this is a test");
+        //We know for sure the file exists so our tested method should agree with us
+        Assert.assertTrue(delegate.normalize(file).exists());
+
+        //Now lets mimic a situation where we have a contentlet that has a valid file asset locally
+        //But we receive the same route but with prepended absolute route.
+        //This typically what happens when we unpack a starter that was generated in cloud
+        final Host host = new SiteDataGen().nextPersisted();
+        final Folder folder = new FolderDataGen().name("testFolder").site(host).nextPersisted();
+        final Contentlet contentlet = new FileAssetDataGen(file).host(host).folder(folder).setPolicy(IndexPolicy.WAIT_FOR).nextPersisted();
+        final File binary = (File)contentlet.get(FileAssetAPI.BINARY_FIELD);
+        final String rootPath = ConfigUtils.getRelativeAssetPath();
+        final String path = binary.getPath();
+        final int index = path.indexOf(rootPath);
+        //Drop the relative part and prepend a route like the one that typically has a file packed in the starter
+        final String assetPath = path.substring(index + rootPath.length() );
+        //The route is slightly different so we don't get an unwanted match when running tests in cloud
+        final Path absoluteNoneExistingPath = Path.of("/data/shared2/" + assetPath).normalize();
+        //Since we're mimicking an invalid file scenario. The file must not exist.
+        Assert.assertFalse(absoluteNoneExistingPath.toFile().exists());
+        //Moment of truth the file should be fixed and converted into the local equivalent file
+        final File normalizedExistingPath = delegate.normalize(absoluteNoneExistingPath.toFile());
+        Assert.assertTrue(normalizedExistingPath.exists());
+    }
+
+
+}

--- a/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/model/hydration/MetadataDelegateTest.java
@@ -55,12 +55,13 @@ public class MetadataDelegateTest {
         final Folder folder = new FolderDataGen().name("testFolder").site(host).nextPersisted();
         final Contentlet contentlet = new FileAssetDataGen(file).host(host).folder(folder).setPolicy(IndexPolicy.WAIT_FOR).nextPersisted();
         final File binary = (File)contentlet.get(FileAssetAPI.BINARY_FIELD);
+        Assert.assertTrue(String.format("binary %s should exist. ",binary.getPath()),delegate.normalize(binary).exists());
         final String rootPath = ConfigUtils.getAbsoluteAssetsRootPath();
         final String path = binary.getPath();
         final int index = path.indexOf(rootPath);
         //Drop the relative part and prepend a route like the one that typically has a file packed in the starter
         final String assetPath = path.substring(index + rootPath.length() );
-        //The route is slightly different so we don't get an unwanted match when running tests in cloud
+        //The route is slightly different, so we don't get an unwanted match when running tests in cloud
         final Path absoluteNoneExistingPath = Path.of("/data/shared2/" + assetPath).normalize();
         //Since we're mimicking an invalid file scenario. The file must not exist.
         Assert.assertFalse(absoluteNoneExistingPath.toFile().exists());

--- a/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
+++ b/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
@@ -114,7 +114,7 @@ public class MetadataDelegate implements HydrationDelegate {
         try {
             // Something like this is what we're aiming for
             // /0/1/0134ab84-e618-42ae-8be8-58c9c33e8901/fileAsset/lg.ttf
-            final String path = in.getPath().toLowerCase();
+            final String path = in.getPath();
 
             final String[] parts = path.split(Pattern.quote(File.separator));
             final int fileIndex = parts.length - 1;
@@ -134,11 +134,11 @@ public class MetadataDelegate implements HydrationDelegate {
             final String rebuiltPath = String.join(File.separator, assetsRootPath, char1, char2,
                     inode,
                     folder, file);
-            Logger.info(MetadataDelegate.class,"::: Rebuilt path "+rebuiltPath);
+            Logger.debug(MetadataDelegate.class,"::: Rebuilt path "+rebuiltPath);
             //get rid of any repetitive separator
             final File normalizedFile = Path.of(rebuiltPath).toFile();
             if (!normalizedFile.exists()) {
-                Logger.warn(MetadataDelegate.class,()->String.format("::: Unable to re-build a matching file path %s ",normalizedFile.getPath()));
+                Logger.debug(MetadataDelegate.class,()->String.format("::: Unable to re-build a matching file path %s ",normalizedFile.getPath()));
             } else {
                 //if we succeed then return
                 return normalizedFile;

--- a/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
+++ b/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
@@ -136,7 +136,7 @@ public class MetadataDelegate implements HydrationDelegate {
                     folder, file);
             Logger.info(MetadataDelegate.class,"::: Rebuilt path "+rebuiltPath);
             //get rid of any repetitive separator
-            final File normalizedFile = Path.of(rebuiltPath).normalize().toFile();
+            final File normalizedFile = Path.of(rebuiltPath).toFile();
             if (!normalizedFile.exists()) {
                 Logger.warn(MetadataDelegate.class,()->String.format("::: Unable to re-build a matching file path %s ",normalizedFile.getPath()));
             } else {

--- a/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
+++ b/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
@@ -137,7 +137,7 @@ public class MetadataDelegate implements HydrationDelegate {
             //get rid of any repetitive separator
             final File normalizedFile = Path.of(rebuiltPath).normalize().toFile();
             if (!normalizedFile.exists()) {
-                Logger.warn(MetadataDelegate.class,()->String.format(":::Unable to re-build a matching file path %s ",normalizedFile.getPath()));
+                Logger.warn(MetadataDelegate.class,()->String.format("::: Unable to re-build a matching file path %s ",normalizedFile.getPath()));
             } else {
                 //if we succeed then return
                 return normalizedFile;

--- a/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
+++ b/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
@@ -136,9 +136,10 @@ public class MetadataDelegate implements HydrationDelegate {
                     folder, file);
             //get rid of any repetitive separator
             final File normalizedFile = Path.of(rebuiltPath).normalize().toFile();
-            if (normalizedFile.exists()) {
+            if (!normalizedFile.exists()) {
+                Logger.warn(MetadataDelegate.class,()->String.format(":::Unable to re-build a matching file path %s ",normalizedFile.getPath()));
+            } else {
                 //if we succeed then return
-                Logger.warn(MetadataDelegate.class,()->String.format(":::Incoming invalid file fixed %s",normalizedFile.getPath()));
                 return normalizedFile;
             }
         } catch (Exception e) {

--- a/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
+++ b/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
@@ -138,11 +138,11 @@ public class MetadataDelegate implements HydrationDelegate {
             final File normalizedFile = Path.of(rebuiltPath).normalize().toFile();
             if (normalizedFile.exists()) {
                 //if we succeed then return
-                Logger.warn(MetadataDelegate.class,()->String.format("Incoming invalid file fixed %s",normalizedFile.getPath()));
+                Logger.warn(MetadataDelegate.class,()->String.format(":::Incoming invalid file fixed %s",normalizedFile.getPath()));
                 return normalizedFile;
             }
         } catch (Exception e) {
-            Logger.warn(MetadataDelegate.class, () -> "Error normalizing file path.", e);
+            Logger.warn(MetadataDelegate.class, () -> ":::Error normalizing file path.", e);
         }
         //If we failed normalizing the incoming file we return the incoming file and let the metadata delegate fail
         return in;

--- a/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
+++ b/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
@@ -138,11 +138,11 @@ public class MetadataDelegate implements HydrationDelegate {
             final File normalizedFile = Path.of(rebuiltPath).normalize().toFile();
             if (normalizedFile.exists()) {
                 //if we succeed then return
-                Logger.debug(MetadataDelegate.class,()->String.format("Incoming invalid file fixed %s",normalizedFile.getPath()));
+                Logger.warn(MetadataDelegate.class,()->String.format("Incoming invalid file fixed %s",normalizedFile.getPath()));
                 return normalizedFile;
             }
         } catch (Exception e) {
-            Logger.debug(MetadataDelegate.class, e, () -> "Error normalizing file path.");
+            Logger.warn(MetadataDelegate.class, () -> "Error normalizing file path.", e);
         }
         //If we failed normalizing the incoming file we return the incoming file and let the metadata delegate fail
         return in;

--- a/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
+++ b/dotCMS/src/main/java/com/dotcms/content/model/hydration/MetadataDelegate.java
@@ -134,6 +134,7 @@ public class MetadataDelegate implements HydrationDelegate {
             final String rebuiltPath = String.join(File.separator, assetsRootPath, char1, char2,
                     inode,
                     folder, file);
+            Logger.info(MetadataDelegate.class,"::: Rebuilt path "+rebuiltPath);
             //get rid of any repetitive separator
             final File normalizedFile = Path.of(rebuiltPath).normalize().toFile();
             if (!normalizedFile.exists()) {

--- a/dotCMS/src/main/java/com/dotmarketing/util/ConfigUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ConfigUtils.java
@@ -138,18 +138,16 @@ public class ConfigUtils {
             realPath = realPath + File.separator;
         }
         if (!UtilMethods.isSet(realPath)) {
-            final String path = getRelativeAssetPath();
+            final String path = Try
+                    .of(() -> Config.getStringProperty("ASSET_PATH", DEFAULT_RELATIVE_ASSET_PATH))
+                    .getOrElse(DEFAULT_RELATIVE_ASSET_PATH);
             return FileUtil.getRealPath(path);
         } else {
             return realPath;
         }
     }
     
-    public static String getRelativeAssetPath(){
-		return Try
-				.of(() -> Config.getStringProperty("ASSET_PATH", DEFAULT_RELATIVE_ASSET_PATH))
-				.getOrElse(DEFAULT_RELATIVE_ASSET_PATH);
-	}
+
 
     private static final String LOCAL = "LOCAL";
     public static String getDotGeneratedPath() {

--- a/dotCMS/src/main/java/com/dotmarketing/util/ConfigUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ConfigUtils.java
@@ -138,16 +138,18 @@ public class ConfigUtils {
             realPath = realPath + File.separator;
         }
         if (!UtilMethods.isSet(realPath)) {
-            final String path = Try
-                    .of(() -> Config.getStringProperty("ASSET_PATH", DEFAULT_RELATIVE_ASSET_PATH))
-                    .getOrElse(DEFAULT_RELATIVE_ASSET_PATH);
+            final String path = getRelativeAssetPath();
             return FileUtil.getRealPath(path);
         } else {
             return realPath;
         }
     }
     
-    
+    public static String getRelativeAssetPath(){
+		return Try
+				.of(() -> Config.getStringProperty("ASSET_PATH", DEFAULT_RELATIVE_ASSET_PATH))
+				.getOrElse(DEFAULT_RELATIVE_ASSET_PATH);
+	}
 
     private static final String LOCAL = "LOCAL";
     public static String getDotGeneratedPath() {


### PR DESCRIPTION
### Proposed Changes
* Since the starter is generated using an absolute file-path on for file assets this causes the import starter metadata to fail. This will attempt to fix such a situation by matching the file against the local file that has been already written


Here's what I would test. Locate a few random files coming from the starter and locate the current live version inode
then do `select contentlet_as_json from contentlet where inode = '3cf956ce-62ea-4a93-835a-045732763802'`
and make sure there's a metadata entry next to the file asset like this:

```
"fileAsset":{
         "type":"Binary",
         "value":"user-info.vtl",
         "metadata":{
            "name":"user-info.vtl",
            "sha256":"3bd0c166c797c3b6b128ffcbe6360da6daf001eb74d94995887ac965d10b2a57",
            "isImage":false,
            "contentType":"text/velocity"
         }
      },

```

Messages like these : 
```
17:53:29.080  WARN  hydration.MetadataDelegate - error calculating metadata 
17:53:29.080  WARN  hydration.MetadataDelegate - the binary `/data/shared/assets/0/1/0134ab84-e618-42ae-8be8-58c9c33e8901/fileAsset/lg.ttf` isn't accessible 
```
Should no longer appear 
