### PR TITLE
#23302 organize postman tests into folders

### DIFF
--- a/.github/workflows/publish-docker-image-on-release.yml
+++ b/.github/workflows/publish-docker-image-on-release.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ env.BUILD_ID }}
+          token: ${{ secrets.CICD_GITHUB_TOKEN }}
+          submodules: recursively
       - name: Set Common Vars
         run: |
           BUILD_HASH=$(git log -1 --pretty=%h)
@@ -53,25 +55,36 @@ jobs:
           echo "jobRun=${jobRun}" >> $GITHUB_ENV
       - name: Discover docker tags
         id: discover-docker-tags
-        uses: dotcms/discover-docker-tags-action@main
+        uses: dotcms/discover-docker-tags-action@v2.0
         with:
           version: ${{ env.DOTCMS_VERSION }}
           hash: ${{ env.BUILD_HASH }}
           label: 'SNAPSHOT'
           update_stable: false
           also_latest: false
+          image_name: dotcms/dotcms
         if: env.jobRun == 'true'
-      - name: Publish docker image
-        id: publish-docker-image
-        uses: dotcms/publish-docker-image-action@main
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.2.1
         with:
-          dot_cicd_branch: master
-          build_id: ${{ env.BUILD_ID }}
+          version: v0.10.0
+          driver-opts: |
+            image=moby/buildkit:master
+          platforms: linux/amd64,linux/arm64
+      - name: Docker Hub login
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: ./docker/dotcms
+          push: true
           tags: ${{ steps.discover-docker-tags.outputs.discovered_tags }}
-          github_user_token: ${{ secrets.CICD_GITHUB_TOKEN }}
-          docker_hub_username: ${{ secrets.DOCKER_USERNAME }}
-          docker_hub_token: ${{ secrets.DOCKER_TOKEN }}
-          dry_run: false
+          platforms: ${{ steps.docker-setup-buildx.outputs.platforms }}
         if: env.jobRun == 'true'
       - name: Slack Notification
         if: success() && env.jobRun == 'true' 

--- a/.github/workflows/publish-dotcms-docker-image.yml
+++ b/.github/workflows/publish-dotcms-docker-image.yml
@@ -1,4 +1,4 @@
-name: publish-dotcms-docker-image
+name: Publish DotCMS docker image
 on:
   workflow_dispatch:
     inputs:
@@ -17,6 +17,10 @@ on:
         description: 'Dry Run (does not publish to docker hub)'
         required: false
         default: 'false'
+      multi_arch:
+        description: 'Multi-arch flag, true: linux/amd64,linux/arm64 or false: linux/amd64'
+        required: false
+        default: 'false'
 jobs:
   publish_image:
     name: Publish DotCMS docker image
@@ -28,34 +32,53 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
         if: env.DEBUG == 'true'
       - name: Checkout core
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.CICD_GITHUB_TOKEN }}
+          submodules: recursively
       - name: Set Common Vars
         run: |
           BUILD_ID=$(basename "${{ github.ref }}")
           BUILD_HASH=$(git log -1 --pretty=%h)
           eval $(cat dotCMS/gradle.properties| grep dotcmsReleaseVersion)
           DOTCMS_VERSION="${dotcmsReleaseVersion}"
+          PLATFORMS='linux/amd64'
+          [[ "${{ github.event.inputs.multi_arch }}" == 'true' ]] && PLATFORMS='linux/amd64,linux/arm64'
 
           echo "BUILD_ID=${BUILD_ID}" >> $GITHUB_ENV
           echo "BUILD_HASH=${BUILD_HASH}" >> $GITHUB_ENV
           echo "DOTCMS_VERSION=${DOTCMS_VERSION}" >> $GITHUB_ENV
+          echo "PLATFORMS=${PLATFORMS}" >> $GITHUB_ENV
       - name: Discover docker tags
         id: discover-docker-tags
-        uses: dotcms/discover-docker-tags-action@main
+        uses: dotcms/discover-docker-tags-action@v2.0
         with:
           version: ${{ env.DOTCMS_VERSION }}
           hash: ${{ env.BUILD_HASH }}
           label: ${{ github.event.inputs.custom_label }}
           update_stable: ${{ github.event.inputs.update_stable }}
           also_latest: ${{ github.event.inputs.also_latest }}
-      - name: Publish docker image
-        id: publish-docker-image
-        uses: dotcms/publish-docker-image-action@main
+          image_name: dotcms/dotcms
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
         with:
-          dot_cicd_branch: master
-          build_id: ${{ env.BUILD_ID }}
+          platforms: amd64,arm64
+        if: github.event.inputs.multi_arch == 'true'
+      - id: docker-setup-buildx
+        name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.2.1
+        with:
+          platforms: ${{ env.PLATFORMS }}
+        if: github.event.inputs.multi_arch == 'true'
+      - name: Docker Hub login
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: ./docker/dotcms
+          push: true
           tags: ${{ steps.discover-docker-tags.outputs.discovered_tags }}
-          github_user_token: ${{ secrets.CICD_GITHUB_TOKEN }}
-          docker_hub_username: ${{ secrets.DOCKER_USERNAME }}
-          docker_hub_token: ${{ secrets.DOCKER_TOKEN }}
-          dry_run: ${{ github.event.inputs.dry_run }}
+          platforms: ${{ env.PLATFORMS }}

--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -63,12 +63,13 @@ jobs:
     env:
       GITHUB_USER_TOKEN: ${{ secrets.CICD_GITHUB_TOKEN }}
       PULL_REQUEST: ${{ github.event.number }}
-      REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
-      REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}
       DEBUG: true
     steps:
       - name: Checkout core
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.CICD_GITHUB_TOKEN }}
+          submodules: recursively
       - name: Set Common Vars
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
@@ -98,7 +99,6 @@ jobs:
           fi
 
           echo "BUILD_ID=${BUILD_ID}" >> $GITHUB_ENV
-          echo "EE_BUILD_ID=${BUILD_ID}" >> $GITHUB_ENV
           echo "BUILD_HASH=${BUILD_HASH}" >> $GITHUB_ENV
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
           echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_ENV
@@ -107,23 +107,35 @@ jobs:
           echo "ALSO_LATEST=${ALSO_LATEST}" >> $GITHUB_ENV
       - name: Discover docker tags
         id: discover-docker-tags
-        uses: dotcms/discover-docker-tags-action@main
+        uses: dotcms/discover-docker-tags-action@v2.0
         with:
           version: ${{ env.RELEASE_VERSION }}
           hash: ${{ env.BUILD_HASH }}
           label: ${{ env.RELEASE_LABEL }}
           update_stable: ${{ env.IS_RELEASE }}
           also_latest: ${{ env.ALSO_LATEST }}
-      - name: Publish docker image
-        id: publish-docker-image
-        uses: dotcms/publish-docker-image-action@main
+          image_name: dotcms/dotcms
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.2.1
         with:
-          dot_cicd_branch: ${{ env.DOT_CICD_BRANCH }}
-          build_id: ${{ env.BUILD_ID }}
+          version: v0.10.0
+          driver-opts: |
+            image=moby/buildkit:master
+          platforms: linux/amd64,linux/arm64
+      - name: Docker Hub login
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: ./docker/dotcms
+          push: true
           tags: ${{ steps.discover-docker-tags.outputs.discovered_tags }}
