### PR TITLE
(#22605): Fix of wrong keyword to replace when running migration task.

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task211020CreateHostIntegrityCheckerResultTables.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task211020CreateHostIntegrityCheckerResultTables.java
@@ -18,7 +18,7 @@ public class Task211020CreateHostIntegrityCheckerResultTables extends AbstractJD
             " local_live_inode VARCHAR(36)," +
             " remote_working_inode VARCHAR(36)," +
             " remote_live_inode VARCHAR(36)," +
-            " language_id int8," +
+            " language_id INT8," +
             " host VARCHAR(255)," +
             " PRIMARY KEY (local_working_inode, language_id, endpoint_id)" +
             ");\n";


### PR DESCRIPTION
Tested locally updating a 21.06 MSSQL instance to 22.07.