### PR TITLE
#22501 : Menu reorder is not working.

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/action/OrderMenuAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/action/OrderMenuAction.java
@@ -626,7 +626,7 @@ public class OrderMenuAction extends DotPortletAction {
 					Folder folder = ((Folder) item);
 					title = folder.getTitle();
 					title = retrieveTitle(title, user);
-					inode = folder.getInode();
+					inode = folder.getIdentifier();
 					if (folder.isShowOnMenu()) {
 						if (!APILocator.getPermissionAPI().doesUserHavePermission(folder, PermissionAPI.PERMISSION_PUBLISH, user, false)) {
 							show = false;


### PR DESCRIPTION
### Proposed Changes
* In the previous release, we updated the `Folder` class to stop inheriting from `Inode`. The menu reordering code was relying on that, so it stopped working after the change. We're now passing down the Identifier to make it work as expected.

### Checklist
- [ ] Tests