### PR TITLE
dotCMS/core#23837 Delete from SessionStorage the Key variantName

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -8,7 +8,7 @@ import { Component, DebugElement, ElementRef, EventEmitter, Input, Output } from
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ConfirmationService } from 'primeng/api';
@@ -188,6 +188,7 @@ describe('DotEditContentComponent', () => {
     let dotLicenseService: DotLicenseService;
     let dotEventsService: DotEventsService;
     let dotSessionStorageService: DotSessionStorageService;
+    let router: Router;
 
     function detectChangesForIframeRender(fix) {
         fix.detectChanges();
@@ -340,6 +341,7 @@ describe('DotEditContentComponent', () => {
         dotLicenseService = de.injector.get(DotLicenseService);
         dotEventsService = de.injector.get(DotEventsService);
         dotSessionStorageService = de.injector.get(DotSessionStorageService);
+        router = de.injector.get(Router);
         spyOn(dotPageStateService, 'reload');
 
         spyOn(dotEditContentHtmlService, 'renderAddedForm').and.returnValue(
@@ -1489,5 +1491,12 @@ describe('DotEditContentComponent', () => {
         spyOn(dotSessionStorageService, 'removeVariantId');
         component.ngOnDestroy();
         expect(dotSessionStorageService.removeVariantId).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep variant key from session storage if going to layout portlet', () => {
+        router.routerState.snapshot.url = '/edit-page/layout';
+        spyOn(dotSessionStorageService, 'removeVariantId');
+        component.ngOnDestroy();
+        expect(dotSessionStorageService.removeVariantId).toHaveBeenCalledTimes(0);
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -186,7 +186,10 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy(): void {
-        this.dotSessionStorageService.removeVariantId();
+        if (!this.router.routerState.snapshot.url.startsWith('/edit-page/layout')) {
+            this.dotSessionStorageService.removeVariantId();
+        }
+
         this.destroy$.next(true);
         this.destroy$.complete();
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/layout/dot-edit-layout/dot-edit-layout.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/layout/dot-edit-layout/dot-edit-layout.component.ts
@@ -2,7 +2,7 @@ import { Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, HostBinding, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { debounceTime, filter, finalize, pluck, switchMap, take, takeUntil } from 'rxjs/operators';
 
@@ -11,7 +11,11 @@ import { DotEditLayoutService } from '@dotcms/app/api/services/dot-edit-layout/d
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
 import { DotTemplateContainersCacheService } from '@dotcms/app/api/services/dot-template-containers-cache/dot-template-containers-cache.service';
-import { DotMessageService, DotPageLayoutService } from '@dotcms/data-access';
+import {
+    DotMessageService,
+    DotPageLayoutService,
+    DotSessionStorageService
+} from '@dotcms/data-access';
 import { ResponseView } from '@dotcms/dotcms-js';
 import {
     DotContainer,
@@ -43,7 +47,9 @@ export class DotEditLayoutComponent implements OnInit, OnDestroy {
         private dotEditLayoutService: DotEditLayoutService,
         private dotPageLayoutService: DotPageLayoutService,
         private dotMessageService: DotMessageService,
-        private templateContainersCacheService: DotTemplateContainersCacheService
+        private templateContainersCacheService: DotTemplateContainersCacheService,
+        private dotSessionStorageService: DotSessionStorageService,
+        private router: Router
     ) {}
 
     ngOnInit() {
@@ -64,6 +70,10 @@ export class DotEditLayoutComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
+        if (!this.router.routerState.snapshot.url.startsWith('/edit-page/content')) {
+            this.dotSessionStorageService.removeVariantId();
+        }
+
         this.destroy$.next(true);
         this.destroy$.complete();
     }


### PR DESCRIPTION
### Proposed Changes
* VarianName should persist between `layout` and `edit` screens. 