### PR TITLE
Issue 22864 categories use inode table

### DIFF
--- a/dotCMS/src/curl-test/VanityURL.postman_collection.json
+++ b/dotCMS/src/curl-test/VanityURL.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "3875c184-d685-419e-9898-2d955324fa1a",
+		"_postman_id": "d0681ce1-9d22-4d9e-a138-11c51bea2b71",
 		"name": "VanityURL",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "4500400"
+		"_exporter_id": "5403727"
 	},
 	"item": [
 		{
@@ -222,7 +222,7 @@
 							"    pm.response.to.have.status(404);",
 							"    var body = pm.response.body;",
 							"",
-							"    pm.expect(pm.response.text(), \"Got wrong page\").to.include(\"Page Not Found\");",
+							"    pm.expect(pm.response.text(), \"Got wrong page\").to.include(\"Not Found\");",
 							"});"
 						],
 						"type": "text/javascript"

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1478,24 +1478,23 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     return contentlet.getFolder();
                 }
             } else if (theField instanceof CategoryField) {
-                final Category category = this.categoryAPI.find(theField.values(), currentUser, respectFrontEndRoles);
+                final Category categoryField = this.categoryAPI.find(theField.values(), currentUser, respectFrontEndRoles);
                 // Get all the Contentlets Categories
                 final List<Category> selectedCategories = this.categoryAPI
                         .getParents(contentlet, currentUser, respectFrontEndRoles);
-                final Set<Category> categoryList = new HashSet<>();
-                final List<Category> categoryTree = this.categoryAPI
-                        .getAllChildren(category, currentUser, respectFrontEndRoles);
-                if (selectedCategories.size() > 0 && categoryTree != null) {
-                    for (int k = 0; k < categoryTree.size(); k++) {
-                        final Category cat = categoryTree.get(k);
-                        for (final Category categ : selectedCategories) {
-                            if (categ.getInode().equalsIgnoreCase(cat.getInode())) {
-                                categoryList.add(cat);
-                            }
-                        }
-                    }
+                if(selectedCategories.isEmpty()) {
+                    return List.of();
                 }
-                return categoryList;
+                final List<Category> availableCategories = this.categoryAPI
+                        .getAllChildren(categoryField, currentUser, respectFrontEndRoles);
+                if(availableCategories.isEmpty()) {
+                    return List.of();
+                }
+                selectedCategories.retainAll(availableCategories);
+                
+                return selectedCategories;
+                
+
 
             } else if (theField instanceof RelationshipField) {
                 final ContentletRelationships contentletRelationships = new ContentletRelationships(

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1486,7 +1486,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     return List.of();
                 }
                 final List<Category> availableCategories = this.categoryAPI
-                        .getAllChildren(categoryField, currentUser, respectFrontEndRoles);
+                        .getAllChildren(categoryField, APILocator.systemUser(), false);
                 if(availableCategories.isEmpty()) {
                     return List.of();
                 }

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/ContentMap.java
@@ -234,9 +234,9 @@ public class ContentMap {
 				}
 			}
 			if(f != null && f.getFieldType().equals(Field.FieldType.CATEGORY.toString())){
-				return perAPI.filterCollection(new ArrayList<Category>((Set<Category>)
+				return 
 						conAPI.getFieldValue(content, new LegacyFieldTransformer(f).from(),
-								this.user, respectFrontEndRoles)), PermissionAPI.PERMISSION_USE, true, user);
+								this.user, respectFrontEndRoles);
 			}else if(f != null && (f.getFieldType().equals(Field.FieldType.FILE.toString()) || f.getFieldType().equals(Field.FieldType.IMAGE.toString()))){
                 // Check if image or file is in fieldValueMap hashmap
                 Object fieldvalue = retriveFieldValue(f);

--- a/dotCMS/src/main/java/com/dotmarketing/business/PageCacheParameters.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PageCacheParameters.java
@@ -33,10 +33,9 @@ public class PageCacheParameters {
      * @return The subkey which is specific for a page.
      */
     public String getKey() {
-        Logger.debug(this.getClass(), ()-> "page_cache_key:" + getKey());
-        return String.join("_", this.params);
-
-
+        final String key = String.join("_", this.params);
+        Logger.debug(this.getClass(), ()-> "page_cache_key:" + key);
+        return key;
     }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryAPIImpl.java
@@ -332,7 +332,10 @@ public class CategoryAPIImpl implements CategoryAPI {
 			throws DotDataException, DotSecurityException {
 
 		List<Category> categories = categoryFactory.getChildren(parent);
-
+		if(categories.isEmpty()) {
+		    return categories;
+		}
+		
 		if(onlyActive) {
 			List<Category> resultList = new ArrayList<>();
 			for (Category cat : categories) {
@@ -543,22 +546,16 @@ public class CategoryAPIImpl implements CategoryAPI {
 		categoryFactory.setParents(child, parents);
 	}
 
-	@CloseDBIfOpened
-	public List<Category> getAllChildren(final Category category, final User user,
-										 final boolean respectFrontendRoles)
-			throws DotDataException, DotSecurityException {
+    @CloseDBIfOpened
+    public List<Category> getAllChildren(final Category category, final User user, final boolean respectFrontendRoles)
+                    throws DotDataException, DotSecurityException {
 
-		List<Category> categoryTree = new ArrayList<Category>();
-		LinkedList<Category> children = new LinkedList<Category>(getChildren(category, user, respectFrontendRoles));
-		if (children != null) {
-			while(children.size() > 0) {
-				Category child = children.poll();
-				children.addAll(getChildren(child, user, respectFrontendRoles));
-				categoryTree.add(child);
-			}
-		}
-		return categoryTree;
-	}
+
+        return permissionAPI.filterCollection(categoryFactory.getAllChildren(category), PermissionAPI.PERMISSION_READ,
+                        respectFrontendRoles, user);
+
+
+    }
 
 	@CloseDBIfOpened
 	public List<Category> removeAllChildren(final Category parentCategory, final User user,

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryCacheImpl.java
@@ -130,6 +130,16 @@ public class CategoryCacheImpl extends CategoryCache {
 		cache.remove(primaryGroup + object.getCategoryId(),primaryGroup);
 	}
 
+	
+	
+    @SuppressWarnings ("unchecked")
+    @Override
+    void removeChildren ( String parentId ) throws DotDataException, DotCacheException {
+        removeChildrenInternal(parentId);
+        removeChildrenInternal(parentId + CategoryFactory.ALL_CHILDREN_SUFFIX);
+	
+    }
+	
     /**
      * Removes the list of children categories based using the given parent id/inode
      *
@@ -140,7 +150,7 @@ public class CategoryCacheImpl extends CategoryCache {
      */
     @SuppressWarnings ("unchecked")
     @Override
-    protected void removeChildren ( String parentId ) throws DotDataException, DotCacheException {
+    private void removeChildrenInternal ( String parentId ) throws DotDataException, DotCacheException {
         List<Category> childrenIds = null;
         try {
             childrenIds = (List<Category>) cache.get( categoryChildrenCacheGroup + parentId, categoryChildrenCacheGroup );

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryCacheImpl.java
@@ -134,7 +134,7 @@ public class CategoryCacheImpl extends CategoryCache {
 	
     @SuppressWarnings ("unchecked")
     @Override
-    void removeChildren ( String parentId ) throws DotDataException, DotCacheException {
+    protected void removeChildren ( String parentId ) throws DotDataException, DotCacheException {
         removeChildrenInternal(parentId);
         removeChildrenInternal(parentId + CategoryFactory.ALL_CHILDREN_SUFFIX);
 	
@@ -149,7 +149,6 @@ public class CategoryCacheImpl extends CategoryCache {
      * @throws DotCacheException
      */
     @SuppressWarnings ("unchecked")
-    @Override
     private void removeChildrenInternal ( String parentId ) throws DotDataException, DotCacheException {
         List<Category> childrenIds = null;
         try {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactory.java
@@ -12,7 +12,7 @@ import com.dotmarketing.portlets.categories.model.Category;
  *
  */
 public abstract class CategoryFactory {
-
+    final static String ALL_CHILDREN_SUFFIX=":all-children";
 	/**
 	 * Totally removes a category from the system
 	 * @param object
@@ -264,6 +264,14 @@ public abstract class CategoryFactory {
 
 	abstract protected  void clearCache();
 
-	abstract protected List<Category> getAllChildren(Categorizable parent) throws DotDataException ;
+    /**
+     * This method recurses down the category tree returns all the children, grandchildren, great
+     * grandchildren, etc under this category
+     * 
+     * @param parent
+     * @return
+     * @throws DotDataException
+     */
+    abstract protected List<Category> getAllChildren(Categorizable parent) throws DotDataException;
 	
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactory.java
@@ -243,12 +243,6 @@ public abstract class CategoryFactory {
 	abstract protected List<Category> findTopLevelCategoriesByFilter(String filter, String sort) throws DotDataException;
 	
 	/**
-	 * Deletes all the Children of a given parent inode
-	 * @return
-	 */
-	abstract protected void deleteChildren(String inode);
-	
-	/**
 	 * Returns the children categories of the category with the supplied inode filtered by a string  
 	 * @return
 	 * @throws DotDataException
@@ -269,5 +263,7 @@ public abstract class CategoryFactory {
 	abstract protected String suggestVelocityVarName (String categoryVelVarName) throws DotDataException;
 
 	abstract protected  void clearCache();
+
+	abstract protected List<Category> getAllChildren(Categorizable parent) throws DotDataException ;
 	
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactoryImpl.java
@@ -356,13 +356,12 @@ public class CategoryFactoryImpl extends CategoryFactory {
             
             final List<Category> categoryTree = new ArrayList<Category>();
             final LinkedList<Category> children = new LinkedList<Category>(getChildren(parentCategory));
-            if (children != null) {
-                while(children.size() > 0) {
-                    Category child = children.poll();
-                    children.addAll(getChildren(child));
-                    categoryTree.add(child);
-                }
+            while(children.size() > 0) {
+                Category child = children.poll();
+                children.addAll(getChildren(child));
+                categoryTree.add(child);
             }
+            
             try {
                 catCache.putChildren(allChildrenKey, categoryTree);
             } catch (DotCacheException e) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactoryImpl.java
@@ -8,6 +8,9 @@ import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.DeterministicIdentifierAPI;
 import com.dotmarketing.business.DotCacheException;
 import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.business.PermissionSummary;
+import com.dotmarketing.business.Permissionable;
+import com.dotmarketing.business.RelatedPermissionableGroup;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.util.SQLUtil;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -18,6 +21,7 @@ import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.VelocityUtil;
+import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -25,6 +29,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -130,7 +135,7 @@ public class CategoryFactoryImpl extends CategoryFactory {
 
 		final List<Map<String, Object>> result = new DotConnect()
 				.setSQL(" SELECT * FROM category WHERE lower(category_velocity_var_name) = ?")
-				.addParam(variable)
+				.addParam(variable.toLowerCase())
 				.loadObjectResults();
 
 		return result.isEmpty() ? null : convertForCategory(result.get(0));
@@ -138,10 +143,12 @@ public class CategoryFactoryImpl extends CategoryFactory {
 
 	@Override
 	protected Category findByName(final String name) throws DotDataException {
-
+	    if(null==name) {
+	        return null;
+	    }
 		final List<Map<String, Object>> result = new DotConnect()
-				.setSQL(" SELECT * FROM category WHERE category_name = ?")
-				.addParam(name)
+				.setSQL(" SELECT * FROM category WHERE category_name = lower(?)")
+				.addParam(name.toLowerCase())
 				.loadObjectResults();
 
 		return result.isEmpty() ? null : convertForCategory(result.get(0));
@@ -325,6 +332,115 @@ public class CategoryFactoryImpl extends CategoryFactory {
 
 		return children;
 	}
+	
+	
+	class AllCategoryChildren implements Categorizable, Serializable{
+
+	    private final String id;
+	    
+	    public AllCategoryChildren(String id){
+	        this.id=id;
+	    }
+	    
+        @Override
+        public String getCategoryId() {
+
+            return "all-category-children:" + id;
+        }
+
+
+
+        @Override
+        public String getPermissionId() {
+            return null;
+        }
+
+
+
+        @Override
+        public String getOwner() {
+
+            return null;
+        }
+
+
+
+        @Override
+        public void setOwner(String owner) {
+
+            
+        }
+
+
+
+        @Override
+        public List<PermissionSummary> acceptedPermissions() {
+            return null;
+        }
+
+
+
+        @Override
+        public List<RelatedPermissionableGroup> permissionDependencies(int requiredPermission) {
+            return null;
+        }
+
+
+
+        @Override
+        public Permissionable getParentPermissionable() throws DotDataException {
+            return null;
+        }
+
+
+
+        @Override
+        public String getPermissionType() {
+            return null;
+        }
+
+
+
+        @Override
+        public boolean isParentPermissionable() {
+            return false;
+        }
+	    
+	    
+	    
+	}
+	
+	
+    @SuppressWarnings("unchecked")
+    @Override
+    protected List<Category> getAllChildren(final Categorizable parentCategory) throws DotDataException {
+
+        final AllCategoryChildren allChildrenKey = new AllCategoryChildren(parentCategory.getCategoryId());
+        final List<Category> cachedChildren = catCache.getChildren(allChildrenKey);
+        if(cachedChildren!=null) {
+            return cachedChildren;
+        }
+        
+        final List<Category> categoryTree = new ArrayList<Category>();
+        final LinkedList<Category> children = new LinkedList<Category>(getChildren(parentCategory));
+        if (children != null) {
+            while(children.size() > 0) {
+                Category child = children.poll();
+                children.addAll(getChildren(child));
+                categoryTree.add(child);
+            }
+        }
+        try {
+            catCache.putChildren(allChildrenKey, categoryTree);
+        } catch (DotCacheException e) {
+            throw new DotDataException(e.getMessage(), e);
+        }
+        
+
+        return categoryTree;
+    }
+
+
 
 	@SuppressWarnings("unchecked")
 	@Override
@@ -333,9 +449,8 @@ public class CategoryFactoryImpl extends CategoryFactory {
 		orderBy = SQLUtil.sanitizeSortBy(orderBy);
 
 		final List<Map<String, Object>> result = new DotConnect()
-				.setSQL("select category.* from inode category_1_, category, tree where " +
-						"category.inode = tree.child and tree.parent = ? and category_1_.inode = category.inode " +
-						"and category_1_.type = 'category' order by " + orderBy)
+				.setSQL("select category.* from category, tree where " +
+						"category.inode = tree.child and tree.parent = ? order by " + orderBy)
 				.addParam(parent.getCategoryId())
 				.loadObjectResults();
 
@@ -352,9 +467,8 @@ public class CategoryFactoryImpl extends CategoryFactory {
 			orderBy = "tree_order";
 
 		final List<Map<String, Object>> result = new DotConnect()
-				.setSQL("select category.* from inode category_1_, category, tree where " +
-						"tree.relation_type = ? and category.inode = tree.child and tree.parent = ? and category_1_.inode = category.inode " +
-						"and category_1_.type = 'category' order by " + orderBy)
+				.setSQL("select category.* from category, tree where " +
+						"tree.relation_type = ? and category.inode = tree.child and tree.parent = ? order by " + orderBy)
 				.addParam(relationType)
 				.addParam(parent.getCategoryId())
 				.loadObjectResults();
@@ -367,9 +481,8 @@ public class CategoryFactoryImpl extends CategoryFactory {
 	protected List<Category> getParents(final Categorizable child, final String relationType) throws DotDataException {
 
 		final List<Map<String, Object>> result = new DotConnect()
-				.setSQL("select category.* from inode category_1_, category, tree " +
-						"where tree.relation_type = ? and tree.child = ? and tree.parent = category.inode and category_1_.inode = category.inode " +
-						"and category_1_.type = 'category' order by sort_order asc, category_name asc")
+				.setSQL("select category.* from category, tree " +
+						"where tree.relation_type = ? and tree.child = ? and tree.parent = category.inode order by sort_order asc, category_name asc")
 				.addParam(relationType)
 				.addParam(child.getCategoryId())
 				.loadObjectResults();
@@ -386,9 +499,8 @@ public class CategoryFactoryImpl extends CategoryFactory {
         if ( parentIds == null ) {
 
 			final List<Map<String, Object>> result = new DotConnect()
-					.setSQL("select category.* from inode category_1_, category, tree " +
-							"where tree.child = ? and tree.parent = category.inode and category_1_.inode = category.inode " +
-							"and category_1_.type = 'category' order by sort_order asc, category_name asc")
+					.setSQL("select category.* from category, tree " +
+							"where tree.child = ? and tree.parent = category.inode order by sort_order asc, category_name asc")
 					.addParam(child.getCategoryId())
 					.loadObjectResults();
 
@@ -616,36 +728,7 @@ public class CategoryFactoryImpl extends CategoryFactory {
 		return category;
 	}
 
-	@Override
-	@Deprecated
-	//  Have to delete from cache
-	protected void deleteChildren(String inode) {
-		inode = SQLUtil.sanitizeParameter(inode);
-		Statement s = null;
-		Connection conn = null;
-		try {
-			conn = DbConnectionFactory.getDataSource().getConnection();
-			conn.setAutoCommit(false);
-			s = conn.createStatement();
-			StringBuilder sql = new StringBuilder();
-			sql.append("delete  from  category c where exists ( select 1 from category cat inner join inode category_1_ on (category_1_.inode = cat.inode) ");
-			sql.append(" inner join tree on (cat.inode = tree.child) where ");
-			sql.append(" tree.parent = '").append(inode).append("' and category_1_.type = 'category' and cat.inode = c.inode ) ");
-			s.executeUpdate(sql.toString());
-			conn.commit();
-		} catch (SQLException e) {
-			if (conn != null) {
-				try {
-					conn.rollback();
-				} catch (SQLException e1) {
-					//Quiet
-				}
-			}
-			Logger.error(CategoryFactoryImpl.class, e);
-		} finally {
-			CloseUtils.closeQuietly(s, conn);
-		}
-	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	protected List<Category> findChildrenByFilter(String inode, String filter, String sort) throws DotDataException {
@@ -658,8 +741,7 @@ public class CategoryFactoryImpl extends CategoryFactory {
 
 			final DotConnect dc = new DotConnect();
 
-			String selectQuery = "SELECT * FROM inode, category, tree WHERE category.inode = tree.child AND tree.parent = ? "
-					+ "AND inode.inode = category.inode AND inode.type = 'category'";
+			String selectQuery = "SELECT * FROM category, tree WHERE category.inode = tree.child AND tree.parent = ? ";
 
 			if ( UtilMethods.isSet(filter) ) {
 				filter = filter.toLowerCase();
@@ -708,11 +790,11 @@ public class CategoryFactoryImpl extends CategoryFactory {
 	public boolean  hasDependencies(final Category cat) throws DotDataException {
 
 		final DotConnect dotConnect = new DotConnect();
-		dotConnect.setSQL("select count(*) as count from Tree  Tree, Inode inode_ where Tree.parent = '"+cat.getInode()+"' and  inode_.type = 'category' and  Tree.child = inode_.inode" );
+		dotConnect.setSQL("select count(*) as count from Tree  Tree where Tree.parent = ? ").addParam(cat.getInode());
 		int count1 = dotConnect.getInt("count");
-		dotConnect.setSQL("select count(*) as count  from Tree  Tree, Inode inode_ where Tree.child = '"+cat.getInode()+"' and Tree.parent = inode_.inode and inode_.type <> 'category'");
+		dotConnect.setSQL("select count(*) as count  from Tree  Tree where Tree.child = ? ").addParam(cat.getInode());
 		int count2 = dotConnect.getInt("count");
-		dotConnect.setSQL("select count(*) as count from Field field where field_values like '"+cat.getInode()+"'");
+		dotConnect.setSQL("select count(*) as count from Field field where field_values like ?").addParam(cat.getInode());
 		int count3 = dotConnect.getInt("count");
 
 		return (count1 != 0) || (count2 != 0) || (count3 != 0);
@@ -765,12 +847,6 @@ public class CategoryFactoryImpl extends CategoryFactory {
 			conn.setAutoCommit(false);
 			statement = conn.createStatement();
 			String sql;
-
-            if ( DbConnectionFactory.isOracle() ){
-                //For Oracle we need to avoid ORA-01027 by creating the table before.
-                sql = catSQL.createCategoryReorderTable();
-                statement.execute( sql );
-            }
 
 			PreparedStatement createSortPreparedStatement = conn.prepareStatement( catSQL.getCreateSortChildren() );
             createSortPreparedStatement.setString( 1, inode );

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactoryImpl.java
@@ -43,7 +43,9 @@ public class CategoryFactoryImpl extends CategoryFactory {
 
 	CategoryCache catCache;
 	final CategorySQL categorySQL;
-
+	
+	
+	
 	public CategoryFactoryImpl () {
 		catCache = CacheLocator.getCategoryCache();
 		this.categorySQL = CategorySQL.getInstance();
@@ -334,44 +336,41 @@ public class CategoryFactoryImpl extends CategoryFactory {
 	}
 	
 	
-
-	
     @SuppressWarnings("unchecked")
     @Override
     protected List<Category> getAllChildren(final Categorizable parentCategory) throws DotDataException {
 
         final Category allChildrenKey = new Category();
-        allChildrenKey.setInode(parentCategory.getCategoryId()+ ":all-children");
-        
+        allChildrenKey.setInode(parentCategory.getCategoryId() + ALL_CHILDREN_SUFFIX);
+
         List<Category> cachedChildren = catCache.getChildren(allChildrenKey);
-        if(cachedChildren!=null) {
+        if (cachedChildren != null) {
             return cachedChildren;
         }
-        
+
         synchronized (allChildrenKey.getCategoryId().intern()) {
             cachedChildren = catCache.getChildren(allChildrenKey);
-            if(cachedChildren!=null) {
+            if (cachedChildren != null) {
                 return cachedChildren;
             }
-            
+
             final List<Category> categoryTree = new ArrayList<Category>();
             final LinkedList<Category> children = new LinkedList<Category>(getChildren(parentCategory));
-            while(children.size() > 0) {
+            while (children.size() > 0) {
                 Category child = children.poll();
                 children.addAll(getChildren(child));
                 categoryTree.add(child);
             }
-            
+
             try {
                 catCache.putChildren(allChildrenKey, categoryTree);
             } catch (DotCacheException e) {
                 throw new DotDataException(e.getMessage(), e);
             }
-            
+
             return categoryTree;
         }
     }
-
 
 
 	@SuppressWarnings("unchecked")
@@ -827,19 +826,7 @@ public class CategoryFactoryImpl extends CategoryFactory {
      * @throws DotCacheException
      */
     private void cleanParentChildrenCaches ( final Category category ) throws DotDataException, DotCacheException {
-
-		final List<String> parentIds = catCache.getParents( category );
-        if ( parentIds != null ) {
-            for ( String parentId : parentIds ) {
-                catCache.removeChildren( parentId );
-            }
-        }
-		final List<Category> children = catCache.getChildren( category );
-		if ( children != null ) {
-			for ( final Category child : children ) {
-				catCache.removeParents( child.getCategoryId() );
-			}
-		}
+        catCache.clearCache();
     }
 
     protected String suggestVelocityVarName(final String categoryVelVarName) throws DotDataException {

--- a/dotCMS/src/main/java/com/dotmarketing/util/Logger.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Logger.java
@@ -89,15 +89,15 @@ public class Logger {
     }
 
     public static void info(Class clazz, final Supplier<String> message) {
-        if (isInfoEnabled(clazz)) {
+       
             info(clazz, message.get());
-        }
+        
     }
 
     public static void info(final Object ob, final Supplier<String> message) {
-        if (isInfoEnabled(ob.getClass())) {
+
             info(ob.getClass(), message.get());
-        }
+        
     }
 
     public static void info(Object ob, String message) {
@@ -117,21 +117,18 @@ public class Logger {
     }
 
     public static void debug(final Object ob, final Supplier<String> message) {
-        if (isDebugEnabled(ob.getClass())) {
-            debug(ob.getClass(), message.get());
-        }
+        debug(ob.getClass(), message.get());
+        
     }
 
     public static void debug(final String className, final Supplier<String> message) {
-        if (isDebugEnabled(className)) {
-            debug(className, message.get());
-        }
+        debug(className, message.get());
+        
     }
 
     public static void debug(final Object ob, final Throwable throwable, final Supplier<String> message) {
-        if (isDebugEnabled(ob.getClass())) {
-            debug(ob.getClass(), message.get(), throwable);
-        }
+        debug(ob.getClass(), message.get(), throwable);
+
     }
 
     public static void debug(Object ob, String message) {
@@ -364,21 +361,21 @@ public class Logger {
     }
 
     public static void warn(final Object ob, final Supplier<String> message) {
-        if (isWarnEnabled(ob.getClass())) {
+
             warn(ob.getClass(), message.get());
-        }
+        
     }
 
     public static void warn(final String className, final Supplier<String> message) {
-        if (isWarnEnabled(className)) {
+
             warn(className, message.get());
-        }
+        
     }
 
     public static void warn(Class clazz, final Supplier<String> message) {
-        if (isWarnEnabled(clazz)) {
+
             warn(clazz, message.get());
-        }
+        
     }
 
     public static void warn(Class clazz, final Supplier<String> message, Throwable ex) {


### PR DESCRIPTION
This pr has a number of improvements
- Removes inode tables from category SQL
- Removes unnecessary calls to `isLevelEnabled` in the `Logger.java`.  These extra lookups were minor but visible slow points in glowroot traces
- Removes the redundant call to `permissionAPI.filterCollection`
- Added a cache for the call to the `CategoryAPI.getAllChildren` method call.  This gets called every time you retrieve categories from the `ContentMap` and was doing a recursive `getChildren` on all the children categories, which was a bit slow. 

With these changes, in a large scale .vtl that generates json by pulling back a nested list of content, relationships and categories, it changed the execution time from ~1:50 to 1:20. 

Test categories pulling on demo against the "Product" content type:
```
curl -u admin@dotcms.com:admin -XGET https://demo.dotcms.com/api/vtl/dynamic/  \
-H "Content-Type:text/plain" \
-d '
#foreach($product in $dotcontent.pull( "+contentType:Product", 100, "modDate desc" ))
$velocityCount. $!{product.title}  (Categories: #foreach($cat in $product.category)$!{cat.categoryName},#end) \n
#end
'
```



