### PR TITLE
Catching exception when invalid host

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
@@ -299,7 +299,8 @@ public class ApiTokenResource implements Serializable {
         } catch (ProcessingException e){
             if (e.getCause().getClass() == UnknownHostException.class ||
                     e.getCause().getClass() == NoRouteToHostException.class ||
-                    e.getCause().getClass() == ConnectException.class) {
+                    e.getCause().getClass() == ConnectException.class ||
+                    e.getCause().getClass() == IllegalStateException.class) {
                 Logger.error(ApiTokenResource.class, String.format("Invalid server URL: %s", remoteURL));
                 return Response.status(Response.Status.NOT_FOUND).build();
             } else {


### PR DESCRIPTION
The exception thrown when passing an invalid URL changed after the Swagger changes. As a part of those changes we upgraded Jackson librabary...but not sure why that made the exception to change. 

This includes the new exception thrown in the catch. 