### PR TITLE
dotCMS/core#22487 Support inline editing for block editor field 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.spec.ts
@@ -16,8 +16,9 @@ import { of, throwError } from 'rxjs';
 import { MockDotMessageService } from '@tests/dot-message-service.mock';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
 import { mockResponseView } from '@tests/response-view.mock';
-import { DotGlobalMessageService } from '@components/_common/dot-global-message/dot-global-message.service';
 import { DotContentTypeService } from '@services/dot-content-type';
+import { DotAlertConfirmService } from '@services/dot-alert-confirm';
+import { ConfirmationService } from 'primeng/api';
 
 @Component({
     selector: 'dot-block-editor',
@@ -60,7 +61,8 @@ class MockDotContentTypeService {
 }
 
 const messageServiceMock = new MockDotMessageService({
-    'editpage.inline.error': 'An error occurred'
+    'editpage.inline.error': 'An error occurred',
+    error: 'Error'
 });
 
 const clickEvent = {
@@ -78,7 +80,7 @@ describe('DotBlockEditorSidebarComponent', () => {
     let fixture: ComponentFixture<DotBlockEditorSidebarComponent>;
     let dotEventsService: DotEventsService;
     let dotWorkflowActionsFireService: DotWorkflowActionsFireService;
-    let dotGlobalMessageService: DotGlobalMessageService;
+    let dotAlertConfirmService: DotAlertConfirmService;
     let dotContentTypeService: DotContentTypeService;
     let de: DebugElement;
 
@@ -98,12 +100,13 @@ describe('DotBlockEditorSidebarComponent', () => {
                 { provide: DotContentTypeService, useClass: MockDotContentTypeService },
                 DotWorkflowActionsFireService,
                 DotEventsService,
-                DotGlobalMessageService
+                DotAlertConfirmService,
+                ConfirmationService
             ]
         }).compileComponents();
         dotEventsService = TestBed.inject(DotEventsService);
         dotWorkflowActionsFireService = TestBed.inject(DotWorkflowActionsFireService);
-        dotGlobalMessageService = TestBed.inject(DotGlobalMessageService);
+        dotAlertConfirmService = TestBed.inject(DotAlertConfirmService);
         dotContentTypeService = TestBed.inject(DotContentTypeService);
     });
 
@@ -150,7 +153,6 @@ describe('DotBlockEditorSidebarComponent', () => {
 
         const updateBtn = de.query(By.css('[data-testId="updateBtn"]'));
         updateBtn.triggerEventHandler('click');
-
         expect(dotWorkflowActionsFireService.saveContentlet).toHaveBeenCalledWith({
             testName: JSON.stringify({ data: 'test value ' }),
             inode: clickEvent.dataset.inode,
@@ -160,11 +162,11 @@ describe('DotBlockEditorSidebarComponent', () => {
 
     it('should display a toast on saving error', () => {
         const error404 = mockResponseView(404, '', null, {
-            errors: [{ message: 'An error occurred' }]
+            error: { message: 'An error occurred' }
         });
 
         dotEventsService.notify('edit-block-editor', clickEvent);
-        spyOn(dotGlobalMessageService, 'error').and.callThrough();
+        spyOn(dotAlertConfirmService, 'alert').and.callThrough();
         spyOn(dotWorkflowActionsFireService, 'saveContentlet').and.returnValue(
             throwError(error404)
         );
@@ -173,7 +175,7 @@ describe('DotBlockEditorSidebarComponent', () => {
         const updateBtn = de.query(By.css('[data-testId="updateBtn"]'));
         updateBtn.triggerEventHandler('click');
 
-        expect(dotGlobalMessageService.error).toHaveBeenCalledWith('An error occurred');
+        expect(dotAlertConfirmService.alert).toHaveBeenCalledTimes(1);
     });
 
     it('should close the sidebar', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.ts
@@ -6,9 +6,9 @@ import { Observable, of, Subject } from 'rxjs';
 import { DotBlockEditorComponent } from '@dotcms/block-editor';
 import { HttpErrorResponse } from '@angular/common/http';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
-import { DotGlobalMessageService } from '@components/_common/dot-global-message/dot-global-message.service';
 import { DotContentTypeService } from '@services/dot-content-type';
 import { DotCMSContentTypeField, DotCMSContentTypeFieldVariable } from '@dotcms/dotcms-models';
+import { DotAlertConfirmService } from '@dotcms/app/api/services/dot-alert-confirm';
 
 export interface BlockEditorInput {
     content: { [key: string]: string };
@@ -38,7 +38,7 @@ export class DotBlockEditorSidebarComponent implements OnInit, OnDestroy {
         private dotWorkflowActionsFireService: DotWorkflowActionsFireService,
         private dotEventsService: DotEventsService,
         private dotMessageService: DotMessageService,
-        private dotGlobalMessageService: DotGlobalMessageService,
+        private dotAlertConfirmService: DotAlertConfirmService,
         private dotContentTypeService: DotContentTypeService
     ) {}
 
@@ -77,13 +77,17 @@ export class DotBlockEditorSidebarComponent implements OnInit, OnDestroy {
                         detail: { name: 'in-iframe' }
                     });
                     window.top.document.dispatchEvent(customEvent);
-                    this.closeSidebar();
                 },
                 (e: HttpErrorResponse) => {
-                    const message =
-                        e.error.errors[0].message ||
-                        this.dotMessageService.get('editpage.inline.error');
-                    this.dotGlobalMessageService.error(message);
+                    this.saving = false;
+                    this.dotAlertConfirmService.alert({
+                        accept: () => {
+                            this.closeSidebar();
+                        },
+                        header: this.dotMessageService.get('error'),
+                        message:
+                            e.error?.message || this.dotMessageService.get('editpage.inline.error')
+                    });
                 }
             );
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.ts
@@ -77,6 +77,7 @@ export class DotBlockEditorSidebarComponent implements OnInit, OnDestroy {
                         detail: { name: 'in-iframe' }
                     });
                     window.top.document.dispatchEvent(customEvent);
+                    this.closeSidebar();
                 },
                 (e: HttpErrorResponse) => {
                     this.saving = false;


### PR DESCRIPTION
### Proposed Changes
* Feedback on error message when saving: 

<img width="450" alt="image" src="https://user-images.githubusercontent.com/31667212/192381547-f312e17e-e953-49e9-936b-6d1438603d06.png">
