### PR TITLE
Issue 23159 allow add or remove contentlet to a specific pages version variant

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/ContentletDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/ContentletDataGen.java
@@ -4,6 +4,7 @@ import static com.dotmarketing.business.ModDateTestUtil.updateContentletVersionD
 import com.dotcms.contenttype.model.field.DataTypes;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.UserAPI;
@@ -49,6 +50,7 @@ public class ContentletDataGen extends AbstractDataGen<Contentlet> {
     private boolean skipValidation = false;
     private IndexPolicy policy = null;
     private Date modDate;
+    private String variantId;
 
     public ContentletDataGen(final ContentType contentType) {
         this(contentType.id());
@@ -66,6 +68,11 @@ public class ContentletDataGen extends AbstractDataGen<Contentlet> {
      */
     public ContentletDataGen languageId(long languageId){
         this.languageId = languageId;
+        return this;
+    }
+
+    public ContentletDataGen variant(final Variant variant) {
+        this.variantId = variant.name();
         return this;
     }
 
@@ -176,6 +183,8 @@ public class ContentletDataGen extends AbstractDataGen<Contentlet> {
         if (modDate != null) {
             contentlet.setProperty("_use_mod_date", modDate);
         }
+
+        contentlet.setVariantId(variantId);
 
         return contentlet;
     }

--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/MultiTreeDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/MultiTreeDataGen.java
@@ -1,5 +1,7 @@
 package com.dotcms.datagen;
 
+import com.dotcms.variant.VariantAPI;
+import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.MultiTree;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
@@ -14,6 +16,7 @@ public class MultiTreeDataGen extends AbstractDataGen<MultiTree> {
     private Contentlet contentlet;
     private String instanceID = "1";
     private String personalization = MultiTree.DOT_PERSONALIZATION_DEFAULT;
+    private String variantId = VariantAPI.DEFAULT_VARIANT.name();
     private int treeOrder;
     private HTMLPageAsset page;
 
@@ -26,6 +29,7 @@ public class MultiTreeDataGen extends AbstractDataGen<MultiTree> {
         multiTree.setInstanceId(instanceID);
         multiTree.setTreeOrder(treeOrder);
         multiTree.setPersonalization(personalization);
+        multiTree.setVariantId(variantId);
         multiTree.setTreeOrder(1);
 
         return multiTree;
@@ -73,6 +77,11 @@ public class MultiTreeDataGen extends AbstractDataGen<MultiTree> {
 
     public MultiTreeDataGen setPersona(Persona persona) {
         personalization = Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON + persona.getKeyTag();
+        return this;
+    }
+
+    public MultiTreeDataGen setVariant(final Variant variant) {
+        this.variantId = variant.name();
         return this;
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/common/db/DotDatabaseMetaDataTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/common/db/DotDatabaseMetaDataTest.java
@@ -1,7 +1,11 @@
 package com.dotmarketing.common.db;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.db.HibernateUtil;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.workflows.business.BaseWorkflowIntegrationTest;
@@ -9,8 +13,10 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -34,7 +40,7 @@ public class DotDatabaseMetaDataTest extends BaseWorkflowIntegrationTest {
                         Arrays.asList("structure_inode"), Arrays.asList("inode"));
 
         Assert.assertNotNull(foreignKey);
-        Assert.assertEquals("FK_structure_inode".toLowerCase(), foreignKey.getForeignKeyName().toLowerCase());
+        assertEquals("FK_structure_inode".toLowerCase(), foreignKey.getForeignKeyName().toLowerCase());
     }
 
     @Test
@@ -83,4 +89,34 @@ public class DotDatabaseMetaDataTest extends BaseWorkflowIntegrationTest {
         }
     }
 
+    /**
+     * Method to test: {@link DotDatabaseMetaData#getPrimaryKeysFields(String)}
+     * When: Call the method with templates table
+     * Should: return a list with 'inode'
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void getPrimaryKeyFields() {
+        final List<String> primaryKeysFields = DotDatabaseMetaData.getPrimaryKeysFields("template");
+        assertEquals(1, primaryKeysFields.size());
+
+        assertTrue(primaryKeysFields.contains("inode"));
+    }
+
+    /**
+     * Method to test: {@link DotDatabaseMetaData#getPrimaryKeysFields(String)}
+     * When: Call the method with contentlet_version_info table
+     * Should: return a list with 'inode'
+     *
+     * @throws SQLException
+     */
+    @Test
+    public void getContentletVersionInfoPrimaryKeyFields() {
+        final List<String> primaryKeysFields = DotDatabaseMetaData.getPrimaryKeysFields("contentlet_version_info");
+        assertEquals(3, primaryKeysFields.size());
+        assertTrue(primaryKeysFields.contains("lang"));
+        assertTrue(primaryKeysFields.contains("identifier"));
+        assertTrue(primaryKeysFields.contains("variant_id"));
+    }
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/factories/MultiTreeAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/factories/MultiTreeAPITest.java
@@ -172,6 +172,12 @@ public class MultiTreeAPITest extends IntegrationTestBase {
         assertTrue("multiTree reorders", list.get(4).getContentlet().equals("CONTENTLET4"));
     }
 
+    /**
+     * Method to test: {@link MultiTreeAPIImpl#saveMultiTreeAndReorder(MultiTree)}
+     * When: A {@link MultiTree} is saved with not the last treeorder expected with a specific {@link Variant}
+     * Should: Save it and reorder all the {@link MultiTree} that already exists to this {@link Variant}
+     * @throws Exception
+     */
     @Test
     public  void testReorderWithVariant() throws Exception {
         final Variant variant = new VariantDataGen().nextPersisted();

--- a/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task221018CreateVariantFieldInMultiTreeTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/startup/runonce/Task221018CreateVariantFieldInMultiTreeTest.java
@@ -1,0 +1,139 @@
+package com.dotmarketing.startup.runonce;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import graphql.Assert;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class Task221018CreateVariantFieldInMultiTreeTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+
+        checkIfFieldExist();
+        checkIfFieldIsIntoPrimaryKey();
+    }
+
+    /**
+     * Method to test: {@link Task221018CreateVariantFieldInMultiTree#executeUpgrade()} and {@link Task221018CreateVariantFieldInMultiTree#forceRun()}
+     * When: Run the {@link Task221018CreateVariantFieldInMultiTree#executeUpgrade()}
+     * Should: Create a new variantId field in the multi_tree table.
+     * Also should add the new field into the primarykey
+     *
+     * @throws SQLException
+     * @throws DotDataException
+     */
+    @Test
+    public void createField() throws SQLException, DotDataException {
+        cleanUp();
+        final DotDatabaseMetaData databaseMetaData = new DotDatabaseMetaData();
+
+        assertFalse(databaseMetaData
+                .hasColumn("multi_tree", "variantId"));
+        assertEquals(5, DotDatabaseMetaData.getPrimaryKeysFields("multi_tree").size());
+
+        final Task221018CreateVariantFieldInMultiTree task221018CreateMultiTreeField = new Task221018CreateVariantFieldInMultiTree();
+        assertTrue(task221018CreateMultiTreeField.forceRun());
+
+        task221018CreateMultiTreeField.executeUpgrade();
+
+        checkIfFieldExist();
+        checkIfFieldIsIntoPrimaryKey();
+        assertFalse(task221018CreateMultiTreeField.forceRun());
+    }
+
+    /**
+     * Method to test: {@link Task221018CreateVariantFieldInMultiTree#executeUpgrade()}
+     * When: Run the {@link Task221018CreateVariantFieldInMultiTree#executeUpgrade()} twice
+     * Should: Not throw any exception
+     *
+     * @throws SQLException
+     * @throws DotDataException
+     */
+    @Test
+    public void runTwice() throws SQLException, DotDataException {
+        cleanUp();
+        final DotDatabaseMetaData databaseMetaData = new DotDatabaseMetaData();
+
+        assertFalse(databaseMetaData
+                .hasColumn("multi_tree", "variantId"));
+        assertEquals(5, DotDatabaseMetaData.getPrimaryKeysFields("multi_tree").size());
+
+        final Task221018CreateVariantFieldInMultiTree task221018CreateMultiTreeField = new Task221018CreateVariantFieldInMultiTree();
+        assertTrue(task221018CreateMultiTreeField.forceRun());
+
+        task221018CreateMultiTreeField.executeUpgrade();
+        task221018CreateMultiTreeField.executeUpgrade();
+
+        checkIfFieldExist();
+        checkIfFieldIsIntoPrimaryKey();
+        assertFalse(task221018CreateMultiTreeField.forceRun());
+    }
+
+    private static void checkIfFieldIsIntoPrimaryKey() {
+        final List<String> multiTreePrimaryKey = DotDatabaseMetaData.getPrimaryKeysFields("multi_tree");
+        assertEquals(6, multiTreePrimaryKey.size());
+    }
+
+    private static void cleanUp () throws SQLException {
+
+        final String constraintName = DotDatabaseMetaData.getPrimaryKeyName("multi_tree")
+                .orElse("multi_tree_pkey");
+
+        try {
+            new DotConnect().executeStatement(
+                    "ALTER TABLE multi_tree DROP COLUMN variantId");
+        } catch (SQLException e) {
+            //ignore
+        }
+
+        try {
+            DotDatabaseMetaData.dropPrimaryKey("multi_tree");
+        } catch (Exception e) {
+            //ignore
+        }
+
+        new DotConnect().executeStatement(String.format("ALTER TABLE multi_tree "
+                + " ADD CONSTRAINT %s PRIMARY KEY (child, parent1, parent2, relation_type, personalization)", constraintName));
+    }
+
+    private static void checkIfFieldExist() throws SQLException {
+        final Connection connection = DbConnectionFactory.getConnection();
+
+        final ResultSet columnsMetaData = DotDatabaseMetaData
+                .getColumnsMetaData(connection, "multi_tree");
+
+        boolean variantIdFound = false;
+        while(columnsMetaData.next()){
+            final String columnName = columnsMetaData.getString("COLUMN_NAME");
+            final String columnType = columnsMetaData.getString(6);
+
+            if ("variant_id".equals(columnName)) {
+                variantIdFound = true;
+
+                if (DbConnectionFactory.isPostgres()) {
+                    assertEquals("varchar", columnType);
+                } else {
+                    assertEquals("nvarchar", columnType);
+                }
+
+                assertEquals("The column sice should be 255", "255", columnsMetaData.getString(7));
+            }
+        }
+
+        Assert.assertTrue( variantIdFound, "Should exists de variant_id field in multi_tree");
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -8078,7 +8078,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                                     multitree.getContentlet(),
                                     multitree.getRelationType(),
                                     multitree.getTreeOrder(),
-                                    multitree.getPersonalization()));
+                                    multitree.getPersonalization(),
+                                    multitree.getVariantId()));
                 }
             }
         }