-          github_user_token: ${{ secrets.CICD_GITHUB_TOKEN }}
-          docker_hub_username: ${{ secrets.DOCKER_USERNAME }}
-          docker_hub_token: ${{ secrets.DOCKER_TOKEN }}
+          platforms: ${{ steps.docker-setup-buildx.outputs.platforms }}
         if: success()
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2

--- a/dotCMS/src/curl-test/Experiments Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Experiments Resource.postman_collection.json
@@ -1,11 +1,358 @@
 {
 	"info": {
-		"_postman_id": "324b2215-c877-43a5-b7d6-84a39f6a7e9f",
+		"_postman_id": "20e0245f-a5b6-4b23-9ca9-d0b91fdf4d0a",
 		"name": "Experiments Resource",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "4500400"
 	},
 	"item": [
+		{
+			"name": "Preconditions",
+			"item": [
+				{
+					"name": "pre_ImportBundleWithPage",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Bundle uploaded sucessfully\", function () {",
+									"    pm.response.to.have.status(200);",
+									"",
+									"    var jsonData = pm.response.json();",
+									"    console.log(jsonData);",
+									"",
+									"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"page_experiment.tar.gz\");",
+									"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/octet-stream"
+							},
+							{
+								"key": "Content-Disposition",
+								"type": "text",
+								"value": "attachment"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "file",
+									"type": "file",
+									"src": "resources/Experiments/page_experiment.tar.gz"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/bundle?sync=true",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"bundle"
+							],
+							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
+								{
+									"key": "AUTH_TOKEN",
+									"value": "",
+									"disabled": true
+								}
+							]
+						},
+						"description": "Imports a Bundle that includes:\n* A piece of content with a tag field without any tags selected"
+					},
+					"response": []
+				},
+				{
+					"name": "pre_PublishPage",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200 \", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"",
+									"",
+									"pm.test(\"Valid response\", function () {",
+									"    pm.expect(pm.response.json().entity.identifier).to.be.eq(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
+									"    pm.expect(pm.response.json().entity.live).to.be.true;",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?identifier=e424abd7e2e7a9031c5a0a3c18182f1b",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"workflow",
+								"actions",
+								"default",
+								"fire",
+								"PUBLISH"
+							],
+							"query": [
+								{
+									"key": "identifier",
+									"value": "e424abd7e2e7a9031c5a0a3c18182f1b"
+								}
+							]
+						},
+						"description": "Fire any action using the actionId\n\nOptional: If you pass ?inode={inode}, you don't need body here.\n\n@Path(\"/actions/{actionId}/fire\")"
+					},
+					"response": []
+				},
+				{
+					"name": "pre_ImportBundleWithSecondPage",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Bundle uploaded sucessfully\", function () {",
+									"    pm.response.to.have.status(200);",
+									"",
+									"    var jsonData = pm.response.json();",
+									"    console.log(jsonData);",
+									"",
+									"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"second-experiment-page.tar.gz\");",
+									"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/octet-stream"
+							},
+							{
+								"key": "Content-Disposition",
+								"type": "text",
+								"value": "attachment"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "file",
+									"type": "file",
+									"src": "resources/Experiments/second-experiment-page.tar.gz"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/bundle?sync=true",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"bundle"
+							],
+							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
+								{
+									"key": "AUTH_TOKEN",
+									"value": "",
+									"disabled": true
+								}
+							]
+						},
+						"description": "Imports a Bundle that includes:\n* A piece of content with a tag field without any tags selected"
+					},
+					"response": []
+				},
+				{
+					"name": "pre_PublishSecondPage",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200 \", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"",
+									"",
+									"pm.test(\"Valid response\", function () {",
+									"    pm.expect(pm.response.json().entity.identifier).to.be.eq(\"9044ec0fdb3788a814ccabf789f376d4\");",
+									"    pm.expect(pm.response.json().entity.live).to.be.true;",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?identifier=9044ec0fdb3788a814ccabf789f376d4",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"workflow",
+								"actions",
+								"default",
+								"fire",
+								"PUBLISH"
+							],
+							"query": [
+								{
+									"key": "identifier",
+									"value": "9044ec0fdb3788a814ccabf789f376d4"
+								}
+							]
+						},
+						"description": "Fire any action using the actionId\n\nOptional: If you pass ?inode={inode}, you don't need body here.\n\n@Path(\"/actions/{actionId}/fire\")"
+					},
+					"response": []
+				}
+			]
+		},
 		{
 			"name": "GET Experiment",
 			"item": [
@@ -962,3457 +1309,3097 @@
 			]
 		},
 		{
-			"name": "pre_ImportBundleWithPage",
-			"event": [
+			"name": "POST Experiment",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Bundle uploaded sucessfully\", function () {",
-							"    pm.response.to.have.status(200);",
-							"",
-							"    var jsonData = pm.response.json();",
-							"    console.log(jsonData);",
-							"",
-							"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"page_experiment.tar.gz\");",
-							"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "createExperiment_shoudSucceed",
+					"event": [
 						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						},
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.description).equal(\"my experiment description\");",
+									"    pm.expect(jsonData.entity.name).equal(\"my experiment\");",
+									"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
+									"    pm.expect(jsonData.entity.modDate).is.not.null;",
+									"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
+									"    pm.expect(jsonData.entity.trafficAllocation).equal(100.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"});",
+									"",
+									"pm.collectionVariables.set(\"experimentId\", jsonData.entity.id);",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"type": "text",
-						"value": "application/octet-stream"
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pageId\": \"e424abd7e2e7a9031c5a0a3c18182f1b\",\n    \"name\": \"my experiment\",\n    \"description\": \"my experiment description\" \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								""
+							]
+						}
 					},
-					{
-						"key": "Content-Disposition",
-						"type": "text",
-						"value": "attachment"
-					}
-				],
-				"body": {
-					"mode": "formdata",
-					"formdata": [
-						{
-							"key": "file",
-							"type": "file",
-							"src": "resources/Experiments/page_experiment.tar.gz"
-						}
-					]
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/bundle?sync=true",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"bundle"
-					],
-					"query": [
-						{
-							"key": "sync",
-							"value": "true"
-						},
-						{
-							"key": "AUTH_TOKEN",
-							"value": "",
-							"disabled": true
-						}
-					]
-				},
-				"description": "Imports a Bundle that includes:\n* A piece of content with a tag field without any tags selected"
-			},
-			"response": []
+					"response": []
+				}
+			]
 		},
 		{
-			"name": "pre_PublishPage",
-			"event": [
+			"name": "PATCH Experiment",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200 \", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"",
-							"",
-							"pm.test(\"Valid response\", function () {",
-							"    pm.expect(pm.response.json().entity.identifier).to.be.eq(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
-							"    pm.expect(pm.response.json().entity.live).to.be.true;",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "updateExperimentNameAndDesc_shoudSucceed",
+					"event": [
 						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						},
-						{
-							"key": "saveHelperData",
-							"type": "any"
-						},
-						{
-							"key": "showPassword",
-							"value": false,
-							"type": "boolean"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.description).equal(\"my patched experiment description\");",
+									"    pm.expect(jsonData.entity.name).equal(\"my patched experiment\");",
+									"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
+									"    pm.expect(jsonData.entity.modDate).is.not.null;",
+									"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
+									"    pm.expect(jsonData.entity.trafficAllocation).equal(100.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
-				},
-				"method": "PUT",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?identifier=e424abd7e2e7a9031c5a0a3c18182f1b",
-					"host": [
-						"{{serverURL}}"
 					],
-					"path": [
-						"api",
-						"v1",
-						"workflow",
-						"actions",
-						"default",
-						"fire",
-						"PUBLISH"
-					],
-					"query": [
-						{
-							"key": "identifier",
-							"value": "e424abd7e2e7a9031c5a0a3c18182f1b"
-						}
-					]
-				},
-				"description": "Fire any action using the actionId\n\nOptional: If you pass ?inode={inode}, you don't need body here.\n\n@Path(\"/actions/{actionId}/fire\")"
-			},
-			"response": []
-		},
-		{
-			"name": "createExperiment_shoudSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.description).equal(\"my experiment description\");",
-							"    pm.expect(jsonData.entity.name).equal(\"my experiment\");",
-							"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
-							"    pm.expect(jsonData.entity.modDate).is.not.null;",
-							"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
-							"    pm.expect(jsonData.entity.trafficAllocation).equal(100.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"});",
-							"",
-							"pm.collectionVariables.set(\"experimentId\", jsonData.entity.id);",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
 						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"pageId\": \"e424abd7e2e7a9031c5a0a3c18182f1b\",\n    \"name\": \"my experiment\",\n    \"description\": \"my experiment description\" \n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateExperimentNameAndDesc_shoudSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.description).equal(\"my patched experiment description\");",
