### PR TITLE
#22049 Correcting Checkbox field .values property

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/CheckboxMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/CheckboxMap.java
@@ -52,8 +52,18 @@ public class CheckboxMap {
 
 	/**
 	 * @return the value
+	 * DEPRECATED: This is a years-old typo that was not reflected in the documentation.
+	 * getValues() has been added below as the corrected form; getValue() will remain
+	 * in place for now to retain backwards compatibility.
 	 */
 	public List<String> getValue() {
+		return values;
+	}
+	
+	/**
+	 * @return all checkbox values
+	 */
+	public List<String> getValues() {
 		return values;
 	}
 


### PR DESCRIPTION
Adding `getValues()` in addition to `getValue()` to preserve backwards compatibility. (Noted in comments, too.)

Full details in https://github.com/dotCMS/core/issues/22049