### PR TITLE
fix-block-editor-form-misspelling

### DIFF
--- a/core-web/libs/block-editor/src/lib/extensions/bubble-form/bubble-form.component.html
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-form/bubble-form.component.html
@@ -1,34 +1,34 @@
 <form *ngIf="form" [formGroup]="form" (ngSubmit)="onSubmit()">
-    <div *ngFor="let control of dynamicControls" class="form-row">
+    <div class="form-row" *ngFor="let control of dynamicControls">
         <label [for]="control.key">{{ control.label | titlecase }}</label>
         <ng-container [ngSwitch]="control.type">
             <input
-                *ngSwitchDefault
                 #group
-                pInputText
-                type="control.type"
+                *ngSwitchDefault
                 [formControlName]="control.key"
                 [id]="control.key"
                 [style]="{ width: '100%', fontSize: '14px', height: '40px' }"
+                pInputText
+                type="control.type"
             />
         </ng-container>
     </div>
 
     <div class="form-action">
         <button
-            pButton
-            type="button"
-            label="CANCEL"
             class="p-button-outlined"
             [style]="{ width: '120px' }"
             (click)="hide.emit(true)"
+            pButton
+            type="button"
+            label="CANCEL"
         ></button>
         <button
-            pButton
-            type="submit"
-            label="APPLAY"
             class="p-button"
             [style]="{ padding: '11.5px 24px' }"
+            pButton
+            type="submit"
+            label="APPLY"
         ></button>
     </div>
 </form>


### PR DESCRIPTION
We just fix this misspelling on the block editor form.

<img width="389" alt="misspelling" src="https://user-images.githubusercontent.com/72418962/196479179-046ffe00-c360-4355-ba7a-88120b371739.png">
