### PR TITLE
Fixing next versions in dotcms-ui and dotcms-webcomponents

### DIFF
--- a/core-web/libs/dotcms-webcomponents/package.json
+++ b/core-web/libs/dotcms-webcomponents/package.json
@@ -1,6 +1,6 @@
   {
   "name": "dotcms-webcomponents",
-  "version": "22.8.0-next.7",
+  "version": "22.9.0-next.1",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.js",
   "es2015": "./dist/esm/index.mjs",

--- a/core-web/package.json
+++ b/core-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dotcms-ui",
-    "version": "22.8.0-next.10",
+    "version": "22.9.0-next.1",
     "license": "MIT",
     "engines": {
         "node": ">=16.13.2"


### PR DESCRIPTION
`next` tag in core-web now points to 22.9