### PR TITLE
dotCMS/core#23845 Containers: Lazy load the content of permissions and history

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-create.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-create.component.html
@@ -7,10 +7,16 @@
                 </ng-template>
             </p-tabPanel>
             <p-tabPanel *ngIf="containerId" [header]="'message.containers.tab.permissions' | dm">
-                <dot-container-permissions [containerId]="containerId"></dot-container-permissions>
+                <ng-template pTemplate="content">
+                    <dot-container-permissions
+                        [containerId]="containerId"
+                    ></dot-container-permissions>
+                </ng-template>
             </p-tabPanel>
             <p-tabPanel *ngIf="containerId" [header]="'message.containers.tab.history' | dm">
-                <dot-container-history [containerId]="containerId"></dot-container-history>
+                <ng-template pTemplate="content">
+                    <dot-container-history [containerId]="containerId"></dot-container-history>
+                </ng-template>
             </p-tabPanel>
         </p-tabView>
     </div>


### PR DESCRIPTION
### Proposed Changes
* Add lazy loading for permissions and history tab in edit container

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
