### PR TITLE
Renaming variant field

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/VariantDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/VariantDataGen.java
@@ -9,17 +9,17 @@ import org.apache.commons.lang.RandomStringUtils;
 
 public class VariantDataGen extends AbstractDataGen<Variant> {
 
-    private String id;
     private String name;
+    private String description;
     private boolean archived = false;
-
-    public VariantDataGen id(final String id) {
-        this.id = id;
-        return this;
-    }
 
     public VariantDataGen name(final String name) {
         this.name = name;
+        return this;
+    }
+
+    public VariantDataGen description(final String description) {
+        this.description = description;
         return this;
     }
 
@@ -31,12 +31,11 @@ public class VariantDataGen extends AbstractDataGen<Variant> {
     @Override
     public Variant next() {
 
-        final String innerId = id == null ? UUIDGenerator.generateUuid() : id;
-
-        final String randomAlphanumeric = RandomStringUtils.randomAlphanumeric(20);
-        final String innerName = name == null ? "Variant_" +  randomAlphanumeric : name;
+        final String innerName = name == null ? "VariantTest_" + RandomStringUtils.randomAlphanumeric(10) : name;
+        final String innerDescription = description
+                == null ? "Description for: " + innerName : description;
         return Variant.builder()
-                .identifier(innerId)
+                .description(innerDescription)
                 .name(innerName)
                 .archived(archived)
                 .build();

--- a/dotCMS/src/integration-test/java/com/dotcms/variant/business/VariantCacheTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/variant/business/VariantCacheTest.java
@@ -19,45 +19,7 @@ public class VariantCacheTest {
     }
 
     /**
-     * Method to test: {@link VariantCacheImpl#put(Variant)} and {@link VariantCacheImpl#getById(String)}
-     * When: Add a Variant
-     * Should: be able to get it by ID
-     */
-    @Test
-    public void getVariantById(){
-        final Variant variant = new VariantDataGen().nextPersisted();
-
-        CacheLocator.getVariantCache().put(variant);
-
-        final Variant variantById = CacheLocator.getVariantCache()
-                .getById(variant.identifier());
-
-        assertEquals(variant.identifier(), variantById.identifier());
-        assertEquals(variant.name(), variantById.name());
-        assertEquals(variant.archived(), variantById.archived());
-    }
-
-    /**
-     * Method to test: {@link VariantCacheImpl#putById(String, Variant)} (Variant)} and {@link VariantCacheImpl#getById(String)}
-     * When: Put a Variant by ID
-     * Should: be able to get it by the same ID
-     */
-    @Test
-    public void putVariantById(){
-        final Variant variant = new VariantDataGen().nextPersisted();
-
-        CacheLocator.getVariantCache().putById("ANY_ID", variant);
-
-        final Variant variantById = CacheLocator.getVariantCache()
-                .getById("ANY_ID");
-
-        assertEquals(variant.identifier(), variantById.identifier());
-        assertEquals(variant.name(), variantById.name());
-        assertEquals(variant.archived(), variantById.archived());
-    }
-
-    /**
-     * Method to test: {@link VariantCacheImpl#put(Variant)} and {@link VariantCacheImpl#getByName(String)} (String)}
+     * Method to test: {@link VariantCacheImpl#put(Variant)} and {@link VariantCacheImpl#get(String)} (String)}
      * When: Add a Variant
      * Should: be able to get it by Name
      */
@@ -68,15 +30,15 @@ public class VariantCacheTest {
         CacheLocator.getVariantCache().put(variant);
 
         final Variant variantById = CacheLocator.getVariantCache()
-                .getByName(variant.name());
+                .get(variant.name());
 
-        assertEquals(variant.identifier(), variantById.identifier());
+        assertEquals(variant.name(), variantById.name());
         assertEquals(variant.name(), variantById.name());
         assertEquals(variant.archived(), variantById.archived());
     }
 
     /**
-     * Method to test: {@link VariantCacheImpl#putByName(String, Variant)} (Variant)} and {@link VariantCacheImpl#getByName(String)} (String)}
+     * Method to test: {@link VariantCacheImpl#put(String, Variant)} (Variant)} and {@link VariantCacheImpl#get(String)} (String)}
      * When: Add a Variant by name
      * Should: be able to get it by the same Name
      */
@@ -84,60 +46,41 @@ public class VariantCacheTest {
     public void putVariantByName(){
         final Variant variant = new VariantDataGen().nextPersisted();
 
-        CacheLocator.getVariantCache().putByName("ANY_NAME", variant);
+        CacheLocator.getVariantCache().put("ANY_NAME", variant);
 
         final Variant variantById = CacheLocator.getVariantCache()
-                .getByName("ANY_NAME");
+                .get("ANY_NAME");
 
-        assertEquals(variant.identifier(), variantById.identifier());
+        assertEquals(variant.name(), variantById.name());
         assertEquals(variant.name(), variantById.name());
         assertEquals(variant.archived(), variantById.archived());
     }
 
     /**
-     * Method to test: {@link VariantCacheImpl#getById(String)}
-     * When: Call the method with an id that not was put before
-     * Should: return null
-     */
-    @Test
-    public void getVariantByIdNotExists(){
-        assertNull(CacheLocator.getVariantCache().getById("NotExists"));
-    }
-
-    /**
-     * Method to test: {@link VariantCacheImpl#getByName(String)}
+     * Method to test: {@link VariantCacheImpl#get(String)}
      * When: Call the method with a Name that not was put before
      * Should: return null
      */
     @Test
     public void getVariantByNameNotExists(){
-        assertNull(CacheLocator.getVariantCache().getById("NotExists"));
+        assertNull(CacheLocator.getVariantCache().get("NotExists"));
     }
 
-    /**
-     * Method to test: {@link VariantCacheImpl#getById(String)}
-     * When: Call the method with null
-     * Should: throw a {@link NullPointerException}
-     */
-    @Test(expected = NullPointerException.class)
-    public void getVariantByIdWithNull(){
-        assertNull(CacheLocator.getVariantCache().getById(null));
-    }
 
     /**
-     * Method to test: {@link VariantCacheImpl#getByName(String)}
+     * Method to test: {@link VariantCacheImpl#get(String)}
      * When: Call the method with null
      * Should: throw a {@link NullPointerException}
      */
     @Test(expected = NullPointerException.class)
     public void getVariantByNameWithNull(){
-        assertNull(CacheLocator.getVariantCache().getByName(null));
+        assertNull(CacheLocator.getVariantCache().get(null));
     }
 
     /**
      * Method to test: {@link VariantCacheImpl#remove(Variant)}
      * When: Remove a Variant from cache
-     * Should: get Null when call {@link VariantCacheImpl#getByName(String)} or  {@link VariantCacheImpl#getById(String)} (String)}
+     * Should: get Null when call {@link VariantCacheImpl#get(String)}
      */
     @Test
     public void remove(){
@@ -152,7 +95,6 @@ public class VariantCacheTest {
 
         CacheLocator.getVariantCache().remove(variant);
         checkFromCacheNull(variant);
-
         checkFromCacheNotNull(variant_2);
     }
 
@@ -179,22 +121,14 @@ public class VariantCacheTest {
     }
 
     private void checkFromCacheNull(final Variant variant) {
-        final Variant variantById = CacheLocator.getVariantCache()
-                .getById(variant.identifier());
-        assertNull(variantById);
-
         final Variant variantByName = CacheLocator.getVariantCache()
-                .getByName(variant.name());
+                .get(variant.name());
         assertNull(variantByName);
     }
 
     private void checkFromCacheNotNull(final Variant variant) {
-        final Variant variantById = CacheLocator.getVariantCache()
-                .getById(variant.identifier());
-        assertNotNull(variantById);
-
         final Variant variantByName = CacheLocator.getVariantCache()
-                .getByName(variant.name());
+                .get(variant.name());
         assertNotNull(variantByName);
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/business/IdentifierCacheImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/business/IdentifierCacheImplTest.java
@@ -34,7 +34,7 @@ public class IdentifierCacheImplTest {
         final ContentletVersionInfo contentletVersionInfo = new ContentletVersionInfo();
         contentletVersionInfo.setIdentifier(id);
         contentletVersionInfo.setLang(language.getId());
-        contentletVersionInfo.setVariant(VariantAPI.DEFAULT_VARIANT.identifier());
+        contentletVersionInfo.setVariant(VariantAPI.DEFAULT_VARIANT.name());
 
         CacheLocator.getIdentifierCache().addContentletVersionInfoToCache(contentletVersionInfo);
 
@@ -44,7 +44,7 @@ public class IdentifierCacheImplTest {
         assertEquals(contentletVersionInfo, contentletVersionInfoFromCache);
 
         final ContentletVersionInfo contentletVersionInfoFromCache2 = CacheLocator.getIdentifierCache()
-                .getContentVersionInfo(id, language.getId(), VariantAPI.DEFAULT_VARIANT.identifier());
+                .getContentVersionInfo(id, language.getId(), VariantAPI.DEFAULT_VARIANT.name());
         assertNotNull(contentletVersionInfoFromCache2);
         assertEquals(contentletVersionInfo, contentletVersionInfoFromCache2);
     }
@@ -63,12 +63,12 @@ public class IdentifierCacheImplTest {
         final ContentletVersionInfo contentletVersionInfo = new ContentletVersionInfo();
         contentletVersionInfo.setIdentifier(id);
         contentletVersionInfo.setLang(language.getId());
-        contentletVersionInfo.setVariant(variant.identifier());
+        contentletVersionInfo.setVariant(variant.name());
 
         CacheLocator.getIdentifierCache().addContentletVersionInfoToCache(contentletVersionInfo);
 
         final ContentletVersionInfo contentletVersionInfoFromCache = CacheLocator.getIdentifierCache()
-                .getContentVersionInfo(id, language.getId(), variant.identifier());
+                .getContentVersionInfo(id, language.getId(), variant.name());
         assertNotNull(contentletVersionInfoFromCache);
         assertEquals(contentletVersionInfo, contentletVersionInfoFromCache);
     }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/business/VersionableFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/business/VersionableFactoryImplTest.java
@@ -21,7 +21,6 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.BeforeClass;
@@ -92,11 +91,11 @@ public class VersionableFactoryImplTest {
 
         final ContentletVersionInfo contentletVersionInfo = FactoryLocator.getVersionableFactory()
                 .createContentletVersionInfo(identifier, language.getId(), contentlet.getInode(),
-                        variant.identifier());
+                        variant.name());
 
         assertEquals(contentlet.getIdentifier(), contentletVersionInfo.getIdentifier());
         assertEquals(language.getId(), contentletVersionInfo.getLang());
-        assertEquals(variant.identifier(), contentletVersionInfo.getVariant());
+        assertEquals(variant.name(), contentletVersionInfo.getVariant());
 
         final ArrayList results = new DotConnect().setSQL(
                         "select * from contentlet_version_info where identifier =? AND lang = ?")
@@ -108,7 +107,7 @@ public class VersionableFactoryImplTest {
 
         assertEquals(contentlet.getIdentifier(), ((Map) results.get(0)).get("identifier"));
         assertEquals(language.getId(), Long.parseLong(((Map) results.get(0)).get("lang").toString()));
-        assertEquals(variant.identifier(), ((Map) results.get(0)).get("variant_id"));
+        assertEquals(variant.name(), ((Map) results.get(0)).get("variant_id"));
         assertEquals(contentlet.getInode(), ((Map) results.get(0)).get("working_inode"));
     }
 
@@ -136,16 +135,16 @@ public class VersionableFactoryImplTest {
 
         assertEquals(contentlet.getIdentifier(), contentletVersionInfo.get().getIdentifier());
         assertEquals(language.getId(), contentletVersionInfo.get().getLang());
-        assertEquals(VariantAPI.DEFAULT_VARIANT.identifier(), contentletVersionInfo.get().getVariant());
+        assertEquals(VariantAPI.DEFAULT_VARIANT.name(), contentletVersionInfo.get().getVariant());
         assertEquals(contentlet.getInode(), contentletVersionInfo.get().getWorkingInode());
 
         final ContentletVersionInfo contentletVersionInfoFromCache = CacheLocator.getIdentifierCache()
                 .getContentVersionInfo(contentlet.getIdentifier(),
-                        language.getId(), VariantAPI.DEFAULT_VARIANT.identifier());
+                        language.getId(), VariantAPI.DEFAULT_VARIANT.name());
 
         assertEquals(contentlet.getIdentifier(), contentletVersionInfoFromCache.getIdentifier());
         assertEquals(language.getId(), contentletVersionInfoFromCache.getLang());
-        assertEquals(VariantAPI.DEFAULT_VARIANT.identifier(), contentletVersionInfoFromCache.getVariant());
+        assertEquals(VariantAPI.DEFAULT_VARIANT.name(), contentletVersionInfoFromCache.getVariant());
 
 
         final ContentletVersionInfo contentletVersionInfoFromCache_2 = CacheLocator.getIdentifierCache()
@@ -153,7 +152,7 @@ public class VersionableFactoryImplTest {
 
         assertEquals(contentlet.getIdentifier(), contentletVersionInfoFromCache_2.getIdentifier());
         assertEquals(language.getId(), contentletVersionInfoFromCache_2.getLang());
-        assertEquals(VariantAPI.DEFAULT_VARIANT.identifier(), contentletVersionInfoFromCache_2.getVariant());
+        assertEquals(VariantAPI.DEFAULT_VARIANT.name(), contentletVersionInfoFromCache_2.getVariant());
     }
 
     /**
@@ -180,7 +179,7 @@ public class VersionableFactoryImplTest {
 
         assertEquals(contentlet.getIdentifier(), contentletVersionInfo.get().getIdentifier());
         assertEquals(language.getId(), contentletVersionInfo.get().getLang());
-        assertEquals(VariantAPI.DEFAULT_VARIANT.identifier(), contentletVersionInfo.get().getVariant());
+        assertEquals(VariantAPI.DEFAULT_VARIANT.name(), contentletVersionInfo.get().getVariant());
         assertEquals(contentlet.getInode(), contentletVersionInfo.get().getWorkingInode());
     }
 
@@ -200,29 +199,29 @@ public class VersionableFactoryImplTest {
                 .find(contentlet.getIdentifier());
 
         FactoryLocator.getVersionableFactory()
-                .createContentletVersionInfo(identifier, language.getId(), contentlet.getInode(), VariantAPI.DEFAULT_VARIANT.identifier());
+                .createContentletVersionInfo(identifier, language.getId(), contentlet.getInode(), VariantAPI.DEFAULT_VARIANT.name());
 
         FactoryLocator.getVersionableFactory()
-                .createContentletVersionInfo(identifier, language.getId(), contentlet.getInode(), variant.identifier());
+                .createContentletVersionInfo(identifier, language.getId(), contentlet.getInode(), variant.name());
 
         final Optional<ContentletVersionInfo> contentletVersionInfo = FactoryLocator.getVersionableFactory()
-                .getContentletVersionInfo(contentlet.getIdentifier(), language.getId(), variant.identifier());
+                .getContentletVersionInfo(contentlet.getIdentifier(), language.getId(), variant.name());
 
         assertTrue(contentletVersionInfo.isPresent());
 
         assertEquals(contentlet.getIdentifier(), contentletVersionInfo.get().getIdentifier());
         assertEquals(language.getId(), contentletVersionInfo.get().getLang());
-        assertEquals(variant.identifier(), contentletVersionInfo.get().getVariant());
+        assertEquals(variant.name(), contentletVersionInfo.get().getVariant());
         assertEquals(contentlet.getInode(), contentletVersionInfo.get().getWorkingInode());
 
 
         final ContentletVersionInfo contentletVersionInfoFromCache = CacheLocator.getIdentifierCache()
                 .getContentVersionInfo(contentlet.getIdentifier(),
-                        language.getId(), variant.identifier());
+                        language.getId(), variant.name());
 
         assertEquals(contentlet.getIdentifier(), contentletVersionInfoFromCache.getIdentifier());
         assertEquals(language.getId(), contentletVersionInfoFromCache.getLang());
-        assertEquals(variant.identifier(), contentletVersionInfoFromCache.getVariant());
+        assertEquals(variant.name(), contentletVersionInfoFromCache.getVariant());
     }
 
     /**
@@ -241,20 +240,20 @@ public class VersionableFactoryImplTest {
                 .find(contentlet.getIdentifier());
 
         FactoryLocator.getVersionableFactory().createContentletVersionInfo(identifier,
-                language.getId(), contentlet.getInode(), variant.identifier());
+                language.getId(), contentlet.getInode(), variant.name());
 
 
         FactoryLocator.getVersionableFactory()
-                .createContentletVersionInfo(identifier, language.getId(), contentlet.getInode(), VariantAPI.DEFAULT_VARIANT.identifier());
+                .createContentletVersionInfo(identifier, language.getId(), contentlet.getInode(), VariantAPI.DEFAULT_VARIANT.name());
 
         final Optional<ContentletVersionInfo> contentletVersionInfo = FactoryLocator.getVersionableFactory()
-                .findContentletVersionInfoInDB(contentlet.getIdentifier(), language.getId(), variant.identifier());
+                .findContentletVersionInfoInDB(contentlet.getIdentifier(), language.getId(), variant.name());
 
         assertTrue(contentletVersionInfo.isPresent());
 
         assertEquals(contentlet.getIdentifier(), contentletVersionInfo.get().getIdentifier());
         assertEquals(language.getId(), contentletVersionInfo.get().getLang());
-        assertEquals(variant.identifier(), contentletVersionInfo.get().getVariant());
+        assertEquals(variant.name(), contentletVersionInfo.get().getVariant());
         assertEquals(contentlet.getInode(), contentletVersionInfo.get().getWorkingInode());
     }
 
@@ -285,7 +284,7 @@ public class VersionableFactoryImplTest {
                 .setSQL("UPDATE contentlet_version_info SET deleted = ? WHERE identifier = ? AND variant_id = ? AND lang = ?")
                 .addParam(true)
                 .addParam(contentlet.getIdentifier())
-                .addParam(VariantAPI.DEFAULT_VARIANT.identifier())
+                .addParam(VariantAPI.DEFAULT_VARIANT.name())
                 .addParam(language.getId())
                 .loadResult();
 
@@ -298,7 +297,7 @@ public class VersionableFactoryImplTest {
         final ArrayList<Map> results = new DotConnect()
                 .setSQL("SELECT deleted FROM contentlet_version_info WHERE identifier = ? AND variant_id = ? AND lang = ?")
                 .addParam(contentlet.getIdentifier())
-                .addParam(VariantAPI.DEFAULT_VARIANT.identifier())
+                .addParam(VariantAPI.DEFAULT_VARIANT.name())
                 .addParam(language.getId())
                 .loadResults();
 
@@ -325,11 +324,11 @@ public class VersionableFactoryImplTest {
                 .find(contentlet.getIdentifier());
 
         FactoryLocator.getVersionableFactory()
-                .createContentletVersionInfo(identifier, language.getId(), contentlet.getInode(), variant.identifier());
+                .createContentletVersionInfo(identifier, language.getId(), contentlet.getInode(), variant.name());
 
         final ContentletVersionInfo contentletVersionInfoBefore = FactoryLocator.getVersionableFactory()
                 .getContentletVersionInfo(contentlet.getIdentifier(), language.getId(),
-                        variant.identifier())
+                        variant.name())
                 .orElseThrow(() -> new AssertionError("ContentletVersioNinfo expected"));
 
         assertFalse(contentletVersionInfoBefore.isDeleted());
@@ -338,12 +337,12 @@ public class VersionableFactoryImplTest {
                 .setSQL("UPDATE contentlet_version_info SET deleted = ? WHERE identifier = ? AND variant_id = ? AND lang = ?")
                 .addParam(true)
                 .addParam(contentlet.getIdentifier())
-                .addParam(variant.identifier())
+                .addParam(variant.name())
                 .addParam(language.getId())
                 .loadResult();
 
         final ContentletVersionInfo contentletVersionInfoAfter = FactoryLocator.getVersionableFactory()
-                .getContentletVersionInfo(contentlet.getIdentifier(), language.getId(), variant.identifier())
+                .getContentletVersionInfo(contentlet.getIdentifier(), language.getId(), variant.name())
                 .orElseThrow(() -> new AssertionError("ContentletVersioNinfo expected"));
 
         assertFalse(contentletVersionInfoAfter.isDeleted());
@@ -351,7 +350,7 @@ public class VersionableFactoryImplTest {
         final ArrayList<Map> results = new DotConnect()
                 .setSQL("SELECT deleted FROM contentlet_version_info WHERE identifier = ? AND variant_id = ? AND lang = ?")
                 .addParam(contentlet.getIdentifier())
-                .addParam(variant.identifier())
+                .addParam(variant.name())
                 .addParam(language.getId())
                 .loadResults();
 

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task220824CreateDefaultVariantTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task220824CreateDefaultVariantTest.java
@@ -34,7 +34,7 @@ public class Task220824CreateDefaultVariantTest {
 
     private static void checkIfVariantDefaultExists() throws DotDataException {
 
-        final ArrayList results = new DotConnect().setSQL("SELECT * FROM variant WHERE id = 'DEFAULT'")
+        final ArrayList results = new DotConnect().setSQL("SELECT * FROM variant WHERE name = 'DEFAULT'")
                 .loadResults();
 
         assertEquals("The DEFAULT Variant should exists", 1, results.size());
@@ -165,8 +165,8 @@ public class Task220824CreateDefaultVariantTest {
         final DotConnect dotConnect = new DotConnect();
 
         try {
-            dotConnect.setSQL("DELETE FROM variant WHERE id = ?")
-                    .addParam(VariantAPI.DEFAULT_VARIANT.identifier())
+            dotConnect.setSQL("DELETE FROM variant WHERE name = ?")
+                    .addParam(VariantAPI.DEFAULT_VARIANT.name())
                     .loadResult();
         } catch (Exception e) {
 
@@ -178,7 +178,7 @@ public class Task220824CreateDefaultVariantTest {
                                 + "FROM sysobjects so JOIN sysconstraints sc ON so.id = sc.constid "
                                 + "WHERE object_name(so.parent_obj) = 'contentlet_version_info' AND "
                                 + "sc.colid in  (select colid from syscolumns where name = 'variant_id')")
-                        .addParam(VariantAPI.DEFAULT_VARIANT.identifier())
+                        .addParam(VariantAPI.DEFAULT_VARIANT.name())
                         .loadResults();
 
                 dotConnect.setSQL("ALTER TABLE contentlet_version_info DROP CONSTRAINT " + loadResults.get(0).get("name").toString() )

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -16,9 +16,7 @@ import com.dotcms.content.business.json.ContentletJsonAPI;
 import com.dotcms.content.business.json.ContentletJsonHelper;
 import com.dotcms.content.elasticsearch.ESQueryCache;
 import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
-import com.dotcms.contenttype.model.field.DataTypes;
 import com.dotcms.contenttype.model.type.BaseContentType;
-import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.enterprise.license.LicenseManager;
 import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.notifications.bean.NotificationLevel;
@@ -73,7 +71,6 @@ import com.dotmarketing.portlets.workflows.business.WorkFlowFactory;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.NumberUtil;
 import com.dotmarketing.util.PaginatedArrayList;
 import com.dotmarketing.util.RegEX;
 import com.dotmarketing.util.RegExMatch;
@@ -1038,7 +1035,7 @@ public class ESContentFactoryImpl extends ContentletFactory {
 
 	@Override
 	protected Contentlet findContentletByIdentifier(String identifier, Boolean live, Long languageId) throws DotDataException {
-        return findContentletByIdentifier(identifier, live, languageId, VariantAPI.DEFAULT_VARIANT.identifier());
+        return findContentletByIdentifier(identifier, live, languageId, VariantAPI.DEFAULT_VARIANT.name());
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/content/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotcms/content/model/Contentlet.java
@@ -56,7 +56,7 @@ public interface Contentlet {
     String friendlyName();
     @Value.Default
     default String variantId() {
-        return VariantAPI.DEFAULT_VARIANT.identifier();
+        return VariantAPI.DEFAULT_VARIANT.name();
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantAPI.java
@@ -7,8 +7,8 @@ import java.util.Optional;
 public interface VariantAPI {
 
     Variant DEFAULT_VARIANT = Variant.builder()
-            .identifier("DEFAULT")
             .name("DEFAULT")
+            .description("Variant use by DEFAULT when a Contentlet is created")
             .archived(false)
             .build();
 
@@ -40,28 +40,21 @@ public interface VariantAPI {
     /**
      * Delete a {@link Variant}
      *
-     * @param id Variant's id to be deleted
+     * @param name Variant's id to be deleted
      */
-    void delete(final String id) throws DotDataException;
+    void delete(final String name) throws DotDataException;
 
     /**
      * Archive a {@link Variant}
      *
-     * @param id Variant's id to be archive
+     * @param name Variant's id to be archive
      */
-    void archive(final String id) throws DotDataException;
-
-    /**
-     * Return a {@link Variant} by Identifier
-     * @param identifier {@link Variant}'s identifier
-     * @return {@link Variant}
-     */
-    Optional<Variant> get(final String identifier) throws DotDataException;
+    void archive(final String name) throws DotDataException;
 
     /**
      * Return a {@link Variant} by Name
      * @param name {@link Variant}'s name
      * @return {@link Variant}
      */
-    Optional<Variant> getByName(final String name) throws DotDataException;
+    Optional<Variant> get(final String name) throws DotDataException;
 }

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
@@ -53,10 +53,10 @@ public class VariantAPIImpl implements VariantAPI {
     public void update(final Variant variant) throws DotDataException {
         Preconditions.checkNotNull(variant.name(), IllegalArgumentException.class,
                 "Variant name should not be null");
-        Preconditions.checkNotNull(variant.identifier(), IllegalArgumentException.class ,
+        Preconditions.checkNotNull(variant.name(), IllegalArgumentException.class ,
                 "Variant ID should not be null");
 
-        get(variant.identifier())
+        get(variant.name())
                 .orElseThrow(() -> new DoesNotExistException("The variant does not exists"));
 
         Logger.debug(this, () -> "Updating Variant: " + variant);
@@ -83,51 +83,35 @@ public class VariantAPIImpl implements VariantAPI {
 
     /**
      * Implementation for {@link VariantAPI#archive(String)}
-     * @param id Variant's id to be archive
+     * @param name Variant's id to be archive
      */
     @Override
     @WrapInTransaction
-    public void archive(final String id) throws DotDataException {
-        final Variant variant = get(id)
+    public void archive(final String name) throws DotDataException {
+        final Variant variant = get(name)
                 .orElseThrow(() -> new DoesNotExistException("The Variant does not exists"));
 
-        final Variant variantArchived = Variant.builder()
-                .identifier(variant.identifier())
+        final Variant variantArchived = variant.builder()
                 .name(variant.name())
-                .archived(true)
-                .build();
+                .description(variant.description())
+                .archived(true).build();
 
         Logger.debug(this, () -> "Archiving Variant: " + variant);
         update(variantArchived);
     }
 
     /**
-     * Implementation for {@link VariantAPI#get(String)}
-     *
-     * @param identifier {@link Variant}'s identifier
-     * @return
-     */
-    @Override
-    @CloseDBIfOpened
-    public Optional<Variant> get(final String identifier) throws DotDataException {
-        Preconditions.checkNotNull(identifier, "Variant ID should not be null");
-        Logger.debug(this, ()-> "Getting Variant by ID: " + identifier);
-
-        return variantFactory.get(identifier);
-    }
-
-    /**
-     * Implementation for {@link VariantAPI#getByName(String)} (String)}
+     * Implementation for {@link VariantAPI#get(String)} (String)}
      *
      * @param name {@link Variant}'s identifier
      * @return
      */
     @Override
     @CloseDBIfOpened
-    public Optional<Variant> getByName(final String name) throws DotDataException {
+    public Optional<Variant> get(final String name) throws DotDataException {
         Preconditions.checkNotNull(name, "Variant Name should not be null");
         Logger.debug(this, ()-> "Getting Variant by Name: " + name);
 
-        return variantFactory.getByName(name);
+        return variantFactory.get(name);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantFactory.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface VariantFactory {
 
     Variant VARIANT_404 = Variant.builder()
-            .identifier("VARIANT_404")
+            .description("Not found variant")
             .name("VARIANT_404")
             .archived(false)
             .build();
@@ -41,22 +41,15 @@ public interface VariantFactory {
     /**
      * Delete a {@link Variant}
      *
-     * @param id Variant's id to be deleted
+     * @param name Variant's id to be deleted
      */
-    void delete(final String id) throws DotDataException;
-
-    /**
-     * Return a {@link Variant} by Identifier
-     * @param identifier {@link Variant}'s identifier
-     * @return {@link Variant}
-     */
-    Optional<Variant> get(final String identifier) throws DotDataException;
+    void delete(final String name) throws DotDataException;
 
     /**
      * Return a {@link Variant} by Name
      * @param name {@link Variant}'s name
      * @return {@link Variant}
      */
-    Optional<Variant> getByName(final String name) throws DotDataException;
+    Optional<Variant> get(final String name) throws DotDataException;
 
 }

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantFactoryImpl.java
@@ -2,26 +2,24 @@ package com.dotcms.variant;
 
 import com.dotcms.util.DotPreconditions;
 import com.dotcms.util.transform.TransformerLocator;
-import com.dotcms.variant.model.transform.VariantTransformer;
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.UtilMethods;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.codec.digest.DigestUtils;
 
 public class VariantFactoryImpl implements VariantFactory{
 
-    private String VARIANT_INSERT_QUERY = "INSERT INTO variant (id, name, archived) VALUES (?, ?, ?)";
-    private String VARIANT_UPDATE_QUERY = "UPDATE variant SET name = ?, archived = ? WHERE id =?";
-    private String VARIANT_DELETE_QUERY = "DELETE from variant WHERE id =?";
-    private String VARIANT_SELECT_QUERY = "SELECT * from variant WHERE id =?";
-    private String VARIANT_SELECT_BY_NAME_QUERY = "SELECT * from variant WHERE name =?";
+    private String VARIANT_INSERT_QUERY = "INSERT INTO variant (name, description, archived) VALUES (?, ?, ?)";
+    private String VARIANT_UPDATE_QUERY = "UPDATE variant SET description = ?, archived = ? WHERE name =?";
+    private String VARIANT_DELETE_QUERY = "DELETE from variant WHERE name =?";
+    private String VARIANT_SELECT_QUERY = "SELECT * from variant WHERE name =?";
 
     /**
      * Implementation for {@link VariantFactory#save(Variant)}
@@ -35,39 +33,25 @@ public class VariantFactoryImpl implements VariantFactory{
 
         DotPreconditions.checkNotNull(variant.name(), IllegalArgumentException.class,
                 "Name must not be null");
-        final String identifier = getId(variant);
+        DotPreconditions.checkArgument(validateName(variant.name()), IllegalArgumentException.class,
+                "Name must have just alphanumeric characters and '_' or '/'");
 
         new DotConnect().setSQL(VARIANT_INSERT_QUERY)
-                .addParam(identifier)
                 .addParam(variant.name())
+                .addParam(variant.description())
                 .addParam(variant.archived())
                 .loadResult();
 
-        final Variant variantWithID = Variant.builder()
-                .identifier(identifier)
-                .name(variant.name())
-                .archived(variant.archived()).build();
+        final Variant variantFromDataBase = get(variant.name()).orElseThrow(
+                () -> new DotRuntimeException("Error Saving variant " + variant));
 
-        CacheLocator.getVariantCache().remove(variantWithID);
-        return variantWithID;
+        CacheLocator.getVariantCache().remove(variant);
+
+        return variantFromDataBase;
     }
 
-    private String getId(final Variant variant) {
-
-        final String deterministicID = DigestUtils.sha256Hex(variant.name());
-
-        final Optional<Variant> variantFromDataBase;
-        try {
-            variantFromDataBase = get(deterministicID);
-
-            if (variantFromDataBase.isPresent()) {
-                return UUIDGenerator.generateUuid();
-            } else {
-                return deterministicID;
-            }
-        } catch (DotDataException e) {
-            return UUIDGenerator.generateUuid();
-        }
+    private boolean validateName(final String name) {
+        return name.matches("^[a-zA-Z]([_a-zA-Z0-9]+/?)*$");
     }
 
     /**
@@ -79,56 +63,32 @@ public class VariantFactoryImpl implements VariantFactory{
     @Override
 
     public void update(final Variant variant) throws DotDataException {
-        DotPreconditions.checkNotNull(variant.identifier(), IllegalArgumentException.class,
+        DotPreconditions.checkNotNull(variant.name(), IllegalArgumentException.class,
                 "The ID should not bee null");
 
         new DotConnect().setSQL(VARIANT_UPDATE_QUERY)
-                .addParam(variant.name())
+                .addParam(variant.description())
                 .addParam(variant.archived())
-                .addParam(variant.identifier())
+                .addParam(variant.name())
                 .loadResult();
 
         CacheLocator.getVariantCache().remove(variant);
     }
 
     @Override
-    public void delete(final String id) throws DotDataException {
-        final Variant variant = get(id).orElseThrow(() ->
-                new DoesNotExistException(String.format("Variant with id %s does not exists", id)));
+    public void delete(final String name) throws DotDataException {
+        final Variant variant = get(name).orElseThrow(() ->
+                new DoesNotExistException(String.format("Variant with id %s does not exists", name)));
 
         new DotConnect().setSQL(VARIANT_DELETE_QUERY)
-                .addParam(id)
+                .addParam(name)
                 .loadResult();
 
         CacheLocator.getVariantCache().remove(variant);
-    }
-
-    @Override
-    public Optional<Variant> get(final String identifier) throws DotDataException {
-        Variant variant = CacheLocator.getVariantCache().getById(identifier);
-
-        if (UtilMethods.isSet(variant)) {
-            return variant.equals(VARIANT_404) ? Optional.empty() : Optional.of(variant);
-        } else {
-            final Optional<Variant> variantFromDataBase = getFromDataBaseById(identifier);
-
-            if (variantFromDataBase.isPresent()) {
-                CacheLocator.getVariantCache().put(variantFromDataBase.get());
-            } else {
-                CacheLocator.getVariantCache().putById(identifier, VariantFactory.VARIANT_404);
-            }
-
-            return variantFromDataBase;
-        }
-
-    }
-
-    private Optional<Variant> getFromDataBaseById(final String identifier) throws DotDataException {
-        return getFromDataBase(VARIANT_SELECT_QUERY, identifier);
     }
 
     private Optional<Variant> getFromDataBaseByName(final String name) throws DotDataException {
-        return getFromDataBase(VARIANT_SELECT_BY_NAME_QUERY, name);
+        return getFromDataBase(VARIANT_SELECT_QUERY, name);
     }
 
     private Optional<Variant> getFromDataBase(final String query, final String parameter) throws DotDataException {
@@ -141,9 +101,10 @@ public class VariantFactoryImpl implements VariantFactory{
                 Optional.empty();
     }
 
-    public Optional<Variant> getByName(final String name) throws DotDataException {
+    @Override
+    public Optional<Variant> get(final String name) throws DotDataException {
 
-        Variant variant = CacheLocator.getVariantCache().getByName(name);
+        Variant variant = CacheLocator.getVariantCache().get(name);
 
         if (UtilMethods.isSet(variant)) {
             return variant.equals(VARIANT_404) ? Optional.empty() : Optional.of(variant);
@@ -153,7 +114,7 @@ public class VariantFactoryImpl implements VariantFactory{
             if (variantFromDataBase.isPresent()) {
                 CacheLocator.getVariantCache().put(variantFromDataBase.get());
             } else {
-                CacheLocator.getVariantCache().putByName(name, VariantFactory.VARIANT_404);
+                CacheLocator.getVariantCache().put(name, VariantFactory.VARIANT_404);
             }
 
             return variantFromDataBase;

--- a/dotCMS/src/main/java/com/dotcms/variant/business/VariantCache.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/business/VariantCache.java
@@ -17,27 +17,10 @@ public interface VariantCache extends Cachable {
     /**
      * Add a {@link Variant} into the cache.
      *
-     * @param id Id to use as key
-     * @param variant to be storage
-     */
-    void putById(final String id, final Variant variant);
-
-    /**
-     * Add a {@link Variant} into the cache.
-     *
      * @param name Name to use as key
      * @param variant to be storage
      */
-    void putByName(final String name, final Variant variant);
-
-
-    /**
-     * Get a {@link Variant} from cache by Id.
-     *
-     * @param id
-     * @return
-     */
-    Variant getById(final String id);
+    void put(final String name, final Variant variant);
 
     /**
      * Get a {@link Variant} from cache by name.
@@ -45,7 +28,7 @@ public interface VariantCache extends Cachable {
      * @param name
      * @return
      */
-    Variant getByName(final String name);
+    Variant get(final String name);
 
     /**
      * Remove a {@link Variant} from cache.

--- a/dotCMS/src/main/java/com/dotcms/variant/business/VariantCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/business/VariantCacheImpl.java
@@ -15,28 +15,14 @@ public class VariantCacheImpl implements VariantCache{
     public void put(final Variant variant) {
 
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-        cache.put(VARIANT_BY_ID + variant.identifier(), variant, getPrimaryGroup());
+        cache.put(VARIANT_BY_ID + variant.name(), variant, getPrimaryGroup());
         cache.put(VARIANT_BY_NAME + variant.name(), variant, getPrimaryGroup());
 
-        putById(variant);
         putByName(variant);
     }
 
-
     @Override
-    public Variant getById(final String id) {
-        DotPreconditions.checkNotNull(id);
-
-        try{
-            DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-            return  (Variant) cache.get(getKeyById(id), getPrimaryGroup());
-        } catch (DotCacheException e) {
-            return null;
-        }
-    }
-
-    @Override
-    public Variant getByName(final String name) {
+    public Variant get(final String name) {
         DotPreconditions.checkNotNull(name);
 
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
@@ -55,7 +41,7 @@ public class VariantCacheImpl implements VariantCache{
     @Override
     public void remove(final Variant variant){
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-        cache.remove(getKeyById(variant.identifier()), getPrimaryGroup());
+        cache.remove(getKeyById(variant.name()), getPrimaryGroup());
         cache.remove(getKeyByName(variant.name()), getPrimaryGroup());
     }
 
@@ -79,24 +65,12 @@ public class VariantCacheImpl implements VariantCache{
         return VARIANT_BY_ID + id;
     }
 
-    private void putById(final Variant variant) {
-        putById(variant.identifier(), variant);
-    }
-
-    @Override
-    public void putById(final String id, final Variant variant) {
-        DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-        cache.put(getKeyById(id), variant, getPrimaryGroup());
-
-        cache.put(getKeyById(variant.identifier()), variant, getPrimaryGroup());
-    }
-
     private void putByName(final Variant variant) {
-        putByName(variant.name(), variant);
+        put(variant.name(), variant);
     }
 
     @Override
-    public void putByName(final String name, final Variant variant) {
+    public void put(final String name, final Variant variant) {
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
         cache.put(getKeyByName(name), variant, getPrimaryGroup());
 

--- a/dotCMS/src/main/java/com/dotcms/variant/model/AbstractVariant.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/model/AbstractVariant.java
@@ -16,11 +16,11 @@ import org.immutables.value.Value;
 @Value.Style(typeImmutable="*", typeAbstract="Abstract*")
 @Value.Immutable
 public interface AbstractVariant extends Serializable {
-    @JsonProperty("identifier")
-    String identifier();
-
     @JsonProperty("name")
     String name();
+
+    @JsonProperty("description")
+    String description();
 
     @JsonProperty("archived")
     boolean archived();

--- a/dotCMS/src/main/java/com/dotcms/variant/model/transform/VariantTransformer.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/model/transform/VariantTransformer.java
@@ -42,7 +42,7 @@ public class VariantTransformer implements DBTransformer {
 
     private Variant transform(final Map<String, Object> variantMap) {
         return Variant.builder()
-                .identifier(variantMap.get("id").toString())
+                .description(variantMap.get("description").toString())
                 .name(variantMap.get("name").toString())
                 .archived(ConversionUtils.toBooleanFromDb(variantMap.get("archived")))
                 .build();

--- a/dotCMS/src/main/java/com/dotmarketing/business/IdentifierCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/IdentifierCacheImpl.java
@@ -251,7 +251,7 @@ public class IdentifierCacheImpl extends IdentifierCache {
 	}
 
 	private String getKey(final String identifier, final long lang) {
-		return getKey(identifier, lang, VariantAPI.DEFAULT_VARIANT.identifier());
+		return getKey(identifier, lang, VariantAPI.DEFAULT_VARIANT.name());
 	}
 
 	@Override
@@ -276,7 +276,7 @@ public class IdentifierCacheImpl extends IdentifierCache {
 
 	@Override
     protected ContentletVersionInfo getContentVersionInfo(final String identifier, final long lang) {
-		return getContentVersionInfo(identifier, lang, VariantAPI.DEFAULT_VARIANT.identifier());
+		return getContentVersionInfo(identifier, lang, VariantAPI.DEFAULT_VARIANT.name());
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactoryImpl.java
@@ -2,9 +2,7 @@ package com.dotmarketing.business;
 
 import static com.dotcms.util.CollectionsUtils.set;
 
-import com.dotcms.content.elasticsearch.business.ESContentFactoryImpl;
 import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
-import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.transform.TransformerLocator;
 import com.dotcms.variant.VariantAPI;
 import com.dotmarketing.beans.Identifier;
@@ -325,7 +323,7 @@ public class VersionableFactoryImpl extends VersionableFactory {
     @Override
     protected Optional<ContentletVersionInfo> getContentletVersionInfo(final String identifier,
 			final long lang) throws DotDataException, DotStateException {
-        return getContentletVersionInfo(identifier, lang, VariantAPI.DEFAULT_VARIANT.identifier());
+        return getContentletVersionInfo(identifier, lang, VariantAPI.DEFAULT_VARIANT.name());
     }
 
 	@Override
@@ -375,7 +373,7 @@ public class VersionableFactoryImpl extends VersionableFactory {
 
     @Override
     protected Optional<ContentletVersionInfo> findContentletVersionInfoInDB(String identifier, long lang)throws DotDataException, DotStateException {
-		return findContentletVersionInfoInDB(identifier, lang, VariantAPI.DEFAULT_VARIANT.identifier());
+		return findContentletVersionInfoInDB(identifier, lang, VariantAPI.DEFAULT_VARIANT.name());
     }
 
 	@Override
@@ -462,7 +460,7 @@ public class VersionableFactoryImpl extends VersionableFactory {
 
     @Override
     protected ContentletVersionInfo createContentletVersionInfo(Identifier identifier, long lang, String workingInode) throws DotStateException, DotDataException {
-		return createContentletVersionInfo(identifier, lang, workingInode, VariantAPI.DEFAULT_VARIANT.identifier());
+		return createContentletVersionInfo(identifier, lang, workingInode, VariantAPI.DEFAULT_VARIANT.name());
     }
 
 	@Override

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/web/ContentletWebAPIImpl.java
@@ -8,7 +8,6 @@ import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.PageContentType;
 import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
-import com.dotcms.enterprise.license.LicenseManager;
 import com.dotcms.publisher.environment.bean.Environment;
 import com.dotcms.repackage.javax.portlet.WindowState;
 import com.dotcms.repackage.org.directwebremoting.WebContextFactory;
@@ -19,7 +18,6 @@ import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.beans.MultiTree;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
-import com.dotmarketing.business.FactoryLocator;
 import com.dotmarketing.business.IdentifierAPI;
 import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.business.UserAPI;
@@ -78,7 +76,6 @@ import java.text.MessageFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -822,10 +819,10 @@ public class ContentletWebAPIImpl implements ContentletWebAPI {
 			if(UtilMethods.isSet(contentletFormData.get(VariantAPI.VARIANT_KEY))) {
 				final String variantName = contentletFormData.get(VariantAPI.VARIANT_KEY).toString();
 
-				final Variant variant = APILocator.getVariantAPI().getByName(variantName)
+				final Variant variant = APILocator.getVariantAPI().get(variantName)
 						.orElse(VariantAPI.DEFAULT_VARIANT);
 
-				contentlet.setVariantId(variant.identifier());
+				contentlet.setVariantId(variant.name());
 			}
 
 			List<String> disabled = new ArrayList<>();

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -53,7 +53,6 @@ import com.dotmarketing.tag.model.Tag;
 import com.dotmarketing.tag.model.TagInode;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.annotations.VisibleForTesting;
@@ -1624,7 +1623,7 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 		map.put(VARIANT_ID, variantId);
     }
 	public String getVariantId() {
-		return map.getOrDefault(VARIANT_ID, VariantAPI.DEFAULT_VARIANT.identifier()).toString();
+		return map.getOrDefault(VARIANT_ID, VariantAPI.DEFAULT_VARIANT.name()).toString();
 	}
 
     private class ContentletHashMap extends ConcurrentHashMap<String, Object> {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/ContentletVersionInfo.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/ContentletVersionInfo.java
@@ -13,7 +13,7 @@ public class ContentletVersionInfo extends VersionInfo implements Serializable {
     private String variant;
 
     public String getVariant() {
-        return UtilMethods.isSet(variant) ? variant : VariantAPI.DEFAULT_VARIANT.identifier();
+        return UtilMethods.isSet(variant) ? variant : VariantAPI.DEFAULT_VARIANT.name();
     }
 
     public void setVariant(final String variant) {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220822CreateVariantTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220822CreateVariantTable.java
@@ -12,8 +12,8 @@ import java.sql.SQLException;
 public class Task220822CreateVariantTable implements StartupTask {
 
     private final String POSTGRES_QUERY = "CREATE TABLE IF NOT EXISTS variant ("
-            + "  id varchar(255) primary key,"
-            + "  name varchar(255) not null UNIQUE,"
+            + "  name varchar(255) primary key,"
+            + "  description varchar(255) not null,"
             + "  archived boolean NOT NULL default false"
             + ")";
 
@@ -22,8 +22,8 @@ public class Task220822CreateVariantTable implements StartupTask {
             "WHERE name = 'variant'";
 
     private final String MSSQL_QUERY = "CREATE TABLE variant ("
-            + "  id NVARCHAR(255) primary key,"
-            + "  name NVARCHAR(255) not null UNIQUE,"
+            + "  name NVARCHAR(255) primary key,"
+            + "  description NVARCHAR(255) not null,"
             + "  archived tinyint not null"
             + ")";
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220824CreateDefaultVariant.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220824CreateDefaultVariant.java
@@ -22,8 +22,8 @@ public class Task220824CreateDefaultVariant implements StartupTask  {
     public boolean forceRun() {
         try{
             final ArrayList results = new DotConnect()
-                    .setSQL("SELECT * FROM variant WHERE id = ?")
-                    .addParam(VariantAPI.DEFAULT_VARIANT.identifier())
+                    .setSQL("SELECT * FROM variant WHERE name = ?")
+                    .addParam(VariantAPI.DEFAULT_VARIANT.name())
                     .loadResults();
             return results.isEmpty();
         } catch (DotDataException e) {
@@ -42,8 +42,8 @@ public class Task220824CreateDefaultVariant implements StartupTask  {
 
     private void createDefaultVariant(DotConnect dotConnect) throws DotDataException {
         if (!defaultVariantExists(dotConnect)) {
-            dotConnect.setSQL("INSERT INTO variant (id, name, archived) VALUES (?, ?, ?)")
-                    .addParam(VariantAPI.DEFAULT_VARIANT.identifier())
+            dotConnect.setSQL("INSERT INTO variant (name, description, archived) VALUES (?, ?, ?)")
+                    .addParam(VariantAPI.DEFAULT_VARIANT.name())
                     .addParam(VariantAPI.DEFAULT_VARIANT.name())
                     .addParam(ConversionUtils.toBooleanFromDb(false))
                     .loadResult();
@@ -51,8 +51,8 @@ public class Task220824CreateDefaultVariant implements StartupTask  {
     }
 
     private boolean defaultVariantExists(DotConnect dotConnect) throws DotDataException {
-        return !dotConnect.setSQL("SELECT * FROM variant WHERE id = ?")
-                .addParam(VariantAPI.DEFAULT_VARIANT.identifier())
+        return !dotConnect.setSQL("SELECT * FROM variant WHERE name = ?")
+                .addParam(VariantAPI.DEFAULT_VARIANT.name())
                 .loadResults()
                 .isEmpty();
     }

--- a/dotCMS/src/main/resources/mssql.sql
+++ b/dotCMS/src/main/resources/mssql.sql
@@ -2687,8 +2687,8 @@ CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until datetime NOT NULL,
                       locked_at datetime NOT NULL, locked_by VARCHAR(255) NOT NULL, PRIMARY KEY (name));
 
 create table variant (
-     id NVARCHAR(255) primary key,
-     name NVARCHAR(255) not null UNIQUE,
+     name NVARCHAR(255) primary key,
+     description NVARCHAR(255) not null,
      archived tinyint not null default 0,
 );
 

--- a/dotCMS/src/main/resources/postgres.sql
+++ b/dotCMS/src/main/resources/postgres.sql
@@ -2486,8 +2486,8 @@ CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until timestamptz NOT NULL
 
 
 create table variant (
-     id varchar(255) primary key,
-     name varchar(255) not null UNIQUE,
+     name varchar(255) primary key,
+     description varchar(255) not null,
      archived boolean NOT NULL default false
 );
 


### PR DESCRIPTION
Renaming variant fiel

Before field:

- ID: hash from name
- Name: variant name
-
both fields were UNIQUE

Now field
- Rename ID by name and this is going to be a hash anymore, now this is a input from the user that must fulfill the follow rule:
     - Must start with a letter
     - Must contains just alphanumeric characters or '_' or '/'
     - Must not have two '/' in a row 
- Rename Name by description and this is not unique anymore
