### PR TITLE
dotCMS/core#23382 Block editor does not show content in inline editing

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.scss
@@ -1,8 +1,16 @@
 @use "libs/dot-primeng-theme-styles/src/scss/variables" as *;
 
 :host {
+    .container {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+    }
+
     dot-block-editor {
-        height: calc(100% - 5rem);
+        display: flex;
+        flex-direction: column;
+        height: calc(100% - 4rem);
     }
 }
 
@@ -30,7 +38,6 @@
 footer {
     display: flex;
     justify-content: flex-end;
-    margin-top: $spacing-5;
 
     .p-button-secondary {
         margin-right: $spacing-3;


### PR DESCRIPTION
Fix styles for the block editor in inline editing view due to this comment https://github.com/dotcms/core/issues/23382#issuecomment-1353796709

|  After   |    Before    |
|----------|:-------------:|
| <img width="1674" alt="After" src="https://user-images.githubusercontent.com/72418962/208129959-7c07ebff-a500-4249-927f-438ade0efcd7.png"> |  <img width="1677" alt="Before" src="https://user-images.githubusercontent.com/72418962/208130012-1ff28fa0-be98-4dae-b953-0cd0c3b79f4d.png"> |



