### PR TITLE
#22598 fix login route not found when redirect

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/login/dot-login-page-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/dot-login-page-routing.module.ts
@@ -25,6 +25,7 @@ const routes: Routes = [
     },
     {
         path: '',
+        pathMatch: 'full',
         redirectTo: '/login'
     }
 ];


### PR DESCRIPTION
Describe the bug
When you try to login to dotCMS the frontend does not find the proper route after the update to Ng 14.

To Reproduce
Steps to reproduce the behavior:

When you are log out go to login form
See error
![Screen Shot 2022-07-20 at 10 15 12 AM](https://user-images.githubusercontent.com/1909643/180020240-630743c5-770b-4da6-bdf2-cd5b163b6569.png)


Expected behavior
Show the login form.

