### PR TITLE
Issue 22445 experiment targeting

### DIFF
--- a/dotCMS/src/curl-test/Experiments Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Experiments Resource.postman_collection.json
@@ -2787,6 +2787,290 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "pre_createExperiment",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var jsonData = pm.response.json();",
+							"",
+							"",
+							"pm.test(\"Status code should be ok 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.collectionVariables.set(\"experimentTargeting\", jsonData.entity[0].id);",
+							"",
+							"",
+							"",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin@dotcms.com",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"pageId\": \"e424abd7e2e7a9031c5a0a3c18182f1b\",\n    \"name\": \"20220901\",\n    \"description\": \"experiment with goals and variants\", \n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{serverURL}}/api/v1/experiments/",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"experiments",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "addTargetingConditions_shouldSucceed",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var jsonData = pm.response.json();",
+							"",
+							"",
+							"pm.test(\"Status code should be ok 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Experiment should have the expected values\", function () {",
+							"    pm.expect(jsonData.entity[0].goals.primary.type).equal(\"REACH_PAGE\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.name).equal(\"Reach thank-you page\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[0].operator).equal(\"EQUALS\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[0].parameter).equal(\"url\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[0].value).equal(\"thank-you\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[1].operator).equal(\"EQUALS\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[1].parameter).equal(\"referrer\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[1].value).equal(\"home\");",
+							"    pm.expect(jsonData.entity[0].targetingConditions.length).equal(3);",
+							"",
+							"});",
+							"",
+							"pm.collectionVariables.set(\"conditionId\", jsonData.entity[0].targetingConditions[0].id);",
+							"",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin@dotcms.com",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"targetingConditions\": [\n        {\n            \"conditionKey\": \"UsersBrowserConditionlet\",\n             \"values\": {\n                 \"comparison\": \"is\", \n                 \"browser\": \"Chrome\"\n             }   \n        }, \n        {\n            \"conditionKey\": \"UsersPlatformConditionlet\",\n             \"values\": {\n                 \"comparison\": \"is\", \n                 \"platform\": \"MOBILE\"\n             }   \n        }, \n        {\n            \"conditionKey\": \"VisitorsGeolocationConditionlet\",\n             \"values\": {\n                 \"comparison\": \"withinDistance\", \n                 \"latitude\": \"38.8977\", \n                 \"longitude\": \"-77.0365\", \n                 \"preferredDisplayUnits\": \"mi\", \n                 \"radius\": \"16191.182801892148\"\n             }   \n        }\n    ]\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{serverURL}}/api/v1/experiments/{{experimentTargeting}}",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"experiments",
+						"{{experimentTargeting}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "updateTargetingConditions_shouldSucceed",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var jsonData = pm.response.json();",
+							"",
+							"",
+							"pm.test(\"Status code should be ok 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Experiment should have the expected values\", function () {",
+							"    pm.expect(jsonData.entity[0].goals.primary.type).equal(\"REACH_PAGE\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.name).equal(\"Reach thank-you page\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[0].operator).equal(\"EQUALS\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[0].parameter).equal(\"url\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[0].value).equal(\"thank-you\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[1].operator).equal(\"EQUALS\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[1].parameter).equal(\"referrer\");",
+							"    pm.expect(jsonData.entity[0].goals.primary.conditions[1].value).equal(\"home\");",
+							"    pm.expect(jsonData.entity[0].targetingConditions.length).equal(3);",
+							"",
+							"});",
+							"",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin@dotcms.com",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"targetingConditions\": [\n        {\n            \"id\": \"{{conditionId}}\",\n            \"conditionKey\": \"UsersBrowserConditionlet\",\n             \"values\": {\n                 \"comparison\": \"is\", \n                 \"browser\": \"Firefox\"\n             }   \n        }\n    ]\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{serverURL}}/api/v1/experiments/{{experimentTargeting}}",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"experiments",
+						"{{experimentTargeting}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "deleteTargetingCondition_shouldSucceed",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var jsonData = pm.response.json();",
+							"",
+							"",
+							"pm.test(\"Started Experiment with expected values\", function () {",
+							"    pm.response.to.have.status(200);",
+							"    pm.expect(jsonData.entity[0].targetingConditions.length).equal(2);",
+							"});",
+							"",
+							"",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin@dotcms.com",
+							"type": "string"
+						}
+					]
+				},
+				"method": "DELETE",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{serverURL}}/api/v1/experiments/{{experimentTargeting}}/targetingConditions/{{conditionId}}",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"experiments",
+						"{{experimentTargeting}}",
+						"targetingConditions",
+						"{{conditionId}}"
+					]
+				}
+			},
+			"response": []
 		}
 	],
 	"variable": [
@@ -2824,6 +3108,14 @@
 		},
 		{
 			"key": "secondVariantId",
+			"value": ""
+		},
+		{
+			"key": "experimentTargeting",
+			"value": ""
+		},
+		{
+			"key": "conditionId",
 			"value": ""
 		}
 	]

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
@@ -104,4 +104,6 @@ public interface ExperimentsAPI {
      */
     Experiment deleteVariant(String experimentId, String variantName, User user)
             throws DotDataException, DotSecurityException;
+
+
 }

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
@@ -105,5 +105,11 @@ public interface ExperimentsAPI {
     Experiment deleteVariant(String experimentId, String variantName, User user)
             throws DotDataException, DotSecurityException;
 
+    /**
+     * Deletes the {@link com.dotcms.experiments.model.TargetingCondition} with the given id from
+     * the {@link Experiment} with the given id
+     */
 
+    Experiment deleteTargetingCondition(String experimentId, String conditionId, User user)
+            throws DotDataException, DotSecurityException;
 }

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -36,6 +36,7 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.rules.model.Condition;
 import com.dotmarketing.portlets.rules.model.ConditionGroup;
 import com.dotmarketing.portlets.rules.model.LogicalOperator;
