### PR TITLE
fixing bug

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220912UpdateCorrectShowOnMenuProperty.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220912UpdateCorrectShowOnMenuProperty.java
@@ -81,7 +81,7 @@ public class Task220912UpdateCorrectShowOnMenuProperty implements StartupTask {
             if (isPostgres()) {
                 columnReference += " OR " + ContentletJsonAPI.CONTENTLET_AS_JSON + "->'fields'->'" + VELOCITY_VAR_NAME + "'->>'value' = 'true'";
             } else if (isMsSql()) {
-                columnReference += " OR " + "JSON_VALUE(c." + ContentletJsonAPI.CONTENTLET_AS_JSON + ", '$.fields." + VELOCITY_VAR_NAME + ".value') = 'true'";
+                columnReference += " OR " + "JSON_VALUE(" + ContentletJsonAPI.CONTENTLET_AS_JSON + ", '$.fields." + VELOCITY_VAR_NAME + ".value') = 'true'";
             }
         }
         return "(" + columnReference + ")";

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task221018CreateVariantFieldInMultiTree.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task221018CreateVariantFieldInMultiTree.java
@@ -39,7 +39,7 @@ public class Task221018CreateVariantFieldInMultiTree extends AbstractJDBCStartup
         final String dataBaseFieldType = DbConnectionFactory.isMsSql() ? "NVARCHAR" : "varchar";
 
         return String.format(
-                "ALTER TABLE multi_tree ADD variant_id %s(255) NOT NULL",
+                "ALTER TABLE multi_tree ADD variant_id %s(255) NOT NULL default 'DEFAULT'",
                 dataBaseFieldType);
     }
 


### PR DESCRIPTION
Fixing two bug that we have when try to upgrade to 22.10

- The first one is when try to create a new field in multi_tree table and add it into the primary key, but this new field does not have any default value when is created by the UpgradeTask so it throw a Exception because you can not include a field with null values into a primary key.
I not include test because we already have this change into master with test and refactoring included.

https://github.com/dotCMS/core/commit/8b06c0a93a5a6b4c43a40dba24560464fe8a069b

- The second one is a sintax error in the Task220912UpdateCorrectShowOnMenuProperty in the mssql query, I don't include test here because we already have a test failing 

https://raw.githack.com/dotCMS/test-results/master/projects/core/integration/mssql/reports/html/classes/com.dotmarketing.startup.runonce.Task220912UpdateCorrectShowOnMenuPropertyTest.html#testExecuteUpgrade
