### PR TITLE
Issue 22916 ut in lts

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
@@ -246,7 +246,8 @@ public class StartupTasksExecutor {
                 HibernateUtil.startTransaction();
                 name = c.getCanonicalName();
                 name = name.substring(name.lastIndexOf(".") + 1);
-                if (StartupTask.class.isAssignableFrom(c)) {
+                int taskId = Integer.parseInt(id); 
+		if (StartupTask.class.isAssignableFrom(c) && taskId > Config.DB_VERSION) {
                     StartupTask  task = (StartupTask) c.newInstance();
                     if (task.forceRun()) {
                         HibernateUtil.startTransaction();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
@@ -246,6 +246,7 @@ public class StartupTasksExecutor {
                 HibernateUtil.startTransaction();
                 name = c.getCanonicalName();
                 name = name.substring(name.lastIndexOf(".") + 1);
+		String id = getTaskId(name);
                 int taskId = Integer.parseInt(id); 
 		if (StartupTask.class.isAssignableFrom(c) && taskId > Config.DB_VERSION) {
                     StartupTask  task = (StartupTask) c.newInstance();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
@@ -227,6 +227,52 @@ public class StartupTasksExecutor {
 
 
     }
+	
+	/**
+     * This will execute all the UT that were backported to the LTS version.
+     * Will be run everytime the server gets restarted just like the Startup Tasks.
+     * But these will be run after the upgradeTasks.
+     *
+     * @throws DotDataException
+     */
+    public void executeBackportedTasks() throws DotDataException {
+        Logger.debug(this.getClass(), "Running Backported Tasks");
+        String name = null;
+        try {
+            Logger.info(this, "Running Backported Tasks");
+
+
+            for (Class<?> c : TaskLocatorUtil.getBackportedUpgradeTaskClasses()) {
+                HibernateUtil.startTransaction();
+                name = c.getCanonicalName();
+                name = name.substring(name.lastIndexOf(".") + 1);
+                if (StartupTask.class.isAssignableFrom(c)) {
+                    StartupTask  task = (StartupTask) c.newInstance();
+                    if (task.forceRun()) {
+                        HibernateUtil.startTransaction();
+                        Logger.info(this, "Running Backported Tasks : " + name);
+                        task.executeUpgrade();
+                    } else {
+                        Logger.info(this, "Not Running Backported Tasks: " + name);
+                    }
+                }
+                HibernateUtil.closeAndCommitTransaction();
+            }
+            Logger.info(this, "Finishing Backported tasks.");
+        } catch (Throwable e) {
+            HibernateUtil.rollbackTransaction();
+            Logger.error(this, "FATAL: Unable to execute the upgrade task : " + name, e);
+            if(Config.getBooleanProperty("SYSTEM_EXIT_ON_STARTUP_FAILURE", true)){
+                e.printStackTrace();
+                System.exit(1);
+            }
+        } finally {
+            // This will commit the changes and close the connection
+            HibernateUtil.closeAndCommitTransaction();
+        }
+
+
+    }
 
 
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -358,5 +358,11 @@ public class TaskLocatorUtil {
 		ret.add(Task00050LoadAppsSecrets.class);
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
 	}
+	
+		//UT that were backported to LTS
+	public static List<Class<?>> getBackportedUpgradeTaskClasses() {
+		final List<Class<?>> ret = new ArrayList<Class<?>>();
+		return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
+	}
 
 }

--- a/dotCMS/src/main/java/com/liferay/portal/servlet/MainServlet.java
+++ b/dotCMS/src/main/java/com/liferay/portal/servlet/MainServlet.java
@@ -117,6 +117,7 @@ public class MainServlet extends ActionServlet {
       try {
         StartupTasksExecutor.getInstance().executeStartUpTasks();
         StartupTasksExecutor.getInstance().executeUpgrades();
+        StartupTasksExecutor.getInstance().executeBackportedTasks();
 
         final Task00030ClusterInitialize clusterInitializeTask = new Task00030ClusterInitialize();
         if(clusterInitializeTask.forceRun()){


### PR DESCRIPTION
With the following code, support will be able to add UT to LTS.

These UT will be run every time the server starts up, but since UT are idempotent shouldn't matter.

UT will not affect `db_version` so when upgrading to a release that has that UT will be inserted.
