### PR TITLE
issue-22963-make-DotFavoritePage-feature-enabled-with-a-property-conf…

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.spec.ts
@@ -59,6 +59,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { ESContent } from '@dotcms/app/shared/models/dot-es-content/dot-es-content.model';
 import { DotPageRender } from '@dotcms/app/shared/models/dot-page/dot-rendered-page.model';
 import { mockDotRenderedPage } from '@dotcms/app/test/dot-page-render.mock';
+import { DotPropertiesService } from '@dotcms/app/api/services/dot-properties/dot-properties.service';
 
 @Component({
     selector: 'dot-test-host-component',
@@ -171,7 +172,8 @@ describe('DotEditPageToolbarComponent', () => {
                 UserModel,
                 DotIframeService,
                 DialogService,
-                DotESContentService
+                DotESContentService,
+                DotPropertiesService
             ]
         });
     });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
@@ -5,14 +5,15 @@ import {
     EventEmitter,
     Output,
     OnChanges,
-    OnDestroy,
-    isDevMode
+    OnDestroy
 } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { DotLicenseService } from '@services/dot-license/dot-license.service';
 import { DotPageRenderState } from '@portlets/dot-edit-page/shared/models';
 import { DotPageMode } from '@models/dot-page/dot-page-mode.enum';
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
+import { DotPropertiesService } from '@dotcms/app/api/services/dot-properties/dot-properties.service';
+import { take } from 'rxjs/operators';
 @Component({
     selector: 'dot-edit-page-toolbar',
     templateUrl: './dot-edit-page-toolbar.component.html',
@@ -35,13 +36,19 @@ export class DotEditPageToolbarComponent implements OnInit, OnChanges, OnDestroy
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
 
-    constructor(private dotLicenseService: DotLicenseService) {}
+    constructor(
+        private dotLicenseService: DotLicenseService,
+        private dotConfigurationService: DotPropertiesService
+    ) {}
 
     ngOnInit() {
         // TODO: Remove next line when total functionality of Favorite page is done for release
-        if (isDevMode()) {
-            this.showFavoritePageStar = true;
-        }
+        this.dotConfigurationService
+            .getKey('DOTFAVORITEPAGE_FEATURE_ENABLE')
+            .pipe(take(1))
+            .subscribe((enabled: string) => {
+                this.showFavoritePageStar = enabled === 'true';
+            });
 
         this.isEnterpriseLicense$ = this.dotLicenseService.isEnterprise();
         this.apiLink = `api/v1/page/render${this.pageState.page.pageURI}?language_id=${this.pageState.page.languageId}`;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.module.ts
@@ -16,6 +16,7 @@ import { DotFavoritePageModule } from '../../../components/dot-favorite-page/dot
 import { DialogService } from 'primeng/dynamicdialog';
 import { UiDotIconButtonModule } from '@components/_common/dot-icon-button/dot-icon-button.module';
 import { TooltipModule } from 'primeng/tooltip';
+import { DotPropertiesService } from '@dotcms/app/api/services/dot-properties/dot-properties.service';
 
 @NgModule({
     imports: [
@@ -37,6 +38,6 @@ import { TooltipModule } from 'primeng/tooltip';
     ],
     exports: [DotEditPageToolbarComponent],
     declarations: [DotEditPageToolbarComponent],
-    providers: [DialogService]
+    providers: [DialogService, DotPropertiesService]
 })
 export class DotEditPageToolbarModule {}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ConfigurationResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ConfigurationResource.java
@@ -63,7 +63,7 @@ public class ConfigurationResource implements Serializable {
 	private static final Set<String> WHITE_LIST = ImmutableSet.copyOf(
 			Config.getStringArrayProperty("CONFIGURATION_WHITE_LIST",
 					new String[] {"EMAIL_SYSTEM_ADDRESS", "CHARSET","CONTENT_PALETTE_HIDDEN_CONTENT_TYPES",
-					"FEATURE_FLAG_EXPERIMENTS"}));
+					"FEATURE_FLAG_EXPERIMENTS", "DOTFAVORITEPAGE_FEATURE_ENABLE"}));
 
 
 	private boolean isOnBlackList(final String key) {


### PR DESCRIPTION
…iguration

### Proposed Changes
* Enable DotFavoritePage icon on EDIT page setting `true` a property called `DOTFAVORITEPAGE_FEATURE_ENABLE` in the property file `dotmarketing-config.properties`

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
