### PR TITLE
#23015 skip validating relationships if no rel-field headers

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -7230,6 +7230,32 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
+    public void validateContentletNoRels(final Contentlet contentlet,
+            final List<Category> cats) throws DotContentletValidationException {
+        if (null != contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME)) {
+            return;
+        }
+        final String contentTypeId = contentlet.getContentTypeId();
+        if (!InodeUtils.isSet(contentTypeId)) {
+            final String errorMsg = "Contentlet [" + contentlet.getIdentifier() + "] has an empty Content Type ID";
+            Logger.error(this, errorMsg);
+            throw new DotContentletValidationException(errorMsg);
+        }
+        try {
+            validateContentlet(contentlet, cats);
+            if (BaseContentType.PERSONA.getType() == contentlet.getContentType().baseType().getType()) {
+                APILocator.getPersonaAPI().validatePersona(contentlet);
+            }
+            if (contentlet.isVanityUrl()) {
+                APILocator.getVanityUrlAPI().validateVanityUrl(contentlet);
+            }
+        } catch (final DotContentletValidationException ve) {
+            throw ve;
+        }
+    }
+
+    @CloseDBIfOpened
+    @Override
     public void validateContentlet(final Contentlet contentlet, final ContentletRelationships contentRelationships,
             final List<Category> cats) throws DotContentletValidationException {
         if (null != contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME)) {
@@ -7252,7 +7278,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
         } catch (final DotContentletValidationException ve) {
             throw ve;
         }
