### PR TITLE
#24092 return proper status when starting Experiments

### DIFF
--- a/dotCMS/src/curl-test/Experiments Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Experiments Resource.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "5e17ba52-ac1b-48d7-b724-b3bb46b78d11",
+		"_postman_id": "cbba7b98-cbab-4f76-a787-3eae34b58268",
 		"name": "Experiments Resource",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "1549189"
+		"_exporter_id": "4500400"
 	},
 	"item": [
 		{
@@ -4046,7 +4046,7 @@
 									"",
 									"pm.test(\"Status code should be ok 400\", function () {",
 									"    pm.response.to.have.status(400);",
-									"    pm.expect(jsonData.message).equal(\"Cannot start an already started Experiment.\");",
+									"    pm.expect(jsonData.message).equal(\"Only DRAFT experiments can be started\");",
 									"});",
 									"",
 									"",

--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/ExperimentDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/ExperimentDataGen.java
@@ -5,6 +5,7 @@ import com.dotcms.analytics.metrics.Condition;
 import com.dotcms.analytics.metrics.Metric;
 import com.dotcms.analytics.metrics.MetricType;
 import com.dotcms.cache.DotJSONCacheAddTestCase;
+import com.dotcms.experiments.model.AbstractExperiment.Status;
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.experiments.model.Experiment.Builder;
 import com.dotcms.experiments.model.Goals;
@@ -35,6 +36,8 @@ public class ExperimentDataGen  extends AbstractDataGen<Experiment> {
     private User user = APILocator.systemUser();
     private List<TargetingCondition> targetingConditions = new ArrayList<>();
     private Scheduling scheduling;
+
+    private Status status = Status.DRAFT;
 
     private Goals goal;
 
@@ -68,6 +71,11 @@ public class ExperimentDataGen  extends AbstractDataGen<Experiment> {
         return this;
     }
 
+    public ExperimentDataGen status(final Status status) {
+        this.status = status;
+        return this;
+    }
+
     @Override
     public Experiment next() {
         final String innerName = UtilMethods.isSet(name) ? name : getRandomName();
@@ -84,7 +92,8 @@ public class ExperimentDataGen  extends AbstractDataGen<Experiment> {
                 .lastModifiedBy(user.getUserId())
                 .pageId(page.getIdentifier())
                 .goals(innerGoal)
-                .trafficAllocation(trafficAllocation);
+                .trafficAllocation(trafficAllocation)
+                .status(status);
 
         return UtilMethods.isSet(scheduling) ? experimentBuilder.scheduling(scheduling).build() :
                 experimentBuilder.build();

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/web/ExperimentWebAPIImplIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/web/ExperimentWebAPIImplIT.java
@@ -290,13 +290,13 @@ public class ExperimentWebAPIImplIT {
                 .operator(LogicalOperator.AND)
                 .build();
 
-        final Experiment experiment = new ExperimentDataGen()
+        Experiment experiment = new ExperimentDataGen()
                 .trafficAllocation(100)
                 .addTargetingConditions(targetingCondition)
                 .nextPersisted();
 
         try{
-            ExperimentDataGen.start(experiment);
+            experiment = ExperimentDataGen.start(experiment);
 
             final HttpServletRequest request = mock(HttpServletRequest.class);
 
@@ -313,6 +313,7 @@ public class ExperimentWebAPIImplIT {
                 assertTrue(selectedExperiments.getIncludedExperimentIds().contains(experiment.id().get()));
                 assertTrue(selectedExperiments.getExcludedExperimentIds().isEmpty());
             }
+
         } finally {
             ExperimentDataGen.end(experiment);
         }
@@ -335,7 +336,7 @@ public class ExperimentWebAPIImplIT {
                 .operator(LogicalOperator.AND)
                 .build();
 
-        final Experiment experiment = new ExperimentDataGen()
+        Experiment experiment = new ExperimentDataGen()
                 .trafficAllocation(100)
                 .addTargetingConditions(targetingCondition)
                 .nextPersisted();
@@ -343,7 +344,7 @@ public class ExperimentWebAPIImplIT {
         final HTMLPageAsset htmlPageAsset = getExperimentPage(experiment);
 
         try{
-            ExperimentDataGen.start(experiment);
+            experiment = ExperimentDataGen.start(experiment);
 
             final HttpServletRequest request = mock(HttpServletRequest.class);
             when(request.getAttribute("testing-attribute")).thenReturn("testing");
@@ -383,13 +384,13 @@ public class ExperimentWebAPIImplIT {
                 .operator(LogicalOperator.AND)
                 .build();
 
-        final Experiment experiment_1 = new ExperimentDataGen()
+        Experiment experiment_1 = new ExperimentDataGen()
                 .trafficAllocation(100)
                 .addTargetingConditions(targetingCondition)
                 .nextPersisted();
 
 
-        final Experiment experiment_2 = new ExperimentDataGen()
+        Experiment experiment_2 = new ExperimentDataGen()
                 .trafficAllocation(100)
                 .addTargetingConditions(targetingCondition)
                 .nextPersisted();
@@ -398,8 +399,8 @@ public class ExperimentWebAPIImplIT {
         final HTMLPageAsset htmlPageAsset_2 = getExperimentPage(experiment_2);
 
         try{
-            ExperimentDataGen.start(experiment_1);
-            ExperimentDataGen.start(experiment_2);
+            experiment_1 = ExperimentDataGen.start(experiment_1);
+            experiment_2 = ExperimentDataGen.start(experiment_2);
 
             final HttpServletRequest request = mock(HttpServletRequest.class);
             when(request.getAttribute("testing-attribute")).thenReturn("testing");
@@ -425,6 +426,7 @@ public class ExperimentWebAPIImplIT {
                 assertTrue(selectedExperiments.getIncludedExperimentIds().contains(experiment_2.id().get()));
                 assertTrue(selectedExperiments.getExcludedExperimentIds().isEmpty());
             }
+
         } finally {
             ExperimentDataGen.end(experiment_1);
             ExperimentDataGen.end(experiment_2);

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
@@ -83,6 +83,17 @@ public interface ExperimentsAPI {
             throws DotDataException, DotSecurityException;
 
     /**
+     * Starts the SCHEDULED Experiment with the given id
+     * @param experimentId the id
+     * @param user the user
+     * @return
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    Experiment startScheduled(String experimentId, User user)
+            throws DotDataException, DotSecurityException;
+
+    /**
      * Ends an already started {@link Experiment}. The Experiment needs to be in
      * {@link Status#RUNNING} status to be able to end it.
      */
@@ -95,6 +106,11 @@ public interface ExperimentsAPI {
     Experiment addVariant(String experimentId, String variantName, User user)
             throws DotDataException, DotSecurityException;
 
+    /**
+     * Only starts Experiments in the SCHEDULED status whose startDate is in the past 
+     * @param user
+     * @throws DotDataException
+     */
     void startScheduledToStartExperiments(User user) throws DotDataException;
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -194,12 +194,8 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
                     ORIGINAL_VARIANT, user));
         }
 
-        if(savedExperiment.get().scheduling().isEmpty()) {
-            final Scheduling scheduling = startNowScheduling(savedExperiment.get());
-            savedExperiment = Optional.of(savedExperiment.get().withScheduling(scheduling));
-        } else if(experiment.status()!=ENDED) {
-            Scheduling scheduling = validateScheduling(savedExperiment.get().scheduling().get());
-            savedExperiment = Optional.of(savedExperiment.get().withScheduling(scheduling));
+        if(!savedExperiment.get().scheduling().isEmpty()) {
+            validateScheduling(savedExperiment.get().scheduling().get());
         }
 
         return savedExperiment.get();

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -3,6 +3,7 @@ package com.dotcms.experiments.business;
 import static com.dotcms.experiments.model.AbstractExperiment.Status.DRAFT;
 import static com.dotcms.experiments.model.AbstractExperiment.Status.ENDED;
 import static com.dotcms.experiments.model.AbstractExperiment.Status.RUNNING;
+import static com.dotcms.experiments.model.AbstractExperiment.Status.SCHEDULED;
 import static com.dotcms.experiments.model.AbstractExperimentVariant.EXPERIMENT_VARIANT_NAME_PREFIX;
 import static com.dotcms.experiments.model.AbstractExperimentVariant.EXPERIMENT_VARIANT_NAME_SUFFIX;
 
@@ -31,8 +32,6 @@ import com.dotcms.experiments.business.result.Event;
 import com.dotcms.experiments.business.result.ExperimentAnalyzerUtil;
 import com.dotcms.experiments.business.result.ExperimentResults;
 import com.dotcms.experiments.business.result.ExperimentResultsQueryFactory;
-import com.dotcms.experiments.business.result.ExperimentResult;
-import com.dotcms.experiments.business.result.ExperimentResultQueryFactory;
 import com.dotcms.exception.NotAllowedException;
 import com.dotcms.experiments.model.AbstractExperiment.Status;
 import com.dotcms.experiments.model.AbstractTrafficProportion.Type;
@@ -445,7 +444,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
                         + "Experiment Id: " + persistedExperiment.id());
 
         DotPreconditions.isTrue(persistedExperiment.status()!=Status.RUNNING ||
-                        persistedExperiment.status() == Status.SCHEDULED,()-> "Cannot start an already started Experiment.",
+                        persistedExperiment.status() != Status.SCHEDULED,()-> "Cannot start an already started Experiment.",
                 DotStateException.class);
 
         DotPreconditions.isTrue(persistedExperiment.status()== DRAFT
@@ -458,24 +457,46 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
         DotPreconditions.checkState(persistedExperiment.goals().isPresent(), "The Experiment needs to "
                 + "have the Goal set.");
 
-        final Experiment experimentToStart;
+        Experiment toReturn;
 
         if(persistedExperiment.scheduling().isEmpty()) {
             final Scheduling scheduling = startNowScheduling(persistedExperiment);
-            experimentToStart = persistedExperiment.withScheduling(scheduling);
+            toReturn = save(persistedExperiment.withScheduling(scheduling).withStatus(RUNNING), user);
+            publishContentOnExperimentVariants(user, toReturn);
         } else {
             Scheduling scheduling = validateScheduling(persistedExperiment.scheduling().get());
-            experimentToStart = persistedExperiment.withScheduling(scheduling);
+            toReturn = save(persistedExperiment.withScheduling(scheduling).withStatus(SCHEDULED)
+                    ,user);
         }
 
-        Experiment running = experimentToStart.withStatus(Status.RUNNING);
-        running = save(running, user);
+        return toReturn;
+    }
 
+    @Override
+    public Experiment startScheduled(String experimentId, User user)
+            throws DotDataException, DotSecurityException {
+        DotPreconditions.isTrue(hasValidLicense(), InvalidLicenseException.class,
+                invalidLicenseMessageSupplier);
+        DotPreconditions.checkArgument(UtilMethods.isSet(experimentId), "experiment Id must be provided.");
+
+        final Experiment persistedExperiment =  find(experimentId, user).orElseThrow(
+                ()-> new IllegalArgumentException("Experiment with provided id not found")
+        );
+
+        validatePermissions(user, persistedExperiment,
+                "You don't have permission to start the Experiment. "
+                        + "Experiment Id: " + persistedExperiment.id());
+
+        DotPreconditions.isTrue(persistedExperiment.status() == Status.SCHEDULED,()-> "Cannot start an already started Experiment.",
+                DotStateException.class);
+
+        Experiment running = save(persistedExperiment.withStatus(RUNNING), user);
         publishContentOnExperimentVariants(user, running);
 
         return running;
-
     }
+
+
     private void publishContentOnExperimentVariants(final User user,
             final Experiment runningExperiment)
             throws DotDataException, DotSecurityException {
@@ -866,12 +887,12 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
     @Override
     public void startScheduledToStartExperiments(final User user) throws DotDataException {
         final List<Experiment> scheduledToStartExperiments = list(ExperimentFilter.builder()
-                .statuses(CollectionsUtils.set(DRAFT)).build(), user).stream()
+                .statuses(CollectionsUtils.set(SCHEDULED)).build(), user).stream()
                 .filter((experiment -> experiment.scheduling().isPresent() && experiment.scheduling().get().startDate().orElseThrow()
                         .isAfter(Instant.now()))).collect(Collectors.toList());
 
         scheduledToStartExperiments.forEach((experiment ->
-                Try.of(()->start(experiment.id().orElseThrow(), user)).getOrElseThrow((e)->
+                Try.of(()->startScheduled(experiment.id().orElseThrow(), user)).getOrElseThrow((e)->
                         new DotStateException("Unable to start Experiment. Cause:" + e))));
     }
     


### PR DESCRIPTION
Changes included: 
* After starting an Experiment with an Scheduling, the status of the Experiment will become SCHEDULED
* Updated Integration
* Updated postman