--- a/dotCMS/src/main/java/com/dotmarketing/beans/MultiTree.java
+++ b/dotCMS/src/main/java/com/dotmarketing/beans/MultiTree.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.beans;
 
 
+import com.dotcms.variant.VariantAPI;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.containers.business.FileAssetContainerUtil;
 import com.dotmarketing.portlets.containers.model.Container;
@@ -42,13 +43,16 @@ public class MultiTree implements Serializable {
 
     private String personalization;
 
+    private String variantId;
+
     /** full constructor */
     public MultiTree(final String htmlPage,
                      final String container,
                      final String child,
                      final String instanceId,
                      final int treeOrder,
-                     final String personalization) {
+                     final String personalization,
+                     final String variantId) {
 
         this.parent1      = htmlPage;
         this.parent2      = container;
@@ -56,6 +60,7 @@ public class MultiTree implements Serializable {
         this.relationType = (instanceId == null) ? LEGACY_INSTANCE_ID : instanceId;
         this.treeOrder    = (treeOrder < 0) ? 0 : treeOrder;
         this.personalization = personalization;
+        this.variantId = variantId;
     }
 
     /** full constructor */
@@ -65,7 +70,18 @@ public class MultiTree implements Serializable {
                      final String instanceId,
                      final int treeOrder) {
 
-        this(htmlPage, container, child, instanceId, treeOrder, DOT_PERSONALIZATION_DEFAULT);
+        this(htmlPage, container, child, instanceId, treeOrder, DOT_PERSONALIZATION_DEFAULT,
+                VariantAPI.DEFAULT_VARIANT.name());
+    }
+
+    public MultiTree(final String htmlPage,
+            final String container,
+            final String child,
+            final String instanceId,
+            final int treeOrder,
+            final String personalization) {
+
+        this (htmlPage, container, child, instanceId, treeOrder, personalization, VariantAPI.DEFAULT_VARIANT.name());
     }
 
     /** default constructor */
@@ -79,7 +95,15 @@ public class MultiTree implements Serializable {
     }
 
     private MultiTree(MultiTree tree) {
-        this(tree.parent1, tree.parent2, tree.child, tree.relationType, tree.treeOrder, tree.getPersonalization());
+        this(tree.parent1, tree.parent2, tree.child, tree.relationType, tree.treeOrder, tree.getPersonalization(), tree.getVariantId());
+    }
+
+    public String getVariantId() {
+        return variantId != null ? variantId : VariantAPI.DEFAULT_VARIANT.name();
+    }
+
+    public void setVariantId(final String variantId) {
+        this.variantId = variantId;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/beans/MultiTree.java
+++ b/dotCMS/src/main/java/com/dotmarketing/beans/MultiTree.java
@@ -45,6 +45,15 @@ public class MultiTree implements Serializable {
 
     private String variantId;
 
+    /**
+     * @param htmlPage page's id
+     * @param container container's id
+     * @param child contentlet's id
+     * @param instanceId container UI ID
+     * @param treeOrder order to be show into the page
+     * @param personalization persona's tag
+     * @param variantId variant's name
+     */
     /** full constructor */
     public MultiTree(final String htmlPage,
                      final String container,

--- a/dotCMS/src/main/java/com/dotmarketing/beans/MultiTree.java
+++ b/dotCMS/src/main/java/com/dotmarketing/beans/MultiTree.java
@@ -102,8 +102,9 @@ public class MultiTree implements Serializable {
         return variantId != null ? variantId : VariantAPI.DEFAULT_VARIANT.name();
     }
 
-    public void setVariantId(final String variantId) {
+    public MultiTree setVariantId(final String variantId) {
         this.variantId = variantId;
+        return new MultiTree(this);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/beans/transform/MultiTreeTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/beans/transform/MultiTreeTransformer.java
@@ -18,6 +18,7 @@ public class MultiTreeTransformer implements DBTransformer<MultiTree> {
     private static final String RELATION_TYPE = "relation_type";
     private static final String TREE_ORDER = "tree_order";
     private static final String PERSONALIZATION = "personalization";
+    private static final String VARIANT = "variant_id";
 
     private final ArrayList<MultiTree> list = new ArrayList<>();
 
@@ -47,7 +48,9 @@ public class MultiTreeTransformer implements DBTransformer<MultiTree> {
         if (UtilMethods.isSet(map.get(TREE_ORDER))) {
             multiTree.setTreeOrder(ConversionUtils.toInt(map.get(TREE_ORDER), 0));
         }
-
+        if (UtilMethods.isSet(map.get(VARIANT))) {
+            multiTree.setVariantId(map.get(VARIANT).toString());
+        }
         return multiTree;
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/common/db/DotDatabaseMetaData.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/db/DotDatabaseMetaData.java
@@ -700,6 +700,12 @@ public class DotDatabaseMetaData {
         return indexMeta.stream().map(map -> map.get("index_name").toString()).collect(Collectors.toList());
     }
 
+    /**
+     * Return a list of the fields that make up the table primary key
+     *
+     * @param tableName
+     * @return
+     */
     public static List<String> getPrimaryKeysFields(final String tableName)  {
         try {
             final Connection connection = DbConnectionFactory.getConnection();

--- a/dotCMS/src/main/java/com/dotmarketing/common/db/DotDatabaseMetaData.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/db/DotDatabaseMetaData.java
@@ -4,6 +4,7 @@ import com.dotcms.util.CloseUtils;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.db.DbType;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.startup.AbstractJDBCStartupTask;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
@@ -699,6 +700,54 @@ public class DotDatabaseMetaData {
         return indexMeta.stream().map(map -> map.get("index_name").toString()).collect(Collectors.toList());
     }
 
+    public static List<String> getPrimaryKeysFields(final String tableName)  {
+        try {
+            final Connection connection = DbConnectionFactory.getConnection();
+            final ResultSet pkColumns = connection.getMetaData()
+                    .getPrimaryKeys(null, null, tableName);
+
+            List<String> primaryKeysFields = new ArrayList();
+
+            while (pkColumns.next()) {
+                primaryKeysFields.add(pkColumns.getString("COLUMN_NAME"));
+            }
+
+            return primaryKeysFields;
+        }catch (SQLException e) {
+            throw new DotRuntimeException(e);
+        }
+    }
+
+    public static void dropPrimaryKey(final String tableName){
+        final Optional<String> constraintNameOptional = getPrimaryKeyName(tableName);
+
+        if (constraintNameOptional.isPresent()) {
+            try {
+                new DotConnect().executeStatement(
+                        String.format("ALTER TABLE %s DROP CONSTRAINT %s", tableName,
+                                constraintNameOptional.get()));
+
+            } catch (Exception e) {
+                throw new DotRuntimeException(e);
+            }
+        }
+    }
+
+    public static Optional<String> getPrimaryKeyName(final String tableName)  {
+        try {
+            final ArrayList arrayList = new DotConnect()
+                    .setSQL("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS T "
+                            + "WHERE table_name = ? "
+                            + "AND constraint_type = 'PRIMARY KEY'")
+                    .addParam(tableName)
+                    .loadResults();
+
+            return arrayList.isEmpty() ? Optional.empty() :
+                    Optional.of((((Map) arrayList.get(0))).get("constraint_name").toString());
+        } catch (DotDataException e) {
+            return Optional.empty();
+        }
+    }
 
 } // E:O:F:DotDatabaseMetaData.
 

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPI.java
@@ -261,6 +261,18 @@ public interface MultiTreeAPI {
      * @param container
      * @param childContent
      * @param containerInstance
+     * @return
+     * @throws DotDataException
+     */
+    MultiTree getMultiTree(String htmlPage, String container, String childContent, String containerInstance, String personalization, String variantId) throws DotDataException;
+
+    /**
+     * Gets a specific MultiTree entry
+     *
+     * @param htmlPage
+     * @param container
+     * @param childContent
+     * @param containerInstance
      * @param personalization
      * @return MultiTree
      * @throws DotDataException

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPI.java
@@ -380,9 +380,30 @@ public interface MultiTreeAPI {
      * @throws DotDataException
      */
     void overridesMultitreesByPersonalization(final String pageId,
-                                                     final String personalization,
-                                                     final List<MultiTree> multiTrees,
-                                                     final Optional<Long> languageIdOpt) throws DotDataException;
+            final String personalization,
+            final List<MultiTree> multiTrees,
+            final Optional<Long> languageIdOpt
+    ) throws DotDataException;
+
+    /**
+     * Save a collection of {@link MultiTree} and link them with a page, Also delete all the
+     * {@link MultiTree} linked previously with the page.
+     *
+     * @param pageId {@link String} Page's identifier
+     * @param personalization {@link String} personalization token
+     * @param multiTrees {@link List} of {@link MultiTree} to safe
+     * @param languageIdOpt {@link Optional} {@link Long}  optional language, if present will deletes only the contentlets that have a version on this language.
+     *                                      Since it is by identifier, when deleting for instance in spanish, will remove the english and any other lang version too.
+     * @param variantId {@link com.dotcms.variant.model.Variant}'s id
+     *
+     * @throws DotDataException
+     */
+    void overridesMultitreesByPersonalization(final String pageId,
+                                             final String personalization,
+                                             final List<MultiTree> multiTrees,
+                                             final Optional<Long> languageIdOpt,
+                                             final String variantId
+                                        ) throws DotDataException;
 
     /**
      * Updates the current personalization to a new personalization

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -645,7 +645,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
     private void deleteMultiTreeToMySQL(
             final String pageId,
             final String personalization,
-            final Optional<Long> languageIdOpt, String variantId) throws DotDataException {
+            final Optional<Long> languageIdOpt, final String variantId) throws DotDataException {
         final DotConnect db = new DotConnect();
 
         final List<String> multiTreesId = db.setSQL(SELECT_MULTI_TREE_BY_LANG)

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -89,7 +89,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
             "select distinct contentlet.identifier from contentlet,multi_tree where multi_tree.child = contentlet.identifier and multi_tree.parent1 = ? and language_id = ? and variant_id = ?";
 
     private static final String UPDATE_MULTI_TREE_PERSONALIZATION = "update multi_tree set personalization = ? where personalization = ?";
-    private static final String SELECT_SQL = "select * from multi_tree where parent1 = ? and parent2 = ? and child = ? and  relation_type = ? and personalization = ? and variant_id = 'DEFAULT'";
+    private static final String SELECT_SQL = "select * from multi_tree where parent1 = ? and parent2 = ? and child = ? and  relation_type = ? and personalization = ? and variant_id = ?";
 
     private static final String INSERT_SQL = "insert into multi_tree (parent1, parent2, child, relation_type, tree_order, personalization, variant_id) values (?,?,?,?,?,?,?)  ";
 
@@ -189,13 +189,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
                                   final String containerInstance, final String personalization)
             throws DotDataException {
 
-        final DotConnect db =
-                new DotConnect().setSQL(SELECT_SQL).addParam(htmlPage).addParam(container)
-                        .addParam(childContent).addParam(containerInstance)
-                        .addParam(personalization);
-        db.loadResult();
-
-        return TransformerLocator.createMultiTreeTransformer(db.loadObjectResults()).findFirst();
+        return this.getMultiTree(htmlPage, container, childContent, containerInstance, personalization, VariantAPI.DEFAULT_VARIANT.name());
 
     }
 
@@ -203,7 +197,21 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
     public MultiTree getMultiTree(final String htmlPage, final String container, final String childContent, final String containerInstance)
             throws DotDataException {
 
-        return this.getMultiTree(htmlPage, container, childContent, containerInstance, MultiTree.DOT_PERSONALIZATION_DEFAULT);
+        return this.getMultiTree(htmlPage, container, childContent, containerInstance, MultiTree.DOT_PERSONALIZATION_DEFAULT, VariantAPI.DEFAULT_VARIANT.name());
+    }
+
+    @Override
+    public MultiTree getMultiTree(final String htmlPage, final String container, final String childContent,
+            final String containerInstance,  final String personalization, final String variantId)
+            throws DotDataException {
+        final DotConnect db =
+                new DotConnect().setSQL(SELECT_SQL).addParam(htmlPage).addParam(container)
+                        .addParam(childContent).addParam(containerInstance)
+                        .addParam(personalization).addParam(variantId);
+        db.loadResult();
+
+        return TransformerLocator.createMultiTreeTransformer(db.loadObjectResults()).findFirst();
+
     }
 
     /**
@@ -716,7 +724,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
             for (final MultiTree tree : mTrees) {
                 insertParams
                         .add(new Params(pageId, tree.getContainerAsID(), tree.getContentlet(),
-                                tree.getRelationType(), tree.getTreeOrder(), tree.getPersonalization()));
+                                tree.getRelationType(), tree.getTreeOrder(), tree.getPersonalization(), tree.getVariantId()));
                 newContainers.add(tree.getContainer());
             }
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task221007AddVariantIntoPrimaryKey.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task221007AddVariantIntoPrimaryKey.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.startup.runonce;
 
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
@@ -17,7 +18,7 @@ public class Task221007AddVariantIntoPrimaryKey extends AbstractJDBCStartupTask 
 
     @Override
     public boolean forceRun() {
-        final List<String> primaryKeysFields = getPrimaryKeysFields();
+        final List<String> primaryKeysFields = DotDatabaseMetaData.getPrimaryKeysFields("contentlet_version_info");
         return primaryKeysFields.size() != 3 ||
                 (!primaryKeysFields.contains("identifier") ||
                 !primaryKeysFields.contains("variant_id") ||
@@ -51,23 +52,5 @@ public class Task221007AddVariantIntoPrimaryKey extends AbstractJDBCStartupTask 
         final String createStatement = String.format("ALTER TABLE contentlet_version_info "
                 + " ADD CONSTRAINT %s PRIMARY KEY (identifier, lang, variant_id)", name);
         return dropStatement + ";" + createStatement + ";";
-    }
-
-    private List<String> getPrimaryKeysFields()  {
-        try {
-            final Connection connection = DbConnectionFactory.getConnection();
-            final ResultSet pkColumns = connection.getMetaData()
-                    .getPrimaryKeys(null, null, "contentlet_version_info");
-
-            List<String> primaryKeysFields = new ArrayList();
-
-            while (pkColumns.next()) {
-                primaryKeysFields.add(pkColumns.getString("COLUMN_NAME"));
-            }
-
-            return primaryKeysFields;
-        } catch (SQLException e) {
-            return Collections.emptyList();
-        }
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task221018CreateVariantFieldInMultiTree.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task221018CreateVariantFieldInMultiTree.java
@@ -1,0 +1,54 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.db.DbConnectionFactory;
+
+import com.dotmarketing.startup.AbstractJDBCStartupTask;
+import com.liferay.util.StringPool;
+import java.sql.SQLException;
+import java.util.Optional;
+
+public class Task221018CreateVariantFieldInMultiTree extends AbstractJDBCStartupTask {
+
+    @Override
+    public boolean forceRun() {
+        return !hasAddRemoveField();
+    }
+
+    private boolean hasAddRemoveField() {
+        final DotDatabaseMetaData databaseMetaData = new DotDatabaseMetaData();
+
+        try {
+            return databaseMetaData.hasColumn("multi_tree", "variantId");
+        } catch (SQLException e) {
+            return false;
+        }
+    }
+
+    public String getPostgresScript() {
+        return hasAddRemoveField() ? StringPool.BLANK : getCreateFieldStatement() + ";" + addVariantIdIntoPrimaryKey() + ";";
+    }
+
+
+    public String getMSSQLScript(){
+        return hasAddRemoveField() ? StringPool.BLANK : getCreateFieldStatement()  + ";" + addVariantIdIntoPrimaryKey() + ";";
+    }
+
+
+    private String getCreateFieldStatement() {
+        final String dataBaseFieldType = DbConnectionFactory.isMsSql() ? "NVARCHAR" : "varchar";
+
+        return String.format(
+                "ALTER TABLE multi_tree ADD variantId %s(255)",
+                dataBaseFieldType);
+    }
+
+    private String addVariantIdIntoPrimaryKey() {
+        final Optional<String> primaryKeyName = DotDatabaseMetaData.getPrimaryKeyName("multi_tree");
+        final String dropStatement = String.format("ALTER TABLE multi_tree DROP CONSTRAINT %s", primaryKeyName.get());
+
+        final String createStatement = String.format("ALTER TABLE multi_tree "
+                + " ADD CONSTRAINT %s PRIMARY KEY (child, parent1, parent2, relation_type, personalization, variant_id)", primaryKeyName.get());
+        return dropStatement + ";" + createStatement + ";";
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -227,6 +227,7 @@ import com.dotmarketing.startup.runonce.Task220829CreateExperimentsTable;
 import com.dotmarketing.startup.runonce.Task220912UpdateCorrectShowOnMenuProperty;
 import com.dotmarketing.startup.runonce.Task220928AddLookbackWindowColumnToExperiment;
 import com.dotmarketing.startup.runonce.Task221007AddVariantIntoPrimaryKey;
+import com.dotmarketing.startup.runonce.Task221018CreateVariantFieldInMultiTree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -529,6 +530,7 @@ public class TaskLocatorUtil {
 		.add(Task220825CreateVariantField.class)
 		.add(Task220928AddLookbackWindowColumnToExperiment.class)
 		.add(Task221007AddVariantIntoPrimaryKey.class)
+		.add(Task221018CreateVariantFieldInMultiTree.class)
 		.build();
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
 	}

--- a/dotCMS/src/main/resources/mssql.sql
+++ b/dotCMS/src/main/resources/mssql.sql
@@ -1298,7 +1298,8 @@ create table multi_tree (
    relation_type NVARCHAR(64) not null,
    tree_order int null,
    personalization NVARCHAR(255) not null  default 'dot:default',
-   primary key (child, parent1, parent2, relation_type, personalization)
+   variant_id NVARCHAR(255) default 'DEFAULT' not null,
+   primary key (child, parent1, parent2, relation_type, personalization, variant_id)
 );
 create table workflow_task (
    id NVARCHAR(36) not null,

--- a/dotCMS/src/main/resources/postgres.sql
+++ b/dotCMS/src/main/resources/postgres.sql
@@ -1063,7 +1063,8 @@ create table multi_tree (
    relation_type varchar(64) not null,
    tree_order int4,
    personalization varchar(255) not null default 'dot:default',
-   primary key (child, parent1, parent2, relation_type, personalization)
+   variant_id varchar(255) default 'DEFAULT' not null,
+   primary key (child, parent1, parent2, relation_type, personalization, variant_id)
 );
 create table workflow_task (
    id varchar(36) not null,


### PR DESCRIPTION
### Proposed Changes
* Add a new variant_id field into the multi_tree table
* Also use this new field into MultiTreeAPIImpl
* Move some methods to DotDatabaseMetaData to reuse
* Modify the SLECT that we have right now to hit the multi_tree table, they were update to add the variant_id field in different ways:
- Add variant as parameters because it is use into the save variant API method to check if the primary key is not duplicated

https://github.com/dotCMS/core/pull/23211/files#diff-926e9e9e22e2c282fa305bbe50022e93d9d91d6b83a5c33c8e29cacde4a0b52cR82

- This one is used to delete all the multi_tree before add the new ones, when we change any multi_tree into the page really what we are doing is deleting all the multi_tree and then add all of them again

https://github.com/dotCMS/core/pull/23211/files#diff-926e9e9e22e2c282fa305bbe50022e93d9d91d6b83a5c33c8e29cacde4a0b52cR88

- For the others was added the filter to get just the DEFAULT versions, because:
Some of them are been using into API methods that we are not using into our code but the client can be using them so we don't want to change the behavior for this method right now.
Also some then are be using into features like Push Publish and even though we need to change the behavior of PP to send new concept like Experiment, Variants, etc, I think it is better to change it when we will be really working on that

 https://github.com/dotCMS/core/pull/23211/files#diff-926e9e9e22e2c282fa305bbe50022e93d9d91d6b83a5c33c8e29cacde4a0b52cL95-L104
