### PR TITLE
#22618 adding the ability to retrieve field variables on velocity

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentMapTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentMapTest.java
@@ -9,6 +9,8 @@ import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.FieldAPI;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.FieldBuilder;
+import com.dotcms.contenttype.model.field.FieldVariable;
+import com.dotcms.contenttype.model.field.ImmutableFieldVariable;
 import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.type.ContentType;
@@ -42,6 +44,8 @@ import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
 import com.liferay.portal.model.User;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.velocity.context.Context;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -74,6 +78,48 @@ public class ContentMapTest extends IntegrationTestBase {
         languageAPI    = APILocator.getLanguageAPI();
         defaultHost    = hostAPI.findDefaultHost(user, false);
         relationshipAPI = APILocator.getRelationshipAPI();
+    }
+
+    /**
+     * This test is for issue https://github.com/dotCMS/core/issues/16409
+     * Categories should be pulled in Front End
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    @Test
+    public void testGet_Field_Variable() throws DotDataException, DotSecurityException {
+
+        final ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(APILocator.systemUser());
+        final ContentType contentType = contentTypeAPI.find("webPageContent");
+        final Field field = contentType.fieldMap().get("title");
+        final FieldVariable fieldVariable = ImmutableFieldVariable.builder()
+                .fieldId(field.inode())
+                .name("format").key("format").value("txt").userId(APILocator.systemUser().getUserId())
+                .build();
+
+        APILocator.getContentTypeFieldAPI().save(fieldVariable, APILocator.systemUser());
+
+        // Create dummy "News" content
+        final ContentletDataGen contentletDataGen = new ContentletDataGen(contentType.inode())
+                .structure(contentType.id())
+                .host(defaultHost);
+
+        contentletDataGen.setProperty("title", "test");
+        contentletDataGen.setProperty("body", "test");
+
+        // Persist dummy "News" contents to ensure at least one result will be returned
+        final Contentlet contentlet = contentletDataGen.nextPersisted();
+        ContentletDataGen.publish(contentlet);
+
+        final Context velocityContext = mock(Context.class);
+
+        final ContentMap contentMap = new ContentMap(contentlet, userAPI.getAnonymousUser(),
+                PageMode.LIVE,defaultHost,velocityContext);
+
+        Map<String, FieldVariable> fieldVariableMap = (Map<String, FieldVariable>) contentMap.getFieldVariables("title");
+
+        Assert.assertNotNull(fieldVariableMap);
+        Assert.assertEquals("txt", fieldVariableMap.get("format").value());
     }
 
     /**

--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentMapTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/ContentMapTest.java
@@ -81,8 +81,9 @@ public class ContentMapTest extends IntegrationTestBase {
     }
 
     /**
-     * This test is for issue https://github.com/dotCMS/core/issues/16409
-     * Categories should be pulled in Front End
+     * Method to test: {@link ContentMap#getFieldVariables(String)}
+     * Given Scenario: Creates a field variable over the generic content called format, which value is 'txt'.
+     * ExpectedResult: The ContentMap should retrieve that field variable
      * @throws DotDataException
      * @throws DotSecurityException
      */

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentMap.java
@@ -3,6 +3,7 @@
  */
 package com.dotcms.rendering.velocity.viewtools.content;
 
+import com.dotcms.contenttype.model.field.FieldVariable;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.transform.field.LegacyFieldTransformer;
 import com.dotcms.rendering.velocity.services.VelocityType;
@@ -125,6 +126,23 @@ public class ContentMap {
 		return get(fieldVariableName, false);
 	}
 
+	/**
+	 * Recovery the field variables for a content type field (if the field already exists, otherwise returns an empty collection)
+	 * @param fieldVariableName String field var name
+	 * @return Map
+	 */
+	public Object getFieldVariables(String fieldVariableName) {
+
+		final  Map<String, com.dotcms.contenttype.model.field.Field> fieldMap =
+				this.content.getContentType().fieldMap();
+
+		if (fieldMap.containsKey(fieldVariableName)) {
+
+			return fieldMap.get(fieldVariableName).fieldVariablesMap();
+		}
+
+		return Collections.emptyMap();
+	}
 
 	private Object get(String fieldVariableName, Boolean parseVelocity) {
 		try {
@@ -543,5 +561,4 @@ public class ContentMap {
 	public Contentlet getContentObject() {
 		return this.content;
 	}
-
 }

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/LazyLoaderContentMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/LazyLoaderContentMap.java
@@ -89,4 +89,8 @@ public class LazyLoaderContentMap {
 
         return load().getContentObject();
     }
+
+    public Object getFieldVariables(String fieldVariableName) {
+        return load().getFieldVariables(fieldVariableName);
+    }
 }


### PR DESCRIPTION
adding the ability to retrieve field variables on velocity

It can be retrieve such as

```
#set($fieldBody = 'body')
#set($fieldVariableMap = $dotContentMap.getFieldVariables($fieldBody))
#set($fieldVariable = $fieldVariableMap.get('format'))
value: $fieldVariable.value()
```