### PR TITLE
dotCMS/core#23764 Take the `Paragraph` option out of the `Allowed Blocks` field

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.spec.ts
@@ -165,4 +165,17 @@ describe('DotContentTypeFieldsVariablesComponent', () => {
             expect(multiselect.options).toEqual(BLOCK_EDITOR_BLOCKS);
         });
     });
+
+    describe('Options', () => {
+        it('should not have a "paragraph" option', () => {
+            const options = component.settingsMap.allowedBlocks.options;
+            const paragraphOption = options.find(
+                ({ label, code }) =>
+                    code.trim().toLowerCase() === 'paragraph' ||
+                    label.trim().toLowerCase() === 'paragraph'
+            );
+
+            expect(paragraphOption).not.toBeDefined();
+        });
+    });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.ts
@@ -36,7 +36,6 @@ export const BLOCK_EDITOR_BLOCKS = [
     { label: 'Heading 3', code: 'heading3' },
     { label: 'Horizontal Line', code: 'horizontalRule' },
     { label: 'Image', code: 'image' },
-    { label: '`Paragraph`', code: 'paragraph' },
     { label: 'Ordered List', code: 'orderedList' },
     { label: 'Table', code: 'table' }
 ];

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.ts
@@ -24,8 +24,6 @@ import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot
 
 import { DotFieldVariablesService } from '../fields/dot-content-type-fields-variables/services/dot-field-variables.service';
 
-// Interfaces
-
 export const BLOCK_EDITOR_BLOCKS = [
     { label: 'Block Quote', code: 'blockquote' },
     { label: 'Bullet List', code: 'bulletList' },


### PR DESCRIPTION
**What we did**

1. We only remove the `Paragraph` option from the Allowed Blocks.
2. Add a test to check there is not a `paragraph` option.