-							"    pm.expect(jsonData.entity.name).equal(\"my patched experiment\");",
-							"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
-							"    pm.expect(jsonData.entity.modDate).is.not.null;",
-							"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
-							"    pm.expect(jsonData.entity.trafficAllocation).equal(100.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"my patched experiment\",\n    \"description\": \"my patched experiment description\" \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
 						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"name\": \"my patched experiment\",\n    \"description\": \"my patched experiment description\" \n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateExperimentTrafficAllocation_shoudSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.description).equal(\"my patched experiment description\");",
-							"    pm.expect(jsonData.entity.name).equal(\"my patched experiment\");",
-							"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
-							"    pm.expect(jsonData.entity.modDate).is.not.null;",
-							"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
-							"    pm.expect(jsonData.entity.trafficAllocation).equal(20.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"trafficAllocation\": 20  \n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateExperimentStartAndEndDate_shoudSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.description).equal(\"my patched experiment description\");",
-							"    pm.expect(jsonData.entity.name).equal(\"my patched experiment\");",
-							"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
-							"    pm.expect(jsonData.entity.modDate).is.not.null;",
-							"    pm.expect(jsonData.entity.scheduling.startDate).to.equal(2608661952000);",
-							"    pm.expect(jsonData.entity.scheduling.endDate).to.equal(2611340352000);",
-							"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
-							"    pm.expect(jsonData.entity.trafficAllocation).equal(20.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"scheduling\": {\n    \"startDate\": \"2052-08-30T20:19:12Z\",\n    \"endDate\": \"2052-09-30T20:19:12Z\"\n}}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateExperimentStartAndEndDate with timestamp",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.description).equal(\"my patched experiment description\");",
-							"    pm.expect(jsonData.entity.name).equal(\"my patched experiment\");",
-							"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
-							"    pm.expect(jsonData.entity.modDate).is.not.null;",
-							"    pm.expect(jsonData.entity.scheduling.startDate).to.equal(2608661952010);",
-							"    pm.expect(jsonData.entity.scheduling.endDate).to.equal(2611340352010);",
-							"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
-							"    pm.expect(jsonData.entity.trafficAllocation).equal(20.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"scheduling\": {\n    \"startDate\": 2608661952010,\n    \"endDate\": 2611340352010\n}}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateScheduling_startDateInPast_shouldFail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"    pm.expect(jsonData.message).to.contain(\"Invalid Scheduling. Start date is in the past\");",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"scheduling\": {\n    \"startDate\": \"2020-08-30T20:19:12Z\"\n}}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateScheduling_endDateInPast_shouldFail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"    pm.expect(jsonData.message).to.contain(\"Invalid Scheduling. End date is in the past\");",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"scheduling\": {\n    \"endDate\": \"2020-08-30T20:19:12Z\"\n}}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateScheduling_endDateBeforeStartDate_shouldFail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"    pm.expect(jsonData.message).to.contain(\"Invalid Scheduling. End date must be after the start date\");",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"scheduling\": {\n    \"startDate\": \"2051-08-30T20:19:12Z\",\n    \"endDate\": \"2050-08-30T20:19:12Z\"\n}}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateScheduling_experimentDurationMoreThanMax_shouldFail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"    pm.expect(jsonData.message).to.contain(\"Experiment duration must be less than 35 days\");",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"scheduling\": {\n    \"startDate\": \"2051-08-30T20:19:12Z\",\n    \"endDate\": \"2052-08-30T20:19:12Z\"\n}}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateExperimentLookbackWindow_shoudSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.description).equal(\"my patched experiment description\");",
-							"    pm.expect(jsonData.entity.name).equal(\"my patched experiment\");",
-							"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
-							"    pm.expect(jsonData.entity.modDate).is.not.null;",
-							"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
-							"    pm.expect(jsonData.entity.trafficAllocation).equal(20.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"    pm.expect(jsonData.entity.lookbackWindow).equal(20);",
-							"",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"lookbackWindow\": 20  \n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "createDraftExperiment_shoudSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.description).equal(\"my experiment description\");",
-							"    pm.expect(jsonData.entity.name).equal(\"my experiment\");",
-							"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
-							"    pm.expect(jsonData.entity.modDate).is.not.null;",
-							"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
-							"    pm.expect(jsonData.entity.trafficAllocation).equal(100.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"});",
-							"",
-							"pm.collectionVariables.set(\"draftExperimentId\", jsonData.entity.id);",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"pageId\": \"e424abd7e2e7a9031c5a0a3c18182f1b\",\n    \"name\": \"my experiment\",\n    \"description\": \"my experiment description\" \n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "deleteExperiment_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity).equal(\"Experiment deleted\");",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "DELETE",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{draftExperimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{draftExperimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "listExperimentsByPageId_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Lists of experiments should not be empty\", function () {",
-							"    pm.expect(jsonData.entity.length).to.be.greaterThan(0);",
-							"});",
-							"",
-							"pm.test(\"All returned experiments should have the pageId in the filter\", function () {",
-							"    for(let i in jsonData.entity) {",
-							"        let experiment = jsonData.entity[i]",
-							"        pm.expect(experiment.pageId).to.be.eq('e424abd7e2e7a9031c5a0a3c18182f1b');",
-							"    }",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments?pageId=e424abd7e2e7a9031c5a0a3c18182f1b",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments"
-					],
-					"query": [
-						{
-							"key": "pageId",
-							"value": "e424abd7e2e7a9031c5a0a3c18182f1b"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "pre_ImportBundleWithSecondPage",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Bundle uploaded sucessfully\", function () {",
-							"    pm.response.to.have.status(200);",
-							"",
-							"    var jsonData = pm.response.json();",
-							"    console.log(jsonData);",
-							"",
-							"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"second-experiment-page.tar.gz\");",
-							"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						},
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"type": "text",
-						"value": "application/octet-stream"
 					},
-					{
-						"key": "Content-Disposition",
-						"type": "text",
-						"value": "attachment"
-					}
-				],
-				"body": {
-					"mode": "formdata",
-					"formdata": [
-						{
-							"key": "file",
-							"type": "file",
-							"src": "resources/Experiments/second-experiment-page.tar.gz"
-						}
-					]
+					"response": []
 				},
-				"url": {
-					"raw": "{{serverURL}}/api/bundle?sync=true",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"bundle"
-					],
-					"query": [
+				{
+					"name": "updateExperimentTrafficAllocation_shoudSucceed",
+					"event": [
 						{
-							"key": "sync",
-							"value": "true"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.description).equal(\"my patched experiment description\");",
+									"    pm.expect(jsonData.entity.name).equal(\"my patched experiment\");",
+									"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
+									"    pm.expect(jsonData.entity.modDate).is.not.null;",
+									"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
+									"    pm.expect(jsonData.entity.trafficAllocation).equal(20.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
 						},
-						{
-							"key": "AUTH_TOKEN",
-							"value": "",
-							"disabled": true
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"trafficAllocation\": 20  \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
 						}
-					]
+					},
+					"response": []
 				},
-				"description": "Imports a Bundle that includes:\n* A piece of content with a tag field without any tags selected"
-			},
-			"response": []
+				{
+					"name": "updateExperimentStartAndEndDate_shoudSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.description).equal(\"my patched experiment description\");",
+									"    pm.expect(jsonData.entity.name).equal(\"my patched experiment\");",
+									"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
+									"    pm.expect(jsonData.entity.modDate).is.not.null;",
+									"    pm.expect(jsonData.entity.scheduling.startDate).to.equal(2608661952000);",
+									"    pm.expect(jsonData.entity.scheduling.endDate).to.equal(2611340352000);",
+									"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
+									"    pm.expect(jsonData.entity.trafficAllocation).equal(20.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"scheduling\": {\n    \"startDate\": \"2052-08-30T20:19:12Z\",\n    \"endDate\": \"2052-09-30T20:19:12Z\"\n}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateExperimentStartAndEndDate with timestamp",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.description).equal(\"my patched experiment description\");",
+									"    pm.expect(jsonData.entity.name).equal(\"my patched experiment\");",
+									"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
+									"    pm.expect(jsonData.entity.modDate).is.not.null;",
+									"    pm.expect(jsonData.entity.scheduling.startDate).to.equal(2608661952010);",
+									"    pm.expect(jsonData.entity.scheduling.endDate).to.equal(2611340352010);",
+									"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
+									"    pm.expect(jsonData.entity.trafficAllocation).equal(20.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"scheduling\": {\n    \"startDate\": 2608661952010,\n    \"endDate\": 2611340352010\n}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateScheduling_startDateInPast_shouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.expect(jsonData.message).to.contain(\"Invalid Scheduling. Start date is in the past\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"scheduling\": {\n    \"startDate\": \"2020-08-30T20:19:12Z\"\n}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateScheduling_endDateInPast_shouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.expect(jsonData.message).to.contain(\"Invalid Scheduling. End date is in the past\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"scheduling\": {\n    \"endDate\": \"2020-08-30T20:19:12Z\"\n}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateScheduling_endDateBeforeStartDate_shouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.expect(jsonData.message).to.contain(\"Invalid Scheduling. End date must be after the start date\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"scheduling\": {\n    \"startDate\": \"2051-08-30T20:19:12Z\",\n    \"endDate\": \"2050-08-30T20:19:12Z\"\n}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateScheduling_experimentDurationMoreThanMax_shouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.expect(jsonData.message).to.contain(\"Experiment duration must be less than 35 days\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"scheduling\": {\n    \"startDate\": \"2051-08-30T20:19:12Z\",\n    \"endDate\": \"2052-08-30T20:19:12Z\"\n}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateExperimentLookbackWindow_shoudSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.description).equal(\"my patched experiment description\");",
+									"    pm.expect(jsonData.entity.name).equal(\"my patched experiment\");",
+									"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
+									"    pm.expect(jsonData.entity.modDate).is.not.null;",
+									"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
+									"    pm.expect(jsonData.entity.trafficAllocation).equal(20.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"    pm.expect(jsonData.entity.lookbackWindow).equal(20);",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"lookbackWindow\": 20  \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		},
 		{
-			"name": "pre_PublishSecondPage",
-			"event": [
+			"name": "DELETE Experiment",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200 \", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"",
-							"",
-							"pm.test(\"Valid response\", function () {",
-							"    pm.expect(pm.response.json().entity.identifier).to.be.eq(\"9044ec0fdb3788a814ccabf789f376d4\");",
-							"    pm.expect(pm.response.json().entity.live).to.be.true;",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
+					"name": "createDraftExperiment_shoudSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.description).equal(\"my experiment description\");",
+									"    pm.expect(jsonData.entity.name).equal(\"my experiment\");",
+									"    pm.expect(jsonData.entity.pageId).equal(\"e424abd7e2e7a9031c5a0a3c18182f1b\");",
+									"    pm.expect(jsonData.entity.modDate).is.not.null;",
+									"    pm.expect(jsonData.entity.status).equal(\"DRAFT\");",
+									"    pm.expect(jsonData.entity.trafficAllocation).equal(100.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"});",
+									"",
+									"pm.collectionVariables.set(\"draftExperimentId\", jsonData.entity.id);",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pageId\": \"e424abd7e2e7a9031c5a0a3c18182f1b\",\n    \"name\": \"my experiment\",\n    \"description\": \"my experiment description\" \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteExperiment_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity).equal(\"Experiment deleted\");",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{draftExperimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{draftExperimentId}}"
+							]
+						}
+					},
+					"response": []
 				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						},
