### PR TITLE
dotCMS/core#22754 fix dot-key-value-encoding-chars-coming-from-BE-to-avoid-breaking-webcomponent

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -1187,7 +1187,7 @@
             final Object object = keyValueMap.get(key);
             if(null != object) {
                 keyValueDataRaw.append(key).append(":").append(object.toString());
-                dotKeyValueDataRaw.append("&#x22;" + key + "&#x22;").append(":").append("&#x22;" + object.toString() + "&#x22;");
+                dotKeyValueDataRaw.append("&#x22;" + key.replaceAll(":", "&#58;").replaceAll(",", "&#44;") + "&#x22;").append(":").append("&#x22;" + object.toString() + "&#x22;");
                 if (iterator.hasNext()) {
                     keyValueDataRaw.append(',');
                     dotKeyValueDataRaw.append(',');


### PR DESCRIPTION
when the dot-key-value is used to render metadata,  the table fails to render a focalPoint

This is because the forcalPoint is written into a json that looks like this:

{
   "modDate":1662744961363,
   "sha256":"9461f042f37b5a399f045551b02de3164428ddd53e0cf30e98a037c7d09eb410",
   "length":64882,
   "title":"synchronicity.jpeg",
   "version":20220201,
   "content":"",
   "path":"f/e/fe09444d-6bef-436f-bbf2-3a91f8d2d5c0/fileAsset/synchronicity.jpeg",
   "isImage":true,
   "dot:focalPoint":"0.541666,70.49",
   "fileSize":64882,
   "name":"synchronicity.jpeg",
   "width":600,
   "contentType":"image/jpeg",
   "height":600
}
and the focalPoint itself has many components that could break the json

"dot:focalPoint":"0.541666,70.49"

### Proposed Changes
* encode chars from BE

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
