### PR TITLE
get sonarqube under 500k loc

### DIFF
--- a/.github/workflows/gradleSonarQube.yml
+++ b/.github/workflows/gradleSonarQube.yml
@@ -2,13 +2,15 @@ name: Sonar Qube Scan Gradle
 on:
   push:
     branches:
-      - master # or the name of your main branch
+      - master 
       - testing-sonarqube
+    paths: ['dotCMS/**']
   pull_request:
     # Sequence of patterns matched against refs/heads
     branches:    
       - master
       - release-*
+    paths: ['dotCMS/**']
 
 jobs:
   build:

--- a/.github/workflows/gradleSonarQube.yml
+++ b/.github/workflows/gradleSonarQube.yml
@@ -3,13 +3,12 @@ on:
   push:
     branches:
       - master # or the name of your main branch
-
+      - testing-sonarqube
   pull_request:
     # Sequence of patterns matched against refs/heads
     branches:    
       - master
       - release-*
-      - testing-sonarqube
 
 jobs:
   build:

--- a/.github/workflows/gradleSonarQube.yml
+++ b/.github/workflows/gradleSonarQube.yml
@@ -9,6 +9,7 @@ on:
     branches:    
       - master
       - release-*
+      - testing-sonarqube
 
 jobs:
   build:
@@ -36,6 +37,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: Build and analyze
         env:
+          SONAR_SCANNER_OPTS: "-Xmx3g"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -28,6 +28,7 @@ sonarqube {
   properties {
     property "sonar.projectKey", "dotCMS_core_AYSbIemxK43eThAXTlt-"
     property "sonar.projectName", "dotcms-core"
+    property "sonar.exclusions", "src/main/webapp/dotcms-webcomponents/**,src/main/webapp/dotcms-webcomponents/**, src/main/plugins/**, src/main/java/org/**, src/main/java/com/liferay/**, src/main/java/net/**"
   }
 }
 

--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 sonarqube {
   properties {
-    property "sonar.projectKey", "dotCMS_core_AYQvQCMIJs0IgspqN39B"
+    property "sonar.projectKey", "dotCMS_core_AYSbIemxK43eThAXTlt-"
     property "sonar.projectName", "dotcms-core"
   }
 }

--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -28,6 +28,8 @@ sonarqube {
   properties {
     property "sonar.projectKey", "dotCMS_core_AYSbIemxK43eThAXTlt-"
     property "sonar.projectName", "dotcms-core"
+    property "sonar.host.url", "https://sonarqube.dotcms.site"
+    property "sonar.sourceEncoding", "UTF-8"
     property "sonar.exclusions", "src/main/webapp/dotcms-webcomponents/**,src/main/webapp/dotcms-webcomponents/**, src/main/plugins/**, src/main/java/org/**, src/main/java/com/liferay/**, src/main/java/net/**"
   }
 }

--- a/dotCMS/gradle.properties
+++ b/dotCMS/gradle.properties
@@ -44,8 +44,3 @@ nodeVersion=7.9.0
 
 #Immutables
 generatedSourceFolder=src/main/generated
-
-#Sonarqube
-systemProp.sonar.host.url=https://sonarqube.dotcms.site
-systemProp.sonar.projectKey=dotCMS_core_AYSbIemxK43eThAXTlt-
-systemProp.sonar.sourceEncoding=UTF-8

--- a/dotCMS/gradle.properties
+++ b/dotCMS/gradle.properties
@@ -37,10 +37,15 @@ licenseProjectHome=src/main/license
 enterpriseProjectHome=src/main/enterprise
 
 #memory settings
-org.gradle.jvmargs=-Xms512m -Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xms512m -Xmx4g -Dfile.encoding=UTF-8
 
 #node
 nodeVersion=7.9.0
 
 #Immutables
 generatedSourceFolder=src/main/generated
+
+#Sonarqube
+systemProp.sonar.host.url=https://sonarqube.dotcms.site
+systemProp.sonar.projectKey=dotCMS_core_AYSbIemxK43eThAXTlt-
+systemProp.sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Our Sonarqube stopped running because the core-web scanning took us over our licensed 500k lines of code.  This gets us back under by ignoring these non-core directories:

- src/main/webapp/dotcms-webcomponents/**
- src/main/plugins/**
- src/main/java/org/**
-  src/main/java/com/liferay/**
- src/main/java/net/**