### PR TITLE
Issue 22963 highlight star icon on create fav page

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.spec.ts
@@ -17,8 +17,8 @@ import { DotPageRender } from '@dotcms/app/shared/models/dot-page/dot-rendered-p
 import { mockDotRenderedPage } from '@dotcms/app/test/dot-page-render.mock';
 import { DotPageRenderState } from '../../shared/models';
 import { MultiSelectModule } from 'primeng/multiselect';
-import { of } from 'rxjs';
-import { DotFavoritePageStore } from './store/dot-favorite-page.store';
+import { DotFavoritePageActionState, DotFavoritePageStore } from './store/dot-favorite-page.store';
+import { of } from 'rxjs/internal/observable/of';
 @Component({
     selector: 'dot-form-dialog',
     template: '<ng-content></ng-content>',
@@ -61,6 +61,9 @@ const storeMock = {
     get closeDialog$() {
         return of(false);
     },
+    get actionState$() {
+        return of(null);
+    },
     setLoading: jasmine.createSpy(),
     setLoaded: jasmine.createSpy(),
     setInitialStateData: jasmine.createSpy(),
@@ -72,7 +75,8 @@ const storeMock = {
         imgWidth: 1024,
         imgHeight: 768.192048012003,
         loading: false,
-        closeDialog: false
+        closeDialog: false,
+        actionState: null
     })
 };
 
@@ -82,6 +86,7 @@ describe('DotFavoritePageComponent', () => {
     let component: DotFavoritePageComponent;
     let injector: TestBed;
     let dialogRef: DynamicDialogRef;
+    let dialogConfig: DynamicDialogConfig;
     let store: DotFavoritePageStore;
 
     beforeEach(() => {
@@ -124,7 +129,8 @@ describe('DotFavoritePageComponent', () => {
                             page: {
                                 pageState: mockRenderedPageState,
                                 pageRenderedHtml: '<p>test</p>'
-                            }
+                            },
+                            onSave: jasmine.createSpy()
                         }
                     }
                 }
@@ -141,171 +147,190 @@ describe('DotFavoritePageComponent', () => {
         injector = getTestBed();
 
         dialogRef = injector.inject(DynamicDialogRef);
-
-        fixture.detectChanges();
+        dialogConfig = TestBed.inject(DynamicDialogConfig);
     });
 
-    describe('HTML', () => {
-        it('should setup <form> class', () => {
-            const form = de.query(By.css('[data-testId="form"]'));
-            expect(form.classes['p-fluid']).toBe(true);
-        });
-
-        describe('fields', () => {
-            it('should setup thumbnail preview', () => {
-                const field = de.query(By.css('[data-testId="thumbnailField"]'));
-                const label = field.query(By.css('label'));
-                const webcomponent = field.query(By.css('dot-html-to-image'));
-
-                expect(field.classes['field']).toBe(true);
-
-                expect(label.classes['p-label-input-required']).toBe(true);
-                expect(label.attributes.for).toBe('previewThumbnail');
-                expect(label.nativeElement.textContent).toBe('Preview');
-
-                expect(webcomponent.attributes['ng-reflect-height']).toBe('768.192048012003');
-                expect(webcomponent.attributes['ng-reflect-width']).toBe('1024');
-            });
-
-            it('should setup title', () => {
-                const field = de.query(By.css('[data-testId="titleField"]'));
-                const label = field.query(By.css('label'));
-                const input = field.query(By.css('input'));
-                const message = field.query(By.css('dot-field-validation-message'));
-
-                expect(field.classes['field']).toBe(true);
-
-                expect(label.classes['p-label-input-required']).toBe(true);
-                expect(label.attributes.for).toBe('title');
-                expect(label.nativeElement.textContent).toBe('Title');
-
-                expect(input.attributes.autofocus).toBeDefined();
-                expect(input.attributes.pInputText).toBeDefined();
-                expect(input.attributes.formControlName).toBe('title');
-                expect(input.attributes.id).toBe('title');
-
-                expect(message).toBeDefined();
-            });
-
-            it('should setup url', () => {
-                const field = de.query(By.css('[data-testId="urlField"]'));
-                const label = field.query(By.css('label'));
-                const input = field.query(By.css('input'));
-                const message = field.query(By.css('dot-field-validation-message'));
-
-                expect(field.classes['field']).toBe(true);
-
-                expect(label.attributes.for).toBe('url');
-                expect(label.nativeElement.textContent).toBe('Url');
-
-                expect(input.attributes.pInputText).toBeDefined();
-                expect(input.attributes.formControlName).toBe('url');
-                expect(input.attributes.id).toBe('url');
-
-                expect(message).toBeDefined();
-            });
-
-            it('should setup order', () => {
-                const field = de.query(By.css('[data-testId="orderField"]'));
-                const label = field.query(By.css('label'));
-                const input = field.query(By.css('input'));
-                const message = field.query(By.css('dot-field-validation-message'));
-
-                expect(field.classes['field']).toBe(true);
-
-                expect(label.attributes.for).toBe('order');
-                expect(label.nativeElement.textContent).toBe('Order');
-
-                expect(input.attributes.pInputText).toBeDefined();
-                expect(input.attributes.formControlName).toBe('order');
-                expect(input.attributes.id).toBe('order');
-
-                expect(message).toBeDefined();
-            });
-
-            it('should setup permissions', () => {
-                const field = de.query(By.css('[data-testId="shareWithField"]'));
-                const label = field.query(By.css('label'));
-                const selector = field.query(By.css('p-multiSelect'));
-
-                expect(field.classes['field']).toBe(true);
-
-                expect(label.attributes.for).toBe('permissions');
-                expect(label.nativeElement.textContent).toBe('Share With');
-
-                expect(selector.attributes.formControlName).toBe('permissions');
-                expect(selector.attributes.id).toBe('permissions');
-            });
-        });
-    });
-
-    describe('form', () => {
-        it('should get value from config and set initial data on store', () => {
-            expect(component.form.value).toEqual({
-                currentUserRoleId: '1',
-                thumbnail: null,
-                title: 'A title',
-                url: '/an/url/test?language_id=1',
-                order: 1,
-                permissions: null
-            });
-
-            expect(store.setInitialStateData).toHaveBeenCalled();
-        });
-
-        it('should be invalid by default', () => {
-            expect(component.form.valid).toBe(false);
-        });
-
-        it('should be valid when emitted thumbnail', () => {
-            const thumbnailEvent = new CustomEvent('pageThumbnail', {
-                detail: { file: 'test' },
-                bubbles: true,
-                cancelable: true
-            });
-            const el = de.nativeElement.querySelector('dot-html-to-image div');
-            el.dispatchEvent(thumbnailEvent);
-
+    describe('Default configuration', () => {
+        beforeEach(() => {
             fixture.detectChanges();
+        });
 
-            expect(component.form.valid).toBe(true);
-            expect(component.form.value).toEqual({
-                currentUserRoleId: '1',
-                thumbnail: 'test',
-                title: 'A title',
-                url: '/an/url/test?language_id=1',
-                order: 1,
-                permissions: null
+        describe('HTML', () => {
+            it('should setup <form> class', () => {
+                const form = de.query(By.css('[data-testId="form"]'));
+                expect(form.classes['p-fluid']).toBe(true);
+            });
+
+            describe('fields', () => {
+                it('should setup thumbnail preview', () => {
+                    const field = de.query(By.css('[data-testId="thumbnailField"]'));
+                    const label = field.query(By.css('label'));
+                    const webcomponent = field.query(By.css('dot-html-to-image'));
+
+                    expect(field.classes['field']).toBe(true);
+
+                    expect(label.classes['p-label-input-required']).toBe(true);
+                    expect(label.attributes.for).toBe('previewThumbnail');
+                    expect(label.nativeElement.textContent).toBe('Preview');
+
+                    expect(webcomponent.attributes['ng-reflect-height']).toBe('768.192048012003');
+                    expect(webcomponent.attributes['ng-reflect-width']).toBe('1024');
+                });
+
+                it('should setup title', () => {
+                    const field = de.query(By.css('[data-testId="titleField"]'));
+                    const label = field.query(By.css('label'));
+                    const input = field.query(By.css('input'));
+                    const message = field.query(By.css('dot-field-validation-message'));
+
+                    expect(field.classes['field']).toBe(true);
+
+                    expect(label.classes['p-label-input-required']).toBe(true);
+                    expect(label.attributes.for).toBe('title');
+                    expect(label.nativeElement.textContent).toBe('Title');
+
+                    expect(input.attributes.autofocus).toBeDefined();
+                    expect(input.attributes.pInputText).toBeDefined();
+                    expect(input.attributes.formControlName).toBe('title');
+                    expect(input.attributes.id).toBe('title');
+
+                    expect(message).toBeDefined();
+                });
+
+                it('should setup url', () => {
+                    const field = de.query(By.css('[data-testId="urlField"]'));
+                    const label = field.query(By.css('label'));
+                    const input = field.query(By.css('input'));
+                    const message = field.query(By.css('dot-field-validation-message'));
+
+                    expect(field.classes['field']).toBe(true);
+
+                    expect(label.attributes.for).toBe('url');
+                    expect(label.nativeElement.textContent).toBe('Url');
+
+                    expect(input.attributes.pInputText).toBeDefined();
+                    expect(input.attributes.formControlName).toBe('url');
+                    expect(input.attributes.id).toBe('url');
+
+                    expect(message).toBeDefined();
+                });
+
+                it('should setup order', () => {
+                    const field = de.query(By.css('[data-testId="orderField"]'));
+                    const label = field.query(By.css('label'));
+                    const input = field.query(By.css('input'));
+                    const message = field.query(By.css('dot-field-validation-message'));
+
+                    expect(field.classes['field']).toBe(true);
+
+                    expect(label.attributes.for).toBe('order');
+                    expect(label.nativeElement.textContent).toBe('Order');
+
+                    expect(input.attributes.pInputText).toBeDefined();
+                    expect(input.attributes.formControlName).toBe('order');
+                    expect(input.attributes.id).toBe('order');
+
+                    expect(message).toBeDefined();
+                });
+
+                it('should setup permissions', () => {
+                    const field = de.query(By.css('[data-testId="shareWithField"]'));
+                    const label = field.query(By.css('label'));
+                    const selector = field.query(By.css('p-multiSelect'));
+
+                    expect(field.classes['field']).toBe(true);
+
+                    expect(label.attributes.for).toBe('permissions');
+                    expect(label.nativeElement.textContent).toBe('Share With');
+
+                    expect(selector.attributes.formControlName).toBe('permissions');
+                    expect(selector.attributes.id).toBe('permissions');
+                });
             });
         });
 
-        it('should be valid when required fields are set', () => {
-            component.form.get('thumbnail').setValue('test');
+        describe('form', () => {
+            it('should get value from config and set initial data on store', () => {
+                expect(component.form.value).toEqual({
+                    currentUserRoleId: '1',
+                    thumbnail: null,
+                    title: 'A title',
+                    url: '/an/url/test?&language_id=1',
+                    order: 1,
+                    permissions: null
+                });
 
-            expect(component.form.valid).toBe(true);
-            expect(component.form.value).toEqual({
-                currentUserRoleId: '1',
-                thumbnail: 'test',
-                title: 'A title',
-                url: '/an/url/test?language_id=1',
-                order: 1,
-                permissions: null
+                expect(store.setInitialStateData).toHaveBeenCalled();
+            });
+
+            it('should be invalid by default', () => {
+                expect(component.form.valid).toBe(false);
+            });
+
+            it('should be valid when emitted thumbnail', () => {
+                const thumbnailEvent = new CustomEvent('pageThumbnail', {
+                    detail: { file: 'test' },
+                    bubbles: true,
+                    cancelable: true
+                });
+                const el = de.nativeElement.querySelector('dot-html-to-image div');
+                el.dispatchEvent(thumbnailEvent);
+
+                fixture.detectChanges();
+
+                expect(component.form.valid).toBe(true);
+                expect(component.form.value).toEqual({
+                    currentUserRoleId: '1',
+                    thumbnail: 'test',
+                    title: 'A title',
+                    url: '/an/url/test?&language_id=1',
+                    order: 1,
+                    permissions: null
+                });
+            });
+
+            it('should be valid when required fields are set', () => {
+                component.form.get('thumbnail').setValue('test');
+
+                expect(component.form.valid).toBe(true);
+                expect(component.form.value).toEqual({
+                    currentUserRoleId: '1',
+                    thumbnail: 'test',
+                    title: 'A title',
+                    url: '/an/url/test?&language_id=1',
+                    order: 1,
+                    permissions: null
+                });
+            });
+        });
+
+        describe('dot-form-dialog', () => {
+            it('should call save functionality in store', () => {
+                const dialog = de.query(By.css('[data-testId="dialogForm"]'));
+                dialog.triggerEventHandler('save', {});
+
+                expect(store.saveFavoritePage).toHaveBeenCalledWith(component.form.getRawValue());
+            });
+
+            it('should call cancel from config', () => {
+                const dialog = de.query(By.css('[data-testId="dialogForm"]'));
+                dialog.triggerEventHandler('cancel', {});
+                expect(dialogRef.close).toHaveBeenCalledWith(true);
             });
         });
     });
 
-    describe('dot-form-dialog', () => {
-        it('should call save functionality in store', () => {
-            const dialog = de.query(By.css('[data-testId="dialogForm"]'));
-            dialog.triggerEventHandler('save', {});
-
-            expect(store.saveFavoritePage).toHaveBeenCalledWith(component.form.getRawValue());
-        });
-
-        it('should call cancel from config', () => {
-            const dialog = de.query(By.css('[data-testId="dialogForm"]'));
-            dialog.triggerEventHandler('cancel', {});
+    describe('Store state changes', () => {
+        it('should call close ref event when closeDialog event is executed from store', () => {
+            spyOnProperty(store, 'closeDialog$', 'get').and.returnValue(of(true));
+            fixture.detectChanges();
             expect(dialogRef.close).toHaveBeenCalledWith(true);
         });
-    });
+        
+        it('should call onSave ref event when actionState event is executed from store with Saved value', () => {
+            spyOnProperty(store, 'actionState$', 'get').and.returnValue(of(DotFavoritePageActionState.SAVED));
+            fixture.detectChanges();
+            expect(dialogConfig.data.onSave).toHaveBeenCalledTimes(1);
+        });
+    })
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.ts
@@ -5,7 +5,12 @@ import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { map, startWith, takeUntil } from 'rxjs/operators';
 import { DotRole } from '@dotcms/app/shared/models/dot-role/dot-role.model';
 import { DotPageRenderState } from '../../shared/models';
-import { DotFavoritePageState, DotFavoritePageStore } from './store/dot-favorite-page.store';
+import {
+    DotFavoritePageState,
+    DotFavoritePageStore,
+    DotFavoritePageActionState
+} from './store/dot-favorite-page.store';
+import { generateDotFavoritePageUrl } from '@dotcms/app/shared/dot-utils';
 
 export interface DotFavoritePageProps {
     pageRenderedHtml?: string;
@@ -71,6 +76,14 @@ export class DotFavoritePageComponent implements OnInit, AfterViewInit, OnDestro
                 this.ref.close(true);
             }
         });
+
+        this.store.actionState$
+            .pipe(takeUntil(this.destroy$))
+            .subscribe((actionState: DotFavoritePageActionState) => {
+                if (actionState === DotFavoritePageActionState.SAVED) {
+                    this.config.data?.onSave?.();
+                }
+            });
     }
 
     ngAfterViewInit(): void {
@@ -104,14 +117,7 @@ export class DotFavoritePageComponent implements OnInit, AfterViewInit, OnDestro
     }
 
     private setupForm(page: DotFavoritePageProps) {
-        const url =
-            `${page.pageState.params.page?.pageURI}?language_id=${page.pageState.params.viewAs.language.id}` +
-            (page.pageState.params.viewAs.device?.identifier
-                ? `&device_id=${page.pageState.params.viewAs.device?.identifier}`
-                : '') +
-            (page.pageState.params.site?.identifier
-                ? `&host_id=${page.pageState.params.site?.identifier}`
-                : '');
+        const url = generateDotFavoritePageUrl(page.pageState);
 
         return {
             currentUserRoleId: ['', Validators.required],

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.spec.ts
@@ -169,7 +169,7 @@ describe('DotFavoritePageStore', () => {
         expect(dotTempFileUploadService.upload).toHaveBeenCalledWith(file);
 
         expect(dotWorkflowActionsFireService.publishContentletAndWaitForIndex).toHaveBeenCalledWith(
-            'favoritePage',
+            'dotFavoritePage',
             {
                 screenshot: 'temp-file_123',
                 title: 'A title',
@@ -204,7 +204,7 @@ describe('DotFavoritePageStore', () => {
         });
 
         expect(dotWorkflowActionsFireService.publishContentletAndWaitForIndex).toHaveBeenCalledWith(
-            'favoritePage',
+            'dotFavoritePage',
             {
                 screenshot: 'temp-file_123',
                 title: 'A title',

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.spec.ts
@@ -17,7 +17,7 @@ import { mockDotRenderedPage } from '@dotcms/app/test/dot-page-render.mock';
 import { mockUser } from '@dotcms/app/test/login-service.mock';
 import { Observable, of } from 'rxjs';
 import { DotPageRenderState } from '../../../shared/models';
-import { DotFavoritePageStore } from './dot-favorite-page.store';
+import { DotFavoritePageActionState, DotFavoritePageStore } from './dot-favorite-page.store';
 
 @Injectable()
 class MockDotRolesService {
@@ -117,7 +117,8 @@ describe('DotFavoritePageStore', () => {
             imgHeight: 768.192048012003,
             loading: false,
             pageRenderedHtml: '<p>test</p>',
-            closeDialog: false
+            closeDialog: false,
+            actionState: null
         };
 
         dotFavoritePageStore.state$.subscribe((state) => {
@@ -168,7 +169,7 @@ describe('DotFavoritePageStore', () => {
         expect(dotTempFileUploadService.upload).toHaveBeenCalledWith(file);
 
         expect(dotWorkflowActionsFireService.publishContentletAndWaitForIndex).toHaveBeenCalledWith(
-            'Screenshot',
+            'favoritePage',
             {
                 screenshot: 'temp-file_123',
                 title: 'A title',
@@ -180,6 +181,7 @@ describe('DotFavoritePageStore', () => {
 
         dotFavoritePageStore.state$.subscribe((state) => {
             expect(state.closeDialog).toEqual(true);
+            expect(state.actionState).toEqual(DotFavoritePageActionState.SAVED);
             done();
         });
     });
@@ -202,7 +204,7 @@ describe('DotFavoritePageStore', () => {
         });
 
         expect(dotWorkflowActionsFireService.publishContentletAndWaitForIndex).toHaveBeenCalledWith(
-            'Screenshot',
+            'favoritePage',
             {
                 screenshot: 'temp-file_123',
                 title: 'A title',

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.ts
@@ -14,6 +14,11 @@ import { DotCMSContentlet, DotCMSTempFile } from '@dotcms/dotcms-models';
 import { DotCurrentUserService } from '@dotcms/app/api/services/dot-current-user/dot-current-user.service';
 import { DotCurrentUser } from '@dotcms/app/shared/models/dot-current-user/dot-current-user';
 
+export const enum DotFavoritePageActionState {
+    SAVED = 'SAVED',
+    DELETED = 'DELETED'
+}
+
 export interface DotFavoritePageState {
     roleOptions: DotRole[];
     currentUserRoleId: string;
@@ -23,6 +28,7 @@ export interface DotFavoritePageState {
     imgHeight: number;
     loading: boolean;
     closeDialog: boolean;
+    actionState: DotFavoritePageActionState;
 }
 
 interface DotFavoritePageInitialProps {
@@ -41,6 +47,7 @@ export class DotFavoritePageStore extends ComponentStore<DotFavoritePageState> {
     readonly vm$ = this.state$;
 
     // SELECTORS
+    public readonly actionState$ = this.select(({ actionState }) => actionState);
     public readonly closeDialog$ = this.select(({ closeDialog }) => closeDialog);
     public readonly currentUserRoleId$ = this.select(({ currentUserRoleId }) => currentUserRoleId);
 
@@ -70,7 +77,7 @@ export class DotFavoritePageStore extends ComponentStore<DotFavoritePageState> {
                         }
 
                         return this.dotWorkflowActionsFireService.publishContentletAndWaitForIndex<DotCMSContentlet>(
-                            'Screenshot',
+                            'favoritePage',
                             {
                                 screenshot: id,
                                 title: formData.title,
@@ -83,7 +90,11 @@ export class DotFavoritePageStore extends ComponentStore<DotFavoritePageState> {
                     take(1),
                     tapResponse(
                         () => {
-                            this.patchState({ closeDialog: true, loading: false });
+                            this.patchState({
+                                closeDialog: true,
+                                loading: false,
+                                actionState: DotFavoritePageActionState.SAVED
+                            });
                         },
                         (error: HttpErrorResponse) => {
                             this.dotHttpErrorManagerService.handle(error);
@@ -130,7 +141,8 @@ export class DotFavoritePageStore extends ComponentStore<DotFavoritePageState> {
             imgHeight: propsData.imgHeight,
             loading: true,
             closeDialog: false,
-            pageRenderedHtml: props.pageRenderedHtml
+            pageRenderedHtml: props.pageRenderedHtml,
+            actionState: null
         });
 
         forkJoin([this.dotRolesService.search(), this.dotCurrentUser.getCurrentUser()])

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.ts
@@ -77,7 +77,7 @@ export class DotFavoritePageStore extends ComponentStore<DotFavoritePageState> {
                         }
 
                         return this.dotWorkflowActionsFireService.publishContentletAndWaitForIndex<DotCMSContentlet>(
-                            'favoritePage',
+                            'dotFavoritePage',
                             {
                                 screenshot: id,
                                 title: formData.title,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.html
@@ -7,12 +7,12 @@
         ></dot-edit-page-info>
         <dot-icon-button
             *ngIf="showFavoritePageStar"
-            [icon]="dotFavoritePageIconName"
+            [icon]="pageState.favoritePage ? 'grade' : 'star_outline'"
             [ngClass]="{
-                'dot-favorite-page-highlight': dotFavoritePageIconName === 'grade'
+                'dot-favorite-page-highlight': pageState.favoritePage
             }"
             [pTooltip]="'favoritePage.star.icon.tooltip' | dm"
-            (click)="addFavoritePage()"
+            (click)="favoritePage.emit(true)"
             data-testId="addFavoritePageButton"
             tooltipPosition="bottom"
         ></dot-icon-button>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.html
@@ -5,11 +5,17 @@
             [url]="pageState.page.pageURI"
             [apiLink]="apiLink"
         ></dot-edit-page-info>
-        <!-- <dot-icon-button
-            data-testId="addFavoritePageButton"
-            icon="star_outline"
+        <dot-icon-button
+            *ngIf="showFavoritePageStar"
+            [icon]="dotFavoritePageIconName"
+            [ngClass]="{
+                'dot-favorite-page-highlight': dotFavoritePageIconName === 'grade'
+            }"
+            [pTooltip]="'favoritePage.star.icon.tooltip' | dm"
             (click)="addFavoritePage()"
-        ></dot-icon-button> -->
+            data-testId="addFavoritePageButton"
+            tooltipPosition="bottom"
+        ></dot-icon-button>
     </div>
 
     <div class="main-toolbar-right">
@@ -22,15 +28,15 @@
 
     <div class="lower-toolbar-left">
         <dot-edit-page-state-controller
-            (modeChange)="stateChange()"
             [pageState]="pageState"
+            (modeChange)="stateChange()"
         ></dot-edit-page-state-controller>
 
         <p-checkbox
             class="dot-edit__what-changed-button"
+            *ngIf="showWhatsChanged && isEnterpriseLicense$ | async"
             [binary]="true"
             [label]="'dot.common.whats.changed' | dm"
-            *ngIf="showWhatsChanged && isEnterpriseLicense$ | async"
             (onChange)="whatschange.emit($event.checked)"
         ></p-checkbox>
     </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.scss
@@ -12,3 +12,7 @@
     align-items: center;
     display: flex;
 }
+
+.dot-favorite-page-highlight ::ng-deep i {
+    color: $brand-primary;
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.spec.ts
@@ -56,6 +56,7 @@ import { DotFormatDateServiceMock } from '@dotcms/app/test/format-date-service.m
 import { DialogService } from 'primeng/dynamicdialog';
 import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot-es-content.service';
 import { TooltipModule } from 'primeng/tooltip';
+import { ESContent } from '@dotcms/app/shared/models/dot-es-content/dot-es-content.model';
 
 @Component({
     selector: 'dot-test-host-component',
@@ -86,6 +87,13 @@ class MockDotLicenseService {
     }
 }
 
+@Injectable()
+class MockDotPageStateService{
+    requestFavoritePageData(_urlParam: string): Observable<ESContent> {
+        return of();
+    }
+}
+
 describe('DotEditPageToolbarComponent', () => {
     let fixtureHost: ComponentFixture<TestHostComponent>;
     let componentHost: TestHostComponent;
@@ -93,7 +101,7 @@ describe('DotEditPageToolbarComponent', () => {
     let de: DebugElement;
     let deHost: DebugElement;
     let dotLicenseService: DotLicenseService;
-    let dotESContentService: DotESContentService;
+    let dotPageStateService: DotPageStateService;
     let dotMessageDisplayService: DotMessageDisplayService;
     let dotDialogService: DialogService;
 
@@ -133,7 +141,7 @@ describe('DotEditPageToolbarComponent', () => {
                 },
                 {
                     provide: DotPageStateService,
-                    useValue: {}
+                    useClass: MockDotPageStateService
                 },
                 {
                     provide: SiteService,
@@ -175,7 +183,7 @@ describe('DotEditPageToolbarComponent', () => {
         de = deHost.query(By.css('dot-edit-page-toolbar'));
         component = de.componentInstance;
 
-        dotESContentService = de.injector.get(DotESContentService);
+        dotPageStateService = de.injector.get(DotPageStateService);
         dotLicenseService = de.injector.get(DotLicenseService);
         dotMessageDisplayService = de.injector.get(DotMessageDisplayService);
         dotDialogService = de.injector.get(DialogService);
@@ -316,7 +324,7 @@ describe('DotEditPageToolbarComponent', () => {
 
     describe("what's change", () => {
         it('should change icon on favorite page if contentlet exist', () => {
-            spyOn(dotESContentService, 'get').and.returnValue(
+            spyOn(dotPageStateService, 'requestFavoritePageData').and.returnValue(
                 of({
                     contentTook: 0,
                     jsonObjectView: {
@@ -331,7 +339,7 @@ describe('DotEditPageToolbarComponent', () => {
         });
 
         it('should show empty star icon on favorite page if NO contentlet exist', () => {
-            spyOn(dotESContentService, 'get').and.returnValue(
+            spyOn(dotPageStateService, 'requestFavoritePageData').and.returnValue(
                 of({
                     contentTook: 0,
                     jsonObjectView: {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
@@ -13,12 +13,6 @@ import { DotLicenseService } from '@services/dot-license/dot-license.service';
 import { DotPageRenderState } from '@portlets/dot-edit-page/shared/models';
 import { DotPageMode } from '@models/dot-page/dot-page-mode.enum';
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
-import { DialogService } from 'primeng/dynamicdialog';
-import { DotFavoritePageComponent } from '../../../components/dot-favorite-page/dot-favorite-page.component';
-import { DotMessageService } from '@dotcms/app/api/services/dot-message/dot-messages.service';
-import { ESContent } from '@dotcms/app/shared/models/dot-es-content/dot-es-content.model';
-import { generateDotFavoritePageUrl } from '@dotcms/app/shared/dot-utils';
-import { DotPageStateService } from '../../services/dot-page-state/dot-page-state.service';
 @Component({
     selector: 'dot-edit-page-toolbar',
     templateUrl: './dot-edit-page-toolbar.component.html',
@@ -28,25 +22,20 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
     @Input() pageState: DotPageRenderState;
     @Output() cancel = new EventEmitter<boolean>();
     @Output() actionFired = new EventEmitter<DotCMSContentlet>();
+    @Output() favoritePage = new EventEmitter<boolean>();
     @Output() whatschange = new EventEmitter<boolean>();
 
     isEnterpriseLicense$: Observable<boolean>;
     showWhatsChanged: boolean;
     apiLink: string;
     pageRenderedHtml: string;
-    dotFavoritePageIconName = 'star_outline';
 
     // TODO: Remove next line when total functionality of Favorite page is done for release
     showFavoritePageStar = false;
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
 
-    constructor(
-        private dotLicenseService: DotLicenseService,
-        private dialogService: DialogService,
-        private dotMessageService: DotMessageService,
-        private dotPageStateService: DotPageStateService
-    ) {}
+    constructor(private dotLicenseService: DotLicenseService) {}
 
     ngOnInit() {
         // TODO: Remove next line when total functionality of Favorite page is done for release
@@ -56,8 +45,6 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
 
         this.isEnterpriseLicense$ = this.dotLicenseService.isEnterprise();
         this.apiLink = `api/v1/page/render${this.pageState.page.pageURI}?language_id=${this.pageState.page.languageId}`;
-
-        this.loadFavoritePageData();
     }
 
     ngOnChanges(): void {
@@ -85,52 +72,9 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
         }
     }
 
-    /**
-     * Instantiate dialog to Add Favorite Page
-     *
-     * @memberof DotEditPageToolbarComponent
-     */
-    addFavoritePage(): void {
-        this.dialogService.open(DotFavoritePageComponent, {
-            header: this.dotMessageService.get('favoritePage.dialog.header.add.page'),
-            width: '80rem',
-            data: {
-                page: {
-                    pageState: this.pageState,
-                    pageRenderedHtml: this.pageRenderedHtml || null
-                },
-                onSave: () => {
-                    this.setDotFavoritePageHighlighted();
-                    this.loadFavoritePageData();
-                }
-            }
-        });
-    }
-
-    /**
-     * Calls ES endpoint to verify if DotFavoritePage contentlet exist on current page
-     *
-     * @memberof DotEditPageToolbarComponent
-     */
-    loadFavoritePageData(): void {
-        const urlParam = generateDotFavoritePageUrl(this.pageState);
-
-        this.dotPageStateService
-            .requestFavoritePageData(urlParam)
-            .subscribe((response: ESContent) => {
-                if (response.resultsSize > 0) {
-                    this.setDotFavoritePageHighlighted();
-                }
-            });
-    }
-
     private updateRenderedHtml(): string {
         return this.pageState?.params.viewAs.mode === DotPageMode.PREVIEW
             ? this.pageState.params.page.rendered
             : this.pageRenderedHtml;
-    }
-
-    private setDotFavoritePageHighlighted(): void {
-        this.dotFavoritePageIconName = 'grade';
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
@@ -5,7 +5,8 @@ import {
     EventEmitter,
     Output,
     OnChanges,
-    OnDestroy
+    OnDestroy,
+    isDevMode
 } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { DotLicenseService } from '@services/dot-license/dot-license.service';
@@ -15,7 +16,6 @@ import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DialogService } from 'primeng/dynamicdialog';
 import { DotFavoritePageComponent } from '../../../components/dot-favorite-page/dot-favorite-page.component';
 import { DotMessageService } from '@dotcms/app/api/services/dot-message/dot-messages.service';
-import { LoggerService } from '@dotcms/dotcms-js';
 import { ESContent } from '@dotcms/app/shared/models/dot-es-content/dot-es-content.model';
 import { generateDotFavoritePageUrl } from '@dotcms/app/shared/dot-utils';
 import { DotPageStateService } from '../../services/dot-page-state/dot-page-state.service';
@@ -37,7 +37,7 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
     dotFavoritePageIconName = 'star_outline';
 
     // TODO: Remove next line when total functionality of Favorite page is done for release
-    showFavoritePageStar: boolean;
+    showFavoritePageStar = false;
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
 
@@ -45,15 +45,14 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
         private dotLicenseService: DotLicenseService,
         private dialogService: DialogService,
         private dotMessageService: DotMessageService,
-        private dotPageStateService: DotPageStateService,
-
-        // TODO: Remove next line when total functionality of Favorite page is done for release
-        private loggerService: LoggerService
+        private dotPageStateService: DotPageStateService
     ) {}
 
     ngOnInit() {
         // TODO: Remove next line when total functionality of Favorite page is done for release
-        this.showFavoritePageStar = this.loggerService.shouldShowLogs();
+        if (isDevMode()) {
+            this.showFavoritePageStar = true;
+        }
 
         this.isEnterpriseLicense$ = this.dotLicenseService.isEnterprise();
         this.apiLink = `api/v1/page/render${this.pageState.page.pageURI}?language_id=${this.pageState.page.languageId}`;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
@@ -15,6 +15,11 @@ import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DialogService } from 'primeng/dynamicdialog';
 import { DotFavoritePageComponent } from '../../../components/dot-favorite-page/dot-favorite-page.component';
 import { DotMessageService } from '@dotcms/app/api/services/dot-message/dot-messages.service';
+import { LoggerService } from '@dotcms/dotcms-js';
+import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot-es-content.service';
+import { take } from 'rxjs/operators';
+import { ESContent } from '@dotcms/app/shared/models/dot-es-content/dot-es-content.model';
+import { generateDotFavoritePageUrl } from '@dotcms/app/shared/dot-utils';
 @Component({
     selector: 'dot-edit-page-toolbar',
     templateUrl: './dot-edit-page-toolbar.component.html',
@@ -30,18 +35,31 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
     showWhatsChanged: boolean;
     apiLink: string;
     pageRenderedHtml: string;
+    dotFavoritePageIconName = 'star_outline';
+
+    // TODO: Remove next line when total functionality of Favorite page is done for release
+    showFavoritePageStar: boolean;
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
 
     constructor(
         private dotLicenseService: DotLicenseService,
         private dialogService: DialogService,
-        private dotMessageService: DotMessageService
+        private dotMessageService: DotMessageService,
+        private dotESContentService: DotESContentService,
+
+        // TODO: Remove next line when total functionality of Favorite page is done for release
+        private loggerService: LoggerService
     ) {}
 
     ngOnInit() {
+        // TODO: Remove next line when total functionality of Favorite page is done for release
+        this.showFavoritePageStar = this.loggerService.shouldShowLogs();
+
         this.isEnterpriseLicense$ = this.dotLicenseService.isEnterprise();
         this.apiLink = `api/v1/page/render${this.pageState.page.pageURI}?language_id=${this.pageState.page.languageId}`;
+
+        this.loadFavoritePageData();
     }
 
     ngOnChanges(): void {
@@ -82,14 +100,44 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
                 page: {
                     pageState: this.pageState,
                     pageRenderedHtml: this.pageRenderedHtml || null
+                },
+                onSave: () => {
+                    this.setDotFavoritePageHighlighted();
+                    this.loadFavoritePageData();
                 }
             }
         });
+    }
+
+    /**
+     * Calls ES endpoint to verify if DotFavoritePage contentlet exist on current page
+     *
+     * @memberof DotEditPageToolbarComponent
+     */
+    loadFavoritePageData(): void {
+        const urlParam = generateDotFavoritePageUrl(this.pageState);
+
+        this.dotESContentService
+            .get({
+                itemsPerPage: 10,
+                offset: '0',
+                query: `+contentType:FavoritePage +favoritePage.url_dotraw:${urlParam}`
+            })
+            .pipe(take(1))
+            .subscribe((response: ESContent) => {
+                if (response.resultsSize > 0) {
+                    this.setDotFavoritePageHighlighted();
+                }
+            });
     }
 
     private updateRenderedHtml(): string {
         return this.pageState?.params.viewAs.mode === DotPageMode.PREVIEW
             ? this.pageState.params.page.rendered
             : this.pageRenderedHtml;
+    }
+
+    private setDotFavoritePageHighlighted(): void {
+        this.dotFavoritePageIconName = 'grade';
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
@@ -16,10 +16,9 @@ import { DialogService } from 'primeng/dynamicdialog';
 import { DotFavoritePageComponent } from '../../../components/dot-favorite-page/dot-favorite-page.component';
 import { DotMessageService } from '@dotcms/app/api/services/dot-message/dot-messages.service';
 import { LoggerService } from '@dotcms/dotcms-js';
-import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot-es-content.service';
-import { take } from 'rxjs/operators';
 import { ESContent } from '@dotcms/app/shared/models/dot-es-content/dot-es-content.model';
 import { generateDotFavoritePageUrl } from '@dotcms/app/shared/dot-utils';
+import { DotPageStateService } from '../../services/dot-page-state/dot-page-state.service';
 @Component({
     selector: 'dot-edit-page-toolbar',
     templateUrl: './dot-edit-page-toolbar.component.html',
@@ -46,7 +45,7 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
         private dotLicenseService: DotLicenseService,
         private dialogService: DialogService,
         private dotMessageService: DotMessageService,
-        private dotESContentService: DotESContentService,
+        private dotPageStateService: DotPageStateService,
 
         // TODO: Remove next line when total functionality of Favorite page is done for release
         private loggerService: LoggerService
@@ -117,13 +116,8 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
     loadFavoritePageData(): void {
         const urlParam = generateDotFavoritePageUrl(this.pageState);
 
-        this.dotESContentService
-            .get({
-                itemsPerPage: 10,
-                offset: '0',
-                query: `+contentType:FavoritePage +favoritePage.url_dotraw:${urlParam}`
-            })
-            .pipe(take(1))
+        this.dotPageStateService
+            .requestFavoritePageData(urlParam)
             .subscribe((response: ESContent) => {
                 if (response.resultsSize > 0) {
                     this.setDotFavoritePageHighlighted();

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.module.ts
@@ -15,6 +15,7 @@ import { DotGlobalMessageModule } from '@dotcms/app/view/components/_common/dot-
 import { DotFavoritePageModule } from '../../../components/dot-favorite-page/dot-favorite-page.module';
 import { DialogService } from 'primeng/dynamicdialog';
 import { UiDotIconButtonModule } from '@components/_common/dot-icon-button/dot-icon-button.module';
+import { TooltipModule } from 'primeng/tooltip';
 
 @NgModule({
     imports: [
@@ -28,6 +29,7 @@ import { UiDotIconButtonModule } from '@components/_common/dot-icon-button/dot-i
         DotSecondaryToolbarModule,
         FormsModule,
         ToolbarModule,
+        TooltipModule,
         DotPipesModule,
         DotGlobalMessageModule,
         DotFavoritePageModule,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
@@ -14,11 +14,12 @@
     <dot-loading-indicator fullscreen="true"></dot-loading-indicator>
     <ng-container *ngIf="pageState$ | async as pageState">
         <dot-edit-page-toolbar
+            class="dot-edit__toolbar"
+            [pageState]="pageState"
             (cancel)="onCancelToolbar()"
             (actionFired)="reload($event)"
+            (favoritePage)="showFavoritePageDialog($event)"
             (whatschange)="showWhatsChanged = $event"
-            [pageState]="pageState"
-            class="dot-edit__toolbar"
         ></dot-edit-page-toolbar>
 
         <div
@@ -42,22 +43,22 @@
                         (click)="iframeOverlayService.hide()"
                     ></dot-overlay-mask>
                     <dot-whats-changed
+                        *ngIf="showWhatsChanged"
                         [pageId]="pageState.page.identifier"
                         [languageId]="pageState.viewAs.language.id"
-                        *ngIf="showWhatsChanged"
                     ></dot-whats-changed>
                     <iframe
-                        *ngIf="showIframe"
-                        #iframe
-                        width="100%"
-                        height="100%"
-                        frameborder="0"
                         class="dot-edit__iframe"
-                        (load)="onLoad($event)"
+                        #iframe
+                        *ngIf="showIframe"
                         [ngStyle]="{
                             visibility: showWhatsChanged ? 'hidden' : '',
                             position: showWhatsChanged ? 'absolute' : ''
                         }"
+                        (load)="onLoad($event)"
+                        width="100%"
+                        height="100%"
+                        frameborder="0"
                     ></iframe>
                 </div>
             </div>
@@ -77,9 +78,9 @@
     </dot-palette>
     <div
         class="dot-edit-content__palette-visibility"
-        data-testId="palette-visibility"
         (click)="paletteCollapsed = !paletteCollapsed"
+        data-testId="palette-visibility"
     >
-        <dot-icon size="22" [name]="paletteCollapsed ? 'chevron_left' : 'chevron_right'"></dot-icon>
+        <dot-icon [name]="paletteCollapsed ? 'chevron_left' : 'chevron_right'" size="22"></dot-icon>
     </div>
 </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -150,7 +150,7 @@ const mockRenderedPageState = new DotPageRenderState(
     new DotPageRender(mockDotRenderedPage())
 );
 
-fdescribe('DotEditContentComponent', () => {
+describe('DotEditContentComponent', () => {
     const siteServiceMock = new SiteServiceMock();
     let component: DotEditContentComponent;
     let de: DebugElement;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -85,6 +85,7 @@ import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot
 import { mockDotLanguage } from '@dotcms/app/test/dot-language.mock';
 import { mockDotRenderedPageState } from '@dotcms/app/test/dot-rendered-page-state.mock';
 import { DotWorkflowActionsFireService } from '@dotcms/app/api/services/dot-workflow-actions-fire/dot-workflow-actions-fire.service';
+import { DialogService } from 'primeng/dynamicdialog';
 
 @Component({
     selector: 'dot-global-message',
@@ -131,8 +132,9 @@ export class MockDotFormSelectorComponent {
 })
 export class MockDotEditPageToolbarComponent {
     @Input() pageState = mockDotRenderedPageState;
-    @Output() cancel = new EventEmitter<boolean>();
     @Output() actionFired = new EventEmitter<DotCMSContentlet>();
+    @Output() cancel = new EventEmitter<boolean>();
+    @Output() favoritePage = new EventEmitter<boolean>();
     @Output() whatschange = new EventEmitter<boolean>();
 }
 
@@ -165,6 +167,7 @@ describe('DotEditContentComponent', () => {
     let iframeOverlayService: IframeOverlayService;
     let dotLoadingIndicatorService: DotLoadingIndicatorService;
     let dotContentletEditorService: DotContentletEditorService;
+    let dialogService: DialogService;
     let dotDialogService: DotAlertConfirmService;
     let dotCustomEventHandlerService: DotCustomEventHandlerService;
     let dotConfigurationService: DotPropertiesService;
@@ -226,6 +229,7 @@ describe('DotEditContentComponent', () => {
                 ])
             ],
             providers: [
+                DialogService,
                 DotContentletLockerService,
                 DotPageRenderService,
                 DotContainerContentletService,
@@ -312,6 +316,7 @@ describe('DotEditContentComponent', () => {
         iframeOverlayService = de.injector.get(IframeOverlayService);
         dotLoadingIndicatorService = de.injector.get(DotLoadingIndicatorService);
         dotContentletEditorService = de.injector.get(DotContentletEditorService);
+        dialogService = de.injector.get(DialogService);
         dotDialogService = de.injector.get(DotAlertConfirmService);
         dotCustomEventHandlerService = de.injector.get(DotCustomEventHandlerService);
         dotConfigurationService = de.injector.get(DotPropertiesService);
@@ -380,6 +385,7 @@ describe('DotEditContentComponent', () => {
             let toolbarElement: DebugElement;
 
             beforeEach(() => {
+                spyOn(dialogService, 'open');
                 fixture.detectChanges();
                 toolbarElement = de.query(By.css('dot-edit-page-toolbar'));
             });
@@ -425,6 +431,11 @@ describe('DotEditContentComponent', () => {
                     fixture.detectChanges();
                     whatschange = de.query(By.css('dot-whats-changed'));
                     expect(whatschange).not.toBeNull();
+                });
+
+                it('should instantiate dialog with DotFavoritePageComponent', () => {
+                    toolbarElement.triggerEventHandler('favoritePage', true);
+                    expect(dialogService.open).toHaveBeenCalledTimes(1);
                 });
             });
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -30,7 +30,6 @@ import { DotCMSContentlet, DotCMSContentType } from '@dotcms/dotcms-models';
 import { DotAlertConfirmService } from '@services/dot-alert-confirm/index';
 import { DotEditContentHtmlService } from './services/dot-edit-content-html/dot-edit-content-html.service';
 import { DotEditPageService } from '@services/dot-edit-page/dot-edit-page.service';
-import { DotEditPageToolbarModule } from './components/dot-edit-page-toolbar/dot-edit-page-toolbar.module';
 import { DotGlobalMessageService } from '@components/_common/dot-global-message/dot-global-message.service';
 import { DotLoadingIndicatorModule } from '@components/_common/iframe/dot-loading-indicator/dot-loading-indicator.module';
 import { DotMessageService } from '@services/dot-message/dot-messages.service';
@@ -84,6 +83,8 @@ import { DotPropertiesService } from '@services/dot-properties/dot-properties.se
 import { PageModelChangeEventType } from './services/dot-edit-content-html/models';
 import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot-es-content.service';
 import { mockDotLanguage } from '@dotcms/app/test/dot-language.mock';
+import { mockDotRenderedPageState } from '@dotcms/app/test/dot-rendered-page-state.mock';
+import { DotWorkflowActionsFireService } from '@dotcms/app/api/services/dot-workflow-actions-fire/dot-workflow-actions-fire.service';
 
 @Component({
     selector: 'dot-global-message',
@@ -125,6 +126,17 @@ export class MockDotFormSelectorComponent {
 }
 
 @Component({
+    selector: 'dot-edit-page-toolbar',
+    template: ''
+})
+export class MockDotEditPageToolbarComponent {
+    @Input() pageState = mockDotRenderedPageState;
+    @Output() cancel = new EventEmitter<boolean>();
+    @Output() actionFired = new EventEmitter<DotCMSContentlet>();
+    @Output() whatschange = new EventEmitter<boolean>();
+}
+
+@Component({
     selector: 'dot-palette',
     template: ''
 })
@@ -138,7 +150,7 @@ const mockRenderedPageState = new DotPageRenderState(
     new DotPageRender(mockDotRenderedPage())
 );
 
-describe('DotEditContentComponent', () => {
+fdescribe('DotEditContentComponent', () => {
     const siteServiceMock = new SiteServiceMock();
     let component: DotEditContentComponent;
     let de: DebugElement;
@@ -189,6 +201,7 @@ describe('DotEditContentComponent', () => {
                 DotEditContentComponent,
                 MockDotWhatsChangedComponent,
                 MockDotFormSelectorComponent,
+                MockDotEditPageToolbarComponent,
                 MockDotIconComponent,
                 MockDotPaletteComponent,
                 HostTestComponent,
@@ -200,7 +213,6 @@ describe('DotEditContentComponent', () => {
                 ButtonModule,
                 DialogModule,
                 DotContentletEditorModule,
-                DotEditPageToolbarModule,
                 DotEditPageInfoModule,
                 DotLoadingIndicatorModule,
                 DotEditPageWorkflowsActionsModule,
@@ -225,6 +237,7 @@ describe('DotEditContentComponent', () => {
                 DotEditPageService,
                 DotGlobalMessageService,
                 DotPageStateService,
+                DotWorkflowActionsFireService,
                 DotGenerateSecurePasswordService,
                 DotCustomEventHandlerService,
                 DotPropertiesService,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -41,6 +41,8 @@ import { DotLicenseService } from '@services/dot-license/dot-license.service';
 import { DotContentletEventAddContentType } from './services/dot-edit-content-html/models/dot-contentlets-events.model';
 import { DotIframeEditEvent } from '@dotcms/dotcms-models';
 import { DotEventsService } from '@services/dot-events/dot-events.service';
+import { DialogService } from 'primeng/dynamicdialog';
+import { DotFavoritePageComponent } from '../components/dot-favorite-page/dot-favorite-page.component';
 
 export const EDIT_BLOCK_EDITOR_CUSTOM_EVENT = 'edit-block-editor';
 
@@ -78,6 +80,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
     private pageStateInternal: DotPageRenderState;
 
     constructor(
+        private dialogService: DialogService,
         private dotContentletEditorService: DotContentletEditorService,
         private dotDialogService: DotAlertConfirmService,
         private dotEditPageService: DotEditPageService,
@@ -263,6 +266,32 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
     addFormContentType(): void {
         this.editForm = true;
         this.dotEditContentHtmlService.removeContentletPlaceholder();
+    }
+
+    /**
+     * Fires a dynamic dialog instance with DotFavoritePage component
+     *
+     * @param boolean openDialog
+     * @memberof DotEditContentComponent
+     */
+    showFavoritePageDialog(openDialog: boolean): void {
+        this.pageState$.pipe(take(1)).subscribe((pageState: DotPageRenderState) => {
+            if (openDialog) {
+                this.dialogService.open(DotFavoritePageComponent, {
+                    header: this.dotMessageService.get('favoritePage.dialog.header.add.page'),
+                    width: '80rem',
+                    data: {
+                        page: {
+                            pageState: pageState,
+                            pageRenderedHtml: pageState.params.page.rendered || null
+                        },
+                        onSave: () => {
+                            this.dotPageStateService.setFavoritePageHighlight(true);
+                        }
+                    }
+                });
+            }
+        });
     }
 
     private setAllowedContent(pageState: DotPageRenderState): void {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
@@ -24,6 +24,7 @@ import { mockResponseView } from '@tests/response-view.mock';
 import { PageModelChangeEventType } from '../dot-edit-content-html/models';
 import { mockDotPersona } from '@tests/dot-persona.mock';
 import { mockUserAuth } from '@tests/dot-auth-user.mock';
+import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot-es-content.service';
 
 const getDotPageRenderStateMock = () => {
     return new DotPageRenderState(mockUser(), mockDotRenderedPage());
@@ -36,6 +37,7 @@ describe('DotPageStateService', () => {
     let dotPageRenderService: DotPageRenderService;
     let dotPageRenderServiceGetSpy: jasmine.Spy;
     let dotRouterService: DotRouterService;
+    let dotESContentService: DotESContentService;
     let loginService: LoginService;
     let injector: TestBed;
     let service: DotPageStateService;
@@ -51,6 +53,7 @@ describe('DotPageStateService', () => {
                 DotAlertConfirmService,
                 ConfirmationService,
                 DotFormatDateService,
+                DotESContentService,
                 { provide: CoreWebService, useClass: CoreWebServiceMock },
                 { provide: DotRouterService, useClass: MockDotRouterService },
                 {
@@ -66,6 +69,7 @@ describe('DotPageStateService', () => {
         dotHttpErrorManagerService = injector.get(DotHttpErrorManagerService);
         dotPageRenderService = injector.get(DotPageRenderService);
         dotRouterService = injector.get(DotRouterService);
+        dotESContentService = injector.inject(DotESContentService);
         loginService = injector.get(LoginService);
 
         dotPageRenderServiceGetSpy = spyOn(dotPageRenderService, 'get').and.returnValue(
@@ -107,6 +111,28 @@ describe('DotPageStateService', () => {
                 },
                 {}
             ]);
+        });
+    });
+
+    describe('DotFavoritePage', () => {
+        it('should load FavoritePage data from ES using a specific url', () => {
+            spyOn(dotESContentService, 'get').and.returnValue(
+                of({
+                    contentTook: 0,
+                    jsonObjectView: {
+                        contentlets: []
+                    },
+                    queryTook: 1,
+                    resultsSize: 20
+                })
+            );
+            service.requestFavoritePageData('test');
+
+            expect(dotESContentService.get).toHaveBeenCalledWith({
+                itemsPerPage: 10,
+                offset: '0',
+                query: `+contentType:FavoritePage +favoritePage.url_dotraw:test`
+            });
         });
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
@@ -1,6 +1,7 @@
+/* eslint-disable no-console */
 import { of, Observable, Subject, BehaviorSubject } from 'rxjs';
 
-import { pluck, take, map, catchError, tap } from 'rxjs/operators';
+import { pluck, take, map, catchError, tap, switchMap } from 'rxjs/operators';
 import { LoginService, User, HttpCode } from '@dotcms/dotcms-js';
 import { DotPageRenderState } from '../../../shared/models/dot-rendered-page-state.model';
 import {
@@ -21,6 +22,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { DotPageRenderParameters } from '@models/dot-page/dot-rendered-page.model';
 import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot-es-content.service';
 import { ESContent } from '@dotcms/app/shared/models/dot-es-content/dot-es-content.model';
+import { generateDotFavoritePageUrl } from '@dotcms/app/shared/dot-utils';
 
 @Injectable()
 export class DotPageStateService {
@@ -162,6 +164,17 @@ export class DotPageStateService {
     }
 
     /**
+     * Set the FavoritePageHighlight flag status
+     *
+     * @param {boolean} highlight
+     * @memberof DotPageStateService
+     */
+    setFavoritePageHighlight(highlight: boolean): void {
+        this.currentState.favoritePage = highlight;
+        this.state$.next(this.currentState);
+    }
+
+    /**
      * Update page content status
      *
      * @param {PageModelChangeEvent} event
@@ -189,34 +202,36 @@ export class DotPageStateService {
         return this.dotPageRenderService.get(options, extraParams).pipe(
             catchError((err) => this.handleSetPageStateFailed(err)),
             take(1),
-            map((page: DotPageRenderParameters) => {
+            switchMap((page: DotPageRenderParameters) => {
                 if (page) {
-                    const pageState = new DotPageRenderState(this.getCurrentUser(), page);
-                    this.setCurrentState(pageState);
+                    const urlParam = generateDotFavoritePageUrl(page);
 
-                    return pageState;
+                    return this.dotESContentService
+                        .get({
+                            itemsPerPage: 10,
+                            offset: '0',
+                            query: `+contentType:DotFavoritePage +DotFavoritePage.url_dotraw:${urlParam}`
+                        })
+                        .pipe(
+                            take(1),
+                            switchMap((response: ESContent) => {
+                                const favoritePage = response.resultsSize > 0;
+                                const pageState = new DotPageRenderState(
+                                    this.getCurrentUser(),
+                                    page,
+                                    favoritePage
+                                );
+
+                                this.setCurrentState(pageState);
+
+                                return of(pageState);
+                            })
+                        );
                 }
 
-                return this.currentState;
+                return of(this.currentState);
             })
         );
-    }
-
-    /**
-     * Calls ES endpoint to fetch DotFavoritePage data using a specific url
-     *
-     * @param {string} url
-     * @returns {Observable<ESContent>}
-     * @memberof DotPageStateService
-     */
-    requestFavoritePageData(url: string): Observable<ESContent> {
-        return this.dotESContentService
-            .get({
-                itemsPerPage: 10,
-                offset: '0',
-                query: `+contentType:FavoritePage +favoritePage.url_dotraw:${url}`
-            })
-            .pipe(take(1));
     }
 
     private contentAdded(): void {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
@@ -19,6 +19,8 @@ import { DotRouterService } from '@services/dot-router/dot-router.service';
 import { PageModelChangeEvent, PageModelChangeEventType } from '../dot-edit-content-html/models';
 import { HttpErrorResponse } from '@angular/common/http';
 import { DotPageRenderParameters } from '@models/dot-page/dot-rendered-page.model';
+import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot-es-content.service';
+import { ESContent } from '@dotcms/app/shared/models/dot-es-content/dot-es-content.model';
 
 @Injectable()
 export class DotPageStateService {
@@ -30,6 +32,7 @@ export class DotPageStateService {
 
     constructor(
         private dotContentletLockerService: DotContentletLockerService,
+        private dotESContentService: DotESContentService,
         private dotHttpErrorManagerService: DotHttpErrorManagerService,
         private dotPageRenderService: DotPageRenderService,
         private dotRouterService: DotRouterService,
@@ -197,6 +200,23 @@ export class DotPageStateService {
                 return this.currentState;
             })
         );
+    }
+
+    /**
+     * Calls ES endpoint to fetch DotFavoritePage data using a specific url
+     *
+     * @param {string} url
+     * @returns {Observable<ESContent>}
+     * @memberof DotPageStateService
+     */
+    requestFavoritePageData(url: string): Observable<ESContent> {
+        return this.dotESContentService
+            .get({
+                itemsPerPage: 10,
+                offset: '0',
+                query: `+contentType:FavoritePage +favoritePage.url_dotraw:${url}`
+            })
+            .pipe(take(1));
     }
 
     private contentAdded(): void {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/dot-edit-page.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/dot-edit-page.module.ts
@@ -11,6 +11,7 @@ import { DotPageStateService } from './content/services/dot-page-state/dot-page-
 import { DotEditPageResolver } from './shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service';
 import { DotPipesModule } from '@pipes/dot-pipes.module';
 import { DotFeatureFlagResolver } from '@portlets/shared/resolvers/dot-feature-flag-resolver.service';
+import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot-es-content.service';
 
 @NgModule({
     imports: [
@@ -25,6 +26,7 @@ import { DotFeatureFlagResolver } from '@portlets/shared/resolvers/dot-feature-f
     providers: [
         DotContentletLockerService,
         DotEditPageResolver,
+        DotESContentService,
         DotPageStateService,
         DotPageRenderService,
         DotPageLayoutService,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/models/dot-rendered-page-state.model.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/models/dot-rendered-page-state.model.ts
@@ -8,6 +8,7 @@ import { DotPage } from '@models/dot-page/dot-page.model';
 import { DotPageRender, DotPageRenderParameters } from '@models/dot-page/dot-rendered-page.model';
 
 interface DotPageState {
+    favoritePage?: boolean;
     locked?: boolean;
     lockedByAnotherUser?: boolean;
     mode: DotPageMode;
@@ -16,12 +17,17 @@ interface DotPageState {
 export class DotPageRenderState extends DotPageRender {
     private _state: DotPageState;
 
-    constructor(private _user: User, private dotRenderedPage: DotPageRenderParameters) {
+    constructor(
+        private _user: User,
+        private dotRenderedPage: DotPageRenderParameters,
+        _favoritePage?: boolean
+    ) {
         super(dotRenderedPage);
         const locked = !!dotRenderedPage.page.lockedBy;
         const lockedByAnotherUser = locked ? dotRenderedPage.page.lockedBy !== _user.userId : false;
 
         this._state = {
+            favoritePage: _favoritePage || false,
             locked: locked,
             lockedByAnotherUser: lockedByAnotherUser,
             mode: dotRenderedPage.viewAs.mode
@@ -62,6 +68,14 @@ export class DotPageRenderState extends DotPageRender {
 
     get user(): User {
         return this._user;
+    }
+
+    get favoritePage(): boolean {
+        return this._state.favoritePage;
+    }
+
+    set favoritePage(status: boolean) {
+        this._state.favoritePage = status;
     }
 
     set dotRenderedPageState(dotRenderedPageState: DotPageRender) {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
@@ -22,6 +22,7 @@ import { MockDotRouterService } from '@tests/dot-router-service.mock';
 import { mockResponseView } from '@tests/response-view.mock';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { DotPageRender } from '@models/dot-page/dot-rendered-page.model';
+import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot-es-content.service';
 
 const route: any = jasmine.createSpyObj<ActivatedRouteSnapshot>('ActivatedRouteSnapshot', [
     'toString'
@@ -51,6 +52,7 @@ describe('DotEditPageResolver', () => {
                 DotAlertConfirmService,
                 ConfirmationService,
                 DotFormatDateService,
+                DotESContentService,
                 { provide: DotRouterService, useClass: MockDotRouterService },
                 {
                     provide: ActivatedRouteSnapshot,

--- a/core-web/apps/dotcms-ui/src/app/shared/dot-utils.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/shared/dot-utils.spec.ts
@@ -1,4 +1,8 @@
 import * as dotUtils from '@shared/dot-utils';
+import { DotPageRenderState } from '../portlets/dot-edit-page/shared/models';
+import { mockDotRenderedPage } from '../test/dot-page-render.mock';
+import { mockUser } from '../test/login-service.mock';
+import { DotPageRender } from './models/dot-page/dot-rendered-page.model';
 
 describe('Dot Utils', () => {
     it('should return anchor with the correct values', () => {
@@ -9,5 +13,28 @@ describe('Dot Utils', () => {
 
         expect(anchor.download).toEqual(fileName);
         expect(window.URL.createObjectURL).toHaveBeenCalledWith(blobMock);
+    });
+
+    it('should return unique URL with host, language and device Ids', () => {
+        const mockRenderedPageState = new DotPageRenderState(
+            mockUser(),
+            new DotPageRender({
+                ...mockDotRenderedPage(),
+                viewAs: {
+                    ...mockDotRenderedPage().viewAs,
+                    device: {
+                        identifier: 'abc123',
+                        cssHeight: '800',
+                        cssWidth: '1200',
+                        name: 'custom',
+                        inode: '123zxc'
+                    }
+                }
+            })
+        );
+
+        const url = dotUtils.generateDotFavoritePageUrl(mockRenderedPageState);
+
+        expect(url).toEqual('/an/url/test?&language_id=1&device_id=abc123');
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/shared/dot-utils.ts
+++ b/core-web/apps/dotcms-ui/src/app/shared/dot-utils.ts
@@ -1,4 +1,4 @@
-import { DotPageRenderState } from '../portlets/dot-edit-page/shared/models';
+import { DotPageRenderParameters } from './models/dot-page/dot-rendered-page.model';
 
 /**
  * Generate an anchor element with a Blob file to eventually be click to force a download
@@ -20,13 +20,13 @@ export function formatMessage(message: string, args: string[]): string {
 }
 
 // Generates an unique Url with host, language and device Ids
-export function generateDotFavoritePageUrl(pageState: DotPageRenderState): string {
+export function generateDotFavoritePageUrl(params: DotPageRenderParameters): string {
+    const { page, site, viewAs } = params;
+
     return (
-        `${pageState.params.page?.pageURI}?` +
-        (pageState.params.site?.identifier ? `host_id=${pageState.params.site?.identifier}` : '') +
-        `&language_id=${pageState.params.viewAs.language.id}` +
-        (pageState.params.viewAs.device?.identifier
-            ? `&device_id=${pageState.params.viewAs.device?.identifier}`
-            : '')
+        `${page?.pageURI}?` +
+        (site?.identifier ? `host_id=${site?.identifier}` : '') +
+        `&language_id=${viewAs.language.id}` +
+        (viewAs.device?.identifier ? `&device_id=${viewAs.device?.identifier}` : '')
     );
 }

--- a/core-web/apps/dotcms-ui/src/app/shared/dot-utils.ts
+++ b/core-web/apps/dotcms-ui/src/app/shared/dot-utils.ts
@@ -1,3 +1,5 @@
+import { DotPageRenderState } from '../portlets/dot-edit-page/shared/models';
+
 /**
  * Generate an anchor element with a Blob file to eventually be click to force a download
  * This approach is needed because FF do not hear WS events while waiting for a request.
@@ -15,4 +17,16 @@ export function formatMessage(message: string, args: string[]): string {
     return message.replace(/{(\d+)}/g, (match, number) => {
         return typeof args[number] !== 'undefined' ? args[number] : match;
     });
+}
+
+// Generates an unique Url with host, language and device Ids
+export function generateDotFavoritePageUrl(pageState: DotPageRenderState): string {
+    return (
+        `${pageState.params.page?.pageURI}?` +
+        (pageState.params.site?.identifier ? `host_id=${pageState.params.site?.identifier}` : '') +
+        `&language_id=${pageState.params.viewAs.language.id}` +
+        (pageState.params.viewAs.device?.identifier
+            ? `&device_id=${pageState.params.viewAs.device?.identifier}`
+            : '')
+    );
 }

--- a/core-web/apps/dotcms-ui/src/app/shared/models/dot-page/dot-rendered-page.model.ts
+++ b/core-web/apps/dotcms-ui/src/app/shared/models/dot-page/dot-rendered-page.model.ts
@@ -43,6 +43,10 @@ export class DotPageRender {
         return this._params.containers;
     }
 
+    get site(): DotSite {
+        return this._params.site;
+    }
+
     get template(): DotTemplate {
         return this._params.template;
     }

--- a/core-web/apps/dotcms-ui/src/app/test/dot-rendered-page-state.mock.ts
+++ b/core-web/apps/dotcms-ui/src/app/test/dot-rendered-page-state.mock.ts
@@ -5,5 +5,6 @@ import { DotPageRender } from '@models/dot-page/dot-rendered-page.model';
 
 export const mockDotRenderedPageState = new DotPageRenderState(
     mockUser(),
-    new DotPageRender(mockDotRenderedPage())
+    new DotPageRender(mockDotRenderedPage()),
+    false
 );

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/dot-iframe-porlet-legacy-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/dot-iframe-porlet-legacy-resolver.service.spec.ts
@@ -15,6 +15,7 @@ import { DotPageRenderState } from '@portlets/dot-edit-page/shared/models';
 import { DotIframePortletLegacyResolver } from './dot-iframe-porlet-legacy-resolver.service';
 import { DotLicenseService } from '@services/dot-license/dot-license.service';
 import { DotPageRender } from '@models/dot-page/dot-rendered-page.model';
+import { DotESContentService } from '@dotcms/app/api/services/dot-es-content/dot-es-content.service';
 
 const route: any = jasmine.createSpyObj<ActivatedRouteSnapshot>('ActivatedRouteSnapshot', [
     'toString'
@@ -39,6 +40,7 @@ describe('DotIframePorletLegacyResolver', () => {
                     DotPageRenderService,
                     DotContentletLockerService,
                     DotLicenseService,
+                    DotESContentService,
                     {
                         provide: ActivatedRouteSnapshot,
                         useValue: route


### PR DESCRIPTION
### Proposed Changes
As a user once that a new Favorite Page is created the Star icon needs to be highlighted to show that there's a contentlet created

![image](https://user-images.githubusercontent.com/37185433/193896144-ae71c007-5437-4197-a6e8-27aa3da98a1d.png)


![image](https://user-images.githubusercontent.com/37185433/193896171-9bea42e5-ba78-453b-a5ff-cb8827fe002b.png)


### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
