### PR TITLE
dotCMS/core#21848 fix filter-log-resetting-highlighted-value-using-arrow-keys

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log.jsp
@@ -192,6 +192,8 @@
         }
 
         function performMark(callback) {
+            dataLogPrintedElem.innerHTML = dataLogSourceElem.innerHTML;
+
             var keyword = keywordLogInput.value;
 
             if (keyword && keyword.length > 2) {
@@ -212,7 +214,6 @@
         }
 
         function filterLog(event) {
-            dataLogPrintedElem.innerHTML = dataLogSourceElem.innerHTML;
             const ignoredKeys = ["ArrowLeft", "ArrowUp", "ArrowDown", "ArrowRight"];
 
             if (event.key === 'Enter') {


### PR DESCRIPTION
fix the highlight disappears when I use the arrow keys in filter log

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
