### PR TITLE
#22809 : Adding Upgrade Task to fix the 'Show On Menu' property.

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task220912UpdateCorrectShowOnMenuPropertyTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task220912UpdateCorrectShowOnMenuPropertyTest.java
@@ -1,0 +1,95 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotcms.content.business.json.ContentletJsonAPI;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.common.db.DotConnect;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.dotmarketing.db.DbConnectionFactory.getDBFalse;
+import static com.dotmarketing.db.DbConnectionFactory.isMsSql;
+import static com.dotmarketing.db.DbConnectionFactory.isPostgres;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Integration Test for the {@link Task220912UpdateCorrectShowOnMenuProperty} Upgrade Task.
+ *
+ * @author Jose Castro
+ * @since Sep 12th, 2022
+ */
+public class Task220912UpdateCorrectShowOnMenuPropertyTest {
+
+    private static final String VELOCITY_VAR_NAME = "showOnMenu";
+    private static final String FIND_CONTENT_TYPES_WITH_FIELD = "SELECT structure_inode, field_contentlet FROM field " +
+                                                                        "WHERE velocity_var_name = ?";
+    private static final String FIND_CONTENTS_WITH_INCORRECT_SHOW_ON_MENU_VALUE = "SELECT COUNT(*) FROM contentlet " +
+                                                                                          "WHERE %s = 'true' AND " +
+                                                                                          "show_on_menu = " + getDBFalse() + " AND " +
+                                                                                          "structure_inode = ?";
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        // Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to Test:</b>{@link Task220912UpdateCorrectShowOnMenuProperty#executeUpgrade()}</li>
+     *     <li><b>Given Scenario:</b>The {@code show_on_menu} column in the {@code contentlet} table must reflect the
+     *     actual value of the 'Show On Menu' field. There situations during customer upgrades in which these two values
+     *     didn't match, which caused several problems for the Support Team.</li>
+     *     <li><b>Expected Result:</b>Both the {@code show_on_menu} column and the {@code showOnMenu} attribute in the
+     *     {@code contentlet_as_json} column must be the same.</li>
+     * </ul>
+     */
+    @Test
+    public void testExecuteUpgrade() {
+        final Task220912UpdateCorrectShowOnMenuProperty upgradeTask = new Task220912UpdateCorrectShowOnMenuProperty();
+        assertTrue("There must be at least one Content Type with a 'Show On Menu' field, like the 'Page' type.",
+                upgradeTask.forceRun());
+        try {
+            upgradeTask.executeUpgrade();
+            final List<Map<String, Object>> typesWithShowOnMenuField =
+                    new DotConnect().setSQL(FIND_CONTENT_TYPES_WITH_FIELD).addParam(VELOCITY_VAR_NAME).loadObjectResults();
+            for (final Map<String, Object> contentTypeInfo : typesWithShowOnMenuField) {
+                final String sqlQuery = String.format(FIND_CONTENTS_WITH_INCORRECT_SHOW_ON_MENU_VALUE,
+                        getExpectedColumnReference(contentTypeInfo.get("field_contentlet").toString()));
+                final String contentTypeId = contentTypeInfo.get("structure_inode").toString();
+                final List<Map<String, Object>> contentletList =
+                        new DotConnect().setSQL(sqlQuery).addParam(contentTypeId).loadObjectResults();
+                assertTrue("There must be NO contentlets with an inconsistent 'Show On Menu' field after the upgrade" +
+                                   ".", "0".equals(contentletList.get(0).get("count").toString()));
+            }
+        } catch (final Exception e) {
+            fail(String.format("An error occurred when running the 'Task220912UpdateCorrectShowOnMenuProperty' " +
+                                       "UT: %s", e.getMessage()));
+        }
+    }
+
+    /**
+     * Returns the expected column based on the current JSON-supported database. If not, the legacy {@code text }column
+     * name will be used.
+     *
+     * @param columnName The legacy text column.
+     *
+     * @return The correct database column.
+     */
+    private String getExpectedColumnReference(String columnName) {
+        if (APILocator.getContentletJsonAPI().isJsonSupportedDatabase()) {
+            if (isPostgres()) {
+                columnName = ContentletJsonAPI.CONTENTLET_AS_JSON + "->'fields'->'" + VELOCITY_VAR_NAME + "'->>'value'";
+            } else if (isMsSql()) {
+                columnName =
+                        "JSON_VALUE(c." + ContentletJsonAPI.CONTENTLET_AS_JSON + ", '$.fields." + VELOCITY_VAR_NAME + ".value')";
+            }
+        }
+        return columnName;
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220912UpdateCorrectShowOnMenuProperty.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220912UpdateCorrectShowOnMenuProperty.java
@@ -1,0 +1,91 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotcms.business.WrapInTransaction;
+import com.dotcms.content.business.json.ContentletJsonAPI;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.startup.StartupTask;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.dotmarketing.db.DbConnectionFactory.getDBFalse;
+import static com.dotmarketing.db.DbConnectionFactory.getDBTrue;
+import static com.dotmarketing.db.DbConnectionFactory.isMsSql;
+import static com.dotmarketing.db.DbConnectionFactory.isPostgres;
+
+/**
+ * This Upgrade Task makes sure that all Contentlets with a {@code showOnMenu} property have the correct information at
+ * the database level. There were situations during customer upgrades in which the values of the {@code show_on_menu}
+ * and the {@code contentlet_as_json} columns didn't match, which was not the expected output.
+ *
+ * @author Jose Castro
+ * @since Sep 12th, 2022
+ */
+public class Task220912UpdateCorrectShowOnMenuProperty implements StartupTask {
+
+    private static final String VELOCITY_VAR_NAME = "showOnMenu";
+    private static final String FIND_CONTENT_TYPES_WITH_FIELD = "SELECT structure_inode, field_contentlet FROM field WHERE velocity_var_name = ?";
+    private static final String UPDATE_SHOW_ON_MENU_COLUMN = "UPDATE contentlet SET show_on_menu = " + getDBTrue() + " WHERE show_on_menu = " + getDBFalse() + " AND %s AND structure_inode = ?;";
+
+    @Override
+    public boolean forceRun() {
+        try {
+            // If one or more Content Types have a 'Show On Menu' field, run this task
+            final boolean forceRun =
+                    UtilMethods.isSet(new DotConnect().setSQL(FIND_CONTENT_TYPES_WITH_FIELD).addParam(VELOCITY_VAR_NAME).loadObjectResults());
+            if (!forceRun) {
+                Logger.info(this, "There are no Content Types with a 'Show On Menu' field.");
+            }
+            return forceRun;
+        } catch (final DotDataException e) {
+            Logger.error(this, "An error occurred when checking what Content Types have a 'Show On Menu' field. " +
+                                       "Skipping Upgrade Task...");
+            return Boolean.FALSE;
+        }
+    }
+
+    @WrapInTransaction
+    @Override
+    public void executeUpgrade() throws DotDataException {
+        final List<Map<String, Object>> dbResults =
+                new DotConnect().setSQL(FIND_CONTENT_TYPES_WITH_FIELD).addParam(VELOCITY_VAR_NAME).loadObjectResults();
+        for (final Map<String, Object> contentTypeInfo : dbResults) {
+            final String sqlQuery = String.format(UPDATE_SHOW_ON_MENU_COLUMN, getExpectedColumnReference(contentTypeInfo.get(
+                    "field_contentlet").toString()));
+            final String contentTypeId = contentTypeInfo.get("structure_inode").toString();
+            Logger.info(this, String.format("Updating value of 'Show On Menu' field in all contents of type '%s'",
+                    contentTypeId));
+            new DotConnect().setSQL(sqlQuery).addParam(DbConnectionFactory.getDBTrue())
+                    .addParam(contentTypeId).loadObjectResults();
+        }
+    }
+
+    /**
+     * Returns the column or columns that must be inspected in order to get the actual value of the 'Show On Menu'
+     * field. For instance, customers may NOT be using a database that supports JSON, in which case the legacy
+     * {@code text} column must be inspected, and not the new {@code contentlet_as_json} column. Another scenario is if
+     * the {@code contentlet_as_json} column has just been created during the same upgrade and it's still empty. In this
+     * case, we still need to read the legacy column.
+     *
+     * @param columnName Legacy data column from the {@code contentlet} table.
+     *
+     * @return The SQL code used to read the value of the existing 'Show On Menu' value.
+     */
+    private String getExpectedColumnReference(String columnName) {
+        String columnReference = columnName + " = ?";
+        if (APILocator.getContentletJsonAPI().isJsonSupportedDatabase()) {
+            if (isPostgres()) {
+                columnReference += " OR " + ContentletJsonAPI.CONTENTLET_AS_JSON + "->'fields'->'" + VELOCITY_VAR_NAME + "'->>'value' = 'true'";
+            } else if (isMsSql()) {
+                columnReference += " OR " + "JSON_VALUE(c." + ContentletJsonAPI.CONTENTLET_AS_JSON + ", '$.fields." + VELOCITY_VAR_NAME + ".value') = 'true'";
+            }
+        }
+        return "(" + columnReference + ")";
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -320,22 +320,20 @@ public class TaskLocatorUtil {
 		.add(Task220413IncreasePublishedPushedAssetIdCol.class)
 		.add(Task220512UpdateNoHTMLRegexValue.class)
 		.add(Task220606UpdatePushNowActionletName.class)
-    .add(Task220822CreateVariantTable.class)
+    	.add(Task220822CreateVariantTable.class)
 		.add(Task220829CreateExperimentsTable.class)
+		.add(Task220912UpdateCorrectShowOnMenuProperty.class)
 		.build();
         
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
 
 	}
-
 	
     final static private Comparator<Class<?>> classNameComparator = new Comparator<Class<?>>() {
         public int compare(Class<?> o1, Class<?> o2) {
             return o1.getName().compareTo(o2.getName());
         }
     };
-    
-	
 	
 	/**
 	 * Returns list of tasks that are run <b>every time</b> that dotCMS starts
@@ -346,7 +344,7 @@ public class TaskLocatorUtil {
 	 * @return The list of Run-Always Tasks.
 	 */
 	public static List<Class<?>> getStartupRunAlwaysTaskClasses() {
-		final List<Class<?>> ret = new ArrayList<Class<?>>();
+		final List<Class<?>> ret = new ArrayList<>();
 		ret.add(Task00001LoadSchema.class);
 		ret.add(Task00003CreateSystemRoles.class);
 		ret.add(Task00004LoadStarter.class);


### PR DESCRIPTION
### Proposed Changes
* During some customer upgrades, there was a situation in which the value of the `show_on_menu` column in the `contentlet` table didn't match the value present in the `text` column. This new task checks both the legacy `text` column and the new `contentlet_as_json` column to see if the 'Show On Menu' property is enabled. If it is, the `show_on_menu` value is updated to match it.

### Checklist
- [x] Tests