### PR TITLE
dotCMS/core#23367 App card css messed up

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.scss
@@ -52,4 +52,5 @@
     overflow-y: auto;
     padding-top: $spacing-4;
     width: 100%;
+    height: 100%;
 }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/dot-portlet-base.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/dot-portlet-base.component.scss
@@ -4,6 +4,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    width: 100%;
 }
 
 dot-portlet-box {


### PR DESCRIPTION
This PR is to fix the issue commented here: https://github.com/dotCMS/core/issues/23367#issuecomment-1372831025

| **Before**  | **After** |
|---|---|
| ![before](https://user-images.githubusercontent.com/72418962/210925900-5389dd67-3e7d-4080-9584-ad56de38ae48.png) | <img width="1792" alt="after" src="https://user-images.githubusercontent.com/72418962/210925933-103e1031-6f57-4c65-bd49-cc5573b17e94.png"> |