### PR TITLE
dotCMS/core#22810 fix Contentlet editor behaving oddly (styles broken…

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dojo/custom-build/build-report.txt
+++ b/dotCMS/src/main/webapp/html/js/dojo/custom-build/build-report.txt
@@ -1,4 +1,4 @@
-Build started: Tue Jun 28 2022 18:27:29 GMT-0600 (Central Standard Time)
+Build started: Mon Aug 22 2022 16:27:13 GMT-0600 (Central Standard Time)
 Build application version: 1.17.2 (c950c9a)
 Messages:
 info(100) Assumed module uses legacy loader API.
@@ -121,8 +121,8 @@ info(100) Assumed module uses legacy loader API.
 	module: dojox/xmpp/xmppSession
 	module: dojox/xmpp/widget/ChatSession
 info(103) Optimizing module complete.
-	/Users/morera/dev/dotcms/core/dotCMS/src/main/webapp/html/js/dojo/custom-build/dojo/dojo.js (compile time:1.076s)
-	/Users/morera/dev/dotcms/core/dotCMS/src/main/webapp/html/js/dojo/custom-build/build/build.js (compile time:6.348s)
+	/Users/alfredo-li/code/core/dotCMS/src/main/webapp/html/js/dojo/custom-build/dojo/dojo.js (compile time:5.136s)
+	/Users/alfredo-li/code/core/dotCMS/src/main/webapp/html/js/dojo/custom-build/build/build.js (compile time:23.247s)
 info(107) Package Version:
 	package: dojo; version: 1.17.2
 	package: dijit; version: 1.17.2
@@ -130,7 +130,7 @@ info(107) Package Version:
 warn(205) Module not tagged as pure AMD yet it contains AMD API applications.
 	module: build/build
 warn(209) Missing or empty package.json.
-	filename: /Users/morera/dev/dotcms/core/dotCMS/src/main/webapp/html/js/dojo/src/dojo-release-1.17.2-src/build/package.json
+	filename: /Users/alfredo-li/code/core/dotCMS/src/main/webapp/html/js/dojo/src/dojo-release-1.17.2-src/build/package.json
 warn(216) dojo/has plugin resource could not be resolved during build-time.
 	plugin resource id: dojo-firebug?./_firebug/firebug; reference module id: dojo/main
 	plugin resource id: dom-addeventlistener?:./aspect; reference module id: dojo/on
@@ -508,15 +508,15 @@ build/build:
 	dojox/widget/Calendar
 
 Optimizer Messages:
-/Users/morera/dev/dotcms/core/dotCMS/src/main/webapp/html/js/dojo/custom-build/dojo/dojo.js:
-Done (compile time:1.076s)
-/Users/morera/dev/dotcms/core/dotCMS/src/main/webapp/html/js/dojo/custom-build/dojo/dojo.js:
-Done (compile time:1.076s)
-/Users/morera/dev/dotcms/core/dotCMS/src/main/webapp/html/js/dojo/custom-build/build/build.js:
-Done (compile time:6.348s)
+/Users/alfredo-li/code/core/dotCMS/src/main/webapp/html/js/dojo/custom-build/dojo/dojo.js:
+Done (compile time:5.136s)
+/Users/alfredo-li/code/core/dotCMS/src/main/webapp/html/js/dojo/custom-build/dojo/dojo.js:
+Done (compile time:5.136s)
+/Users/alfredo-li/code/core/dotCMS/src/main/webapp/html/js/dojo/custom-build/build/build.js:
+Done (compile time:23.247s)
 
 
 Process finished normally
 	errors: 0
 	warnings: 63
-	build time: 8.087 seconds
+	build time: 27.533 seconds

--- a/dotCMS/src/main/webapp/html/js/dojo/custom-build/dijit/themes/dijit.css
+++ b/dotCMS/src/main/webapp/html/js/dojo/custom-build/dijit/themes/dijit.css
@@ -46,11 +46,13 @@ table.dijitInline {
 }
 
 .dijitHidden {
+    /* A revert of styles in dijit.css file was done, there is no clear explanation from the author why this was changed, more information on https://github.com/dojo/dojo/issues/326 */
 	/* To hide unselected panes in StackContainer etc. */
 	display: none !important;
 }
 
 .dijitVisible {
+    /* A revert of styles in dijit.css file was done, there is no clear explanation from the author why this was changed, more information on https://github.com/dojo/dojo/issues/326 */
 	/* To show selected pane in StackContainer etc. */
 	display: block !important;	/* override user's display:none setting via style setting or indirectly via class */
 	position: relative;			/* to support setting width/height, see #2033 */

--- a/dotCMS/src/main/webapp/html/js/dojo/custom-build/dijit/themes/dijit.css
+++ b/dotCMS/src/main/webapp/html/js/dojo/custom-build/dijit/themes/dijit.css
@@ -47,18 +47,13 @@ table.dijitInline {
 
 .dijitHidden {
 	/* To hide unselected panes in StackContainer etc. */
-	position: absolute; /* remove from normal document flow to simulate display: none */
-	visibility: hidden; /* hide element from view, but don't break scrolling, see #18612 */
-}
-.dijitHidden * {
-	visibility: hidden !important; /* hide visibility:visible descendants of class=dijitHidden nodes, see #18799 */
+	display: none !important;
 }
 
 .dijitVisible {
 	/* To show selected pane in StackContainer etc. */
 	display: block !important;	/* override user's display:none setting via style setting or indirectly via class */
 	position: relative;			/* to support setting width/height, see #2033 */
-	visibility: visible;
 }
 
 .dj_ie6 .dijitComboBox .dijitInputContainer,


### PR DESCRIPTION
dotCMS/core#22810 fix Contentlet editor behaving oddly (styles broken?) in 22.09.
    
A revert of styles (2 css classes) in dijit.css file was done, there is no clear explanation from the author why this was changed, more information on https://github.com/dotCMS/core/issues/22810


### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
