### PR TITLE
Adds LANG var to 00-config-defaults.sh

### DIFF
--- a/docker/dotcms/ROOT/srv/00-config-defaults.sh
+++ b/docker/dotcms/ROOT/srv/00-config-defaults.sh
@@ -8,6 +8,8 @@
 
 set -e
 
+export LANG=${LANG:-"C.UTF-8"}
+
 ## Tomcat config
 
 # Auto-set Tomcat version from container build var, used for proper pathing


### PR DESCRIPTION
### Proposed Changes
* add `export LANG=${LANG:-"C.UTF-8"}` to docker ENV vars in 00-config-defaults.sh