-						{
-							"key": "saveHelperData",
-							"type": "any"
-						},
-						{
-							"key": "showPassword",
-							"value": false,
-							"type": "boolean"
-						}
-					]
-				},
-				"method": "PUT",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?identifier=9044ec0fdb3788a814ccabf789f376d4",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"workflow",
-						"actions",
-						"default",
-						"fire",
-						"PUBLISH"
-					],
-					"query": [
-						{
-							"key": "identifier",
-							"value": "9044ec0fdb3788a814ccabf789f376d4"
-						}
-					]
-				},
-				"description": "Fire any action using the actionId\n\nOptional: If you pass ?inode={inode}, you don't need body here.\n\n@Path(\"/actions/{actionId}/fire\")"
-			},
-			"response": []
+			]
 		},
 		{
-			"name": "pre_createExperimentInSecondPage",
-			"event": [
+			"name": "GET List of Experiments",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.collectionVariables.set(\"secondExperimentId\", jsonData.entity.id);",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "listExperimentsByPageId_shouldSucceed",
+					"event": [
 						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Lists of experiments should not be empty\", function () {",
+									"    pm.expect(jsonData.entity.length).to.be.greaterThan(0);",
+									"});",
+									"",
+									"pm.test(\"All returned experiments should have the pageId in the filter\", function () {",
+									"    for(let i in jsonData.entity) {",
+									"        let experiment = jsonData.entity[i]",
+									"        pm.expect(experiment.pageId).to.be.eq('e424abd7e2e7a9031c5a0a3c18182f1b');",
+									"    }",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"pageId\": \"9044ec0fdb3788a814ccabf789f376d4\",\n    \"name\": \"second page experiment\",\n    \"description\": \"second page experiment description\" \n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/",
-					"host": [
-						"{{serverURL}}"
 					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						""
-					]
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments?pageId=e424abd7e2e7a9031c5a0a3c18182f1b",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments"
+							],
+							"query": [
+								{
+									"key": "pageId",
+									"value": "e424abd7e2e7a9031c5a0a3c18182f1b"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "pre_createExperimentInSecondPage",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.collectionVariables.set(\"secondExperimentId\", jsonData.entity.id);",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pageId\": \"9044ec0fdb3788a814ccabf789f376d4\",\n    \"name\": \"second page experiment\",\n    \"description\": \"second page experiment description\" \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "listExperimentsNoFilter_shouldIncludeAll",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Lists of experiments should not be empty\", function () {",
+									"    pm.expect(jsonData.entity.length).to.be.greaterThan(0);",
+									"});",
+									"",
+									"pm.test(\"The two experiments with different pageId are included\", function () {",
+									"    let experiment1ID = pm.collectionVariables.get(\"experimentId\")",
+									"    let experiment2ID = pm.collectionVariables.get(\"secondExperimentId\");",
+									"    pm.expect(isExperimentIncluded(experiment1ID)).to.be.true;",
+									"    pm.expect(isExperimentIncluded(experiment2ID)).to.be.true;",
+									"});",
+									"",
+									"function isExperimentIncluded(id) {",
+									"    for(let i in jsonData.entity) {",
+									"        let experiment = jsonData.entity[i]",
+									"        if(experiment.id===id) return true;",
+									"    }",
+									"",
+									"    return false;",
+									"}",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "listExperimentsFilterBySingleStatus_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Lists of experiments should not be empty\", function () {",
+									"    pm.expect(jsonData.entity.length).to.be.greaterThan(0);",
+									"});",
+									"",
+									"pm.test(\"All returned experiments should have the status DRAFT\", function () {",
+									"    for(let i in jsonData.entity) {",
+									"        let experiment = jsonData.entity[i]",
+									"        pm.expect(experiment.status).to.be.eq('DRAFT');",
+									"    }",
+									"});",
+									"",
+									"",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments?status=DRAFT",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments"
+							],
+							"query": [
+								{
+									"key": "status",
+									"value": "DRAFT"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "pre_createExperimentUniqueName",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pageId\": \"9044ec0fdb3788a814ccabf789f376d4\",\n    \"name\": \"20220901\",\n    \"description\": \"second page experiment description\" \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "listExperimentsFilterByName_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Lists of experiments should not be empty\", function () {",
+									"    pm.expect(jsonData.entity.length).to.be.greaterThan(0);",
+									"});",
+									"",
+									"pm.test(\"Experiments with DRAFT and ENDED statuses returned\", function () {",
+									"    pm.expect(jsonData.entity[0].name).to.be.eq('20220901')",
+									"});",
+									"",
+									"",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments?name=20220901",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments"
+							],
+							"query": [
+								{
+									"key": "name",
+									"value": "20220901"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "listExperimentsFilterByPartialName_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Lists of experiments should not be empty\", function () {",
+									"    pm.expect(jsonData.entity.length).to.be.greaterThan(0);",
+									"});",
+									"",
+									"pm.test(\"Experiments with DRAFT and ENDED statuses returned\", function () {",
+									"    pm.expect(jsonData.entity[0].name).to.be.eq('20220901')",
+									"});",
+									"",
+									"",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments?name=2022",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments"
+							],
+							"query": [
+								{
+									"key": "name",
+									"value": "2022"
+								}
+							]
+						}
+					},
+					"response": []
 				}
-			},
-			"response": []
+			]
 		},
 		{
-			"name": "listExperimentsNoFilter_shouldIncludeAll",
-			"event": [
+			"name": "Goal",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Lists of experiments should not be empty\", function () {",
-							"    pm.expect(jsonData.entity.length).to.be.greaterThan(0);",
-							"});",
-							"",
-							"pm.test(\"The two experiments with different pageId are included\", function () {",
-							"    let experiment1ID = pm.collectionVariables.get(\"experimentId\")",
-							"    let experiment2ID = pm.collectionVariables.get(\"secondExperimentId\");",
-							"    pm.expect(isExperimentIncluded(experiment1ID)).to.be.true;",
-							"    pm.expect(isExperimentIncluded(experiment2ID)).to.be.true;",
-							"});",
-							"",
-							"function isExperimentIncluded(id) {",
-							"    for(let i in jsonData.entity) {",
-							"        let experiment = jsonData.entity[i]",
-							"        if(experiment.id===id) return true;",
-							"    }",
-							"",
-							"    return false;",
-							"}",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "setExperimentGoal_shoudSucceed",
+					"event": [
 						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.goals.primary.type).equal(\"REACH_PAGE\");",
+									"    pm.expect(jsonData.entity.goals.primary.name).equal(\"Reach thank-you page\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].operator).equal(\"EQUALS\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].parameter).equal(\"url\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].value).equal(\"thank-you\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].operator).equal(\"EQUALS\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].parameter).equal(\"referrer\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].value).equal(\"home\");",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
-				},
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments",
-					"host": [
-						"{{serverURL}}"
 					],
-					"path": [
-						"api",
-						"v1",
-						"experiments"
-					]
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "setExperimentGoal_InvalidCondition_ShouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Expected error message\", function () {",
+									"    pm.expect(jsonData.message).equal(\"Invalid Parameters provided: [does-not-exist]\")",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"does-not-exist\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "setExperimentGoal_MissingRequiredParameter_ShouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Expected error message\", function () {",
+									"    pm.expect(jsonData.message).equal(\"Missing required Parameters: [url]\")",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "setExperimentGoal_MissingAllRequiredParameter_ShouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Expected error message\", function () {",
+									"    pm.expect(jsonData.message).equal(\"At least one of these are required Parameters: [id, class, target]\")",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"CLICK_ON_ELEMENT\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"pageUrl\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "removeExperimentGoal_shoudSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have null goals\", function () {",
+									"    pm.expect(jsonData.entity.goals).is.null;",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}/goals/primary",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}",
+								"goals",
+								"primary"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "setExperimentGoal_ProvideAtLeastOneRequiredParameter_ShouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Expected Goal with two Conditions created\", function () {",
+									"    pm.expect(jsonData.entity.goals.primary.conditions.length).to.be.eq(2)",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"CLICK_ON_ELEMENT\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"pageUrl\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }, \n                {\n                    \"parameter\": \"id\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"my-button\"\n                }\n            ]\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentId}}"
+							]
+						}
+					},
+					"response": []
 				}
