### PR TITLE
dotCMS/core#22552 fix Log Filter: The console gets blank after switching log files

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log.jsp
@@ -78,9 +78,17 @@
         }
 
         document.querySelector('.logViewerPrinted').innerHTML = '';
-        setTimeout(() => {
-            attachLogIframeEvents()
-        }, 100);
+        document.querySelector('#keywordLogFilterInput').value = '';
+
+        var iframeContentInterval = setInterval(() => { 
+            var contentLoaded = document.getElementById('tailingFrame').contentDocument.body?.innerHTML;
+
+            if (contentLoaded) {
+                clearInterval(iframeContentInterval);
+                attachLogIframeEvents()
+            }
+        }, 200);
+
 	}
 
     function disableFollowOnScrollUp() {


### PR DESCRIPTION


Log Filter: The console gets blank after switching log files

- Steps to reproduce:

Go Maintenance > Log Files
Tail any log file, make sure the Follow flag is on and type a filter
Tail another file keeping the filter
Keep switching files. Eventually, the console gets blank.



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
