### PR TITLE
#22426 updating dotcms docker java to 11.0.15.9.1-amzn

### DIFF
--- a/docker/dotcms/Dockerfile
+++ b/docker/dotcms/Dockerfile
@@ -32,7 +32,7 @@ RUN chmod -R 666 /srv && find /srv/ -type d -exec chmod a+x {} \;
 # Stage 2:  Construct our container using the minimal-java image
 #           and copying the prebuilt dotcms
 # ----------------------------------------------
-FROM dotcms/java-base:11.0.14.10.1-amzn as container-base
+FROM dotcms/java-base:11.0.15.9.1-amzn as container-base
 
 WORKDIR /srv
 

--- a/docker/dotcms/ROOT/srv/OVERRIDE/tomcat/conf/server.xml
+++ b/docker/dotcms/ROOT/srv/OVERRIDE/tomcat/conf/server.xml
@@ -99,7 +99,7 @@
         compressionMinSize="128"
         useSendfile="false"
         SSLEnabled="true"
-        keystoreFile="conf/server.keystore"
+        SSLCertificateFile="conf/local.dotcms.site.pem"
         keystorePass="dotcms"
     />
 

--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:20.04 as base-builder
 WORKDIR /srv
 
 # Defining default Java, can be any java provided by sdkman
-ARG JAVA_VERSION="11.0.14.10.1-amzn"
+ARG JAVA_VERSION="11.0.15.9.1-amzn"
 
 ENV JAVA_OUTPUT_DIR="/java"
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/java-base/README.md
+++ b/docker/java-base/README.md
@@ -2,8 +2,12 @@
 
 This Dockerfile builds the base container that will be used to build and run dotCMS. It uses the tool sdkman (https://sdkman.io/) to supply the java version that will be included in the base container. You can specify a JAVA_VERSION to use as a build arg. The intent is to provide a simple that allow us to update the java versions that we use to run dotCMS. 
 
-### Custom JAVA_VERSION :
+### Available JAVA_VERSION :
 Setting the build arg `JAVA_VERSION` allows you to specify any java version >= java 11 that is supplied by sdkman. To see what versions are available, install sdkman and run `sdk update` and then `sdk ls java` - the value you want to supply is found in the `Identifier` column.
+
+You can see the list of available JAVA versions here.  It is updated frequently.
+
+https://api.sdkman.io/2/candidates/java/linux/versions/list?installed=
 
 ### Building Multiarch
 To enable "multiarch" building, you need to use `docker buildx` and have defined a new builder (you might need to enable "experimental" features in order to enable `docker buildx`). If you have `buildx` installed, you can see what buildx builders you have available by doing a `ls`:


### PR DESCRIPTION
### Proposed Changes
* This updates dotCMS java version to `11.0.15.9.1-amzn` and also points to the correct ssl cert for `local.dotcms.site`

