### PR TITLE
#when ran from quarkus the cli does not resolve meta chars fix

### DIFF
--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/SiteCommand.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/SiteCommand.java
@@ -2,33 +2,27 @@ package com.dotcms.cli.command;
 
 import com.dotcms.api.SiteAPI;
 import com.dotcms.api.client.RestClientFactory;
-import com.dotcms.api.client.ServiceManager;
-import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.model.ResponseEntityView;
 import com.dotcms.model.site.Site;
 import java.util.List;
-import java.util.concurrent.Callable;
 import javax.enterprise.context.control.ActivateRequestContext;
 import javax.inject.Inject;
+import org.jboss.logging.Logger;
 import picocli.CommandLine;
-import picocli.CommandLine.ArgGroup;
-import picocli.CommandLine.ExitCode;
 
 @ActivateRequestContext
 @CommandLine.Command(name = "site", description = "@|bold,green Retrieves Sites info.|@ Option params @|bold,cyan -n|@ to filter by name. @|bold,cyan -a|@ Shows archived sites. @|bold,cyan -l|@ Shows live Sites. @|bold,cyan -p|@ (Page) @|bold,cyan -ps|@ (PageSize) Can be used combined for pagination.")
-public class SiteCommand implements Callable<Integer> {
+public class SiteCommand implements Runnable {
 
+    private static final Logger logger = Logger.getLogger(SiteCommand.class);
 
-    static final String NAME = "site";
-
-    /*
-    @CommandLine.Option(names = {"-n", "--name"}, description = "Filter by site name.")
+    @CommandLine.Option(names = {"-n", "--name"}, description = "Filter by site name.", interactive = true)
     String name;
 
     @CommandLine.Option(names = {"-a", "--archived"}, description = "Show archived sites.", defaultValue = "false")
     Boolean archived;
 
-    @CommandLine.Option(names = {"-li", "--live"}, description = "Show live sites.", defaultValue = "true")
+    @CommandLine.Option(names = {"-l", "--live"}, description = "Show live sites.", defaultValue = "true")
     Boolean live;
 
     @CommandLine.Option(names = {"-p", "--page"}, description = "Page Number.", defaultValue = "1")
@@ -36,65 +30,23 @@ public class SiteCommand implements Callable<Integer> {
 
     @CommandLine.Option(names = {"-ps", "--pageSize"}, description = "Items per page.", defaultValue = "25")
     Integer pageSize;
-*/
-    static class ListAllOptionGroup {
-
-        @CommandLine.Option(names = {"-l", "--list"}, description = "List all sites.", required = true)
-        Boolean list;
-    }
-
-    static class SearchOptionGroup {
-
-        @CommandLine.Option(names = {"-f", "--find"}, description = "Find site by name", required = true)
-        Boolean find;
-
-        @CommandLine.Option(names = {"-n", "--name"}, description = "Filter by site name.", required = true)
-        String name;
-    }
-
-    @ArgGroup(exclusive = true, multiplicity = "0..1")
-    ListAllOptionGroup listOption;
-
-
-    @ArgGroup(exclusive = true, multiplicity = "0..1")
-    SearchOptionGroup searchOption;
-
-    @CommandLine.Mixin(name = "output")
-    protected OutputOptionMixin output;
-
-    @Inject
-    ServiceManager serviceManager;
 
     @Inject
     RestClientFactory clientFactory;
 
-
-
     @Override
-    public Integer call() {
+    public void run() {
 
-        System.out.println("@|bold,green Testing.|@");
-
-        if(null != listOption) {
-            System.out.println(listOption.list);
-        }
-
-        if(null != searchOption) {
-            System.out.println(searchOption.name);
-        }
-        /*
         final SiteAPI siteAPI = clientFactory.getClient(SiteAPI.class);
-        final ResponseEntityView<List<Site>> response = siteAPI.getSites(name, archived, live, false, page, pageSize);
+        final ResponseEntityView<List<Site>> response = siteAPI.getSites(name, archived, live, true, page, pageSize);
         final List<Site> sites = response.entity();
         if (sites.isEmpty()) {
-
+            logger.info("I couldn't find any sites with this search criteria.");
         } else {
             for (final Site site : sites) {
-
+                logger.info(site);
             }
-        }*/
-
-        return ExitCode.OK;
+        }
 
     }
 

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/SiteCommand.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/SiteCommand.java
@@ -2,27 +2,33 @@ package com.dotcms.cli.command;
 
 import com.dotcms.api.SiteAPI;
 import com.dotcms.api.client.RestClientFactory;
+import com.dotcms.api.client.ServiceManager;
+import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.model.ResponseEntityView;
 import com.dotcms.model.site.Site;
 import java.util.List;
+import java.util.concurrent.Callable;
 import javax.enterprise.context.control.ActivateRequestContext;
 import javax.inject.Inject;
-import org.jboss.logging.Logger;
 import picocli.CommandLine;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.ExitCode;
 
 @ActivateRequestContext
 @CommandLine.Command(name = "site", description = "@|bold,green Retrieves Sites info.|@ Option params @|bold,cyan -n|@ to filter by name. @|bold,cyan -a|@ Shows archived sites. @|bold,cyan -l|@ Shows live Sites. @|bold,cyan -p|@ (Page) @|bold,cyan -ps|@ (PageSize) Can be used combined for pagination.")
-public class SiteCommand implements Runnable {
+public class SiteCommand implements Callable<Integer> {
 
-    private static final Logger logger = Logger.getLogger(SiteCommand.class);
 
-    @CommandLine.Option(names = {"-n", "--name"}, description = "Filter by site name.", interactive = true)
+    static final String NAME = "site";
+
+    /*
+    @CommandLine.Option(names = {"-n", "--name"}, description = "Filter by site name.")
     String name;
 
     @CommandLine.Option(names = {"-a", "--archived"}, description = "Show archived sites.", defaultValue = "false")
     Boolean archived;
 
-    @CommandLine.Option(names = {"-l", "--live"}, description = "Show live sites.", defaultValue = "true")
+    @CommandLine.Option(names = {"-li", "--live"}, description = "Show live sites.", defaultValue = "true")
     Boolean live;
 
     @CommandLine.Option(names = {"-p", "--page"}, description = "Page Number.", defaultValue = "1")
@@ -30,23 +36,65 @@ public class SiteCommand implements Runnable {
 
     @CommandLine.Option(names = {"-ps", "--pageSize"}, description = "Items per page.", defaultValue = "25")
     Integer pageSize;
+*/
+    static class ListAllOptionGroup {
+
+        @CommandLine.Option(names = {"-l", "--list"}, description = "List all sites.", required = true)
+        Boolean list;
+    }
+
+    static class SearchOptionGroup {
+
+        @CommandLine.Option(names = {"-f", "--find"}, description = "Find site by name", required = true)
+        Boolean find;
+
+        @CommandLine.Option(names = {"-n", "--name"}, description = "Filter by site name.", required = true)
+        String name;
+    }
+
+    @ArgGroup(exclusive = true, multiplicity = "0..1")
+    ListAllOptionGroup listOption;
+
+
+    @ArgGroup(exclusive = true, multiplicity = "0..1")
+    SearchOptionGroup searchOption;
+
+    @CommandLine.Mixin(name = "output")
+    protected OutputOptionMixin output;
+
+    @Inject
+    ServiceManager serviceManager;
 
     @Inject
     RestClientFactory clientFactory;
 
-    @Override
-    public void run() {
 
+
+    @Override
+    public Integer call() {
+
+        System.out.println("@|bold,green Testing.|@");
+
+        if(null != listOption) {
+            System.out.println(listOption.list);
+        }
+
+        if(null != searchOption) {
+            System.out.println(searchOption.name);
+        }
+        /*
         final SiteAPI siteAPI = clientFactory.getClient(SiteAPI.class);
-        final ResponseEntityView<List<Site>> response = siteAPI.getSites(name, archived, live, true, page, pageSize);
+        final ResponseEntityView<List<Site>> response = siteAPI.getSites(name, archived, live, false, page, pageSize);
         final List<Site> sites = response.entity();
         if (sites.isEmpty()) {
-            logger.info("I couldn't find any sites with this search criteria.");
+
         } else {
             for (final Site site : sites) {
-                logger.info(site);
+
             }
-        }
+        }*/
+
+        return ExitCode.OK;
 
     }
 

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/CommandTest.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/CommandTest.java
@@ -1,0 +1,38 @@
+package com.dotcms.cli.command;
+
+import com.dotcms.api.client.ServiceManager;
+import com.dotcms.model.config.ServiceBean;
+import io.quarkus.picocli.runtime.PicocliCommandLineFactory;
+import java.io.IOException;
+import javax.inject.Inject;
+
+public abstract class CommandTest {
+
+    private static final String PICOCLI_ANSI = "picocli.ansi";
+
+    /**
+     * This here to prevent an issue running test from within quarkus:dev console on which coloring/styling meta chars are not resolved. Therefore, this breaks our tests.
+     */
+     static void disableAnsi() {
+        System.setProperty(PICOCLI_ANSI, Boolean.FALSE.toString());
+    }
+
+    /**
+     * This removes the flag to prevent issues outside the test execution
+     */
+    static void enableAnsi() {
+        System.clearProperty(PICOCLI_ANSI);
+    }
+
+    @Inject
+    PicocliCommandLineFactory factory;
+
+    @Inject
+    ServiceManager serviceManager;
+
+    ServiceManager resetServiceProfiles() throws IOException {
+        return serviceManager.removeAll()
+                .persist(ServiceBean.builder().name("default").active(true).build());
+    }
+
+}

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/InstanceCommandTest.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/InstanceCommandTest.java
@@ -9,7 +9,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Optional;
 import javax.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -17,18 +19,21 @@ import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
 
 @QuarkusTest
-public class InstanceCommandTest {
+public class InstanceCommandTest extends CommandTest {
 
-    @Inject
-    PicocliCommandLineFactory factory;
+    @BeforeAll
+    public static void beforeAll() {
+        disableAnsi();
+    }
 
-    @Inject
-    ServiceManager serviceManager;
+    @AfterAll
+    public static void afterAll() {
+        enableAnsi();
+    }
 
     @BeforeEach
     public void setupTest() throws IOException {
-        serviceManager.removeAll()
-                .persist(ServiceBean.builder().name("default").active(true).build());
+        resetServiceProfiles();
     }
 
     /**
@@ -67,9 +72,9 @@ public class InstanceCommandTest {
                 Assertions.assertEquals(ExitCode.OK, status);
                 final String output = writer.toString();
                 Assertions.assertTrue(
-                        output.contains("Profile [default], Uri [http://localhost:8080/api]"));
+                        output.contains("Profile [default], Uri [http://localhost:8080/api]"),()->output);
                 Assertions.assertTrue(
-                        output.contains("Profile [demo], Uri [https://demo.dotcms.com/api]"));
+                        output.contains("Profile [demo], Uri [https://demo.dotcms.com/api]"), ()->output);
             }
         }
     }
@@ -115,7 +120,7 @@ public class InstanceCommandTest {
                 final String output = writer.toString();
                 Assertions.assertTrue(output.contains(String.format(
                         "The instance name [%s] does not match any configured server! Use --list option.",
-                        instance)));
+                        instance)),()->output);
             }
         }
     }
@@ -151,7 +156,7 @@ public class InstanceCommandTest {
                 final String output = writer.toString();
                 Assertions.assertTrue(output.contains(
                         String.format("The instance name [%s] is now the active profile.",
-                                newProfile)));
+                                newProfile)),()->output);
             }
         }
     }

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/LoginCommandTest.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/LoginCommandTest.java
@@ -8,7 +8,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import javax.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -16,17 +18,21 @@ import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
 
 @QuarkusTest
-public class LoginCommandTest {
+public class LoginCommandTest extends CommandTest {
 
-    @Inject
-    PicocliCommandLineFactory factory;
+    @BeforeAll
+    public static void beforeAll() {
+        disableAnsi();
+    }
 
-    @Inject
-    ServiceManager serviceManager;
+    @AfterAll
+    public static void afterAll() {
+        enableAnsi();
+    }
 
     @BeforeEach
     public void setupTest() throws IOException {
-        serviceManager.removeAll().persist(ServiceBean.builder().name("default").active(true).build());
+        resetServiceProfiles();
     }
 
     /**
@@ -102,7 +108,5 @@ public class LoginCommandTest {
         }
 
     }
-
-
 
 }

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/StatusCommandTest.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/StatusCommandTest.java
@@ -11,7 +11,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Optional;
 import javax.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
@@ -19,21 +21,25 @@ import picocli.CommandLine.ExitCode;
 
 
 @QuarkusTest
-public class StatusCommandTest {
-
-    @Inject
-    PicocliCommandLineFactory factory;
-
-    @Inject
-    ServiceManager serviceManager;
+public class StatusCommandTest extends CommandTest {
 
     @Inject
     AuthenticationContext authenticationContext;
 
+    @BeforeAll
+    public static void beforeAll() {
+        disableAnsi();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        enableAnsi();
+    }
+
     @BeforeEach
     public void setupTest() throws IOException {
         //Destroy the config file that say what dotCMS instance we're connected to.
-        serviceManager.removeAll().persist(ServiceBean.builder().name("default").active(true).build());
+        resetServiceProfiles();
         //in case any other test has already logged in.
         authenticationContext.reset();
     }
@@ -69,8 +75,7 @@ public class StatusCommandTest {
     @Test
     public void Test_Command_Status_Default_Profile_Not_Logged_In() throws IOException {
 
-        serviceManager.removeAll()
-                .persist(ServiceBean.builder().name("default").active(true).build());
+        resetServiceProfiles();
 
         final CommandLine commandLine = factory.create();
         final StringWriter writer = new StringWriter();
@@ -125,8 +130,7 @@ public class StatusCommandTest {
         final String user = "admin@dotCMS.com";
         final String passwd = "admin";
 
-        serviceManager.removeAll()
-                .persist(ServiceBean.builder().name("default").active(true).build());
+        resetServiceProfiles();
         authenticationContext.login(user, passwd.toCharArray());
 
         //Test the user and credential got stored after an OK login


### PR DESCRIPTION
### Proposed Changes
* When Integration test were executed from within quarkus:dev terminal via option (R) a weird behavior was showing. All metacharacters used to give style and coloring were not resolved properly however when executed from a regular terminal or from maven test goal they were working properly. This is a workaround that solves that issue + I'm moving all that common logic into a base class for all Command Test classes 