### PR TITLE
dotCMS/core#23314 Click in the container row should edit

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.html
@@ -10,6 +10,7 @@
             [actions]="[]"
             [checkbox]="true"
             (selectedItems)="updateSelectedContainers($event)"
+            (rowWasClicked)="handleRowClick($event)"
             url="v1/containers?system=true"
             dataKey="inode"
         >

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.spec.ts
@@ -147,9 +147,11 @@ class ActivatedRouteMock {
 
 describe('ContainerListComponent', () => {
     let fixture: ComponentFixture<ContainerListComponent>;
+    let comp: ContainerListComponent;
     let dotListingDataTable: DotListingDataTableComponent;
     let dotPushPublishDialogService: DotPushPublishDialogService;
     let coreWebService: CoreWebService;
+    let dotRouterService: DotRouterService;
 
     const messageServiceMock = new MockDotMessageService(messages);
 
@@ -204,8 +206,10 @@ describe('ContainerListComponent', () => {
             schemas: [CUSTOM_ELEMENTS_SCHEMA]
         }).compileComponents();
         fixture = TestBed.createComponent(ContainerListComponent);
+        comp = fixture.componentInstance;
         dotPushPublishDialogService = TestBed.inject(DotPushPublishDialogService);
         coreWebService = TestBed.inject(CoreWebService);
+        dotRouterService = TestBed.inject(DotRouterService);
     });
 
     describe('with data', () => {
@@ -231,6 +235,14 @@ describe('ContainerListComponent', () => {
             expect(dotListingDataTable.actions).toEqual([]);
             expect(dotListingDataTable.checkbox).toEqual(true);
             expect(dotListingDataTable.dataKey).toEqual('inode');
+        });
+
+        it('should clicked on row and emit dotRouterService', () => {
+            comp.listing.dataTable.tableViewChild.nativeElement.rows[1].click();
+            expect(dotRouterService.goToEditContainer).toHaveBeenCalledTimes(1);
+            expect(dotRouterService.goToEditContainer).toHaveBeenCalledWith(
+                containersMock[0].identifier
+            );
         });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.ts
@@ -60,6 +60,15 @@ export class ContainerListComponent implements OnDestroy {
     }
 
     /**
+     * Get the clicked container row and redirect to edit container page.
+     * @param {DotContainer} container
+     * @memberof ContainerListComponent
+     */
+    handleRowClick(container: DotContainer) {
+        this.store.editContainer(container);
+    }
+
+    /**
      * Handle filter for hide / show archive containers
      * @param {boolean} checked
      *

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/store/dot-container-list.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/store/dot-container-list.store.ts
@@ -443,11 +443,10 @@ export class DotContainerListStore extends ComponentStore<DotContainerListState>
 
     /**
      * Handle selected container.
-     *
      * @param {DotContainer} container
      * @memberof DotContainerListComponent
      */
-    private editContainer(container: DotContainer): void {
+    editContainer(container: DotContainer): void {
         this.isContainerAsFile(container)
             ? this.dotSiteBrowserService
                   .setSelectedFolder(container.identifier)

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.ts
@@ -129,8 +129,11 @@ export class DotListingDataTableComponent implements OnInit {
      * @memberof DotListingDataTableComponent
      */
     handleRowClick(rowData: Record<string, unknown>): void {
-        // If the system template is clicked, do nothings.
-        if (rowData?.identifier === 'SYSTEM_TEMPLATE') {
+        // If the system template or system contaier is clicked, do nothings.
+        if (
+            rowData?.identifier === 'SYSTEM_TEMPLATE' ||
+            rowData?.identifier === 'SYSTEM_CONTAINER'
+        ) {
             return;
         }
 


### PR DESCRIPTION

### Proposed Changes
* When the User clicks on the container row it is redirected to the container edit screen.
* disabled click on System Container row.

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
