### PR TITLE
dotCMS/core#23557 Add container code to advanced template is broken

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.spec.ts
@@ -116,7 +116,6 @@ describe('DotTemplateAdvancedComponent', () => {
     });
 
     beforeEach(() => {
-
         fixture = TestBed.createComponent(DotTemplateAdvancedComponent);
         component = fixture.componentInstance;
         de = fixture.debugElement;
@@ -125,8 +124,8 @@ describe('DotTemplateAdvancedComponent', () => {
 
         const code = de.query(By.css('dot-textarea-content'));
         code.triggerEventHandler('monacoInit', {
-            executeEdits: jasmine.createSpy(),
-            getSelection: () => 100
+            name: 'testEditor',
+            editor: { executeEdits: jasmine.createSpy(), getSelection: () => 100 }
         });
     });
 
@@ -170,7 +169,6 @@ describe('DotTemplateAdvancedComponent', () => {
     });
 
     describe('events', () => {
-
         it('should emit updateTemplate event when the form changes', () => {
             const updateTemplate = spyOn(component.updateTemplate, 'emit');
             component.form.get('body').setValue('<body></body>');

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.ts
@@ -24,6 +24,11 @@ interface MonacoEditorOperation {
     forceMoveMarkers: boolean;
 }
 
+interface MonacoEditorInfo {
+    name: string;
+    editor: MonacoEditor;
+}
+
 interface MonacoEditor {
     getSelection: () => number;
     executeEdits: (action: string, data: MonacoEditorOperation[]) => void;
@@ -74,11 +79,11 @@ export class DotTemplateAdvancedComponent implements OnInit, OnDestroy, OnChange
     /**
      * This method initializes the monaco editor
      *
-     * @param {*} editor
+     * @param {*} editorInfo
      * @memberof DotTemplateComponent
      */
-    initEditor(editor: MonacoEditor): void {
-        this.editor = editor;
+    initEditor(editorInfo: MonacoEditorInfo): void {
+        this.editor = editorInfo.editor;
     }
 
     /**

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.ts
@@ -79,7 +79,7 @@ export class DotTemplateAdvancedComponent implements OnInit, OnDestroy, OnChange
     /**
      * This method initializes the monaco editor
      *
-     * @param {*} editorInfo
+     * @param {MonacoEditorInfo} editorInfo
      * @memberof DotTemplateComponent
      */
     initEditor(editorInfo: MonacoEditorInfo): void {

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.spec.ts
@@ -189,7 +189,7 @@ describe('DotTextareaContentComponent', () => {
         expect(spy).toHaveBeenCalledTimes(2);
     });
 
-    fit('should init editor with the correct value', () => {
+    it('should init editor with the correct value', () => {
         const mockEditor = { test: 'editor' };
         component.editorName = 'testName';
         spyOn(component.monacoInit, 'emit');

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.spec.ts
@@ -41,18 +41,16 @@ describe('DotTextareaContentComponent', () => {
     let fixture: ComponentFixture<DotTextareaContentComponent>;
     let de: DebugElement;
 
-    beforeEach(
-        waitForAsync(() => {
-            TestBed.configureTestingModule({
-                declarations: [DotTextareaContentComponent, MonacoEditorMockComponent],
-                imports: [SelectButtonModule, InputTextareaModule, FormsModule]
-            }).compileComponents();
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            declarations: [DotTextareaContentComponent, MonacoEditorMockComponent],
+            imports: [SelectButtonModule, InputTextareaModule, FormsModule]
+        }).compileComponents();
 
-            fixture = TestBed.createComponent(DotTextareaContentComponent);
-            component = fixture.componentInstance;
-            de = fixture.debugElement;
-        })
-    );
+        fixture = TestBed.createComponent(DotTextareaContentComponent);
+        component = fixture.componentInstance;
+        de = fixture.debugElement;
+    }));
 
     it('should show a select mode buttons by default', () => {
         fixture.detectChanges();
@@ -189,6 +187,18 @@ describe('DotTextareaContentComponent', () => {
         });
 
         expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should init editor with the correct value', async () => {
+        const mockEditor = { test: 'editor' };
+        component.editorName = 'testName';
+        spyOn(component.monacoInit, 'emit');
+        fixture.detectChanges();
+        component.onInit(mockEditor);
+        expect(component.monacoInit.emit).toHaveBeenCalledWith({
+            name: 'testName',
+            editor: mockEditor
+        });
     });
 
     describe('code', () => {

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.spec.ts
@@ -189,7 +189,7 @@ describe('DotTextareaContentComponent', () => {
         expect(spy).toHaveBeenCalledTimes(2);
     });
 
-    it('should init editor with the correct value', async () => {
+    fit('should init editor with the correct value', () => {
         const mockEditor = { test: 'editor' };
         component.editorName = 'testName';
         spyOn(component.monacoInit, 'emit');


### PR DESCRIPTION
### Proposed Changes
* Fix reference of the monaco editor in advanced template. 