### PR TITLE
Updating ES version and increasing heap size

### DIFF
--- a/.github/actions/run-integration-tests/dist/index.js
+++ b/.github/actions/run-integration-tests/dist/index.js
@@ -488,7 +488,7 @@ const getOverrides = (propertyMap) => {
                     },
                     {
                         original: '^ES_HOSTNAME=.*$',
-                        replacement: 'ES_HOSTNAME=localhost'
+                        replacement: '#ES_HOSTNAME=localhost'
                     }
                 ]
             },
@@ -550,6 +550,13 @@ const getAppends = (propertyMap) => {
                     `felix.felix.undeployed.dir=${felixFolder}/undeploy`,
                     'dotcms.concurrent.locks.disable=false',
                     `system.felix.base.dir=${systemFelixFolder}`
+                ]
+            },
+            {
+                file: `${itResourcesFolder}/it-dotcms-config-cluster.properties`,
+                lines: [
+                    'ES_ENDPOINTS=http://localhost:9200',
+                    'ES_PROTOCOL=http'
                 ]
             },
             {

--- a/.github/actions/run-integration-tests/src/it-setup.ts
+++ b/.github/actions/run-integration-tests/src/it-setup.ts
@@ -183,7 +183,7 @@ const getOverrides = (propertyMap: Map<string, string>): OverrideProperties => {
           },
           {
             original: '^ES_HOSTNAME=.*$',
-            replacement: 'ES_HOSTNAME=localhost'
+            replacement: '#ES_HOSTNAME=localhost'
           }
         ]
       },
@@ -248,6 +248,10 @@ const getAppends = (propertyMap: Map<string, string>): AppendProperties => {
           'dotcms.concurrent.locks.disable=false',
           `system.felix.base.dir=${systemFelixFolder}`
         ]
+      },
+      {
+        file: `${itResourcesFolder}/it-dotcms-config-cluster.properties`,
+        lines: ['ES_ENDPOINTS=http://localhost:9200', 'ES_PROTOCOL=http']
       },
       {
         file: `${dotCmsFolder}/src/main/webapp/WEB-INF/elasticsearch/config/elasticsearch-override.yml`,

--- a/cicd/docker/dotcms-compose.yml
+++ b/cicd/docker/dotcms-compose.yml
@@ -27,7 +27,7 @@ services:
       DB_BASE_URL: "jdbc:postgresql://database/dotcms"
       DB_USERNAME: "postgres"
       DB_PASSWORD: "postgres"
-      DOT_ES_ENDPOINTS: 'https://elasticsearch:9200'
+      DOT_ES_ENDPOINTS: 'http://elasticsearch:9200'
       DOT_DOTCMS_DEV_MODE: 'true'
       DB_MAX_TOTAL: 15
       DOT_INDEX_POLICY_SINGLE_CONTENT: "FORCE"

--- a/cicd/docker/dotcms-compose.yml
+++ b/cicd/docker/dotcms-compose.yml
@@ -28,6 +28,7 @@ services:
       DB_USERNAME: "postgres"
       DB_PASSWORD: "postgres"
       DOT_ES_ENDPOINTS: 'http://elasticsearch:9200'
+      DOT_ES_PROTOCOL: 'http'
       DOT_DOTCMS_DEV_MODE: 'true'
       DB_MAX_TOTAL: 15
       DOT_INDEX_POLICY_SINGLE_CONTENT: "FORCE"

--- a/cicd/docker/open-distro-compose.yml
+++ b/cicd/docker/open-distro-compose.yml
@@ -3,12 +3,13 @@ version: "3.7"
 services:
 
   elasticsearch:
-    image: "dotcms/es-open-distro:1.3.0"
-    ports:
-      - "9200:9200"
-      - "9600:9600"
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
     environment:
-      PROVIDER_ELASTICSEARCH_HEAP_SIZE: "1500m"
-      PROVIDER_ELASTICSEARCH_DNSNAMES: "localhost"
-      ES_ADMIN_PASSWORD: "admin"
-      discovery.type: "single-node"
+      - cluster.name=elastic-cluster
+      - discovery.type=single-node
+      - data
+      - bootstrap.memory_lock=true
+      - CLI_JAVA_OPTS="-Xms3g -Xmx3g"
+    ports:
+      - 9200:9200
+      - 9600:9600


### PR DESCRIPTION
This PR includes: 
- ES heap size was increased to avoid `full sweep` warning when tests run
- Migration from `dotcms/es-open-distro:1.3.0` to `docker.elastic.co/elasticsearch/elasticsearch:7.9.1`