+import com.dotmarketing.portlets.rules.model.ParameterModel;
 import com.dotmarketing.portlets.rules.model.Rule;
 import com.dotmarketing.portlets.rules.model.Rule.FireOn;
 import com.dotmarketing.util.Logger;
@@ -46,9 +47,10 @@ import io.vavr.control.Try;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -56,6 +58,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.persistence.ParameterMode;
 import org.jetbrains.annotations.NotNull;
 
 public class ExperimentsAPIImpl implements ExperimentsAPI {
@@ -141,20 +144,23 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
             experimentRule = createRuleAndConditionGroup(experiment, user);
         }
 
-        // transform TargetingConditions into conditions
+        // transform and save TargetingConditions into conditions
         experiment.targetingConditions().get().forEach((targetingCondition -> {
             createAndSaveCondition(user, experimentRule, targetingCondition);
         }));
 
     }
 
-    private void createAndSaveCondition(User user, Rule experimentRule, TargetingCondition targetingCondition) {
-        final Condition condition = new Condition();
-        condition.setConditionGroup(experimentRule.getGroups().get(0).getId());
+    private void createAndSaveCondition(User user, Rule experimentRule,
+            TargetingCondition targetingCondition) {
+        Condition condition = targetingCondition.id().isPresent()
+            ? Try.of(()->rulesAPI.getConditionById(targetingCondition.id().get(), user, false))
+                .getOrElseThrow(()->new IllegalArgumentException("Invalid targeting Condition Id provided. Id: " + targetingCondition.id().get()))
+            : createCondition(experimentRule, targetingCondition);
+
         condition.setOperator(targetingCondition.operator());
         condition.setConditionletId(targetingCondition.conditionKey());
-
-        // add all values using condition.addValue
+        condition.setValues(new ArrayList<>());
         targetingCondition.values().forEach(condition::addValue);
 
         condition.checkValid();
@@ -162,6 +168,13 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
         Try.run(()->rulesAPI.saveCondition(condition, user, false))
                 .getOrElseThrow(()->new DotStateException("Error saving Condition: "
                         + condition.getConditionletId()));
+    }
+
+    private Condition createCondition(final Rule experimentRule,
+            final TargetingCondition targetingCondition) {
+        final Condition condition = new Condition();
+        condition.setConditionGroup(experimentRule.getGroups().get(0).getId());
+        return condition;
     }
 
     @NotNull
@@ -192,17 +205,40 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
                 invalidLicenseMessageSupplier);
         DotPreconditions.checkArgument(UtilMethods.isSet(id), "Experiment Id is required");
 
