### PR TITLE
Issue 22996 add variant to index build

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESMappingAPITest.java
@@ -327,8 +327,10 @@ public class ESMappingAPITest {
 
         final VersionableAPI versionableAPI = mock(VersionableAPIImpl.class);
         final ContentletVersionInfo versionInfo = mock(ContentletVersionInfo.class);
-        when(versionableAPI
-                .getContentletVersionInfo(Matchers.any(String.class), Matchers.any(Long.class), Matchers.any(String.class)))
+        when(versionableAPI.getContentletVersionInfo(
+                Matchers.any(String.class),
+                Matchers.any(Long.class),
+                Matchers.any(String.class)))
                 .thenReturn(Optional.of(versionInfo));
 
         final ESMappingAPIImpl esMappingAPI = new ESMappingAPIImpl(
@@ -381,7 +383,10 @@ public class ESMappingAPITest {
         final VersionableAPI versionableAPI = mock(VersionableAPIImpl.class);
         final ContentletVersionInfo versionInfo = mock(ContentletVersionInfo.class);
         when(versionableAPI
-                .getContentletVersionInfo(Matchers.any(String.class), Matchers.any(Long.class), Matchers.any(String.class)))
+                .getContentletVersionInfo(
+                        Matchers.any(String.class),
+                        Matchers.any(Long.class),
+                        Matchers.any(String.class)))
                 .thenReturn(Optional.of(versionInfo));
 
         final ESMappingAPIImpl esMappingAPI = new ESMappingAPIImpl(

--- a/dotCMS/src/integration-test/java/com/dotmarketing/common/reindex/ReindexAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/common/reindex/ReindexAPITest.java
@@ -5,21 +5,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.dotmarketing.util.Config;
-import java.sql.Connection;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import com.dotmarketing.db.LocalTransaction;
-import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.ImmutableTextField;
@@ -30,10 +15,23 @@ import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.db.LocalTransaction;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
+import com.dotmarketing.util.Config;
 import com.google.common.collect.ImmutableList;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Test for {@link ReindexQueueAPI}
@@ -307,4 +305,5 @@ public class ReindexAPITest extends IntegrationTestBase {
 
         ReindexThread.unpause();
     }
+
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -4,6 +4,7 @@ import static com.dotcms.content.business.json.ContentletJsonAPI.SAVE_CONTENTLET
 import static com.dotcms.contenttype.model.type.BaseContentType.FILEASSET;
 import static com.dotcms.util.CollectionsUtils.map;
 import static com.dotmarketing.business.APILocator.getContentTypeFieldAPI;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.VARIANT_ID;
 import static java.io.File.separator;
 import static java.util.Collections.list;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -19,6 +20,7 @@ import static org.junit.Assert.fail;
 import com.dotcms.api.system.event.ContentletSystemEventUtil;
 import com.dotcms.concurrent.DotConcurrentFactory;
 import com.dotcms.concurrent.DotSubmitter;
+import com.dotcms.content.elasticsearch.business.ESContentFactoryImpl;
 import com.dotcms.content.elasticsearch.business.ESContentletAPIImpl;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.ContentTypeAPIImpl;
@@ -42,6 +44,7 @@ import com.dotcms.uuid.shorty.ShortyId;
 import com.dotcms.uuid.shorty.ShortyIdAPI;
 import com.dotcms.uuid.shorty.ShortyIdCache;
 import com.dotcms.variant.VariantAPI;
+import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.beans.MultiTree;
@@ -104,6 +107,7 @@ import com.dotmarketing.util.DateUtil;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
+import com.dotmarketing.util.StringUtils;
 import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
@@ -145,6 +149,7 @@ import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.context.Context;
 import org.apache.velocity.context.InternalContextAdapterImpl;
 import org.apache.velocity.runtime.parser.node.SimpleNode;
+import org.elasticsearch.action.search.SearchResponse;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -7602,6 +7607,70 @@ public class ContentletAPITest extends ContentletBaseTest {
             }
             fail("Should have thrown ValidationException");
         }
+    }
+
+    /**
+     * Method to test: checkIn content
+     * Given scenario: given indexed content in different variants
+     * Expected result: each document contain the proper variant in the id
+     *
+     */
+    @Test
+    public void test_variant_present_in_document_id() throws Exception {
+        final ContentType type = new ContentTypeDataGen()
+                .fields(ImmutableList
+                        .of(ImmutableTextField.builder().name("Title").variable("title")
+                                .searchable(true).listed(true).build()))
+                .nextPersisted();
+
+        final Variant newVariant = new VariantDataGen().nextPersisted();
+
+        // saves with DEFAULT variant
+        final Contentlet contentDefaultVariant = new ContentletDataGen(type.id())
+                .setProperty("title", "contentTest " + System.currentTimeMillis())
+                .nextPersisted();
+
+        // saves with newly created variant
+        final Contentlet contentNewVariant =
+                new ContentletDataGen(type.id())
+                        .setProperty("title", "contentTest " + System.currentTimeMillis())
+                        .setProperty(VARIANT_ID, newVariant.name())
+                        .nextPersisted();
+
+
+        final String queryContentOnDefaultVariant = "{"
+                + "query: {"
+                + "   query_string: {"
+                + "        query: \"+identifier: "+contentDefaultVariant.getIdentifier()+"\""
+                + "     }"
+                + "  },"
+                + "}";
+
+        final SearchResponse responseDefaultVariant = APILocator.getContentletAPI().esSearchRaw(
+                StringUtils.lowercaseStringExceptMatchingTokens(queryContentOnDefaultVariant,
+                        ESContentFactoryImpl.LUCENE_RESERVED_KEYWORDS_REGEX),
+                false, APILocator.systemUser(), false);
+
+        assertEquals(contentDefaultVariant.getIdentifier() + "_"
+                        + contentDefaultVariant.getLanguageId() + "_" + contentDefaultVariant.getVariantId(),
+                responseDefaultVariant.getHits().iterator().next().getId());
+
+        final String queryContentOnNewVariant = "{"
+                + "query: {"
+                + "   query_string: {"
+                + "        query: \"+identifier: "+contentNewVariant.getIdentifier()+"\""
+                + "     }"
+                + "  },"
+                + "}";
+
+        final SearchResponse responseNewVariant = APILocator.getContentletAPI().esSearchRaw(
+                StringUtils.lowercaseStringExceptMatchingTokens(queryContentOnNewVariant,
+                        ESContentFactoryImpl.LUCENE_RESERVED_KEYWORDS_REGEX),
+                false, APILocator.systemUser(), false);
+
+        assertEquals(contentNewVariant.getIdentifier() + "_"
+                        + contentNewVariant.getLanguageId() + "_" + contentNewVariant.getVariantId(),
+                responseNewVariant.getHits().iterator().next().getId());
     }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -158,7 +158,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
 /**
- * Created by Jonathan Gamba.
+ * Created by Jonathan Gamba. 
  * Date: 3/20/12
  * Time: 12:12 PM
  */

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -881,8 +881,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         for (Language language : languages) {
             for (final String index : info.asMap().values()) {
                 for(final Variant variant: variants) {
-                    final String id = entry.getIdentToIndex() + "_" + language.getId()
-                            + "_" + variant.name();
+                    final String id = entry.getIdentToIndex() + StringPool.UNDERLINE + language.getId()
+                            + StringPool.UNDERLINE + variant.name();
 
                     System.err.println("deleting:" + id);
                     bulk.add(new DeleteRequest(index, "_doc", id));

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -744,7 +744,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
 
         for (final Contentlet contentlet : contentToIndexSet) {
 
-            final String id = contentlet.getIdentifier() + "_" + contentlet.getLanguageId();
+            final String id = contentlet.getIdentifier() + "_" + contentlet.getLanguageId()
+                    + "_" + contentlet.getVariantId();
             Logger.debug(this,
                     () -> "\n*********----------- Indexing : " + Thread.currentThread().getName()
                             + ", id: "

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -389,6 +389,7 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 			contentletMap.put(ESMappingConstants.DELETED + TEXT, Boolean.toString(contentlet.isArchived()));
 			contentletMap.put(ESMappingConstants.LANGUAGE_ID, contentlet.getLanguageId());
 			contentletMap.put(ESMappingConstants.LANGUAGE_ID + TEXT, Long.toString(contentlet.getLanguageId()));
+			contentletMap.put(ESMappingConstants.VARIANT, contentlet.getVariantId());
 			contentletMap.put(ESMappingConstants.IDENTIFIER, contentIdentifier.getId());
 			contentletMap.put(ESMappingConstants.CONTENTLET_HOST, contentIdentifier.getHostId());
 			contentletMap.put(ESMappingConstants.CONTENTLET_HOSTNAME, contentSite.getHostname());

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -71,7 +71,6 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.ThreadSafeSimpleDateFormat;
 import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.liferay.portal.model.User;
@@ -83,7 +82,6 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -337,9 +335,10 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
                         .getIdentifier());
                 throw new DotDataException(errorMsg);
             }
-			final Optional<ContentletVersionInfo> versionInfo = versionableAPI.getContentletVersionInfo(contentIdentifier.getId(),
-					contentlet.getLanguageId(), contentlet.getVariantId());
-
+			final Optional<ContentletVersionInfo> versionInfo = versionableAPI.getContentletVersionInfo(
+					contentIdentifier.getId(),
+					contentlet.getLanguageId(),
+					contentlet.getVariantId());
             if (!versionInfo.isPresent()) {
                 final String errorMsg = String.format("Version Info for Identifier '%s' and Language '%s' was not" +
                         " found via API.", contentIdentifier.getId(), contentlet.getLanguageId());

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/constants/ESMappingConstants.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/constants/ESMappingConstants.java
@@ -55,6 +55,7 @@ public final class ESMappingConstants {
     public static final String LOCKED = "locked";
     public static final String DELETED = "deleted";
     public static final String LANGUAGE_ID = "languageId";
+    public static final String VARIANT = "variant";
     public static final String IDENTIFIER = "identifier";
     public static final String CONTENTLET_HOST = "conHost";
     public static final String CONTENTLET_HOSTNAME = "conHostName";

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
@@ -7,6 +7,7 @@ import com.dotmarketing.business.PermissionSummary;
 import com.dotmarketing.business.Permissionable;
 import com.dotmarketing.business.RelatedPermissionableGroup;
 import com.dotmarketing.business.Ruleable;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vavr.control.Try;
 import java.io.Serializable;
@@ -123,6 +124,7 @@ public interface AbstractExperiment extends Serializable, ManifestItem, Ruleable
         return Collections.emptyList();
     }
 
+    @JsonIgnore
     @Value.Derived
     @JsonIgnore
     default Permissionable getParentPermissionable() {

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
@@ -23,7 +23,7 @@ import org.immutables.value.Value;
  * and then get a report on which page performed better according to the decided goals.
  * <p>
  * The Experiment can be started now or scheduled to start and finish according to given dates
- * <p>
+ * <p> 
  *
  */
 @Value.Style(typeImmutable="*", typeAbstract="Abstract*")

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
@@ -23,7 +23,7 @@ import org.immutables.value.Value;
  * and then get a report on which page performed better according to the decided goals.
  * <p>
  * The Experiment can be started now or scheduled to start and finish according to given dates
- * <p> 
+ * <p>
  *
  */
 @Value.Style(typeImmutable="*", typeAbstract="Abstract*")

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
@@ -7,8 +7,6 @@ import com.dotmarketing.business.PermissionSummary;
 import com.dotmarketing.business.Permissionable;
 import com.dotmarketing.business.RelatedPermissionableGroup;
 import com.dotmarketing.business.Ruleable;
-import com.dotmarketing.exception.DotDataException;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vavr.control.Try;
 import java.io.Serializable;

--- a/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/model/AbstractExperiment.java
@@ -124,7 +124,6 @@ public interface AbstractExperiment extends Serializable, ManifestItem, Ruleable
         return Collections.emptyList();
     }
 
-    @JsonIgnore
     @Value.Derived
     @JsonIgnore
     default Permissionable getParentPermissionable() {

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantAPI.java
@@ -2,6 +2,7 @@ package com.dotcms.variant;
 
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.exception.DotDataException;
+import java.util.List;
 import java.util.Optional;
 
 public interface VariantAPI {
@@ -57,4 +58,10 @@ public interface VariantAPI {
      * @return {@link Variant}
      */
     Optional<Variant> get(final String name) throws DotDataException;
+
+    /**
+     * Gets all persisted {@link Variant}
+     * @return the variants
+     */
+    List<Variant> getVariants() throws DotDataException;
 }

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
@@ -117,6 +117,7 @@ public class VariantAPIImpl implements VariantAPI {
     }
 
     @Override
+    @CloseDBIfOpened
     public List<Variant> getVariants() throws DotDataException {
         return variantFactory.getVariants();
     }

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
@@ -10,6 +10,7 @@ import com.dotmarketing.business.FactoryLocator;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Logger;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -113,5 +114,10 @@ public class VariantAPIImpl implements VariantAPI {
         Logger.debug(this, ()-> "Getting Variant by Name: " + name);
 
         return variantFactory.get(name);
+    }
+
+    @Override
+    public List<Variant> getVariants() throws DotDataException {
+        return variantFactory.getVariants();
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantFactory.java
@@ -2,6 +2,7 @@ package com.dotcms.variant;
 
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.exception.DotDataException;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -52,4 +53,9 @@ public interface VariantFactory {
      */
     Optional<Variant> get(final String name) throws DotDataException;
 
+    /**
+     * Gets all persisted {@link Variant}
+     * @return the variants
+     */
+    List<Variant> getVariants() throws DotDataException;
 }

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantFactoryImpl.java
@@ -23,7 +23,7 @@ public class VariantFactoryImpl implements VariantFactory{
     private String VARIANT_UPDATE_QUERY = "UPDATE variant SET description = ?, archived = ? WHERE name =?";
     private String VARIANT_DELETE_QUERY = "DELETE from variant WHERE name =?";
     private String VARIANT_SELECT_QUERY = "SELECT * from variant WHERE name =?";
-    private String VARIANT_SELECT_ALL_QUERY = "SELECT * from variant";
+    private String VARIANT_SELECT_ALL_QUERY = "SELECT * from variant WHERE archived=?";
 
     /**
      * Implementation for {@link VariantFactory#save(Variant)}
@@ -127,6 +127,7 @@ public class VariantFactoryImpl implements VariantFactory{
     public List<Variant> getVariants() throws DotDataException {
         return TransformerLocator.createVariantTransformer(new DotConnect()
                 .setSQL(VARIANT_SELECT_ALL_QUERY)
+                .addParam(false)
                 .loadResults()).asList();
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantFactoryImpl.java
@@ -11,6 +11,8 @@ import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.UtilMethods;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -21,6 +23,7 @@ public class VariantFactoryImpl implements VariantFactory{
     private String VARIANT_UPDATE_QUERY = "UPDATE variant SET description = ?, archived = ? WHERE name =?";
     private String VARIANT_DELETE_QUERY = "DELETE from variant WHERE name =?";
     private String VARIANT_SELECT_QUERY = "SELECT * from variant WHERE name =?";
+    private String VARIANT_SELECT_ALL_QUERY = "SELECT * from variant";
 
     /**
      * Implementation for {@link VariantFactory#save(Variant)}
@@ -118,5 +121,12 @@ public class VariantFactoryImpl implements VariantFactory{
 
             return variantFromDataBase;
         }
+    }
+
+    @Override
+    public List<Variant> getVariants() throws DotDataException {
+        return TransformerLocator.createVariantTransformer(new DotConnect()
+                .setSQL(VARIANT_SELECT_ALL_QUERY)
+                .loadResults()).asList();
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPIImpl.java
@@ -6,16 +6,12 @@ import static com.dotcms.util.CollectionsUtils.list;
 import com.dotcms.api.system.event.message.MessageSeverity;
 import com.dotcms.api.system.event.message.MessageType;
 import com.dotcms.api.system.event.message.SystemMessageEventUtil;
-import com.dotcms.api.system.event.message.builder.SystemMessage;
 import com.dotcms.api.system.event.message.builder.SystemMessageBuilder;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.concurrent.Debouncer;
-import com.dotcms.concurrent.DotConcurrentFactory;
-import com.dotcms.enterprise.LicenseUtil;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.beans.VersionInfo;
-import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
@@ -38,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.jetbrains.annotations.NotNull;
 
 public class VersionableAPIImpl implements VersionableAPI {
 
@@ -310,8 +305,10 @@ public class VersionableAPIImpl implements VersionableAPI {
         if (contentlet.isHost()){
             info = versionableFactory.findAnyContentletVersionInfo(contentlet.getIdentifier());
         } else{
-            info = versionableFactory
-                    .getContentletVersionInfo(contentlet.getIdentifier(), contentlet.getLanguageId(), contentlet.getVariantId());
+            info = versionableFactory.getContentletVersionInfo(
+                    contentlet.getIdentifier(),
+                    contentlet.getLanguageId(),
+                    contentlet.getVariantId());
         }
 
         if(!info.isPresent())

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkActionListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkActionListener.java
@@ -1,5 +1,7 @@
 package com.dotmarketing.common.reindex;
 
+import static com.dotmarketing.common.reindex.BulkProcessorListener.getMatchingReservedIdIfAny;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -56,10 +58,13 @@ class BulkActionListener implements ActionListener<BulkResponse> {
             final DocWriteResponse itemResponse = bulkItemResponse.getResponse();
             String id;
             if (bulkItemResponse.isFailed() || itemResponse == null) {
-                id = bulkItemResponse.getFailure().getId().substring(0,
+                final String reservedId = getMatchingReservedIdIfAny(bulkItemResponse.getFailure().getId());
+
+                id = reservedId!=null ? reservedId: bulkItemResponse.getFailure().getId().substring(0,
                         bulkItemResponse.getFailure().getId().indexOf(StringPool.UNDERLINE));
             } else {
-                id = itemResponse.getId()
+                final String reservedId = getMatchingReservedIdIfAny(itemResponse.getId());
+                id = reservedId!=null ? reservedId: itemResponse.getId()
                         .substring(0, itemResponse.getId().indexOf(StringPool.UNDERLINE));
             }
 

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkActionListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkActionListener.java
@@ -57,10 +57,10 @@ class BulkActionListener implements ActionListener<BulkResponse> {
             String id;
             if (bulkItemResponse.isFailed() || itemResponse == null) {
                 id = bulkItemResponse.getFailure().getId().substring(0,
-                        bulkItemResponse.getFailure().getId().lastIndexOf(StringPool.UNDERLINE));
+                        bulkItemResponse.getFailure().getId().indexOf(StringPool.UNDERLINE));
             } else {
                 id = itemResponse.getId()
-                        .substring(0, itemResponse.getId().lastIndexOf(StringPool.UNDERLINE));
+                        .substring(0, itemResponse.getId().indexOf(StringPool.UNDERLINE));
             }
 
             ReindexEntry idx = workingRecords.get(id);

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
@@ -106,7 +106,7 @@ public class BulkProcessorListener implements BulkProcessor.Listener {
     static String getMatchingReservedIdIfAny(String id) {
         String matchingReservedId = null;
 
-        for (String reservedId : RESERVED_IDS) {
+        for (final String reservedId : RESERVED_IDS) {
             if(id.contains(reservedId)) {
                 matchingReservedId = reservedId;
                 break;

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
@@ -71,10 +71,10 @@ public class BulkProcessorListener implements BulkProcessor.Listener {
             String id;
             if (bulkItemResponse.isFailed() || itemResponse == null) {
                 id = bulkItemResponse.getFailure().getId().substring(0,
-                        bulkItemResponse.getFailure().getId().lastIndexOf(StringPool.UNDERLINE));
+                        bulkItemResponse.getFailure().getId().indexOf(StringPool.UNDERLINE));
             } else {
                 id = itemResponse.getId()
-                        .substring(0, itemResponse.getId().lastIndexOf(StringPool.UNDERLINE));
+                        .substring(0, itemResponse.getId().indexOf(StringPool.UNDERLINE));
             }
 
             ReindexEntry idx = workingRecords.get(id);

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
@@ -109,6 +109,7 @@ public class BulkProcessorListener implements BulkProcessor.Listener {
         for (String reservedId : RESERVED_IDS) {
             if(id.contains(reservedId)) {
                 matchingReservedId = reservedId;
+                break;
             }
         }
 

--- a/dotCMS/src/main/resources/es-content-mapping.json
+++ b/dotCMS/src/main/resources/es-content-mapping.json
@@ -60,7 +60,7 @@
           {
               "keywordmapping" : {
                   "match_pattern": "regex",
-                  "path_match": "categories|tags|conhost|conhostname|wfstep|structurename|contenttype|parentpath|path|urlmap|moduser|owner|metadata.contenttype|metadata.keywords",
+                  "path_match": "categories|tags|conhost|conhostname|wfstep|structurename|contenttype|parentpath|path|urlmap|moduser|owner|metadata.contenttype|metadata.keywords|variant",
                   "mapping": {
                       "type": "keyword"
                   }


### PR DESCRIPTION
Adds the variantName to the ID of the ES document.
Makes "variant" field a keyword so it doesn't get tokenized.
Integration tests.

Already approved in https://github.com/dotCMS/core/pull/23077