### PR TITLE
Issue 23552 binary metadata

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/BinaryMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/BinaryMap.java
@@ -1,6 +1,9 @@
 package com.dotcms.rendering.velocity.viewtools.content;
 
 import java.io.File;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.transform.field.LegacyFieldTransformer;
@@ -8,6 +11,8 @@ import com.dotcms.storage.model.Metadata;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.image.filter.ImageFilterAPI;
+import com.dotmarketing.image.focalpoint.FocalPoint;
+import com.dotmarketing.image.focalpoint.FocalPointAPIImpl;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
@@ -85,7 +90,28 @@ public class BinaryMap {
 		}
 		return "";
 	}
-
+    /**
+     * The name of the file
+     * @return the name
+     */
+    public Object get(String key) {
+        if(meta.get() != null) {
+            return meta.get().getMap().get(key);
+        }
+        return null;
+    }
+    
+    /**
+     * The name of the file
+     * @return the name
+     */
+    public Map<String,Serializable> getMeta() {
+        if(meta.get() != null) {
+            return meta.get().getMap();
+        }
+        return Map.of();
+    }
+    
 	/**
 	 * The rawURI is link to the actual full image
 	 * @return the rawUri
@@ -130,7 +156,7 @@ public class BinaryMap {
 	public String getResizeUri() {
 	    if(getName().length()==0) return "";
 	    final String imageId =  UtilMethods.isSet(content.getIdentifier()) ? content.getIdentifier() : content.getInode();
-		return "/contentAsset/image/"+imageId+"/"+field.variable()+"/filter/Resize"; 
+		return "/dA/"+imageId+"/"+field.variable()+"/"; 
 
 	}
 	
@@ -146,9 +172,9 @@ public class BinaryMap {
 	    StringBuilder uri=new StringBuilder();
 	    uri.append(getResizeUri());
 	    if(width!=null && width>0)
-	        uri.append("/resize_w/").append(width);
+	        uri.append("/").append(width).append("w");
 	    if(height!=null && height>0)
-	        uri.append("/resize_h/").append(height);
+	        uri.append("/").append(height).append("h");
 	    return uri.toString();
 	}
 	
@@ -210,10 +236,40 @@ public class BinaryMap {
         }
 
         return ImageFilterAPI.apiInstance.apply().getWidthHeight(getFile()).height;
-        
-
     }
-
+    
+    public float getFpx() {
+        if(meta.get() ==null || !meta.get().isImage()) {
+            return 0;
+        }
+        Optional<FocalPoint> optPoint = new FocalPointAPIImpl().readFocalPoint(content.getInode(), field.variable());
+        
+        if(optPoint.isEmpty()) {
+            return 0;
+        }
+        return optPoint.get().x;
+    }
+    
+    public float getFpy() {
+        if(meta.get() ==null || !meta.get().isImage()) {
+            return 0;
+        }
+        Optional<FocalPoint> optPoint = new FocalPointAPIImpl().readFocalPoint(content.getInode(), field.variable());
+        
+        if(optPoint.isEmpty()) {
+            return 0;
+        }
+        return optPoint.get().y;
+    }
+    
+    public String getFocalPoint() {
+        return getFpx() + "," + getFpy();
+    }
+    public String getFocalpoint() {
+        return getFocalPoint();
+    }
+    
+    
     public int getWidth() {
         if(meta.get() ==null || !meta.get().isImage()) {
             return 0;

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/BinaryMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/BinaryMap.java
@@ -95,10 +95,9 @@ public class BinaryMap {
      * @return the name
      */
     public Object get(String key) {
-        if(meta.get() != null) {
-            return meta.get().getMap().get(key);
-        }
-        return null;
+
+        return getMeta().get(key);
+
     }
     
     /**
@@ -116,15 +115,16 @@ public class BinaryMap {
 	 * The rawURI is link to the actual full image
 	 * @return the rawUri
 	 */
