### PR TITLE
removing SonarQube excludes

### DIFF
--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -30,7 +30,7 @@ sonarqube {
     property "sonar.projectName", "dotcms-core"
     property "sonar.host.url", "https://sonarqube.dotcms.site"
     property "sonar.sourceEncoding", "UTF-8"
-    property "sonar.exclusions", "src/main/webapp/dotcms-webcomponents/**,src/main/webapp/dotcms-webcomponents/**, src/main/plugins/**, src/main/java/org/**, src/main/java/com/liferay/**, src/main/java/net/**"
+    property "sonar.exclusions", "src/main/webapp/dotcms-webcomponents/**, src/main/plugins/**"
   }
 }
 


### PR DESCRIPTION
We bought the license for 1m LOC, so we no longer need to exclude the other java src that we ship with.