### PR TITLE
dotCMS/core#23837 Delete from SessionStorage the Key variantName 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -186,6 +186,7 @@ describe('DotEditContentComponent', () => {
     let dotConfigurationService: DotPropertiesService;
     let dotLicenseService: DotLicenseService;
     let dotEventsService: DotEventsService;
+    let dotSessionStorageService: DotSessionStorageService;
 
     function detectChangesForIframeRender(fix) {
         fix.detectChanges();
@@ -260,6 +261,7 @@ describe('DotEditContentComponent', () => {
                 DotCustomEventHandlerService,
                 DotPropertiesService,
                 DotESContentService,
+                DotSessionStorageService,
                 {
                     provide: LoginService,
                     useClass: LoginServiceMock
@@ -336,6 +338,7 @@ describe('DotEditContentComponent', () => {
         dotConfigurationService = de.injector.get(DotPropertiesService);
         dotLicenseService = de.injector.get(DotLicenseService);
         dotEventsService = de.injector.get(DotEventsService);
+        dotSessionStorageService = de.injector.get(DotSessionStorageService);
         spyOn(dotPageStateService, 'reload');
 
         spyOn(dotEditContentHtmlService, 'renderAddedForm').and.returnValue(
@@ -1479,5 +1482,11 @@ describe('DotEditContentComponent', () => {
             fixture.detectChanges();
             expect(component.allowedContent).toEqual([...allowedContent]);
         }));
+    });
+
+    it('should remove variant key from session storage on destoy', () => {
+        spyOn(dotSessionStorageService, 'removeVariationId');
+        component.ngOnDestroy();
+        expect(dotSessionStorageService.removeVariationId).toHaveBeenCalledTimes(1);
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -1485,8 +1485,8 @@ describe('DotEditContentComponent', () => {
     });
 
     it('should remove variant key from session storage on destoy', () => {
-        spyOn(dotSessionStorageService, 'removeVariationId');
+        spyOn(dotSessionStorageService, 'removeVariantId');
         component.ngOnDestroy();
-        expect(dotSessionStorageService.removeVariationId).toHaveBeenCalledTimes(1);
+        expect(dotSessionStorageService.removeVariantId).toHaveBeenCalledTimes(1);
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -185,7 +185,7 @@ browse from the page internal links
     }
 
     ngOnDestroy(): void {
-        this.dotSessionStorageService.removeVariationId();
+        this.dotSessionStorageService.removeVariantId();
         this.destroy$.next(true);
         this.destroy$.complete();
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -19,7 +19,8 @@ import {
     DotEventsService,
     DotLicenseService,
     DotMessageService,
-    DotPropertiesService
+    DotPropertiesService,
+    DotSessionStorageService
 } from '@dotcms/data-access';
 import { SiteService } from '@dotcms/dotcms-js';
 import {
@@ -112,7 +113,8 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
         private dotConfigurationService: DotPropertiesService,
         private dotLicenseService: DotLicenseService,
         private dotEventsService: DotEventsService,
-        private dotESContentService: DotESContentService
+        private dotESContentService: DotESContentService,
+        private dotSessionStorageService: DotSessionStorageService
     ) {
         if (!this.customEventsHandler) {
             this.customEventsHandler = {
@@ -183,6 +185,7 @@ browse from the page internal links
     }
 
     ngOnDestroy(): void {
+        this.dotSessionStorageService.removeVariationId();
         this.destroy$.next(true);
         this.destroy$.complete();
     }

--- a/core-web/libs/data-access/src/lib/dot-session-storage/dot-session-storage.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-session-storage/dot-session-storage.service.ts
@@ -33,7 +33,7 @@ export class DotSessionStorageService {
      *
      * @memberof DotSessionStorageService
      */
-    removeVariationId(): void {
+    removeVariantId(): void {
         sessionStorage.removeItem(SESSION_STORAGE_VARIATION_KEY);
     }
 }


### PR DESCRIPTION
### Proposed Changes
* delete the SessionStorage key variantName when DotEditContent is destroyed 