-			},
-			"response": []
+			]
 		},
 		{
-			"name": "listExperimentsFilterBySingleStatus_shouldSucceed",
-			"event": [
+			"name": "Variants",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Lists of experiments should not be empty\", function () {",
-							"    pm.expect(jsonData.entity.length).to.be.greaterThan(0);",
-							"});",
-							"",
-							"pm.test(\"All returned experiments should have the status DRAFT\", function () {",
-							"    for(let i in jsonData.entity) {",
-							"        let experiment = jsonData.entity[i]",
-							"        pm.expect(experiment.status).to.be.eq('DRAFT');",
-							"    }",
-							"});",
-							"",
-							"",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "pre_createExperiment",
+					"event": [
 						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.collectionVariables.set(\"experimentToAddVariant\", jsonData.entity.id);",
+									"",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
 						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pageId\": \"9044ec0fdb3788a814ccabf789f376d4\",\n    \"name\": \"20220901\",\n    \"description\": \"experiment with goals and variants\", \n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								""
+							]
 						}
-					]
+					},
+					"response": []
 				},
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments?status=DRAFT",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments"
-					],
-					"query": [
+				{
+					"name": "addVariantToExperiment_shouldSucceed",
+					"event": [
 						{
-							"key": "status",
-							"value": "DRAFT"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Variants with correct weight\", function () {",
+									"    var experimetnShortId = pm.collectionVariables.get(\"experimentToAddVariant\").substring(0, 11).replace('-', '');",
+									"",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].url).equal(\"/another-experiment-page?variantName=dotexperiment-\" + experimetnShortId + \"-variant-1\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My first Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].url).equal(\"/another-experiment-page?variantName=dotexperiment-\" + experimetnShortId + \"-variant-2\");",
+									"    ",
+									"    pm.collectionVariables.set(\"variantToDelete\", jsonData.entity.trafficProportion.variants[1].id);",
+									"",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"My first Variant\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}",
+								"variants"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "addSecondVariantToExperiment_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Variants with correct weight\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(3);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(33.333332);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My first Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(33.333332);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[2].name).equal(\"My second Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[2].weight).equal(33.333332);",
+									"",
+									"    pm.collectionVariables.set(\"secondVariantId\", jsonData.entity.trafficProportion.variants[2].id);",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"My second Variant\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}",
+								"variants"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteVariantOfExperiment_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Started Experiment with expected values\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My second Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants/{{variantToDelete}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}",
+								"variants",
+								"{{variantToDelete}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateExperimentTrafficProportion_shoudSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Variants with correct weight\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"CUSTOM_PERCENTAGES\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(80.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"Variant 2\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(20.0);",
+									"",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"trafficProportion\": {\n        \"type\": \"CUSTOM_PERCENTAGES\",\n        \"variants\": [\n            {\n                \"name\": \"Original\",\n                \"id\": \"DEFAULT\",\n                \"weight\": 80\n            },\n            {\n                \"name\": \"Variant 2\",\n                \"id\": \"{{secondVariantId}}\",\n                \"weight\": 20\n            }\n        ]\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "addVariantToExperiment_CustomPercentages_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Variants with correct weight\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"CUSTOM_PERCENTAGES\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(3);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(80.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My third Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(0.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[2].name).equal(\"Variant 2\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[2].weight).equal(20.0);",
+									"",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"My third Variant\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}",
+								"variants"
+							]
+						}
+					},
+					"response": []
 				}
