### PR TITLE
#18742 : Shallow Push must work as expected.

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/enterprise/publishing/remote/PushPublishBundleGeneratorTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/enterprise/publishing/remote/PushPublishBundleGeneratorTest.java
@@ -578,11 +578,11 @@ public class PushPublishBundleGeneratorTest extends IntegrationTestBase {
         Assert.assertNotNull(listOfAssetsWithNewFilter);
         Assert.assertFalse(listOfAssetsWithNewFilter.getStructures().isEmpty());
         Assert.assertTrue(listOfAssetsWithNewFilter.getStructures().contains(parentContentType.id()));
-        Assert.assertFalse(listOfAssetsWithNewFilter.getStructures().contains(childContentType.id()));
+        Assert.assertTrue(listOfAssetsWithNewFilter.getStructures().contains(childContentType.id()));
         Assert.assertFalse(listOfAssetsWithNewFilter.getContentlets().isEmpty());
         Assert.assertTrue(listOfAssetsWithNewFilter.getContentlets().contains(parentContentlet.getIdentifier()));
         Assert.assertFalse(listOfAssetsWithNewFilter.getContentlets().contains(childContentlet.getIdentifier()));
-        Assert.assertTrue(listOfAssetsWithNewFilter.getRelationships().isEmpty());
+        Assert.assertFalse(listOfAssetsWithNewFilter.getRelationships().isEmpty());
     }
 
     /**

--- a/dotCMS/src/integration-test/java/com/dotcms/enterprise/publishing/remote/bundler/DependencyBundlerTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/enterprise/publishing/remote/bundler/DependencyBundlerTest.java
@@ -102,10 +102,12 @@ public class DependencyBundlerTest {
                 .dependencies(false)
                 .next();
 
+        // Revisar con integration tests aqui
         filterDescriptorNotRelationship = new FilterDescriptorDataGen()
                 .relationships(false)
                 .next();
 
+        // Revisar con integration tests aqui
         filterDescriptorNotDependenciesRelationship = new FilterDescriptorDataGen()
                 .relationships(false)
                 .dependencies(false)
@@ -625,7 +627,7 @@ public class DependencyBundlerTest {
                 list(host, contentType, language, folder));
 
         final Map<String, List<ManifestItem>> contentletWithRelationshipExcludes = map(
-                FILTER_EXCLUDE_REASON, list(host, relationship, contentTypeParent, language),
+                FILTER_EXCLUDE_REASON, list(host, contentTypeParent, language, contentTypeChild),
                 EXCLUDE_SYSTEM_FOLDER_HOST, list(systemFolder));
 
         final Map<String, List<ManifestItem>> contentWithCategoryExcludes = map(FILTER_EXCLUDE_REASON,
@@ -654,11 +656,11 @@ public class DependencyBundlerTest {
 
                 new TestData(contentletWithRelationship, contentletWithRelationshipIncludes, excludeSystemFolder,
                         filterDescriptorAllDependencies, "Contentlet with Relationship and filterDescriptorAllDependencies"),
-                new TestData(contentletWithRelationship, map(), contentletWithRelationshipExcludes, filterDescriptorNotDependencies, "Contentlet with Relationship and filterDescriptorNotDependencies"),
-                new TestData(contentletWithRelationship, map(contentletWithRelationship, list(host, contentTypeParent, language), contentTypeParent, list(systemWorkflowScheme)),
-                        map(FILTER_EXCLUDE_REASON, list(relationship), EXCLUDE_SYSTEM_FOLDER_HOST, list(systemFolder)),
+                new TestData(contentletWithRelationship, map(contentTypeParent, list(relationship), contentletWithRelationship, list(relationship)), contentletWithRelationshipExcludes, filterDescriptorNotDependencies, "Contentlet with Relationship and filterDescriptorNotDependencies"),
+                new TestData(contentletWithRelationship, map(contentletWithRelationship, list(host, contentTypeParent, language, relationship), contentTypeParent, list(systemWorkflowScheme, relationship), relationship, list(contentTypeChild)),
+                        map(FILTER_EXCLUDE_REASON, list(), EXCLUDE_SYSTEM_FOLDER_HOST, list(systemFolder)),
                         filterDescriptorNotRelationship, "Contentlet with Relationship and filterDescriptorNotRelationship"),
-                new TestData(contentletWithRelationship, map(), contentletWithRelationshipExcludes,
+                new TestData(contentletWithRelationship, map(contentletWithRelationship, list(relationship), contentTypeParent, list(relationship)), contentletWithRelationshipExcludes,
                         filterDescriptorNotDependenciesRelationship, "Contentlet with Relationship and filterDescriptorNotDependenciesRelationship"),
 
                 new TestData(contentWithCategory, contentWithCategoryIncludes, excludeSystemFolder,
@@ -1178,12 +1180,12 @@ public class DependencyBundlerTest {
                         EXCLUDE_SYSTEM_FOLDER_HOST, list(systemFolder)), filterDescriptorNotDependenciesRelationship, "Contentype with Category and filterDescriptorNotDependenciesRelationship"),
 
                 new TestData(contentTypeParent, contentTypeParentIncludes, excludeSystemFolder, filterDescriptorAllDependencies, "Contentype with Relationship and filterDescriptorAllDependencies"),
-                new TestData(contentTypeParent, map(), map(FILTER_EXCLUDE_REASON, list(host, systemWorkflowScheme, relationship),
+                new TestData(contentTypeParent, map(contentTypeParent, list(relationship)), map(FILTER_EXCLUDE_REASON, list(host, systemWorkflowScheme, contentTypeChild),
                         EXCLUDE_SYSTEM_FOLDER_HOST, list(systemFolder)), filterDescriptorNotDependencies, "Contentype with Relationship and filterDescriptorNotDependencies"),
-                new TestData(contentTypeParent, map(contentTypeParent, list(host, systemWorkflowScheme)),
-                        map(FILTER_EXCLUDE_REASON, list(relationship), EXCLUDE_SYSTEM_FOLDER_HOST, list(systemFolder)),
+                new TestData(contentTypeParent, map(contentTypeParent, list(host, systemWorkflowScheme, relationship), relationship, list(contentTypeChild)),
+                        map(FILTER_EXCLUDE_REASON, list(), EXCLUDE_SYSTEM_FOLDER_HOST, list(systemFolder)),
                         filterDescriptorNotRelationship, "Contentype with Relationship and filterDescriptorNotRelationship"),
-                new TestData(contentTypeParent, map(), map(FILTER_EXCLUDE_REASON, list(host, systemWorkflowScheme, relationship),
+                new TestData(contentTypeParent, map(contentTypeParent, list(relationship)), map(FILTER_EXCLUDE_REASON, list(host, systemWorkflowScheme, contentTypeChild),
                         EXCLUDE_SYSTEM_FOLDER_HOST, list(systemFolder)), filterDescriptorNotDependenciesRelationship, "Contentype with Relationship and filterDescriptorNotDependenciesRelationship")
         );
     }

--- a/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
@@ -59,14 +59,14 @@ import java.util.stream.Collectors;
  */
 public class PushPublishigDependencyProcesor implements DependencyProcessor {
 
-    private PublisherFilter publisherFilter;
-    private PushPublisherConfig config;
-    private User user;
-    private ConcurrentDependencyProcessor dependencyProcessor;
-    private PushPublishigDependencyProvider pushPublishigDependencyProvider;
+    private final PublisherFilter publisherFilter;
+    private final PushPublisherConfig config;
+    private final User user;
+    private final ConcurrentDependencyProcessor dependencyProcessor;
+    private final PushPublishigDependencyProvider pushPublishigDependencyProvider;
 
-    private DependencyModDateUtil dependencyModDateUtil;
-    private PushedAssetUtil pushedAssetUtil;
+    private final DependencyModDateUtil dependencyModDateUtil;
+    private final PushedAssetUtil pushedAssetUtil;
 
     /**
      * Creates an instance of the Push Publishing Dependency Processor mechanism, and initializes all the different data
@@ -924,14 +924,24 @@ public class PushPublishigDependencyProcesor implements DependencyProcessor {
     }
 
     private <T> boolean isExcludeByFilter(final PusheableAsset pusheableAsset) {
-
-        return (
-            !publisherFilter.isDependencies() ||
-            PusheableAsset.RELATIONSHIP == pusheableAsset && !publisherFilter.isRelationships()) ||
-            publisherFilter.doesExcludeDependencyClassesContainsType(pusheableAsset.getType()
-        );
+        return !isRelationshipObject(pusheableAsset) && (!publisherFilter.isDependencies() ||
+            publisherFilter.doesExcludeDependencyClassesContainsType(pusheableAsset.getType()));
     }
 
+    /**
+     * Checks whether the specified Pusheable Asset represents a {@link Relationship} object or not. Unless the
+     * {@code excludeDependencyClasses} attribute in the Filter Descriptor YAML file includes the {@link Relationship}
+     * class, we should <b>ALWAYS</b> send the Relationship object when a Contentlet with a relationship field is being
+     * pushed. Otherwise, shallow pushing a Contentlet with related content and then shallow pushing such a related
+     * content will result in the parent content not having its relationship set as expected.
+     *
+     * @param pusheableAsset The {@link PusheableAsset} that is being analyzed.
+     *
+     * @return If the Pusheable Asset is a {@link Relationship} object, return {@code true}.
+     */
+    private boolean isRelationshipObject(final PusheableAsset pusheableAsset) {
+        return (PusheableAsset.RELATIONSHIP == pusheableAsset && !publisherFilter.doesExcludeDependencyClassesContainsType(pusheableAsset.getType()));
+    }
 
     private <T> boolean shouldCheckModDate(T asset) {
         return !Language.class.isInstance(asset);

--- a/dotCMS/src/main/webapp/WEB-INF/publishing-filters/ContentOnly.yml
+++ b/dotCMS/src/main/webapp/WEB-INF/publishing-filters/ContentOnly.yml
@@ -15,5 +15,5 @@ filters:
    excludeDependencyClasses: [ContentType,Template,Containers,Folder,Host,Links,Workflow,Language,Rule]
    ## force push as always worked, if true will push regardless the pushed asset history
    forcePush: false
-   ## check for relationships (if false neither the Relationship object nor the related content nor the related content type will be pushed)
+   ## check for relationships (if false neither the related content nor the related content type will be pushed)
    relationships: true

--- a/dotCMS/src/main/webapp/WEB-INF/publishing-filters/ForcePush.yml
+++ b/dotCMS/src/main/webapp/WEB-INF/publishing-filters/ForcePush.yml
@@ -15,5 +15,5 @@ filters:
    excludeDependencyClasses: []
    ## force push as always worked, if true will push regardless the pushed asset history
    forcePush: true
-   ## check for relationships (if false neither the Relationship object nor the related content nor the related content type will be pushed)
+   ## check for relationships (if false neither the related content nor the related content type will be pushed)
    relationships: true

--- a/dotCMS/src/main/webapp/WEB-INF/publishing-filters/Intelligent.yml
+++ b/dotCMS/src/main/webapp/WEB-INF/publishing-filters/Intelligent.yml
@@ -15,5 +15,5 @@ filters:
    excludeDependencyClasses: []
    ## force push as always worked, if true will push regardless the pushed asset history
    forcePush: false
-   ## check for relationships (if false neither the Relationship object nor the related content nor the related content type will be pushed)
+   ## check for relationships (if false neither the related content nor the related content type will be pushed)
    relationships: true

--- a/dotCMS/src/main/webapp/WEB-INF/publishing-filters/ShallowPush.yml
+++ b/dotCMS/src/main/webapp/WEB-INF/publishing-filters/ShallowPush.yml
@@ -15,5 +15,5 @@ filters:
    excludeDependencyClasses: []
    ## force push as always worked, if true will push regardless the pushed asset history
    forcePush: false
-   ## check for relationships (if false neither the Relationship object nor the related content nor the related content type will be pushed)
+   ## check for relationships (if false neither the related content nor the related content type will be pushed)
    relationships: false

--- a/dotCMS/src/main/webapp/WEB-INF/publishing-filters/WebContentOnly.yml
+++ b/dotCMS/src/main/webapp/WEB-INF/publishing-filters/WebContentOnly.yml
@@ -15,5 +15,5 @@ filters:
    excludeDependencyClasses: [Host, Workflow, ContentType, Language]
    ## force push as always worked, if true will push regardless the pushed asset history
    forcePush: false
-   ## check for relationships (if false neither the Relationship object nor the related content nor the related content type will be pushed)
+   ## check for relationships (if false neither the related content nor the related content type will be pushed)
    relationships: true


### PR DESCRIPTION
### Proposed Changes
* There are situations in which an HTML Page is shallow-pushed, i.e., none of its child contents are pushed along. If a User opens up that page in the receiving instance, this can result in the MultiTree cache storing an entry with an empty list of child contents. So, the next time any of such contents are pushed, they will not show up in the HTML Page, requiring the MultiTree cache to be flushed. This PR checks this situation, and flushes the respective cache entry when appropriate.