### PR TITLE
Trigger dotcms-ui build in 22.07 with copy prepare to fix

### DIFF
--- a/.github/workflows/publish_dotcms_ui.yml
+++ b/.github/workflows/publish_dotcms_ui.yml
@@ -105,6 +105,12 @@ jobs:
       - name: "Publish to npm"
         run: |
           cd core-web
+
+          ## We need to copy prepare for publish because it will look for it in one-level-down
+          ## core-web folder
+          mkdir dist/apps/core-web
+          cp prepare.js ./dist/apps/core-web/prepare.js
+
           npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
           cd dist/apps/dotcms-ui
           if [[ $(basename "${{ github.ref }}") =~ ^release-.* ]]; then


### PR DESCRIPTION
### Proposed Changes
- Copy `prepare.js` to `dist/apps/core-web` so the `npm publish` prepare script can find it 

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
