### PR TITLE
Adds jdk.localedata module to java-base docker image using jlink

### DIFF
--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -45,7 +45,7 @@ RUN bash -c "source /root/.sdkman/bin/sdkman-init.sh && \
     /root/.sdkman/candidates/java/$JAVA_VERSION/bin/jlink \
     --verbose \
     --add-modules \
-        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns \
+        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata \
     --compress 2 \
     --no-header-files \
     --no-man-pages \
@@ -63,3 +63,4 @@ RUN rm -rf /root/.sdkman && \
 # ----------------------------------------------
 FROM scratch
 COPY --from=base-builder / /
+


### PR DESCRIPTION
Fixes #22603 

### Proposed Changes
* Adds `jdk.localedata` module to java-base docker image

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
Locales were moved to `jdk.localedata` as of Java 9 see https://www.oracle.com/java/technologies/javase/jdk11-suported-locales.html#modules
