### PR TITLE
dotCMS/core#23119 fix Field variables form breaks with long texts

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-input-row/dot-key-value-table-input-row.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-input-row/dot-key-value-table-input-row.component.scss
@@ -22,6 +22,7 @@
 
     td:nth-child(-n + 2) {
         padding-right: $spacing-4;
+        width: 37%;
     }
 }
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.html
@@ -12,20 +12,23 @@
             <p-cellEditor>
                 <ng-template pTemplate="input">
                     <input
-                        pInputText
                         class="field-value-input"
-                        autocomplete="false"
+                        [(ngModel)]="variableCopy.value"
                         [type]="variableCopy.hidden ? 'password' : 'text'"
                         [placeholder]="'keyValue.value_input.placeholder' | dm"
                         (focus)="editFieldInit()"
                         (keyup)="editFieldInit()"
                         (keydown.escape)="onCancel($event)"
                         (keydown.enter)="onPressEnter()"
-                        [(ngModel)]="variableCopy.value"
+                        pInputText
+                        autocomplete="false"
                     />
                 </ng-template>
                 <ng-template pTemplate="output">
-                    <span *ngIf="variableCopy.value && !variableCopy.hidden">
+                    <span
+                        class="dot-key-value-table-row__value-label"
+                        *ngIf="variableCopy.value && !variableCopy.hidden"
+                    >
                         {{ variableCopy.value }}
                     </span>
                     <span *ngIf="variableCopy.hidden"> ******** </span>
@@ -36,39 +39,39 @@
             </p-cellEditor>
         </td>
     </ng-template>
-    <td *ngIf="showHiddenField" class="dot-key-value-table-row__variables-hidden">
+    <td class="dot-key-value-table-row__variables-hidden" *ngIf="showHiddenField">
         <p-inputSwitch
             [(ngModel)]="variableCopy.hidden"
-            (onChange)="showEditMenu = true"
             [disabled]="isHiddenField"
+            (onChange)="showEditMenu = true"
         ></p-inputSwitch>
     </td>
     <td class="dot-key-value-table-row__variables-actions">
         <ng-template [ngIf]="showEditMenu" [ngIfElse]="formButtons">
             <button
-                pButton
                 class="dot-key-value-table-row__variables-actions-edit-cancel p-button-secondary p-button-sm"
                 [label]="'Cancel' | dm"
                 (click)="onCancel($event)"
+                pButton
             ></button>
             <button
-                #saveButton
-                pButton
                 class="dot-key-value-table-row__variables-actions-edit-save p-button-sm"
+                #saveButton
                 [label]="'Save' | dm"
                 [disabled]="saveDisabled"
                 (click)="saveVariable()"
+                pButton
             ></button>
         </ng-template>
         <ng-template #formButtons>
             <dot-icon-button
-                icon="delete_outline"
                 (click)="delete.emit(variableCopy)"
+                icon="delete_outline"
             ></dot-icon-button>
             <dot-icon-button
-                icon="edit"
                 [attr.disabled]="isHiddenField || null"
                 (click)="focusKeyInput($event)"
+                icon="edit"
             ></dot-icon-button>
         </ng-template>
     </td>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.scss
@@ -19,6 +19,11 @@
 
 .dot-key-value-table-row td:nth-child(-n + 2) {
     padding-right: $spacing-4;
+    width: 37%;
+}
+
+.dot-key-value-table-row__value-label {
+    word-break: break-word;
 }
 
 .dot-key-value-table-row td,


### PR DESCRIPTION
### Proposed Changes
* I need to be able to type and edit anything in the field variable form. Right now, long text or comma separated text are breaking the UI.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
