### PR TITLE
(#22935): Adding Bayesian calculation classes with corresponding tests

### DIFF
--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation group: 'com.dotcms.lib', name: 'dot.dwr', version:'3rc2modified_3'
 
     implementation group: 'com.lmax', name: 'disruptor', version: '3.3.4'
+    implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
+    implementation group: 'org.apache.commons', name: 'commons-numbers-gamma', version: '1.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.17.1'

--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -1,5 +1,6 @@
 package com.dotcms;
 
+import com.dotcms.analytics.bayesian.BayesianAPIImplTest;
 import com.dotcms.auth.providers.saml.v1.DotSamlResourceTest;
 import com.dotcms.auth.providers.saml.v1.SAMLHelperTest;
 import com.dotcms.cache.lettuce.DotObjectCodecTest;
@@ -586,7 +587,8 @@ import org.junit.runners.Suite.SuiteClasses;
         IdentifierCacheImplTest.class,
         VariantCacheTest.class,
         VersionableFactoryImplTest.class,
-        Task220928AddLookbackWindowColumnToExperimentTest.class
+        Task220928AddLookbackWindowColumnToExperimentTest.class,
+        BayesianAPIImplTest.class
 })
 public class MainSuite {
 

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BayesianAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BayesianAPI.java
@@ -1,0 +1,16 @@
+package com.dotcms.analytics.bayesian;
+
+
+import com.dotcms.analytics.bayesian.model.BayesianInput;
+import com.dotcms.analytics.bayesian.model.BayesianResult;
+
+/**
+ * Bayesian calculation API.
+ *
+ * @author vico
+ */
+public interface BayesianAPI {
+
+    BayesianResult calcABTesting(BayesianInput input);
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BayesianAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BayesianAPIImpl.java
@@ -1,0 +1,250 @@
+package com.dotcms.analytics.bayesian;
+
+
+import com.dotcms.analytics.bayesian.model.AbstractSampleData;
+import com.dotcms.analytics.bayesian.model.BayesianInput;
+import com.dotcms.analytics.bayesian.model.BayesianResult;
+import com.dotcms.analytics.bayesian.model.DifferenceData;
+import com.dotcms.analytics.bayesian.model.QuantilePair;
+import com.dotcms.analytics.bayesian.model.SampleData;
+import com.dotcms.analytics.bayesian.model.SampleGroup;
+import com.dotmarketing.util.Config;
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.numbers.gamma.LogBeta;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+
+/**
+ * Bayesian calculation API.
+ * So far it implements on method that calculates the probability for an A/B test that B (test) beats A (control).
+ *
+ * @author vico
+ */
+public class BayesianAPIImpl implements BayesianAPI {
+
+    private static final double DEFAULT_VALUE = (double) 3 / 8;
+    private static final double[] QUANTILES = { 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.975, 0.99 };
+    private static final int SAMPLE_SIZE = Config.getIntProperty("BETA_DISTRIBUTION_SAMPLE_SIZE", 1000);
+    private static final BiFunction<Integer, Integer, Double> LOG_BETA_FN = LogBeta::value;
+
+    /**
+     * Calculates probability that B (Test) beats A (Control) based on this pseudo (Julia) code:
+     *
+     * <pre>
+     *     𝛼𝐴 is one plus the number of successes for A
+     *     𝛽𝐴 is one plus the number of failures for A
+     *     𝛼𝐵 is one plus the number of successes for B
+     *     𝛽𝐵 is one plus the number of failures for B
+     *
+     *     function probability_B_beats_A(α_A, β_A, α_B, β_B)
+     *         total = 0.0
+     *         for i = 0:(α_B-1)
+     *             total += exp(logbeta(α_A+i, β_B+β_A)
+     *                 - log(β_B+i) - logbeta(1+i, β_B) - logbeta(α_A, β_A))
+     *         end
+     *         return total
+     *     end
+     * </pre>
+     *
+     * Instead of using the provided logBeta function from Apache Commons Math we will use our own implementation:
+     * {@link BetaDistribution} which provides en density function {@see DotBetaDistribution.pdf()}.
+     *
+     * @param input {@link BayesianInput} instance
+     */
+    @Override
+    public BayesianResult calcABTesting(final BayesianInput input) {
+        // validate input
+        validateInput(input);
+
+        final BetaDistribution controlData = new BetaModel(input).distribution();
+        final BetaDistribution testData = new BetaModel(input).distribution();
+        final DifferenceData differenceData = generateDifferenceData(controlData, testData);
+
+        // call calculation
+        return BayesianResult.builder()
+                .result(calcABTesting(
+                        input.controlSuccesses(),
+                        input.controlFailures(),
+                        input.testSuccesses(),
+                        input.testFailures()))
+                .distributionPdfs(calcDistributionsPdfs(controlData, testData))
+                .differenceData(differenceData)
+                .quantiles(calcQuantiles(differenceData.differences(), null, null))
+                .build();
+    }
+
+    /**
+     * Calculates probability that B (Test) beats A (Control) just as main {@link #calcABTesting(BayesianInput)}
+     *
+     * @param alphaA control successes
+     * @param betaA control failures
+     * @param alphaB test successes
+     * @param betaB test failures
+     * @return result representing probability that B beats A
+     */
+    private double calcABTesting(final int alphaA, final int betaA, final int alphaB, final int betaB) {
+        return IntStream.range(0, alphaB)
+                .mapToDouble(i -> Math.exp(
+                        logBeta(alphaA + i, betaB + betaA)
+                                - Math.log(betaB + i)
+                                - logBeta(1 + i, betaB)
+                                - logBeta(alphaA, betaA)))
+                .sum();
+    }
+
+    /**
+     * Given a {@link BetaDistribution} instance calculates density (pdf) elements.
+     *
+     * @param distribution provided beta distribution
+     * @return list of {@link AbstractSampleData} instances
+     */
+    private List<AbstractSampleData> calcPdfElements(final BetaDistribution distribution) {
+        return IntStream
+                .range(0, SAMPLE_SIZE)
+                .mapToObj(operand -> {
+                    final double x = (double) operand / SAMPLE_SIZE;
+                    final double temp = distribution.pdf(x);
+                    final double y = temp == Double.POSITIVE_INFINITY ? 0 : temp;
+                    return SampleData.builder()
+                            .x(x)
+                            .y(y)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Given a couple {@link BetaDistribution} objects calculates dendity(PDF) for both control (A) and test (B).
+     *
+     * @param controlDistribution provided control beta distribution
+     * @param testDistribution provided test beta distribution
+     * @return {@link SampleGroup} containing each sample list against an identifier
+     */
+    private SampleGroup calcDistributionsPdfs(final BetaDistribution controlDistribution,
+                                              final BetaDistribution testDistribution) {
+        return SampleGroup.builder()
+                .samples(ImmutableMap.of(
+                        "A", calcPdfElements(controlDistribution),
+                        "B", calcPdfElements(testDistribution)))
+                .build();
+    }
+
+    /**
+     * Given a couple {@link BetaDistribution} objects generates difference between test and control sample data.
+     *
+     * @param controlDistribution provided control beta distribution
+     * @param testDistribution provided test beta distribution
+     * @return {@link  DifferenceData} instance with control and test data and its difference
+     */
+    private DifferenceData generateDifferenceData(final BetaDistribution controlDistribution,
+                                                  final BetaDistribution testDistribution) {
+        final double[] controlData = controlDistribution.rvs(SAMPLE_SIZE);
+        final double[] testData = testDistribution.rvs(SAMPLE_SIZE);
+        return DifferenceData.builder()
+                .controlData(controlData)
+                .testData(testData)
+                .differences(
+                        IntStream.range(0, controlData.length)
+                                .mapToDouble(i -> testData[i] - controlData[i])
+                                .toArray())
+                .build();
+    }
+
+    /**
+     * Gets the maximum number between a given number and the minimum between two other numbers.
+     *
+     * @param arg number
+     * @param min number
+     * @param max number
+     * @return maximum result
+     */
+    private double clip(final double arg, final double min, final double max) {
+        return Math.max(min, Math.min(arg, max));
+    }
+
+    /**
+     * Calculates quantiles from a difference data array, an alpha and beta values.
+     *
+     * @param differences difference data array
+     * @param alpha alpha value
+     * @param beta beta value
+     * @return list of calculated quantiles double values
+     */
+    private Map<Double, QuantilePair> calcQuantiles(final double[] differences, final Double alpha, final Double beta) {
+        final double[] sorted = Arrays.copyOf(differences, differences.length);
+        Arrays.sort(sorted);
+
+        final int size = differences.length;
+        final double alphaFinal = Objects.requireNonNullElse(alpha, DEFAULT_VALUE);
+        final double betaFinal = Objects.requireNonNullElse(beta, DEFAULT_VALUE);
+
+        return Arrays.stream(QUANTILES)
+                .boxed()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        quantile -> {
+                            final double p = quantile;
+                            final double m = alphaFinal + p * (1 - alphaFinal - betaFinal);
+                            final double aleph = size * p + m;
+                            final int k = (int) Math.floor(clip(aleph, 1, size - 1));
+                            final double gamma = clip(aleph - k, 0, 1);
+                            final double result = (1 - gamma) * sorted[k - 1] + gamma * sorted[k];
+                            return QuantilePair.builder()
+                                    .quantile(result)
+                                    .formatted((double) Math.round(100 * result) / 100)
+                                    .build();
+                        }));
+    }
+
+    /**
+     * Executes Apache's Common Math log beta function for provided alpha and beta values
+     *
+     * @param alpha alpha value
+     * @param beta beta value
+     * @return results from log beta function
+     */
+    private double logBeta(final int alpha, final int beta) {
+        return LOG_BETA_FN.apply(alpha, beta);
+    }
+
+    /**
+     * Validates passed {@link BayesianInput} instance to have the right parameters.
+     *
+     * @param input Bayesian calculation input
+     */
+    private void validateInput(final BayesianInput input) {
+        Objects.requireNonNull(input, "Bayesian input is missing");
+        if (input.priorAlpha() <= 0.0) {
+            throw new IllegalArgumentException("Prior alpha cannot have a zero or negative value");
+        }
+
+        if (input.priorBeta() <= 0.0) {
+            throw new IllegalArgumentException("Prior beta cannot have a zero or negative value");
+        }
+
+        if (input.controlSuccesses() < 0) {
+            throw new IllegalArgumentException("Control successes cannot have negative value");
+        }
+
+        if (input.controlFailures() < 0) {
+            throw new IllegalArgumentException("Control failures cannot have negative value");
+        }
+
+        if (input.testSuccesses() < 0) {
+            throw new IllegalArgumentException("Test successes cannot have negative value");
+        }
+
+        if (input.testFailures() < 0) {
+            throw new IllegalArgumentException("Test failures cannot have negative value");
+        }
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BetaDistribution.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BetaDistribution.java
@@ -1,0 +1,121 @@
+package com.dotcms.analytics.bayesian;
+
+import org.apache.commons.numbers.gamma.LogGamma;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+
+/**
+ * Customized Beta Distribution class wrapping utilities found in Apache's Common Math and Apache's Commons Numbers
+ * libraries.
+ *
+ * @author vico
+ */
+public class BetaDistribution {
+
+    private final double alpha;
+    private final double beta;
+    // do we even need to set this for Commons Math ?
+    private final double betaInverse;
+
+    /**
+     * Instantiates class with alpha and beta parameters.
+     *
+     * @param alpha alpha value
+     * @param beta beta value
+     */
+    private BetaDistribution(final double alpha, final double beta) {
+        this.alpha = alpha;
+        this.beta = beta;
+        // do we need to set this for Commons Math ?
+        betaInverse = LogGamma.value(this.alpha + this.beta) - LogGamma.value(this.alpha) - LogGamma.value(this.beta);
+    }
+
+    /**
+     * Creates new instance of {@link BetaDistribution}.
+     *
+     * @param alpha alpha value
+     * @param beta beta value
+     * @return a new {@link BetaDistribution} instance
+     */
+    public static BetaDistribution create(final double alpha, final double beta) {
+        return new BetaDistribution(alpha, beta);
+    }
+
+    /**
+     * Creates a function that returns the log density for a provided number.
+     *
+     * @return {@link Function} instance
+     */
+    public Function<Double, Double> lp() {
+        return x -> distribution().logDensity(x);
+    }
+
+    /**
+     * Returns log density actual result.
+     *
+     * @param x number to calculate density from
+     * @return log density result
+     */
+    public double lp(final double x) {
+        return lp().apply(x);
+    }
+
+    /**
+     * Creates a function that returns the density for a provided number.
+     *
+     * @return {@link Function} instance
+     */
+    public Function<Double, Double> pdf() {
+        return x -> distribution().density(x);
+    }
+
+    /**
+     * Returns density actual result.
+     *
+     * @param x number to calculate density from
+     * @return density result
+     */
+    public double pdf(final double x) {
+        return pdf().apply(x);
+    }
+
+    /**
+     * Creates a distribution sample.
+     *
+     * @return double sample
+     */
+    public double rv() {
+        return distribution().sample();
+    }
+
+    /**
+     * Creates a limited (by provided size) generation of samples.
+     *
+     * @param size size
+     * @return list of samples
+     */
+    public double[] rvs(final long size) {
+        return Stream.generate(this::rv).limit(size).mapToDouble(Double::doubleValue).toArray();
+    }
+
+    /**
+     * Creates a {@link org.apache.commons.math3.distribution.BetaDistribution} instance based on current instance's alpha, beta and inverse beta values.
+     *
+     * @return Apache's Commons Math beta distribution instance.
+     */
+    private org.apache.commons.math3.distribution.BetaDistribution distribution() {
+        return new org.apache.commons.math3.distribution.BetaDistribution(alpha, beta, betaInverse);
+    }
+
+    @Override
+    public String toString() {
+        return "DotBetaDistribution{" +
+                "alpha=" + alpha +
+                ", beta=" + beta +
+                ", betaInverse=" + betaInverse +
+                '}';
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BetaModel.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BetaModel.java
@@ -1,0 +1,51 @@
+package com.dotcms.analytics.bayesian;
+
+import com.dotcms.analytics.bayesian.model.BayesianInput;
+
+
+/**
+ * Beta Distribution wrapping class.
+ *
+ * @author vico
+ */
+public class BetaModel {
+
+    private double alpha;
+
+    private double beta;
+
+    public BetaModel(final BayesianInput input) {
+        setValues(input.priorAlpha(), input.priorBeta());
+    }
+
+    /**
+     * Adds provided successes and failures values to current alpha and beta attributes.
+     *
+     * @param successes number os successes
+     * @param failures number of failures
+     */
+    public void update(final int successes, final int failures) {
+        setValues(alpha + successes, beta + failures);
+    }
+
+    /**
+     * Creates a new instance of {@link BetaDistribution} with already provided alpha and beta values.
+     *
+     * @return a beta distribution object.
+     */
+    public BetaDistribution distribution() {
+        return BetaDistribution.create(alpha, beta);
+    }
+
+    /**
+     * Set alpha and beta values.
+     *
+     * @param alpha alpha value
+     * @param beta beta value
+     */
+    private void setValues(final double alpha, final double beta) {
+        this.alpha = alpha;
+        this.beta = beta;
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractBayesianInput.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractBayesianInput.java
@@ -1,0 +1,42 @@
+package com.dotcms.analytics.bayesian.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.immutables.value.Value;
+
+
+/**
+ * Bayesian inference calculation input. It consists in 6 known parameters:
+ *  <ul>
+ *      <li>prior alpha: prior data for alpha</li>
+ *      <li>prior beta: prior data for beta </li>
+ *      <li>control successes: number of successes for control (A)</li>
+ *      <li><control failures: number of failures for control (A)/li>
+ *      <li>test successes: number of </li>
+ *      <li>test failures:</li>
+ *  </ul>
+ *
+ * @author vico
+ */
+@Value.Style(typeImmutable="*", typeAbstract="Abstract*")
+@Value.Immutable
+public interface AbstractBayesianInput {
+
+    @JsonProperty("priorAlpha")
+    double priorAlpha();
+
+    @JsonProperty("priorBeta")
+    double priorBeta();
+
+    @JsonProperty("controlSuccesses")
+    int controlSuccesses();
+
+    @JsonProperty("controlFailures")
+    int controlFailures();
+
+    @JsonProperty("testSuccesses")
+    int testSuccesses();
+
+    @JsonProperty("testFailures")
+    int testFailures();
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractBayesianResult.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractBayesianResult.java
@@ -1,0 +1,30 @@
+package com.dotcms.analytics.bayesian.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.immutables.value.Value;
+
+import java.util.Map;
+
+
+/**
+ * Bayesian calculation result wrapper.
+ *
+ * @author vico
+ */
+@Value.Style(typeImmutable="*", typeAbstract="Abstract*")
+@Value.Immutable
+public interface AbstractBayesianResult {
+
+    @JsonProperty("result")
+    double result();
+
+    @JsonProperty("distributionPdfs")
+    AbstractSampleGroup distributionPdfs();
+
+    @JsonProperty("differenceData")
+    AbstractDifferenceData differenceData();
+
+    @JsonProperty("quantiles")
+    Map<Double, AbstractQuantilePair> quantiles();
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractDifferenceData.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractDifferenceData.java
@@ -1,0 +1,25 @@
+package com.dotcms.analytics.bayesian.model;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.immutables.value.Value;
+
+/**
+ * Bean to hold control and test data and its difference.
+ *
+ * @author vico
+ */
+@Value.Style(typeImmutable="*", typeAbstract="Abstract*")
+@Value.Immutable
+public interface AbstractDifferenceData {
+
+    @JsonProperty("controlData")
+    double[] controlData();
+
+    @JsonProperty("testData")
+    double[] testData();
+
+    @JsonProperty("differences")
+    double[] differences();
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractQuantilePair.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractQuantilePair.java
@@ -1,0 +1,22 @@
+package com.dotcms.analytics.bayesian.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.immutables.value.Value;
+
+
+/**
+ * Holder for quantile value and its rounded-formatted value.
+ *
+ * @author vico
+ */
+@Value.Style(typeImmutable="*", typeAbstract="Abstract*")
+@Value.Immutable
+public interface AbstractQuantilePair {
+
+    @JsonProperty("quantile")
+    double quantile();
+
+    @JsonProperty("formatted")
+    double formatted();
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractSampleData.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractSampleData.java
@@ -1,0 +1,22 @@
+package com.dotcms.analytics.bayesian.model;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.immutables.value.Value;
+
+/**
+ * Sample data POJO.
+ *
+ * @author vico
+ */
+@Value.Style(typeImmutable="*", typeAbstract="Abstract*")
+@Value.Immutable
+public interface AbstractSampleData {
+
+    @JsonProperty("x")
+    double x();
+
+    @JsonProperty("y")
+    double y();
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractSampleGroup.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractSampleGroup.java
@@ -1,0 +1,22 @@
+package com.dotcms.analytics.bayesian.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.immutables.value.Value;
+
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Sample data map.
+ *
+ * @author vico
+ */
+@Value.Style(typeImmutable="*", typeAbstract="Abstract*")
+@Value.Immutable
+public interface AbstractSampleGroup {
+
+    @JsonProperty("samples")
+    Map<String, List<AbstractSampleData>> samples();
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/business/APILocator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/APILocator.java
@@ -1,5 +1,7 @@
 package com.dotmarketing.business;
 
+import com.dotcms.analytics.bayesian.BayesianAPI;
+import com.dotcms.analytics.bayesian.BayesianAPIImpl;
 import com.dotcms.api.system.event.SystemEventsAPI;
 import com.dotcms.api.system.event.SystemEventsFactory;
 import com.dotcms.api.tree.TreeableAPI;
@@ -1103,6 +1105,14 @@ public class APILocator extends Locator<APIIndex>{
 	}
 
 	/**
+	 * Creates a single instance of the {@link com.dotcms.analytics.bayesian.BayesianAPI} class.
+	 * @return
+	 */
+	public static BayesianAPI getBayesianAPI(){
+		return (BayesianAPI) getInstance(APIIndex.BAYESIAN_API);
+	}
+
+	/**
 	 * Generates a unique instance of the specified dotCMS API.
 	 *
 	 * @param index
@@ -1250,7 +1260,9 @@ enum APIIndex
 	DETERMINISTIC_IDENTIFIER_API,
 	CONTENTLET_JSON_API,
 	VARIANT_API,
-	EXPERIMENTS_API;
+	EXPERIMENTS_API,
+
+	BAYESIAN_API;
 
 	Object create() {
 		switch(this) {
@@ -1336,6 +1348,7 @@ enum APIIndex
 			case CONTENTLET_JSON_API: return new ContentletJsonAPIImpl();
 			case VARIANT_API: return new VariantAPIImpl();
 			case EXPERIMENTS_API: return new ExperimentsAPIImpl();
+			case BAYESIAN_API: return new BayesianAPIImpl();
 		}
 		throw new AssertionError("Unknown API index: " + this);
 	}

--- a/dotCMS/src/test/java/com/dotcms/analytics/bayesian/BayesianAPIImplTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/bayesian/BayesianAPIImplTest.java
@@ -1,0 +1,111 @@
+package com.dotcms.analytics.bayesian;
+
+import com.dotcms.analytics.bayesian.model.BayesianInput;
+import com.dotcms.analytics.bayesian.model.BayesianResult;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BayesianAPIImplTest {
+
+    private BayesianAPI bayesianAPI;
+
+    @Before
+    public void setup() {
+        bayesianAPI = new BayesianAPIImpl();
+    }
+
+    @Test
+    public void test_calculateABTesting() {
+        final BayesianInput input = BayesianInput.builder()
+                .priorAlpha(10)
+                .priorBeta(10)
+                .controlSuccesses(5)
+                .controlFailures(3)
+                .testSuccesses(6)
+                .testFailures(2)
+                .build();
+        final BayesianResult result = bayesianAPI.calcABTesting(input);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("0.72", String.format("%.2f", result.result()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_calculateABTesting_invalidPriorAlpha() {
+        BayesianInput input = BayesianInput.builder()
+                .priorAlpha(0)
+                .priorBeta(10)
+                .controlSuccesses(5)
+                .controlFailures(3)
+                .testSuccesses(5)
+                .testFailures(3)
+                .build();
+        bayesianAPI.calcABTesting(input);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_calculateABTesting_invalidPriorBeta() {
+        BayesianInput input = BayesianInput.builder()
+                .priorAlpha(10)
+                .priorBeta(0)
+                .controlSuccesses(5)
+                .controlFailures(3)
+                .testSuccesses(5)
+                .testFailures(3)
+                .build();
+        bayesianAPI.calcABTesting(input);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_calculateABTesting_invalidControlSuccesses() {
+        BayesianInput input = BayesianInput.builder()
+                .priorAlpha(10)
+                .priorBeta(10)
+                .controlSuccesses(-1)
+                .controlFailures(3)
+                .testSuccesses(5)
+                .testFailures(3)
+                .build();
+        bayesianAPI.calcABTesting(input);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_calculateABTesting_invalidControlFailures() {
+        BayesianInput input = BayesianInput.builder()
+                .priorAlpha(10)
+                .priorBeta(10)
+                .controlSuccesses(5)
+                .controlFailures(-1)
+                .testSuccesses(5)
+                .testFailures(3)
+                .build();
+        bayesianAPI.calcABTesting(input);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_calculateABTesting_invalidTestSuccesses() {
+        BayesianInput input = BayesianInput.builder()
+                .priorAlpha(10)
+                .priorBeta(10)
+                .controlSuccesses(5)
+                .controlFailures(3)
+                .testSuccesses(-1)
+                .testFailures(3)
+                .build();
+        bayesianAPI.calcABTesting(input);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_calculateABTesting_invalidTestFailures() {
+        BayesianInput input = BayesianInput.builder()
+                .priorAlpha(10)
+                .priorBeta(10)
+                .controlSuccesses(5)
+                .controlFailures(3)
+                .testSuccesses(5)
+                .testFailures(-1)
+                .build();
+        bayesianAPI.calcABTesting(input);
+    }
+
+}

--- a/dotCMS/src/test/java/com/dotcms/analytics/bayesian/BayesianAPIImplTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/bayesian/BayesianAPIImplTest.java
@@ -6,6 +6,12 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+
+/**
+ * Bayesian API implementation class unit tests.
+ *
+ * @author vico
+ */
 public class BayesianAPIImplTest {
 
     private BayesianAPI bayesianAPI;
@@ -15,6 +21,20 @@ public class BayesianAPIImplTest {
         bayesianAPI = new BayesianAPIImpl();
     }
 
+    /**
+     * Given Bayesian input parameters with these values:
+     *
+     * <pre>
+     *     priorAlpha: 10
+     *     priorBeta: 10
+     *     controlSuccesses: 5
+     *     controlFailures: 3
+     *     testSuccesses: 6
+     *     testFailures: 2
+     * </pre>
+     *
+     * Expect that the probability B beats A is at least 0.72.
+     */
     @Test
     public void test_calculateABTesting() {
         final BayesianInput input = BayesianInput.builder()
@@ -30,6 +50,10 @@ public class BayesianAPIImplTest {
         Assert.assertEquals("0.72", String.format("%.2f", result.result()));
     }
 
+    /**
+     * Given Bayesian input parameters with an invalid prior alpha.
+     * Expect a IllegalArgumentException to be thrown.
+     */
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidPriorAlpha() {
         BayesianInput input = BayesianInput.builder()
@@ -43,6 +67,10 @@ public class BayesianAPIImplTest {
         bayesianAPI.calcABTesting(input);
     }
 
+    /**
+     * Given Bayesian input parameters with an invalid prior beta.
+     * Expect a IllegalArgumentException to be thrown.
+     */
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidPriorBeta() {
         BayesianInput input = BayesianInput.builder()
@@ -56,6 +84,10 @@ public class BayesianAPIImplTest {
         bayesianAPI.calcABTesting(input);
     }
 
+    /**
+     * Given Bayesian input parameters with an invalid control successes.
+     * Expect a IllegalArgumentException to be thrown.
+     */
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidControlSuccesses() {
         BayesianInput input = BayesianInput.builder()
@@ -69,6 +101,10 @@ public class BayesianAPIImplTest {
         bayesianAPI.calcABTesting(input);
     }
 
+    /**
+     * Given Bayesian input parameters with an invalid control failures.
+     * Expect a IllegalArgumentException to be thrown.
+     */
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidControlFailures() {
         BayesianInput input = BayesianInput.builder()
@@ -82,6 +118,10 @@ public class BayesianAPIImplTest {
         bayesianAPI.calcABTesting(input);
     }
 
+    /**
+     * Given Bayesian input parameters with an invalid test successes.
+     * Expect a IllegalArgumentException to be thrown.
+     */
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidTestSuccesses() {
         BayesianInput input = BayesianInput.builder()
@@ -95,6 +135,10 @@ public class BayesianAPIImplTest {
         bayesianAPI.calcABTesting(input);
     }
 
+    /**
+     * Given Bayesian input parameters with an invalid test failures.
+     * Expect a IllegalArgumentException to be thrown.
+     */
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidTestFailures() {
         BayesianInput input = BayesianInput.builder()

--- a/dotCMS/src/test/java/com/dotcms/analytics/bayesian/BetaDistributionTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/bayesian/BetaDistributionTest.java
@@ -1,0 +1,52 @@
+package com.dotcms.analytics.bayesian;
+
+import io.vavr.Tuple2;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+
+/**
+ * DotBetaDistribution unit test.
+ *
+ * @author vico
+ */
+public class BetaDistributionTest {
+
+    private BetaDistribution distribution;
+
+    @Before
+    public void setup() {
+        distribution = BetaDistribution.create(10, 10);
+    }
+
+    /**
+     * Given a defined number of elements to calculate to simulate graph points in a two dimensions chart,
+     * verify that its returned values are within the expected parameters.
+     * Values to compare were taken from Bayesian calculator we based ou work from:
+     * <a href="https://making.lyst.com/bayesian-calculator/">...</a>
+     */
+    @Test
+    public void test_pdfElements() {
+        final var limit = 1000;
+        final var graphValues = IntStream
+                .range(0, limit)
+                .mapToObj(operand -> {
+                    final double x = (double) operand / limit;
+                    final double temp = distribution.pdf(x);
+                    final double y = temp == Double.POSITIVE_INFINITY ? 0 : temp;
+                    return new Tuple2<>(x, y);
+                })
+                .collect(Collectors.toList());
+        Assert.assertEquals(0.0, graphValues.get(0)._1, 0.0);
+        Assert.assertEquals(0.0, graphValues.get(0)._2, 0.0);
+        Assert.assertEquals(0.5, graphValues.get(500)._1, 0.0);
+        Assert.assertEquals(3.523941040071157, graphValues.get(500)._2, 0.000000000100000);
+        Assert.assertEquals(0.999, graphValues.get(999)._1, 0.0);
+        Assert.assertEquals(9.154991586071056e-22, graphValues.get(999)._2, 0.000000000100000);
+    }
+
+}


### PR DESCRIPTION
Introducing classes to calculate probability that Test (B) beats Control (A) using the Bayesian calculations.
Main `BayesianAPIImpl` class was introduced as main entrypoint to perform a series of calculations based on the following inputs:
- Prior alpha
- Prior beta
- Control successes
- Control failures
- Test successess
- Test faiulures