### PR TITLE
#23954 Remove UnitTests from Integration test suite

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -633,12 +633,6 @@ import org.junit.runners.Suite.SuiteClasses;
         UtilMethodsITest.class,
         Task220912UpdateCorrectShowOnMenuPropertyTest.class,
         HashedLocalFileRepositoryManagerTest.class,
-        PersonaActionletTest.class,
-        SendRedirectActionletTest.class,
-        SetRequestAttributeActionletTest.class,
-        StopProcessingActionletTest.class,
-        HttpMethodConditionletTest.class,
-        PagesViewedConditionletTest.class,
         ManifestUtilTest.class,
         ZipUtilTest.class,
         Task230110MakeSomeSystemFieldsRemovableByBaseTypeTest.class


### PR DESCRIPTION
follow up additional Unit tests needing removal from the Integration test MainSuite

 PersonaActionletTest.class,
        SendRedirectActionletTest.class,
        SetRequestAttributeActionletTest.class,
        StopProcessingActionletTest.class,
        HttpMethodConditionletTest.class,
        PagesViewedConditionletTest.class,