-			},
-			"response": []
+			]
 		},
 		{
-			"name": "pre_createExperimentUniqueName",
-			"event": [
+			"name": "Start Experiment",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "startExperiment_shouldSucceed",
+					"event": [
 						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Started Experiment with expected values\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.status).equal(\"RUNNING\");",
+									"    pm.expect(jsonData.entity.scheduling.startDate).to.be.not.null;",
+									"    pm.expect(jsonData.entity.scheduling.endDate).to.be.not.null;",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"pageId\": \"9044ec0fdb3788a814ccabf789f376d4\",\n    \"name\": \"20220901\",\n    \"description\": \"second page experiment description\" \n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/",
-					"host": [
-						"{{serverURL}}"
 					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						""
-					]
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/_start",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}",
+								"_start"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "pre_createExperiment_NoGoal_NoVariant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.collectionVariables.set(\"experimentNoGoalsId\", jsonData.entity.id);",
+									"",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pageId\": \"9044ec0fdb3788a814ccabf789f376d4\",\n    \"name\": \"20220901\",\n    \"description\": \"experiment with goals and variants\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "startExperiment_MissingVariants_shouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Experiment without Goal should fail\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.expect(jsonData.message).equal(\"The Experiment needs at least one Page Variant in order to be started.\");",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/_start",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentNoGoalsId}}",
+								"_start"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "pre_addVariantToExperiment",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Variants with correct weight\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"Some other Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
+									"",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"Some other Variant\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/variants",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentNoGoalsId}}",
+								"variants"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "startExperiment_MissingGoal_shouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Experiment without Goal should fail\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.expect(jsonData.message).equal(\"The Experiment needs to have the Goal set.\");",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/_start",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentNoGoalsId}}",
+								"_start"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "pre_setExperimentGoal",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.goals.primary.type).equal(\"REACH_PAGE\");",
+									"    pm.expect(jsonData.entity.goals.primary.name).equal(\"Reach thank-you page\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].operator).equal(\"EQUALS\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].parameter).equal(\"url\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].value).equal(\"thank-you\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].operator).equal(\"EQUALS\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].parameter).equal(\"referrer\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].value).equal(\"home\");",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentNoGoalsId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "startExperiment_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Started Experiment with expected values\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.status).equal(\"RUNNING\");",
+									"    pm.expect(jsonData.entity.scheduling.startDate).to.be.not.null;",
+									"    pm.expect(jsonData.entity.scheduling.endDate).to.be.not.null;",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/_start",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentNoGoalsId}}",
+								"_start"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "startAlreadyStarterExperiment_shouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.expect(jsonData.message).equal(\"Cannot start an already started Experiment.\");",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/_start",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentNoGoalsId}}",
+								"_start"
+							]
+						}
+					},
+					"response": []
 				}
