### PR TITLE
dotCMS/core#23619 When edit mode is loading the palette UI isbroken

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.scss
@@ -2,10 +2,10 @@
     background-color: white;
     display: block;
     height: 100%;
+    overflow: hidden;
 }
 
 div {
     display: flex;
     height: 100%;
-    flex-direction: column;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.scss
@@ -2,7 +2,6 @@
     background-color: white;
     display: block;
     height: 100%;
-    overflow: hidden;
 }
 
 div {


### PR DESCRIPTION
**Original Issue**

https://user-images.githubusercontent.com/72418962/209208654-31b29b5f-b207-4440-a662-452a48e116b8.mov


**Fix**

https://user-images.githubusercontent.com/72418962/209208674-c02ed47d-e26d-4fe8-aca2-4fcf5aeffd42.mov



| **After** |  **Before**  |
|---|---|
| ![after](https://user-images.githubusercontent.com/72418962/209164679-8cce9fbc-59ea-4a47-afc0-a70d0ef40025.jpeg) | ![image](https://user-images.githubusercontent.com/72418962/209163889-e4343ed0-a413-4a7f-914e-5b9021a4ee78.png)  |
