### PR TITLE
#23245: fixing some breaking changes introduced by #23781

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/analytics/AccessTokenRenewRunnable.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/AccessTokenRenewRunnable.java
@@ -86,6 +86,7 @@ public class AccessTokenRenewRunnable implements Runnable {
 
         try {
             analyticsAPI.refreshAccessToken(analyticsApp);
+            Logger.info(this, String.format("ACCESS_TOKEN for clientId %s has been successfully renewed", clientId));
         } catch (AnalyticsException e) {
             Logger.error(this, String.format("Could not renew token for clientId %s", clientId), e);
             if (e instanceof UnrecoverableAnalyticsException) {

--- a/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
@@ -173,13 +173,23 @@ public class AnalyticsHelper {
     public static void checkAccessToken(final AccessToken accessToken) throws AnalyticsException {
         final TokenStatus tokenStatus = resolveTokenStatus(accessToken);
 
-        if (tokenStatus != TokenStatus.OK) {
+        if (!canUseToken(tokenStatus)) {
             throw new AnalyticsException(
                 String.format(
                     "ACCESS_TOKEN for clientId %s is %s",
                     accessToken.clientId(),
                     tokenStatus.name()));
         }
+    }
+
+    /**
+     * Evaluates if provided {@link TokenStatus} is {@link TokenStatus#OK} or {@link TokenStatus#IN_WINDOW}
+     *
+     * @param tokenStatus token status
+     * @return true if it has a {@link TokenStatus#OK} or {@link TokenStatus#IN_WINDOW}
+     */
+    private static boolean canUseToken(final TokenStatus tokenStatus) {
+        return tokenStatus == TokenStatus.OK || tokenStatus == TokenStatus.IN_WINDOW;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/analytics/listener/AnalyticsAppListener.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/listener/AnalyticsAppListener.java
@@ -96,7 +96,7 @@ public final class AnalyticsAppListener implements EventSubscriber<AppSecretSave
                         } catch (AnalyticsException e) {
                             Logger.error(
                                 this,
-                                String.format("Cannot process event %s due to: %s", event, e.getMessage()), e);
+                                String.format("Cannot process event for app update due to: %s", e.getMessage()), e);
                         }
                     });
             });


### PR DESCRIPTION
Changing to the correct time window for the JWT to expire.
Reversing a incorrect evaluation that will always show as the token was expired.
Adding a log message when the token gets renewed.
Fixing typo and removing printing of the access token response, which included the actual token.