-			},
-			"response": []
+			]
 		},
 		{
-			"name": "listExperimentsFilterByName_shouldSucceed",
-			"event": [
+			"name": "End Experiment",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Lists of experiments should not be empty\", function () {",
-							"    pm.expect(jsonData.entity.length).to.be.greaterThan(0);",
-							"});",
-							"",
-							"pm.test(\"Experiments with DRAFT and ENDED statuses returned\", function () {",
-							"    pm.expect(jsonData.entity[0].name).to.be.eq('20220901')",
-							"});",
-							"",
-							"",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "endExperiment_shouldSucceed",
+					"event": [
 						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Ended Experiment with expected values\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.status).equal(\"ENDED\");",
+									"    pm.expect(jsonData.entity.scheduling.startDate).to.be.not.null;",
+									"    pm.expect(jsonData.entity.scheduling.endDate).to.be.not.null;",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
 						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/_end",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentNoGoalsId}}",
+								"_end"
+							]
 						}
-					]
+					},
+					"response": []
 				},
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments?name=20220901",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments"
-					],
-					"query": [
+				{
+					"name": "pre_createExperiment",
+					"event": [
 						{
-							"key": "name",
-							"value": "20220901"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.collectionVariables.set(\"experimentTargeting\", jsonData.entity.id);",
+									"",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pageId\": \"e424abd7e2e7a9031c5a0a3c18182f1b\",\n    \"name\": \"20220901\",\n    \"description\": \"experiment with goals and variants\", \n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								""
+							]
+						}
+					},
+					"response": []
 				}
-			},
-			"response": []
+			]
 		},
 		{
-			"name": "listExperimentsFilterByPartialName_shouldSucceed",
-			"event": [
+			"name": "Targeting Conditions",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Lists of experiments should not be empty\", function () {",
-							"    pm.expect(jsonData.entity.length).to.be.greaterThan(0);",
-							"});",
-							"",
-							"pm.test(\"Experiments with DRAFT and ENDED statuses returned\", function () {",
-							"    pm.expect(jsonData.entity[0].name).to.be.eq('20220901')",
-							"});",
-							"",
-							"",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "addTargetingConditions_shouldSucceed",
+					"event": [
 						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.goals.primary.type).equal(\"REACH_PAGE\");",
+									"    pm.expect(jsonData.entity.goals.primary.name).equal(\"Reach thank-you page\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].operator).equal(\"EQUALS\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].parameter).equal(\"url\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].value).equal(\"thank-you\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].operator).equal(\"EQUALS\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].parameter).equal(\"referrer\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].value).equal(\"home\");",
+									"    pm.expect(jsonData.entity.targetingConditions.length).equal(3);",
+									"",
+									"});",
+									"",
+									"pm.collectionVariables.set(\"conditionId\", jsonData.entity.targetingConditions[0].id);",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
 						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"targetingConditions\": [\n        {\n            \"conditionKey\": \"UsersBrowserConditionlet\",\n             \"values\": {\n                 \"comparison\": \"is\", \n                 \"browser\": \"Chrome\"\n             }   \n        }, \n        {\n            \"conditionKey\": \"UsersPlatformConditionlet\",\n             \"values\": {\n                 \"comparison\": \"is\", \n                 \"platform\": \"MOBILE\"\n             }   \n        }, \n        {\n            \"conditionKey\": \"VisitorsGeolocationConditionlet\",\n             \"values\": {\n                 \"comparison\": \"withinDistance\", \n                 \"latitude\": \"38.8977\", \n                 \"longitude\": \"-77.0365\", \n                 \"preferredDisplayUnits\": \"mi\", \n                 \"radius\": \"16191.182801892148\"\n             }   \n        }\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentTargeting}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentTargeting}}"
+							]
 						}
-					]
+					},
+					"response": []
 				},
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments?name=2022",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments"
-					],
-					"query": [
-						{
-							"key": "name",
-							"value": "2022"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "setExperimentGoal_shoudSucceed",
-			"event": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.goals.primary.type).equal(\"REACH_PAGE\");",
-							"    pm.expect(jsonData.entity.goals.primary.name).equal(\"Reach thank-you page\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].operator).equal(\"EQUALS\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].parameter).equal(\"url\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].value).equal(\"thank-you\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].operator).equal(\"EQUALS\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].parameter).equal(\"referrer\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].value).equal(\"home\");",
-							"",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "updateTargetingConditions_shouldSucceed",
+					"event": [
 						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Experiment should have the expected values\", function () {",
+									"    pm.expect(jsonData.entity.goals.primary.type).equal(\"REACH_PAGE\");",
+									"    pm.expect(jsonData.entity.goals.primary.name).equal(\"Reach thank-you page\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].operator).equal(\"EQUALS\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].parameter).equal(\"url\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[0].value).equal(\"thank-you\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].operator).equal(\"EQUALS\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].parameter).equal(\"referrer\");",
+									"    pm.expect(jsonData.entity.goals.primary.conditions[1].value).equal(\"home\");",
+									"    pm.expect(jsonData.entity.targetingConditions.length).equal(3);",
+									"",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
 					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "setExperimentGoal_InvalidCondition_ShouldFail",
-			"event": [
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"targetingConditions\": [\n        {\n            \"id\": \"{{conditionId}}\",\n            \"conditionKey\": \"UsersBrowserConditionlet\",\n             \"values\": {\n                 \"comparison\": \"is\", \n                 \"browser\": \"Firefox\"\n             }   \n        }\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentTargeting}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentTargeting}}"
+							]
+						}
+					},
+					"response": []
+				},
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"});",
-							"",
-							"pm.test(\"Expected error message\", function () {",
-							"    pm.expect(jsonData.message).equal(\"Invalid Parameters provided: [does-not-exist]\")",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "deleteTargetingCondition_shouldSucceed",
+					"event": [
 						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Started Experiment with expected values\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.targetingConditions.length).equal(2);",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"does-not-exist\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
 					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "setExperimentGoal_MissingRequiredParameter_ShouldFail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"});",
-							"",
-							"pm.test(\"Expected error message\", function () {",
-							"    pm.expect(jsonData.message).equal(\"Missing required Parameters: [url]\")",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
 						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "setExperimentGoal_MissingAllRequiredParameter_ShouldFail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"});",
-							"",
-							"pm.test(\"Expected error message\", function () {",
-							"    pm.expect(jsonData.message).equal(\"At least one of these are required Parameters: [id, class, target]\")",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentTargeting}}/targetingConditions/{{conditionId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentTargeting}}",
+								"targetingConditions",
+								"{{conditionId}}"
+							]
 						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"CLICK_ON_ELEMENT\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"pageUrl\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
+					},
+					"response": []
 				}
