### PR TITLE
fix: test - DotFormSelectorComponent show dialog data events trigger event when click select button

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-form-selector/dot-form-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-form-selector/dot-form-selector.component.spec.ts
@@ -139,14 +139,15 @@ describe('DotFormSelectorComponent', () => {
             });
 
             describe('events', () => {
-                beforeEach(() => {
+                beforeEach(async () => {
                     spyOn(component.pick, 'emit');
                     spyOn(component.shutdown, 'emit');
 
                     fixture.componentInstance.show = true;
                     paginatorService.totalRecords = 1;
                     paginatorService.paginationPerPage = 1;
-                    fixture.detectChanges();
+
+                    await fixture.whenStable();
                 });
 
                 it('should emit close', () => {
@@ -156,14 +157,11 @@ describe('DotFormSelectorComponent', () => {
                     expect(component.shutdown.emit).toHaveBeenCalledWith(true);
                 });
 
-                it('trigger event when click select button', (done) => {
-                    setTimeout(() => {
-                        fixture.detectChanges();
-                        const button = de.query(By.css('.form-selector__button'));
-                        button.triggerEventHandler('click', null);
-                        expect(component.pick.emit).toHaveBeenCalledWith(mockContentType);
-                        done();
-                    }, 0);
+                it('trigger event when click select button', () => {
+                    fixture.detectChanges();
+                    const button = de.query(By.css('.form-selector__button'));
+                    button.triggerEventHandler('click', null);
+                    expect(component.pick.emit).toHaveBeenCalledWith(mockContentType);
                 });
             });
         });


### PR DESCRIPTION
**What we did**

1. Remove the `setTimeout`.
2. Wait until the `fixture` is `stable`.
3. Get the `tested button` from the `document`.


**Test**
<img width="1792" alt="Screen Shot 2022-08-10 at 12 04 54 PM" src="https://user-images.githubusercontent.com/72418962/183958364-b8fa9733-8c4e-4ee9-950f-5b0fe288272f.png">
