### PR TITLE
#23761 use true instead of getDBTrue

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220912UpdateCorrectShowOnMenuProperty.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220912UpdateCorrectShowOnMenuProperty.java
@@ -76,7 +76,7 @@ public class Task220912UpdateCorrectShowOnMenuProperty implements StartupTask {
      * @return The SQL code used to read the value of the existing 'Show On Menu' value.
      */
     private String getExpectedColumnReference(String columnName) {
-        String columnReference = columnName + " = " + getDBTrue();
+        String columnReference = columnName + " = 'true'";
         if (APILocator.getContentletJsonAPI().isJsonSupportedDatabase()) {
             if (isPostgres()) {
                 columnReference += " OR " + ContentletJsonAPI.CONTENTLET_AS_JSON + "->'fields'->'" + VELOCITY_VAR_NAME + "'->>'value' = 'true'";


### PR DESCRIPTION
We need to use the word `true` instead of the getDBTrue method here since it will return `1` for MSSQL and for the text columns we stored the `true` value as a string.