### PR TITLE
#23833 only fetch contentlet in default variant

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
@@ -974,6 +974,7 @@ public class ContentletAjax {
 		lastSearchMap.put("orderBy", orderBy);
 
 		luceneQuery.append(" +working:true");
+		luceneQuery.append(" +variant:default");
         final String luceneQueryToShow= luceneQuery.toString().replaceAll("\\s+", " ");
 
 		//Executing the query


### PR DESCRIPTION
Include a filter for bringing only contentlet in default variant in the lucene query.