### PR TITLE
dotCMS/core#22843 Fix Clicking-crumbtrail-opens-new-window due to target being undefined

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.spec.ts
@@ -147,10 +147,12 @@ describe('DotCrumbtrailService', () => {
         expect(firstCrumb).toEqual([
             {
                 label: 'menu',
+                target: '_self',
                 url: '#/menulink/first_portlet'
             },
             {
                 label: 'Potlet Label',
+                target: '_self',
                 url: '#/menulink/portlet'
             }
         ]);
@@ -163,10 +165,12 @@ describe('DotCrumbtrailService', () => {
         expect(secondCrumb).toEqual([
             {
                 label: 'menu',
+                target: '_self',
                 url: '#/menulink/first_portlet'
             },
             {
                 label: 'First Portlet Label',
+                target: '_self',
                 url: '#/menulink/first_portlet'
             }
         ]);
@@ -179,10 +183,12 @@ describe('DotCrumbtrailService', () => {
         expect(secondCrumb).toEqual([
             {
                 label: 'menu',
+                target: '_self',
                 url: '#/menulink/first_portlet'
             },
             {
                 label: 'First Portlet Label',
+                target: '_self',
                 url: '#/menulink/first_portlet'
             }
         ]);
@@ -199,10 +205,12 @@ describe('DotCrumbtrailService', () => {
         expect(secondCrumb).toEqual([
             {
                 label: 'Types & Tag',
+                target: '_self',
                 url: '#/content-types-angular'
             },
             {
                 label: 'Content Types',
+                target: '_self',
                 url: '#/content-types-angular'
             }
         ]);
@@ -236,14 +244,17 @@ describe('DotCrumbtrailService', () => {
         expect(secondCrumb).toEqual([
             {
                 label: 'Types & Tag',
+                target: '_self',
                 url: '#/content-types-angular'
             },
             {
                 label: 'Content Types',
+                target: '_self',
                 url: '#/content-types-angular'
             },
             {
                 label: 'Content Type Testing',
+                target: '_self',
                 url: ''
             }
         ]);
@@ -282,14 +293,17 @@ describe('DotCrumbtrailService', () => {
         expect(secondCrumb).toEqual([
             {
                 label: 'site',
+                target: '_self',
                 url: '#/c/site-browser'
             },
             {
                 label: 'Browser',
+                target: '_self',
                 url: '#/c/site-browser'
             },
             {
                 label: 'About Us',
+                target: '_self',
                 url: ''
             }
         ]);
@@ -326,6 +340,7 @@ describe('DotCrumbtrailService', () => {
         expect(secondCrumb).toEqual([
             {
                 label: 'Google Translate',
+                target: '_self',
                 url: ''
             }
         ]);
@@ -362,6 +377,7 @@ describe('DotCrumbtrailService', () => {
         expect(secondCrumb).toEqual([
             {
                 label: 'Template-01',
+                target: '_self',
                 url: ''
             }
         ]);
@@ -390,6 +406,7 @@ describe('DotCrumbtrailService', () => {
         expect(secondCrumb).toEqual([
             {
                 label: 'new',
+                target: '_self',
                 url: ''
             }
         ]);

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.ts
@@ -64,10 +64,12 @@ export class DotCrumbtrailService {
                             res = [
                                 {
                                     label: menu.name,
+                                    target: '_self',
                                     url: `#/${menu.menuItems[0].menuLink}`
                                 },
                                 {
                                     label: menuItem.label,
+                                    target: '_self',
                                     url: `#/${menuItem.menuLink}`
                                 }
                             ];
@@ -124,6 +126,7 @@ export class DotCrumbtrailService {
 
                     crumbTrail.push({
                         label: sectionLabel ? sectionLabel : sections[1],
+                        target: '_self',
                         url: ''
                     });
                 }
@@ -146,5 +149,6 @@ export class DotCrumbtrailService {
 
 export interface DotCrumb {
     label: string;
+    target?: string;
     url: string;
 }


### PR DESCRIPTION
When a user clicks the crumbtrail at the top of the dotCMS admin screens, it loads the screen in a new tab. If you click the crumbtrail in that new tab, it works as expected.

https://user-images.githubusercontent.com/934364/186438284-fc8d0fc8-4bfa-4b85-ae3b-41bad07c5774.gif


### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
