### PR TITLE
dotCMS/core#22754 fix dot-key-value-webComponent-escaping-special-characters

### DIFF
--- a/core-web/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/utils/index.ts
+++ b/core-web/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-form/utils/index.ts
@@ -1,5 +1,5 @@
 import { DotFormFields } from './fields';
-import { getStringFromDotKeyArray, isStringType } from '../../../../utils';
+import { getJsonStringFromDotKeyArray, isStringType } from '../../../../utils';
 import {
     DotCMSContentTypeField,
     DotCMSContentTypeLayoutRow,
@@ -137,7 +137,7 @@ const fieldParamsConversionFromBE = {
             const valuesArray = Object.keys(field.defaultValue).map((key: string) => {
                 return { key: key, value: field.defaultValue[key] };
             });
-            field.defaultValue = getStringFromDotKeyArray(valuesArray);
+            field.defaultValue = getJsonStringFromDotKeyArray(valuesArray);
         }
         return DotFormFields['Key-Value'](field);
     }

--- a/core-web/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/dot-key-value.e2e.ts
+++ b/core-web/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/dot-key-value.e2e.ts
@@ -322,7 +322,7 @@ describe('dot-key-value', () => {
 
         describe('duplicatedKeyMessage', () => {
             it('should show default', async () => {
-                element.setProperty('value', 'hello|world,hola|mundo');
+                element.setProperty('value', '{"hello":"world&#x22;,&#x22;hola":"mundo"}');
                 await page.waitForChanges();
 
                 const form = await getForm();
@@ -349,12 +349,12 @@ describe('dot-key-value', () => {
 
         describe('value', () => {
             it('should set items', async () => {
-                element.setProperty('value', 'hello|world,hola|mundo');
+                element.setProperty('value', '{"hello":"world&#x22;,&#x22;ho&#x22;la":"mundo"}');
                 await page.waitForChanges();
                 const list = await getList();
                 expect(await list.getProperty('items')).toEqual([
                     { key: 'hello', value: 'world' },
-                    { key: 'hola', value: 'mundo' }
+                    { key: 'ho"la', value: 'mundo' }
                 ]);
             });
 

--- a/core-web/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/dot-key-value.tsx
+++ b/core-web/libs/dotcms-webcomponents/src/components/contenttypes-fields/dot-key-value/dot-key-value.tsx
@@ -23,7 +23,7 @@ import {
     getClassNames,
     getDotOptionsFromFieldValue,
     getOriginalStatus,
-    getStringFromDotKeyArray,
+    getJsonStringFromDotKeyArray,
     getTagError,
     getTagHint,
     updateStatus,
@@ -160,7 +160,19 @@ export class DotKeyValueComponent {
     @Watch('value')
     valueWatch(): void {
         this.value = checkProp<DotKeyValueComponent, string>(this, 'value', 'string');
-        this.items = getDotOptionsFromFieldValue(this.value).map(mapToKeyValue);
+
+        let formattedValue = '';
+        if (this.value) {
+            formattedValue = this.value
+                .replace(/[|]/gi, '&#124;')
+                .replace(/&#x22;:&#x22;/gi, '|')
+                .replace(/&#x22;,&#x22;/gi, ',')
+                .replace(/{&#x22;/gi, '')
+                .replace(/&#x22;}/gi, '')
+                .replace(/&#x22;/gi, '"');
+        }
+
+        this.items = getDotOptionsFromFieldValue(formattedValue).map(mapToKeyValue);
     }
 
     /**
@@ -346,7 +358,7 @@ export class DotKeyValueComponent {
     }
 
     private emitValueChange(): void {
-        const returnedValue = getStringFromDotKeyArray(this.items);
+        const returnedValue = getJsonStringFromDotKeyArray(this.items);
         this.dotValueChange.emit({
             name: this.name,
             value: returnedValue

--- a/core-web/libs/dotcms-webcomponents/src/utils/utils.spec.ts
+++ b/core-web/libs/dotcms-webcomponents/src/utils/utils.spec.ts
@@ -6,11 +6,13 @@ import {
     getId,
     getLabelId,
     getOriginalStatus,
-    getStringFromDotKeyArray,
+    getJsonStringFromDotKeyArray,
     getTagError,
     getTagHint,
     isFileAllowed,
-    updateStatus
+    updateStatus,
+    decodeChars,
+    encodeChars
 } from './utils';
 
 describe('getClassNames', () => {
@@ -124,10 +126,26 @@ describe('getOriginalStatus', () => {
     });
 });
 
-describe('getStringFromDotKeyArray', () => {
+describe('encodeChars', () => {
+    it('should encode chars', () => {
+        expect(
+            encodeChars('a"b\\c|d:e,')
+        ).toBe('a&#34;b&#92;c&#124;d&#58;e&#44;');
+    });
+});
+
+describe('decodeChars', () => {
+    it('should decode chars', () => {
+        expect(
+            decodeChars('a&#34;b&#92;c&#124;d&#58;e&#44;')
+        ).toBe('a"b\\c|d:e,');
+    });
+});
+
+describe('getJsonStringFromDotKeyArray', () => {
     it('should transform to string', () => {
         expect(
-            getStringFromDotKeyArray([
+            getJsonStringFromDotKeyArray([
                 {
                     key: 'some1',
                     value: 'val1'
@@ -137,7 +155,7 @@ describe('getStringFromDotKeyArray', () => {
                     value: 'val99'
                 }
             ])
-        ).toBe('some1|val1,some45|val99');
+        ).toBe('{"some1":"val1","some45":"val99"}');
     });
 });
 

--- a/core-web/libs/dotcms-webcomponents/src/utils/utils.tsx
+++ b/core-web/libs/dotcms-webcomponents/src/utils/utils.tsx
@@ -60,7 +60,9 @@ export function getDotOptionsFromFieldValue(rawString: string): DotOption[] {
               .split(',')
               .filter((item) => !!item.length)
               .map((item) => {
-                  const [label, value] = item.split('|');
+                  let [label, value] = item.split('|');
+                  label = decodeChars(label);
+                  value = decodeChars(value);
                   return { label, value };
               })
         : [];
@@ -125,13 +127,46 @@ export function getOriginalStatus(isValid?: boolean): DotFieldStatus {
 }
 
 /**
- * Returns a single string formatted as "Key|Value" separated with commas from a DotKeyValueField array
+ * Returns a string with chars encoded
+ *
+ * @param string value
+ * @returns string
+ */
+export function encodeChars(value: string): string {
+    let encodedValue = value
+        .replace(/\"/gi, '&#34;')
+        .replace(/\\/gi, '&#92;')
+        .replace(/:/gi, '&#58;')
+        .replace(/,/gi, '&#44;');
+    return encodedValue;
+}
+
+/**
+ * Returns a string with chars decoded
+ *
+ * @param string value
+ * @returns string
+ */
+ export function decodeChars(value: string): string {
+    let decodedValue = value
+        .replace(/&#34;/gi, '"')
+        .replace(/&#92;/gi, '\\')
+        .replace(/&#124;/gi, '|')
+        .replace(/&#58;/gi, ':')
+        .replace(/&#44;/gi, ',');
+    return decodedValue;
+}
+
+/**
+ * Returns a single JSON string formatted as "Key":"Value" separated with commas from a DotKeyValueField array
  *
  * @param DotKeyValueField[] values
  * @returns string
  */
-export function getStringFromDotKeyArray(values: DotKeyValueField[]): string {
-    return values.map((item: DotKeyValueField) => `${item.key}|${item.value}`).join(',');
+export function getJsonStringFromDotKeyArray(values: DotKeyValueField[]): string {
+    return `{${values
+        .map((item: DotKeyValueField) => `"${encodeChars(item.key)}":"${encodeChars(item.value)}"`)
+        .join(',')}}`;
 }
 
 /**

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -1169,7 +1169,7 @@
         }
 
         final StringBuilder keyValueDataRaw = new StringBuilder("{");
-        final StringBuilder dotKeyValueDataRaw = new StringBuilder();
+        final StringBuilder dotKeyValueDataRaw = new StringBuilder("{");
 
         final Iterator<String> iterator = keyValueMap.keySet().iterator();
 
@@ -1177,16 +1177,16 @@
             final String key = iterator.next();
             final Object object = keyValueMap.get(key);
             if(null != object) {
-                final String sanitized = UtilMethods.htmlifyString(UtilMethods.escapeDoubleQuotes(object.toString()));
-                keyValueDataRaw.append(key).append(":").append(sanitized);
-                dotKeyValueDataRaw.append(key).append("|").append(sanitized);
+                keyValueDataRaw.append(key).append(":").append(object.toString());
+                dotKeyValueDataRaw.append("&#x22;" + key + "&#x22;").append(":").append("&#x22;" + object.toString() + "&#x22;");
                 if (iterator.hasNext()) {
                     keyValueDataRaw.append(',');
                     dotKeyValueDataRaw.append(',');
                 }
             }
         }
-        keyValueDataRaw.append('}');
+        keyValueDataRaw.append("}");
+        dotKeyValueDataRaw.append("}");
 
         List<FieldVariable> fieldVariables=APILocator.getFieldAPI().getFieldVariablesForField(field.getInode(), user, true);
         String whiteListKeyValues = "";
@@ -1196,7 +1196,7 @@
             }
         }
     %>
-        <input type="hidden" class ="<%=field.getVelocityVarName()%>" name="<%=field.getFieldContentlet()%>" id="<%=field.getVelocityVarName()%>" value="<%=keyValueDataRaw.toString()%>" />
+        <input type="hidden" class ="<%=field.getVelocityVarName()%>" name="<%=field.getFieldContentlet()%>" id="<%=field.getVelocityVarName()%>" />
         <style>
             dot-key-value key-value-table tr {
                 cursor: move;
@@ -1256,11 +1256,24 @@
         </style>
 
         <dot-key-value id="<%=field.getVelocityVarName()%>KeyValue"></dot-key-value>
-
         <script>
+            function escapeQuoteAndBackSlash(value) {
+                return value.replaceAll('\"','&#34;').replaceAll(/\\/g, '&#92;');
+            }
+
+            function formatToJsonData(value) {
+                var removedBrackets = value.trim().substring(1, value.length-1);
+                var preformatted = removedBrackets.replaceAll(/:/g, '":"').replaceAll(/,/g, '","');
+                return `{"${preformatted}"}`;
+            }
+
+            // Escape chars and set value to hidden input
+            var dotKeyValueHiddenIput = document.getElementById('<%=field.getVelocityVarName()%>');
+            dotKeyValueHiddenIput.value = formatToJsonData(escapeQuoteAndBackSlash("<%=keyValueDataRaw%>"));
+
             var dotKeyValue = document.querySelector('#<%=field.getVelocityVarName()%>KeyValue');
             dotKeyValue.uniqueKeys = "true";
-            dotKeyValue.value = '<%=dotKeyValueDataRaw.toString()%>';
+            dotKeyValue.value = "<%=dotKeyValueDataRaw.toString()%>";
             dotKeyValue.disabled = '<%=field.isReadOnly()%>';
             dotKeyValue.whiteList = '<%=whiteListKeyValues%>';
             dotKeyValue.formKeyLabel = '<%= LanguageUtil.get(pageContext, "Key") %>'
@@ -1270,11 +1283,12 @@
             dotKeyValue.whiteListEmptyOptionLabel = '<%= LanguageUtil.get(pageContext, "Pick-an-option") %>'
             dotKeyValue.requiredMessage = '<%= LanguageUtil.get(pageContext, "message.fieldvariables.key.required") %>'
 
-                dotKeyValue.addEventListener('dotValueChange', function (event) {
-                    var formattedData = event.detail.value.replace(/[|]/g, ':');
-                    var keyfieldId = document.getElementById('<%=field.getVelocityVarName()%>');
-                    keyfieldId.value = `{${formattedData}}`
-                }, false);
+            dotKeyValue.addEventListener('dotValueChange', function (event) {
+                var escapedData = "{" + escapeQuoteAndBackSlash(event.detail.value) + "}";
+                var formattedData = formatToJsonData(escapedData);
+                var keyfieldId = document.getElementById('<%=field.getVelocityVarName()%>');
+                keyfieldId.value = event.detail.value;
+            }, false);
 
         </script>
     <%}%>


### PR DESCRIPTION
After I upgraded from dotCMS 22.03 to 22.08 I noticed that the apostrophes, colons and semicolons contained in key/value fields make them not to display in the back end. So on my backend all key/values that contain apostrophes, colons and semincolons do not display on the backend and the fields display "No Values")

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
