### PR TITLE
dotCMS/core#22787 Can't add categories to a contentlet 

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories_dialog.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories_dialog.jsp
@@ -169,7 +169,7 @@
 		if(value == undefined || value==null || value=="null"){
 			value="&nbsp;";
 		}
-		
+
 		return "<div style='width:100%;cursor:pointer;' onclick=\"addCat<%=counter%>("+index+")\" >"+value+"</div>";
 	};
 
@@ -219,7 +219,6 @@
 				structure : layout,
 				plugins : {
 					pagination : {
-						pageSizes : [  ],
 						description : "45%",
 						sizeSwitch : "260px",
 						pageStepper : "30em",

--- a/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories_dialog.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories_dialog.jsp
@@ -219,6 +219,7 @@
 				structure : layout,
 				plugins : {
 					pagination : {
+					    pageSizes : [ "10", "All" ],
 						description : "45%",
 						sizeSwitch : "260px",
 						pageStepper : "30em",


### PR DESCRIPTION
### Proposed Changes
* new value is `pageSizes : [ "10", "All" ],`


### Additional Info
With the version of Dojo `1.17.2`,  the property `pageSizes` in the plugin `Pagination` in  `EnhancedGrid` can't be an empty array. 

### Screenshots
<img width="642" alt="image" src="https://user-images.githubusercontent.com/31667212/186271978-45e9ef54-4258-4917-b8cc-d0d3bb6100a3.png">