-        validateRelationships(contentlet, contentRelationships);
+
+        if(Try.of(()->!contentlet.getBoolProperty(Contentlet.SKIP_RELATIONSHIPS_VALIDATION)).getOrElse(true)) {
+            validateRelationships(contentlet, contentRelationships);
+        }
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -1727,7 +1727,11 @@ public interface ContentletAPI {
 	 * Use the notValidFields property of the exception to get which fields where not valid
 	 */
 	public void validateContentlet(Contentlet contentlet,Map<Relationship, List<Contentlet>> contentRelationships,List<Category> cats) throws DotContentletValidationException;
-	
+
+	@CloseDBIfOpened
+	void validateContentletNoRels(Contentlet contentlet,
+			List<Category> cats) throws DotContentletValidationException;
+
 	/**
 	 * Use to validate your contentlet.
 	 * @param contentlet

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -1955,6 +1955,21 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 	}
 
 	@Override
+	public void validateContentletNoRels(Contentlet contentlet, List<Category> cats) throws DotContentletValidationException {
+		for(ContentletAPIPreHook pre : preHooks){
+			boolean preResult = pre.validateContentletNoRels(contentlet, cats);
+			if(!preResult){
+				Logger.error(this, "The following prehook failed " + pre.getClass().getName());
+				throw new DotRuntimeException("The following prehook failed " + pre.getClass().getName());
+			}
+		}
+		conAPI.validateContentletNoRels(contentlet, cats);
+		for(ContentletAPIPostHook post : postHooks){
+			post.validateContentletNoRels(contentlet, cats);
+		}
+	}
+
+	@Override
 	public void addPreHook(String className) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
 		Object o = Class.forName(className).newInstance();
         addPreHook( o );

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
@@ -978,8 +978,16 @@ public interface ContentletAPIPostHook {
 	 * @param contentRelationships
 	 * @param cats - categories
 	 */
-	public default void validateContentlet(Contentlet contentlet, ContentletRelationships contentRelationships, List<Category> cats){} 
-	
+	public default void validateContentlet(Contentlet contentlet, ContentletRelationships contentRelationships, List<Category> cats){}
+
+	/**
+	 * Use to validate your contentlet.
+	 * @param contentlet
+	 * @param cats - categories
+	 */
+	default void validateContentletNoRels(Contentlet contentlet, List<Category> cats){}
+
+
 	/**
 	 * Use to determine if if the field value is a String value withing the contentlet object
 	 * @param field

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
@@ -1143,8 +1143,17 @@ public interface ContentletAPIPreHook {
 	 */
 	public default boolean validateContentlet(Contentlet contentlet, ContentletRelationships contentRelationships, List<Category> cats){
       return true;
-    } 
-	
+    }
+
+	/**
+	 * Use to validate your contentlet.
+	 * @param contentlet
+	 * @param cats - categories
+	 */
+	default boolean validateContentletNoRels(Contentlet contentlet, List<Category> cats){
+		return true;
+	}
+
 	/**
 	 * Use to determine if if the field value is a String value withing the contentlet object
 	 * @param field

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -159,6 +159,8 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
   public static final String TEMP_BINARY_IMAGE_INODES_LIST = "tempBinaryImageInodesList";
   public static final String RELATIONSHIP_KEY = "__##relationships##__";
 
+  public static final String SKIP_RELATIONSHIPS_VALIDATION = "__skipRelationshipValidation__";
+
   private transient ContentType contentType;
   protected Map<String, Object> map = new ContentletHashMap();
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/SaveContentActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/SaveContentActionlet.java
@@ -68,6 +68,8 @@ public class SaveContentActionlet extends WorkFlowActionlet {
 
 			checkoutContentlet.setProperty(Contentlet.WORKFLOW_IN_PROGRESS, Boolean.TRUE);
 			checkoutContentlet.setProperty(Contentlet.TO_BE_PUBLISH, contentlet.getBoolProperty(Contentlet.TO_BE_PUBLISH));
+			checkoutContentlet.setProperty(Contentlet.SKIP_RELATIONSHIPS_VALIDATION,
+					contentlet.getBoolProperty(Contentlet.SKIP_RELATIONSHIPS_VALIDATION));
 
 			final ContentletDependencies contentletDependencies = processor.getContentletDependencies();
 			final boolean respectFrontendPermission = contentletDependencies != null ?

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -1334,8 +1334,18 @@ public class ImportUtil {
                             csvRelationshipRecordsParentOnly, csvRelationshipRecordsChildOnly,
                             csvRelationshipRecords, cont);
 
+                    final boolean skipRelationshipsValidation = headers.values().stream()
+                            .noneMatch((field -> field.getFieldType()
+                                    .equals(FieldType.RELATIONSHIP.toString())));
+
                     try {
-                        conAPI.validateContentlet(cont, contentletRelationships, new ArrayList<>(categories));
+                        if(skipRelationshipsValidation) {
+                            conAPI.validateContentletNoRels(cont, new ArrayList<>(categories));
+
+                        } else {
+                            conAPI.validateContentlet(cont, contentletRelationships,
+                                    new ArrayList<>(categories));
+                        }
                     } catch (DotContentletValidationException ex) {
                         StringBuffer sb = new StringBuffer("Line #" + lineNumber + " contains errors\n");
                         HashMap<String,List<Field>> errors = (HashMap<String,List<Field>>) ex.getNotValidFields();
@@ -1412,6 +1422,8 @@ public class ImportUtil {
 
                         if (userCanExecuteAction) {
                           cont.setIndexPolicy(IndexPolicy.DEFER);
+
+                          cont.setBoolProperty(Contentlet.SKIP_RELATIONSHIPS_VALIDATION, skipRelationshipsValidation);
 
                           Logger.debug(ImportUtil.class, "fireContentWorkflow: " + executeWfAction.getName() + ", id: " + executeWfAction.getId());
                             cont = workflowAPI.fireContentWorkflow(cont,

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -1330,10 +1330,6 @@ public class ImportUtil {
 
                 if(!ignoreLine){
                     //Check the new contentlet with the validator
-                    ContentletRelationships contentletRelationships = loadRelationshipRecords(
-                            csvRelationshipRecordsParentOnly, csvRelationshipRecordsChildOnly,
-                            csvRelationshipRecords, cont);
-
                     final boolean skipRelationshipsValidation = headers.values().stream()
                             .noneMatch((field -> field.getFieldType()
                                     .equals(FieldType.RELATIONSHIP.toString())));
@@ -1343,6 +1339,10 @@ public class ImportUtil {
                             conAPI.validateContentletNoRels(cont, new ArrayList<>(categories));
 
                         } else {
+                            ContentletRelationships contentletRelationships = loadRelationshipRecords(
+                                    csvRelationshipRecordsParentOnly, csvRelationshipRecordsChildOnly,
+                                    csvRelationshipRecords, cont);
+
                             conAPI.validateContentlet(cont, contentletRelationships,
                                     new ArrayList<>(categories));
                         }
@@ -1419,6 +1419,10 @@ public class ImportUtil {
                     //If not preview save the contentlet
                     if (!preview) {
                         cont.setLowIndexPriority(true);
+
+                        ContentletRelationships contentletRelationships = loadRelationshipRecords(
+                                csvRelationshipRecordsParentOnly, csvRelationshipRecordsChildOnly,
+                                csvRelationshipRecords, cont);
 
                         if (userCanExecuteAction) {
                           cont.setIndexPolicy(IndexPolicy.DEFER);


### PR DESCRIPTION
Validating relationships takes a long time and it was happening once per processed line. 
This change: 
* Introduces a new method to avoid the validation of relationships when validating content. 
* if no rel-field headers are present in the CSV being imported this new method is called.  