-	public String getRawUri() {
-		return getName().length()>0? UtilMethods.espaceForVelocity("/contentAsset/raw-data/"+content.getIdentifier()+"/"+ field.variable()):"";
-	}
+    public String getRawUri() {
+        return getName().length() > 0
+            ? UtilMethods.espaceForVelocity("/dA/" + content.getIdentifier() + "/" + field.variable() + "/" + getName()+ "?language_id=" + content.getLanguageId())
+            : null;
+    }
 
     public String getShortyUrl() {
 
         if(meta.get() != null) {
-            String shorty = APILocator.getShortyAPI().shortify(content.getIdentifier());
-            return "/dA/"+shorty+"/"+field.variable()+"/" + getName();
+            return "/dA/"+getShorty()+"/"+field.variable()+"/" + getName()+ "?language_id=" + content.getLanguageId();
         } else {
 	        return null;
         }
@@ -154,7 +154,7 @@ public class BinaryMap {
 	 * @return the resizeUri
 	 */
 	public String getResizeUri() {
-	    if(getName().length()==0) return "";
+	    if(getName().length()==0) return null;
 	    final String imageId =  UtilMethods.isSet(content.getIdentifier()) ? content.getIdentifier() : content.getInode();
 		return "/dA/"+imageId+"/"+field.variable()+"/"; 
 
@@ -207,7 +207,9 @@ public class BinaryMap {
 	 * @return
 	 */
 	public String getThumbnailUri(Integer width, Integer height, String background){
-	    if(getName().length()==0) return "";
+	    if(getName().length()==0) {
+	        return "";
+	    }
         StringBuilder uri=new StringBuilder();
         uri.append(getThumbnailUri());
         if(width!=null && width>0)
@@ -265,6 +267,8 @@ public class BinaryMap {
     public String getFocalPoint() {
         return getFpx() + "," + getFpy();
     }
+    
+    @SuppressWarnings("java:S1845")
     public String getFocalpoint() {
         return getFocalPoint();
     }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
@@ -51,7 +51,9 @@ import com.google.common.collect.ImmutableMap;
 import com.liferay.portal.model.User;
 import io.vavr.control.Try;
 import java.io.File;
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -205,45 +207,52 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
             return;
         }
 
+        
+        if (!options.contains(BINARIES)) {
+            return;
+        }
         // if we want to include binaries as they are (java.io.File) this is the flag you should turn on.
-        if (options.contains(BINARIES)) {
-            if (contentlet.isFileAsset()) {
-                final Optional<Identifier> identifier = Optional
-                        .of(Try.of(() -> toolBox.identifierAPI.find(contentlet.getIdentifier()))
-                                .getOrNull());
-                if(identifier.isPresent()){
-                    putBinaryLinks(FILE_ASSET, identifier.get().getAssetName(), contentlet, map);
-                } else {
-                   try {
-                       final Metadata metadata = contentlet.getBinaryMetadata(FILE_ASSET);
-                       putBinaryLinks(FILE_ASSET, metadata.getName(), contentlet, map);
-                   }catch (final Exception e){
-                       Logger.warn(this, String.format("An error occurred when retrieving the Binary Metadata from " +
-                               "FileAsset in Contentlet with ID '%s': %s", contentlet.getIdentifier(), e.getMessage()));
-                   }
-                }
-            } else {
-                for (final Field field : binaries) {
-                    try {
-                        final String velocityVarName = field.variable();
-                        //Extra precaution in case we are attempting to process a contentlet that has already been transformed.
-                        if (map.get(velocityVarName) instanceof File) {
-                            final Metadata metadata = contentlet.getBinaryMetadata(velocityVarName);
-                            if (null != metadata) {
-                                putBinaryLinks(velocityVarName, metadata.getName(), contentlet, map);
-                            } else {
-                                Logger.warn(FileAssetViewStrategy.class, String.format("Binary file from field '%s' " +
-                                        "in Contentlet with ID '%s' is not present", velocityVarName, contentlet
-                                        .getIdentifier()));
-                            }
-                        }
-                    } catch (final Exception e) {
-                        Logger.warn(this, String.format("An error occurred when retrieving the Binary file from field" +
-                                " '%s' in Contentlet with ID '%s': %s", field.variable(), contentlet.getIdentifier(),
-                                e.getMessage()));
+        for (final Field field : binaries) {
+
+            try {
+                final String velocityVarName = field.variable();
+                if (contentlet.isFileAsset() && FILE_ASSET.equals(field.variable())) {
+                    final Optional<Identifier> identifier =
+                                    Optional.of(Try.of(() -> toolBox.identifierAPI.find(contentlet.getIdentifier())).getOrNull());
+                    if (identifier.isPresent()) {
+                        putBinaryLinks(FILE_ASSET, identifier.get().getAssetName(), contentlet, map);
+                    } else {
+                        final Metadata metadata = contentlet.getBinaryMetadata(FILE_ASSET);
+                        putBinaryLinks(FILE_ASSET, metadata.getName(), contentlet, map);
                     }
+                    continue;
                 }
+
+
+                
+                // Extra precaution in case we are attempting to process a contentlet that has already been
+                // transformed.
+
+                final Metadata metadata = contentlet.getBinaryMetadata(velocityVarName);
+                if (null != metadata) {
+                    Map<String, Serializable> metaMap = new HashMap<>(metadata.getMap());
+                    metaMap.remove("path");
+                    map.put(velocityVarName + "MetaData", metaMap);
+                    putBinaryLinks(velocityVarName, metadata.getName(), contentlet, map);
+                } else {
+                    Logger.warn(FileAssetViewStrategy.class,
+                                    String.format("Binary file from field '%s' " + "in Contentlet with ID '%s' is not present",
+                                                    velocityVarName, contentlet.getIdentifier()));
+
+                }
+            } catch (final Exception e) {
+                Logger.warn(this,
+                                String.format("An error occurred when retrieving the Binary file from field"
+                                                + " '%s' in Contentlet with ID '%s': %s", field.variable(),
+                                                contentlet.getIdentifier(), e.getMessage()));
             }
+
+
         }
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
@@ -216,7 +216,7 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
 
             try {
                 final String velocityVarName = field.variable();
-                if (contentlet.isFileAsset() && FILE_ASSET.equals(field.variable())) {
+                if (contentlet.isFileAsset() && FILE_ASSET.equals(velocityVarName)) {
                     final Optional<Identifier> identifier =
                                     Optional.of(Try.of(() -> toolBox.identifierAPI.find(contentlet.getIdentifier())).getOrNull());
                     if (identifier.isPresent()) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
@@ -199,9 +199,9 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
 
         //If we dont want any binaries making it into the final map
         if (options.contains(FILTER_BINARIES)) {
-            binaries.forEach(field -> {
-                map.remove(field.variable());
-            });
+            binaries.forEach(field -> 
+                map.remove(field.variable())
+            );
             Logger.info(DefaultTransformStrategy.class,
                     () -> "Transformer was instructed to exclude binaries.");
             return;
@@ -211,6 +211,7 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
         if (!options.contains(BINARIES)) {
             return;
         }
+        
         // if we want to include binaries as they are (java.io.File) this is the flag you should turn on.
         for (final Field field : binaries) {
 
@@ -219,12 +220,11 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
                 if (contentlet.isFileAsset() && FILE_ASSET.equals(velocityVarName)) {
                     final Optional<Identifier> identifier =
                                     Optional.of(Try.of(() -> toolBox.identifierAPI.find(contentlet.getIdentifier())).getOrNull());
-                    if (identifier.isPresent()) {
-                        putBinaryLinks(FILE_ASSET, identifier.get().getAssetName(), contentlet, map);
-                    } else {
-                        final Metadata metadata = contentlet.getBinaryMetadata(FILE_ASSET);
-                        putBinaryLinks(FILE_ASSET, metadata.getName(), contentlet, map);
-                    }
+                    String name = identifier.isPresent()
+                        ? identifier.get().getAssetName()
+                        : contentlet.getBinaryMetadata(FILE_ASSET).getName();
+
+                    putBinaryLinks(FILE_ASSET, name, contentlet, map);
                     continue;
                 }
 
@@ -239,12 +239,7 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
                     metaMap.remove("path");
                     map.put(velocityVarName + "MetaData", metaMap);
                     putBinaryLinks(velocityVarName, metadata.getName(), contentlet, map);
-                } else {
-                    Logger.debug(FileAssetViewStrategy.class,
-                                    String.format("Binary file from field '%s' " + "in Contentlet with ID '%s' is not present",
-                                                    velocityVarName, contentlet.getIdentifier()));
-
-                }
+                } 
             } catch (final Exception e) {
                 Logger.warn(this,
                                 String.format("An error occurred when retrieving the Binary file from field"

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
@@ -240,7 +240,7 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
                     map.put(velocityVarName + "MetaData", metaMap);
                     putBinaryLinks(velocityVarName, metadata.getName(), contentlet, map);
                 } else {
-                    Logger.warn(FileAssetViewStrategy.class,
+                    Logger.debug(FileAssetViewStrategy.class,
                                     String.format("Binary file from field '%s' " + "in Contentlet with ID '%s' is not present",
                                                     velocityVarName, contentlet.getIdentifier()));
 


### PR DESCRIPTION
### Proposed Changes
- Adds metadata to all binaries that are part of API responses - under the key of `{fieldVariable}MetaData`.  I would have rather had a map under the `{fieldVariable}` key with all the info about the binary but that would be a breaking api change.
- Adds ability to get metaData information from the velocity as well, e.g.:

`$con.asset.focalPoint` (x,y of the focal point)
`$con.asset.fpx` (the x value of the focal point)
`$con.binaryOne.meta.length` (reads the length value from the binary metadata)

Here is the api response for a contentlet that has 2 binary assets:

![Screen Shot 2022-12-16 at 4 09 44 PM](https://user-images.githubusercontent.com/934364/208189557-a7dae4e6-b24f-4f54-be24-cdc56494b611.png)



