### PR TITLE
fix-block-editor-set-content-comments

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -196,9 +196,9 @@
             <script>
 
                 /**
-                 * "<%=JSONValue%>" is by default an empty Object.
+                 * "JSONValue" is by default an empty Object.
                  *  If that's the case we set "JSONValue" as null.
-                 *  Otherwise, we set "JSONValue" equals to "<%=JSONValue%>".
+                 *  Otherwise, we set "JSONValue" equals to "JSONValue".
                  */
                 const JSONValue = JSON.stringify(<%=JSONValue%>) !== JSON.stringify({}) ? <%=JSONValue%> : null;
                 let content;
@@ -209,7 +209,7 @@
                  */
                 try {
                     // If JSONValue is an valid Object, we use it as the Block Editor Content.
-                    // Otherwise, we try to parse the "<%=textValue%>".
+                    // Otherwise, we try to parse the "textValue".
                     content = JSONValue || JSON.parse(<%=textValue%>);
                 } catch (error) {
                     content = <%=textValue%>;


### PR DESCRIPTION
**What we did**

remove the `<%={variables}%>` from the comments because the `.jsp` doesn't differentiate between comment and code, so it replaces the variable with the value.