### PR TITLE
dotCMS/core#22754 - fix creating a keyValue contentlet with empty values

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -1273,7 +1273,7 @@
             function formatToJsonData(value) {
                 var removedBrackets = value.trim().substring(1, value.length-1);
                 var preformatted = removedBrackets.replaceAll(/:/g, '":"').replaceAll(/,/g, '","');
-                return `{"${preformatted}"}`;
+                return preformatted ? `{"${preformatted}"}` : '';
             }
 
             // Escape chars and set value to hidden input


### PR DESCRIPTION
fix bug for creating a keyValue contentlet with empty values


### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
