### PR TITLE
#23871 use default variant as original variant

### DIFF
--- a/dotCMS/src/curl-test/Experiments Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Experiments Resource.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "9043147d-8a40-47ea-81e5-665c81175bfc",
+		"_postman_id": "20e0245f-a5b6-4b23-9ca9-d0b91fdf4d0a",
 		"name": "Experiments Resource",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "1549189"
+		"_exporter_id": "4500400"
 	},
 	"item": [
 		{
@@ -1241,7 +1241,7 @@
 					"response": []
 				},
 				{
-					"name": "editVariantDescription_OriginalVairnant_shouldFail",
+					"name": "editVariantDescription_OriginalVariant_shouldFail",
 					"event": [
 						{
 							"listen": "test",
@@ -1252,7 +1252,7 @@
 									"",
 									"pm.test(\"Cannot update Original Variant\", function () {",
 									"    pm.response.to.have.status(400);",
-									"    pm.expect(jsonData.message).equal(\"Cannot update Original Variant\");",
+									"    pm.expect(jsonData.message).equal(\"Invalid Variant provided\");",
 									"});",
 									"",
 									"",
@@ -1301,6 +1301,507 @@
 								"{{variantExperiment}}",
 								"variants",
 								"{{originalVariant}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "pre_createExperiment",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.collectionVariables.set(\"experimentToAddVariant\", jsonData.entity.id);",
+									"",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"pageId\": \"9044ec0fdb3788a814ccabf789f376d4\",\n    \"name\": \"20220901\",\n    \"description\": \"experiment with goals and variants\", \n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "addVariantToExperiment_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Variants with correct weight\", function () {",
+									"    var experimetnShortId = pm.collectionVariables.get(\"experimentToAddVariant\").substring(0, 11).replace('-', '');",
+									"",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].url).equal(\"/another-experiment-page?variantName=DEFAULT\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My first Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].url).equal(\"/another-experiment-page?variantName=dotexperiment-\" + experimetnShortId + \"-variant-1\");",
+									"    ",
+									"    pm.collectionVariables.set(\"variantToDelete\", jsonData.entity.trafficProportion.variants[1].id);",
+									"",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"My first Variant\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}",
+								"variants"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "addSecondVariantToExperiment_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Variants with correct weight\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(3);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(33.333332);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My first Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(33.333332);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[2].name).equal(\"My second Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[2].weight).equal(33.333332);",
+									"",
+									"    pm.collectionVariables.set(\"secondVariantId\", jsonData.entity.trafficProportion.variants[2].id);",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"My second Variant\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}",
+								"variants"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteVariantOfExperiment_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Started Experiment with expected values\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My second Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants/{{variantToDelete}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}",
+								"variants",
+								"{{variantToDelete}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateExperimentTrafficProportion_shoudSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Variants with correct weight\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"CUSTOM_PERCENTAGES\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(80.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"Variant 2\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(20.0);",
+									"",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"trafficProportion\": {\n        \"type\": \"CUSTOM_PERCENTAGES\",\n        \"variants\": [\n            {\n                \"name\": \"Original\",\n                \"id\": \"DEFAULT\",\n                \"weight\": 80\n            },\n            {\n                \"name\": \"Variant 2\",\n                \"id\": \"{{secondVariantId}}\",\n                \"weight\": 20\n            }\n        ]\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "addVariantToExperiment_CustomPercentages_shouldSucceed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Variants with correct weight\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"CUSTOM_PERCENTAGES\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(3);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(80.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My third Variant\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(0.0);",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[2].name).equal(\"Variant 2\");",
+									"    pm.expect(jsonData.entity.trafficProportion.variants[2].weight).equal(20.0);",
+									"",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"My third Variant\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}",
+								"variants"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteOriginalVariant_shouldFail",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Started Experiment with expected values\", function () {",
+									"    pm.response.to.have.status(400);",
+									"    pm.expect(jsonData.message).equal(\"Invalid Variant provided\");",
+									"});",
+									"",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants/DEFAULT",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"{{experimentToAddVariant}}",
+								"variants",
+								"DEFAULT"
 							]
 						}
 					},
@@ -3056,446 +3557,6 @@
 			]
 		},
 		{
-			"name": "Variants",
-			"item": [
-				{
-					"name": "pre_createExperiment",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"",
-									"pm.test(\"Status code should be ok 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.collectionVariables.set(\"experimentToAddVariant\", jsonData.entity.id);",
-									"",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"pageId\": \"9044ec0fdb3788a814ccabf789f376d4\",\n    \"name\": \"20220901\",\n    \"description\": \"experiment with goals and variants\", \n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                },\n                {\n                    \"parameter\": \"referrer\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"home\"\n                }\n            ]\n        }\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/experiments/",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"experiments",
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "addVariantToExperiment_shouldSucceed",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"",
-									"pm.test(\"Variants with correct weight\", function () {",
-									"    var experimetnShortId = pm.collectionVariables.get(\"experimentToAddVariant\").substring(0, 11).replace('-', '');",
-									"",
-									"    pm.response.to.have.status(200);",
-									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].url).equal(\"/another-experiment-page?variantName=dotexperiment-\" + experimetnShortId + \"-variant-1\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My first Variant\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].url).equal(\"/another-experiment-page?variantName=dotexperiment-\" + experimetnShortId + \"-variant-2\");",
-									"    ",
-									"    pm.collectionVariables.set(\"variantToDelete\", jsonData.entity.trafficProportion.variants[1].id);",
-									"",
-									"});",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"name\": \"My first Variant\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"experiments",
-								"{{experimentToAddVariant}}",
-								"variants"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "addSecondVariantToExperiment_shouldSucceed",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"",
-									"pm.test(\"Variants with correct weight\", function () {",
-									"    pm.response.to.have.status(200);",
-									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(3);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(33.333332);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My first Variant\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(33.333332);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[2].name).equal(\"My second Variant\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[2].weight).equal(33.333332);",
-									"",
-									"    pm.collectionVariables.set(\"secondVariantId\", jsonData.entity.trafficProportion.variants[2].id);",
-									"});",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"name\": \"My second Variant\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"experiments",
-								"{{experimentToAddVariant}}",
-								"variants"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "deleteVariantOfExperiment_shouldSucceed",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"",
-									"pm.test(\"Started Experiment with expected values\", function () {",
-									"    pm.response.to.have.status(200);",
-									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My second Variant\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
-									"});",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								}
-							]
-						},
-						"method": "DELETE",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants/{{variantToDelete}}",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"experiments",
-								"{{experimentToAddVariant}}",
-								"variants",
-								"{{variantToDelete}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "updateExperimentTrafficProportion_shoudSucceed",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"",
-									"pm.test(\"Status code should be ok 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Variants with correct weight\", function () {",
-									"    pm.response.to.have.status(200);",
-									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"CUSTOM_PERCENTAGES\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(80.0);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"Variant 2\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(20.0);",
-									"",
-									"});",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PATCH",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"trafficProportion\": {\n        \"type\": \"CUSTOM_PERCENTAGES\",\n        \"variants\": [\n            {\n                \"name\": \"Original\",\n                \"id\": \"DEFAULT\",\n                \"weight\": 80\n            },\n            {\n                \"name\": \"Variant 2\",\n                \"id\": \"{{secondVariantId}}\",\n                \"weight\": 20\n            }\n        ]\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"experiments",
-								"{{experimentToAddVariant}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "addVariantToExperiment_CustomPercentages_shouldSucceed",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"",
-									"pm.test(\"Variants with correct weight\", function () {",
-									"    pm.response.to.have.status(200);",
-									"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"CUSTOM_PERCENTAGES\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(3);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(80.0);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"My third Variant\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(0.0);",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[2].name).equal(\"Variant 2\");",
-									"    pm.expect(jsonData.entity.trafficProportion.variants[2].weight).equal(20.0);",
-									"",
-									"});",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"name\": \"My third Variant\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/variants",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"experiments",
-								"{{experimentToAddVariant}}",
-								"variants"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
 			"name": "Start Experiment",
 			"item": [
 				{
@@ -4033,70 +4094,6 @@
 								"experiments",
 								"{{experimentNoGoalsId}}",
 								"_start"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "stopExperiment_shouldSucceed",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"",
-									"pm.test(\"Started Experiment with expected values\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/experiments/{{experimentToAddVariant}}/_end",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"experiments",
-								"{{experimentToAddVariant}}",
-								"_end"
 							]
 						}
 					},

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
@@ -152,8 +152,9 @@ public class ExperimentAPIImpIT {
 
             List<Contentlet> experimentContentlets = APILocator.getContentletAPI()
                     .getAllContentByVariants(APILocator.systemUser(),
-                            false, newExperiment.trafficProportion().variants()
-                                    .stream().map(ExperimentVariant::id).toArray(String[]::new));
+                            false, newExperiment.trafficProportion().variants().stream()
+                                    .map(ExperimentVariant::id).filter((id) -> !id.equals(DEFAULT_VARIANT.name()))
+                                    .toArray(String[]::new));
 
             experimentContentlets.forEach((contentlet -> {
                 assertTrue(Try.of(contentlet::isLive).getOrElse(false));
@@ -167,59 +168,6 @@ public class ExperimentAPIImpIT {
                     , APILocator.systemUser());
         }
 
-    }
-
-    /**
-     * Method to test: {@link ExperimentsAPI#addVariant(String, String, User)} (String, User)}
-     * When: The {@link com.dotcms.experiments.model.AbstractExperimentVariant#ORIGINAL_VARIANT} variant is created
-     * Should: copy the page and the contentlet related to the page in the new variant
-     */
-    @Test
-    public void testAddOriginalVariant_shouldCopyPageAndContentletToVariant()
-            throws DotDataException, DotSecurityException {
-        final HTMLPageAsset page = APILocator.getHTMLPageAssetAPI().fromContentlet(
-                TestDataUtils.getPageContent(true, 1));
-        ContentletDataGen.publish(page);
-
-        final Container container = new ContainerDataGen().nextPersisted();
-
-        final ContentType contentType = new ContentTypeDataGen().nextPersisted();
-
-        final Contentlet content1 = new ContentletDataGen(contentType)
-                .nextPersisted();
-        ContentletDataGen.publish(content1);
-
-        final Contentlet content2 = new ContentletDataGen(contentType)
-                .nextPersisted();
-        ContentletDataGen.publish(content2);
-
-        final Contentlet content3 = new ContentletDataGen(contentType)
-                .nextPersisted();
-        ContentletDataGen.publish(content3);
-
-        new MultiTreeDataGen().setPage(page).setContainer(container)
-                .setContentlet(content1).nextPersisted();
-
-        new MultiTreeDataGen().setPage(page).setContainer(container)
-                .setContentlet(content2).nextPersisted();
-
-        new MultiTreeDataGen().setPage(page).setContainer(container)
-                .setContentlet(content3).nextPersisted();
-
-        final Experiment newExperiment = new ExperimentDataGen()
-                .page(page)
-                .addVariant("Test Gray Button")
-                .nextPersisted();
-
-        final ExperimentVariant originalVariant = newExperiment.
-                trafficProportion().variants().first();
-
-        List<Contentlet> experimentContentlets = APILocator.getContentletAPI()
-                .getAllContentByVariants(APILocator.systemUser(),
-                        false, originalVariant.id());
-
-        // expecting the page + the 3 contentlets
-        assertEquals(4, experimentContentlets.size());
     }
 
     /*

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -466,12 +466,6 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
                     .description(Optional.of(variantDescription)).build());
         }
 
-        // TODO commenting out for know while we evaluate this approach
-//        multiTreeAPI.copyVariantForPage(experiment.pageId(),
-//                DEFAULT_VARIANT.name(), variantName);
-//
-//        copyPageAndItsContentForVariant(experiment, variantDescription, user, variantName, pageContentlet);
-
         final Contentlet pageContentlet = contentletAPI
         .findContentletByIdentifierAnyLanguage(experiment.pageId(), false);
 

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -452,25 +452,28 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
             throws DotDataException {
 
         final String experimentId = experiment.getIdentifier();
-        final String variantName = getVariantName(experimentId);
+        String variantName = null;
 
         if(variantDescription.equals(ORIGINAL_VARIANT)) {
             DotPreconditions.isTrue(
                     experiment.trafficProportion().variants().stream().noneMatch((variant) ->
                             variant.description().equals(ORIGINAL_VARIANT)),
                     "Original Variant already created");
+            variantName = DEFAULT_VARIANT.name();
+        } else {
+            variantName = getVariantName(experimentId);
+            variantAPI.save(Variant.builder().name(variantName)
+                    .description(Optional.of(variantDescription)).build());
         }
 
-        variantAPI.save(Variant.builder().name(variantName)
-                .description(Optional.of(variantDescription)).build());
-
-        multiTreeAPI.copyVariantForPage(experiment.pageId(),
-                DEFAULT_VARIANT.name(), variantName);
+        // TODO commenting out for know while we evaluate this approach
+//        multiTreeAPI.copyVariantForPage(experiment.pageId(),
+//                DEFAULT_VARIANT.name(), variantName);
+//
+//        copyPageAndItsContentForVariant(experiment, variantDescription, user, variantName, pageContentlet);
 
         final Contentlet pageContentlet = contentletAPI
-                .findContentletByIdentifierAnyLanguage(experiment.pageId(), false);
-
-        copyPageAndItsContentForVariant(experiment, variantDescription, user, variantName, pageContentlet);
+        .findContentletByIdentifierAnyLanguage(experiment.pageId(), false);
 
         final HTMLPageAsset page = pageAssetAPI.fromContentlet(pageContentlet);
 


### PR DESCRIPTION
With this change we use the already existing DEFAULT variant as the Original variant of both the page in the Experiment and its content, instead of creating a new "Original" variant. 

Included
* Postman tests updated
* Integration tests updated
* Postman test added for attempting to delete the DEFAULT variant.