### PR TITLE
dotCMS/core#22861 Have better Tool icon fallbacks if no icon is selected. 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.html
@@ -1,16 +1,21 @@
 <div class="dot-nav__title">
     <div
+        class="dot-nav__item"
+        [class.dot-nav__item--active]="data.active"
         (click)="clickHandler($event, data)"
         (mouseenter)="setSubMenuPosition()"
-        [class.dot-nav__item--active]="data.active"
         appendTo="target"
-        class="dot-nav__item"
     >
-        <dot-nav-icon [icon]="data.tabIcon" aria-hidden="true"></dot-nav-icon>
+        <dot-nav-icon
+            [icon]="
+                data.tabIcon === labelImportantIcon ? (data.tabName | dotRandomIcon) : data.tabIcon
+            "
+            aria-hidden="true"
+        ></dot-nav-icon>
         <span class="dot-nav__item-label">{{ data.tabName }}</span>
         <dot-icon
-            aria-hidden="true"
             class="dot-nav__item-arrow"
+            aria-hidden="true"
             name="{{ data.isOpen ? 'arrow_drop_down' : 'arrow_drop_up' }}"
         >
         </dot-icon>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts
@@ -83,7 +83,7 @@ describe('DotNavItemComponent', () => {
         fixtureHost.detectChanges();
         const icon: DebugElement = de.query(By.css('dot-nav-icon'));
 
-        expect(icon.componentInstance.icon).not.toBe('icon');
+        expect(icon.componentInstance.icon).not.toBe(LABEL_IMPORTANT_ICON);
     });
 
     it('should emit menuClick when nav__item is clicked', () => {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts
@@ -11,6 +11,8 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { dotMenuMock } from '../../services/dot-navigation.service.spec';
 import { DotMenu } from '@models/navigation';
 import { TooltipModule } from 'primeng/tooltip';
+import { LABEL_IMPORTANT_ICON } from '@pipes/dot-radom-icon/dot-random-icon.pipe';
+import { DotRandomIconPipeModule } from '@pipes/dot-radom-icon/dot-random-icon.pipe.module';
 
 @Component({
     selector: 'dot-test-host-component',
@@ -33,20 +35,19 @@ describe('DotNavItemComponent', () => {
     let navItem: DebugElement;
     let subNav: DebugElement;
 
-    beforeEach(
-        waitForAsync(() => {
-            TestBed.configureTestingModule({
-                declarations: [TestHostComponent, DotNavItemComponent, DotSubNavComponent],
-                imports: [
-                    DotNavIconModule,
-                    DotIconModule,
-                    RouterTestingModule,
-                    BrowserAnimationsModule,
-                    TooltipModule
-                ]
-            }).compileComponents();
-        })
-    );
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestHostComponent, DotNavItemComponent, DotSubNavComponent],
+            imports: [
+                DotNavIconModule,
+                DotIconModule,
+                RouterTestingModule,
+                BrowserAnimationsModule,
+                TooltipModule,
+                DotRandomIconPipeModule
+            ]
+        }).compileComponents();
+    }));
 
     beforeEach(() => {
         fixtureHost = TestBed.createComponent(TestHostComponent);
@@ -75,6 +76,14 @@ describe('DotNavItemComponent', () => {
 
         expect(icon.componentInstance.icon).toBe('icon');
         expect(arrow.componentInstance.name).toBe('arrow_drop_up');
+    });
+
+    it('should avoid label_important icon', () => {
+        componentHost.menu.tabIcon = LABEL_IMPORTANT_ICON;
+        fixtureHost.detectChanges();
+        const icon: DebugElement = de.query(By.css('dot-nav-icon'));
+
+        expect(icon.componentInstance.icon).not.toBe('icon');
     });
 
     it('should emit menuClick when nav__item is clicked', () => {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { DotMenu, DotMenuItem } from '@models/navigation';
 import { DotSubNavComponent } from '../dot-sub-nav/dot-sub-nav.component';
+import { LABEL_IMPORTANT_ICON } from '@pipes/dot-radom-icon/dot-random-icon.pipe';
 
 @Component({
     selector: 'dot-nav-item',
@@ -35,6 +36,7 @@ export class DotNavItemComponent {
     mainHeaderHeight = 60;
 
     private windowHeight = window.innerHeight;
+    labelImportantIcon = LABEL_IMPORTANT_ICON;
 
     constructor(private hostElRef: ElementRef) {}
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/dot-navigation.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/dot-navigation.module.ts
@@ -10,6 +10,7 @@ import { DotSubNavComponent } from './components/dot-sub-nav/dot-sub-nav.compone
 import { DotNavItemComponent } from './components/dot-nav-item/dot-nav-item.component';
 import { TooltipModule } from 'primeng/tooltip';
 import { DotOverlayMaskModule } from '@components/_common/dot-overlay-mask/dot-overlay-mask.module';
+import { DotRandomIconPipeModule } from '@pipes/dot-radom-icon/dot-random-icon.pipe.module';
 
 @NgModule({
     imports: [
@@ -18,7 +19,8 @@ import { DotOverlayMaskModule } from '@components/_common/dot-overlay-mask/dot-o
         DotNavIconModule,
         DotIconModule,
         TooltipModule,
-        DotOverlayMaskModule
+        DotOverlayMaskModule,
+        DotRandomIconPipeModule
     ],
     declarations: [DotNavigationComponent, DotSubNavComponent, DotNavItemComponent],
     providers: [DotNavigationService],

--- a/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DotRandomIconPipe } from '@pipes/dot-radom-icon/dot-random-icon.pipe';
+
+@NgModule({
+    imports: [CommonModule],
+    declarations: [DotRandomIconPipe],
+    exports: [DotRandomIconPipe]
+})
+export class DotRandomIconPipeModule {}

--- a/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.spec.ts
@@ -1,0 +1,10 @@
+import { DotRandomIconPipe } from './dot-random-icon.pipe';
+
+fdescribe('DotRandomIconPipe', () => {
+    it('should return a random icon', () => {
+        const randomText = 'Content';
+        const pipe = new DotRandomIconPipe();
+
+        expect(pipe.transform(randomText)).toEqual('grid_view');
+    });
+});

--- a/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.spec.ts
@@ -1,6 +1,6 @@
 import { DotRandomIconPipe } from './dot-random-icon.pipe';
 
-fdescribe('DotRandomIconPipe', () => {
+describe('DotRandomIconPipe', () => {
     it('should return a random icon', () => {
         const randomText = 'Content';
         const pipe = new DotRandomIconPipe();

--- a/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.ts
@@ -35,6 +35,7 @@ export class DotRandomIconPipe implements PipeTransform {
             hash = (hash << 5) - hash + char.charCodeAt(0);
             hash |= 0;
         });
+
         return Math.abs(hash) % 19;
     }
 

--- a/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.ts
@@ -1,0 +1,44 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+export const LABEL_IMPORTANT_ICON = 'label_important';
+
+@Pipe({
+    name: 'dotRandomIcon'
+})
+export class DotRandomIconPipe implements PipeTransform {
+    iconsArray = [
+        'grid_view',
+        'settings',
+        'format_align_left',
+        'folder_open',
+        'file_copy',
+        'settings_ethernet',
+        'dashboard',
+        'double_arrow',
+        'window',
+        'adjust',
+        'api',
+        'apps',
+        'blur_on',
+        'code',
+        'equalizer',
+        'wysiwyg',
+        'stream',
+        'storage',
+        'schema',
+        'poll'
+    ];
+
+    hasCode(value: string): number {
+        let hash = 0;
+        [...value].forEach((char) => {
+            hash = (hash << 5) - hash + char.charCodeAt(0);
+            hash |= 0;
+        });
+        return Math.abs(hash) % 19;
+    }
+
+    transform(value: string): string {
+        return this.iconsArray[this.hasCode(value)];
+    }
+}

--- a/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.ts
@@ -2,6 +2,8 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 export const LABEL_IMPORTANT_ICON = 'label_important';
 
+// the 'label_important' icon is not supported as a valid icon, instead the system will randomly assign a new icon
+// The reference id the icon comes from this file: Task210316UpdateLayoutIcons.java
 @Pipe({
     name: 'dotRandomIcon'
 })
@@ -29,7 +31,7 @@ export class DotRandomIconPipe implements PipeTransform {
         'poll'
     ];
 
-    hasCode(value: string): number {
+    private hasCode(value: string): number {
         let hash = 0;
         [...value].forEach((char) => {
             hash = (hash << 5) - hash + char.charCodeAt(0);

--- a/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/pipes/dot-radom-icon/dot-random-icon.pipe.ts
@@ -3,7 +3,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export const LABEL_IMPORTANT_ICON = 'label_important';
 
 // the 'label_important' icon is not supported as a valid icon, instead the system will randomly assign a new icon
-// The reference id the icon comes from this file: Task210316UpdateLayoutIcons.java
+// The reference of the icon comes from this file: Task210316UpdateLayoutIcons.java
 @Pipe({
     name: 'dotRandomIcon'
 })

--- a/core-web/libs/dotcms-webcomponents/src/elements/dot-material-icon-picker/dot-material-icon-picker.tsx
+++ b/core-web/libs/dotcms-webcomponents/src/elements/dot-material-icon-picker/dot-material-icon-picker.tsx
@@ -11,6 +11,7 @@ import {
 } from '@stencil/core';
 import { MaterialIconClasses } from './material-icon-classes';
 import '@material/mwc-icon';
+import { LABEL_IMPORTANT_ICON } from '@pipes/dot-radom-icon/dot-random-icon.pipe';
 
 @Component({
     tag: 'dot-material-icon-picker',
@@ -193,7 +194,7 @@ export class DotMaterialIcon {
                             class="dot-material-icon__preview"
                             style={{ color: this.colorValue }}
                         >
-                            {this.value}
+                            {this.value === LABEL_IMPORTANT_ICON ? '' : this.value}
                         </mwc-icon>
                         <input
                             class="dot-material-icon__input"

--- a/core-web/libs/dotcms-webcomponents/src/elements/dot-material-icon-picker/material-icon-classes.tsx
+++ b/core-web/libs/dotcms-webcomponents/src/elements/dot-material-icon-picker/material-icon-classes.tsx
@@ -865,7 +865,6 @@ export const MaterialIconClasses = [
     'kitchen',
     'kitesurfing',
     'label',
-    'label_important',
     'label_off',
     'landscape',
     'language',


### PR DESCRIPTION
### Proposed Changes
* If the menu icon is set to `label_important` the system will randomly assign an icon to that group, based on the Name 
* `label_important` should not be placed as menu icon.  
