### PR TITLE
dotCMS/core#23554 Can't close query dialog on content search screen

### DIFF
--- a/core-web/libs/dojo-theme/scss/backend/dot-admin/portlets/_content-search.scss
+++ b/core-web/libs/dojo-theme/scss/backend/dot-admin/portlets/_content-search.scss
@@ -26,7 +26,6 @@
 
 .content-search__show-query-dialog {
     .dijitDialogTitleBar {
-        height: 0px;
         z-index: 1;
     }
 }

--- a/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
+++ b/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
@@ -9277,7 +9277,6 @@ Styles for commons fields along the backend
   color: #fff;
   cursor: pointer;
   padding: 0 1rem;
-
 }
 .fileAjaxUploader input[type=file]::-webkit-file-upload-button:hover {
   background-color: var(--color-main_mod);
@@ -10477,7 +10476,6 @@ a.category_higlighted, a.tag_higlighted {
 }
 
 .content-search__show-query-dialog .dijitDialogTitleBar {
-  height: 0px;
   z-index: 1;
 }
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
@@ -806,7 +806,7 @@
         <!-- END Right Column -->
 
         <!-- START Show Query -->
-        <div id="queryDiv" dojoType="dijit.Dialog" title="" class="content-search__show-query-dialog" style="display: none;padding-top:15px\9;">
+        <div id="queryDiv" dojoType="dijit.Dialog" title="<%= LanguageUtil.get(pageContext, "Query) %></div>" class="content-search__show-query-dialog" style="display: none;padding-top:15px\9;">
             <div id="queryResults"></div>
         </div>
         <!-- END Show Query -->


### PR DESCRIPTION
### Proposed Changes
* Bring back the CSS that I remove during the dojo-theme merge to core.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
