### PR TITLE
#22168 Correct the generated REST URLs from Content Search 'Show Quer…

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
@@ -2554,10 +2554,7 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
 
         function fillQuery (counters) {
                         <%
-                        String restBaseUrl="http://"+
-                           APILocator.getHostAPI().find((String)session.getAttribute(com.dotmarketing.util.WebKeys.CMS_SELECTED_HOST_ID), user, false).getHostname()+
-                           ((request.getLocalPort()!=80) ? ":"+request.getLocalPort() : "")+
-                           "/api/content/render/false";
+                        String restBaseUrl= "/api/content/render/false";
 
                         String restBasePostUrl="http://"+
                            APILocator.getHostAPI().find((String)session.getAttribute(com.dotmarketing.util.WebKeys.CMS_SELECTED_HOST_ID), user, false).getHostname()+
@@ -2570,7 +2567,7 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
                         var encodedQueryRaw = queryRaw.replace(/'/g, "%27").replace(/"/g, "%22");
                         var queryfield=document.getElementById("luceneQuery");
                         queryfield.value=queryRaw;
-                        var queryFrontend = counters["luceneQueryFrontend"];
+                        var velocityCode = counters["velocityCode"];
                         var relatedQueryByChild = counters["relatedQueryByChild"];
                         var sortBy = counters["sortByUF"];
                         var div = document.getElementById("queryResults");
@@ -2587,7 +2584,7 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
                         div.innerHTML = "<div class='contentViewDialog' style=\"white-space: pre;\">" +
 
                             "<div class='contentViewTitle'><%= LanguageUtil.get(pageContext, "frontend-query") %></div>"+
-                            "<div class='contentViewQuery'><code>#foreach($con in $dotcontent.pull(\"" + queryFrontend + "\",10,\"" + sortBy + "\"))<br/>...<br/>#end</code></div>";
+                            "<div class='contentViewQuery'><code>" + velocityCode + "</code></div>";
 
                         if (relatedQueryByChild == null){
                             div.innerHTML += "<div class='contentViewTitle'><%= LanguageUtil.get(pageContext, "The-actual-query-") %></div>"+
@@ -2622,13 +2619,6 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
 
                             "<div class='contentViewTitle'><%= LanguageUtil.get(pageContext, "rest-api-call-urlencoded") %></div>"+
                             "<div class='contentViewQuery'><code>"+apicall_urlencode+"</code></div>"+
-
-                            "<div class='contentViewQuery' style='padding:20px;padding-top:10px;color:#333;'>REST API: " +
-	                            "<span class='dot-api-link' " +
-                                "onClick=\"queryContentJSONPost('<%= restBasePostUrl %>', '" + encodedQueryRaw + "', '" + sortBy + "')\">API</span></a>"+
-
-                            "</div>"+
-
 
                             "<b><%= LanguageUtil.get(pageContext, "Ordered-by") %>:</b> " + sortBy +
                             "<ul><li><%= LanguageUtil.get(pageContext, "message.contentlet.hint2") %> " +


### PR DESCRIPTION
Proposed Changes
We are going to provide a relative path instead of a absolute one
https://github.com/dotCMS/core/compare/issue-22168-Correct-the-generated-REST-URLs-from-Content-Search-Show-Query?expand=1#diff-1260ed1ed8b9f22ca5c14f1e4caa3e4d3c1ada11674f6bf7572ac34cdc209497R2557

Also we are going to provide a different code velocity when the user filter by a relationship field
To fix this: https://github.com/dotCMS/core/issues/22168#issuecomment-1119789184

now we are going to provide this code

#foreach($con in $dotcontent.pull("+contentType:Blog",10,"score,modDate desc"))
    #set( $related_Blogauthor = $dotcontent.pullRelatedField( "$con.identifier", "Blog.author", "+identifier:af884e69-1820-4c2b-b0ad-6792662cb39c") )
    #if (!$related_Blogauthor.isEmpty())
        ...
    #end
#end