### PR TITLE
dotCMS/core#22908 Block Editor: Add UI to configure block editor field

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.html
@@ -1,6 +1,6 @@
 <!-- Block Editor Settings -->
 <form class="wrapper" [formGroup]="form">
-    <div class="form-control" *ngFor="let setting of settings">
+    <div class="field" *ngFor="let setting of settings">
         <label [class.required]="setting.required">{{ setting.label }}</label>
         <p-multiSelect
             [placeholder]="setting.placeholder"

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.scss
@@ -7,23 +7,9 @@
         padding: $spacing-6;
     }
 
-    .form-control {
-        align-items: flex-start;
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-start;
-        margin-bottom: $spacing-4;
-        width: 100%;
-
-        label {
-            display: inline-block;
-            margin-bottom: $spacing-2;
-        }
-
-        .required:after {
-            content: " \002A";
-            color: $error;
-        }
+    label.required:after {
+        content: " \002A";
+        color: $error;
     }
 
     p-multiselect {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.ts
@@ -65,7 +65,7 @@ export class DotBlockEditorSettingsComponent implements OnInit, OnDestroy, OnCha
     public form: FormGroup;
     public settingsMap = {
         allowedBlocks: {
-            label: 'Allowed Content',
+            label: 'Allowed Blocks',
             placeholder: 'Select Blocks',
             options: BLOCK_EDITOR_BLOCKS,
             key: 'allowedBlocks',


### PR DESCRIPTION
This PR is to fix this: https://github.com/dotCMS/core/issues/22908#issuecomment-1339648759

https://user-images.githubusercontent.com/72418962/205986486-7c6ff9a2-dbdc-4840-9759-a4c6d6b469c1.mov