-        final Optional<Experiment> experiment =  factory.find(id);
+        Optional<Experiment> experiment =  factory.find(id);
 
         if(experiment.isPresent()) {
             validatePermissions(user, experiment.get(),
                     "You don't have permission to get the Experiment. "
                             + "Experiment Id: " + experiment.get().id());
+
+            experiment = Optional.of(addTargetingConditions(experiment.get(), user));
         }
 
-//        addTargetingConditions
-
         return experiment;
+    }
+
+    private Experiment addTargetingConditions(final Experiment experiment, final User user) {
+        List<Rule> rules = Try.of(()->rulesAPI
+                        .getAllRulesByParent(experiment, user, false))
+                .getOrElse(Collections::emptyList);
+
+        if(!UtilMethods.isSet(rules)) {
+            return experiment;
+        }
+
+        final Rule experimentRule = rules.get(0);
+        final List<TargetingCondition> targetingConditions = new ArrayList<>();
+        experimentRule.getGroups().get(0).getConditions().forEach((condition -> {
+            targetingConditions.add(TargetingCondition.builder()
+                    .id(condition.getId())
+                    .conditionKey(condition.getConditionletId())
+                    .putAllValues(condition.getValues().stream().collect(Collectors.toMap(
+                            ParameterModel::getKey, ParameterModel::getValue)))
+                    .build());
+        }));
+
+        return experiment.withTargetingConditions(targetingConditions);
     }
 
     @Override
@@ -414,6 +450,27 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
         variantAPI.archive(toDelete.name());
         variantAPI.delete(toDelete.name());
         return fromDB;
+
+    }
+
+    @Override
+    public Experiment deleteTargetingCondition(String experimentId, String conditionId, User user)
+            throws DotDataException, DotSecurityException {
+        final Experiment persistedExperiment = find(experimentId, user)
+                .orElseThrow(()->new DoesNotExistException("Experiment with provided id not found"));
+
+        DotPreconditions.isTrue(persistedExperiment.id().isPresent(), "Invalid Experiment");
+
+        DotPreconditions.isTrue(UtilMethods.isSet(conditionId), ()->"Invalid Variant provided",
+                IllegalArgumentException.class);
+
+        final Condition conditionToDelete = rulesAPI.getConditionById(conditionId, user, false);
+        rulesAPI.deleteCondition(conditionToDelete, user, false);
+
+        final Optional<Experiment> toReturn = find(persistedExperiment.id().get(), user);
+        DotPreconditions.isTrue(toReturn.isPresent(), "Experiment not found");
+
+        return toReturn.get();
 
     }
 

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -50,7 +50,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -58,7 +57,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.persistence.ParameterMode;
 import org.jetbrains.annotations.NotNull;
 
 public class ExperimentsAPIImpl implements ExperimentsAPI {
@@ -187,7 +185,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
         experimentRule.setName(experiment.name());
         experimentRule.setFireOn(FireOn.EVERY_PAGE);
         experimentRule.setEnabled(true);
-        rulesAPI.saveRuleNoParentCheck(experimentRule, user, false);
+        rulesAPI.saveRule(experimentRule, user, false);
 
         final ConditionGroup conditionGroup = new ConditionGroup();
         conditionGroup.setRuleId(experimentRule.getId());

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -57,7 +57,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.jetbrains.annotations.NotNull;
 
 public class ExperimentsAPIImpl implements ExperimentsAPI {
 
@@ -143,9 +142,9 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
         }
 
         // transform and save TargetingConditions into conditions
-        experiment.targetingConditions().get().forEach((targetingCondition -> {
+        experiment.targetingConditions().get().forEach(targetingCondition -> {
             createAndSaveCondition(user, experimentRule, targetingCondition);
-        }));
+        });
 
     }
 
@@ -175,7 +174,6 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
         return condition;
     }
 
-    @NotNull
     private Rule createRuleAndConditionGroup(Experiment experiment, User user)
             throws DotDataException, DotSecurityException {
         DotPreconditions.isTrue(experiment.id().isPresent(), ()->"Error saving Experiment Targeting");
@@ -451,6 +449,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
     }
 
     @Override
