### PR TITLE
dotCMS/core#23341 Menu Nav in the BE not showing options when collapse

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-sub-nav/dot-sub-nav.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-sub-nav/dot-sub-nav.component.scss
@@ -8,6 +8,7 @@
 
 ul {
     @include naked-list;
+    position: relative;
 }
 
 a {


### PR DESCRIPTION
### Proposed Changes
* Adding position `relative` to the `ul` to avoid the default browser position `static` remove the random odd behavior after a few test.  


### Screenshots
**Before:** 
<img width="525" alt="image" src="https://user-images.githubusercontent.com/31667212/209867602-f32e3593-605e-4d43-91e0-725429b0da32.png">

**After:** 
<img width="342" alt="image" src="https://user-images.githubusercontent.com/31667212/209867681-58d7234a-2a89-4f69-bdbe-746c7a25644c.png">
