### PR TITLE
Issue 22763 copy folder duplicates content on pages

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -490,11 +490,6 @@ public class FolderFactoryImpl extends FolderFactory {
 		for(IHTMLPage page : pageAssetList) {
 		    Contentlet cont = APILocator.getContentletAPI().find(page.getInode(), APILocator.getUserAPI().getSystemUser(), false);
             Contentlet newContent = APILocator.getContentletAPI().copyContentlet(cont, newFolder, APILocator.getUserAPI().getSystemUser(), false);
-            List<MultiTree> pageContents = APILocator.getMultiTreeAPI().getMultiTrees(cont.getIdentifier());
-            for(MultiTree m : pageContents){
-            	MultiTree mt = new MultiTree(newContent.getIdentifier(), m.getParent2(), m.getChild());
-            	APILocator.getMultiTreeAPI().saveMultiTree(mt);
-            }
             pagesCopied.put(cont.getInode(), new IHTMLPage[] {page , APILocator.getHTMLPageAssetAPI().fromContentlet(cont)});
 		}
 		


### PR DESCRIPTION
Dupe of #22877 (A cleaner PR was created)

Removing unnecessary lines when copying pages in a folder. This creates duplicated entries with the wrong relation_type. This is an edge case that occurs when the relation_type is different from `LEGACY_RELATION_TYPE`

An IT was implemented.