### PR TITLE
Postman improvements

### DIFF
--- a/.github/actions/build-core/dist/index.js
+++ b/.github/actions/build-core/dist/index.js
@@ -51,17 +51,7 @@ const COMMANDS = {
     gradle: [
         {
             cmd: gradleCmd,
-            args: ['createDistPrep'],
-            workingDir: dotCmsRoot
-        },
-        {
-            cmd: gradleCmd,
-            args: ['compileIntegrationTestJava'],
-            workingDir: dotCmsRoot
-        },
-        {
-            cmd: gradleCmd,
-            args: ['prepareIntegrationTests'],
+            args: ['createDistPrep', 'compileIntegrationTestJava', 'prepareIntegrationTests'],
             workingDir: dotCmsRoot
         }
     ],

--- a/.github/actions/build-core/src/core-builder.ts
+++ b/.github/actions/build-core/src/core-builder.ts
@@ -21,17 +21,7 @@ const COMMANDS: Commands = {
   gradle: [
     {
       cmd: gradleCmd,
-      args: ['createDistPrep'],
-      workingDir: dotCmsRoot
-    },
-    {
-      cmd: gradleCmd,
-      args: ['compileIntegrationTestJava'],
-      workingDir: dotCmsRoot
-    },
-    {
-      cmd: gradleCmd,
-      args: ['prepareIntegrationTests'],
+      args: ['createDistPrep', 'compileIntegrationTestJava', 'prepareIntegrationTests'],
       workingDir: dotCmsRoot
     }
   ],

--- a/.github/actions/cache-core/action.yml
+++ b/.github/actions/cache-core/action.yml
@@ -19,11 +19,11 @@ inputs:
     default: |
             {
               "gradle": {
-                "dependencies": "${{ runner.os }}-gradle-dependencies-${{ hashFiles('**/build.gradle', '**/dependencies.gradle', '**/deploy.gradle', '**/immutables.gradle', '**/settings.gradle', '**/gradle.properties', '**/gradle-wrapper.properties') }}",
+                "dependencies": "${{ runner.os }}-gradle-dependencies-${{ hashFiles('**/build.gradle', '**/dependencies.gradle', '**/deploy.gradle', '**/immutables.gradle', '**/settings.gradle', '**/gradle.properties', '**/gradle-wrapper.properties', '**/core-cicd-tests.yml') }}",
                 "buildOutput": "${{ runner.os }}-gradle-build-output-${{ github.SHA }}"
               },
               "maven": {
-                "dependencies": "${{ runner.os }}-maven-dependencies-${{ hashFiles('**/pom.xml') }}",
+                "dependencies": "${{ runner.os }}-maven-dependencies-${{ hashFiles('**/pom.xml', '**/core-cicd-tests.yml') }}",
                 "buildOutput": "${{ runner.os }}-maven-build-output-${{ github.SHA }}"
               }
             }

--- a/.github/actions/cache-core/dist/index.js
+++ b/.github/actions/cache-core/dist/index.js
@@ -42,6 +42,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.cacheCore = void 0;
 const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
+const exec = __importStar(__nccwpck_require__(1514));
 const cache_1 = __nccwpck_require__(7799);
 const EMPTY_CACHE_RESULT = {
     cacheKey: '',
@@ -68,7 +69,7 @@ const cacheCore = () => __awaiter(void 0, void 0, void 0, function* () {
         locations: []
     };
     const locationTypes = Object.keys(cacheLocations);
-    core.info(`Caching these locations: ${locationTypes}`);
+    core.info(`Caching these locations: ${locationTypes.join(', ')}`);
     for (const locationType of locationTypes) {
         const cacheLocationMetadata = yield cacheLocation(cacheLocations, cacheKeys, locationType);
         if (cacheLocationMetadata !== EMPTY_CACHE_RESULT) {
@@ -89,10 +90,14 @@ exports.cacheCore = cacheCore;
 const cacheLocation = (cacheLocations, resolvedKeys, locationType) => __awaiter(void 0, void 0, void 0, function* () {
     const cacheKey = resolvedKeys[locationType];
     const resolvedLocations = cacheLocations[locationType];
-    core.info(`Caching locations:\n  [${resolvedLocations}]\n  with key: ${cacheKey}`);
+    core.info(`Caching locations:\n  [${resolvedLocations.join(', ')}]\n  with key: ${cacheKey}`);
     let cacheResult = EMPTY_CACHE_RESULT;
     try {
         const cacheId = yield cache.saveCache(resolvedLocations, cacheKey);
+        core.info('Location contents');
+        for (const location of resolvedLocations) {
+            ls(location);
+        }
         core.info(`Cache id found: ${cacheId}`);
         cacheResult = {
             cacheKey,
@@ -116,6 +121,15 @@ const cacheLocation = (cacheLocations, resolvedKeys, locationType) => __awaiter(
         }
     }
     return Promise.resolve(cacheResult);
+});
+const ls = (location) => __awaiter(void 0, void 0, void 0, function* () {
+    core.info(`Listing folder ${location}`);
+    try {
+        yield exec.exec('ls', ['-las', location]);
+    }
+    catch (err) {
+        core.info(`Cannot list folder ${location}`);
+    }
 });
 
 

--- a/.github/actions/cache-core/package-lock.json
+++ b/.github/actions/cache-core/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/cache": "^1.0.9",
         "@actions/core": "^1.6.0",
-        "@actions/exec": "^1.1.0"
+        "@actions/exec": "^1.1.1"
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.2",

--- a/.github/actions/cache-core/package.json
+++ b/.github/actions/cache-core/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@actions/cache": "^1.0.9",
     "@actions/core": "^1.6.0",
-    "@actions/exec": "^1.1.0"
+    "@actions/exec": "^1.1.1"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.2",

--- a/.github/actions/core-cache-locator/dist/index.js
+++ b/.github/actions/core-cache-locator/dist/index.js
@@ -92,12 +92,13 @@ exports.getCacheLocations = getCacheLocations;
 const resolveLocations = (buildEnv, cacheLocations, key, decorateFn) => {
     const cacheEnableKey = key.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
     const cacheEnable = core.getBooleanInput(`cache_${cacheEnableKey}`);
+    const locationKey = key;
     if (!cacheEnable) {
         core.notice(`Core cache is disabled for ${key}`);
+        cacheLocations[locationKey] = undefined;
         return;
     }
     core.info(`Looking cache configuration for ${key}`);
-    const locationKey = key;
     const locations = cacheLocations[locationKey];
     if (!locations) {
         core.warning(`Cannot resolve any ${key} locations for build env ${buildEnv}`);

--- a/.github/actions/core-cache-locator/dist/index.js
+++ b/.github/actions/core-cache-locator/dist/index.js
@@ -34,22 +34,31 @@ exports.getCacheLocations = void 0;
 const core = __importStar(__nccwpck_require__(186));
 const fs = __importStar(__nccwpck_require__(147));
 const path = __importStar(__nccwpck_require__(17));
+const HOME_FOLDER = path.join('/home', 'runner');
+const GRADLE_FOLDER = path.join(HOME_FOLDER, '.gradle');
+const M2_FOLDER = path.join(HOME_FOLDER, '.m2');
+const PROJECT_ROOT = core.getInput('project_root');
+const DOTCMS_ROOT = path.join(PROJECT_ROOT, 'dotCMS');
 const CACHE_CONFIGURATION = {
     gradle: {
-        dependencies: ['~/.gradle/caches', '~/.gradle/wrapper'],
-        buildOutput: ['dotCMS/.gradle', 'dotCMS/build/classes', 'dotCMS/build/resources']
+        dependencies: [path.join(GRADLE_FOLDER, 'caches'), path.join(GRADLE_FOLDER, 'wrapper')],
+        buildOutput: [
+            path.join(DOTCMS_ROOT, '.gradle'),
+            path.join(DOTCMS_ROOT, 'build', 'classes'),
+            path.join(DOTCMS_ROOT, 'build', 'resources')
+        ]
     },
     maven: {
-        dependencies: ['~/.m2/repository'],
-        buildOutput: ['dotCMS/target']
+        dependencies: [path.join(M2_FOLDER, 'repository')],
+        buildOutput: [path.join(DOTCMS_ROOT, 'target')]
     }
 };
 const EMPTY_CACHE_LOCATIONS = {
     dependencies: [],
     buildOutput: []
 };
-const BUILD_OUTPUT = 'buildOutput';
-const CACHE_FOLDER = path.join(path.dirname(core.getInput('project_root')), 'cache');
+//const BUILD_OUTPUT = 'buildOutput'
+//const CACHE_FOLDER = path.join(path.dirname(core.getInput('project_root')), 'cache')
 /**
  * Resolves locations to be cached after building core.
  *
@@ -65,7 +74,9 @@ const getCacheLocations = () => {
         return EMPTY_CACHE_LOCATIONS;
     }
     // For each cache location resolves the location to be cached
-    Object.keys(cacheLocations).forEach(key => resolveLocations(buildEnv, cacheLocations, key, key === BUILD_OUTPUT ? decorateBuildOutput : undefined));
+    for (const key of Object.keys(cacheLocations)) {
+        resolveLocations(buildEnv, cacheLocations, key, undefined);
+    }
     return cacheLocations;
 };
 exports.getCacheLocations = getCacheLocations;
@@ -111,7 +122,7 @@ const resolveLocations = (buildEnv, cacheLocations, key, decorateFn) => {
  * @param location location
  * @returns decorated string
  */
-const decorateBuildOutput = (location) => path.join(CACHE_FOLDER, location);
+//const decorateBuildOutput = (location: string): string => path.join(CACHE_FOLDER, location)
 
 
 /***/ }),

--- a/.github/actions/core-cache-locator/src/cache-locator.ts
+++ b/.github/actions/core-cache-locator/src/cache-locator.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs'
 import * as path from 'path'
 
 interface CacheLocations {
-  dependencies: string[]
-  buildOutput: string[]
+  dependencies?: string[]
+  buildOutput?: string[]
 }
 
 interface CacheConfiguration {
@@ -81,13 +81,14 @@ const resolveLocations = (
 ) => {
   const cacheEnableKey = key.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`)
   const cacheEnable = core.getBooleanInput(`cache_${cacheEnableKey}`)
+  const locationKey = key as keyof CacheLocations
   if (!cacheEnable) {
     core.notice(`Core cache is disabled for ${key}`)
+    cacheLocations[locationKey] = undefined
     return
   }
 
   core.info(`Looking cache configuration for ${key}`)
-  const locationKey = key as keyof CacheLocations
   const locations = cacheLocations[locationKey]
   if (!locations) {
     core.warning(`Cannot resolve any ${key} locations for build env ${buildEnv}`)

--- a/.github/actions/core-cache-locator/src/cache-locator.ts
+++ b/.github/actions/core-cache-locator/src/cache-locator.ts
@@ -12,14 +12,23 @@ interface CacheConfiguration {
   maven: CacheLocations
 }
 
+const HOME_FOLDER = path.join('/home', 'runner')
+const GRADLE_FOLDER = path.join(HOME_FOLDER, '.gradle')
+const M2_FOLDER = path.join(HOME_FOLDER, '.m2')
+const PROJECT_ROOT = core.getInput('project_root')
+const DOTCMS_ROOT = path.join(PROJECT_ROOT, 'dotCMS')
 const CACHE_CONFIGURATION: CacheConfiguration = {
   gradle: {
-    dependencies: ['~/.gradle/caches', '~/.gradle/wrapper'],
-    buildOutput: ['dotCMS/.gradle', 'dotCMS/build/classes', 'dotCMS/build/resources']
+    dependencies: [path.join(GRADLE_FOLDER, 'caches'), path.join(GRADLE_FOLDER, 'wrapper')],
+    buildOutput: [
+      path.join(DOTCMS_ROOT, '.gradle'),
+      path.join(DOTCMS_ROOT, 'build', 'classes'),
+      path.join(DOTCMS_ROOT, 'build', 'resources')
+    ]
   },
   maven: {
-    dependencies: ['~/.m2/repository'],
-    buildOutput: ['dotCMS/target']
+    dependencies: [path.join(M2_FOLDER, 'repository')],
+    buildOutput: [path.join(DOTCMS_ROOT, 'target')]
   }
 }
 
@@ -28,8 +37,8 @@ const EMPTY_CACHE_LOCATIONS: CacheLocations = {
   buildOutput: []
 }
 
-const BUILD_OUTPUT = 'buildOutput'
-const CACHE_FOLDER = path.join(path.dirname(core.getInput('project_root')), 'cache')
+//const BUILD_OUTPUT = 'buildOutput'
+//const CACHE_FOLDER = path.join(path.dirname(core.getInput('project_root')), 'cache')
 
 /**
  * Resolves locations to be cached after building core.
@@ -48,9 +57,9 @@ export const getCacheLocations = (): CacheLocations => {
   }
 
   // For each cache location resolves the location to be cached
-  Object.keys(cacheLocations).forEach(key =>
-    resolveLocations(buildEnv, cacheLocations, key, key === BUILD_OUTPUT ? decorateBuildOutput : undefined)
-  )
+  for (const key of Object.keys(cacheLocations)) {
+    resolveLocations(buildEnv, cacheLocations, key, undefined)
+  }
 
   return cacheLocations
 }
@@ -108,4 +117,4 @@ const resolveLocations = (
  * @param location location
  * @returns decorated string
  */
-const decorateBuildOutput = (location: string): string => path.join(CACHE_FOLDER, location)
+//const decorateBuildOutput = (location: string): string => path.join(CACHE_FOLDER, location)

--- a/.github/actions/restore-core/package-lock.json
+++ b/.github/actions/restore-core/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^1.0.11",
-        "@actions/core": "^1.6.0"
+        "@actions/core": "^1.6.0",
+        "@actions/exec": "^1.1.1"
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.2",

--- a/.github/actions/restore-core/package.json
+++ b/.github/actions/restore-core/package.json
@@ -21,7 +21,8 @@
   "license": "MIT",
   "dependencies": {
     "@actions/cache": "^1.0.11",
-    "@actions/core": "^1.6.0"
+    "@actions/core": "^1.6.0",
+    "@actions/exec": "^1.1.1"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.2",

--- a/.github/actions/run-postman-tests/dist/index.js
+++ b/.github/actions/run-postman-tests/dist/index.js
@@ -131,9 +131,8 @@ const resourcesFolder = path.join(cicdFolder, 'resources', 'postman');
 const dockerFolder = path.join(cicdFolder, 'docker');
 const licenseFolder = path.join(dockerFolder, 'license');
 const dotCmsRoot = path.join(projectRoot, 'dotCMS');
-const logsFolder = path.join(dockerFolder, 'logs');
-const logFile = 'dotcms.log';
-const volumes = [licenseFolder, path.join(dockerFolder, 'cms-shared'), path.join(dockerFolder, 'cms-local'), logsFolder];
+const logFile = path.join(dotCmsRoot, 'dotcms.log');
+const volumes = [licenseFolder, path.join(dockerFolder, 'cms-shared'), path.join(dockerFolder, 'cms-local')];
 const postmanTestsPath = path.join(dotCmsRoot, 'src', 'curl-test');
 const postmanEnvFile = 'postman_environment.json';
 const resultsFolder = path.join(dotCmsRoot, 'build', 'test-results', 'postmanTest');
@@ -179,18 +178,15 @@ exports.runTests = runTests;
 /**
  * Copies logs from docker volume to standard DotCMS location.
  */
-const copyOutputs = () => {
+const copyOutputs = () => __awaiter(void 0, void 0, void 0, function* () {
     printInfo();
-    execCmd(toCommand('docker', ['cp', 'docker_dotcms-app_1:/srv/dotserver/tomcat-9.0.60/logs/dotcms.log', logsFolder]));
-    execCmd(toCommand('pwd', [], logsFolder));
-    execCmd(toCommand('ls', ['-las', '.'], logsFolder));
-    try {
-        fs.copyFileSync(path.join(logsFolder, logFile), path.join(dotCmsRoot, logFile));
-    }
-    catch (err) {
-        core.error(`Error copying log file: ${err}`);
-    }
-};
+    yield execCmd(toCommand('docker', [
+        'cp',
+        'docker_dotcms-app_1:/srv/dotserver/tomcat-9.0.60/logs/dotcms.log',
+        logFile
+    ]));
+    yield execCmd(toCommand('ls', ['-las', dotCmsRoot]));
+});
 /**
  * Sets up everuthing needed to run postman collections.
  */
@@ -200,20 +196,20 @@ const setup = () => {
     prepareLicense();
     printInfo();
 };
-const printInfo = () => {
-    execCmd(toCommand('docker', ['images']));
-    execCmd(toCommand('docker', ['ps']));
-};
+const printInfo = () => __awaiter(void 0, void 0, void 0, function* () {
+    yield execCmd(toCommand('docker', ['images']));
+    yield execCmd(toCommand('docker', ['ps']));
+});
 /**
  * Install necessary dependencies to run the postman collections.
  */
-const installDeps = () => {
+const installDeps = () => __awaiter(void 0, void 0, void 0, function* () {
     core.info('Installing newman');
     const npmArgs = ['install', '--location=global', 'newman'];
     if (exportReport) {
         npmArgs.push('newman-reporter-htmlextra');
     }
-    execCmd(toCommand('npm', npmArgs));
+    yield execCmd(toCommand('npm', npmArgs));
     // if (!fs.existsSync(tomcatRoot) && buildEnv === 'gradle') {
     //   core.info(`Tomcat root does not exist, creating it`)
     //   await exec.exec('./gradlew', ['clonePullTomcatDist'])
@@ -222,7 +218,7 @@ const installDeps = () => {
     //     throw new Error('Cannot find any Tomcat root folder')
     //   }
     // }
-};
+});
 /**
  * Start postman depencies: db, ES and DotCMS isntance.
  */
@@ -238,7 +234,7 @@ const startDeps = () => {
 /**
  * Stop postman depencies: db, ES and DotCMS isntance.
  */
-const stopDeps = () => {
+const stopDeps = () => __awaiter(void 0, void 0, void 0, function* () {
     //await stopDotCMS()
     // Stopping dependencies
     core.info(`
@@ -246,12 +242,12 @@ const stopDeps = () => {
     Stopping postman tests dependencies
     ===================================`);
     try {
-        execCmd(toCommand('docker-compose', ['-f', 'open-distro-compose.yml', '-f', `${dbType}-compose.yml`, '-f', 'dotcms-compose.yml', 'down'], dockerFolder, DEPS_ENV));
+        yield execCmd(toCommand('docker-compose', ['-f', 'open-distro-compose.yml', '-f', `${dbType}-compose.yml`, '-f', 'dotcms-compose.yml', 'down'], dockerFolder, DEPS_ENV));
     }
     catch (err) {
         console.error(`Error stopping dependencies: ${err}`);
     }
-};
+});
 // const startDotCMS = async () => {
 //   core.info(`
 //     =======================================
@@ -336,7 +332,7 @@ const runPostmanCollections = () => __awaiter(void 0, void 0, void 0, function* 
  * @param normalized normalized collection
  * @returns promise with process return code
  */
-const runPostmanCollection = (collection, normalized) => {
+const runPostmanCollection = (collection, normalized) => __awaiter(void 0, void 0, void 0, function* () {
     core.info(`Running Postman collection: ${collection}`);
     const resultFile = path.join(resultsFolder, `${normalized}.xml`);
     const page = `${normalized}.html`;
@@ -359,8 +355,8 @@ const runPostmanCollection = (collection, normalized) => {
         args.push('--reporter-htmlextra-export');
         args.push(reportFile);
     }
-    return execCmd(toCommand('newman', args, postmanTestsPath));
-};
+    return yield execCmd(toCommand('newman', args, postmanTestsPath));
+});
 /*
  * Process results.
  *
@@ -413,17 +409,16 @@ const createFolders = () => {
     for (const folder of folders) {
         fs.mkdirSync(folder, { recursive: true });
     }
-    shelljs.touch(path.join(dockerFolder, logFile));
 };
 /**
  * Creates license folder and file with appropiate key.
  */
-const prepareLicense = () => {
+const prepareLicense = () => __awaiter(void 0, void 0, void 0, function* () {
     const licenseFile = path.join(licenseFolder, 'license.dat');
     core.info(`Adding license to ${licenseFile}`);
     fs.writeFileSync(licenseFile, licenseKey, { encoding: 'utf8', flag: 'a+', mode: 0o777 });
-    execCmd(toCommand('ls', ['-las', licenseFile]));
-};
+    yield execCmd(toCommand('ls', ['-las', licenseFile]));
+});
 /**
  * Resolves tests when provided
  *

--- a/.github/workflows/core-cicd-tests.yml
+++ b/.github/workflows/core-cicd-tests.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           build_id: ${{ env.BUILD_ID }}
           current: core
-      - name: Get commit message
-        id: get-commit-message
+      - id: get-commit-message
+        name: Get commit message
         uses: dotcms/get-commit-message@master
         with:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions/core-cache-locator
         with:
           build_env: ${{ env.BUILD_ENV }}
-          cache_build_output: true
+          cache_build_output: false
         if: success()
       - id: cache-core
         name: Cache Core
@@ -72,7 +72,7 @@ jobs:
   run-unit-tests-job:
     name: Run Unit Tests
     runs-on: ubuntu-latest
-    needs: build-core-job
+    needs: [repo-metadata-job, build-core-job]
     if: success()
     outputs:
       tests_results_status: ${{ steps.run-unit-tests.outputs.tests_results_status }}
@@ -144,7 +144,7 @@ jobs:
           github_user: ${{ env.GITHUB_USER }}
           cicd_github_token: ${{ secrets.CICD_GITHUB_TOKEN }}
           tests_report_url: ${{ steps.github-publish-unit-tests.outputs.test_logs_url }}
-        if: (success() || failure()) && steps.publish-unit-tests.outputs.tests_report_url != ''
+        if: (success() || failure()) && steps.github-publish-unit-tests.outputs.tests_report_url != ''
   integration-tests-thread-setup-job:
     name: Integration tests thread (matrix) setup
     runs-on: ubuntu-latest
@@ -174,7 +174,7 @@ jobs:
   run-integration-tests-job:
     name: Run Integration Tests
     runs-on: ubuntu-latest
-    needs: [ build-core-job, integration-tests-thread-setup-job ]
+    needs: [repo-metadata-job, build-core-job, integration-tests-thread-setup-job]
     strategy:
       fail-fast: false
       matrix:
@@ -252,7 +252,7 @@ jobs:
           ci_total: 2
           ci_label: ${{ matrix.db_type }}
           debug: true
-          if: (success() || failure()) && steps.run-integration-tests.outputs.tests_results_skip_report != 'true'
+        if: (success() || failure()) && steps.run-integration-tests.outputs.tests_results_skip_report != 'true'
       - id: github-status
         name: Send Github Status
         uses: ./.github/actions/github-status
@@ -264,11 +264,11 @@ jobs:
           github_user: ${{ env.GITHUB_USER }}
           cicd_github_token: ${{ secrets.CICD_GITHUB_TOKEN }}
           tests_report_url: ${{ steps.github-publish-integration-tests.outputs.tests_report_url }}
-        if: (success() || failure()) && steps.publish-integration-tests.outputs.tests_report_url != ''
+        if: (success() || failure()) && steps.github-publish-integration-tests.outputs.tests_report_url != ''
   integration-tests-complete-job:
     name: Integration tests publish complete setup
     runs-on: ubuntu-latest
-    needs: [ integration-tests-thread-setup-job, run-integration-tests-job ]
+    needs: [integration-tests-thread-setup-job, run-integration-tests-job]
     if: (success() || failure()) && needs.run-integration-tests-job.outputs.tests_results_skip_report != 'true'
     steps:
       - id: fetch-core
@@ -357,7 +357,7 @@ jobs:
           test_type: postman
           tests_results_location: ${{ steps.run-postman-tests.outputs.tests_results_location }}/*.xml
           debug: true
-        if: steps.run-postman-tests.outputs.tests_results_skip_report != 'true'
+        if: (success() || failure()) && steps.run-postman-tests.outputs.tests_results_skip_report != 'true'
       - id: github-status
         name: Send Github Status
         uses: ./.github/actions/github-status
@@ -368,11 +368,11 @@ jobs:
           github_user: ${{ env.GITHUB_USER }}
           cicd_github_token: ${{ secrets.CICD_GITHUB_TOKEN }}
           tests_report_url: ${{ steps.github-publish-postman-tests.outputs.tests_report_url }}
-        if: (success() || failure()) && steps.publish-postman-tests.outputs.tests_report_url != ''
+        if: (success() || failure()) && steps.github-publish-postman-tests.outputs.tests_report_url != ''
   test-results-handler-job:
     name: Tests results handler
     runs-on: ubuntu-latest
-    needs: [run-unit-tests-job, integration-tests-complete-job, run-postman-tests-job]
+    needs: [run-unit-tests-job, run-integration-tests-job, integration-tests-complete-job, run-postman-tests-job]
     if: (success() || failure()) && (needs.run-unit-tests-job.outputs.tests_results_report_url != '' || needs.run-integration-tests-job.outputs.postgres_tests_results_report_url != '' || needs.run-integration-tests-job.outputs.mssql_tests_results_report_url != '' || needs.run-postman-tests-job.outputs.tests_results_report_url != '')
     steps:
       - id: fetch-core

--- a/cicd/local-env.sh
+++ b/cicd/local-env.sh
@@ -21,6 +21,7 @@ echo
 docker-compose version
 echo
 
+echo "HOME: ${HOME}"
 export DOTCMS_ROOT="${GITHUB_WORKSPACE}/dotCMS"
 echo "DOTCMS_ROOT: ${DOTCMS_ROOT}"
 [[ -f ${DOTCMS_ROOT}/gradlew && -f ${DOTCMS_ROOT}/build.gradle ]] && gradle_env=true


### PR DESCRIPTION
Postman collections now have a duration column in the test results.
Rearrange the workflow file so the postman tests can start without waiting for the build core job finishes.
Building core takes less now.
Using absolute paths when it comes to cache dependencies and build output.