### PR TITLE
dotCMS/core#22840 Add relationship is broken in many to one relationship

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp
@@ -776,7 +776,6 @@
                  var srcNode = document.getElementById("<%=relationJsName%>Table");
                  var row = document.createElement("tr");
                  row.id="<%=relationJsName%>TableMessage"
-				row.className = 'dataRow<%=relationJsName%>';
                  var cell = row.insertCell (0);
                  cell.setAttribute("colspan", "100");
                  cell.setAttribute("style","text-align:center");


### PR DESCRIPTION
**Issue**

https://user-images.githubusercontent.com/72418962/186279265-88239194-0cae-4953-869f-d9f7bffa56d8.mov

**Reason**

I forgot to remove the class [`dataRow<%=relationJsName%>`] I added to a `tr` element, as a part of my first approach, to determine whether or not the relationships were loaded  [#22467].  (The way we determine that has changed in this PR #22699).

What was happing is that we use the class `dataRow<%=relationJsName%>` to determine how many `relationships` the `contentlet` has:

https://github.com/dotCMS/core/blob/afdd617ca54ade5cb65622bbdece8e4bf76167a2/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp#L364-L367

And, in the case of `many to one` relationship, we only allow the user to add one `relationship`, so as I added that class [`dataRow<%=relationJsName%>`] to another element, the condition of having one `relationship` always returned `true` even if there was no relationship.

https://github.com/dotCMS/core/blob/afdd617ca54ade5cb65622bbdece8e4bf76167a2/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp#L406-L421

**Fix**

https://user-images.githubusercontent.com/72418962/186480866-d42247da-c14c-45be-aa2d-fbb969ef41a8.mov

**NOTE:** Maybe we can use [custom data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) for these kinds of approaches where we want to get `elements` from the `dom`, `classes` are usually for `styles` and should not be used to get `elements` with sensitive data.

