### PR TITLE
dotCMS/core#22549 DotRelationShipTree not taking input updates

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-relationship-tree/dot-relationship-tree.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-relationship-tree/dot-relationship-tree.component.spec.ts
@@ -1,4 +1,4 @@
-import { DebugElement } from '@angular/core';
+import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DotCopyButtonModule } from '@components/dot-copy-button/dot-copy-button.module';
@@ -23,15 +23,26 @@ const fakeContentType: DotCMSContentType = {
     baseType: 'testBaseType'
 };
 
+@Component({
+    selector: 'dot-test-host-component',
+    template: ` <dot-relationship-tree [velocityVar]="velocityVar"
+    [contentType]="contentType" [isParentField]="isParentField"></dot-relationship-tree>`
+})
+class TestHostComponent {
+    velocityVar = 'Parent.Children';
+    contentType = fakeContentType;
+    isParentField = false;
+}
+
 describe('DotRelationshipTreeComponent', () => {
     describe('with dot - is Child Field', () => {
-        let component: DotRelationshipTreeComponent;
-        let fixture: ComponentFixture<DotRelationshipTreeComponent>;
+        let fixture: ComponentFixture<TestHostComponent>;
+        let deHost: DebugElement;
         let de: DebugElement;
-
+        
         beforeEach(async () => {
             await TestBed.configureTestingModule({
-                declarations: [DotRelationshipTreeComponent],
+                declarations: [TestHostComponent, DotRelationshipTreeComponent],
                 imports: [DotIconModule, DotPipesModule, DotCopyButtonModule],
                 providers: [
                     {
@@ -43,12 +54,9 @@ describe('DotRelationshipTreeComponent', () => {
         });
 
         beforeEach(() => {
-            fixture = TestBed.createComponent(DotRelationshipTreeComponent);
-            component = fixture.componentInstance;
-            de = fixture.debugElement;
-            component.velocityVar = 'Parent.Children';
-            component.contentType = fakeContentType;
-            component.isParentField = false;
+            fixture = TestBed.createComponent(TestHostComponent);
+            deHost = fixture.debugElement;
+            de = deHost.query(By.css('dot-relationship-tree'));
             fixture.detectChanges();
         });
 
@@ -73,13 +81,13 @@ describe('DotRelationshipTreeComponent', () => {
     });
 
     describe('without dot - is Parent Field', () => {
-        let component: DotRelationshipTreeComponent;
-        let fixture: ComponentFixture<DotRelationshipTreeComponent>;
+        let fixture: ComponentFixture<TestHostComponent>;
+        let deHost: DebugElement;
         let de: DebugElement;
-
+        
         beforeEach(async () => {
             await TestBed.configureTestingModule({
-                declarations: [DotRelationshipTreeComponent],
+                declarations: [TestHostComponent, DotRelationshipTreeComponent],
                 imports: [DotIconModule, DotPipesModule, DotCopyButtonModule],
                 providers: [
                     {
@@ -91,12 +99,11 @@ describe('DotRelationshipTreeComponent', () => {
         });
 
         beforeEach(() => {
-            fixture = TestBed.createComponent(DotRelationshipTreeComponent);
-            component = fixture.componentInstance;
-            de = fixture.debugElement;
-            component.velocityVar = 'Parent';
-            component.contentType = fakeContentType;
-            component.isParentField = true;
+            fixture = TestBed.createComponent(TestHostComponent);
+            deHost = fixture.debugElement;
+            de = deHost.query(By.css('dot-relationship-tree'));
+            deHost.componentInstance.velocityVar = 'Parent';
+            deHost.componentInstance.isParentField = true;
             fixture.detectChanges();
         });
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-relationship-tree/dot-relationship-tree.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-relationship-tree/dot-relationship-tree.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { DotCMSContentType } from '@dotcms/dotcms-models';
 
 @Component({
@@ -6,7 +6,7 @@ import { DotCMSContentType } from '@dotcms/dotcms-models';
     templateUrl: './dot-relationship-tree.component.html',
     styleUrls: ['./dot-relationship-tree.component.scss']
 })
-export class DotRelationshipTreeComponent implements OnInit {
+export class DotRelationshipTreeComponent implements OnChanges {
     @Input() velocityVar: string;
     @Input() contentType: DotCMSContentType;
     @Input() isParentField: boolean;
@@ -14,7 +14,7 @@ export class DotRelationshipTreeComponent implements OnInit {
     child: string;
     parent: string;
 
-    ngOnInit(): void {
+    ngOnChanges(): void {
         this.setInitialValues();
     }
     /**

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-relationship-tree/dot-relationship-tree.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-relationship-tree/dot-relationship-tree.component.ts
@@ -15,14 +15,14 @@ export class DotRelationshipTreeComponent implements OnChanges {
     parent: string;
 
     ngOnChanges(): void {
-        this.setInitialValues();
+        this.setValues();
     }
     /**
-     * Sets initial values of the relationship tree component
+     * Sets values of the relationship tree component
      *
      * @memberof DotRelationshipTreeComponent
      */
-    setInitialValues(): void {
+    setValues(): void {
         const [relatedContentType] = this.velocityVar?.split('.') || '';
         const contentTypeName = this.contentType?.name;
 


### PR DESCRIPTION
The relationship is not showing correctly on the other side of the relationship, due to DotRelationShipTree not taking input updates after the form has changed

Steps to reproduce:

Create two content types (Type1 and Type2)
Add a ManyToOne relationship field on Type1. Type1 is shown as child and Type2 as parent which is ok.
Go to Type2 and create the other side of the same relationship. In this case Type2 is shown as child and Type1 as parent which is not correct because is the same relationship.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
