### PR TITLE
Fix imports order: add @angular always at top of the file

### DIFF
--- a/core-web/.eslintrc.json
+++ b/core-web/.eslintrc.json
@@ -82,7 +82,7 @@
                             "type"
                         ],
                         "pathGroups": [
-                            { "pattern": "@angular/**", "group": "external", "position": "after" },
+                            { "pattern": "@angular/**", "group": "external", "position": "before" },
                             { "pattern": "primeng/**", "group": "external", "position": "after" },
                             { "pattern": "rxjs/**", "group": "external", "position": "after" },
                             { "pattern": "@tiptap/**", "group": "external", "position": "after" },

--- a/core-web/apps/dotcdn/src/app/app.component.ts
+++ b/core-web/apps/dotcdn/src/app/app.component.ts
@@ -1,8 +1,8 @@
-import { ChartOptions } from 'chart.js';
-import { Observable } from 'rxjs';
-
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+
+import { ChartOptions } from 'chart.js';
+import { Observable } from 'rxjs';
 
 import { SelectItem } from 'primeng/api';
 import { UIChart } from 'primeng/chart';

--- a/core-web/apps/dotcdn/src/app/dotcdn.component.store.spec.ts
+++ b/core-web/apps/dotcdn/src/app/dotcdn.component.store.spec.ts
@@ -1,7 +1,7 @@
-import { of } from 'rxjs';
-
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import {
     CoreWebService,

--- a/core-web/apps/dotcdn/src/app/dotcdn.component.store.ts
+++ b/core-web/apps/dotcdn/src/app/dotcdn.component.store.ts
@@ -1,7 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { ComponentStore, tapResponse } from '@ngrx/component-store';
 import { Observable, of } from 'rxjs';
-
-import { Injectable } from '@angular/core';
 
 import { SelectItem } from 'primeng/api';
 

--- a/core-web/apps/dotcdn/src/app/dotcdn.service.ts
+++ b/core-web/apps/dotcdn/src/app/dotcdn.service.ts
@@ -1,7 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { format, subDays } from 'date-fns';
 import { Observable } from 'rxjs';
-
-import { Injectable } from '@angular/core';
 
 import { mergeMap, pluck } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/add-to-menu/add-to-menu.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/add-to-menu/add-to-menu.service.spec.ts
@@ -1,7 +1,8 @@
-import { throwError } from 'rxjs';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { getTestBed, TestBed } from '@angular/core/testing';
+
+import { throwError } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/add-to-menu/add-to-menu.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/add-to-menu/add-to-menu.service.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable, of } from 'rxjs';
 
 import { catchError, map, pluck, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-account-service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-account-service.spec.ts
@@ -1,7 +1,8 @@
-import { throwError } from 'rxjs';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed, waitForAsync } from '@angular/core/testing';
+
+import { throwError } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-account-service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-account-service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { catchError, map, pluck, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { throwError } from 'rxjs';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+
+import { throwError } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { catchError, map, pluck, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-categories/dot-categories.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-categories/dot-categories.service.spec.ts
@@ -1,7 +1,8 @@
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import {
     CATEGORY_SOURCE,

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-categories/dot-categories.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-categories/dot-categories.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { LazyLoadEvent } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-containers/dot-containers.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-containers/dot-containers.service.spec.ts
@@ -1,7 +1,8 @@
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import { CoreWebService } from '@dotcms/dotcms-js';
 import {

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-containers/dot-containers.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-containers/dot-containers.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { catchError, map, pluck, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-download-bundle-dialog/dot-download-bundle-dialog.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-download-bundle-dialog/dot-download-bundle-dialog.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable, Subject } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 @Injectable()
 export class DotDownloadBundleDialogService {

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-edit-layout/dot-edit-layout.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-edit-layout/dot-edit-layout.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 
 import {

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-format-date-service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-format-date-service.ts
@@ -1,7 +1,8 @@
+import { Injectable } from '@angular/core';
+
 import { differenceInCalendarDays, format, formatDistanceStrict, isValid, parse } from 'date-fns';
 import { format as formatTZ, utcToZonedTime } from 'date-fns-tz';
 
-import { Injectable } from '@angular/core';
 
 import { DotcmsConfigService, DotTimeZone } from '@dotcms/dotcms-js';
 import { DotLocaleOptions } from '@dotcms/dotcms-models';

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-gravatar-service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-gravatar-service.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable, of } from 'rxjs';
 
 import { catchError, map, pluck } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-http-error-manager/dot-http-error-manager.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-http-error-manager/dot-http-error-manager.service.ts
@@ -1,9 +1,10 @@
 
-import { Observable, of } from 'rxjs';
 
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable, of } from 'rxjs';
 
 import { DotAlertConfirmService, DotMessageService } from '@dotcms/data-access';
 import { HttpCode, LoginService } from '@dotcms/dotcms-js';

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import {
     defaultIfEmpty,

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-nav-logo/dot-nav-logo.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-nav-logo/dot-nav-logo.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { BehaviorSubject } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 @Injectable({
     providedIn: 'root'
 })

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-router/dot-router.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-router/dot-router.service.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Subject } from 'rxjs';
 
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { Subject } from 'rxjs';
 
 import { LoginService } from '@dotcms/dotcms-js';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-router/dot-router.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-router/dot-router.service.ts
@@ -1,4 +1,3 @@
-import { Subject } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import {
@@ -7,6 +6,8 @@ import {
     NavigationEnd, NavigationExtras, Params,
     Router
 } from '@angular/router';
+
+import { Subject } from 'rxjs';
 
 import { filter } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-temp-file-upload/dot-temp-file-upload.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-temp-file-upload/dot-temp-file-upload.service.spec.ts
@@ -1,8 +1,9 @@
-import { of } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import { CoreWebService } from '@dotcms/dotcms-js';
 import { CoreWebServiceMock } from '@dotcms/utils-testing';

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-temp-file-upload/dot-temp-file-upload.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-temp-file-upload/dot-temp-file-upload.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { catchError, map, pluck, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.spec.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import { CoreWebService } from '@dotcms/dotcms-js';
 import { DotActionBulkResult, DotTemplate } from '@dotcms/dotcms-models';

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { catchError, map, pluck, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-ui-colors/dot-ui-colors.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-ui-colors/dot-ui-colors.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { TinyColor } from '@ctrl/tinycolor';
 
-import { Injectable } from '@angular/core';
 
 import { DotUiColors } from '@dotcms/dotcms-js';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-wizard/dot-wizard.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-wizard/dot-wizard.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable, Subject } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { DotWizardInput } from '@models/dot-wizard-input/dot-wizard-input.model';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { catchError, map, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/auth-guard.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/auth-guard.service.spec.ts
@@ -1,8 +1,9 @@
-import { Observable, of as observableOf } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/auth-guard.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/auth-guard.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { map } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/contentlet-guard.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/contentlet-guard.service.spec.ts
@@ -1,8 +1,9 @@
-import { of } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { DotNavigationService } from '@components/dot-navigation/services/dot-navigation.service';
 import { DotContentTypeService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/contentlet-guard.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/contentlet-guard.service.ts
@@ -1,7 +1,7 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateChild, RouterStateSnapshot } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { map } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/layout-editor-can-deactivate-guard.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/layout-editor-can-deactivate-guard.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { CanDeactivate } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { filter } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/menu-guard.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/menu-guard.service.spec.ts
@@ -1,8 +1,9 @@
-import { of as observableOf } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+
+import { of as observableOf } from 'rxjs';
 
 import { DotNavigationService } from '@components/dot-navigation/services/dot-navigation.service';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/menu-guard.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/menu-guard.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { map } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/pages-guard.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/pages-guard.service.spec.ts
@@ -1,6 +1,7 @@
+import { TestBed } from '@angular/core/testing';
+
 import { of } from 'rxjs';
 
-import { TestBed } from '@angular/core/testing';
 
 import { MockDotPropertiesService } from '@dotcms/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.spec';
 import { DotPropertiesService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/pages-guard.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/pages-guard.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { CanActivate } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { map, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/public-auth-guard.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/public-auth-guard.service.spec.ts
@@ -1,8 +1,9 @@
-import { Observable, of as observableOf } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/public-auth-guard.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/public-auth-guard.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { map } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/notifications-service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/notifications-service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/push-publish/push-publish.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/push-publish/push-publish.service.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
 import { format } from 'date-fns';
 import { of } from 'rxjs';
 
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { TestBed } from '@angular/core/testing';
 
 import { DotFormatDateService } from '@dotcms/app/api/services/dot-format-date-service';
 import { DotCurrentUserService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/api/services/push-publish/push-publish.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/push-publish/push-publish.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { filter, map, mergeMap, pluck, toArray } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/api/util/string-pixels-util.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/util/string-pixels-util.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import * as _ from 'lodash';
 
-import { Injectable } from '@angular/core';
 @Injectable()
 export class StringPixels {
     private static readonly characterSize = 7;

--- a/core-web/apps/dotcms-ui/src/app/app.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/app.component.spec.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
 
 import { DotUiColorsService } from '@dotcms/app/api/services/dot-ui-colors/dot-ui-colors.service';
 import { DotMessageService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/app.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/app.module.ts
@@ -1,5 +1,3 @@
-import { MonacoEditorModule } from '@materia-ui/ngx-monaco-editor';
-import { MarkdownModule } from 'ngx-markdown';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
@@ -7,6 +5,9 @@ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { MonacoEditorModule } from '@materia-ui/ngx-monaco-editor';
+import { MarkdownModule } from 'ngx-markdown';
 
 // App is our top level component
 import { DotPipesModule } from '@pipes/dot-pipes.module';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.spec.ts
@@ -1,5 +1,4 @@
 
-import { MarkdownService } from 'ngx-markdown';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -7,6 +6,8 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { MarkdownService } from 'ngx-markdown';
 
 import { ButtonModule } from 'primeng/button';
 import { CheckboxModule } from 'primeng/checkbox';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.module.ts
@@ -1,10 +1,11 @@
 
 
-import { MarkdownModule } from 'ngx-markdown';
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+
+import { MarkdownModule } from 'ngx-markdown';
 
 import { ButtonModule } from 'primeng/button';
 import { CheckboxModule } from 'primeng/checkbox';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-resolver.service.spec.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { DotAppsService } from '@dotcms/app/api/services/dot-apps/dot-apps.service';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-resolver.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.spec.ts
@@ -1,6 +1,3 @@
-import * as _ from 'lodash';
-import { MarkdownModule } from 'ngx-markdown';
-import { Observable, of } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Injectable, Input, Output } from '@angular/core';
@@ -8,6 +5,10 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import * as _ from 'lodash';
+import { MarkdownModule } from 'ngx-markdown';
+import { Observable, of } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.ts
@@ -1,7 +1,8 @@
-import * as _ from 'lodash';
 
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import * as _ from 'lodash';
 
 import { pluck, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-header/dot-apps-configuration-header.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-header/dot-apps-configuration-header.component.spec.ts
@@ -1,9 +1,10 @@
-import { MarkdownService } from 'ngx-markdown';
 
 import { CommonModule } from '@angular/common';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { MarkdownService } from 'ngx-markdown';
 
 import { DotAvatarModule } from '@components/_common/dot-avatar/dot-avatar.module';
 import { DotCopyLinkModule } from '@components/dot-copy-link/dot-copy-link.module';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-header/dot-apps-configuration-header.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-header/dot-apps-configuration-header.module.ts
@@ -1,7 +1,8 @@
-import { MarkdownModule } from 'ngx-markdown';
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+
+import { MarkdownModule } from 'ngx-markdown';
 
 import { DotAvatarModule } from '@components/_common/dot-avatar/dot-avatar.module';
 import { DotCopyLinkModule } from '@components/dot-copy-link/dot-copy-link.module';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration-resolver.service.spec.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { DotAppsService } from '@dotcms/app/api/services/dot-apps/dot-apps.service';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration-resolver.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.component.spec.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { MarkdownModule } from 'ngx-markdown';
-import { Observable, of } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -10,6 +8,9 @@ import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angul
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { MarkdownModule } from 'ngx-markdown';
+import { Observable, of } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.component.ts
@@ -1,7 +1,8 @@
-import { fromEvent as observableFromEvent, Subject } from 'rxjs';
 
 import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { fromEvent as observableFromEvent, Subject } from 'rxjs';
 
 import { LazyLoadEvent } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.module.ts
@@ -1,7 +1,8 @@
-import { MarkdownModule } from 'ngx-markdown';
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+
+import { MarkdownModule } from 'ngx-markdown';
 
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.spec.ts
@@ -1,4 +1,3 @@
-import { Observable, of } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -6,6 +5,8 @@ import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { Observable, of } from 'rxjs';
 
 import { InputTextModule } from 'primeng/inputtext';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.ts
@@ -1,4 +1,3 @@
-import { Subject } from 'rxjs';
 
 import {
     Component,
@@ -17,6 +16,8 @@ import {
     UntypedFormGroup,
     Validators
 } from '@angular/forms';
+
+import { Subject } from 'rxjs';
 
 import { take, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-card/dot-apps-card.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-card/dot-apps-card.module.ts
@@ -1,7 +1,8 @@
-import { MarkdownModule } from 'ngx-markdown';
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+
+import { MarkdownModule } from 'ngx-markdown';
 
 import { CardModule } from 'primeng/card';
 import { TooltipModule } from 'primeng/tooltip';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list-resolver.service.spec.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of as observableOf, of } from 'rxjs';
 
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+
+import { of as observableOf, of } from 'rxjs';
 
 import { DotAppsService } from '@dotcms/app/api/services/dot-apps/dot-apps.service';
 import { DotLicenseService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list-resolver.service.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+
+import { Observable, of } from 'rxjs';
 
 import { map, mergeMap, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.spec.ts
@@ -1,9 +1,10 @@
-import { of } from 'rxjs';
 
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.ts
@@ -1,8 +1,9 @@
+import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
 import * as _ from 'lodash';
 import { fromEvent as observableFromEvent, Subject } from 'rxjs';
 
-import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 
 import { debounceTime, pluck, take, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-categories/dot-categories-create-edit/store/dot-categories-create-edit.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-categories/dot-categories-create-edit/store/dot-categories-create-edit.store.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { ComponentStore } from '@ngrx/component-store';
 
-import { Injectable } from '@angular/core';
 
 import { MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-categories/dot-categories-list/dot-categories-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-categories/dot-categories-list/dot-categories-list.component.spec.ts
@@ -1,12 +1,13 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { of } from 'rxjs';
 
 import { SharedModule } from 'primeng/api';
 import { BreadcrumbModule } from 'primeng/breadcrumb';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-categories/dot-categories-list/dot-categories-list.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-categories/dot-categories-list/dot-categories-list.component.ts
@@ -1,6 +1,7 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, ElementRef, ViewChild } from '@angular/core';
 
 import { LazyLoadEvent } from 'primeng/api';
 import { Table } from 'primeng/table';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-categories/dot-categories-list/store/dot-categories-list-store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-categories/dot-categories-list/store/dot-categories-list-store.ts
@@ -1,7 +1,8 @@
+import { Injectable } from '@angular/core';
+
 import { ComponentStore } from '@ngrx/component-store';
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { LazyLoadEvent, MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.spec.ts
@@ -1,4 +1,3 @@
-import { of } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -7,6 +6,8 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { ConfirmationService, SelectItem, SharedModule } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.ts
@@ -1,6 +1,7 @@
+import { Component, OnDestroy, ViewChild } from '@angular/core';
+
 import { Subject } from 'rxjs';
 
-import { Component, OnDestroy, ViewChild } from '@angular/core';
 
 import { DialogService } from 'primeng/dynamicdialog';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/dot-container-list-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/dot-container-list-resolver.service.spec.ts
@@ -1,7 +1,8 @@
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import { take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/dot-container-list-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/dot-container-list-resolver.service.ts
@@ -1,7 +1,8 @@
-import { forkJoin, Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { Resolve } from '@angular/router';
+
+import { forkJoin, Observable } from 'rxjs';
 
 import { map, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/store/dot-container-list.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/store/dot-container-list.store.ts
@@ -1,7 +1,8 @@
-import { ComponentStore } from '@ngrx/component-store';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { ComponentStore } from '@ngrx/component-store';
 
 import { MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-add-variable/dot-add-variable.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-add-variable/dot-add-variable.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import {
@@ -13,6 +12,8 @@ import {
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { ConfirmationService, SharedModule } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-add-variable/store/dot-add-variable.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-add-variable/store/dot-add-variable.store.ts
@@ -1,8 +1,9 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
 import { ComponentStore } from '@ngrx/component-store';
 import { Observable, of } from 'rxjs';
 
-import { HttpErrorResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
 
 import { catchError, switchMap, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.spec.ts
@@ -1,4 +1,3 @@
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, EventEmitter, forwardRef, Input, Output } from '@angular/core';
@@ -13,6 +12,8 @@ import {
     ReactiveFormsModule
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { of } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/store/dot-content-editor.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/store/dot-content-editor.store.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { ComponentStore } from '@ngrx/component-store';
 
-import { Injectable } from '@angular/core';
 
 import { MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-create.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-create.component.spec.ts
@@ -1,8 +1,9 @@
-import { of } from 'rxjs';
 
 import { Pipe, PipeTransform } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
 import { CoreWebService } from '@dotcms/dotcms-js';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/dot-container-properties.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/dot-container-properties.component.spec.ts
@@ -1,4 +1,3 @@
-import { of } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -16,6 +15,8 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@a
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { ConfirmationService, SharedModule } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/dot-container-properties.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/dot-container-properties.component.ts
@@ -1,8 +1,9 @@
-import { Subject } from 'rxjs';
 
 import { animate, style, transition, trigger } from '@angular/animations';
 import { Component, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+
+import { Subject } from 'rxjs';
 
 import { MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/store/dot-container-properties.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/store/dot-container-properties.store.ts
@@ -1,10 +1,11 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
 import { ComponentStore } from '@ngrx/component-store';
 import * as _ from 'lodash';
 import { Observable, of, pipe } from 'rxjs';
 
-import { HttpErrorResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 
 import { catchError, filter, pluck, switchMap, take, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/resolvers/dot-container-edit.resolver.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/resolvers/dot-container-edit.resolver.spec.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { TestBed } from '@angular/core/testing';
+
 import { of } from 'rxjs';
 
-import { TestBed } from '@angular/core/testing';
 
 import { DotContainersService } from '@dotcms/app/api/services/dot-containers/dot-containers.service';
 import { MockDotRouterService } from '@dotcms/utils-testing';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/resolvers/dot-container-edit.resolver.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/resolvers/dot-container-edit.resolver.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { DotContainerEntity } from '@dotcms/dotcms-models';
 import { DotContainersService } from '@services/dot-containers/dot-containers.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.spec.ts
@@ -1,10 +1,11 @@
-import { of, throwError } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, Injectable, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of, throwError } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.ts
@@ -1,7 +1,8 @@
-import { Observable, of, Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+
+import { Observable, of, Subject } from 'rxjs';
 
 import { switchMap, take, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.ts
@@ -1,7 +1,8 @@
-import { Observable, Subject } from 'rxjs';
 
 import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+
+import { Observable, Subject } from 'rxjs';
 
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.spec.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+
+import { Observable, of } from 'rxjs';
 
 import { mockDotCMSTempFile } from '@components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.spec';
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.ts
@@ -1,8 +1,9 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
 import { ComponentStore, tapResponse } from '@ngrx/component-store';
 import { forkJoin, Observable, of, throwError } from 'rxjs';
 
-import { HttpErrorResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
 
 import { switchMap, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.component.ts
@@ -1,5 +1,3 @@
-import { fromEvent as observableFromEvent, Subject } from 'rxjs';
-
 import {
     Component,
     ElementRef,
@@ -10,6 +8,9 @@ import {
     Output,
     ViewChild
 } from '@angular/core';
+
+import { fromEvent as observableFromEvent, Subject } from 'rxjs';
+
 
 import { debounceTime, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.spec.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, EventEmitter, Injectable, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Observable, of } from 'rxjs';
 
 import { DotESContentService, PaginatorService } from '@dotcms/data-access';
 import { CoreWebService, CoreWebServiceMock } from '@dotcms/dotcms-js';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.stories.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.stories.ts
@@ -1,8 +1,9 @@
+import { CommonModule } from '@angular/common';
+import { Injectable } from '@angular/core';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { CommonModule } from '@angular/common';
-import { Injectable } from '@angular/core';
 
 import { DotContentletEditorService } from '@components/dot-contentlet-editor/services/dot-contentlet-editor.service';
 import { DotPaletteComponent } from '@dotcms/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { animate, AnimationEvent, state, style, transition, trigger } from '@angular/animations';
 import { Component, Input, OnInit, ViewChild } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { LazyLoadEvent } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/store/dot-palette.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/store/dot-palette.store.spec.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+
+import { Observable, of } from 'rxjs';
 
 import { DotContentTypeService, DotESContentService, PaginatorService } from '@dotcms/data-access';
 import { DotCMSContentlet, DotCMSContentType, ESContent } from '@dotcms/dotcms-models';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/store/dot-palette.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/store/dot-palette.store.ts
@@ -1,7 +1,8 @@
+import { Injectable } from '@angular/core';
+
 import { ComponentStore } from '@ngrx/component-store';
 import { forkJoin, Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { LazyLoadEvent } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import * as _ from 'lodash';
-import { of } from 'rxjs';
 
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import * as _ from 'lodash';
+import { of } from 'rxjs';
 
 import { InputSwitchModule } from 'primeng/inputswitch';
 import { SelectButtonModule } from 'primeng/selectbutton';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
@@ -1,5 +1,3 @@
-import { from, Observable, of } from 'rxjs';
-
 import {
     Component,
     EventEmitter,
@@ -9,6 +7,9 @@ import {
     SimpleChanges,
     ViewChild
 } from '@angular/core';
+
+import { from, Observable, of } from 'rxjs';
+
 
 import { SelectItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.spec.ts
@@ -1,4 +1,3 @@
-import { Observable, of } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -7,6 +6,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+
+import { Observable, of } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.ts
@@ -1,5 +1,3 @@
-import { Observable, Subject } from 'rxjs';
-
 import {
     Component,
     EventEmitter,
@@ -9,6 +7,9 @@ import {
     OnInit,
     Output
 } from '@angular/core';
+
+import { Observable, Subject } from 'rxjs';
+
 
 import { take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-view-as-controller/dot-edit-page-view-as-controller.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-view-as-controller/dot-edit-page-view-as-controller.component.spec.ts
@@ -1,9 +1,10 @@
-import { of } from 'rxjs';
 
 import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of } from 'rxjs';
 
 import { TooltipModule } from 'primeng/tooltip';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-view-as-controller/dot-edit-page-view-as-controller.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-view-as-controller/dot-edit-page-view-as-controller.component.ts
@@ -1,6 +1,7 @@
+import { Component, Input, OnInit } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, Input, OnInit } from '@angular/core';
 
 import { take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-workflows-actions/dot-edit-page-workflows-actions.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-workflows-actions/dot-edit-page-workflows-actions.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, Input } from '@angular/core';
@@ -8,6 +7,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 import { Menu, MenuModule } from 'primeng/menu';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-workflows-actions/dot-edit-page-workflows-actions.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-workflows-actions/dot-edit-page-workflows-actions.component.ts
@@ -1,5 +1,3 @@
-import { Observable } from 'rxjs';
-
 import {
     ChangeDetectionStrategy,
     Component,
@@ -9,6 +7,9 @@ import {
     Output,
     SimpleChanges
 } from '@angular/core';
+
+import { Observable } from 'rxjs';
+
 
 import { MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-form-selector/dot-form-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-form-selector/dot-form-selector.component.spec.ts
@@ -1,10 +1,11 @@
-import { Observable, of as observableOf } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { TableModule } from 'primeng/table';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.spec.ts
@@ -1,8 +1,9 @@
-import { of } from 'rxjs';
 
 import { Component, DebugElement, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { of } from 'rxjs';
 
 import { IframeComponent } from '@components/_common/iframe/iframe-component';
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of, throwError } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -10,6 +9,8 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of, throwError } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -1,9 +1,10 @@
-import { fromEvent, merge, Observable, of, Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, ElementRef, NgZone, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
+
+import { fromEvent, merge, Observable, of, Subject } from 'rxjs';
 
 import { DialogService } from 'primeng/dynamicdialog';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-container-contentlet.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-container-contentlet.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of, throwError } from 'rxjs';
 
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Injectable } from '@angular/core';
 import { TestBed, waitForAsync } from '@angular/core/testing';
+
+import { Observable, of, throwError } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -1,7 +1,8 @@
-import { fromEvent, Observable, of, Subject, Subscription } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { ElementRef, Injectable, NgZone } from '@angular/core';
+
+import { fromEvent, Observable, of, Subject, Subscription } from 'rxjs';
 
 import { filter, map, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
@@ -1,7 +1,8 @@
-import { of, throwError } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed, TestBed } from '@angular/core/testing';
+
+import { of, throwError } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-console */
-import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 
 import { catchError, map, pluck, switchMap, take, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.spec.ts
@@ -1,7 +1,8 @@
-import { Observable, of as observableOf } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { DotLicenseService, DotMessageService } from '@dotcms/data-access';
 import { MockDotMessageService } from '@dotcms/utils-testing';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/layout/components/dot-template-additional-actions/dot-legacy-template-additional-actions-iframe/dot-legacy-template-additional-actions-iframe.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/layout/components/dot-template-additional-actions/dot-legacy-template-additional-actions-iframe/dot-legacy-template-additional-actions-iframe.component.spec.ts
@@ -1,8 +1,9 @@
-import { of as observableOf } from 'rxjs';
 
 import { Component, Input } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
+
+import { of as observableOf } from 'rxjs';
 
 import { DotMenuService } from '@dotcms/app/api/services/dot-menu.service';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/layout/components/dot-template-additional-actions/dot-legacy-template-additional-actions-iframe/dot-legacy-template-additional-actions-iframe.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/layout/components/dot-template-additional-actions/dot-legacy-template-additional-actions-iframe/dot-legacy-template-additional-actions-iframe.component.ts
@@ -1,7 +1,8 @@
-import { Observable, of as observableOf } from 'rxjs';
 
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { combineLatest, switchMap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/layout/dot-edit-layout/dot-edit-layout.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/layout/dot-edit-layout/dot-edit-layout.component.spec.ts
@@ -1,11 +1,12 @@
 
-import { of, throwError } from 'rxjs';
 
 import { HttpResponse } from '@angular/common/http';
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+
+import { of, throwError } from 'rxjs';
 
 import { DotGlobalMessageService } from '@components/_common/dot-global-message/dot-global-message.service';
 import { DotEditLayoutService } from '@dotcms/app/api/services/dot-edit-layout/dot-edit-layout.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/layout/dot-edit-layout/dot-edit-layout.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/layout/dot-edit-layout/dot-edit-layout.component.ts
@@ -1,8 +1,9 @@
-import { Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, HostBinding, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { Subject } from 'rxjs';
 
 import { debounceTime, filter, finalize, pluck, switchMap, take, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of, Subject } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, EventEmitter, Injectable, Output } from '@angular/core';
@@ -8,6 +7,8 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By, Title } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of, Subject } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.ts
@@ -1,8 +1,9 @@
-import { merge, Observable, Subject } from 'rxjs';
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+
+import { merge, Observable, Subject } from 'rxjs';
 
 import { pluck, takeUntil, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/directives/dot-edit-page-nav.directive.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/directives/dot-edit-page-nav.directive.ts
@@ -1,7 +1,8 @@
-import { Subject } from 'rxjs';
 
 import { Directive, ElementRef, OnDestroy, Optional, Renderer2, Self } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+
+import { Subject } from 'rxjs';
 
 import { filter, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.spec.ts
@@ -1,10 +1,11 @@
-import { Observable, of as observableOf } from 'rxjs';
 
 import { Component, DebugElement, Injectable, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { TooltipModule } from 'primeng/tooltip';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.ts
@@ -1,7 +1,8 @@
-import { Observable, of as observableOf } from 'rxjs';
 
 import { Component, Input, OnChanges } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { map } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of, throwError } from 'rxjs';
 
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed, TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
+
+import { of, throwError } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
@@ -1,8 +1,9 @@
-import { Observable, of, throwError } from 'rxjs';
 
 import { HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { Observable, of, throwError } from 'rxjs';
 
 import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.ts
@@ -1,8 +1,9 @@
-import { Observable } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+
+import { Observable } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.ts
@@ -1,7 +1,8 @@
-import { Observable, Subject } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ComponentRef, ViewChild } from '@angular/core';
+
+import { Observable, Subject } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.spec.ts
@@ -1,7 +1,8 @@
-import { byTestId, createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator';
 
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
+
+import { byTestId, createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator';
 
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -1,6 +1,7 @@
+import { DecimalPipe } from '@angular/common';
+
 import { byTestId, createComponentFactory, Spectator } from '@ngneat/spectator';
 
-import { DecimalPipe } from '@angular/common';
 
 import { ButtonModule } from 'primeng/button';
 import { Card, CardModule } from 'primeng/card';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.spec.ts
@@ -1,9 +1,10 @@
-import { createComponentFactory, mockProvider, Spectator, SpyObject } from '@ngneat/spectator';
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
+
+import { createComponentFactory, mockProvider, Spectator, SpyObject } from '@ngneat/spectator';
+import { of } from 'rxjs';
 
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { DotSessionStorageService } from '@dotcms/data-access';
 import {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.spec.ts
@@ -1,8 +1,9 @@
+import { Title } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+
 import { createServiceFactory, mockProvider, SpectatorService, SpyObject } from '@ngneat/spectator';
 import { of } from 'rxjs';
 
-import { Title } from '@angular/platform-browser';
-import { ActivatedRoute } from '@angular/router';
 
 import { MessageService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.ts
@@ -1,9 +1,10 @@
-import { ComponentStore, tapResponse } from '@ngrx/component-store';
-import { Observable, throwError } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
+
+import { ComponentStore, tapResponse } from '@ngrx/component-store';
+import { Observable, throwError } from 'rxjs';
 
 import { MessageService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-create/dot-experiments-create.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-create/dot-experiments-create.component.ts
@@ -1,8 +1,9 @@
-import { Observable } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+
+import { Observable } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-create/store/dot-experiments-create-store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-create/store/dot-experiments-create-store.ts
@@ -1,9 +1,10 @@
-import { ComponentStore, tapResponse } from '@ngrx/component-store';
-import { Observable, throwError } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
+
+import { ComponentStore, tapResponse } from '@ngrx/component-store';
+import { Observable, throwError } from 'rxjs';
 
 import { MessageService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
@@ -1,6 +1,7 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
 import { byTestId, createComponentFactory, Spectator } from '@ngneat/spectator';
 
-import { Pipe, PipeTransform } from '@angular/core';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmPopup, ConfirmPopupModule } from 'primeng/confirmpopup';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-status-filter/dot-experiments-status-filter.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-status-filter/dot-experiments-status-filter.component.spec.ts
@@ -1,7 +1,8 @@
+import { FormsModule } from '@angular/forms';
+
 import { createComponentFactory, Spectator } from '@ngneat/spectator';
 
 
-import { FormsModule } from '@angular/forms';
 
 import { MultiSelect, MultiSelectModule } from 'primeng/multiselect';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.component.spec.ts
@@ -1,8 +1,9 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
 import { byTestId, createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator';
 import { of } from 'rxjs';
 
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.component.ts
@@ -1,8 +1,9 @@
+import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
+
 import { provideComponentStore } from '@ngrx/component-store';
 import { Observable } from 'rxjs';
 
-import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
-import { Router } from '@angular/router';
 
 import { take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
@@ -1,9 +1,10 @@
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
 
 import { MessageService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.ts
@@ -1,9 +1,10 @@
-import { ComponentStore, OnStoreInit, tapResponse } from '@ngrx/component-store';
-import { EMPTY, Observable, pipe, throwError } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { ComponentStore, OnStoreInit, tapResponse } from '@ngrx/component-store';
+import { EMPTY, Observable, pipe, throwError } from 'rxjs';
 
 import { MessageService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-shell/dot-experiments-shell.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-shell/dot-experiments-shell.component.spec.ts
@@ -1,8 +1,9 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+
 import { createComponentFactory, Spectator } from '@ngneat/spectator';
 import { ComponentStore } from '@ngrx/component-store';
 
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
 import { MessageService } from 'primeng/api';
 import { Toast, ToastModule } from 'primeng/toast';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-shell/store/dot-experiments-shell-store.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-shell/store/dot-experiments-shell-store.service.ts
@@ -1,7 +1,8 @@
-import { ComponentStore, OnStoreInit } from '@ngrx/component-store';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { ComponentStore, OnStoreInit } from '@ngrx/component-store';
 
 import { DotPageRenderState } from '@dotcms/dotcms-models';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/resolvers/dot-experiment-experiment.resolver.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/resolvers/dot-experiment-experiment.resolver.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of, throwError } from 'rxjs';
 
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { getTestBed, TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
+
+import { of, throwError } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/resolvers/dot-experiment-experiment.resolver.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/resolvers/dot-experiment-experiment.resolver.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { Observable, of } from 'rxjs';
 
 import { DotExperiment } from '@dotcms/dotcms-models';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/services/dot-experiments.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/services/dot-experiments.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-form-builder/dot-form-builder.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-form-builder/dot-form-builder.component.spec.ts
@@ -1,9 +1,10 @@
-import { of } from 'rxjs';
 
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { DotFormBuilderComponent } from './dot-form-builder.component';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-form-builder/dot-form-builder.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-form-builder/dot-form-builder.component.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-form-builder/resolvers/dot-form-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-form-builder/resolvers/dot-form-resolver.service.spec.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { waitForAsync } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';
 import { DotLicenseService, DotMessageService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-form-builder/resolvers/dot-form-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-form-builder/resolvers/dot-form-resolver.service.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { Observable, of } from 'rxjs';
 
 import { switchMap, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+
+import { Observable, of } from 'rxjs';
 
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';
 import { MockDotHttpErrorManagerService } from '@dotcms/app/test/dot-http-error-manager.service.mock';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -1,9 +1,10 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
 import { ComponentStore, tapResponse } from '@ngrx/component-store';
 import { forkJoin, Observable } from 'rxjs';
 
 
-import { HttpErrorResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
 
 import { switchMap, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.component.spec.ts
@@ -1,10 +1,11 @@
-import { Observable } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { Component, DebugElement, Injectable, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Observable } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { PanelModule } from 'primeng/panel';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter-resolver.service.spec.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, waitForAsync } from '@angular/core/testing';
+
+import { Observable, of } from 'rxjs';
 
 import { DotCurrentUserService } from '@dotcms/data-access';
 import { CoreWebService } from '@dotcms/dotcms-js';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter-resolver.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { Resolve } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { map, mergeMap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.spec.ts
@@ -1,10 +1,11 @@
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { Checkbox, CheckboxModule } from 'primeng/checkbox';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { map, pluck, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.ts
@@ -1,4 +1,3 @@
-import { Subject } from 'rxjs';
 
 import {
     Component,
@@ -11,6 +10,8 @@ import {
     SimpleChanges
 } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+
+import { Subject } from 'rxjs';
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { BehaviorSubject, of, Subject } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
@@ -8,6 +7,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { BehaviorSubject, of, Subject } from 'rxjs';
 
 
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
@@ -1,7 +1,8 @@
-import { Subject } from 'rxjs';
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+
+import { Subject } from 'rxjs';
 
 import { DialogService } from 'primeng/dynamicdialog';
 import { DynamicDialogRef } from 'primeng/dynamicdialog/dynamicdialog-ref';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-new/dot-template-new.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-new/dot-template-new.component.spec.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
 import { Subject } from 'rxjs';
 
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DialogService } from 'primeng/dynamicdialog';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-props.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-props.component.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Component, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+
+import { Observable } from 'rxjs';
 
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.spec.ts
@@ -1,4 +1,3 @@
-import { of, throwError } from 'rxjs';
 
 import { Component, CUSTOM_ELEMENTS_SCHEMA, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -9,6 +8,8 @@ import {
     UntypedFormGroup
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { of, throwError } from 'rxjs';
 
 
 import { DotTempFileUploadService } from '@dotcms/app/api/services/dot-temp-file-upload/dot-temp-file-upload.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-thumbnail-field/dot-template-thumbnail-field.component.ts
@@ -1,8 +1,9 @@
-import { throwError } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, forwardRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { throwError } from 'rxjs';
 
 import { finalize, switchMap, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.spec.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { TestBed } from '@angular/core/testing';
+
 import { of } from 'rxjs';
 
-import { TestBed } from '@angular/core/testing';
 
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
 import { DotTemplatesService } from '@dotcms/app/api/services/dot-templates/dot-templates.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { map } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of, throwError } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
+
+import { of, throwError } from 'rxjs';
 
 
 import { DotGlobalMessageService } from '@components/_common/dot-global-message/dot-global-message.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/store/dot-template.store.ts
@@ -1,13 +1,14 @@
 
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
 import { ComponentStore } from '@ngrx/component-store';
 import * as _ from 'lodash';
 import { Observable, of, zip } from 'rxjs';
 
 
 
-import { HttpErrorResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 
 import {
     catchError,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list-resolver.service.spec.ts
@@ -1,7 +1,8 @@
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import { take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list-resolver.service.ts
@@ -1,7 +1,8 @@
-import { forkJoin, Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { Resolve } from '@angular/router';
+
+import { forkJoin, Observable } from 'rxjs';
 
 import { map, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of, Subject } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -9,6 +8,8 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
+
+import { of, Subject } from 'rxjs';
 
 import { ConfirmationService, SharedModule } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.ts
@@ -1,7 +1,8 @@
-import { Subject } from 'rxjs';
 
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { Subject } from 'rxjs';
 
 import { MenuItem } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/directives/dot-experiment-class.directive.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/directives/dot-experiment-class.directive.ts
@@ -1,7 +1,8 @@
-import { Subject } from 'rxjs';
 
 import { Directive, ElementRef, OnDestroy, Optional, Renderer2, Self } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
+
+import { Subject } from 'rxjs';
 
 import { DotEditPageNavComponent } from '@portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.spec.ts
@@ -1,10 +1,11 @@
-import { of, throwError } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { DebugElement, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { of, throwError } from 'rxjs';
 
 import { MultiSelect, MultiSelectModule } from 'primeng/multiselect';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.ts
@@ -1,4 +1,3 @@
-import { forkJoin, of, Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import {
@@ -10,6 +9,8 @@ import {
     Output, SimpleChanges
 } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
+
+import { forkJoin, of, Subject } from 'rxjs';
 
 import { catchError, take, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-add-row/content-type-fields-add-row.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-add-row/content-type-fields-add-row.component.ts
@@ -1,5 +1,3 @@
-import { Subject } from 'rxjs';
-
 import {
     Component,
     ElementRef,
@@ -10,6 +8,9 @@ import {
     Output,
     ViewChild
 } from '@angular/core';
+
+import { Subject } from 'rxjs';
+
 
 import { MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.spec.ts
@@ -1,8 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import * as _ from 'lodash';
-import { DragulaModule, DragulaService } from 'ng2-dragula';
-import { Observable, of, Subject } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import {
@@ -20,6 +17,10 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import * as _ from 'lodash';
+import { DragulaModule, DragulaService } from 'ng2-dragula';
+import { Observable, of, Subject } from 'rxjs';
 
 import { CheckboxModule } from 'primeng/checkbox';
 import { TableModule } from 'primeng/table';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.ts
@@ -1,8 +1,3 @@
-import * as autoScroll from 'dom-autoscroller';
-import * as _ from 'lodash';
-import { DragulaService } from 'ng2-dragula';
-import { Subject } from 'rxjs';
-
 import {
     Component,
     ElementRef,
@@ -16,6 +11,12 @@ import {
     SimpleChanges,
     ViewChild
 } from '@angular/core';
+
+import * as autoScroll from 'dom-autoscroller';
+import * as _ from 'lodash';
+import { DragulaService } from 'ng2-dragula';
+import { Subject } from 'rxjs';
+
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.ts
@@ -1,6 +1,3 @@
-import * as _ from 'lodash';
-import { Subject } from 'rxjs';
-
 import {
     Component,
     EventEmitter,
@@ -13,6 +10,10 @@ import {
     ViewChild
 } from '@angular/core';
 import { AbstractControl, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+
+import * as _ from 'lodash';
+import { Subject } from 'rxjs';
+
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/categories-property/categories-property.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/categories-property/categories-property.component.spec.ts
@@ -1,9 +1,10 @@
-import { of } from 'rxjs';
 
 import { Component, DebugElement, EventEmitter, Injectable, Input, Output } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { NgControl, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { of } from 'rxjs';
 
 import { PaginationEvent } from '@components/_common/searchable-dropdown/component';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-cardinality-selector/dot-cardinality-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-cardinality-selector/dot-cardinality-selector.component.spec.ts
@@ -1,8 +1,9 @@
-import { Observable, of } from 'rxjs';
 
 import { Component, DebugElement, EventEmitter, Injectable, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { Observable, of } from 'rxjs';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { MockDotMessageService } from '@dotcms/utils-testing';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-cardinality-selector/dot-cardinality-selector.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-cardinality-selector/dot-cardinality-selector.component.ts
@@ -1,6 +1,7 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 import { DotRelationshipCardinality } from '@portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/model/dot-relationship-cardinality.model';
 import { DotRelationshipService } from '@portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/services/dot-relationship.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-edit-relationship/dot-edit-relationships.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-edit-relationship/dot-edit-relationships.component.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of } from 'rxjs';
 
 import { Component, DebugElement, EventEmitter, Injectable, Input, Output } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { Observable, of } from 'rxjs';
 
 import { PaginationEvent } from '@components/_common/searchable-dropdown/component';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-edit-relationship/dot-edit-relationships.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-edit-relationship/dot-edit-relationships.component.ts
@@ -1,6 +1,7 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+
 import { Observable, of as observableOf } from 'rxjs';
 
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 
 import { flatMap, map, switchMap, toArray } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-new-relationships/dot-new-relationships.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-new-relationships/dot-new-relationships.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of } from 'rxjs';
 
 import {
     Component,
@@ -14,6 +13,8 @@ import {
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { Observable, of } from 'rxjs';
 
 import { PaginationEvent } from '@components/_common/searchable-dropdown/component';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-new-relationships/dot-new-relationships.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-new-relationships/dot-new-relationships.component.ts
@@ -1,5 +1,3 @@
-import { Observable } from 'rxjs';
-
 import {
     Component,
     EventEmitter,
@@ -9,6 +7,9 @@ import {
     Output,
     SimpleChanges
 } from '@angular/core';
+
+import { Observable } from 'rxjs';
+
 
 import { DotContentTypeService, PaginatorService } from '@dotcms/data-access';
 import { DotCMSContentType } from '@dotcms/dotcms-models';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-relationships-property.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-relationships-property.component.ts
@@ -1,7 +1,8 @@
-import * as _ from 'lodash';
 
 import { Component, OnInit } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
+
+import * as _ from 'lodash';
 
 import { DotMessageService } from '@dotcms/data-access';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/services/dot-edit-content-type-cache.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/services/dot-edit-content-type-cache.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import * as _ from 'lodash';
 
-import { Injectable } from '@angular/core';
 
 import { DotCMSContentType } from '@dotcms/dotcms-models';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/services/dot-relationship.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/services/dot-relationship.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { pluck, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.spec.ts
@@ -1,8 +1,9 @@
-import { DragulaModule, DragulaService } from 'ng2-dragula';
 
 import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { DragulaModule, DragulaService } from 'ng2-dragula';
 
 import { UiDotIconButtonTooltipModule } from '@components/_common/dot-icon-button-tooltip/dot-icon-button-tooltip.module';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { DragulaModule, DragulaService } from 'ng2-dragula';
-import { of } from 'rxjs';
 
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { DragulaModule, DragulaService } from 'ng2-dragula';
+import { of } from 'rxjs';
 
 import { DotIconModule } from '@dotcms/ui';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/dot-content-type-fields-variables/dot-content-type-fields-variables.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/dot-content-type-fields-variables/dot-content-type-fields-variables.component.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { of } from 'rxjs';
 
 import { DotKeyValueModule } from '@components/dot-key-value-ng/dot-key-value-ng.module';
 import { DotMessageDisplayService } from '@components/dot-message-display/services';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/dot-content-type-fields-variables/dot-content-type-fields-variables.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/dot-content-type-fields-variables/dot-content-type-fields-variables.component.ts
@@ -1,7 +1,8 @@
-import { Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+
+import { Subject } from 'rxjs';
 
 import { take, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/dot-content-type-fields-variables/services/dot-field-variables.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/dot-content-type-fields-variables/services/dot-field-variables.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-drag-drop.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-drag-drop.service.spec.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { TestBed } from '@angular/core/testing';
+
 import { DragulaService } from 'ng2-dragula';
 import { Observable, Subject } from 'rxjs';
 
-import { TestBed } from '@angular/core/testing';
 
 import { filter, map } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-drag-drop.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-drag-drop.service.ts
@@ -1,8 +1,9 @@
+import { Injectable } from '@angular/core';
+
 import * as _ from 'lodash';
 import { DragulaService } from 'ng2-dragula';
 import { merge, Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { filter, map, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-properties.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-properties.service.spec.ts
@@ -1,7 +1,8 @@
-import { Observable, of as observableOf } from 'rxjs';
 
 import { TestBed } from '@angular/core/testing';
 import { Validators } from '@angular/forms';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 
 import { FieldPropertyService } from './field-properties.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { Observable, of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, forwardRef, Injectable, Input } from '@angular/core';
@@ -14,6 +13,8 @@ import {
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { Observable, of } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { DropdownModule } from 'primeng/dropdown';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.ts
@@ -1,6 +1,3 @@
-import * as _ from 'lodash';
-import { Observable, Subject } from 'rxjs';
-
 import {
     Component,
     ElementRef,
@@ -17,6 +14,10 @@ import {
     UntypedFormGroup,
     Validators
 } from '@angular/forms';
+
+import * as _ from 'lodash';
+import { Observable, Subject } from 'rxjs';
+
 
 import { SelectItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, EventEmitter, Injectable, Input, Output } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { Observable, of } from 'rxjs';
 
 import { MenuItem } from 'primeng/api';
 import { SplitButtonModule } from 'primeng/splitbutton';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.ts
@@ -1,5 +1,3 @@
-import { Observable } from 'rxjs';
-
 import {
     Component,
     ElementRef,
@@ -10,6 +8,9 @@ import {
     Output,
     ViewChild
 } from '@angular/core';
+
+import { Observable } from 'rxjs';
+
 
 import { MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit-resolver.service.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of as observableOf, throwError as observableThrowError } from 'rxjs';
 
 import { waitForAsync } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of as observableOf, throwError as observableThrowError } from 'rxjs';
 
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit-resolver.service.ts
@@ -1,8 +1,9 @@
-import { Observable, of } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { Observable, of } from 'rxjs';
 
 import { catchError, map, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import * as _ from 'lodash';
-import { of, throwError } from 'rxjs';
 
 import { Location } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -12,6 +10,9 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import * as _ from 'lodash';
+import { of, throwError } from 'rxjs';
 
 import { ConfirmationService, MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
@@ -1,8 +1,9 @@
-import { Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+
+import { Subject } from 'rxjs';
 
 import { MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
@@ -1,8 +1,9 @@
-import { DragulaModule, DragulaService } from 'ng2-dragula';
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { DragulaModule, DragulaService } from 'ng2-dragula';
 
 import { ButtonModule } from 'primeng/button';
 import { CheckboxModule } from 'primeng/checkbox';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/components/dot-add-to-menu/dot-add-to-menu.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/components/dot-add-to-menu/dot-add-to-menu.component.spec.ts
@@ -1,4 +1,3 @@
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement } from '@angular/core';
@@ -6,6 +5,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { DropdownModule } from 'primeng/dropdown';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/components/dot-add-to-menu/dot-add-to-menu.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/components/dot-add-to-menu/dot-add-to-menu.component.ts
@@ -1,4 +1,3 @@
-import { Observable, Subject } from 'rxjs';
 
 import {
     Component,
@@ -11,6 +10,8 @@ import {
     ViewChild
 } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+
+import { Observable, Subject } from 'rxjs';
 
 import { switchMap, take, takeUntil, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/components/dot-content-type-copy-dialog/dot-content-type-copy-dialog.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/components/dot-content-type-copy-dialog/dot-content-type-copy-dialog.component.spec.ts
@@ -1,4 +1,3 @@
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement } from '@angular/core';
@@ -6,6 +5,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of } from 'rxjs';
 
 import { DotFieldValidationMessageModule } from '@components/_common/dot-field-validation-message/dot-file-validation-message.module';
 import { DotMdIconSelectorModule } from '@components/_common/dot-md-icon-selector/dot-md-icon-selector.module';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/components/dot-content-type-copy-dialog/dot-content-type-copy-dialog.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/components/dot-content-type-copy-dialog/dot-content-type-copy-dialog.component.ts
@@ -1,4 +1,3 @@
-import { combineLatest, Observable, of } from 'rxjs';
 
 import {
     AfterViewChecked,
@@ -17,6 +16,8 @@ import {
     UntypedFormGroup,
     Validators
 } from '@angular/forms';
+
+import { combineLatest, Observable, of } from 'rxjs';
 
 import { map } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-type.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-type.store.spec.ts
@@ -1,10 +1,11 @@
-import { of, throwError } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of, throwError } from 'rxjs';
 
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';
 import { DotContentTypeService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-type.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-type.store.ts
@@ -1,8 +1,9 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+
 import { ComponentStore } from '@ngrx/component-store';
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
 
 import { catchError, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, EventEmitter, Injectable, Input, Output } from '@angular/core';
@@ -11,6 +10,8 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
 
 import { ConfirmationService, SelectItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.ts
@@ -1,8 +1,9 @@
+import { Component, OnDestroy, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
 import * as _ from 'lodash';
 import { forkJoin, Subject } from 'rxjs';
 
-import { Component, OnDestroy, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
 
 import { map, pluck, take, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/resolvers/dot-feature-flag-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/resolvers/dot-feature-flag-resolver.service.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { Observable, of } from 'rxjs';
 
 import { map } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/shared/dot-save-on-deactivate-service/dot-save-on-deactivate.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/shared/dot-save-on-deactivate-service/dot-save-on-deactivate.service.spec.ts
@@ -1,6 +1,7 @@
+import { Component } from '@angular/core';
+
 import { Observable, of as observableOf } from 'rxjs';
 
-import { Component } from '@angular/core';
 
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';
 import { DotAlertConfirmService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/shared/dot-save-on-deactivate-service/dot-save-on-deactivate.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/shared/dot-save-on-deactivate-service/dot-save-on-deactivate.service.ts
@@ -1,7 +1,8 @@
-import { Observable, Observer, of as observableOf } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanDeactivate, RouterStateSnapshot } from '@angular/router';
+
+import { Observable, Observer, of as observableOf } from 'rxjs';
 
 import { DotAlertConfirmService } from '@dotcms/data-access';
 

--- a/core-web/apps/dotcms-ui/src/app/shared/interceptors/server-error.interceptor.ts
+++ b/core-web/apps/dotcms-ui/src/app/shared/interceptors/server-error.interceptor.ts
@@ -1,4 +1,3 @@
-import { Observable } from 'rxjs';
 
 import {
     HttpErrorResponse,
@@ -8,6 +7,8 @@ import {
     HttpRequest
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { catchError, map, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/test/dot-http-error-manager.service.mock.ts
+++ b/core-web/apps/dotcms-ui/src/app/test/dot-http-error-manager.service.mock.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 @Injectable()
 export class MockDotHttpErrorManagerService {

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-add-to-bundle/dot-add-to-bundle.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-add-to-bundle/dot-add-to-bundle.component.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of as observableOf } from 'rxjs';
 
 import { Component, DebugElement } from '@angular/core';
 import { async, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';
 import { AddToBundleService, DotMessageService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-add-to-bundle/dot-add-to-bundle.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-add-to-bundle/dot-add-to-bundle.component.ts
@@ -1,4 +1,3 @@
-import { Observable, Subject } from 'rxjs';
 
 import {
     AfterViewInit,
@@ -11,6 +10,8 @@ import {
     ViewChild
 } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+
+import { Observable, Subject } from 'rxjs';
 
 import { Dropdown } from 'primeng/dropdown';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-alert-confirm/dot-alert-confirm.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-alert-confirm/dot-alert-confirm.ts
@@ -1,6 +1,7 @@
+import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+
 import { Subject } from 'rxjs';
 
-import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 
 import { ConfirmDialog } from 'primeng/confirmdialog';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-autocomplete-tags/dot-autocomplete-tags.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-autocomplete-tags/dot-autocomplete-tags.component.spec.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of } from 'rxjs';
 
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Observable, of } from 'rxjs';
 
 import { AutoComplete, AutoCompleteModule } from 'primeng/autocomplete';
 import { ChipsModule } from 'primeng/chips';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-download-bundle-dialog/dot-download-bundle-dialog.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-download-bundle-dialog/dot-download-bundle-dialog.component.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of, throwError } from 'rxjs';
 
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { of, throwError } from 'rxjs';
 
 import { Dropdown, DropdownModule } from 'primeng/dropdown';
 import { SelectButton, SelectButtonModule } from 'primeng/selectbutton';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-download-bundle-dialog/dot-download-bundle-dialog.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-download-bundle-dialog/dot-download-bundle-dialog.component.ts
@@ -1,8 +1,9 @@
 
-import { Observable, of, Subject } from 'rxjs';
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+
+import { Observable, of, Subject } from 'rxjs';
 
 import { SelectItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-field-validation-message/dot-field-validation-message.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-field-validation-message/dot-field-validation-message.ts
@@ -2,7 +2,6 @@
 - TODO: maybe crawl the html to find the form parent and save one @Input
 */
 
-import { Subject } from 'rxjs';
 
 import {
     ChangeDetectionStrategy,
@@ -12,6 +11,8 @@ import {
     OnDestroy
 } from '@angular/core';
 import { AbstractControl, UntypedFormControl, ValidationErrors } from '@angular/forms';
+
+import { Subject } from 'rxjs';
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-generate-secure-password/dot-generate-secure-password.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-generate-secure-password/dot-generate-secure-password.component.ts
@@ -1,6 +1,7 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+
 import { Subject } from 'rxjs';
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-global-message/dot-global-message.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-global-message/dot-global-message.component.ts
@@ -1,6 +1,7 @@
+import { ChangeDetectorRef, Component, HostBinding, OnDestroy, OnInit } from '@angular/core';
+
 import { Subject } from 'rxjs';
 
-import { ChangeDetectorRef, Component, HostBinding, OnDestroy, OnInit } from '@angular/core';
 
 import { filter, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-global-message/dot-global-message.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-global-message/dot-global-message.service.spec.ts
@@ -1,6 +1,7 @@
+import { TestBed } from '@angular/core/testing';
+
 import { Observable } from 'rxjs';
 
-import { TestBed } from '@angular/core/testing';
 
 import { DotEventsService, DotMessageService } from '@dotcms/data-access';
 import { DotEvent } from '@dotcms/dotcms-models';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-menu/dot-menu.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-menu/dot-menu.component.ts
@@ -1,6 +1,7 @@
+import { Component, Input, ViewChild } from '@angular/core';
+
 import { fromEvent as observableFromEvent } from 'rxjs';
 
-import { Component, Input, ViewChild } from '@angular/core';
 
 import { MenuItem } from 'primeng/api';
 import { Menu } from 'primeng/menu';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.spec.ts
@@ -1,4 +1,3 @@
-import { Observable, of as observableOf } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { Component, DebugElement, Injectable } from '@angular/core';
@@ -10,6 +9,8 @@ import {
     UntypedFormGroup
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { AutoCompleteModule } from 'primeng/autocomplete';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/dot-page-selector.component.ts
@@ -1,7 +1,8 @@
-import { Observable, of, Subject } from 'rxjs';
 
 import { Component, EventEmitter, forwardRef, Input, Output, ViewChild } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { Observable, of, Subject } from 'rxjs';
 
 import { AutoComplete } from 'primeng/autocomplete';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-page-selector/service/dot-page-selector.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { flatMap, map, pluck } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-dialog/dot-push-publish-dialog.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-dialog/dot-push-publish-dialog.component.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of as observableOf, of } from 'rxjs';
 
 import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Observable, of as observableOf, of } from 'rxjs';
 
 import { DotDialogComponent } from '@components/dot-dialog/dot-dialog.component';
 import { DotDialogModule } from '@components/dot-dialog/dot-dialog.module';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-dialog/dot-push-publish-dialog.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-dialog/dot-push-publish-dialog.component.ts
@@ -1,6 +1,7 @@
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+
 import { Subject } from 'rxjs';
 
-import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-env-selector/dot-push-publish-env-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-push-publish-env-selector/dot-push-publish-env-selector.component.spec.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of as observableOf } from 'rxjs';
 
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { PushPublishService } from '@dotcms/app/api/services/push-publish/push-publish.service';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector-field/dot-site-selector-field.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector-field/dot-site-selector-field.component.ts
@@ -1,7 +1,8 @@
-import { Subscription } from 'rxjs';
 
 import { Component, forwardRef, Input } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { Subscription } from 'rxjs';
 
 import { Site, SiteService } from '@dotcms/dotcms-js';
 /**

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of as observableOf } from 'rxjs';
 
 
 import { CommonModule } from '@angular/common';
@@ -10,6 +9,8 @@ import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angul
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Observable, of as observableOf } from 'rxjs';
 
 import { DotEventsService, DotMessageService, PaginatorService } from '@dotcms/data-access';
 import { CoreWebService, Site, SiteService } from '@dotcms/dotcms-js';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.ts
@@ -1,5 +1,3 @@
-import { Subject } from 'rxjs';
-
 import {
     Component,
     EventEmitter,
@@ -11,6 +9,9 @@ import {
     SimpleChanges,
     ViewChild
 } from '@angular/core';
+
+import { Subject } from 'rxjs';
+
 
 import { delay, retryWhen, take, takeUntil, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { MonacoEditorComponent } from '@materia-ui/ngx-monaco-editor';
 
 import { Component, DebugElement, forwardRef, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { MonacoEditorComponent } from '@materia-ui/ngx-monaco-editor';
 
 import { InputTextareaModule } from 'primeng/inputtextarea';
 import { SelectButtonModule } from 'primeng/selectbutton';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.ts
@@ -1,4 +1,3 @@
-import { MonacoEditorConstructionOptions } from '@materia-ui/ngx-monaco-editor';
 
 import {
     ChangeDetectionStrategy,
@@ -12,6 +11,8 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
+
+import { MonacoEditorConstructionOptions } from '@materia-ui/ngx-monaco-editor';
 
 import { SelectItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.module.ts
@@ -1,8 +1,9 @@
-import { MonacoEditorModule } from '@materia-ui/ngx-monaco-editor';
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+
+import { MonacoEditorModule } from '@materia-ui/ngx-monaco-editor';
 
 import { SelectButtonModule } from 'primeng/selectbutton';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts
@@ -1,5 +1,3 @@
-import { Subject } from 'rxjs';
-
 import {
     Component,
     ComponentFactoryResolver,
@@ -12,6 +10,9 @@ import {
     ViewChild,
     ViewChildren
 } from '@angular/core';
+
+import { Subject } from 'rxjs';
+
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/dot-workflows-actions-selector-field.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/dot-workflows-actions-selector-field.component.spec.ts
@@ -1,9 +1,10 @@
-import { BehaviorSubject } from 'rxjs';
 
 import { Component, DebugElement, OnInit } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { BehaviorSubject } from 'rxjs';
 
 import { SelectItemGroup } from 'primeng/api';
 import { Dropdown, DropdownModule } from 'primeng/dropdown';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/dot-workflows-actions-selector-field.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/dot-workflows-actions-selector-field.component.ts
@@ -1,4 +1,3 @@
-import { Observable } from 'rxjs';
 
 import {
     Component,
@@ -10,6 +9,8 @@ import {
     ViewChild
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { Observable } from 'rxjs';
 
 import { SelectItem, SelectItemGroup } from 'primeng/api';
 import { Dropdown } from 'primeng/dropdown';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/services/dot-workflows-actions-selector-field.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/services/dot-workflows-actions-selector-field.service.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of, throwError } from 'rxjs';
 
 
 
 import { HttpResponse } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
+
+import { of, throwError } from 'rxjs';
 
 import { SelectItemGroup } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/services/dot-workflows-actions-selector-field.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/services/dot-workflows-actions-selector-field.service.ts
@@ -1,7 +1,8 @@
-import { BehaviorSubject, Observable } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { BehaviorSubject, Observable } from 'rxjs';
 
 import { SelectItem, SelectItemGroup } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-selector-field/dot-workflows-selector-field.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-selector-field/dot-workflows-selector-field.component.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Component, forwardRef, OnInit } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { Observable } from 'rxjs';
 
 import { DotWorkflowService } from '@dotcms/data-access';
 import { DotCMSWorkflow } from '@dotcms/dotcms-models';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.spec.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { of } from 'rxjs';
 
 import { Dropdown, DropdownModule } from 'primeng/dropdown';
 import { InputTextareaModule } from 'primeng/inputtextarea';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.ts
@@ -1,7 +1,8 @@
-import { Subject } from 'rxjs';
 
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+
+import { Subject } from 'rxjs';
 
 import { SelectItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/forms/dot-push-publish-form/dot-push-publish-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/forms/dot-push-publish-form/dot-push-publish-form.component.spec.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { of } from 'rxjs';
 
 import { ConfirmationService, SelectItem } from 'primeng/api';
 import { AutoFocusModule } from 'primeng/autofocus';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/forms/dot-push-publish-form/dot-push-publish-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/forms/dot-push-publish-form/dot-push-publish-form.component.ts
@@ -1,4 +1,3 @@
-import { Observable, of, Subject } from 'rxjs';
 
 import {
     Component,
@@ -11,6 +10,8 @@ import {
     ViewChild
 } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+
+import { Observable, of, Subject } from 'rxjs';
 
 import { SelectItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-component/iframe.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-component/iframe.component.ts
@@ -1,6 +1,4 @@
 
-import { Subject } from 'rxjs';
-
 import {
     Component,
     ElementRef,
@@ -12,6 +10,9 @@ import {
     Output,
     ViewChild
 } from '@angular/core';
+
+import { Subject } from 'rxjs';
+
 
 import { debounceTime, filter, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
@@ -8,6 +7,8 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.ts
@@ -1,7 +1,8 @@
-import { BehaviorSubject, Subject } from 'rxjs';
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, UrlSegment } from '@angular/router';
+
+import { BehaviorSubject, Subject } from 'rxjs';
 
 import { map, mergeMap, pluck, skip, takeUntil, withLatestFrom } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/dot-iframe-porlet-legacy-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/dot-iframe-porlet-legacy-resolver.service.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { waitForAsync } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
 
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';
 import {

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/dot-iframe-porlet-legacy-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/dot-iframe-porlet-legacy-resolver.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { DotLicenseService } from '@dotcms/data-access';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/dot-iframe/dot-iframe.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/dot-iframe/dot-iframe.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { Observable, Subject } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { filter } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/iframe-overlay.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/iframe-overlay.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { BehaviorSubject, Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 @Injectable()
 export class IframeOverlayService {

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import * as _ from 'lodash';
 
 import { Component, DebugElement, Input } from '@angular/core';
 import {
@@ -13,6 +12,8 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import * as _ from 'lodash';
 
 import { UiDotIconButtonModule } from '@components/_common/dot-icon-button/dot-icon-button.module';
 import { DotMessageService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.stories.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.stories.ts
@@ -1,10 +1,11 @@
-import { moduleMetadata } from '@storybook/angular';
-import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { CommonModule } from '@angular/common';
 import { Pipe, PipeTransform } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { moduleMetadata } from '@storybook/angular';
+import { Meta, Story } from '@storybook/angular/types-6-0';
 
 
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.ts
@@ -1,6 +1,3 @@
-import * as _ from 'lodash';
-import { fromEvent } from 'rxjs';
-
 import {
     AfterContentInit,
     AfterViewInit,
@@ -20,6 +17,10 @@ import {
     ViewChild
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import * as _ from 'lodash';
+import { fromEvent } from 'rxjs';
+
 
 import { PrimeTemplate } from 'primeng/api';
 import { DataView } from 'primeng/dataview';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-add-persona-dialog.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-add-persona-dialog.component.spec.ts
@@ -1,10 +1,11 @@
-import { of as observableOf, throwError } from 'rxjs';
 
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of as observableOf, throwError } from 'rxjs';
 
 import { FileUploadModule } from 'primeng/fileupload';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.ts
@@ -1,8 +1,9 @@
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+
 import * as _ from 'lodash';
 import { Subject } from 'rxjs';
 
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-base-type-selector/dot-base-type-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-base-type-selector/dot-base-type-selector.component.spec.ts
@@ -1,9 +1,10 @@
-import { of as observableOf } from 'rxjs';
 
 import { DebugElement, Injectable } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of as observableOf } from 'rxjs';
 
 import { SelectItem } from 'primeng/api';
 import { Dropdown } from 'primeng/dropdown';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-base-type-selector/dot-base-type-selector.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-base-type-selector/dot-base-type-selector.component.ts
@@ -1,6 +1,7 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 import { SelectItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-container-selector-layout/dot-container-selector-layout.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-container-selector-layout/dot-container-selector-layout.component.spec.ts
@@ -1,4 +1,3 @@
-import { of as observableOf } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -7,6 +6,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of as observableOf } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-container-selector/dot-container-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-container-selector/dot-container-selector.component.spec.ts
@@ -1,4 +1,3 @@
-import { of as observableOf } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -7,6 +6,8 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of as observableOf } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-container-selector/dot-container-selector.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-container-selector/dot-container-selector.component.ts
@@ -1,6 +1,7 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 import { map, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-dialog/dot-content-compare-dialog.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-dialog/dot-content-compare-dialog.component.ts
@@ -1,6 +1,7 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+
 import { Observable, Subject } from 'rxjs';
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
 
 import { map, pluck, takeUntil, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { of } from 'rxjs';
 
 import { Dropdown, DropdownModule } from 'primeng/dropdown';
 import { SelectButton, SelectButtonModule } from 'primeng/selectbutton';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.component.spec.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { of } from 'rxjs';
 
 import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { of } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.component.ts
@@ -1,6 +1,7 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { DotIframeService } from '@components/_common/iframe/service/dot-iframe/dot-iframe.service';
 import {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/pipes/dot-transform-version-label.pipe.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/pipes/dot-transform-version-label.pipe.spec.ts
@@ -1,8 +1,9 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
 import { formatInTimeZone } from 'date-fns-tz';
 import { of } from 'rxjs';
 
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { TestBed } from '@angular/core/testing';
 
 import { DotFormatDateService } from '@dotcms/app/api/services/dot-format-date-service';
 import { DotMessageService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/store/dot-content-compare.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/store/dot-content-compare.store.spec.ts
@@ -1,6 +1,7 @@
+import { TestBed } from '@angular/core/testing';
+
 import { of } from 'rxjs';
 
-import { TestBed } from '@angular/core/testing';
 
 import { DotContentCompareStore } from '@components/dot-content-compare/store/dot-content-compare.store';
 import { DotFormatDateService } from '@dotcms/app/api/services/dot-format-date-service';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/store/dot-content-compare.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/store/dot-content-compare.store.ts
@@ -1,7 +1,8 @@
+import { Injectable } from '@angular/core';
+
 import { ComponentStore } from '@ngrx/component-store';
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { map, switchMap, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-add-contentlet/dot-add-contentlet.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-add-contentlet/dot-add-contentlet.component.ts
@@ -1,6 +1,7 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 
 
 import { DotContentletEditorService } from '../../services/dot-contentlet-editor.service';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
@@ -8,6 +7,8 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By, Title } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-create-contentlet/dot-create-contentlet.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-create-contentlet/dot-create-contentlet.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, Input } from '@angular/core';
@@ -8,6 +7,8 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { Observable, of } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-create-contentlet/dot-create-contentlet.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-create-contentlet/dot-create-contentlet.component.ts
@@ -1,7 +1,8 @@
-import { merge, Observable } from 'rxjs';
 
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+
+import { merge, Observable } from 'rxjs';
 
 import { filter, pluck } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-create-contentlet/dot-create-contentlet.resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-create-contentlet/dot-create-contentlet.resolver.service.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
+
+import { of } from 'rxjs';
 
 import { DotContentletEditorService } from '@components/dot-contentlet-editor/services/dot-contentlet-editor.service';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-create-contentlet/dot-create-contentlet.resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-create-contentlet/dot-create-contentlet.resolver.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-edit-contentlet/dot-edit-contentlet.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-edit-contentlet/dot-edit-contentlet.component.spec.ts
@@ -1,10 +1,11 @@
-import { of as observableOf } from 'rxjs';
 
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of as observableOf } from 'rxjs';
 
 import { DotMenuService } from '@dotcms/app/api/services/dot-menu.service';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-edit-contentlet/dot-edit-contentlet.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-edit-contentlet/dot-edit-contentlet.component.ts
@@ -1,6 +1,7 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 
 import { DotContentletEditorService } from '../../services/dot-contentlet-editor.service';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/services/dot-contentlet-editor.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/services/dot-contentlet-editor.service.spec.ts
@@ -1,7 +1,8 @@
-import { of as observableOf } from 'rxjs';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+
+import { of as observableOf } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/services/dot-contentlet-editor.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/services/dot-contentlet-editor.service.ts
@@ -1,7 +1,8 @@
-import { Observable, of, Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable, of, Subject } from 'rxjs';
 
 import { catchError, filter, map, mergeMap, pluck, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/dot-crumbtrail.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/dot-crumbtrail.component.spec.ts
@@ -1,8 +1,9 @@
-import { Observable, Subject } from 'rxjs';
 
 import { DebugElement, Injectable } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { Observable, Subject } from 'rxjs';
 
 import { BreadcrumbModule } from 'primeng/breadcrumb';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/dot-crumbtrail.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/dot-crumbtrail.component.ts
@@ -1,6 +1,7 @@
+import { Component, OnInit } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, OnInit } from '@angular/core';
 
 import { DotCrumb, DotCrumbtrailService } from './service/dot-crumbtrail.service';
 @Component({

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+
+import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 
 import { DotCrumb, DotCrumbtrailService } from './dot-crumbtrail.service';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/service/dot-crumbtrail.service.ts
@@ -1,7 +1,8 @@
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ActivatedRoute, Data, NavigationEnd, Router } from '@angular/router';
+
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { filter, map, switchMap, take } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-device-selector/dot-device-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-device-selector/dot-device-selector.component.spec.ts
@@ -2,12 +2,13 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { Component, CUSTOM_ELEMENTS_SCHEMA, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of } from 'rxjs';
 
 import { DotMessagePipe } from '@dotcms/app/view/pipes';
 import { DotDevicesService, DotMessageService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-dialog/dot-dialog.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-dialog/dot-dialog.component.ts
@@ -1,5 +1,3 @@
-import { fromEvent, Subscription } from 'rxjs';
-
 import {
     Component,
     ElementRef,
@@ -11,6 +9,9 @@ import {
     SimpleChanges,
     ViewChild
 } from '@angular/core';
+
+import { fromEvent, Subscription } from 'rxjs';
+
 
 import { filter } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-edit-layout-grid/dot-edit-layout-grid.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-edit-layout-grid/dot-edit-layout-grid.component.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @angular-eslint/component-selector */
 
-import { Subject } from 'rxjs';
 
 import { Component, forwardRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import {
@@ -9,6 +8,8 @@ import {
     UntypedFormBuilder,
     UntypedFormGroup
 } from '@angular/forms';
+
+import { Subject } from 'rxjs';
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.spec.ts
@@ -1,4 +1,3 @@
-import { of } from 'rxjs';
 
 
 
@@ -7,6 +6,8 @@ import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of } from 'rxjs';
 
 import { DataViewModule } from 'primeng/dataview';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.ts
@@ -1,5 +1,3 @@
-import { fromEvent as observableFromEvent, Subject } from 'rxjs';
-
 import {
     ChangeDetectorRef,
     Component,
@@ -11,6 +9,9 @@ import {
     Output,
     ViewChild
 } from '@angular/core';
+
+import { fromEvent as observableFromEvent, Subject } from 'rxjs';
+
 
 import { LazyLoadEvent } from 'primeng/api';
 import { DataView } from 'primeng/dataview';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.spec.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash';
-import { of as observableOf, of } from 'rxjs';
 
 import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -11,6 +9,9 @@ import {
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import * as _ from 'lodash';
+import { of as observableOf, of } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { TooltipModule } from 'primeng/tooltip';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash';
-import { Observable, Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import {
@@ -17,6 +15,9 @@ import {
     ViewChild
 } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+
+import * as _ from 'lodash';
+import { Observable, Subject } from 'rxjs';
 
 import { take, takeUntil, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-form-dialog/dot-form-dialog.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-form-dialog/dot-form-dialog.component.ts
@@ -1,5 +1,3 @@
-import { fromEvent, Subject } from 'rxjs';
-
 import {
     Component,
     ElementRef,
@@ -9,6 +7,9 @@ import {
     OnInit,
     Output
 } from '@angular/core';
+
+import { fromEvent, Subject } from 'rxjs';
+
 
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-ng.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-ng.component.ts
@@ -1,6 +1,7 @@
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+
 import * as _ from 'lodash';
 
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 
 import { DotKeyValue } from '@shared/models/dot-key-value-ng/dot-key-value-ng.model';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash';
-
 import {
     Component,
     ElementRef,
@@ -11,6 +9,9 @@ import {
     SimpleChanges,
     ViewChild
 } from '@angular/core';
+
+import * as _ from 'lodash';
+
 
 import { DotKeyValue } from '@shared/models/dot-key-value-ng/dot-key-value-ng.model';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-language-selector/dot-language-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-language-selector/dot-language-selector.component.spec.ts
@@ -1,9 +1,10 @@
-import { of } from 'rxjs';
 
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of } from 'rxjs';
 
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';
 import { DotLanguagesService, DotMessageService } from '@dotcms/data-access';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-large-message-display/dot-large-message-display.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-large-message-display/dot-large-message-display.component.ts
@@ -1,5 +1,3 @@
-import { Observable, Subject } from 'rxjs';
-
 import {
     AfterViewInit,
     Component,
@@ -8,6 +6,9 @@ import {
     QueryList,
     ViewChildren
 } from '@angular/core';
+
+import { Observable, Subject } from 'rxjs';
+
 
 import { filter, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, Input } from '@angular/core';
@@ -9,6 +8,8 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
 
 import { ConfirmationService, SharedModule } from 'primeng/api';
 import { ContextMenuModule } from 'primeng/contextmenu';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-message-display/dot-message-display.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-message-display/dot-message-display.component.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { Observable, Subject } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Observable, Subject } from 'rxjs';
 
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-message-display/services/dot-message-display.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-message-display/services/dot-message-display.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { merge, Observable, Subject } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { filter, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/dot-navigation.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/dot-navigation.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { BehaviorSubject, Observable } from 'rxjs';
 
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -8,6 +7,8 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NavigationEnd } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { BehaviorSubject, Observable } from 'rxjs';
 
 import { TooltipModule } from 'primeng/tooltip';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/dot-navigation.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/dot-navigation.component.ts
@@ -1,6 +1,7 @@
+import { Component, HostBinding, HostListener, OnInit } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, HostBinding, HostListener, OnInit } from '@angular/core';
 
 import { IframeOverlayService } from '@components/_common/iframe/service/iframe-overlay.service';
 import { DotMenu, DotMenuItem } from '@models/navigation';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/services/dot-navigation.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/services/dot-navigation.service.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of, Subject } from 'rxjs';
 
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
 import { NavigationEnd, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { Observable, of, Subject } from 'rxjs';
 
 import { skip } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/services/dot-navigation.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/services/dot-navigation.service.ts
@@ -1,9 +1,10 @@
 
-import { BehaviorSubject, Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Event, NavigationEnd, Router } from '@angular/router';
+
+import { BehaviorSubject, Observable } from 'rxjs';
 
 import { filter, map, switchMap, take, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selector/dot-persona-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selector/dot-persona-selector.component.spec.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
 
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of } from 'rxjs';
 
 import { TooltipModule } from 'primeng/tooltip';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/dot-portlet-base.stories.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/dot-portlet-base.stories.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { of } from 'rxjs';
 
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
@@ -12,6 +11,8 @@ import {
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of } from 'rxjs';
 
 import { SearchableDropDownModule } from '@components/_common/searchable-dropdown';
 import {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
@@ -1,4 +1,3 @@
-import { fromEvent, Subject } from 'rxjs';
 
 import {
     AfterViewInit,
@@ -10,6 +9,8 @@ import {
     ViewChild
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { fromEvent, Subject } from 'rxjs';
 
 import { LazyLoadEvent } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.stories.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.stories.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-console */
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { Meta, moduleMetadata } from '@storybook/angular';
 import { of } from 'rxjs';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SearchableDropDownModule } from '@components/_common/searchable-dropdown';
 import { DotFormatDateService } from '@dotcms/app/api/services/dot-format-date-service';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-gravatar/dot-gravatar.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-gravatar/dot-gravatar.component.spec.ts
@@ -1,10 +1,11 @@
-import * as md5 from 'md5';
-import { Observable, of } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { Component, DebugElement, Input } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import * as md5 from 'md5';
+import { Observable, of } from 'rxjs';
 
 import { DotGravatarService } from '@dotcms/app/api/services/dot-gravatar-service';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-gravatar/dot-gravatar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-gravatar/dot-gravatar.component.ts
@@ -1,7 +1,8 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+
 import * as md5 from 'md5';
 import { Observable } from 'rxjs';
 
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 
 import { DotGravatarService } from '@dotcms/app/api/services/dot-gravatar-service';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.spec.ts
@@ -1,11 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import {
-    from as observableFrom,
-    of as observableOf,
-    throwError as observableThrowError
-} from 'rxjs';
 
 import { Component, DebugElement, EventEmitter, forwardRef, Input, Output } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
@@ -14,6 +9,12 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import {
+    from as observableFrom,
+    of as observableOf,
+    throwError as observableThrowError
+} from 'rxjs';
 
 import { InputTextModule } from 'primeng/inputtext';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.ts
@@ -1,6 +1,5 @@
 
 
-import { Subject } from 'rxjs';
 
 import {
     Component,
@@ -19,6 +18,8 @@ import {
     UntypedFormGroup,
     Validators
 } from '@angular/forms';
+
+import { Subject } from 'rxjs';
 
 import { take, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.component.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of, throwError } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -9,6 +8,8 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { of, throwError } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 import { CheckboxModule } from 'primeng/checkbox';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-my-account/dot-my-account.component.ts
@@ -1,4 +1,3 @@
-import { BehaviorSubject, Subject } from 'rxjs';
 
 import {
     Component,
@@ -10,6 +9,8 @@ import {
     ViewChild
 } from '@angular/core';
 import { NgForm } from '@angular/forms';
+
+import { BehaviorSubject, Subject } from 'rxjs';
 
 import { map, take, takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-notifications/dot-toolbar-notifications.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-notifications/dot-toolbar-notifications.component.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Observable, of as observableOf, Subject } from 'rxjs';
 
 import { Component, DebugElement, Injectable, Input } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { Observable, of as observableOf, Subject } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
@@ -9,6 +8,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { CheckboxModule } from 'primeng/checkbox';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.ts
@@ -1,6 +1,7 @@
+import { Component, Inject, OnInit, ViewChild } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 
 import { map } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.ts
@@ -1,6 +1,7 @@
+import { Component, Input, OnInit } from '@angular/core';
+
 import { BehaviorSubject } from 'rxjs';
 
-import { Component, Input, OnInit } from '@angular/core';
 
 import { DotNavLogoService } from '@dotcms/app/api/services/dot-nav-logo/dot-nav-logo.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-workflow-task-detail/dot-workflow-task-detail.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-workflow-task-detail/dot-workflow-task-detail.component.spec.ts
@@ -1,10 +1,11 @@
-import { of as observableOf } from 'rxjs';
 
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of as observableOf } from 'rxjs';
 
 import { DotMenuService } from '@dotcms/app/api/services/dot-menu.service';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-workflow-task-detail/dot-workflow-task-detail.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-workflow-task-detail/dot-workflow-task-detail.component.ts
@@ -1,6 +1,7 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+
 import { Observable } from 'rxjs';
 
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 
 import { DotWorkflowTaskDetailService } from './services/dot-workflow-task-detail.service';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-workflow-task-detail/services/dot-workflow-task-detail.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-workflow-task-detail/services/dot-workflow-task-detail.service.spec.ts
@@ -1,7 +1,8 @@
-import { of as observableOf } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+
+import { of as observableOf } from 'rxjs';
 
 import { DotMenuService } from '@dotcms/app/api/services/dot-menu.service';
 import { CoreWebService } from '@dotcms/dotcms-js';

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-workflow-task-detail/services/dot-workflow-task-detail.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-workflow-task-detail/services/dot-workflow-task-detail.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { BehaviorSubject, Observable, of } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { map, mergeMap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/dot-login-component/dot-login.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/dot-login-component/dot-login.component.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { BehaviorSubject, of, throwError } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement, Injectable } from '@angular/core';
@@ -10,6 +9,8 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Params } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { BehaviorSubject, of, throwError } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { Checkbox, CheckboxModule } from 'primeng/checkbox';

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/dot-login-component/dot-login.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/dot-login-component/dot-login.component.ts
@@ -1,9 +1,10 @@
-import { Observable, Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Params } from '@angular/router';
+
+import { Observable, Subject } from 'rxjs';
 
 import { SelectItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/dot-login-page-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/dot-login-page-resolver.service.spec.ts
@@ -1,7 +1,8 @@
-import { of } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import { DotLoginPageResolver } from '@components/login/dot-login-page-resolver.service';
 import { DotLoginPageStateService } from '@components/login/shared/services/dot-login-page-state.service';

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/dot-login-page-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/dot-login-page-resolver.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { Resolve } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { DotLoginPageStateService } from '@components/login/shared/services/dot-login-page-state.service';
 import { DotLoginInformation } from '@dotcms/dotcms-models';

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/forgot-password-component/forgot-password.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/forgot-password-component/forgot-password.component.spec.ts
@@ -1,4 +1,3 @@
-import { of, throwError } from 'rxjs';
 
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -6,6 +5,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of, throwError } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/forgot-password-component/forgot-password.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/forgot-password-component/forgot-password.component.ts
@@ -1,8 +1,9 @@
-import { Observable } from 'rxjs';
 
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { NavigationExtras } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { take, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/main/dot-login-page.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/main/dot-login-page.component.spec.ts
@@ -1,10 +1,11 @@
-import { of } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.spec.ts
@@ -1,4 +1,3 @@
-import { throwError } from 'rxjs';
 
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -7,6 +6,8 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+
+import { throwError } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.ts
@@ -1,8 +1,9 @@
-import { Observable } from 'rxjs';
 
 import { AfterViewChecked, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { take, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/shared/services/dot-login-page-state.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/shared/services/dot-login-page-state.service.spec.ts
@@ -1,6 +1,7 @@
+import { TestBed } from '@angular/core/testing';
+
 import { of } from 'rxjs';
 
-import { TestBed } from '@angular/core/testing';
 
 import { LoginService } from '@dotcms/dotcms-js';
 import { DotLoginInformation } from '@dotcms/dotcms-models';

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/shared/services/dot-login-page-state.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/shared/services/dot-login-page-state.service.ts
@@ -1,6 +1,7 @@
+import { Injectable } from '@angular/core';
+
 import { BehaviorSubject, Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
 
 import { map, take, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/not-licensed/not-licensed.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/not-licensed/not-licensed.component.ts
@@ -1,6 +1,7 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+
 import { Subject } from 'rxjs';
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/directives/dot-maxlength/dot-maxlength.directive.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/directives/dot-maxlength/dot-maxlength.directive.ts
@@ -1,6 +1,7 @@
+import { Directive, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
+
 import { fromEvent, merge, Subject } from 'rxjs';
 
-import { Directive, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
 
 import { delay, filter, takeUntil, tap } from 'rxjs/operators';
 

--- a/core-web/apps/dotcms-ui/src/app/view/pipes/dot-diff/dot-diff.pipe.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/pipes/dot-diff/dot-diff.pipe.ts
@@ -1,6 +1,7 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
 import HtmlDiff from 'htmldiff-js';
 
-import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
     name: 'dotDiff'

--- a/core-web/apps/dotcms-ui/src/stories/dotcms/form/DotCMSForms.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/dotcms/form/DotCMSForms.stories.ts
@@ -1,8 +1,9 @@
+import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { FormsModule } from '@angular/forms';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { AutoCompleteModule } from 'primeng/autocomplete';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/button/SplitButton.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/button/SplitButton.stories.ts
@@ -1,8 +1,9 @@
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SplitButtonModule } from 'primeng/splitbutton';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/data/Table.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/data/Table.stories.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-console */
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { Meta } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/AutoComplete.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/AutoComplete.stories.ts
@@ -1,8 +1,9 @@
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { AutoComplete, AutoCompleteModule } from 'primeng/autocomplete';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/Calendar.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/Calendar.stories.ts
@@ -1,8 +1,9 @@
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { Calendar, CalendarModule } from 'primeng/calendar';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/Checkbox.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/Checkbox.stories.ts
@@ -1,8 +1,9 @@
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { Checkbox, CheckboxModule } from 'primeng/checkbox';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/Chips.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/Chips.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { Chips, ChipsModule } from 'primeng/chips';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/Dropdown.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/Dropdown.stories.ts
@@ -1,7 +1,8 @@
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { Dropdown, DropdownModule } from 'primeng/dropdown';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/FloatLabel.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/FloatLabel.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { InputTextModule } from 'primeng/inputtext';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/InputGroup.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/InputGroup.stories.ts
@@ -1,8 +1,9 @@
+import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { FormsModule } from '@angular/forms';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ButtonModule } from 'primeng/button';
 import { CheckboxModule } from 'primeng/checkbox';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/InputMask.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/InputMask.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { InputMask, InputMaskModule } from 'primeng/inputmask';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/InputNumber.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/InputNumber.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { InputNumberModule } from 'primeng/inputnumber';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/InputSwitch.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/InputSwitch.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { InputSwitch, InputSwitchModule } from 'primeng/inputswitch';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/InputText.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/InputText.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { InputText, InputTextModule } from 'primeng/inputtext';
 import { PasswordModule } from 'primeng/password';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/InputTextArea.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/InputTextArea.stories.ts
@@ -1,9 +1,10 @@
-import { moduleMetadata } from '@storybook/angular';
-import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { moduleMetadata } from '@storybook/angular';
+import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { InputTextareaModule } from 'primeng/inputtextarea';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/KeyFilter.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/KeyFilter.stories.ts
@@ -1,9 +1,10 @@
-import { moduleMetadata } from '@storybook/angular';
-import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { moduleMetadata } from '@storybook/angular';
+import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { InputTextModule } from 'primeng/inputtext';
 import { KeyFilterModule } from 'primeng/keyfilter';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/ListBox.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/ListBox.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ListboxModule } from 'primeng/listbox';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/MultiSelect.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/MultiSelect.stories.ts
@@ -1,8 +1,9 @@
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { MultiSelect, MultiSelectModule } from 'primeng/multiselect';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/Password.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/Password.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { PasswordModule } from 'primeng/password';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/form/RadioButton.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/form/RadioButton.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { RadioButtonModule } from 'primeng/radiobutton';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/menu/Breadcrumb.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/menu/Breadcrumb.stories.ts
@@ -1,7 +1,7 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
-
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { BreadcrumbModule } from 'primeng/breadcrumb';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/menu/ContextMenu.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/menu/ContextMenu.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ContextMenuModule } from 'primeng/contextmenu';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/menu/Menu.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/menu/Menu.stories.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-console */
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { Meta } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ButtonModule } from 'primeng/button';
 import { Menu, MenuModule } from 'primeng/menu';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/messages/Messages.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/messages/Messages.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { MessageModule } from 'primeng/message';
 import { MessagesModule } from 'primeng/messages';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/messages/Toast.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/messages/Toast.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/misc/Defer.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/misc/Defer.stories.ts
@@ -1,9 +1,10 @@
-import { moduleMetadata } from '@storybook/angular';
-import { Meta } from '@storybook/angular/types-6-0';
 
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { moduleMetadata } from '@storybook/angular';
+import { Meta } from '@storybook/angular/types-6-0';
 
 import { MessageService } from 'primeng/api';
 import { DeferModule } from 'primeng/defer';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/misc/FocusTrap.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/misc/FocusTrap.stories.ts
@@ -1,10 +1,11 @@
-import { moduleMetadata } from '@storybook/angular';
-import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { moduleMetadata } from '@storybook/angular';
+import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { AccordionModule } from 'primeng/accordion';
 import { AutoCompleteModule } from 'primeng/autocomplete';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/misc/InPlace.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/misc/InPlace.stories.ts
@@ -1,9 +1,10 @@
-import { moduleMetadata } from '@storybook/angular';
-import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { moduleMetadata } from '@storybook/angular';
+import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { InplaceModule } from 'primeng/inplace';
 import { InputTextModule } from 'primeng/inputtext';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/misc/ProgressBar.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/misc/ProgressBar.stories.ts
@@ -1,9 +1,10 @@
-import { moduleMetadata } from '@storybook/angular';
-import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { moduleMetadata } from '@storybook/angular';
+import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { ProgressBarModule } from 'primeng/progressbar';
 import { ToastModule } from 'primeng/toast';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/misc/ProgressSpinner.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/misc/ProgressSpinner.stories.ts
@@ -1,9 +1,10 @@
-import { moduleMetadata } from '@storybook/angular';
-import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { moduleMetadata } from '@storybook/angular';
+import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/misc/Ripple.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/misc/Ripple.stories.ts
@@ -1,8 +1,9 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta } from '@storybook/angular/types-6-0';
 
-import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/overlay/ConfirmDialog.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/overlay/ConfirmDialog.stories.ts
@@ -1,7 +1,8 @@
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { Meta } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ConfirmationService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/overlay/Dialog.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/overlay/Dialog.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/overlay/DynamicDialog.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/overlay/DynamicDialog.stories.ts
@@ -1,9 +1,10 @@
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
-import { Meta } from '@storybook/angular/types-6-0';
 
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { Meta } from '@storybook/angular/types-6-0';
 
 import { ButtonModule } from 'primeng/button';
 import { DynamicDialogConfig, DynamicDialogModule, DynamicDialogRef } from 'primeng/dynamicdialog';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/overlay/OverlayPanel.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/overlay/OverlayPanel.stories.ts
@@ -1,10 +1,11 @@
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
-import { moduleMetadata } from '@storybook/angular';
-import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { moduleMetadata } from '@storybook/angular';
+import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { ButtonModule } from 'primeng/button';
 import { OverlayPanelModule } from 'primeng/overlaypanel';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/overlay/Tooltip.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/overlay/Tooltip.stories.ts
@@ -1,7 +1,8 @@
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { moduleMetadata } from '@storybook/angular';
 import { Meta, Story } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ButtonModule } from 'primeng/button';
 import { TooltipModule } from 'primeng/tooltip';

--- a/core-web/apps/dotcms-ui/src/stories/primeng/panel/TabView.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/panel/TabView.stories.ts
@@ -1,7 +1,8 @@
 // also exported from '@storybook/angular' if you can deal with breaking changes in 6.1
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { Meta } from '@storybook/angular/types-6-0';
 
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ButtonModule } from 'primeng/button';
 import { Menu } from 'primeng/menu';

--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.stories.ts
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.stories.ts
@@ -1,8 +1,9 @@
-import { of } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { of } from 'rxjs';
 
 import { ListboxModule } from 'primeng/listbox';
 import { MenuModule } from 'primeng/menu';

--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
@@ -1,6 +1,7 @@
+import { Component, Injector, Input, OnDestroy, OnInit, ViewContainerRef } from '@angular/core';
+
 import { Subject } from 'rxjs';
 
-import { Component, Injector, Input, OnDestroy, OnInit, ViewContainerRef } from '@angular/core';
 
 import { debounceTime, takeUntil } from 'rxjs/operators';
 

--- a/core-web/libs/block-editor/src/lib/extensions/action-button/actions-menu.extension.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/action-button/actions-menu.extension.ts
@@ -1,8 +1,9 @@
+import { ComponentRef, ViewContainerRef } from '@angular/core';
+
 import { PluginKey } from 'prosemirror-state';
 import { Subject } from 'rxjs';
 import tippy, { GetReferenceClientRect } from 'tippy.js';
 
-import { ComponentRef, ViewContainerRef } from '@angular/core';
 
 import { filter, take, takeUntil } from 'rxjs/operators';
 

--- a/core-web/libs/block-editor/src/lib/extensions/bubble-form/bubble-form.extension.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-form/bubble-form.extension.ts
@@ -1,8 +1,9 @@
+import { ViewContainerRef } from '@angular/core';
+
 import { PluginKey } from 'prosemirror-state';
 import { Subject } from 'rxjs';
 import { Props } from 'tippy.js';
 
-import { ViewContainerRef } from '@angular/core';
 
 import BubbleMenu from '@tiptap/extension-bubble-menu';
 

--- a/core-web/libs/block-editor/src/lib/extensions/bubble-form/plugins/bubble-form.plugin.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-form/plugins/bubble-form.plugin.ts
@@ -1,10 +1,11 @@
+import { ComponentRef } from '@angular/core';
+
 import { Node } from 'prosemirror-model';
 import { EditorState, NodeSelection, Plugin, PluginKey, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { Observable, Subject } from 'rxjs';
 import tippy, { Instance, Props } from 'tippy.js';
 
-import { ComponentRef } from '@angular/core';
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/libs/block-editor/src/lib/extensions/bubble-link-form/bubble-link-form.extension.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-link-form/bubble-link-form.extension.ts
@@ -1,7 +1,8 @@
+import { ViewContainerRef } from '@angular/core';
+
 import { PluginKey } from 'prosemirror-state';
 import { Props } from 'tippy.js';
 
-import { ViewContainerRef } from '@angular/core';
 
 import { Extension } from '@tiptap/core';
 

--- a/core-web/libs/block-editor/src/lib/extensions/bubble-link-form/plugins/bubble-link-form.plugin.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-link-form/plugins/bubble-link-form.plugin.ts
@@ -1,10 +1,11 @@
+import { ComponentRef } from '@angular/core';
+
 import isEqual from 'lodash.isequal';
 import { EditorState, Plugin, PluginKey, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { Subject } from 'rxjs';
 import tippy, { Instance, Props } from 'tippy.js';
 
-import { ComponentRef } from '@angular/core';
 
 import { takeUntil } from 'rxjs/operators';
 

--- a/core-web/libs/block-editor/src/lib/extensions/bubble-menu/dot-bubble-menu.extension.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-menu/dot-bubble-menu.extension.ts
@@ -1,7 +1,8 @@
+import { ViewContainerRef } from '@angular/core';
+
 import { PluginKey } from 'prosemirror-state';
 import { Props } from 'tippy.js';
 
-import { ViewContainerRef } from '@angular/core';
 
 import BubbleMenu, { BubbleMenuOptions } from '@tiptap/extension-bubble-menu';
 

--- a/core-web/libs/block-editor/src/lib/extensions/bubble-menu/models/index.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-menu/models/index.ts
@@ -1,7 +1,8 @@
+import { ComponentRef, EventEmitter } from '@angular/core';
+
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 
-import { ComponentRef, EventEmitter } from '@angular/core';
 
 import { Editor } from '@tiptap/core';
 import { BubbleMenuPluginProps, BubbleMenuViewProps } from '@tiptap/extension-bubble-menu';

--- a/core-web/libs/block-editor/src/lib/extensions/bubble-menu/plugins/dot-bubble-menu.plugin.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-menu/plugins/dot-bubble-menu.plugin.ts
@@ -1,8 +1,9 @@
+import { ComponentRef } from '@angular/core';
+
 import { EditorState, NodeSelection, Plugin, PluginKey } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import tippy, { Instance } from 'tippy.js';
 
-import { ComponentRef } from '@angular/core';
 
 import { filter, take } from 'rxjs/operators';
 

--- a/core-web/libs/block-editor/src/lib/extensions/drag-handler/drag-handler.extension.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/drag-handler/drag-handler.extension.ts
@@ -1,7 +1,8 @@
+import { ViewContainerRef } from '@angular/core';
+
 import { NodeSelection, Plugin, PluginKey } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 
-import { ViewContainerRef } from '@angular/core';
 
 import { Extension } from '@tiptap/core';
 

--- a/core-web/libs/block-editor/src/lib/extensions/floating-button/floating-button.extension.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/floating-button/floating-button.extension.ts
@@ -1,6 +1,7 @@
+import { Injector, ViewContainerRef } from '@angular/core';
+
 import { PluginKey } from 'prosemirror-state';
 
-import { Injector, ViewContainerRef } from '@angular/core';
 
 import { Extension } from '@tiptap/core';
 

--- a/core-web/libs/block-editor/src/lib/extensions/floating-button/plugin/floating-button.plugin.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/floating-button/plugin/floating-button.plugin.ts
@@ -1,9 +1,10 @@
+import { ComponentRef } from '@angular/core';
+
 import { EditorState, Plugin, PluginKey } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { Subject } from 'rxjs';
 import tippy, { Instance } from 'tippy.js';
 
-import { ComponentRef } from '@angular/core';
 
 import { take, takeUntil, tap } from 'rxjs/operators';
 

--- a/core-web/libs/block-editor/src/lib/extensions/image-tabview-form/image-tabview-form.component.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/image-tabview-form/image-tabview-form.component.ts
@@ -1,4 +1,3 @@
-import { BehaviorSubject, merge } from 'rxjs';
 
 import {
     ChangeDetectionStrategy,
@@ -10,6 +9,8 @@ import {
     ViewChild
 } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
+
+import { BehaviorSubject, merge } from 'rxjs';
 
 import { Observable } from 'rxjs/internal/Observable';
 import { debounceTime, map, mergeMap, tap, throttleTime } from 'rxjs/operators';

--- a/core-web/libs/block-editor/src/lib/extensions/image-tabview-form/image-tabview-form.extension.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/image-tabview-form/image-tabview-form.extension.ts
@@ -1,7 +1,8 @@
+import { ViewContainerRef } from '@angular/core';
+
 import { PluginKey } from 'prosemirror-state';
 import { Props } from 'tippy.js';
 
-import { ViewContainerRef } from '@angular/core';
 
 import BubbleMenu from '@tiptap/extension-bubble-menu';
 

--- a/core-web/libs/block-editor/src/lib/extensions/image-tabview-form/plugins/bubble-image-tabview-form.plugin.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/image-tabview-form/plugins/bubble-image-tabview-form.plugin.ts
@@ -1,9 +1,10 @@
+import { ComponentRef } from '@angular/core';
+
 import { EditorState, Plugin, PluginKey, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { Subject } from 'rxjs';
 import tippy, { Instance, Props } from 'tippy.js';
 
-import { ComponentRef } from '@angular/core';
 
 import { Editor, posToDOMRect } from '@tiptap/core';
 

--- a/core-web/libs/block-editor/src/lib/extensions/image-uploader/image-uploader.extension.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/image-uploader/image-uploader.extension.ts
@@ -1,7 +1,8 @@
+import { ComponentRef, Injector, ViewContainerRef } from '@angular/core';
+
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 
-import { ComponentRef, Injector, ViewContainerRef } from '@angular/core';
 
 import { take } from 'rxjs/operators';
 

--- a/core-web/libs/block-editor/src/lib/extensions/image-uploader/services/dot-image/dot-image.service.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/image-uploader/services/dot-image/dot-image.service.ts
@@ -1,7 +1,8 @@
-import { from, Observable, throwError } from 'rxjs';
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { from, Observable, throwError } from 'rxjs';
 
 import { catchError, pluck, switchMap } from 'rxjs/operators';
 

--- a/core-web/libs/block-editor/src/lib/nodes/contentlet-block/contentlet-block.node.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/contentlet-block/contentlet-block.node.ts
@@ -1,6 +1,7 @@
+import { Injector } from '@angular/core';
+
 import { DOMOutputSpec, ParseRule } from 'prosemirror-model';
 
-import { Injector } from '@angular/core';
 
 import { mergeAttributes, Node, NodeViewRenderer } from '@tiptap/core';
 

--- a/core-web/libs/block-editor/src/lib/shared/components/suggestion-list/components/suggestions-list-item/suggestions-list-item.component.stories.ts
+++ b/core-web/libs/block-editor/src/lib/shared/components/suggestion-list/components/suggestions-list-item/suggestions-list-item.component.stories.ts
@@ -1,6 +1,7 @@
+import { CommonModule } from '@angular/common';
+
 import { moduleMetadata, Story } from '@storybook/angular';
 
-import { CommonModule } from '@angular/common';
 
 import { SuggestionsListItemComponent } from './suggestions-list-item.component';
 

--- a/core-web/libs/block-editor/src/lib/shared/components/suggestion-list/suggestion-list.component.stories.ts
+++ b/core-web/libs/block-editor/src/lib/shared/components/suggestion-list/suggestion-list.component.stories.ts
@@ -1,6 +1,7 @@
+import { CommonModule } from '@angular/common';
+
 import { moduleMetadata, Story } from '@storybook/angular';
 
-import { CommonModule } from '@angular/common';
 
 import { SuggestionsListItemComponent } from './components/suggestions-list-item/suggestions-list-item.component';
 import { SuggestionListComponent } from './suggestion-list.component';

--- a/core-web/libs/block-editor/src/lib/shared/components/suggestion-list/suggestion-list.component.ts
+++ b/core-web/libs/block-editor/src/lib/shared/components/suggestion-list/suggestion-list.component.ts
@@ -1,4 +1,3 @@
-import { Subject } from 'rxjs';
 
 import { FocusKeyManager } from '@angular/cdk/a11y';
 import {
@@ -11,6 +10,8 @@ import {
     OnDestroy,
     QueryList
 } from '@angular/core';
+
+import { Subject } from 'rxjs';
 
 // Components
 import { takeUntil } from 'rxjs/operators';

--- a/core-web/libs/block-editor/src/lib/shared/directives/editor/editor.directive.ts
+++ b/core-web/libs/block-editor/src/lib/shared/directives/editor/editor.directive.ts
@@ -1,4 +1,3 @@
-import { Transaction } from 'prosemirror-state';
 
 import {
     Directive,
@@ -10,6 +9,8 @@ import {
     Renderer2
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { Transaction } from 'prosemirror-state';
 
 import { Content, Editor, JSONContent } from '@tiptap/core';
 

--- a/core-web/libs/block-editor/src/lib/shared/services/dot-language/dot-language.service.ts
+++ b/core-web/libs/block-editor/src/lib/shared/services/dot-language/dot-language.service.ts
@@ -1,7 +1,8 @@
-import { Observable, of } from 'rxjs';
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable, of } from 'rxjs';
 
 import { map, pluck } from 'rxjs/operators';
 

--- a/core-web/libs/block-editor/src/lib/shared/services/search/search.service.ts
+++ b/core-web/libs/block-editor/src/lib/shared/services/search/search.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.ts
+++ b/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.ts
@@ -1,7 +1,8 @@
-import { Observable } from 'rxjs';
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/add-to-bundle/add-to-bundle.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/add-to-bundle/add-to-bundle.service.spec.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
-
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed, getTestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import { ApiRoot, UserModel, LoggerService, StringUtils, CoreWebService } from '@dotcms/dotcms-js';
 import { DotAjaxActionResponseView, DotCurrentUser } from '@dotcms/dotcms-models';
@@ -12,7 +12,6 @@ import { CoreWebServiceMock } from '@dotcms/utils-testing';
 import { AddToBundleService } from './add-to-bundle.service';
 
 import { DotCurrentUserService } from '../dot-current-user/dot-current-user.service';
-
 
 describe('AddToBundleService', () => {
     let injector: TestBed;

--- a/core-web/libs/data-access/src/lib/add-to-bundle/add-to-bundle.service.ts
+++ b/core-web/libs/data-access/src/lib/add-to-bundle/add-to-bundle.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck, mergeMap, map } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-alert-confirm/dot-alert-confirm.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-alert-confirm/dot-alert-confirm.service.ts
@@ -1,6 +1,6 @@
-import { Observable, Subject } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable, Subject } from 'rxjs';
 
 import { ConfirmationService } from 'primeng/api';
 

--- a/core-web/libs/data-access/src/lib/dot-content-type/dot-content-type.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-content-type/dot-content-type.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { defaultIfEmpty, filter, flatMap, map, pluck, take, toArray } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-contentlet-locker/dot-contentlet-locker.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-contentlet-locker/dot-contentlet-locker.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-contentlet/dot-contentlet.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-contentlet/dot-contentlet.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck, take } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-crud/dot-crud.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-crud/dot-crud.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-current-user/dot-current-user.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-current-user/dot-current-user.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { map, pluck, take } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-devices/dot-devices.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-devices/dot-devices.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-edit-page/dot-edit-page.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-edit-page/dot-edit-page.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-es-content/dot-es-content.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-es-content/dot-es-content.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { take, pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-events/dot-events.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-events/dot-events.service.ts
@@ -1,6 +1,6 @@
-import { Observable, Subject } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable, Subject } from 'rxjs';
 
 import { filter } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-generate-secure-password/dot-generate-secure-password.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-generate-secure-password/dot-generate-secure-password.service.ts
@@ -1,6 +1,6 @@
-import { Observable, Subject } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable, Subject } from 'rxjs';
 
 @Injectable()
 export class DotGenerateSecurePasswordService {

--- a/core-web/libs/data-access/src/lib/dot-languages/dot-languages.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-languages/dot-languages.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-license/dot-license.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-license/dot-license.service.spec.ts
@@ -1,14 +1,12 @@
-import { of } from 'rxjs';
-
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, getTestBed } from '@angular/core/testing';
 
+import { of } from 'rxjs';
 
 import { CoreWebService } from '@dotcms/dotcms-js';
 import { CoreWebServiceMock } from '@dotcms/utils-testing';
 
 import { DotLicenseService } from './dot-license.service';
-
 
 describe('DotLicenseService', () => {
     let injector: TestBed;

--- a/core-web/libs/data-access/src/lib/dot-license/dot-license.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-license/dot-license.service.ts
@@ -1,6 +1,6 @@
-import { Observable, Subject, BehaviorSubject } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable, Subject, BehaviorSubject } from 'rxjs';
 
 import { pluck, map, take } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-localstorage/dot-localstorage.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-localstorage/dot-localstorage.service.ts
@@ -1,6 +1,6 @@
-import { fromEvent, Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { fromEvent, Observable } from 'rxjs';
 
 import { map, filter } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-messages/dot-messages.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-messages/dot-messages.service.spec.ts
@@ -1,16 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { of } from 'rxjs';
-
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, getTestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import { CoreWebService, CoreWebServiceMock } from '@dotcms/dotcms-js';
 
 import { DotMessageService } from './dot-messages.service';
 
 import { DotLocalstorageService } from '../dot-localstorage/dot-localstorage.service';
-
 
 describe('DotMessageService', () => {
     let dotMessageService: DotMessageService;

--- a/core-web/libs/data-access/src/lib/dot-page-layout/dot-page-layout.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-page-layout/dot-page-layout.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck, map } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-page-render/dot-page-render.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-page-render/dot-page-render.service.ts
@@ -1,7 +1,7 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
 import { Params } from '@angular/router';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-personalize/dot-personalize.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-personalize/dot-personalize.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-personas/dot-personas.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-personas/dot-personas.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-properties/dot-properties.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-properties/dot-properties.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck, take } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-push-publish-filters/dot-push-publish-filters.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-push-publish-filters/dot-push-publish-filters.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-roles/dot-roles.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-roles/dot-roles.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { map, pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-site-browser/dot-site-browser.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-site-browser/dot-site-browser.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { take } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-tags/dot-tags.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-tags/dot-tags.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { map, pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-themes/dot-themes.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-themes/dot-themes.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-versionable/dot-versionable.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-versionable/dot-versionable.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-workflow-actions-fire/dot-workflow-actions-fire.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-workflow-actions-fire/dot-workflow-actions-fire.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck, take } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-workflow/dot-workflow.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-workflow/dot-workflow.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck, switchMap, take } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/dot-workflows-actions/dot-workflows-actions.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-workflows-actions/dot-workflows-actions.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { pluck } from 'rxjs/operators';
 

--- a/core-web/libs/data-access/src/lib/paginator/paginator.service.ts
+++ b/core-web/libs/data-access/src/lib/paginator/paginator.service.ts
@@ -1,6 +1,6 @@
-import { Observable } from 'rxjs';
-
 import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs';
 
 import { take, map } from 'rxjs/operators';
 


### PR DESCRIPTION
### Proposed Changes
* Update the rule to make `@angular` always to the top of the file. 

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