-			},
-			"response": []
-		},
-		{
-			"name": "removeExperimentGoal_shoudSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have null goals\", function () {",
-							"    pm.expect(jsonData.entity.goals).is.null;",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "DELETE",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}/goals/primary",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}",
-						"goals",
-						"primary"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "setExperimentGoal_ProvideAtLeastOneRequiredParameter_ShouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Expected Goal with two Conditions created\", function () {",
-							"    pm.expect(jsonData.entity.goals.primary.conditions.length).to.be.eq(2)",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"CLICK_ON_ELEMENT\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"pageUrl\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }, \n                {\n                    \"parameter\": \"id\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"my-button\"\n                }\n            ]\n        }\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "pre_createExperiment",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.collectionVariables.set(\"experimentToAddVariant\", jsonData.entity.id);",
-							"",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"pageId\": \"9044ec0fdb3788a814ccabf789f376d4\",\n    \"name\": \"20220901\",\n    \"description\": \"experiment with goals and variants\", \n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "addVariantToExperiment_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Variants with correct weight\", function () {",
-							"    var experimetnShortId = pm.collectionVariables.get(\"experimentToAddVariant\").substring(0, 11).replace('-', '');",
-							"",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].url).equal(\"/another-experiment-page?variantName=dotexperiment-\" + experimetnShortId + \"-variant-1\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My first Variant\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].url).equal(\"/another-experiment-page?variantName=dotexperiment-\" + experimetnShortId + \"-variant-2\");",
-							"    ",
-							"    pm.collectionVariables.set(\"variantToDelete\", jsonData.entity.trafficProportion.variants[1].id);",
-							"",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"name\": \"My first Variant\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentToAddVariant}}",
-						"variants"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "addSecondVariantToExperiment_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Variants with correct weight\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(3);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(33.333332);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My first Variant\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(33.333332);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[2].name).equal(\"My second Variant\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[2].weight).equal(33.333332);",
-							"",
-							"    pm.collectionVariables.set(\"secondVariantId\", jsonData.entity.trafficProportion.variants[2].id);",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"name\": \"My second Variant\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentToAddVariant}}",
-						"variants"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "deleteVariantOfExperiment_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Started Experiment with expected values\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My second Variant\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "DELETE",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants/{{variantToDelete}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentToAddVariant}}",
-						"variants",
-						"{{variantToDelete}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateExperimentTrafficProportion_shoudSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Variants with correct weight\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"CUSTOM_PERCENTAGES\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(80.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"Variant 2\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(20.0);",
-							"",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"trafficProportion\": {\n        \"type\": \"CUSTOM_PERCENTAGES\",\n        \"variants\": [\n            {\n                \"name\": \"Original\",\n                \"id\": \"DEFAULT\",\n                \"weight\": 80\n            },\n            {\n                \"name\": \"Variant 2\",\n                \"id\": \"{{secondVariantId}}\",\n                \"weight\": 20\n            }\n        ]\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentToAddVariant}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "addVariantToExperiment_CustomPercentages_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Variants with correct weight\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"CUSTOM_PERCENTAGES\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(3);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(80.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My third Variant\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(0.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[2].name).equal(\"Variant 2\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[2].weight).equal(20.0);",
-							"",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"name\": \"My third Variant\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentToAddVariant}}",
-						"variants"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "startExperiment_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Started Experiment with expected values\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity.status).equal(\"RUNNING\");",
-							"    pm.expect(jsonData.entity.scheduling.startDate).to.be.not.null;",
-							"    pm.expect(jsonData.entity.scheduling.endDate).to.be.not.null;",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/_start",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentToAddVariant}}",
-						"_start"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "pre_createExperiment_NoGoal_NoVariant",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.collectionVariables.set(\"experimentNoGoalsId\", jsonData.entity.id);",
-							"",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"pageId\": \"9044ec0fdb3788a814ccabf789f376d4\",\n    \"name\": \"20220901\",\n    \"description\": \"experiment with goals and variants\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "startExperiment_MissingVariants_shouldFail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Experiment without Goal should fail\", function () {",
-							"    pm.response.to.have.status(400);",
-							"    pm.expect(jsonData.message).equal(\"The Experiment needs at least one Page Variant in order to be started.\");",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/_start",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentNoGoalsId}}",
-						"_start"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "pre_addVariantToExperiment",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Variants with correct weight\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"Some other Variant\");",
-							"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
-							"",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"name\": \"Some other Variant\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/variants",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentNoGoalsId}}",
-						"variants"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "startExperiment_MissingGoal_shouldFail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Experiment without Goal should fail\", function () {",
-							"    pm.response.to.have.status(400);",
-							"    pm.expect(jsonData.message).equal(\"The Experiment needs to have the Goal set.\");",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/_start",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentNoGoalsId}}",
-						"_start"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "pre_setExperimentGoal",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.goals.primary.type).equal(\"REACH_PAGE\");",
-							"    pm.expect(jsonData.entity.goals.primary.name).equal(\"Reach thank-you page\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].operator).equal(\"EQUALS\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].parameter).equal(\"url\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].value).equal(\"thank-you\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].operator).equal(\"EQUALS\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].parameter).equal(\"referrer\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].value).equal(\"home\");",
-							"",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentNoGoalsId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "startExperiment_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Started Experiment with expected values\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity.status).equal(\"RUNNING\");",
-							"    pm.expect(jsonData.entity.scheduling.startDate).to.be.not.null;",
-							"    pm.expect(jsonData.entity.scheduling.endDate).to.be.not.null;",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/_start",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentNoGoalsId}}",
-						"_start"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "startAlreadyStarterExperiment_shouldFail",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"    pm.expect(jsonData.message).equal(\"Cannot start an already started Experiment.\");",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/_start",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentNoGoalsId}}",
-						"_start"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "endExperiment_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Ended Experiment with expected values\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity.status).equal(\"ENDED\");",
-							"    pm.expect(jsonData.entity.scheduling.startDate).to.be.not.null;",
-							"    pm.expect(jsonData.entity.scheduling.endDate).to.be.not.null;",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentNoGoalsId}}/_end",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentNoGoalsId}}",
-						"_end"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "pre_createExperiment",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.collectionVariables.set(\"experimentTargeting\", jsonData.entity.id);",
-							"",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"pageId\": \"e424abd7e2e7a9031c5a0a3c18182f1b\",\n    \"name\": \"20220901\",\n    \"description\": \"experiment with goals and variants\", \n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "addTargetingConditions_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.goals.primary.type).equal(\"REACH_PAGE\");",
-							"    pm.expect(jsonData.entity.goals.primary.name).equal(\"Reach thank-you page\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].operator).equal(\"EQUALS\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].parameter).equal(\"url\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].value).equal(\"thank-you\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].operator).equal(\"EQUALS\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].parameter).equal(\"referrer\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].value).equal(\"home\");",
-							"    pm.expect(jsonData.entity.targetingConditions.length).equal(3);",
-							"",
-							"});",
-							"",
-							"pm.collectionVariables.set(\"conditionId\", jsonData.entity.targetingConditions[0].id);",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"targetingConditions\": [\n        {\n            \"conditionKey\": \"UsersBrowserConditionlet\",\n             \"values\": {\n                 \"comparison\": \"is\", \n                 \"browser\": \"Chrome\"\n             }   \n        }, \n        {\n            \"conditionKey\": \"UsersPlatformConditionlet\",\n             \"values\": {\n                 \"comparison\": \"is\", \n                 \"platform\": \"MOBILE\"\n             }   \n        }, \n        {\n            \"conditionKey\": \"VisitorsGeolocationConditionlet\",\n             \"values\": {\n                 \"comparison\": \"withinDistance\", \n                 \"latitude\": \"38.8977\", \n                 \"longitude\": \"-77.0365\", \n                 \"preferredDisplayUnits\": \"mi\", \n                 \"radius\": \"16191.182801892148\"\n             }   \n        }\n    ]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentTargeting}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentTargeting}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "updateTargetingConditions_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Experiment should have the expected values\", function () {",
-							"    pm.expect(jsonData.entity.goals.primary.type).equal(\"REACH_PAGE\");",
-							"    pm.expect(jsonData.entity.goals.primary.name).equal(\"Reach thank-you page\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].operator).equal(\"EQUALS\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].parameter).equal(\"url\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[0].value).equal(\"thank-you\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].operator).equal(\"EQUALS\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].parameter).equal(\"referrer\");",
-							"    pm.expect(jsonData.entity.goals.primary.conditions[1].value).equal(\"home\");",
-							"    pm.expect(jsonData.entity.targetingConditions.length).equal(3);",
-							"",
-							"});",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"targetingConditions\": [\n        {\n            \"id\": \"{{conditionId}}\",\n            \"conditionKey\": \"UsersBrowserConditionlet\",\n             \"values\": {\n                 \"comparison\": \"is\", \n                 \"browser\": \"Firefox\"\n             }   \n        }\n    ]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentTargeting}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentTargeting}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "deleteTargetingCondition_shouldSucceed",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Started Experiment with expected values\", function () {",
-							"    pm.response.to.have.status(200);",
-							"    pm.expect(jsonData.entity.targetingConditions.length).equal(2);",
-							"});",
-							"",
-							"",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "DELETE",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentTargeting}}/targetingConditions/{{conditionId}}",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentTargeting}}",
-						"targetingConditions",
-						"{{conditionId}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Stop Experiment",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var jsonData = pm.response.json();",
-							"",
-							"",
-							"pm.test(\"Status code should be ok 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
-						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin@dotcms.com",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"pageId\": \"{{page_id}}\",\n    \"name\": \"Add/Remove content Experiment\",\n    \"description\": \"Expriment ro Add/Remove contentlet from a specific variant page\" \n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/_end",
-					"host": [
-						"{{serverURL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"experiments",
-						"{{experimentToAddVariant}}",
-						"_end"
-					]
-				},
-				"description": "Create a new Experiment named \"Add/Remove content Experiment\" with the page created in the previous request."
-			},
-			"response": []
+			]
 		}
 	],
 	"variable": [


### PR DESCRIPTION
Postman tests for Experiments were all at "root" level. This PR organizes them into folders according to the functionality. 


<img width="472" alt="Screenshot 2023-01-11 at 11 11 01" src="https://user-images.githubusercontent.com/1576794/211883092-c5db3c5c-dd3d-494f-a1d4-e271114b5ee7.png">

