### PR TITLE
dotCMS/core#23547 Make show archive a checkbox on Browser screen

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
@@ -195,14 +195,15 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
         return false;
     }
 
-   function toggleArchive(showArchived){
+   function toggleArchive(archiveCheckboxValue){
        if (selectedFolder != null && isInodeSet(selectedFolder)) {
            //Emptying the assets rigth hand side listing
            cleanContentSide();
+           showArchived = !!archiveCheckboxValue;
 
            //Showing the loading message
            Element.show('loadingContentListing');
-           BrowserAjax.openFolderContent (selectedFolder, '', !!showArchived, selectedLang, selectFolderContentCallBack);
+           BrowserAjax.openFolderContent (selectedFolder, '', showArchived, selectedLang, selectFolderContentCallBack);
        }
    }
 


### PR DESCRIPTION
### Proposed Changes
* Covering the following scenario: When the show archived is checked and the user archive a file, the file didn't show in the list.