### PR TITLE
dotCMS/core#23714 Add the word "image" to the placeholder instead of file

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.html
@@ -1,9 +1,10 @@
 <dot-binary-file
-    (dotValueChange)="onThumbnailChange($event)"
     [disabled]="loading"
     [previewImageUrl]="asset?.inode ? '/dA/' + asset?.inode : null"
     [previewImageName]="asset?.name"
     [style.height.rem]="asset ? '7.14' : '3.35'"
+    [placeholder]="'templates.properties.form.thumbnail.placeholder' | dm"
+    (dotValueChange)="onThumbnailChange($event)"
     accept="image/*"
 ></dot-binary-file>
 <small class="p-invalid" data-testId="error">

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.spec.ts
@@ -16,11 +16,13 @@ import {
     FormsModule,
     ReactiveFormsModule
 } from '@angular/forms';
+import { DotMessagePipe } from '@dotcms/app/view/pipes/dot-message/dot-message.pipe';
 
 const messageServiceMock = new MockDotMessageService({
     'templates.properties.form.thumbnail.error.invalid.url': 'Invalid url',
     'templates.properties.form.thumbnail.error': 'Error',
-    'templates.properties.form.thumbnail.error.invalid.image': 'Invalid image'
+    'templates.properties.form.thumbnail.error.invalid.image': 'Invalid image',
+    'templates.properties.form.thumbnail.placeholder': 'Drop or paste image or image url'
 });
 
 @Component({
@@ -49,7 +51,7 @@ describe('DotTemplateThumbnailFieldComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [DotTemplateThumbnailFieldComponent, TestHostComponent],
+            declarations: [DotTemplateThumbnailFieldComponent, TestHostComponent, DotMessagePipe],
             providers: [
                 {
                     provide: DotTempFileUploadService,
@@ -102,6 +104,7 @@ describe('DotTemplateThumbnailFieldComponent', () => {
 
             expect(field.nativeNode.previewImageUrl).toBeNull();
             expect(field.nativeNode.previewImageName).toBeNull();
+            expect(field.nativeNode.placeholder).toBe('Drop or paste image or image url');
         });
 
         it('should have fillted attr', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.module.ts
@@ -4,9 +4,10 @@ import { CommonModule } from '@angular/common';
 import { DotWorkflowActionsFireService } from '@dotcms/data-access';
 import { DotTemplateThumbnailFieldComponent } from './dot-template-thumbnail-field.component';
 import { DotTempFileUploadService } from '@dotcms/app/api/services/dot-temp-file-upload/dot-temp-file-upload.service';
+import { DotMessagePipeModule } from '@dotcms/app/view/pipes/dot-message/dot-message-pipe.module';
 
 @NgModule({
-    imports: [CommonModule],
+    imports: [CommonModule, DotMessagePipeModule],
     declarations: [DotTemplateThumbnailFieldComponent],
     exports: [DotTemplateThumbnailFieldComponent],
     providers: [DotTempFileUploadService, DotWorkflowActionsFireService],

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5056,6 +5056,7 @@ templates.properties.title = Template Properties
 templates.properties.form.label.title = Title
 templates.properties.form.label.description = Description
 templates.properties.form.label.thumbnail = Thumbnail
+templates.properties.form.thumbnail.placeholder = Drop or paste image or image url
 templates.properties.form.label.theme = Theme
 templates.properties.form.thumbnail.error.invalid.url = The url is invalid, needs to be an image
 templates.design = Design


### PR DESCRIPTION
### Proposed Changes
* change Template thumbnail field placeholder

### Checklist
- [x] Tests
- [x] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
![image](https://user-images.githubusercontent.com/113915849/211031082-4982e946-f87d-482a-8531-71ab80a947da.png)| ![image](https://user-images.githubusercontent.com/113915849/211029692-6ce34b97-91f1-47c7-a9b8-f612fa064c5b.png)

