### PR TITLE
dotCMS/core#22901 Allow users to edit the fields labels in the system fields for any content type

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.spec.ts
@@ -84,7 +84,7 @@ class TestFieldPropertiesService {
     }
 }
 
-xdescribe('ContentTypeFieldsPropertiesFormComponent', () => {
+fdescribe('ContentTypeFieldsPropertiesFormComponent', () => {
     let hostComp: DotHostTesterComponent;
     let hostFixture: ComponentFixture<DotHostTesterComponent>;
 
@@ -142,7 +142,6 @@ xdescribe('ContentTypeFieldsPropertiesFormComponent', () => {
             providers: [
                 UntypedFormBuilder,
                 ComponentFactoryResolver,
-                FieldPropertyService,
                 { provide: FieldPropertyService, useClass: TestFieldPropertiesService },
                 { provide: DotMessageService, useValue: messageServiceMock }
             ]
@@ -255,6 +254,32 @@ xdescribe('ContentTypeFieldsPropertiesFormComponent', () => {
 
             expect(comp.form.get('indexed')).toBe(null);
             expect(comp.form.get('required')).toBe(null);
+        });
+    });
+
+    describe('form fields', () => {
+        beforeEach(() => {
+            spyOn(mockFieldPropertyService, 'getProperties').and.returnValue([
+                'property1',
+                'searchable',
+                'unique',
+                'listed'
+            ]);
+            spyOn(mockFieldPropertyService, 'existsComponent').and.returnValue(true);
+        });
+
+        beforeEach(async () => await startHostComponent());
+
+        it('should only be disabled when isDisabledInEditMode is true', () => {
+            const formProperties = Object.keys(comp.form.controls);
+            formProperties.forEach((property) => {
+                if (
+                    comp.form.controls[property].disabled &&
+                    !mockFieldPropertyService.isDisabledInEditMode(property)
+                ) {
+                    fail();
+                }
+            });
         });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.spec.ts
@@ -84,7 +84,7 @@ class TestFieldPropertiesService {
     }
 }
 
-fdescribe('ContentTypeFieldsPropertiesFormComponent', () => {
+describe('ContentTypeFieldsPropertiesFormComponent', () => {
     let hostComp: DotHostTesterComponent;
     let hostFixture: ComponentFixture<DotHostTesterComponent>;
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.ts
@@ -146,10 +146,7 @@ export class ContentTypeFieldsPropertiesFormComponent implements OnChanges, OnIn
     }
 
     private isPropertyDisabled(property: string): boolean {
-        return (
-            this.fieldPropertyService.isDisabledInEditMode(property) ||
-            (this.formFieldData.fixed && this.fieldPropertyService.isDisabledInFixed(property))
-        );
+        return this.fieldPropertyService.isDisabledInEditMode(property);
     }
 
     private sortProperties(properties: string[]): void {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-properties.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-properties.service.spec.ts
@@ -112,11 +112,6 @@ describe('FieldPropertyService', () => {
         expect(fieldPropertiesService.isDisabledInEditMode('property')).toBeNull();
     });
 
-    it('should return if the property is editable when field is fixed', () => {
-        expect(true).toEqual(fieldPropertiesService.isDisabledInFixed('name'));
-        expect(fieldPropertiesService.isDisabledInFixed('dataType')).toBeUndefined();
-    });
-
     it('should return the right proeprties for a Field Class', () => {
         expect(['property1', 'property2', 'property3']).toEqual(
             fieldPropertiesService.getProperties('fieldClass')

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-properties.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-properties.service.ts
@@ -89,16 +89,6 @@ export class FieldPropertyService {
     }
 
     /**
-     * Return true if field is fixed and the property should be disabled when fixed is true
-     * @param boolean fixed
-     * @param string propertyName
-     * @returns boolean
-     */
-    isDisabledInFixed(propertyName: string): boolean {
-        return PROPERTY_INFO[propertyName] ? PROPERTY_INFO[propertyName].disabledInFixed : false;
-    }
-
-    /**
      * Return the properties's name for a specific field type
      * @param string fieldTypeClass Field type's class
      * @returns string[] properties's name

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-property-info.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-property-info.ts
@@ -54,8 +54,7 @@ export const PROPERTY_INFO = {
         component: NamePropertyComponent,
         defaultValue: '',
         order: 0,
-        validations: [Validators.required, noWhitespaceValidator],
-        disabledInFixed: true
+        validations: [Validators.required, noWhitespaceValidator]
     },
     regexCheck: {
         component: RegexCheckPropertyComponent,


### PR DESCRIPTION
### What we did:

We reverted the changes made in this issue: https://github.com/dotCMS/core/issues/13720 (PR: https://github.com/dotCMS/core-web/pull/584). We want to allow the user to change the System Content Types labels.


**How it works**

https://user-images.githubusercontent.com/72418962/216439298-1c57d634-1336-4835-b217-748294abf75b.mov

