### PR TITLE
#23056 : Set language in docker image to C.UTF8

### DIFF
--- a/cicd/docker/dotcms-compose.yml
+++ b/cicd/docker/dotcms-compose.yml
@@ -22,6 +22,7 @@ services:
       - 8443:8443
       - 8000:8000
     environment:
+      LANG: 'C.UTF-8'
       databaseType: "${DB_TYPE}"
       CATALINA_OPTS: "-XX:+PrintFlagsFinal"
       DB_BASE_URL: "jdbc:postgresql://database/dotcms"

--- a/docker/docker-compose-examples/cluster-mode/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/cluster-mode/docker-compose-node-1.yml
@@ -29,6 +29,7 @@ services:
   dotcms-node-1:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/cluster-mode/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/cluster-mode/docker-compose-node-2.yml
@@ -13,6 +13,7 @@ services:
   dotcms-node-2:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/push-publish/docker-compose-receiver.yml
+++ b/docker/docker-compose-examples/push-publish/docker-compose-receiver.yml
@@ -28,6 +28,7 @@ services:
   dotcms-receiver:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "DB_BASE_URL": "jdbc:postgresql://db-receiver/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/push-publish/docker-compose-sender.yml
+++ b/docker/docker-compose-examples/push-publish/docker-compose-sender.yml
@@ -28,6 +28,7 @@ services:
   dotcms-sender:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "DB_BASE_URL": "jdbc:postgresql://db-sender/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/single-node-debug-mode/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-debug-mode/docker-compose.yml
@@ -29,6 +29,7 @@ services:
   dotcms:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "CMS_JAVA_OPTS": '-Xmx1g -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:8000 '
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'

--- a/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
@@ -29,6 +29,7 @@ services:
   dotcms:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "CATALINA_OPTS": '-Xmx1g '
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'

--- a/docker/docker-compose-examples/single-node/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node/docker-compose.yml
@@ -29,6 +29,7 @@ services:
   dotcms:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "CATALINA_OPTS": '-Xmx1g '
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'

--- a/docker/docker-compose-examples/with-kibana/docker-compose.yml
+++ b/docker/docker-compose-examples/with-kibana/docker-compose.yml
@@ -38,6 +38,7 @@ services:
   dotcms:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/with-mssql-arm/docker-compose.yml
+++ b/docker/docker-compose-examples/with-mssql-arm/docker-compose.yml
@@ -25,6 +25,7 @@ services:
   dotcms-dev:
     image: dotcms/dotcms:latest
     environment:
+      "LANG": 'C.UTF-8'
       "CATALINA_OPTS": " -Xms1g -Xmx1g "
       "DB_BASE_URL": "jdbc:sqlserver://db-dev;databaseName=master"
       "DB_USERNAME": "sa"

--- a/docker/docker-compose-examples/with-mssql/docker-compose.yml
+++ b/docker/docker-compose-examples/with-mssql/docker-compose.yml
@@ -25,6 +25,7 @@ services:
   dotcms-dev:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "CATALINA_OPTS": ' -Xms1g -Xmx1g '
         "DB_BASE_URL": "jdbc:sqlserver://db-dev:1433;databaseName=dotcms"
         "DB_USERNAME": 'SA'

--- a/docker/docker-compose-examples/with-redis/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/with-redis/docker-compose-node-1.yml
@@ -30,6 +30,7 @@ services:
   dotcms-node-1:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'

--- a/docker/docker-compose-examples/with-redis/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/with-redis/docker-compose-node-2.yml
@@ -15,6 +15,7 @@ services:
   dotcms-node-2:
     image: dotcms/dotcms:latest
     environment:
+        "LANG": 'C.UTF-8'
         "DB_BASE_URL": "jdbc:postgresql://db/dotcms"
         "DB_USERNAME": 'dotcmsdbuser'
         "DB_PASSWORD": 'password'


### PR DESCRIPTION
### Proposed Changes
* Adding the following environment variable to all `docker-compose.yml` files in the repo:
```yml
environment:
      LANG: 'C.UTF-8'
```