### PR TITLE
dotCMS/core#23231 Make it easy for admins to view/manage content types 

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
@@ -59,6 +59,19 @@ catch(Exception e){
 
 
 <script>
+function setLinkToContentType(){
+
+   const URLLength = window.parent.location.hash.split('/').length;
+   const contentTypeLink = document.getElementById('contentTypeLink');
+
+  //URL has inode, example: #/c/content/87edb0d5-99aa-4d18-a50d-60eef7c74954
+   if (URLLength>3 && contentTypeLink) {
+        contentTypeLink.addEventListener('click', jumpToContentType);
+        contentTypeLink.setAttribute('href','#');
+   }
+}
+
+setTimeout(setLinkToContentType, 300);
 
 var myHostId = '<%= (myHost != null) ? myHost.getIdentifier() : "" %>';
 
@@ -226,9 +239,9 @@ function jumpToContentType(){
      <tr>
             <th style="vertical-align: top"><%= LanguageUtil.get(pageContext, "Content-Type") %>:</th>
             <td>
-                <%if(isEditing && canEditContentType){%><a onclick="jumpToContentType()" href="#"><%}%>
+                <%if(canEditContentType){%><a id="contentTypeLink" ><%}%>
                 <%=contentlet!=null && contentlet.getContentType()!=null ? contentlet.getContentType().name() : LanguageUtil.get(pageContext, "not-available") %>
-                <%if(isEditing && canEditContentType){%></a><%}%>
+                <%if(canEditContentType){%></a><%}%>
             </td>
         </tr>
         <tr>

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
@@ -24,7 +24,6 @@ WorkflowTask wfTask = APILocator.getWorkflowAPI().findTaskByContentlet(contentle
 
 
 boolean canEditContentType=contentlet.getContentType()!=null && APILocator.getPermissionAPI().doesUserHavePermission(contentlet.getContentType(),2, user);
-boolean isEditing = java.util.Objects.equals(request.getParameter("cmd"), "edit");
 com.dotmarketing.beans.Host myHost =  WebAPILocator.getHostWebAPI().getCurrentHost(request);
 
 List<WorkflowStep> wfSteps = null;


### PR DESCRIPTION
### Proposed Changes
* since we can't trust in the `cmd` query param use a javascript approach to realize if the pop-up is open when creating a new content or while editing. link should show always while editing not creating. 