+    @WrapInTransaction
     public Experiment deleteTargetingCondition(String experimentId, String conditionId, User user)
             throws DotDataException, DotSecurityException {
         final Experiment persistedExperiment = find(experimentId, user)

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -182,8 +182,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
             throws DotDataException, DotSecurityException {
         DotPreconditions.isTrue(experiment.id().isPresent(), ()->"Error saving Experiment Targeting");
 
-        Rule experimentRule;
-        experimentRule = new Rule();
+        final Rule experimentRule = new Rule();
         experimentRule.setParent(experiment.id().get());
         experimentRule.setName(experiment.name());
         experimentRule.setFireOn(FireOn.EVERY_PAGE);

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -2,13 +2,13 @@ package com.dotcms.experiments.business;
 
 import static com.dotcms.experiments.model.AbstractExperiment.Status.DRAFT;
 import static com.dotcms.experiments.model.AbstractExperiment.Status.ENDED;
-import static com.dotcms.experiments.model.AbstractExperimentVariant.EXPERIMENT_VARIANT_DESCRIPTION;
 import static com.dotcms.experiments.model.AbstractExperimentVariant.EXPERIMENT_VARIANT_NAME_PREFIX;
 import static com.dotcms.experiments.model.AbstractExperimentVariant.EXPERIMENT_VARIANT_NAME_SUFFIX;
 
 import com.dotcms.analytics.metrics.MetricsUtil;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
+import com.dotcms.enterprise.rules.RulesAPI;
 import com.dotcms.experiments.model.AbstractExperiment.Status;
 import com.dotcms.experiments.model.AbstractTrafficProportion.Type;
 import com.dotcms.experiments.model.Experiment;
@@ -55,6 +55,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
     final ContentletAPI contentletAPI = APILocator.getContentletAPI();
     final VariantAPI variantAPI = APILocator.getVariantAPI();
     final ShortyIdAPI shortyIdAPI = APILocator.getShortyAPI();
+    final RulesAPI rulesAPI = APILocator.getRulesAPI();
 
     private final LicenseValiditySupplier licenseValiditySupplierSupplier =
             new LicenseValiditySupplier() {};
@@ -95,9 +96,19 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
             MetricsUtil.INSTANCE.validateGoals(experiment.goals().get());
         }
 
+        if(experiment.targetingConditions().isPresent()) {
+            saveTargetingConditions(experiment);
+        }
+
         final Experiment experimentToSave = builder.build();
 
         return factory.save(experimentToSave);
+    }
+
+    private void saveTargetingConditions(final Experiment experiment) {
+        if(experiment.targetingConditions().isPresent()) {
+            rulesAPI.getAllRulesByParent(experiment)
+        }
     }
 
     @CloseDBIfOpened

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsFactory.java
@@ -13,7 +13,7 @@ public interface ExperimentsFactory {
     /**
      * Saves the provided Experiment in the persistence layer
      */
-    Experiment save(final Experiment experiment) throws DotDataException;
+    void save(final Experiment experiment) throws DotDataException;
 
     /**
      * Deletes the provided Experiment from the persistence layer

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsFactoryImpl.java
@@ -40,17 +40,12 @@ public class ExperimentsFactoryImpl implements
     public static final String STATUS_FILTER = "SELECT * from experiment WHERE status = ?";
 
     @Override
-    public Experiment save(Experiment experiment) throws DotDataException {
-        String experimentId = experiment.id().isEmpty() || find(experiment.id().get()).isEmpty()
-            ? insertInDB(experiment)
-            : updateInDB(experiment);
-
-        final Optional<Experiment> saved = find(experimentId);
-
-        if(saved.isEmpty()) {
-            throw new DotDataException("Unable to retrieve saved/updated Experiment");
+    public void save(Experiment experiment) throws DotDataException {
+        if(experiment.id().isEmpty() || find(experiment.id().get()).isEmpty()) {
+             insertInDB(experiment);
+        } else {
+            updateInDB(experiment);
         }
-        return experiment;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsFactoryImpl.java
@@ -50,8 +50,7 @@ public class ExperimentsFactoryImpl implements
         if(saved.isEmpty()) {
             throw new DotDataException("Unable to retrieve saved/updated Experiment");
         }
-
-        return saved.get();
+        return experiment;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
@@ -2,9 +2,17 @@ package com.dotcms.experiments.model;
 
 import com.dotcms.publisher.util.PusheableAsset;
 import com.dotcms.publishing.manifest.ManifestItem;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.PermissionSummary;
+import com.dotmarketing.business.Permissionable;
+import com.dotmarketing.business.RelatedPermissionableGroup;
+import com.dotmarketing.business.Ruleable;
+import com.dotmarketing.exception.DotDataException;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vavr.control.Try;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -21,7 +29,7 @@ import org.immutables.value.Value;
  */
 @Value.Style(typeImmutable="*", typeAbstract="Abstract*")
 @Value.Immutable
-public interface AbstractExperiment extends Serializable, ManifestItem {
+public interface AbstractExperiment extends Serializable, ManifestItem, Ruleable {
     @JsonProperty("name")
     String name();
 
@@ -78,6 +86,51 @@ public interface AbstractExperiment extends Serializable, ManifestItem {
 
     @JsonProperty("targetingConditions")
     Optional<List<TargetingCondition>> targetingConditions();
+
+    // Beginning Permissionable methods
+
+    default String getIdentifier() {
+        return id().orElse("");
+    }
+
+    default String getPermissionId() {
+        return id().orElse("");
+    }
+
+    default String getOwner() {
+        return createdBy();
+    }
+
+    @Value.Derived
+    default void setOwner(String owner){
+
+    }
+
+    @Value.Derived
+    default List<PermissionSummary> acceptedPermissions () {
+        return Collections.emptyList();
+    }
+
+    @Value.Derived
+    default List<RelatedPermissionableGroup> permissionDependencies(int requiredPermission) {
+        return Collections.emptyList();
+    }
+
+    @Value.Derived
+    default Permissionable getParentPermissionable() {
+        return Try.of(()->APILocator.getContentletAPI().findContentletByIdentifierAnyLanguage(pageId()))
+                .getOrNull();
+    }
+
+    @Value.Derived
+    default String getPermissionType() {
+        return this.getClass().getCanonicalName();
+    }
+
+    @Value.Derived
+    default boolean isParentPermissionable() {
+        return false;
+    }
 
     @Value.Derived
     @Override

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
@@ -8,6 +8,7 @@ import com.dotmarketing.business.Permissionable;
 import com.dotmarketing.business.RelatedPermissionableGroup;
 import com.dotmarketing.business.Ruleable;
 import com.dotmarketing.exception.DotDataException;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vavr.control.Try;
 import java.io.Serializable;
@@ -89,14 +90,17 @@ public interface AbstractExperiment extends Serializable, ManifestItem, Ruleable
 
     // Beginning Permissionable methods
 
+    @Value.Derived
     default String getIdentifier() {
         return id().orElse("");
     }
 
+    @Value.Derived
     default String getPermissionId() {
         return id().orElse("");
     }
 
+    @Value.Derived
     default String getOwner() {
         return createdBy();
     }
@@ -105,7 +109,6 @@ public interface AbstractExperiment extends Serializable, ManifestItem, Ruleable
     default void setOwner(String owner){
 
     }
-
     @Value.Derived
     default List<PermissionSummary> acceptedPermissions () {
         return Collections.emptyList();

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
@@ -5,6 +5,7 @@ import com.dotcms.publishing.manifest.ManifestItem;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -74,6 +75,9 @@ public interface AbstractExperiment extends Serializable, ManifestItem {
 
     @JsonProperty("goals")
     Optional<Goals> goals();
+
+    @JsonProperty("targetingConditions")
+    Optional<List<TargetingCondition>> targetingConditions();
 
     @Value.Derived
     @Override

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractTargetingCondition.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractTargetingCondition.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.Serializable;
+import java.util.Map;
 import org.immutables.value.Value;
 
 @Value.Style(typeImmutable="*", typeAbstract="Abstract*")
@@ -15,11 +16,8 @@ public interface AbstractTargetingCondition extends Serializable {
     @JsonProperty("conditionKey")
     String conditionKey();
 
-    @JsonProperty("comparison")
-    String comparison();
-
-    @JsonProperty("value")
-    String value();
+    @JsonProperty("values")
+    Map<String, String> values();
 
     @JsonProperty("operator")
     @Value.Default

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractTargetingCondition.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractTargetingCondition.java
@@ -1,0 +1,29 @@
+package com.dotcms.experiments.model;
+
+import com.dotmarketing.portlets.rules.model.LogicalOperator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.Serializable;
+import org.immutables.value.Value;
+
+@Value.Style(typeImmutable="*", typeAbstract="Abstract*")
+@Value.Immutable
+@JsonSerialize(as = TargetingCondition.class)
+@JsonDeserialize(as = TargetingCondition.class)
+public interface AbstractTargetingCondition extends Serializable {
+    @JsonProperty("conditionKey")
+    String conditionKey();
+
+    @JsonProperty("comparison")
+    String comparison();
+
+    @JsonProperty("value")
+    String value();
+
+    @JsonProperty("operator")
+    @Value.Default
+    default LogicalOperator operator() {
+        return LogicalOperator.AND;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractTargetingCondition.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractTargetingCondition.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Style(typeImmutable="*", typeAbstract="Abstract*")
@@ -13,6 +14,9 @@ import org.immutables.value.Value;
 @JsonSerialize(as = TargetingCondition.class)
 @JsonDeserialize(as = TargetingCondition.class)
 public interface AbstractTargetingCondition extends Serializable {
+    @JsonProperty("id")
+    Optional<String> id();
+
     @JsonProperty("conditionKey")
     String conditionKey();
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/experiments/ExperimentForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/experiments/ExperimentForm.java
@@ -2,11 +2,14 @@ package com.dotcms.rest.api.v1.experiments;
 
 import com.dotcms.experiments.model.Goals;
 import com.dotcms.experiments.model.Scheduling;
+import com.dotcms.experiments.model.TargetingCondition;
 import com.dotcms.experiments.model.TrafficProportion;
 import com.dotcms.repackage.javax.validation.constraints.Size;
 import com.dotcms.rest.api.Validated;
 import com.dotmarketing.business.APILocator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * From to create/update an {@link com.dotcms.experiments.model.Experiment} from REST
@@ -23,6 +26,7 @@ public class ExperimentForm extends Validated {
     private final TrafficProportion trafficProportion;
     private final Scheduling scheduling;
     private final Goals goals;
+    private final List<TargetingCondition> targetingConditions;
 
     private ExperimentForm(final Builder builder) {
         this.name = builder.name;
@@ -32,6 +36,7 @@ public class ExperimentForm extends Validated {
         this.trafficProportion = builder.trafficProportion;
         this.scheduling = builder.scheduling;
         this.goals = builder.goals;
+        this.targetingConditions = builder.targetingConditions;
         checkValid();
     }
 
@@ -68,6 +73,10 @@ public class ExperimentForm extends Validated {
         return goals;
     }
 
+    public List<TargetingCondition> getTargetingConditions() {
+        return targetingConditions;
+    }
+
     public static final class Builder {
         private String name;
         private String description;
@@ -76,6 +85,7 @@ public class ExperimentForm extends Validated {
         private TrafficProportion trafficProportion;
         private Scheduling scheduling;
         private Goals goals;
+        private List<TargetingCondition> targetingConditions = new ArrayList<>();
 
         private Builder() {
         }
@@ -116,6 +126,11 @@ public class ExperimentForm extends Validated {
 
         public Builder withGoals(Goals goals) {
             this.goals = goals;
+            return this;
+        }
+
+        public Builder withTargetingConditions(List<TargetingCondition> targetingConditions) {
+            this.targetingConditions = targetingConditions;
             return this;
         }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/experiments/ExperimentsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/experiments/ExperimentsResource.java
@@ -322,6 +322,31 @@ public class ExperimentsResource {
         return new ResponseEntityExperimentView(Collections.singletonList(updatedExperiment));
     }
 
+    /**
+     * Adds a new {@link com.dotcms.experiments.model.TargetingCondition} to the {@link Experiment}
+     *
+     */
+    @POST
+    @Path("/{experimentId}/targetingCondition")
+    @JSONP
+    @NoCache
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
+    public ResponseEntityExperimentView addTargetingCondition(@Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @PathParam("experimentId") final String experimentId,
+            AddVariantForm addVariantForm) throws DotDataException, DotSecurityException {
+
+        DotPreconditions.isTrue(addVariantForm!=null, ()->"Missing Variant name",
+                IllegalArgumentException.class);
+
+        final InitDataObject initData = getInitData(request, response);
+        final User user = initData.getUser();
+        final Experiment updatedExperiment =  experimentsAPI.addVariant(experimentId,
+                addVariantForm.getName(), user);
+        return new ResponseEntityExperimentView(Collections.singletonList(updatedExperiment));
+    }
+
     private Experiment patchExperiment(final Experiment experimentToUpdate,
             final ExperimentForm experimentForm, final User user) {
 
@@ -349,6 +374,10 @@ public class ExperimentsResource {
 
         if(experimentForm.getGoals()!=null) {
             builder.goals(experimentForm.getGoals());
+        }
+
+        if(experimentForm.getTargetingConditions()!=null) {
+            builder.targetingConditions(experimentForm.getTargetingConditions());
         }
 
         return builder.build();

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/experiments/ExperimentsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/experiments/ExperimentsResource.java
@@ -5,6 +5,7 @@ import com.dotcms.experiments.business.ExperimentsAPI;
 import com.dotcms.experiments.model.AbstractExperiment.Status;
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.experiments.model.Scheduling;
+import com.dotcms.experiments.model.TargetingCondition;
 import com.dotcms.rest.InitDataObject;
 import com.dotcms.rest.PATCH;
 import com.dotcms.rest.ResponseEntityView;
@@ -319,31 +320,6 @@ public class ExperimentsResource {
         final InitDataObject initData = getInitData(request, response);
         final User user = initData.getUser();
         final Experiment updatedExperiment =  experimentsAPI.deleteVariant(experimentId, variantName, user);
-        return new ResponseEntityExperimentView(Collections.singletonList(updatedExperiment));
-    }
-
-    /**
-     * Adds a new {@link com.dotcms.experiments.model.TargetingCondition} to the {@link Experiment}
-     *
-     */
-    @POST
-    @Path("/{experimentId}/targetingCondition")
-    @JSONP
-    @NoCache
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
-    public ResponseEntityExperimentView addTargetingCondition(@Context final HttpServletRequest request,
-            @Context final HttpServletResponse response,
-            @PathParam("experimentId") final String experimentId,
-            AddVariantForm addVariantForm) throws DotDataException, DotSecurityException {
-
-        DotPreconditions.isTrue(addVariantForm!=null, ()->"Missing Variant name",
-                IllegalArgumentException.class);
-
-        final InitDataObject initData = getInitData(request, response);
-        final User user = initData.getUser();
-        final Experiment updatedExperiment =  experimentsAPI.addVariant(experimentId,
-                addVariantForm.getName(), user);
         return new ResponseEntityExperimentView(Collections.singletonList(updatedExperiment));
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/experiments/ExperimentsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/experiments/ExperimentsResource.java
@@ -323,6 +323,26 @@ public class ExperimentsResource {
         return new ResponseEntityExperimentView(Collections.singletonList(updatedExperiment));
     }
 
+    /**
+     * Deletes the {@link TargetingCondition} with the given id from the {@link Experiment} with the given experimentId
+     *
+     */
+    @DELETE
+    @Path("/{experimentId}/targetingConditions/{id}")
+    @JSONP
+    @NoCache
+    @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
+    public ResponseEntityExperimentView deleteTargetingCondition(@Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @PathParam("experimentId") final String experimentId,
+            @PathParam("id") final String conditionId) throws DotDataException, DotSecurityException {
+        final InitDataObject initData = getInitData(request, response);
+        final User user = initData.getUser();
+        final Experiment updatedExperiment =  experimentsAPI
+                .deleteTargetingCondition(experimentId, conditionId, user);
+        return new ResponseEntityExperimentView(Collections.singletonList(updatedExperiment));
+    }
+
     private Experiment patchExperiment(final Experiment experimentToUpdate,
             final ExperimentForm experimentForm, final User user) {
 

--- a/dotCMS/src/main/java/com/dotmarketing/business/Ruleable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/Ruleable.java
@@ -1,7 +1,5 @@
 package com.dotmarketing.business;
 
 public interface Ruleable extends Permissionable{
-
-	public String getIdentifier();
-
+	String getIdentifier();
 }


### PR DESCRIPTION
Includes the ability to add, edit, or delete Targeting Conditions to Experiments via REST. 
It uses existing Rules under the covers. 
It basically creates one rule per experiment with one condition group and N conditions. 
A TargetingCondition immutable was created in order to abstract what's needed from the Experiments point of view. 
Includes postman tests. 