### PR TITLE
#24146 Fix Integration test runs and crossover between tests

### DIFF
--- a/cicd/resources/log4j2.xml
+++ b/cicd/resources/log4j2.xml
@@ -10,22 +10,22 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS}  %-5level %logger{2} - %msg%n" />
         </Console>
-       <Async name="generic">
+        <Async name="generic">
             <AppenderRef ref="GENERIC-FILE"/>
         </Async>
-        
+
         <!--  Generic Logging File -->
         <RollingFile name="GENERIC-FILE"
-                     fileName="${DOTCMS_LOG_FILE}"
-                     filePattern="${DOTCMS_FILENAME_PATTERN}"
-                     immediateFlush="false">
+            fileName="${DOTCMS_LOG_FILE}"
+            filePattern="${DOTCMS_FILENAME_PATTERN}"
+            immediateFlush="false">
             <PatternLayout pattern="${MESSAGE_PATTERN}"/>
             <Policies>
-                <SizeBasedTriggeringPolicy size="20MB"/>
+                <SizeBasedTriggeringPolicy size="90MB"/>
             </Policies>
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
-        
+
     </Appenders>
     <Loggers>
         <Root level="info">

--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -410,6 +410,9 @@ dependencies {
     testImplementation group: 'com.google.guava', name: 'guava', version: '19.0'
     testImplementation group: 'org.apache.tomcat', name: 'tomcat-jdbc', version: '9.0.41'
 
+    testImplementation group: 'org.awaitility', name: 'awaitility', version: '3.0.0'
+    testImplementation group: 'org.awaitility', name: 'awaitility-proxy', version: '3.0.0'
+
     /**
      * Order matters here: OSGI-Core must come after felix.
      */

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
@@ -903,7 +903,7 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
 
     }
 
-    public void waitForEmptyQueue() {
+    private void waitForEmptyQueue() {
         final ReindexQueueAPI reindexQueueAPI = APILocator.getReindexQueueAPI();
         Awaitility.await().atMost(600, TimeUnit.SECONDS)
                 .pollInterval(5, TimeUnit.SECONDS)
@@ -911,7 +911,7 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
                 .until(reindexQueueAPI::areRecordsLeftToIndex, equalTo(false));
     }
 
-    public List<ContentletSearch> pollSearchIndex(int expectedCount, String identifier, String id,
+    private List<ContentletSearch> pollSearchIndex(int expectedCount, String identifier, String id,
             boolean live, int limit, int offset, String sortBy, User user) {
         return Awaitility.await().atMost(10, TimeUnit.SECONDS)
                 .until(() -> {
@@ -920,7 +920,7 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
                 }, hasSize(expectedCount));
     }
 
-    public List<ContentletSearch> searchIndex(String identifier, String id, boolean live, int limit,
+    private List<ContentletSearch> searchIndex(String identifier, String id, boolean live, int limit,
             int offset, String sortBy, User user) throws DotDataException, DotSecurityException {
         StringBuilder luceneQuery = new StringBuilder();
         if (identifier != null) {

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
@@ -1,22 +1,10 @@
 package com.dotcms.content.elasticsearch.business;
 
-import static com.dotcms.content.elasticsearch.business.ESIndexAPI.INDEX_OPERATIONS_TIMEOUT_IN_MS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.FieldAPI;
-import com.dotcms.contenttype.model.field.DataTypes;
-import com.dotcms.contenttype.model.field.DateTimeField;
-import com.dotcms.contenttype.model.field.Field;
-import com.dotcms.contenttype.model.field.FieldBuilder;
-import com.dotcms.contenttype.model.field.ImmutableTextField;
-import com.dotcms.contenttype.model.field.TextField;
-import com.dotcms.contenttype.model.field.WysiwygField;
+import com.dotcms.contenttype.model.field.*;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ContentTypeBuilder;
@@ -34,11 +22,12 @@ import com.dotmarketing.beans.MultiTree;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.PermissionAPI;
-import com.dotmarketing.business.RelationshipAPI;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.model.ContentletSearch;
 import com.dotmarketing.common.reindex.ReindexEntry;
+import com.dotmarketing.common.reindex.ReindexQueueAPI;
 import com.dotmarketing.common.reindex.ReindexThread;
+import com.dotmarketing.db.LocalTransaction;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.containers.model.Container;
@@ -56,21 +45,15 @@ import com.dotmarketing.portlets.structure.factories.StructureFactory;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.sitesearch.business.SiteSearchAPI;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.ThreadUtils;
 import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.UtilMethods;
-import com.google.common.collect.ImmutableList;
 import com.liferay.portal.model.User;
 import com.rainerhahnekamp.sneakythrow.Sneaky;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -81,15 +64,26 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.jetbrains.annotations.Nullable;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.dotcms.content.elasticsearch.business.ESIndexAPI.INDEX_OPERATIONS_TIMEOUT_IN_MS;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
 /**
- * @author Jonathan Gamba
- *         Date: 4/18/13
+ * @author Jonathan Gamba Date: 4/18/13
  */
 public class ContentletIndexAPIImplTest extends IntegrationTestBase {
 
+    public static final String TEST_TITLE = "testTitle";
+    public static final String ID_QUERY = "+id:%s";
+    public static final String MOD_DATA_SORT = "modDate";
     private static String stemmerText;
     private static User user;
     private static Host defaultHost;
@@ -98,34 +92,35 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
 
     private static ContentletAPI contentletAPI;
     private static ContentletIndexAPI indexAPI;
+
+    private static ESIndexAPI esIndexAPI;
     private static ContentTypeAPI contentTypeAPI;
-    private static ESMappingAPIImpl esMappingAPI;
+
     private static FieldAPI fieldAPI;
     private static HostAPI hostAPI;
     private static LanguageAPI languageAPI;
-    private static RelationshipAPI relationshipAPI;
 
 
     @BeforeClass
-    public static void prepare () throws Exception {
-    	//Setting web app environment
+    public static void prepare() throws Exception {
+        //Setting web app environment
         IntegrationTestInitService.getInstance().init();
 
         hostAPI = APILocator.getHostAPI();
         languageAPI = APILocator.getLanguageAPI();
-        fieldAPI  = APILocator.getContentTypeFieldAPI();
+        fieldAPI = APILocator.getContentTypeFieldAPI();
 
         //Setting the test user
         user = APILocator.getUserAPI().getSystemUser();
-        defaultHost = hostAPI.findDefaultHost( user, false );
-      
+        defaultHost = hostAPI.findDefaultHost(user, false);
+
         //Getting the default language
         defaultLanguage = languageAPI.getDefaultLanguage();
 
         contentletAPI = APILocator.getContentletAPI();
-        esMappingAPI = new ESMappingAPIImpl();
         indexAPI = APILocator.getContentletIndexAPI();
-        relationshipAPI = APILocator.getRelationshipAPI();
+        esIndexAPI = APILocator.getESIndexAPI();
+
         contentTypeAPI = APILocator.getContentTypeAPI(user);
 
         /*
@@ -147,7 +142,7 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
     }
 
     @Test
-    public void test_indexContentList_ContentTypeWithPageDetailNotExists() throws Exception{
+    public void test_indexContentList_ContentTypeWithPageDetailNotExists() throws Exception {
         long time = System.currentTimeMillis();
         ContentType type = null;
         try {
@@ -162,14 +157,14 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
             type = contentTypeAPI.save(type);
 
             final Field titleField =
-                    FieldBuilder.builder(TextField.class).name("testTitle").variable("testTitle")
+                    FieldBuilder.builder(TextField.class).name(TEST_TITLE).variable(TEST_TITLE)
                             .unique(true)
                             .contentTypeId(type.id()).dataType(
-                            DataTypes.TEXT).build();
+                                    DataTypes.TEXT).build();
             fieldAPI.save(titleField, user);
 
             final Contentlet contentlet = new ContentletDataGen(type.id())
-                    .setProperty("testTitle", "TestContent").nextPersisted();
+                    .setProperty(TEST_TITLE, "TestContent").nextPersisted();
 
             final List<Contentlet> contentlets = new ArrayList<>();
             contentlets.add(contentlet);
@@ -178,21 +173,21 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
 
             assertTrue(contentletAPI
                     .indexCount("+identifier:" + contentlet.getIdentifier(), user, false) > 0);
-        }finally {
-            if(type!=null){
+        } finally {
+            if (type != null) {
                 contentTypeAPI.delete(type);
             }
         }
 
     }
 
-    private void generateTestContentlets(final int count) throws Exception {
+    private void generateTestContentlets() throws Exception {
         final long languageId = languageAPI.getDefaultLanguage().getId();
 
         final ContentType webPageContentContentType = contentTypeAPI.find("webPageContent");
         final Host host = hostAPI.findDefaultHost(user, false);
 
-        for (int i = 0; i <= count; i++) {
+        for (int i = 0; i <= 50; i++) {
             new ContentletDataGen(
                     webPageContentContentType.id())
                     .languageId(languageId)
@@ -204,19 +199,20 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
     }
 
     @Test
-    public void test_indexContentList_with_diff_refresh_strategies () throws Exception {
+    public void test_indexContentList_with_diff_refresh_strategies() throws Exception {
 
-        generateTestContentlets(50);
+        generateTestContentlets();
 
-        final List<Contentlet>   contentlets = contentletAPI.findAllContent(0, 100)
+        final List<Contentlet> contentlets = contentletAPI.findAllContent(0, 100)
                 .stream().filter(Objects::nonNull).collect(Collectors.toList());
 
         assertNotNull(contentlets);
-        assertTrue("The number of contentlet returned is: " + contentlets.size(),contentlets.size() >= 50);
+        assertTrue("The number of contentlet returned is: " + contentlets.size(),
+                contentlets.size() >= 50);
 
-        final List<Contentlet>   contentletsDefaultRefresh    = contentlets.subList(0, 15);
-        final List<Contentlet>   contentletsImmediateRefresh  = contentlets.subList(15, 30);
-        final List<Contentlet>   contentletsWaitForRefresh    = contentlets.subList(30, 50);
+        final List<Contentlet> contentletsDefaultRefresh = contentlets.subList(0, 15);
+        final List<Contentlet> contentletsImmediateRefresh = contentlets.subList(15, 30);
+        final List<Contentlet> contentletsWaitForRefresh = contentlets.subList(30, 50);
 
         assertNotNull(contentletsDefaultRefresh);
         assertTrue(contentletsDefaultRefresh.size() > 0);
@@ -227,144 +223,161 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
         assertNotNull(contentletsWaitForRefresh);
         assertTrue(contentletsWaitForRefresh.size() > 0);
 
-        contentletsImmediateRefresh.stream().forEach(contentlet -> contentlet.setIndexPolicy(IndexPolicy.FORCE));
-        contentletsWaitForRefresh.stream().forEach(contentlet -> contentlet.setIndexPolicy(IndexPolicy.WAIT_FOR));
-
+        contentletsImmediateRefresh.forEach(
+                contentlet -> contentlet.setIndexPolicy(IndexPolicy.FORCE));
+        contentletsWaitForRefresh.forEach(
+                contentlet -> contentlet.setIndexPolicy(IndexPolicy.WAIT_FOR));
 
         indexAPI.addContentToIndex(contentlets);
 
         for (final Contentlet contentlet : contentletsDefaultRefresh) {
 
             if (null != contentlet.getInode()) {
-                final boolean exists = contentletAPI.indexCount("+identifier:" + contentlet.getIdentifier(), user, false) > 0;
-                System.out.println(contentlet.getIdentifier() + " with default strategy was indexed: " + exists);
+                final boolean exists =
+                        contentletAPI.indexCount("+identifier:" + contentlet.getIdentifier(), user,
+                                false) > 0;
+                Logger.info(ContentletIndexAPIImpl.class,
+                        contentlet.getIdentifier() + " with default strategy was indexed: "
+                                + exists);
             }
         }
 
         for (final Contentlet contentlet : contentletsImmediateRefresh) {
 
             if (null != contentlet.getInode()) {
-                final boolean exists = contentletAPI.indexCount("+identifier:" + contentlet.getIdentifier(), user, false) > 0;
-                System.out.println(contentlet.getIdentifier() + " with immediate strategy was indexed: " + exists);
-                assertTrue(contentlet.getIdentifier() + " with immediate strategy was indexed: " + exists, exists);
+                final boolean exists =
+                        contentletAPI.indexCount("+identifier:" + contentlet.getIdentifier(), user,
+                                false) > 0;
+                Logger.info(ContentletIndexAPIImpl.class,
+                        contentlet.getIdentifier() + " with immediate strategy was indexed: "
+                                + exists);
+                assertTrue(contentlet.getIdentifier() + " with immediate strategy was indexed: "
+                        + exists, exists);
             }
         }
 
         for (final Contentlet contentlet : contentletsWaitForRefresh) {
 
             if (null != contentlet.getInode()) {
-                final boolean exists = contentletAPI.indexCount("+identifier:" + contentlet.getIdentifier(), user, false) > 0;
-                System.out.println(contentlet.getIdentifier() + " with wait for strategy was indexed: " + exists);
-                assertTrue(contentlet.getIdentifier() + " with wait for strategy was indexed: " + exists, exists);
+                final boolean exists =
+                        contentletAPI.indexCount("+identifier:" + contentlet.getIdentifier(), user,
+                                false) > 0;
+                Logger.info(ContentletIndexAPIImpl.class,
+                        contentlet.getIdentifier() + " with wait for strategy was indexed: "
+                                + exists);
+                assertTrue(contentlet.getIdentifier() + " with wait for strategy was indexed: "
+                        + exists, exists);
             }
         }
     }
 
 
     /**
-     * Testing the {@link ContentletIndexAPI#createContentIndex(String)}, {@link ContentletIndexAPI#delete(String)} and
-     * {@link ContentletIndexAPI#listDotCMSIndices()} methods
+     * Testing the {@link ContentletIndexAPI#createContentIndex(String)},
+     * {@link ContentletIndexAPI#delete(String)} and {@link ContentletIndexAPI#listDotCMSIndices()}
+     * methods
      *
      * @throws Exception
      * @see ContentletIndexAPI
      * @see ContentletIndexAPIImpl
      */
     @Test
-    public void createContentIndexAndDelete () throws Exception {
+    public void createContentIndexAndDelete() throws Exception {
 
         //Build the index names
-        String timeStamp = String.valueOf( new Date().getTime() );
+        String timeStamp = String.valueOf(new Date().getTime());
         String workingIndex = IndexType.WORKING.getPrefix() + "_" + timeStamp;
         String liveIndex = IndexType.LIVE.getPrefix() + "_" + timeStamp;
 
         //Get all the indices
         List<String> indices = indexAPI.listDotCMSIndices();
         //Validate
-        assertNotNull( indices );
-        assertTrue( !indices.isEmpty() );
+        assertNotNull(indices);
+        assertFalse(indices.isEmpty());
         int oldIndices = indices.size();
 
         //Creates the working index
-        Boolean result = indexAPI.createContentIndex( workingIndex );
+        boolean result = indexAPI.createContentIndex(workingIndex);
         //Validate
-        assertTrue( result );
+        assertTrue(result);
 
         //Creates the live index
-        result = indexAPI.createContentIndex( liveIndex );
+        result = indexAPI.createContentIndex(liveIndex);
         //Validate
-        assertTrue( result );
+        assertTrue(result);
 
         //***************************************************
         //Get all the indices
         indices = indexAPI.listDotCMSIndices();
         //Validate
-        assertNotNull( indices );
-        assertTrue( !indices.isEmpty() );
+        assertNotNull(indices);
+        assertFalse(indices.isEmpty());
         int newIndices = indices.size();
 
         //Search for the just saved indices
-        Boolean foundWorking = false;
-        Boolean foundLive = false;
-        for ( String index : indices ) {
-            if ( index.equals( liveIndex ) ) {
+        boolean foundWorking = false;
+        boolean foundLive = false;
+        for (String index : indices) {
+            if (index.equals(liveIndex)) {
                 foundLive = true;
-            } else if ( index.equals( workingIndex ) ) {
+            } else if (index.equals(workingIndex)) {
                 foundWorking = true;
             }
         }
         //Validate
-        assertTrue( foundWorking );
-        assertTrue( foundLive );
+        assertTrue(foundWorking);
+        assertTrue(foundLive);
 
         //Verify we just added two more indices
-        assertEquals( oldIndices + 2, newIndices );
+        assertEquals((long) oldIndices + 2, newIndices);
 
         //***************************************************
         //Now lets delete the created indices
-        Boolean deleted = indexAPI.delete( workingIndex );
-        assertTrue( deleted );
-        deleted = indexAPI.delete( liveIndex );
-        assertTrue( deleted );
+        boolean deleted = indexAPI.delete(workingIndex);
+        assertTrue(deleted);
+        deleted = indexAPI.delete(liveIndex);
+        assertTrue(deleted);
 
         //***************************************************
         //Get all the indices again....
         indices = indexAPI.listDotCMSIndices();
         //Validate
-        assertNotNull( indices );
-        assertTrue( !indices.isEmpty() );
+        assertNotNull(indices);
+        assertFalse(indices.isEmpty());
         newIndices = indices.size();
 
         //Verify if we still find the deleted indices
         foundWorking = false;
         foundLive = false;
-        for ( String index : indices ) {
-            if ( index.equals( liveIndex ) ) {
+        for (String index : indices) {
+            if (index.equals(liveIndex)) {
                 foundLive = true;
-            } else if ( index.equals( workingIndex ) ) {
+            } else if (index.equals(workingIndex)) {
                 foundWorking = true;
             }
         }
         //Validate
-        assertFalse( foundWorking );
-        assertFalse( foundLive );
+        assertFalse(foundWorking);
+        assertFalse(foundLive);
 
         //Verify we just added two more indices
-        assertEquals( oldIndices, newIndices );
+        assertEquals(oldIndices, newIndices);
     }
 
     /**
-     * Testing the {@link ContentletIndexAPI#activateIndex(String)}, {@link ContentletIndexAPI#deactivateIndex(String)}
-     * and {@link ContentletIndexAPI#getCurrentIndex()} methods
+     * Testing the {@link ContentletIndexAPI#activateIndex(String)},
+     * {@link ContentletIndexAPI#deactivateIndex(String)} and
+     * {@link ContentletIndexAPI#getCurrentIndex()} methods
      *
      * @throws Exception
      * @see ContentletIndexAPI
      * @see ContentletIndexAPIImpl
      */
     @Test
-    public void activateDeactivateIndex () throws Exception {
+    public void activateDeactivateIndex() throws Exception {
 
         //Build the index names
-        String timeStamp = String.valueOf( new Date().getTime() );
+        String timeStamp = String.valueOf(new Date().getTime());
         String workingIndex = IndexType.WORKING.getPrefix() + "_" + timeStamp;
         String liveIndex = IndexType.LIVE.getPrefix() + "_" + timeStamp;
 
@@ -372,31 +385,31 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
         String oldActiveWorking = indexAPI.getActiveIndexName(IndexType.WORKING.getPrefix());
 
         //Creates the working index
-        Boolean result = indexAPI.createContentIndex( workingIndex );
-        assertTrue( result );
+        boolean result = indexAPI.createContentIndex(workingIndex);
+        assertTrue(result);
         //Activate this working index
-        indexAPI.activateIndex( workingIndex );
+        indexAPI.activateIndex(workingIndex);
 
         //Creates the live index
-        result = indexAPI.createContentIndex( liveIndex );
-        assertTrue( result );
+        result = indexAPI.createContentIndex(liveIndex);
+        assertTrue(result);
         //Activate this live index
-        indexAPI.activateIndex( liveIndex );
+        indexAPI.activateIndex(liveIndex);
 
         //***************************************************
         //Get the current indices
-        String liveActiveIndex = indexAPI.getActiveIndexName( IndexType.LIVE.getPrefix() );
+        String liveActiveIndex = indexAPI.getActiveIndexName(IndexType.LIVE.getPrefix());
 
         //Validate
-        assertNotNull( liveActiveIndex );
-        assertEquals( liveActiveIndex, liveIndex );
+        assertNotNull(liveActiveIndex);
+        assertEquals(liveActiveIndex, liveIndex);
 
         //***************************************************
         //Now lets deactivate the indices
         //Deactivate this working index
-        indexAPI.deactivateIndex( workingIndex );
+        indexAPI.deactivateIndex(workingIndex);
         //Deactivate this live index
-        indexAPI.deactivateIndex( liveIndex );
+        indexAPI.deactivateIndex(liveIndex);
 
         // restore old active index
         indexAPI.activateIndex(oldActiveWorking);
@@ -406,25 +419,24 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
     /**
      * Testing {@link ContentletIndexAPI#isDotCMSIndexName(String)}
      *
-     * @throws Exception
      * @see ContentletIndexAPI
      * @see ContentletIndexAPIImpl
      */
     @Test
-    public void isDotCMSIndexName () throws Exception {
+    public void isDotCMSIndexName() {
 
         //Build the index names
-        String timeStamp = String.valueOf( new Date().getTime() );
+        String timeStamp = String.valueOf(new Date().getTime());
         String workingIndex = IndexType.WORKING.getPrefix() + "_" + timeStamp;
 
         //Verify with a proper name
-        boolean isIndexName = indexAPI.isDotCMSIndexName( workingIndex );
-        assertTrue( isIndexName );
+        boolean isIndexName = indexAPI.isDotCMSIndexName(workingIndex);
+        assertTrue(isIndexName);
 
         //Verify a non proper name
         workingIndex = "TEST" + "_" + timeStamp;
-        isIndexName = indexAPI.isDotCMSIndexName( workingIndex );
-        assertFalse( isIndexName );
+        isIndexName = indexAPI.isDotCMSIndexName(workingIndex);
+        assertFalse(isIndexName);
     }
 
     /**
@@ -435,35 +447,39 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @see ContentletIndexAPIImpl
      */
     @Test
-    public void optimize () throws Exception {
+    public void optimize() throws Exception {
 
         //Build the index names
-        String timeStamp = String.valueOf( new Date().getTime() );
+        String timeStamp = String.valueOf(new Date().getTime());
         String workingIndex = IndexType.WORKING.getPrefix() + "_" + timeStamp;
         String liveIndex = IndexType.LIVE.getPrefix() + "_" + timeStamp;
 
         //Creates the working index
-        Boolean result = indexAPI.createContentIndex( workingIndex );
+        boolean result = indexAPI.createContentIndex(workingIndex);
         //Validate
-        assertTrue( result );
+        assertTrue(result);
 
         //Creates the live index
-        result = indexAPI.createContentIndex( liveIndex );
+        result = indexAPI.createContentIndex(liveIndex);
         //Validate
-        assertTrue( result );
+        assertTrue(result);
 
         //Test the optimize method
-        List<String> indices = new ArrayList<String>();
-        indices.add( workingIndex );
-        indices.add( liveIndex );
-        Boolean optimized = indexAPI.optimize( indices );
+        List<String> indices = new ArrayList<>();
+        indices.add(workingIndex);
+        indices.add(liveIndex);
+        boolean optimized = indexAPI.optimize(indices);
         //Validate
-        assertTrue( optimized );
+        assertTrue(optimized);
     }
 
     /**
-     * Testing the {@link ContentletIndexAPI#addContentToIndex(com.dotmarketing.portlets.contentlet.model.Contentlet)},
-     * {@link ContentletIndexAPI#removeContentFromIndex(com.dotmarketing.portlets.contentlet.model.Contentlet)} methods
+     * Testing the
+     * {@link
+     * ContentletIndexAPI#addContentToIndex(com.dotmarketing.portlets.contentlet.model.Contentlet)},
+     * {@link
+     * ContentletIndexAPI#removeContentFromIndex(com.dotmarketing.portlets.contentlet.model.Contentlet)}
+     * methods
      *
      * @throws Exception
      * @see ContentletAPI
@@ -471,44 +487,46 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @see ContentletIndexAPIImpl
      */
     @Test
-    public void addRemoveContentToIndex () throws Exception {
+    public void addRemoveContentToIndex() throws Exception {
 
         //Creating a test structure
         Structure testStructure = loadTestStructure();
         //Creating a test contentlet
-        Contentlet testContentlet = loadTestContentlet( testStructure );
+        Contentlet testContentlet = loadTestContentlet(testStructure);
 
         try {
 
             //And add it to the index
             testContentlet.setIndexPolicy(IndexPolicy.WAIT_FOR);
-            indexAPI.addContentToIndex( testContentlet );
+            indexAPI.addContentToIndex(testContentlet);
 
             //We are just making time in order to let it apply the index
-            contentletAPI.isInodeIndexed( testContentlet.getInode(), true );
+            contentletAPI.isInodeIndexed(testContentlet.getInode(), true);
 
             //Verify if it was added to the index
-            String query = "+structureName:" + testStructure.getVelocityVarName() + " +deleted:false +live:true";
-            List<Contentlet> result = contentletAPI.search( query, 0, -1, "modDate desc", user, true );
+            String query = "+structureName:" + testStructure.getVelocityVarName()
+                    + " +deleted:false +live:true";
+            List<Contentlet> result = contentletAPI.search(query, 0, -1, "modDate desc", user,
+                    true);
 
             //Validations
-            assertNotNull( result );
-            assertTrue( !result.isEmpty() );
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
 
             //Remove the contentlet from the index
-            indexAPI.removeContentFromIndex( testContentlet );
+            indexAPI.removeContentFromIndex(testContentlet);
 
             //We are just making time in order to let it apply the index
-            wasContentRemoved( query );
+            wasContentRemoved(query);
 
             //Verify if it was removed to the index
-            result = contentletAPI.search( query, 0, -1, "modDate desc", user, true );
+            result = contentletAPI.search(query, 0, -1, "modDate desc", user, true);
 
             //Validations
-            assertTrue( result == null || result.isEmpty() );
+            assertTrue(result == null || result.isEmpty());
         } finally {
             try {
-                contentletAPI.destroy(testContentlet, user, false );
+                contentletAPI.destroy(testContentlet, user, false);
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -525,44 +543,40 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @see ContentletIndexAPIImpl
      */
     @Test
-    public void removeContentFromIndexByStructureInode () throws Exception {
+    public void removeContentFromIndexByStructureInode() throws Exception {
 
         //Creating a test structure
         Structure testStructure = loadTestStructure();
         //Creating a test contentlet
-        Contentlet testContentlet = loadTestContentlet( testStructure );
+        Contentlet testContentlet = loadTestContentlet(testStructure);
 
         try {
             //And add it to the index
             testContentlet.setIndexPolicy(IndexPolicy.FORCE);
-            indexAPI.addContentToIndex( testContentlet );
+            indexAPI.addContentToIndex(testContentlet);
 
             //Verify if it was added to the index
-            String query = "+structureName:" + testStructure.getVelocityVarName() + " +deleted:false +live:true";
-            List<Contentlet> result = contentletAPI.search( query, 0, -1, "modDate desc", user, true );
+            String query = "+structureName:" + testStructure.getVelocityVarName()
+                    + " +deleted:false +live:true";
+            List<Contentlet> result = contentletAPI.search(query, 0, -1, "modDate desc", user,
+                    true);
 
             //Validations
-            assertNotNull( result );
-            assertFalse( result.isEmpty() );
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
 
             //Remove the contentlet from the index
-            indexAPI.removeContentFromIndexByStructureInode( testStructure.getInode() );
+            indexAPI.removeContentFromIndexByStructureInode(testStructure.getInode());
 
-            int x=0;
-            do {
-                Thread.sleep(5000);
-                //Verify if it was removed to the index
-                result = contentletAPI.search( query, 0, -1, "modDate desc", user, true );
-                x++;
-            } while(!result.isEmpty() && x<100);
-
-            //Validations after removing content from index, the result must be empty
-            assertNotNull(result);
-            assertTrue(result.isEmpty());
+            Awaitility.await().atMost(500, TimeUnit.SECONDS)
+                    .pollInterval(5, TimeUnit.SECONDS)
+                    .pollDelay(1, TimeUnit.SECONDS)
+                    .until(() -> contentletAPI.search(query, 0, -1, "modDate desc", user, true),
+                            hasSize(equalTo(0)));
 
         } finally {
             try {
-                contentletAPI.destroy(testContentlet, user, false );
+                contentletAPI.destroy(testContentlet, user, false);
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -571,8 +585,11 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
     }
 
     /**
-     * Testing the {@link SiteSearchAPI#putToIndex(String, com.dotcms.enterprise.publishing.sitesearch.SiteSearchResult, String)},
-     * {@link SiteSearchAPI#search(String, String, int, int)} and {@link SiteSearchAPI#deleteFromIndex(String, String)} methods
+     * Testing the
+     * {@link SiteSearchAPI#putToIndex(String,
+     * com.dotcms.enterprise.publishing.sitesearch.SiteSearchResult, String)},
+     * {@link SiteSearchAPI#search(String, String, int, int)} and
+     * {@link SiteSearchAPI#deleteFromIndex(String, String)} methods
      *
      * @throws Exception
      * @see ContentletAPI
@@ -580,52 +597,49 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @see ContentletIndexAPIImpl
      */
     @Test
-    public void testSearch () throws Exception {
+    public void testSearch() throws Exception {
 
         SiteSearchAPI siteSearchAPI = APILocator.getSiteSearchAPI();
 
-        //*****************************************************************
-        //Verify if we already have and site search index, if not lets create one...
-        IndiciesInfo indiciesInfo = APILocator.getIndiciesAPI().loadIndicies();
-        String currentSiteSearchIndex = indiciesInfo.getSiteSearch();
-        String indexName = currentSiteSearchIndex;
-        if ( currentSiteSearchIndex == null ) {
-            indexName = SiteSearchAPI.ES_SITE_SEARCH_NAME + "_" + ContentletIndexAPIImpl.timestampFormatter.format( new Date() );
-            APILocator.getSiteSearchAPI().createSiteSearchIndex( indexName, null, 1 );
-            APILocator.getSiteSearchAPI().activateIndex( indexName );
-        }
+        String indexName = SiteSearchAPI.ES_SITE_SEARCH_NAME + "_"
+                + ContentletIndexAPIImpl.timestampFormatter.format(new Date());
+        APILocator.getSiteSearchAPI().createSiteSearchIndex(indexName, null, 1);
+        APILocator.getSiteSearchAPI().activateIndex(indexName);
 
         //*****************************************************************
         //Creating a test structure
         Structure testStructure = loadTestStructure();
         //Creating a test contentlet
-        Contentlet testContentlet = loadTestContentlet( testStructure );
+        Contentlet testContentlet = loadTestContentlet(testStructure);
         //Creating a test html page
-        HTMLPageAsset testHtmlPage = loadHtmlPage( testContentlet );
+        HTMLPageAsset testHtmlPage = loadHtmlPage(testContentlet);
 
         //*****************************************************************
         //Build a site search result in order to add it to the index
-        Optional<ContentletVersionInfo> versionInfo = APILocator.getVersionableAPI().getContentletVersionInfo(testHtmlPage.getIdentifier(), testHtmlPage.getLanguageId());
+        Optional<ContentletVersionInfo> versionInfo = APILocator.getVersionableAPI()
+                .getContentletVersionInfo(testHtmlPage.getIdentifier(),
+                        testHtmlPage.getLanguageId());
 
         assertTrue(versionInfo.isPresent());
 
         String docId = testHtmlPage.getIdentifier() + "_" + defaultLanguage.getId();
 
-        SiteSearchResult res = new SiteSearchResult( testHtmlPage.getMap() );
-        res.setLanguage( defaultLanguage.getId() );
-        res.setFileName( testHtmlPage.getFriendlyName() );
-        res.setModified( versionInfo.get().getVersionTs() );
-        res.setHost( defaultHost.getIdentifier() );
-        res.setMimeType( "text/html" );
-        res.setContentLength( 1 );//Just sending something different than 0
-        res.setContent( stemmerText );
-        res.setUri( testHtmlPage.getURI() );
-        res.setUrl( testHtmlPage.getPageUrl() );
-        res.setId( docId );
+        SiteSearchResult res = new SiteSearchResult(testHtmlPage.getMap());
+        res.setLanguage(defaultLanguage.getId());
+        res.setFileName(testHtmlPage.getFriendlyName());
+        res.setModified(versionInfo.get().getVersionTs());
+        res.setHost(defaultHost.getIdentifier());
+        res.setMimeType("text/html");
+        res.setContentLength(1);//Just sending something different than 0
+        res.setContent(stemmerText);
+        res.setUri(testHtmlPage.getURI());
+        res.setUrl(testHtmlPage.getPageUrl());
+        res.setId(docId);
 
         //Adding it to the index
-        siteSearchAPI.putToIndex( indexName, res, "HTMLPage");
-        isDocIndexed( docId );
+        siteSearchAPI.putToIndex(indexName, res, "HTMLPage");
+
+        assertTrue(isDocIndexed(indexName, docId));
 
         try {
 
@@ -645,221 +659,282 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
              */
 
             //Testing the stemer
-            SiteSearchResults siteSearchResults = siteSearchAPI.search( indexName, "argu", 0, 100 );
+            SiteSearchResults siteSearchResults = siteSearchAPI.search(indexName, "argu", 0, 100);
             //Validations
-            assertTrue( siteSearchResults.getError(), siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty() );
-            assertTrue( siteSearchResults.getTotalResults() > 0 );
-            String highLights = siteSearchResults.getResults().get( 0 ).getHighLights()[0];
-            assertTrue( highLights.contains( "<em>argue</em>" ) );
-            assertTrue( highLights.contains( "<em>argued</em>" ) );
-            assertTrue( highLights.contains( "<em>argues</em>" ) );
-            assertTrue( highLights.contains( "<em>arguing</em>" ) );
-            assertTrue( highLights.contains( "<em>argus</em>" ) );
+            assertTrue(siteSearchResults.getError(),
+                    siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty());
+            assertTrue(siteSearchResults.getTotalResults() > 0);
+            String highLights = siteSearchResults.getResults().get(0).getHighLights()[0];
+            assertTrue(highLights.contains("<em>argue</em>"));
+            assertTrue(highLights.contains("<em>argued</em>"));
+            assertTrue(highLights.contains("<em>argues</em>"));
+            assertTrue(highLights.contains("<em>arguing</em>"));
+            assertTrue(highLights.contains("<em>argus</em>"));
 
             //Testing the stemer
-            siteSearchResults = siteSearchAPI.search( indexName, "cats", 0, 100 );
+            siteSearchResults = siteSearchAPI.search(indexName, "cats", 0, 100);
             //Validations
-            assertTrue( siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty() );
-            assertTrue( siteSearchResults.getTotalResults() > 0 );
-            highLights = siteSearchResults.getResults().get( 0 ).getHighLights()[0];
-            assertTrue( highLights.contains( "<em>cat</em>" ) );
+            assertTrue(
+                    siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty());
+            assertTrue(siteSearchResults.getTotalResults() > 0);
+            highLights = siteSearchResults.getResults().get(0).getHighLights()[0];
+            assertTrue(highLights.contains("<em>cat</em>"));
 
             //Testing the stemer
-            siteSearchResults = siteSearchAPI.search( indexName, "stem", 0, 100 );
+            siteSearchResults = siteSearchAPI.search(indexName, "stem", 0, 100);
             //Validations
-            assertTrue( siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty() );
-            assertTrue( siteSearchResults.getTotalResults() > 0 );
-            highLights = siteSearchResults.getResults().get( 0 ).getHighLights()[0];
+            assertTrue(
+                    siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty());
+            assertTrue(siteSearchResults.getTotalResults() > 0);
+            highLights = siteSearchResults.getResults().get(0).getHighLights()[0];
             //assertTrue( highLights.contains( "<em>stemmer</em>" ) );//Not found..., verify this....
-            assertTrue( highLights.contains( "<em>stemming</em>" ) );
-            assertTrue( highLights.contains( "<em>stemmed</em>" ) );
+            assertTrue(highLights.contains("<em>stemming</em>"));
+            assertTrue(highLights.contains("<em>stemmed</em>"));
 
             //Testing the stemer
-            siteSearchResults = siteSearchAPI.search( indexName, "argument", 0, 100 );
+            siteSearchResults = siteSearchAPI.search(indexName, "argument", 0, 100);
             //Validations
-            assertTrue( siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty() );
-            assertTrue( siteSearchResults.getTotalResults() > 0 );
-            highLights = siteSearchResults.getResults().get( 0 ).getHighLights()[0];
-            assertTrue( highLights.contains( "<em>arguments</em>" ) );
+            assertTrue(
+                    siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty());
+            assertTrue(siteSearchResults.getTotalResults() > 0);
+            highLights = siteSearchResults.getResults().get(0).getHighLights()[0];
+            assertTrue(highLights.contains("<em>arguments</em>"));
 
             //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
             //++++++++++++++++++++++++++NGrams++++++++++++++++++++++++++
             //Testing the search with words that are in each extreme of the text
-            siteSearchResults = siteSearchAPI.search( indexName, "english illustrating", 0, 100 );
+            siteSearchResults = siteSearchAPI.search(indexName, "english illustrating", 0, 100);
             //Validations
-            assertTrue( siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty() );
-            assertTrue( siteSearchResults.getTotalResults() > 0 );
+            assertTrue(
+                    siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty());
+            assertTrue(siteSearchResults.getTotalResults() > 0);
 
             //Testing the search with words that are not in find order
-            siteSearchResults = siteSearchAPI.search( indexName, "arguments algorithm", 0, 100 );
+            siteSearchResults = siteSearchAPI.search(indexName, "arguments algorithm", 0, 100);
             //Validations
-            assertTrue( siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty() );
-            assertTrue( siteSearchResults.getTotalResults() > 0 );
+            assertTrue(
+                    siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty());
+            assertTrue(siteSearchResults.getTotalResults() > 0);
 
             //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
             //++++++++++++++++++++++++OTHER TESTS+++++++++++++++++++++++
             //Testing the search by existing word with wildcard
-            siteSearchResults = siteSearchAPI.search( indexName, "engli*", 0, 100 );
+            siteSearchResults = siteSearchAPI.search(indexName, "engli*", 0, 100);
             //Validations
-            assertTrue( siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty() );
-            assertTrue( siteSearchResults.getTotalResults() > 0 );
+            assertTrue(
+                    siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty());
+            assertTrue(siteSearchResults.getTotalResults() > 0);
 
             //Testing the search by existing word with wildcard
-            siteSearchResults = siteSearchAPI.search( indexName, "*engli", 0, 100 );
+            siteSearchResults = siteSearchAPI.search(indexName, "*engli", 0, 100);
             //Validations
-            assertTrue( siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty() );
+            assertTrue(
+                    siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty());
             assertEquals(1, siteSearchResults.getTotalResults());
 
-
             //Testing the search with a non existing word
-            siteSearchResults = siteSearchAPI.search( indexName, "weird", 0, 100 );
+            siteSearchResults = siteSearchAPI.search(indexName, "weird", 0, 100);
             //Validations
-            assertTrue( siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty() );
+            assertTrue(
+                    siteSearchResults.getError() == null || siteSearchResults.getError().isEmpty());
             assertEquals(0, siteSearchResults.getTotalResults());
         } finally {
             //And finally remove the index
             contentTypeAPI.delete(new StructureTransformer(testStructure).from());
-            siteSearchAPI.deleteFromIndex( indexName, docId );
+            siteSearchAPI.deleteFromIndex(indexName, docId);
         }
     }
 
     @Test
-    public void testSearchIndexByDate () throws Exception {
+    public void testSearchIndexByDate() throws Exception {
 
-    	Folder testFolder = null;
-    	Structure testStructure = null;
-    	Contentlet testContent = null;
+        Folder testFolder = null;
+        Structure testStructure = null;
+        Contentlet testContent;
 
-    	try {
-	    	//Creating a test structure
-	    	PermissionAPI permissionAPI = APILocator.getPermissionAPI();
+        try {
+            //Creating a test structure
+            PermissionAPI permissionAPI = APILocator.getPermissionAPI();
 
-	    	//Set up a test folder
-	    	testFolder = APILocator.getFolderAPI().createFolders( "testSearchIndexByDateFolder", defaultHost, user, false );
-	    	permissionAPI.permissionIndividually( permissionAPI.findParentPermissionable( testFolder ), testFolder, user);
+            //Set up a test folder
+            testFolder = APILocator.getFolderAPI()
+                    .createFolders("testSearchIndexByDateFolder", defaultHost, user, false);
+            permissionAPI.permissionIndividually(permissionAPI.findParentPermissionable(testFolder),
+                    testFolder, user);
 
-	    	//Set up a test structure
-	    	String structureName = "testSearchIndexByDateStructure";
-	    	testStructure = new Structure();
-	    	testStructure.setHost( defaultHost.getIdentifier() );
-	    	testStructure.setFolder( testFolder.getInode() );
-	    	testStructure.setName( structureName );
-	    	testStructure.setStructureType( Structure.STRUCTURE_TYPE_CONTENT );
-	    	testStructure.setOwner( user.getUserId() );
-	    	testStructure.setVelocityVarName( structureName );
-	    	StructureFactory.saveStructure( testStructure );
-	    	CacheLocator.getContentTypeCache().add( testStructure );
-	    	//Adding test field
+            //Set up a test structure
+            String structureName = "testSearchIndexByDateStructure";
+            testStructure = new Structure();
+            testStructure.setHost(defaultHost.getIdentifier());
+            testStructure.setFolder(testFolder.getInode());
+            testStructure.setName(structureName);
+            testStructure.setStructureType(Structure.STRUCTURE_TYPE_CONTENT);
+            testStructure.setOwner(user.getUserId());
+            testStructure.setVelocityVarName(structureName);
+            StructureFactory.saveStructure(testStructure);
+            CacheLocator.getContentTypeCache().add(testStructure);
+            //Adding test field
 
             Field field =
-                    FieldBuilder.builder(DateTimeField.class).name("testSearchIndexByDateField").variable("testSearchIndexByDateField")
+                    FieldBuilder.builder(DateTimeField.class).name("testSearchIndexByDateField")
+                            .variable("testSearchIndexByDateField")
                             .required(true).indexed(true).listed(true)
                             .contentTypeId(testStructure.id()).dataType(
-                            DataTypes.DATE).build();
-            field = fieldAPI.save(field,user);
+                                    DataTypes.DATE).build();
+            field = fieldAPI.save(field, user);
 
-	    	//Creating a test contentlet
-	    	testContent = new Contentlet();
-	    	testContent.setStructureInode( testStructure.getInode() );
-	    	testContent.setHost( defaultHost.getIdentifier() );
-	    	testContent.setLanguageId(1);
-	    	testContent.setIndexPolicy(IndexPolicy.FORCE);
-	    	testContent.setIndexPolicyDependencies(IndexPolicy.FORCE);
-	    	testContent.setProperty(field.variable(),"03/05/2014");
+            //Creating a test contentlet
+            testContent = new Contentlet();
+            testContent.setStructureInode(testStructure.getInode());
+            testContent.setHost(defaultHost.getIdentifier());
+            testContent.setLanguageId(1);
+            testContent.setIndexPolicy(IndexPolicy.FORCE);
+            testContent.setIndexPolicyDependencies(IndexPolicy.FORCE);
+            testContent.setProperty(field.variable(), "03/05/2014");
 
-	    	testContent = contentletAPI.checkin( testContent, null, permissionAPI.getPermissions( testStructure ), user, false );
+            testContent = contentletAPI.checkin(testContent, null,
+                    permissionAPI.getPermissions(testStructure), user, false);
 
             testContent.setIndexPolicy(IndexPolicy.FORCE);
             testContent.setIndexPolicyDependencies(IndexPolicy.FORCE);
-	    	APILocator.getVersionableAPI().setLive(testContent);
+            APILocator.getVersionableAPI().setLive(testContent);
 
-			//And add it to the index
-			indexAPI.addContentToIndex( testContent );
+            //And add it to the index
+            indexAPI.addContentToIndex(testContent);
 
-			//We are just making time in order to let it apply the index
-			contentletAPI.isInodeIndexed( testContent.getInode(), true );
+            //We are just making time in order to let it apply the index
+            contentletAPI.isInodeIndexed(testContent.getInode(), true);
 
-			//Verify if it was added to the index
-			String query = "+structureName:" + testStructure.getVelocityVarName() + " +testSearchIndexByDateStructure.testSearchIndexByDateField:03/05/2014 +deleted:false +live:true";
-			List<Contentlet> result = contentletAPI.search( query, 0, -1, "modDate desc", user, true );
+            //Verify if it was added to the index
+            String query = "+structureName:" + testStructure.getVelocityVarName()
+                    + " +testSearchIndexByDateStructure.testSearchIndexByDateField:03/05/2014 +deleted:false +live:true";
+            List<Contentlet> result = contentletAPI.search(query, 0, -1, "modDate desc", user,
+                    true);
 
-			assertTrue(UtilMethods.isSet(result) && !result.isEmpty());
+            assertTrue(UtilMethods.isSet(result) && !result.isEmpty());
 
-    	} catch(Exception e) {
-    		Logger.error("Error executing testSearchIndexByDate", e.getMessage(), e);
-    	} finally {
-    		if(UtilMethods.isSet(testStructure)) {
-    			APILocator.getStructureAPI().delete(testStructure, user);
-    		}
-    		if(UtilMethods.isSet(testFolder)) {
-    			APILocator.getFolderAPI().delete(testFolder, user, false);
-    		}
-    	}
+        } catch (Exception e) {
+            Logger.error("Error executing testSearchIndexByDate", e.getMessage(), e);
+        } finally {
+            if (UtilMethods.isSet(testStructure)) {
+                APILocator.getStructureAPI().delete(testStructure, user);
+            }
+            if (UtilMethods.isSet(testFolder)) {
+                APILocator.getFolderAPI().delete(testFolder, user, false);
+            }
+        }
 
     }
 
-  @Test
-  public void test_that_live_and_working_content_makes_it_into_the_index() throws Exception {
-    ContentType type = new ContentTypeDataGen()
-        .fields(ImmutableList.of(ImmutableTextField.builder().name("Title").variable("title").searchable(true).listed(true).build()))
-        .nextPersisted();
+    @Test
+    public void test_that_live_and_working_content_makes_it_into_the_index() throws Exception {
+        ContentType type = new ContentTypeDataGen()
+                .fields(List.of(ImmutableTextField.builder().name("Title").variable("title")
+                        .searchable(true).listed(true).build()))
+                .nextPersisted();
 
-      String testBody = RandomStringUtils.random(10000000, true, true);
+        String testBody = RandomStringUtils.random(10000000, true, true);
 
-    Contentlet content = new ContentletDataGen(type.id()).setProperty("title", "contentTest " + System.currentTimeMillis())
-            .setProperty("body", testBody).next();
+        Contentlet content = new ContentletDataGen(type.id()).setProperty("title",
+                        "contentTest " + System.currentTimeMillis())
+                .setProperty("body", testBody).next();
 
+        String title = "version1";
+        content.setStringProperty("title", title);
 
-    String title = "version1";
-    content.setStringProperty("title", title);
+        content.setIndexPolicy(IndexPolicy.FORCE);
 
-    content.setIndexPolicy(IndexPolicy.FORCE);
+        // check in the content
+        content = contentletAPI.checkin(content, user, false);
 
-    // check in the content
-    content = contentletAPI.checkin(content, user, false);
+        assertNotNull(content.getIdentifier());
+        assertTrue(content.isWorking());
+        assertFalse(content.isLive());
+        assertEquals(content.getTitle(), title);
+        // publish the content
+        content.setIndexPolicy(IndexPolicy.FORCE);
+        content.setBoolProperty(Contentlet.DISABLE_WORKFLOW, true);
+        contentletAPI.publish(content, user, false);
+        String liveInode = content.getInode();
+        assertTrue(content.isLive());
+        content.setInode(null);
+        title = "version2";
+        content.setStringProperty("title", title);
+        content.setIndexPolicy(IndexPolicy.FORCE);
+        content = contentletAPI.checkin(content, user, false);
+        assertNotNull(content.getIdentifier());
+        assertTrue(content.isWorking());
+        assertFalse(content.isLive());
+        assertTrue(content.hasLiveVersion());
+        String workingInode = content.getInode();
+        final String identifier = content.getIdentifier();
 
-    assertTrue(content.getIdentifier() != null);
-    assertTrue(content.isWorking());
-    assertFalse(content.isLive());
-    assertEquals(content.getTitle(), title);
-    // publish the content
-    content.setIndexPolicy(IndexPolicy.FORCE);
-    content.setBoolProperty(Contentlet.DISABLE_WORKFLOW, true);
-    contentletAPI.publish(content, user, false);
-    String liveInode = content.getInode();
-    assertTrue(content.isLive());
-    content.setInode(null);
-    title = "version2";
-    content.setStringProperty("title", title);
-    content.setIndexPolicy(IndexPolicy.FORCE);
-    content = contentletAPI.checkin(content, user, false);
-    assertTrue(content.getIdentifier() != null);
-    assertTrue(content.isWorking());
-    assertFalse(content.isLive());
-    assertTrue(content.hasLiveVersion());
-    String workingInode = content.getInode();
-    List<ContentletSearch> liveSearch = contentletAPI.searchIndex("+identifier:" + content.getIdentifier() + " +live:true", 1, 0, "modDate", user, false);
-    List<ContentletSearch> workingSearch = contentletAPI.searchIndex("+identifier:" + content.getIdentifier() + " +live:false", 1, 0, "modDate", user, false);
-    assert(liveSearch.size()>0);
-    assert(workingSearch.size()>0);
-    assert(liveSearch.get(0).getInode().equals(liveInode));
-    assert(workingSearch.get(0).getInode().equals(workingInode));
-    assert(!workingSearch.get(0).getInode().equals(liveInode));
-    
-    indexAPI.removeContentFromIndex(content);
-    ReindexThread.startThread();
-    APILocator.getReindexQueueAPI().addContentletReindex(content);
-    ThreadUtils.sleep(10000);
-    liveSearch = contentletAPI.searchIndex("+identifier:" + content.getIdentifier() + " +live:true", 1, 0, "modDate", user, false);
-    workingSearch = contentletAPI.searchIndex("+identifier:" + content.getIdentifier() + " +live:false", 1, 0, "modDate", user, false);
-    assert(liveSearch.size()>0);
-    assert(workingSearch.size()>0);
-    assert(liveSearch.get(0).getInode().equals(liveInode));
-    assert(workingSearch.get(0).getInode().equals(workingInode));
-    assert(!workingSearch.get(0).getInode().equals(liveInode));
-    
-  }
-    
+        List<ContentletSearch> liveSearchResults = pollSearchIndex(1, identifier, null, true, 1, 0,
+                MOD_DATA_SORT, user);
+        assert (liveSearchResults.get(0).getInode().equals(liveInode));
+        List<ContentletSearch> workingSearchResults = pollSearchIndex(1, identifier, null, false, 1,
+                0, MOD_DATA_SORT, user);
+        assert (workingSearchResults.get(0).getInode().equals(workingInode));
+        assert (!workingSearchResults.get(0).getInode().equals(liveInode));
+
+        indexAPI.removeContentFromIndex(content);
+
+        pollSearchIndex(0, identifier, null, true, 1, 0, MOD_DATA_SORT, user);
+        pollSearchIndex(0, identifier, null, false, 1, 0, MOD_DATA_SORT, user);
+
+        Contentlet finalContent = content;
+        LocalTransaction.wrap(() -> {
+            APILocator.getReindexQueueAPI().addContentletReindex(finalContent);
+            ReindexThread.startThread();
+        });
+
+        // wait for empty reindex queue
+
+        waitForEmptyQueue();
+
+        liveSearchResults = pollSearchIndex(1, identifier, null, true, 1, 0, MOD_DATA_SORT, user);
+        workingSearchResults = pollSearchIndex(1, identifier, null, false, 1, 0, MOD_DATA_SORT,
+                user);
+
+        assert (liveSearchResults.get(0).getInode().equals(liveInode));
+
+        assert (workingSearchResults.get(0).getInode().equals(workingInode));
+        assert (!workingSearchResults.get(0).getInode().equals(liveInode));
+
+    }
+
+    public void waitForEmptyQueue() {
+        final ReindexQueueAPI reindexQueueAPI = APILocator.getReindexQueueAPI();
+        Awaitility.await().atMost(600, TimeUnit.SECONDS)
+                .pollInterval(5, TimeUnit.SECONDS)
+                .pollDelay(1, TimeUnit.SECONDS)
+                .until(reindexQueueAPI::areRecordsLeftToIndex, equalTo(false));
+    }
+
+    public List<ContentletSearch> pollSearchIndex(int expectedCount, String identifier, String id,
+            boolean live, int limit, int offset, String sortBy, User user) {
+        return Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                .until(() -> {
+                    CacheLocator.getESQueryCache().clearCache();
+                    return searchIndex(identifier, id, live, limit, offset, sortBy, user);
+                }, hasSize(expectedCount));
+    }
+
+    public List<ContentletSearch> searchIndex(String identifier, String id, boolean live, int limit,
+            int offset, String sortBy, User user) throws DotDataException, DotSecurityException {
+        StringBuilder luceneQuery = new StringBuilder();
+        if (identifier != null) {
+            luceneQuery.append(" +identifier:").append(identifier);
+        }
+        if (id != null) {
+            luceneQuery.append(" +id:").append(id);
+        }
+        luceneQuery.append(" +live:").append(live);
+
+        return contentletAPI.searchIndex(luceneQuery.toString(), limit, offset, sortBy, user,
+                false);
+    }
+
     /**
      * Creates and returns a test html page
      *
@@ -867,49 +942,52 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @throws DotSecurityException
      * @throws DotDataException
      */
-    private HTMLPageAsset loadHtmlPage ( Contentlet contentlet ) throws DotSecurityException, DotDataException {
+    private HTMLPageAsset loadHtmlPage(Contentlet contentlet)
+            throws DotSecurityException, DotDataException {
 
         Structure structure = contentlet.getStructure();
 
         //Create a container for the given contentlet
         Container container = new Container();
-        container.setCode( "this is the code" );
-        container.setFriendlyName( "test container" );
-        container.setTitle( "his is the title" );
-        container.setMaxContentlets( 5 );
-        container.setPreLoop( "preloop code" );
-        container.setPostLoop( "postloop code" );
+        container.setCode("this is the code");
+        container.setFriendlyName("test container");
+        container.setTitle("his is the title");
+        container.setMaxContentlets(5);
+        container.setPreLoop("preloop code");
+        container.setPostLoop("postloop code");
         //Save it
 
-        List<ContainerStructure> csList = new ArrayList<ContainerStructure>();
+        List<ContainerStructure> csList = new ArrayList<>();
         ContainerStructure cs = new ContainerStructure();
         cs.setStructureId(structure.getInode());
         cs.setCode("this is the code");
         csList.add(cs);
 
-        container = APILocator.getContainerAPI().save( container, csList, defaultHost, user, false );
+        container = APILocator.getContainerAPI().save(container, csList, defaultHost, user, false);
 
         //Create a template
-        String body = "<html><body> #parseContainer('" + container.getIdentifier() + "') </body></html>";
+        String body =
+                "<html><body> #parseContainer('" + container.getIdentifier() + "') </body></html>";
         String title = "empty test template " + UUIDGenerator.generateUuid();
 
         Template template = new Template();
-        template.setTitle( title );
-        template.setBody( body );
+        template.setTitle(title);
+        template.setBody(body);
 
-        template = APILocator.getTemplateAPI().saveTemplate( template, defaultHost, user, false );
+        template = APILocator.getTemplateAPI().saveTemplate(template, defaultHost, user, false);
 
         //Create the html page
-        Folder homeFolder = APILocator.getFolderAPI().createFolders( "/home/", defaultHost, user, false );
+        Folder homeFolder = APILocator.getFolderAPI()
+                .createFolders("/home/", defaultHost, user, false);
         HTMLPageAsset htmlPage = new HTMLPageDataGen(homeFolder, template).languageId(1)
-				.nextPersisted();
+                .nextPersisted();
 
         MultiTree multiTree = new MultiTree();
-        multiTree.setParent1( htmlPage.getIdentifier() );
-        multiTree.setParent2( container.getIdentifier() );
-        multiTree.setChild( contentlet.getIdentifier() );
-        multiTree.setTreeOrder( 1 );
-        APILocator.getMultiTreeAPI().saveMultiTree( multiTree );
+        multiTree.setParent1(htmlPage.getIdentifier());
+        multiTree.setParent2(container.getIdentifier());
+        multiTree.setChild(contentlet.getIdentifier());
+        multiTree.setTreeOrder(1);
+        APILocator.getMultiTreeAPI().saveMultiTree(multiTree);
 
         return htmlPage;
     }
@@ -920,31 +998,34 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @return
      * @throws Exception
      */
-    private Structure loadTestStructure () throws Exception {
+    private Structure loadTestStructure() throws Exception {
 
         PermissionAPI permissionAPI = APILocator.getPermissionAPI();
 
         //Set up a test folder
-        Folder testFolder = APILocator.getFolderAPI().createFolders( "/" + new Date().getTime() + "/", defaultHost, user, false );
-        permissionAPI.permissionIndividually( permissionAPI.findParentPermissionable( testFolder ), testFolder, user);
+        Folder testFolder = APILocator.getFolderAPI()
+                .createFolders("/" + new Date().getTime() + "/", defaultHost, user, false);
+        permissionAPI.permissionIndividually(permissionAPI.findParentPermissionable(testFolder),
+                testFolder, user);
 
         //Set up a test structure
         String structureName = "ESContentletIndexAPITest_" + new Date().getTime();
         Structure testStructure = new Structure();
-        testStructure.setHost( defaultHost.getIdentifier() );
-        testStructure.setFolder( testFolder.getInode() );
-        testStructure.setName( structureName );
-        testStructure.setStructureType( Structure.STRUCTURE_TYPE_CONTENT );
-        testStructure.setOwner( user.getUserId() );
-        testStructure.setVelocityVarName( structureName );
-        StructureFactory.saveStructure( testStructure );
-        CacheLocator.getContentTypeCache().add( testStructure );
+        testStructure.setHost(defaultHost.getIdentifier());
+        testStructure.setFolder(testFolder.getInode());
+        testStructure.setName(structureName);
+        testStructure.setStructureType(Structure.STRUCTURE_TYPE_CONTENT);
+        testStructure.setOwner(user.getUserId());
+        testStructure.setVelocityVarName(structureName);
+        StructureFactory.saveStructure(testStructure);
+        CacheLocator.getContentTypeCache().add(testStructure);
         //Adding test field
         final Field field =
-                FieldBuilder.builder(WysiwygField.class).name("Wysiwyg").variable("wysiwyg").required(true).indexed(true).listed(true)
+                FieldBuilder.builder(WysiwygField.class).name("Wysiwyg").variable("wysiwyg")
+                        .required(true).indexed(true).listed(true)
                         .contentTypeId(testStructure.id()).dataType(
-                        DataTypes.LONG_TEXT).build();
-        fieldAPI.save(field,user);
+                                DataTypes.LONG_TEXT).build();
+        fieldAPI.save(field, user);
 
         return testStructure;
     }
@@ -955,121 +1036,104 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
      * @return
      * @throws Exception
      */
-    private Contentlet loadTestContentlet ( Structure testStructure ) throws Exception {
+    private Contentlet loadTestContentlet(Structure testStructure) throws Exception {
 
         //Set up a test contentlet
         Contentlet testContentlet = new Contentlet();
         testContentlet.setIndexPolicy(IndexPolicy.WAIT_FOR);
-        testContentlet.setStructureInode( testStructure.getInode() );
-        testContentlet.setHost( defaultHost.getIdentifier() );
-        testContentlet.setLanguageId( defaultLanguage.getId() );
-        testContentlet.setStringProperty( "wysiwyg", stemmerText );
-        testContentlet = contentletAPI.checkin( testContentlet, user, false );
+        testContentlet.setStructureInode(testStructure.getInode());
+        testContentlet.setHost(defaultHost.getIdentifier());
+        testContentlet.setLanguageId(defaultLanguage.getId());
+        testContentlet.setStringProperty("wysiwyg", stemmerText);
+        testContentlet = contentletAPI.checkin(testContentlet, user, false);
 
         //Make it live
-        APILocator.getVersionableAPI().setLive( testContentlet );
+        APILocator.getVersionableAPI().setLive(testContentlet);
 
         return testContentlet;
     }
 
-    private boolean isDocIndexed ( String id ) {
+    private boolean isDocIndexed(String indexName, String id) {
 
-        if ( !UtilMethods.isSet( id ) ) {
-            Logger.warn( this, "Requested Inode is not indexed because Inode is not set" );
+        if (!UtilMethods.isSet(id)) {
+            Logger.warn(this, "Requested Inode is not indexed because Inode is not set");
         }
-        SearchHits lc;
-        boolean found = false;
-        int counter = 0;
-        while ( counter < 300 ) {
-            try {
-                lc = indexSearch( "+id:" + id, "modDate" );
-            } catch ( Exception e ) {
-                Logger.error( this.getClass(), e.getMessage(), e );
-                return false;
-            }
-            if ( lc.getTotalHits().value > 0 ) {
-                return true;
-            }
-            try {
-                Thread.sleep( 100 );
-            } catch ( Exception e ) {
-                Logger.debug( this, "Cannot sleep : ", e );
-            }
-            counter++;
+        try {
+            Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .until(() ->
+                                    Objects.requireNonNull(
+                                                    indexSearch(indexName, String.format(ID_QUERY, id)))
+                                            .getTotalHits().value,
+                            greaterThan(0L)
+                    );
+            return true;
+        } catch (Exception e) {
+            Logger.error(this.getClass(), e.getMessage(), e);
+            return false;
         }
-        return found;
     }
 
-    private SearchHits indexSearch ( String query, String sortBy ) throws Exception {
+    private SearchHits indexSearch(String indexName, String query) throws Exception {
 
-        String qq = ESContentFactoryImpl.translateQuery( query, sortBy ).getQuery();
+        String qq = ESContentFactoryImpl.translateQuery(query,
+                ContentletIndexAPIImplTest.MOD_DATA_SORT).getQuery();
 
-        // we check the query to figure out wich indexes to hit
-        String indexToHit;
-        IndiciesInfo info;
-        try {
-            info = APILocator.getIndiciesAPI().loadIndicies();
-        } catch ( DotDataException ee ) {
-            Logger.fatal( this, "Can't get indicies information", ee );
-            return null;
-        }
-        indexToHit = info.getSiteSearch();
-        String indexName = indexToHit;
-        if ( indexName == null ) {
-            indexName = SiteSearchAPI.ES_SITE_SEARCH_NAME + "_" + ContentletIndexAPIImpl.timestampFormatter.format( new Date() );
-            APILocator.getSiteSearchAPI().createSiteSearchIndex( indexName, null, 1 );
-            APILocator.getSiteSearchAPI().activateIndex( indexName );
+        if (indexName == null) {
+            indexName = SiteSearchAPI.ES_SITE_SEARCH_NAME + "_"
+                    + ContentletIndexAPIImpl.timestampFormatter.format(new Date());
+            APILocator.getSiteSearchAPI().createSiteSearchIndex(indexName, null, 1);
+            APILocator.getSiteSearchAPI().activateIndex(indexName);
         }
 
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchSourceBuilder.query(QueryBuilders.queryStringQuery( qq ));
+        searchSourceBuilder.query(QueryBuilders.queryStringQuery(qq));
         searchSourceBuilder.timeout(TimeValue.timeValueMillis(INDEX_OPERATIONS_TIMEOUT_IN_MS));
-        searchSourceBuilder.fetchSource(new String[] {"inode"}, null);
+        searchSourceBuilder.fetchSource(new String[]{"inode"}, null);
         searchSourceBuilder.storedField("id");
         SearchRequest searchRequest = new SearchRequest();
-        searchRequest.indices(indexName);
+        searchRequest.indices(esIndexAPI.getNameWithClusterIDPrefix(indexName));
         searchRequest.source(searchSourceBuilder);
 
-        final SearchResponse response = Sneaky.sneak(()->
+        final SearchResponse response = Sneaky.sneak(() ->
                 RestHighLevelClientProvider
                         .getInstance().getClient().search(searchRequest, RequestOptions.DEFAULT));
         return response.getHits();
     }
 
-    public boolean wasContentRemoved ( String query ) {
+    @Nullable
+    private static String getSiteSearchIndex() {
+        String indexToHit;
+        IndiciesInfo info;
+        try {
+            info = APILocator.getIndiciesAPI().loadIndicies();
+        } catch (DotDataException ee) {
+            Logger.fatal(ContentletIndexAPIImpl.class, "Can't get indicies information", ee);
+            return null;
+        }
+        indexToHit = info.getSiteSearch();
+        return indexToHit;
+    }
 
-        boolean removed = false;
-        int counter = 0;
-        while ( counter < 300 ) {
-            try {
-                //Verify if it was removed to the index
-                List<Contentlet> result = contentletAPI.search( query, 0, -1, "modDate desc", user, true );
+    public boolean wasContentRemoved(String query) {
 
-                //Validations
-                if ( result == null || result.isEmpty() ) {
-                    return true;
-                }
-            } catch ( Exception e ) {
-                Logger.error( this.getClass(), e.getMessage(), e );
-                return false;
-            }
-
-            try {
-                Thread.sleep( 100 );
-            } catch ( Exception e ) {
-                Logger.debug( this, "Cannot sleep : ", e );
-            }
-            counter++;
+        try {
+            Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .until(() ->
+                                    contentletAPI.search(query, 0, -1, "modDate desc", user, true).size(),
+                            equalTo(0L)
+                    );
+            return true;
+        } catch (ConditionTimeoutException e) {
+            return false;
         }
 
-        return removed;
     }
 
     @Test
     public void testRemoveContentFromIndex() throws DotDataException, DotSecurityException {
 
         final ContentType type = new ContentTypeDataGen()
-                .fields(ImmutableList
+                .fields(List
                         .of(ImmutableTextField.builder().name("Title").variable("title")
                                 .searchable(true).listed(true).build()))
                 .nextPersisted();
@@ -1092,12 +1156,11 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
                         .languageCode("en").countryCode("x" + i).nextPersisted();
             }
         }
-        languages = new ArrayList<>();
-        languages.addAll(languageAPI.getLanguages());
+        languages = new ArrayList<>(languageAPI.getLanguages());
 
         languages.removeIf(
                 l -> l.getId() == languageAPI.getDefaultLanguage().getId());
-        languages = languages.subList(0, (languages.size() > 5) ? 5 : languages.size());
+        languages = languages.subList(0, Math.min(languages.size(), 5));
 
         // building contentents in multiple languages
         for (Language lang : languages) {
@@ -1112,7 +1175,7 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
 
         // content is in the index
         for (Contentlet content : contents) {
-            assertTrue(content.getIdentifier() != null);
+            assertNotNull(content.getIdentifier());
             assertTrue(content.isWorking());
             assertFalse(content.isLive());
             assertTrue(contentletAPI.indexCount(
@@ -1131,7 +1194,8 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
             content.setIndexPolicy(IndexPolicy.WAIT_FOR);
             content.setBoolProperty(Contentlet.DISABLE_WORKFLOW, true);
             contentletAPI.publish(content, user, false);
-            assertTrue("the contentlet: " + content.getIdentifier() + " must be published",content.isLive());
+            assertTrue("the contentlet: " + content.getIdentifier() + " must be published",
+                    content.isLive());
             assertTrue(contentletAPI.indexCount(
                     "+live:true +identifier:" + content.getIdentifier() + " +inode:" + content
                             .getInode() + " +languageId:" + content.getLanguageId(), user,
@@ -1148,17 +1212,16 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
         indexAPI.appendBulkRequest(bulk, entries.values());
         indexAPI.putToIndex(bulk);
 
-        assertTrue(contentletAPI
-                .indexCount("+live:false +identifier:" + baseCon.getIdentifier(), user, false)
-                == 0);
+        assertEquals(0, contentletAPI
+                .indexCount("+live:false +identifier:" + baseCon.getIdentifier(), user, false));
 
         for (ContentletSearch indexentry : contentletAPI
                 .searchIndex("+live:true +identifier:" + baseCon.getIdentifier(), 0, 0, "moddate",
                         user, false)) {
-            System.err.println(indexentry);
+            Logger.debug(ContentletIndexAPIImpl.class, "indexentry: " + indexentry);
         }
-        assertTrue(contentletAPI
-                .indexCount("+live:true +identifier:" + baseCon.getIdentifier(), user, false) == 0);
+        assertEquals(0, contentletAPI
+                .indexCount("+live:true +identifier:" + baseCon.getIdentifier(), user, false));
 
         assertTrue(contentletAPI.indexCount("+identifier:" + baseCon.getIdentifier(), user, false)
                 == 0);
@@ -1166,22 +1229,21 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link ContentletIndexAPI#getIndexDocumentCount(String)}
-     * Test Case: Tries to get the document count of an active index
-     * Expected Results: Value should be more than 0
+     * Method to test: {@link ContentletIndexAPI#getIndexDocumentCount(String)} Test Case: Tries to
+     * get the document count of an active index Expected Results: Value should be more than 0
      */
     @Test
-    public void testGetIndexDocumentCountSuccess() throws  DotDataException {
+    public void testGetIndexDocumentCountSuccess() throws DotDataException {
         assertTrue(indexAPI.getIndexDocumentCount(indexAPI.getCurrentIndex().get(0)) > 0);
     }
 
     /**
-     * Method to test: {@link ContentletIndexAPI#getIndexDocumentCount(String)}
-     * Test Case: Tries to get the document count of an index that does not exist
-     * Expected Results: Throws ElasticsearchStatusException
+     * Method to test: {@link ContentletIndexAPI#getIndexDocumentCount(String)} Test Case: Tries to
+     * get the document count of an index that does not exist Expected Results: Throws
+     * ElasticsearchStatusException
      */
-    @Test(expected= ElasticsearchStatusException.class)
-    public void testGetIndexDocumentCountWithInvalidIndexNameFails(){
+    @Test(expected = ElasticsearchStatusException.class)
+    public void testGetIndexDocumentCountWithInvalidIndexNameFails() {
         indexAPI.getIndexDocumentCount("invalidIndexName");
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImplTest.java
@@ -828,7 +828,8 @@ public class ESContentFactoryImplTest extends IntegrationTestBase {
        try {
            final SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.searchSource();
 
-           final int limit = (int)Math.random();
+           Random ran = new Random();
+           final int limit = ran.nextInt(100);
 
            Config.setProperty(ES_TRACK_TOTAL_HITS, Integer.toString(limit));
            instance.setTrackHits(searchSourceBuilder);

--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/TestDataUtils.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/TestDataUtils.java
@@ -30,6 +30,7 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.RelationshipAPI;
 import com.dotmarketing.business.Treeable;
+import com.dotmarketing.common.reindex.ReindexQueueAPI;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.image.focalpoint.FocalPointAPITest;
 import com.dotmarketing.portlets.categories.business.CategoryAPI;
@@ -49,6 +50,10 @@ import com.google.common.io.Files;
 import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import io.vavr.control.Try;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.Assert;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -61,8 +66,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * @author Jonathan Gamba 2019-04-16
@@ -83,7 +91,7 @@ public class TestDataUtils {
 
     public static ContentType getBlogLikeContentType(final String contentTypeName,
             final Host site) {
-            return getBlogLikeContentType(contentTypeName, site,null);
+        return getBlogLikeContentType(contentTypeName, site, null);
     }
 
     public static ContentType getBlogLikeContentType(final Host site) {
@@ -92,7 +100,7 @@ public class TestDataUtils {
 
     @WrapInTransaction
     public static ContentType getBlogLikeContentType(final String contentTypeName,
-            final Host site, final Set <String> workflowIds) {
+            final Host site, final Set<String> workflowIds) {
 
         ContentType blogType = null;
         try {
@@ -205,12 +213,13 @@ public class TestDataUtils {
         return getCommentsLikeContentType("Comments" + System.currentTimeMillis());
     }
 
-    public static ContentType getCommentsLikeContentType(final String contentTypeName){
+    public static ContentType getCommentsLikeContentType(final String contentTypeName) {
         return getCommentsLikeContentType(contentTypeName, null);
     }
 
     @WrapInTransaction
-    public static ContentType getCommentsLikeContentType(final String contentTypeName, final Set<String> workflowIds) {
+    public static ContentType getCommentsLikeContentType(final String contentTypeName,
+            final Set<String> workflowIds) {
 
         ContentType commentsType = null;
         try {
@@ -265,13 +274,13 @@ public class TestDataUtils {
     }
 
     public static ContentType getEmployeeLikeContentType(final String contentTypeName,
-    final Host site) {
+            final Host site) {
         return getEmployeeLikeContentType(contentTypeName, site, null);
     }
 
     @WrapInTransaction
     public static ContentType getEmployeeLikeContentType(final String contentTypeName,
-            final Host site,  final Set<String> workflowIds) {
+            final Host site, final Set<String> workflowIds) {
 
         ContentType employeeType = null;
         try {
@@ -364,31 +373,35 @@ public class TestDataUtils {
     }
 
     public static ContentType getNewsLikeContentType() {
-        return getNewsLikeContentType("News" + System.currentTimeMillis(), null, null, null, null,null);
+        return getNewsLikeContentType("News" + System.currentTimeMillis(), null, null, null, null,
+                null);
     }
 
     public static ContentType getNewsLikeContentType(final String contentTypeName) {
-        return getNewsLikeContentType(contentTypeName, null, null, null, null,null);
+        return getNewsLikeContentType(contentTypeName, null, null, null, null, null);
     }
 
-    public static ContentType getNewsLikeContentType(final String contentTypeName, final String parentCategoryInode) {
-        return getNewsLikeContentType(contentTypeName, null, null, null, null,parentCategoryInode);
+    public static ContentType getNewsLikeContentType(final String contentTypeName,
+            final String parentCategoryInode) {
+        return getNewsLikeContentType(contentTypeName, null, null, null, null, parentCategoryInode);
     }
 
     public static ContentType getNewsLikeContentType(final String contentTypeName,
             final Host site) {
-        return getNewsLikeContentType(contentTypeName, site, null, null, null,null);
+        return getNewsLikeContentType(contentTypeName, site, null, null, null, null);
     }
 
     public static ContentType getNewsLikeContentType(final Host site) {
-        return getNewsLikeContentType("News" + System.currentTimeMillis(), site, null, null, null,null);
+        return getNewsLikeContentType("News" + System.currentTimeMillis(), site, null, null, null,
+                null);
     }
 
     public static ContentType getNewsLikeContentType(final String contentTypeName,
             final Host site,
             final String detailPageIdentifier,
             final String urlMapPattern) {
-        return getNewsLikeContentType(contentTypeName, site, detailPageIdentifier, urlMapPattern, null,null);
+        return getNewsLikeContentType(contentTypeName, site, detailPageIdentifier, urlMapPattern,
+                null, null);
     }
 
     @WrapInTransaction
@@ -480,7 +493,7 @@ public class TestDataUtils {
                                 .indexed(true)
                                 .next()
                 );
-                if(!UtilMethods.isSet(parentCategoryInode)) {
+                if (!UtilMethods.isSet(parentCategoryInode)) {
                     parentCategoryInode = new CategoryDataGen().nextPersisted().getInode();
                 }
                 fields.add(
@@ -524,91 +537,92 @@ public class TestDataUtils {
 
     @WrapInTransaction
     public static Contentlet getDotAssetLikeContentlet() {
-        return getDotAssetLikeContentlet(APILocator.getLanguageAPI().getDefaultLanguage().getId(), Try.of(()->APILocator.getHostAPI().findSystemHost()).getOrNull());
-        
+        return getDotAssetLikeContentlet(APILocator.getLanguageAPI().getDefaultLanguage().getId(),
+                Try.of(() -> APILocator.getHostAPI().findSystemHost()).getOrNull());
+
     }
-    
+
     @WrapInTransaction
     public static Contentlet getDotAssetLikeContentlet(final Treeable hostOrFolder) {
-        return getDotAssetLikeContentlet(APILocator.getLanguageAPI().getDefaultLanguage().getId(), hostOrFolder);
-        
+        return getDotAssetLikeContentlet(APILocator.getLanguageAPI().getDefaultLanguage().getId(),
+                hostOrFolder);
+
     }
 
     @WrapInTransaction
-    public static Contentlet getDotAssetLikeContentlet(long languageId, final Treeable hostOrFolder) {
+    public static Contentlet getDotAssetLikeContentlet(long languageId,
+            final Treeable hostOrFolder) {
 
-        Host host=null;
-        Folder folder=null;
+        Host host = null;
+        Folder folder = null;
 
-        host = Try.of(()->APILocator.getHostAPI().find(hostOrFolder.getIdentifier(), APILocator.systemUser(), false)).getOrNull();
-        if(host==null) {
-            folder = Try.of(()->APILocator.getFolderAPI().find(hostOrFolder.getInode(), APILocator.systemUser(), false)).getOrNull();
-            if(folder==null) {
-                folder = Try.of(()->APILocator.getFolderAPI().find(hostOrFolder.getInode(), APILocator.systemUser(), false)).getOrNull();
+        host = Try.of(() -> APILocator.getHostAPI()
+                .find(hostOrFolder.getIdentifier(), APILocator.systemUser(), false)).getOrNull();
+        if (host == null) {
+            folder = Try.of(() -> APILocator.getFolderAPI()
+                    .find(hostOrFolder.getInode(), APILocator.systemUser(), false)).getOrNull();
+            if (folder == null) {
+                folder = Try.of(() -> APILocator.getFolderAPI()
+                        .find(hostOrFolder.getInode(), APILocator.systemUser(), false)).getOrNull();
             }
-            if(folder!=null) {
+            if (folder != null) {
                 final Folder finalFolder = folder;
-                host =  Try.of(()->APILocator.getHostAPI().find(finalFolder.getHostId(),APILocator.systemUser(), false)).getOrNull();
+                host = Try.of(() -> APILocator.getHostAPI()
+                        .find(finalFolder.getHostId(), APILocator.systemUser(), false)).getOrNull();
             }
         }
-        
-        if(host==null) {
-            host = Try.of(()->APILocator.getHostAPI().findSystemHost()).getOrNull();
+
+        if (host == null) {
+            host = Try.of(() -> APILocator.getHostAPI().findSystemHost()).getOrNull();
         }
-            
 
-        ContentType dotAssetType = getDotAssetLikeContentType("dotAsset" + UUIDGenerator.shorty(), host);
+        ContentType dotAssetType = getDotAssetLikeContentType("dotAsset" + UUIDGenerator.shorty(),
+                host);
 
-        
-        
         URL url = FocalPointAPITest.class.getResource("/images/test.jpg");
 
         File testImage = new File(url.getFile());
-        
-        
+
         ContentletDataGen contentletDataGen = new ContentletDataGen(dotAssetType.id())
-                        .languageId(languageId)
-                        .setProperty("asset", testImage)
-                        .setProperty("hostFolder", folder!=null ? folder.getInode() : host.getIdentifier())
-                        .setProperty("tags", "tag1, tag2");
-                        
-        
-        if(folder!=null) {
+                .languageId(languageId)
+                .setProperty("asset", testImage)
+                .setProperty("hostFolder",
+                        folder != null ? folder.getInode() : host.getIdentifier())
+                .setProperty("tags", "tag1, tag2");
+
+        if (folder != null) {
             contentletDataGen.folder(folder);
         }
-        if(host!=null) {
+        if (host != null) {
             contentletDataGen.host(host);
         }
-        
+
         return contentletDataGen.nextPersisted();
 
 
-
     }
-    
-    
+
+
     @WrapInTransaction
     public static ContentType getDotAssetLikeContentType(final String contentTypeVar,
-                    final Host host) {
+            final Host host) {
 
-
-
-        ContentType dotAssetType = Try.of(()->APILocator.getContentTypeAPI(APILocator.systemUser())
+        ContentType dotAssetType = Try.of(
+                () -> APILocator.getContentTypeAPI(APILocator.systemUser())
                         .find(contentTypeVar)).getOrNull();
 
-            if (dotAssetType == null) {
-                ContentTypeDataGen dataGen = new ContentTypeDataGen()
-                                .name(contentTypeVar)
-                                .host(host)
-                                .velocityVarName(contentTypeVar)
-                                .baseContentType(BaseContentType.DOTASSET);
+        if (dotAssetType == null) {
+            ContentTypeDataGen dataGen = new ContentTypeDataGen()
+                    .name(contentTypeVar)
+                    .host(host)
+                    .velocityVarName(contentTypeVar)
+                    .baseContentType(BaseContentType.DOTASSET);
 
-                if(host!=null) {
-                    dataGen.host(host);
-                }
-                dotAssetType = dataGen.nextPersisted();
+            if (host != null) {
+                dataGen.host(host);
             }
-
+            dotAssetType = dataGen.nextPersisted();
+        }
 
         return dotAssetType;
     }
@@ -618,7 +632,8 @@ public class TestDataUtils {
     }
 
     @WrapInTransaction
-    public static ContentType getRichTextLikeContentType(final String contentTypeName, final Set<String> workflowIds) {
+    public static ContentType getRichTextLikeContentType(final String contentTypeName,
+            final Set<String> workflowIds) {
 
         ContentType richTextLike = null;
         try {
@@ -675,56 +690,58 @@ public class TestDataUtils {
      * @param contentTypeName The name of the test Content Type.
      * @param site            The Site where this Content Type will live in.
      * @param workflowIds     The workflows assigned to this type. This can be null.
-     *
      * @return The new test Content Type.
      */
     @WrapInTransaction
-    public static ContentType getWysiwygLikeContentType(final String contentTypeName, final Host site,
-                                                        final Set<String> workflowIds) {
+    public static ContentType getWysiwygLikeContentType(final String contentTypeName,
+            final Host site,
+            final Set<String> workflowIds) {
         ContentType wysiwygType = Try.of(() -> APILocator.getContentTypeAPI(APILocator.systemUser())
-                                                       .find(contentTypeName)).getOrNull();
+                .find(contentTypeName)).getOrNull();
         try {
             if (wysiwygType == null) {
                 final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>();
                 if (null != site) {
                     fields.add(new FieldDataGen()
-                                       .sortOrder(1)
-                                       .name("Site or Folder")
-                                       .velocityVarName("hostfolder")
-                                       .required(Boolean.TRUE)
-                                       .type(HostFolderField.class).next());
+                            .sortOrder(1)
+                            .name("Site or Folder")
+                            .velocityVarName("hostfolder")
+                            .required(Boolean.TRUE)
+                            .type(HostFolderField.class).next());
                 }
                 fields.add(new FieldDataGen()
-                                   .sortOrder(2)
-                                   .name("Title")
-                                   .velocityVarName("title").next());
+                        .sortOrder(2)
+                        .name("Title")
+                        .velocityVarName("title").next());
                 fields.add(new FieldDataGen()
-                                   .sortOrder(3)
-                                   .name("Description")
-                                   .velocityVarName("description")
-                                   .type(WysiwygField.class).next());
+                        .sortOrder(3)
+                        .name("Description")
+                        .velocityVarName("description")
+                        .type(WysiwygField.class).next());
                 final ContentTypeDataGen contentTypeDataGen = new ContentTypeDataGen()
-                                                                .name(contentTypeName)
-                                                                .velocityVarName(contentTypeName)
-                                                                .workflowId(workflowIds)
-                                                                .fields(fields);
+                        .name(contentTypeName)
+                        .velocityVarName(contentTypeName)
+                        .workflowId(workflowIds)
+                        .fields(fields);
                 if (null != site) {
                     contentTypeDataGen.host(site);
                 }
                 wysiwygType = contentTypeDataGen.nextPersisted();
             }
         } catch (final Exception e) {
-            throw new DotRuntimeException(String.format("Error creating test type '%s'", contentTypeName), e);
+            throw new DotRuntimeException(
+                    String.format("Error creating test type '%s'", contentTypeName), e);
         }
         return wysiwygType;
     }
-    
+
     public static ContentType getWikiLikeContentType() {
         return getWikiLikeContentType("Wiki" + System.currentTimeMillis(), null);
     }
 
     @WrapInTransaction
-    public static ContentType getWikiLikeContentType(final String contentTypeName, final Set<String> workflowIds) {
+    public static ContentType getWikiLikeContentType(final String contentTypeName,
+            final Set<String> workflowIds) {
 
         ContentType wikiType = null;
         try {
@@ -789,7 +806,8 @@ public class TestDataUtils {
     }
 
     @WrapInTransaction
-    public static ContentType getWidgetLikeContentType(final String contentTypeName, final Set<String> workflowIds) {
+    public static ContentType getWidgetLikeContentType(final String contentTypeName,
+            final Set<String> workflowIds) {
 
         ContentType simpleWidgetContentType = null;
         try {
@@ -830,7 +848,8 @@ public class TestDataUtils {
     }
 
     @WrapInTransaction
-    public static ContentType getFormLikeContentType(final String contentTypeName, final Set<String> workflowIds) {
+    public static ContentType getFormLikeContentType(final String contentTypeName,
+            final Set<String> workflowIds) {
 
         ContentType formContentType = null;
         try {
@@ -857,11 +876,12 @@ public class TestDataUtils {
     }
 
     public static ContentType getFormWithRequiredFieldsLikeContentType() {
-            return getFormWithRequiredFieldsLikeContentType("Form" + System.currentTimeMillis(), null);
+        return getFormWithRequiredFieldsLikeContentType("Form" + System.currentTimeMillis(), null);
     }
 
     @WrapInTransaction
-    public static ContentType getFormWithRequiredFieldsLikeContentType(final String contentTypeName, Set<String> workFlowsId) {
+    public static ContentType getFormWithRequiredFieldsLikeContentType(final String contentTypeName,
+            Set<String> workFlowsId) {
 
         ContentType formContentType = null;
         try {
@@ -1052,7 +1072,8 @@ public class TestDataUtils {
             return relationship;
         } else {
             relationship = new Relationship();
-            if ((parentContentType == childContentType) || (parentContentType.id().equals(childContentType.id()))) {
+            if ((parentContentType == childContentType) || (parentContentType.id()
+                    .equals(childContentType.id()))) {
                 relationship.setParentRelationName("Child " + parentContentType.name());
                 relationship.setChildRelationName("Parent " + childContentType.name());
             } else {
@@ -1079,7 +1100,8 @@ public class TestDataUtils {
         return getFileAssetContent(persist, languageId, TestFile.SVG);
     }
 
-    public static Contentlet getFileAssetContent(final Boolean persist, final long languageId, final TestFile testFile) {
+    public static Contentlet getFileAssetContent(final Boolean persist, final long languageId,
+            final TestFile testFile) {
 
         try {
             final Folder folder = new FolderDataGen().nextPersisted();
@@ -1112,7 +1134,8 @@ public class TestDataUtils {
         }
     }
 
-    private static Contentlet createFileAsset(final String testImagePath, final Folder folder, final long languageId, final boolean persist) throws Exception{
+    private static Contentlet createFileAsset(final String testImagePath, final Folder folder,
+            final long languageId, final boolean persist) throws Exception {
         //Test file
         final String extension = UtilMethods.getFileExtension(testImagePath);
         final File originalTestImage = new File(
@@ -1224,7 +1247,7 @@ public class TestDataUtils {
     }
 
     public static Contentlet getNewsContent(Boolean persist, long languageId,
-                                            String contentTypeId, Host site) {
+            String contentTypeId, Host site) {
         return getNewsContent(persist, languageId, contentTypeId, site, new Date());
     }
 
@@ -1276,7 +1299,7 @@ public class TestDataUtils {
 
     public static Contentlet getPageContent(Boolean persist, long languageId) {
 
-        return getPageContent(persist,languageId, null);
+        return getPageContent(persist, languageId, null);
     }
 
     public static Contentlet getPageContent(Boolean persist, long languageId, Folder folder) {
@@ -1290,15 +1313,15 @@ public class TestDataUtils {
             Template template = new TemplateDataGen().withContainer(container.getIdentifier())
                     .nextPersisted();
 
-            if(null == folder) {
-               final Host defaultHost = APILocator.getHostAPI()
-                       .findDefaultHost(APILocator.systemUser(), false);
-               final User systemUser = APILocator.systemUser();
+            if (null == folder) {
+                final Host defaultHost = APILocator.getHostAPI()
+                        .findDefaultHost(APILocator.systemUser(), false);
+                final User systemUser = APILocator.systemUser();
 
-               //Create the html page
-               folder = APILocator.getFolderAPI()
-                       .createFolders("/folder" + System.currentTimeMillis() + "/",
-                               defaultHost, systemUser, false);
+                //Create the html page
+                folder = APILocator.getFolderAPI()
+                        .createFolders("/folder" + System.currentTimeMillis() + "/",
+                                defaultHost, systemUser, false);
             }
             ContentletDataGen contentletDataGen = new HTMLPageDataGen(folder, template)
                     .languageId(languageId);
@@ -1329,16 +1352,18 @@ public class TestDataUtils {
     }
 
     public static ContentType getDocumentLikeContentType() {
-       return getDocumentLikeContentType("Document" + System.currentTimeMillis(), null);
+        return getDocumentLikeContentType("Document" + System.currentTimeMillis(), null);
     }
 
     @WrapInTransaction
-    public static ContentType getDocumentLikeContentType(final String contentTypeName, Set<String> workflowIds) {
+    public static ContentType getDocumentLikeContentType(final String contentTypeName,
+            Set<String> workflowIds) {
 
         ContentType simpleWidgetContentType = null;
         try {
             try {
-                simpleWidgetContentType = APILocator.getContentTypeAPI(APILocator.systemUser()).find(contentTypeName);
+                simpleWidgetContentType = APILocator.getContentTypeAPI(APILocator.systemUser())
+                        .find(contentTypeName);
             } catch (NotFoundInDbException e) {
                 //Do nothing...
             }
@@ -1347,8 +1372,8 @@ public class TestDataUtils {
                 final WorkflowScheme documentWorkflow = TestWorkflowUtils.getDocumentWorkflow();
                 final Set<String> collectedWorkflowIds = new HashSet<>();
                 collectedWorkflowIds.add(documentWorkflow.getId());
-                if(null != workflowIds){
-                   collectedWorkflowIds.addAll(workflowIds);
+                if (null != workflowIds) {
+                    collectedWorkflowIds.addAll(workflowIds);
                 }
 
                 List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>();
@@ -1467,7 +1492,8 @@ public class TestDataUtils {
     }
 
 
-    public static ContentType getBannerLikeContentType(final String contentTypeName, final Host site) {
+    public static ContentType getBannerLikeContentType(final String contentTypeName,
+            final Host site) {
         return getBannerLikeContentType(contentTypeName, site, null);
     }
 
@@ -1617,8 +1643,9 @@ public class TestDataUtils {
         }
     }
 
-    public static ContentType getProductLikeContentType(){
-        return  getProductLikeContentType("Product" + System.currentTimeMillis(), APILocator.systemHost(),null);
+    public static ContentType getProductLikeContentType() {
+        return getProductLikeContentType("Product" + System.currentTimeMillis(),
+                APILocator.systemHost(), null);
     }
 
     @WrapInTransaction
@@ -1772,8 +1799,9 @@ public class TestDataUtils {
     }
 
 
-    public static ContentType getYoutubeLikeContentType(){
-        return  getYoutubeLikeContentType("Youtube" + System.currentTimeMillis(), APILocator.systemHost(),null);
+    public static ContentType getYoutubeLikeContentType() {
+        return getYoutubeLikeContentType("Youtube" + System.currentTimeMillis(),
+                APILocator.systemHost(), null);
     }
 
     @WrapInTransaction
@@ -1925,16 +1953,18 @@ public class TestDataUtils {
                 newsPatternPrefix + "{urlTitle}");
 
         return getNewsContent(true, languageId,
-                        newsContentType.id(), host, sysPublishDate);
+                newsContentType.id(), host, sysPublishDate);
     }
 
     public static ContentType getMultipleBinariesContentType() {
-        return getMultipleBinariesContentType("MultipleBinaries" + System.currentTimeMillis(), APILocator.systemHost(),null);
+        return getMultipleBinariesContentType("MultipleBinaries" + System.currentTimeMillis(),
+                APILocator.systemHost(), null);
     }
 
     /**
-     * This will give you a CT that has 3 non-required binaries.
-     * The default metadata generated gets removed.
+     * This will give you a CT that has 3 non-required binaries. The default metadata generated gets
+     * removed.
+     *
      * @param contentTypeName
      * @param site
      * @param workflowIds
@@ -2018,7 +2048,6 @@ public class TestDataUtils {
                                 .next()
                 );
 
-
                 final ContentTypeDataGen contentTypeDataGen = new ContentTypeDataGen()
                         .name(contentTypeName)
                         .velocityVarName(contentTypeName)
@@ -2066,34 +2095,34 @@ public class TestDataUtils {
     }
 
     private static Contentlet persistBinaries(final Boolean persist, final long languageId,
-            final String contentTypeId, final Map<String, Object> files ) {
+            final String contentTypeId, final Map<String, Object> files) {
         try {
 
             final ContentletDataGen contentletDataGen = new ContentletDataGen(contentTypeId)
                     .languageId(languageId)
                     .setProperty("title", "blah");
 
-                   files.forEach((fileName, file) ->{
-                               try {
-                                     if(file instanceof TestFile) {
-                                         final TestFile testFile = (TestFile) file;
-                                         contentletDataGen.setProperty(fileName, nextBinaryFile(testFile));
-                                     } else {
-                                         contentletDataGen.setProperty(fileName, file);
-                                     }
+            files.forEach((fileName, file) -> {
+                        try {
+                            if (file instanceof TestFile) {
+                                final TestFile testFile = (TestFile) file;
+                                contentletDataGen.setProperty(fileName, nextBinaryFile(testFile));
+                            } else {
+                                contentletDataGen.setProperty(fileName, file);
+                            }
 
-                               } catch (Exception e) {
-                                   Logger.error(TestDataUtils.class,e);
-                               }
-                           }
-                   );
+                        } catch (Exception e) {
+                            Logger.error(TestDataUtils.class, e);
+                        }
+                    }
+            );
 
             if (persist) {
                 final Contentlet persisted = contentletDataGen.nextPersisted();
                 files.forEach((fileName, testFile) -> {
                     final Object file = persisted.get(fileName);
-                    if(file instanceof File) {
-                        removeAnyMetadata((File)file);
+                    if (file instanceof File) {
+                        removeAnyMetadata((File) file);
                     }
                 });
                 return persisted;
@@ -2107,12 +2136,14 @@ public class TestDataUtils {
 
     /**
      * This will use one of the internal test-files to generate a temp copy
+     *
      * @param testFile
      * @return
      * @throws IOException
      * @throws URISyntaxException
      */
-    public static File nextBinaryFile(final TestFile testFile) throws IOException, URISyntaxException {
+    public static File nextBinaryFile(final TestFile testFile)
+            throws IOException, URISyntaxException {
         final String testImagePath = testFile.filePath;
         final String ext = UtilMethods.getFileExtension(testImagePath);
         final File originalTestImage = new File(
@@ -2124,16 +2155,18 @@ public class TestDataUtils {
     }
 
     /**
-     * Test data's generated with medata. This removes it.
-     * For the new Api to be able to generate new
+     * Test data's generated with medata. This removes it. For the new Api to be able to generate
+     * new
+     *
      * @param binary
      */
-    public static void removeAnyMetadata(final File binary){
+    public static void removeAnyMetadata(final File binary) {
         final File immediateParent = new File(binary.getParent());
         //delete any previously generated json
         final File[] files = new File(immediateParent.getParent()).listFiles();
-        if(null != files){
-            final List<File> jsonFiles = Stream.of(files).filter(file -> file.getName().endsWith("json"))
+        if (null != files) {
+            final List<File> jsonFiles = Stream.of(files)
+                    .filter(file -> file.getName().endsWith("json"))
                     .collect(Collectors.toList());
             jsonFiles.forEach(file -> file.delete());
         }
@@ -2141,28 +2174,36 @@ public class TestDataUtils {
 
 
     public static ContentType newContentTypeFieldTypesGalore() {
-        final String contentTypeName = String.format("WithAllAvailableFieldTypes%s",System.nanoTime());
-        return newContentTypeFieldTypesGalore(contentTypeName,null);
+        final String contentTypeName = String.format("WithAllAvailableFieldTypes%s",
+                System.nanoTime());
+        return newContentTypeFieldTypesGalore(contentTypeName, null);
     }
 
     public static ContentType newContentTypeFieldTypesGalore(final Category parent) {
-        final String contentTypeName = String.format("WithAllAvailableFieldTypes%s",System.nanoTime());
-        return newContentTypeFieldTypesGalore(contentTypeName,null, parent);
+        final String contentTypeName = String.format("WithAllAvailableFieldTypes%s",
+                System.nanoTime());
+        return newContentTypeFieldTypesGalore(contentTypeName, null, parent);
     }
 
-    public static ContentType newContentTypeFieldTypesGalore(final String contentTypeName, final Set<String> workflowIds) {
+    public static ContentType newContentTypeFieldTypesGalore(final String contentTypeName,
+            final Set<String> workflowIds) {
         final CategoryAPI categoryAPI = APILocator.getCategoryAPI();
-        final Optional<Category> anyTopLevelCategory = Try.of(()->categoryAPI.findTopLevelCategories(APILocator.systemUser(), false).stream().findAny()).get();
-        return newContentTypeFieldTypesGalore(contentTypeName,workflowIds, anyTopLevelCategory.orElse(null));
+        final Optional<Category> anyTopLevelCategory = Try.of(
+                () -> categoryAPI.findTopLevelCategories(APILocator.systemUser(), false).stream()
+                        .findAny()).get();
+        return newContentTypeFieldTypesGalore(contentTypeName, workflowIds,
+                anyTopLevelCategory.orElse(null));
     }
 
     @WrapInTransaction
-    public static ContentType newContentTypeFieldTypesGalore(final String contentTypeName, Set<String> workflowIds, final Category parent) {
+    public static ContentType newContentTypeFieldTypesGalore(final String contentTypeName,
+            Set<String> workflowIds, final Category parent) {
 
         ContentType contentType = null;
         try {
             try {
-                contentType = APILocator.getContentTypeAPI(APILocator.systemUser()).find(contentTypeName);
+                contentType = APILocator.getContentTypeAPI(APILocator.systemUser())
+                        .find(contentTypeName);
             } catch (NotFoundInDbException e) {
                 //Do nothing...
             }
@@ -2171,7 +2212,7 @@ public class TestDataUtils {
                 final WorkflowScheme systemWorkflow = TestWorkflowUtils.getSystemWorkflow();
                 final Set<String> collectedWorkflowIds = new HashSet<>();
                 collectedWorkflowIds.add(systemWorkflow.getId());
-                if(null != workflowIds){
+                if (null != workflowIds) {
                     collectedWorkflowIds.addAll(workflowIds);
                 }
 
@@ -2325,7 +2366,7 @@ public class TestDataUtils {
                 );
 
                 //Category field
-                if(null != parent) {
+                if (null != parent) {
                     fields.add(new FieldDataGen()
                             .name("categoryField")
                             .velocityVarName("categoryField")
@@ -2358,19 +2399,21 @@ public class TestDataUtils {
     }
 
     @WrapInTransaction
-    public static ContentType newContentTypeWithMultipleCategoryFields(final String contentTypeName, Set<String> workflowIds, final List<Category> parents) {
+    public static ContentType newContentTypeWithMultipleCategoryFields(final String contentTypeName,
+            Set<String> workflowIds, final List<Category> parents) {
 
         ContentType contentType;
         try {
 
-            contentType = Try.of(()->APILocator.getContentTypeAPI(APILocator.systemUser()).find(contentTypeName)).getOrNull();
+            contentType = Try.of(() -> APILocator.getContentTypeAPI(APILocator.systemUser())
+                    .find(contentTypeName)).getOrNull();
 
             if (contentType == null) {
 
                 final WorkflowScheme systemWorkflow = TestWorkflowUtils.getSystemWorkflow();
                 final Set<String> collectedWorkflowIds = new HashSet<>();
                 collectedWorkflowIds.add(systemWorkflow.getId());
-                if(null != workflowIds){
+                if (null != workflowIds) {
                     collectedWorkflowIds.addAll(workflowIds);
                 }
 
@@ -2387,13 +2430,13 @@ public class TestDataUtils {
 
                 //Category field
                 int i = 0;
-                for(Category parent:parents){
-                    final String name = "categoryField"+i;
+                for (Category parent : parents) {
+                    final String name = "categoryField" + i;
                     fields.add(new FieldDataGen()
-                          .name(name)
-                          .velocityVarName(name)
-                          .type(CategoryField.class)
-                          .values(parent.getInode()).next());
+                            .name(name)
+                            .velocityVarName(name)
+                            .type(CategoryField.class)
+                            .values(parent.getInode()).next());
                     i++;
                 }
 
@@ -2414,11 +2457,13 @@ public class TestDataUtils {
 
     /**
      * This method creates a parent category and a couple of child categories.
+     *
      * @return the parent category
      */
-    public static Category createCategories(){
+    public static Category createCategories() {
 
-        final String parentCategoryName = String.format("Parent-Category-[%d]", System.currentTimeMillis());
+        final String parentCategoryName = String.format("Parent-Category-[%d]",
+                System.currentTimeMillis());
         final Category parentCategory = new CategoryDataGen()
                 .setCategoryName(parentCategoryName)
                 .setKey(parentCategoryName + "Key")
@@ -2426,8 +2471,9 @@ public class TestDataUtils {
                 .setSortOrder(1)
                 .nextPersisted();
 
-        for(int i=0; i<=2; i++) {
-            final String childCategoryName = String.format("Child-Category-[%d]-[%d]", i, System.currentTimeMillis());
+        for (int i = 0; i <= 2; i++) {
+            final String childCategoryName = String.format("Child-Category-[%d]-[%d]", i,
+                    System.currentTimeMillis());
 
             new CategoryDataGen()
                     .setCategoryName(childCategoryName)
@@ -2439,6 +2485,28 @@ public class TestDataUtils {
         }
 
         return parentCategory;
+    }
+
+    /**
+     * This method waits for the reindex queue to be empty.
+     *
+     * @return the parent category
+     */
+    public static boolean waitForEmptyQueue() {
+        final ReindexQueueAPI reindexQueueAPI = APILocator.getReindexQueueAPI();
+        try {
+            Awaitility.await().atMost(120, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .until(reindexQueueAPI::areRecordsLeftToIndex, equalTo(false));
+            return true;
+        } catch (ConditionTimeoutException e) {
+            Logger.warn(TestWorkflowUtils.class, "Reindex Queue is not empty after 120 seconds");
+            return false;
+        }
+    }
+
+    public static void assertEmptyQueue() {
+        Assert.assertTrue("Queue should be empty", waitForEmptyQueue());
     }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/web/ExperimentWebAPIImplIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/web/ExperimentWebAPIImplIT.java
@@ -65,7 +65,7 @@ public class ExperimentWebAPIImplIT {
 
             final HttpServletRequest request = mock(HttpServletRequest.class);
 
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 100; i++) {
                 final DotCMSMockResponse response = new DotCMSMockResponse();
 
                 final SelectedExperiments selectedExperiments = WebAPILocator.getExperimentWebAPI()
@@ -106,7 +106,7 @@ public class ExperimentWebAPIImplIT {
 
             final HttpServletRequest request = mock(HttpServletRequest.class);
 
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 100; i++) {
                 final DotCMSMockResponse response = new DotCMSMockResponse();
 
 
@@ -148,7 +148,7 @@ public class ExperimentWebAPIImplIT {
 
         final Instant expireDate = Instant.now().plus(30, ChronoUnit.DAYS);
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 100; i++) {
 
             final DotCMSMockResponse response = new DotCMSMockResponse();
             final SelectedExperiments selectedExperiments = WebAPILocator.getExperimentWebAPI()
@@ -183,7 +183,7 @@ public class ExperimentWebAPIImplIT {
             final HttpServletRequest request = mock(HttpServletRequest.class);
             final List<SelectedExperiment> experimentsSelected = new ArrayList<>();
 
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 100; i++) {
                 final DotCMSMockResponse response = new DotCMSMockResponse();
                 final SelectedExperiments selectedExperiments = WebAPILocator.getExperimentWebAPI()
                         .isUserIncluded(request, response, null);
@@ -196,11 +196,13 @@ public class ExperimentWebAPIImplIT {
                 assertTrue(selectedExperiments.getExcludedExperimentIds().isEmpty());
             }
 
+            // Random Failure rate = 0.5^n = 1 in 1/(0.5^50)
             final boolean anyNoneExperiment = experimentsSelected.stream()
                     .anyMatch(experimentSelected -> ExperimentWebAPI.NONE_EXPERIMENT.id().equals(
                             experimentSelected.id()));
             assertTrue("Expected some NONE response", anyNoneExperiment);
 
+            // Random Failure rate = 0.5^n = 1 in 1/(0.5^50) = 1 in 1125899906842624
             final boolean anySelectedExperiment = experimentsSelected.stream()
                     .anyMatch(experimentSelected -> experiment.id().get().equals(
                             experimentSelected.id()));
@@ -229,7 +231,8 @@ public class ExperimentWebAPIImplIT {
             final HttpServletRequest request = mock(HttpServletRequest.class);
             final List<SelectedExperiment> experimentsSelected = new ArrayList<>();
 
-            for (int i = 0; i < 10; i++) {
+
+            for (int i = 0; i < 100; i++) {
                 final DotCMSMockResponse response = new DotCMSMockResponse();
                 final SelectedExperiments selectedExperiments = WebAPILocator.getExperimentWebAPI()
                         .isUserIncluded(request, response, null);
@@ -247,6 +250,7 @@ public class ExperimentWebAPIImplIT {
                 assertTrue(selectedExperiments.getExcludedExperimentIds().isEmpty());
             }
 
+            // Random failure expected is 1 in 1/(0.75^n)
             final boolean anyNoneExperiment = experimentsSelected.stream()
                     .anyMatch(experimentSelected -> ExperimentWebAPI.NONE_EXPERIMENT.name().equals(
                             experimentSelected.name()));
@@ -300,7 +304,7 @@ public class ExperimentWebAPIImplIT {
 
             final HttpServletRequest request = mock(HttpServletRequest.class);
 
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 100; i++) {
                 final DotCMSMockResponse response = new DotCMSMockResponse();
                 final SelectedExperiments selectedExperiments = WebAPILocator.getExperimentWebAPI()
                         .isUserIncluded(request, response, null);
@@ -349,7 +353,7 @@ public class ExperimentWebAPIImplIT {
             final HttpServletRequest request = mock(HttpServletRequest.class);
             when(request.getAttribute("testing-attribute")).thenReturn("testing");
 
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 100; i++) {
                 final DotCMSMockResponse response = new DotCMSMockResponse();
                 final SelectedExperiments selectedExperiments = WebAPILocator.getExperimentWebAPI()
                         .isUserIncluded(request, response, null);
@@ -405,7 +409,7 @@ public class ExperimentWebAPIImplIT {
             final HttpServletRequest request = mock(HttpServletRequest.class);
             when(request.getAttribute("testing-attribute")).thenReturn("testing");
 
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 100; i++) {
                 final DotCMSMockResponse response = new DotCMSMockResponse();
                 final SelectedExperiments selectedExperiments = WebAPILocator.getExperimentWebAPI()
                         .isUserIncluded(request, response, null);
@@ -459,7 +463,7 @@ public class ExperimentWebAPIImplIT {
 
             final List<SelectedExperiment> experiments = new ArrayList<>();
 
-            for (int i = 0; i < 20; i++) {
+            for (int i = 0; i < 100; i++) {
                 final DotCMSMockResponse response = new DotCMSMockResponse();
                 final SelectedExperiments selectedExperiments = WebAPILocator.getExperimentWebAPI()
                         .isUserIncluded(request, response, null);

--- a/dotCMS/src/integration-test/java/com/dotcms/junit/MainBaseSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/junit/MainBaseSuite.java
@@ -2,11 +2,8 @@ package com.dotcms.junit;
 
 import com.dotcms.business.bytebuddy.ByteBuddyFactory;
 import com.dotcms.util.StdOutErrLog;
-import com.dotmarketing.db.DbConnectionFactory;
 import java.util.LinkedList;
 import java.util.List;
-
-import com.dotmarketing.util.Logger;
 import org.junit.runner.Description;
 import org.junit.runner.Runner;
 import org.junit.runner.notification.RunNotifier;
@@ -34,7 +31,6 @@ public class MainBaseSuite extends Suite {
 
     private static List<Runner> getRunners(Class<?>[] classes) throws InitializationError {
 
-        System.out.println("Register ByteBuddy");
         ByteBuddyFactory.init();
         List<Runner> runners = new LinkedList<>();
 
@@ -61,16 +57,7 @@ public class MainBaseSuite extends Suite {
 
         @Override
         public void run(RunNotifier notifier) {
-            try {
-                this.runner.run(notifier);
-            } finally {
-                if (DbConnectionFactory.inTransaction())
-                    Logger.error(DotRunner.class,"Test "+this.getDescription()+" has open transaction after");
-
-                if (DbConnectionFactory.connectionExists())
-                    Logger.error(DotRunner.class,"Test "+this.getDescription()+" has open connection after");
-                DbConnectionFactory.closeSilently();
-            }
+            this.runner.run(notifier);
         }
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/junit/RuleWatcher.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/junit/RuleWatcher.java
@@ -114,7 +114,6 @@ public class RuleWatcher extends TestWatcher {
                     } else {
                         HibernateUtil.rollbackTransaction();
                     }
-                    HibernateUtil.rollbackTransaction();
                 } catch (DotHibernateException e) {
                     Logger.error(RuleWatcher.class,
                             "Error force " + responseAction + " back transaction");

--- a/dotCMS/src/integration-test/java/com/dotcms/junit/RuleWatcher.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/junit/RuleWatcher.java
@@ -1,10 +1,30 @@
 package com.dotcms.junit;
 
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.datagen.TestDataUtils;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.common.reindex.ReindexQueueAPI;
+import com.dotmarketing.common.reindex.ReindexThread;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.db.HibernateUtil;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotHibernateException;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
+import static com.dotmarketing.util.Config.USE_CONFIG_TEST_OVERRIDE_TRACKER;
+
 public class RuleWatcher extends TestWatcher {
+
+    public static final String USE_TEST_INDEXER_TRACKER = "USE_TEST_INDEXER_TRACKER";
+    public static final String USE_TEST_TRANSACTION_TRACKER = "USE_TEST_TRANSACTION_TRACKER";
+    public static final String TEST_TRANSACTION_TRACKER_AUTO_CLOSE_TYPE = "TEST_TRANSACTION_TRACKER_AUTO_CLOSE_TYPE";
+    public static final String TRANSACTION_AUTO_CLOSE_DEFAULT = "rollback";
+    private Map<Integer, Map<String, String>> overrides = new ConcurrentHashMap<>();
 
     @Override
     protected void starting(Description description) {
@@ -14,6 +34,100 @@ public class RuleWatcher extends TestWatcher {
                         description,
                         "starting..."));
         Logger.info(RuleWatcher.class, ">>>>>>>>>>>>>>>>>>>>>>>>>>");
+        configOverrideTrackerBefore(description);
+
+    }
+
+    @Override
+    protected void finished(Description description) {
+        Logger.info(RuleWatcher.class, ">>>>>>>>>cleanup>>>>>>>>>>");
+        transactionTrackerAfter(description);
+        configOverrideTrackerAfter(description);
+        indexerTrackerAfter();
+        Logger.info(RuleWatcher.class,
+                String.format(">>> %s - %s",
+                        description,
+                        "finished..."));
+    }
+    //TODO: these should be moved to different classes they could be handled as their own Rules
+
+    private static void indexerTrackerAfter() {
+        if (Config.getBooleanProperty(USE_TEST_INDEXER_TRACKER, false)) {
+            Logger.info(MainBaseSuite.class, "Checking indexer status...");
+            try {
+                ReindexQueueAPI queueAPI = APILocator.getReindexQueueAPI();
+                if (queueAPI.areRecordsLeftToIndex()) {
+                    Logger.info(MainBaseSuite.class,
+                            "Indexer is not empty, waiting for it to finish");
+                    if (!ReindexThread.isWorking()) {
+                        Logger.info(MainBaseSuite.class, "Indexer was not running, unpausing now");
+                        ReindexThread.unpause();
+                    }
+                    TestDataUtils.waitForEmptyQueue();
+                    boolean queueEmpty = TestDataUtils.waitForEmptyQueue();
+                    Logger.info(MainBaseSuite.class, "Indexer Complete=" + queueEmpty);
+                }
+            } catch (DotDataException e) {
+                throw new RuntimeException("Error accessing Index", e);
+            }
+        }
+    }
+
+
+    private void configOverrideTrackerBefore(Description description) {
+        if (Config.getBooleanProperty(USE_CONFIG_TEST_OVERRIDE_TRACKER, false)) {
+            if (Logger.isDebugEnabled(RuleWatcher.class)) {
+                Config.getOverrides().forEach((k, v) -> Logger.warn(this.getClass(),
+                        () -> "Config overrides before test: " + k + " = " + v));
+            }
+            overrides.put(description.hashCode(), Config.getOverrides());
+        }
+    }
+
+    private void configOverrideTrackerAfter(Description description) {
+        if (Config.getBooleanProperty(USE_CONFIG_TEST_OVERRIDE_TRACKER, false)) {
+            Logger.warn(RuleWatcher.class, "Checking for modified Config overrides...");
+            Map<String, String> modifiedOverrides = Config.compareOverrides(
+                    overrides.get(description.hashCode()));
+            overrides.remove(description.hashCode());
+            if (!modifiedOverrides.isEmpty()) {
+                String mapContents = modifiedOverrides.entrySet().stream()
+                        .map(entry -> entry.getKey() + "=" + entry.getValue())
+                        .reduce((a, b) -> a + ", " + b).orElse("empty");
+                Logger.warn(IntegrationTestBase.class,
+                        "Modified Config overrides after:" + mapContents);
+            }
+        }
+    }
+
+    private static void transactionTrackerAfter(Description description) {
+        if (Config.getBooleanProperty(USE_TEST_TRANSACTION_TRACKER, false)) {
+            if (DbConnectionFactory.inTransaction()) {
+                Logger.error(RuleWatcher.class,
+                        "Test " + description + " has open transaction after");
+                Object responseAction = Config.getStringProperty(
+                        TEST_TRANSACTION_TRACKER_AUTO_CLOSE_TYPE, TRANSACTION_AUTO_CLOSE_DEFAULT);
+                try {
+                    if (Config.getStringProperty(TEST_TRANSACTION_TRACKER_AUTO_CLOSE_TYPE,
+                            TRANSACTION_AUTO_CLOSE_DEFAULT).equals("commit")) {
+                        HibernateUtil.commitTransaction();
+                    } else {
+                        HibernateUtil.rollbackTransaction();
+                    }
+                    HibernateUtil.rollbackTransaction();
+                } catch (DotHibernateException e) {
+                    Logger.error(RuleWatcher.class,
+                            "Error force " + responseAction + " back transaction");
+                }
+            }
+
+            if (DbConnectionFactory.connectionExists()) {
+                Logger.warn(RuleWatcher.class,
+                        "Test " + description + " has open connection after");
+                DbConnectionFactory.closeSilently();
+            }
+
+        }
     }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/publisher/business/PublisherTestUtil.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/publisher/business/PublisherTestUtil.java
@@ -60,20 +60,24 @@ public class PublisherTestUtil {
 
     private final static String PROTOCOL = "http";
     public static final String FILE = "file";
+
     /**
      * Creates a generic TestEnvironment
+     *
      * @param user
      * @return
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    public static Environment createEnvironment (final User user) throws DotDataException, DotSecurityException {
+    public static Environment createEnvironment(final User user)
+            throws DotDataException, DotSecurityException {
 
-        final EnvironmentAPI environmentAPI               = APILocator.getEnvironmentAPI();
-        final Environment      environment1               = new Environment();
-        final List<Permission> permissions1               = new ArrayList<>();
+        final EnvironmentAPI environmentAPI = APILocator.getEnvironmentAPI();
+        final Environment environment1 = new Environment();
+        final List<Permission> permissions1 = new ArrayList<>();
         permissions1.add(new Permission(environment1.getId(),
-                APILocator.getRoleAPI().loadRoleByKey(user.getUserId()).getId(), PermissionAPI.PERMISSION_USE));
+                APILocator.getRoleAPI().loadRoleByKey(user.getUserId()).getId(),
+                PermissionAPI.PERMISSION_USE));
 
         environment1.setName("TestEnvironment_" + valueOf(new Date().getTime()));
         environment1.setPushToAll(false);
@@ -84,69 +88,76 @@ public class PublisherTestUtil {
 
     /**
      * Creates a generic TestEndpoint
+     *
      * @param environment
      * @return
      * @throws DotDataException
      */
-    public static PublishingEndPoint createEndpoint (final Environment environment) throws DotDataException {
+    public static PublishingEndPoint createEndpoint(final Environment environment)
+            throws DotDataException {
 
-        final PublishingEndPointAPI publisherEndPointAPI  = APILocator.getPublisherEndPointAPI();
+        final PublishingEndPointAPI publisherEndPointAPI = APILocator.getPublisherEndPointAPI();
         final PublishingEndPointFactory factory = new PublishingEndPointFactory();
         final PublishingEndPoint endpoint1 = factory.getPublishingEndPoint(PROTOCOL);
-        endpoint1.setServerName( new StringBuilder( "TestEndPoint" + valueOf( new Date().getTime() ) ) );
-        endpoint1.setAddress( "127.0.0.1" );
-        endpoint1.setPort( "999" );
+        endpoint1.setServerName(new StringBuilder("TestEndPoint" + System.nanoTime()));
+        endpoint1.setAddress("127.0.0.1");
+        endpoint1.setPort("999");
         endpoint1.setProtocol(PROTOCOL);
-        endpoint1.setAuthKey( new StringBuilder( PublicEncryptionFactory.encryptString( "1111" ) ) );
-        endpoint1.setEnabled( true );
-        endpoint1.setSending( false );
-        endpoint1.setGroupId( environment.getId() );
+        endpoint1.setAuthKey(new StringBuilder(PublicEncryptionFactory.encryptString("1111")));
+        endpoint1.setEnabled(true);
+        endpoint1.setSending(false);
+        endpoint1.setGroupId(environment.getId());
 
-        publisherEndPointAPI.saveEndPoint( endpoint1 );
+        publisherEndPointAPI.saveEndPoint(endpoint1);
 
         return endpoint1;
     } // createEndpoint
 
     /**
      * Creates a generic TestEndpoint
+     *
      * @param environment
      * @return
      * @throws DotDataException
      */
-    public static PublishingEndPoint createEndpoint (final Environment environment, final Key newKey, final String seedText)
+    public static PublishingEndPoint createEndpoint(final Environment environment, final Key newKey,
+            final String seedText)
             throws DotDataException, EncryptorException {
 
-        final PublishingEndPointAPI publisherEndPointAPI  = APILocator.getPublisherEndPointAPI();
+        final PublishingEndPointAPI publisherEndPointAPI = APILocator.getPublisherEndPointAPI();
         final PublishingEndPointFactory factory = new PublishingEndPointFactory();
         final PublishingEndPoint endpoint1 = factory.getPublishingEndPoint(PROTOCOL);
-        endpoint1.setServerName( new StringBuilder( "TestEndPoint" + valueOf( new Date().getTime() ) ) );
-        endpoint1.setAddress( "127.0.0.1" );
-        endpoint1.setPort( "999" );
+        endpoint1.setServerName(new StringBuilder("TestEndPoint" + valueOf(new Date().getTime())));
+        endpoint1.setAddress("127.0.0.1");
+        endpoint1.setPort("999");
         endpoint1.setProtocol(PROTOCOL);
 
-        final String encryptedKey =  Encryptor.encrypt(newKey,seedText);
-        endpoint1.setAuthKey( new StringBuilder( encryptedKey ) );
-        endpoint1.setEnabled( true );
-        endpoint1.setSending( false );
-        endpoint1.setGroupId( environment.getId() );
+        final String encryptedKey = Encryptor.encrypt(newKey, seedText);
+        endpoint1.setAuthKey(new StringBuilder(encryptedKey));
+        endpoint1.setEnabled(true);
+        endpoint1.setSending(false);
+        endpoint1.setGroupId(environment.getId());
 
-        publisherEndPointAPI.saveEndPoint( endpoint1 );
+        publisherEndPointAPI.saveEndPoint(endpoint1);
 
         return endpoint1;
     } // createEnd
 
     /**
-     * Deletes the bundle, endpoint and environment, specially util at the end of a PP process for testing
+     * Deletes the bundle, endpoint and environment, specially util at the end of a PP process for
+     * testing
+     *
      * @param bundle1
      * @param endpoint1
      * @param environment1
      */
-    public static void cleanBundleEndpointEnv (final Bundle bundle1, final PublishingEndPoint endpoint1,
-                                               final Environment environment1) {
+    public static void cleanBundleEndpointEnv(final Bundle bundle1,
+            final PublishingEndPoint endpoint1,
+            final Environment environment1) {
 
-        final BundleAPI bundleAPI                         = APILocator.getBundleAPI();
-        final PublishingEndPointAPI publisherEndPointAPI  = APILocator.getPublisherEndPointAPI();
-        final EnvironmentAPI   environmentAPI             = APILocator.getEnvironmentAPI();
+        final BundleAPI bundleAPI = APILocator.getBundleAPI();
+        final PublishingEndPointAPI publisherEndPointAPI = APILocator.getPublisherEndPointAPI();
+        final EnvironmentAPI environmentAPI = APILocator.getEnvironmentAPI();
 
         try {
             if (null != bundle1) {
@@ -154,7 +165,9 @@ public class PublisherTestUtil {
                 bundleAPI.deleteBundle(bundle1.getId());
             }
 
-        } catch (Exception e) { e.printStackTrace(); } finally {
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
 
             try {
                 if (null != endpoint1) {
@@ -162,7 +175,9 @@ public class PublisherTestUtil {
                     publisherEndPointAPI.deleteEndPointById(endpoint1.getId());
                 }
 
-            } catch (Exception e) { e.printStackTrace();  } finally {
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
 
                 if (null != environment1) {
                     try {
@@ -177,33 +192,38 @@ public class PublisherTestUtil {
 
     /**
      * Creates a folder generic based on a given name
+     *
      * @param testfolder
      * @return
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    public static  Folder createFolder(final String testfolder) throws DotDataException, DotSecurityException {
+    public static Folder createFolder(final String testfolder)
+            throws DotDataException, DotSecurityException {
 
         final User sysuser = APILocator.getUserAPI().getSystemUser();
-        final Host host    = APILocator.getHostAPI().findDefaultHost(sysuser, false);
+        final Host host = APILocator.getHostAPI().findDefaultHost(sysuser, false);
 
         return APILocator.getFolderAPI().createFolders(
-                testfolder + UUIDGenerator.generateUuid().replaceAll("-", "_"), host, sysuser, false);
+                testfolder + UUIDGenerator.generateUuid().replaceAll("-", "_"), host, sysuser,
+                false);
 
     }
 
     /**
      * Creates and saves bundle
+     *
      * @param bundleName
      * @param user
      * @return
      * @throws DotDataException
      */
-    public static Bundle createBundle (final String bundleName, final User user, final Environment environment)
+    public static Bundle createBundle(final String bundleName, final User user,
+            final Environment environment)
             throws DotDataException {
 
-        final BundleAPI  bundleAPI         = APILocator.getBundleAPI();
-        final Bundle     bundle1           = new Bundle(bundleName, null, null, user.getUserId());
+        final BundleAPI bundleAPI = APILocator.getBundleAPI();
+        final Bundle bundle1 = new Bundle(bundleName, null, null, user.getUserId());
 
         bundleAPI.saveBundle(bundle1);
         bundleAPI.saveBundleEnvironment(bundle1, environment);
@@ -212,23 +232,27 @@ public class PublisherTestUtil {
 
     /**
      * Creates a template, and a generic page based on it, saving the info in a given folder.
+     *
      * @param folder
      * @return
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    public static HTMLPageAsset createPage (final Folder folder, final User user) throws DotDataException, DotSecurityException {
+    public static HTMLPageAsset createPage(final Folder folder, final User user)
+            throws DotDataException, DotSecurityException {
 
-        final User sysuser      = APILocator.getUserAPI().getSystemUser();
-        final Host host         = APILocator.getHostAPI().findDefaultHost(sysuser, false);
-        Template template       = new Template();
-        template.setTitle("a template "+UUIDGenerator.generateUuid());
-        template. setBody("<html><body> I'm mostly empty </body></html>");
-        template                = APILocator.getTemplateAPI().saveTemplate(template, host, sysuser, false);
+        final User sysuser = APILocator.getUserAPI().getSystemUser();
+        final Host host = APILocator.getHostAPI().findDefaultHost(sysuser, false);
+        Template template = new Template();
+        template.setTitle("a template " + UUIDGenerator.generateUuid());
+        template.setBody("<html><body> I'm mostly empty </body></html>");
+        template = APILocator.getTemplateAPI().saveTemplate(template, host, sysuser, false);
 
-        final HTMLPageAsset page = new HTMLPageDataGen(folder, template).languageId(1).nextPersisted();
+        final HTMLPageAsset page = new HTMLPageDataGen(folder, template).languageId(1)
+                .nextPersisted();
 
-        final HTMLPageAsset pageAsset = (HTMLPageAsset)APILocator.getHTMLPageAssetAPI().findPage(page.getInode(), sysuser, false);
+        final HTMLPageAsset pageAsset = (HTMLPageAsset) APILocator.getHTMLPageAssetAPI()
+                .findPage(page.getInode(), sysuser, false);
 
         pageAsset.setIndexPolicy(IndexPolicy.FORCE);
         pageAsset.setIndexPolicyDependencies(IndexPolicy.FORCE);
@@ -241,22 +265,26 @@ public class PublisherTestUtil {
         pageAsset.setBoolProperty(Contentlet.IS_TEST_MODE, true);
 
         APILocator.getContentletIndexAPI().addContentToIndex(pageAsset);
-        assertEquals(1, APILocator.getContentletAPI().indexCount("+inode:" + pageAsset.getInode() + " " + UUIDGenerator.ulid(), user, false));
+        assertEquals(1, APILocator.getContentletAPI()
+                .indexCount("+inode:" + pageAsset.getInode() + " " + UUIDGenerator.ulid(), user,
+                        false));
 
         return pageAsset;
     }
 
     /**
      * Get the assets to push based on a set of contentlet
+     *
      * @param bundle
      * @param contentlets
      * @return
      */
-    public static List<PublishQueueElement> getAssets(final Bundle bundle, final Contentlet... contentlets) {
+    public static List<PublishQueueElement> getAssets(final Bundle bundle,
+            final Contentlet... contentlets) {
 
         final List<PublishQueueElement> queueElements = new ArrayList<>();
 
-        for (final Contentlet contentlet: contentlets) {
+        for (final Contentlet contentlet : contentlets) {
 
             queueElements.add(getAsset(bundle, contentlet));
         }
@@ -266,15 +294,17 @@ public class PublisherTestUtil {
 
     /**
      * Get the assets to push based on a set of folders
+     *
      * @param bundle
      * @param folders
      * @return
      */
-    public static List<PublishQueueElement> getAssets(final Bundle bundle, final Folder... folders) {
+    public static List<PublishQueueElement> getAssets(final Bundle bundle,
+            final Folder... folders) {
 
         final List<PublishQueueElement> queueElements = new ArrayList<>();
 
-        for (final Folder folder: folders) {
+        for (final Folder folder : folders) {
 
             queueElements.add(getAsset(bundle, folder));
         }
@@ -284,17 +314,19 @@ public class PublisherTestUtil {
 
     /**
      * Push a list of assets into a bundle
+     *
      * @param assets
      * @param bundle
      * @throws DotPublisherException
      * @throws DotDataException
      */
-    public static PublishStatus push(final List<PublishQueueElement> assets, final Bundle bundle, final User user)
+    public static PublishStatus push(final List<PublishQueueElement> assets, final Bundle bundle,
+            final User user)
             throws DotPublisherException, DotDataException, IllegalAccessException, InstantiationException, DotSecurityException {
 
-        final PublishAuditStatus  status              = new PublishAuditStatus(bundle.getId());
-        final PublisherConfig     pushPublisherConfig = new PushPublisherConfig();
-        final PublishAuditHistory historyPojo         = new PublishAuditHistory();
+        final PublishAuditStatus status = new PublishAuditStatus(bundle.getId());
+        final PublisherConfig pushPublisherConfig = new PushPublisherConfig();
+        final PublishAuditHistory historyPojo = new PublishAuditHistory();
         final PublisherConfig.DeliveryStrategy deliveryStrategy =
                 PublisherConfig.DeliveryStrategy.ALL_ENDPOINTS;
 
@@ -302,22 +334,26 @@ public class PublisherTestUtil {
         pushPublisherConfig.setAssets(assets);
 
         audit(assets, status, historyPojo);
-        return pushPublish(preparePushConfiguration(assets, bundle, pushPublisherConfig, deliveryStrategy, PushPublisherConfig.Operation.PUBLISH), historyPojo);
+        return pushPublish(
+                preparePushConfiguration(assets, bundle, pushPublisherConfig, deliveryStrategy,
+                        PushPublisherConfig.Operation.PUBLISH), historyPojo);
     }
 
     /**
      * Push a remote remove
+     *
      * @param assets
      * @param bundle
      * @param user
      * @return
      */
-    public static PublishStatus remoteRemove(final List<PublishQueueElement> assets, final Bundle bundle, final User user)
+    public static PublishStatus remoteRemove(final List<PublishQueueElement> assets,
+            final Bundle bundle, final User user)
             throws DotPublisherException, DotDataException, IllegalAccessException, InstantiationException, DotSecurityException {
 
-        final PublishAuditStatus  status              = new PublishAuditStatus(bundle.getId());
-        final PublisherConfig     pushPublisherConfig = new PushPublisherConfig();
-        final PublishAuditHistory historyPojo         = new PublishAuditHistory();
+        final PublishAuditStatus status = new PublishAuditStatus(bundle.getId());
+        final PublisherConfig pushPublisherConfig = new PushPublisherConfig();
+        final PublishAuditHistory historyPojo = new PublishAuditHistory();
         final PublisherConfig.DeliveryStrategy deliveryStrategy =
                 PublisherConfig.DeliveryStrategy.ALL_ENDPOINTS;
 
@@ -325,14 +361,16 @@ public class PublisherTestUtil {
         pushPublisherConfig.setAssets(assets);
 
         audit(assets, status, historyPojo);
-        return pushPublish(preparePushConfiguration(assets, bundle, pushPublisherConfig, deliveryStrategy, PushPublisherConfig.Operation.UNPUBLISH), historyPojo);
+        return pushPublish(
+                preparePushConfiguration(assets, bundle, pushPublisherConfig, deliveryStrategy,
+                        PushPublisherConfig.Operation.UNPUBLISH), historyPojo);
     }
 
     private static PublishQueueElement getAsset(final Bundle bundle, final Contentlet contentlet) {
 
         final PublishQueueElement element = new PublishQueueElement();
 
-        element.setId((int)System.currentTimeMillis());
+        element.setId((int) System.currentTimeMillis());
         element.setAsset(contentlet.getIdentifier());
         element.setBundleId(bundle.getId());
         element.setEnteredDate(new Date());
@@ -346,7 +384,7 @@ public class PublisherTestUtil {
 
         final PublishQueueElement element = new PublishQueueElement();
 
-        element.setId((int)System.currentTimeMillis());
+        element.setId((int) System.currentTimeMillis());
         element.setAsset(folder.getIdentifier());
         element.setBundleId(bundle.getId());
         element.setEnteredDate(new Date());
@@ -357,18 +395,19 @@ public class PublisherTestUtil {
     }
 
 
-
-    private static PublishStatus pushPublish(final PublisherConfig publisherConfig, final PublishAuditHistory historyPojo) throws DotPublisherException {
+    private static PublishStatus pushPublish(final PublisherConfig publisherConfig,
+            final PublishAuditHistory historyPojo) throws DotPublisherException {
 
         final PublishAuditAPI publishAuditAPI = PublishAuditAPI.getInstance();
-        final PublisherAPI    publisherAPI    = PublisherAPI.getInstance();
-        PublishStatus         publishStatus   = null;
+        final PublisherAPI publisherAPI = PublisherAPI.getInstance();
+        PublishStatus publishStatus = null;
 
         try {
             publishStatus = APILocator.getPublisherAPI().publish(publisherConfig);
         } catch (DotPublishingException e) {
 
-            publishAuditAPI.updatePublishAuditStatus(publisherConfig.getId(), PublishAuditStatus.Status.FAILED_TO_BUNDLE, historyPojo);
+            publishAuditAPI.updatePublishAuditStatus(publisherConfig.getId(),
+                    PublishAuditStatus.Status.FAILED_TO_BUNDLE, historyPojo);
             publisherAPI.deleteElementsFromPublishQueueTable(publisherConfig.getId());
         }
 
@@ -376,17 +415,19 @@ public class PublisherTestUtil {
     }
 
     private static PublisherConfig preparePushConfiguration(final List<PublishQueueElement> assets,
-                                                            final Bundle bundle,
-                                                            final PublisherConfig publisherConfig,
-                                                            final PublisherConfig.DeliveryStrategy deliveryStrategy,
-                                                            final PublisherConfig.Operation operation) throws DotDataException, InstantiationException, IllegalAccessException {
+            final Bundle bundle,
+            final PublisherConfig publisherConfig,
+            final PublisherConfig.DeliveryStrategy deliveryStrategy,
+            final PublisherConfig.Operation operation)
+            throws DotDataException, InstantiationException, IllegalAccessException {
 
         publisherConfig.setLuceneQueries(PublisherUtil.prepareQueries(assets));
         publisherConfig.setId(bundle.getId());
         publisherConfig.setUser(APILocator.getUserAPI().getSystemUser());
         publisherConfig.setStartDate(new Date());
         publisherConfig.runNow();
-        publisherConfig.setPublishers(Arrays.asList(TestPushPublisher.class)); // we use our test PP, since we do not really do a http request
+        publisherConfig.setPublishers(Arrays.asList(
+                TestPushPublisher.class)); // we use our test PP, since we do not really do a http request
         publisherConfig.setDeliveryStrategy(deliveryStrategy);
         publisherConfig.setOperation(operation);
 
@@ -398,33 +439,39 @@ public class PublisherTestUtil {
 
         final List<Class> publishers = pconf.getPublishers();
         for (Class<?> publisher : publishers) {
-            pconf = ((Publisher)publisher.newInstance()).setUpConfig(pconf);
+            pconf = ((Publisher) publisher.newInstance()).setUpConfig(pconf);
         }
 
         return pconf;
     }
 
     private static void audit(final List<PublishQueueElement> assets,
-                              final PublishAuditStatus status, final PublishAuditHistory historyPojo) throws DotPublisherException {
+            final PublishAuditStatus status, final PublishAuditHistory historyPojo)
+            throws DotPublisherException {
 
-        final PublishAuditAPI     publishAuditAPI     = PublishAuditAPI.getInstance();
+        final PublishAuditAPI publishAuditAPI = PublishAuditAPI.getInstance();
 
-        historyPojo.setAssets(assets.stream().collect(Collectors.toMap(asset-> asset.getAsset(), asset-> asset.getType())));
+        historyPojo.setAssets(assets.stream()
+                .collect(Collectors.toMap(asset -> asset.getAsset(), asset -> asset.getType())));
         status.setStatusPojo(historyPojo);
 
         //Insert in Audit table
         publishAuditAPI.insertPublishAuditStatus(status);
     }
 
-    public static Optional<BundlerStatus> getBundleStatus(final List<BundlerStatus> bundlerStatuses, final Class<? extends IBundler> contentBundlerClass) {
+    public static Optional<BundlerStatus> getBundleStatus(final List<BundlerStatus> bundlerStatuses,
+            final Class<? extends IBundler> contentBundlerClass) {
 
-        return bundlerStatuses.stream().filter(status -> status.getBundlerClass().equals(contentBundlerClass.getName())).findFirst();
+        return bundlerStatuses.stream()
+                .filter(status -> status.getBundlerClass().equals(contentBundlerClass.getName()))
+                .findFirst();
     }
 
     public static boolean existsFolder(final String bundlePath, final Folder folder) {
 
-        final File folderTestPath   = new File(bundlePath, "/ROOT/" + folder.getName());
-        final File folderIdTestPath = new File(bundlePath, "/ROOT/" + folder.getIdentifier() + ".folder.xml");
+        final File folderTestPath = new File(bundlePath, "/ROOT/" + folder.getName());
+        final File folderIdTestPath = new File(bundlePath,
+                "/ROOT/" + folder.getIdentifier() + ".folder.xml");
 
         return folderTestPath.exists() && folderIdTestPath.exists();
     }
@@ -458,27 +505,29 @@ public class PublisherTestUtil {
         return exists;
     }
 
-    public static Map<String, Object> generateBundle ( final String bundleId, final PushPublisherConfig.Operation operation )
-    throws DotPublisherException, DotDataException, DotPublishingException, IllegalAccessException, InstantiationException, DotBundleException, IOException {
+    public static Map<String, Object> generateBundle(final String bundleId,
+            final PushPublisherConfig.Operation operation)
+            throws DotPublisherException, DotDataException, DotPublishingException, IllegalAccessException, InstantiationException, DotBundleException, IOException {
 
         final PushPublisherConfig pconf = new PushPublisherConfig();
         final PublisherAPI pubAPI = PublisherAPI.getInstance();
 
-        final List<PublishQueueElement> tempBundleContents = pubAPI.getQueueElementsByBundleId( bundleId );
+        final List<PublishQueueElement> tempBundleContents = pubAPI.getQueueElementsByBundleId(
+                bundleId);
         final List<PublishQueueElement> assetsToPublish = new ArrayList<PublishQueueElement>();
 
-        for ( final PublishQueueElement queueElement : tempBundleContents ) {
-            assetsToPublish.add( queueElement );
+        for (final PublishQueueElement queueElement : tempBundleContents) {
+            assetsToPublish.add(queueElement);
         }
 
-        pconf.setDownloading( true );
+        pconf.setDownloading(true);
         pconf.setOperation(operation);
 
-        pconf.setAssets( assetsToPublish );
+        pconf.setAssets(assetsToPublish);
         //Queries creation
-        pconf.setLuceneQueries( PublisherUtil.prepareQueries( tempBundleContents ) );
-        pconf.setId( bundleId );
-        pconf.setUser( APILocator.getUserAPI().getSystemUser() );
+        pconf.setLuceneQueries(PublisherUtil.prepareQueries(tempBundleContents));
+        pconf.setId(bundleId);
+        pconf.setUser(APILocator.getUserAPI().getSystemUser());
 
         //BUNDLERS
 
@@ -486,46 +535,46 @@ public class PublisherTestUtil {
         final List<IBundler> confBundlers = new ArrayList<IBundler>();
 
         final Publisher publisher = new PushPublisher();
-        publisher.init( pconf );
+        publisher.init(pconf);
         //Add the bundles for this publisher
-        for ( final Class <IBundler> clazz : publisher.getBundlers() ) {
-            if ( !bundlers.contains( clazz ) ) {
-                bundlers.add( clazz );
+        for (final Class<IBundler> clazz : publisher.getBundlers()) {
+            if (!bundlers.contains(clazz)) {
+                bundlers.add(clazz);
             }
         }
 
-        final File bundleRoot = BundlerUtil.getBundleRoot( pconf );
+        final File bundleRoot = BundlerUtil.getBundleRoot(pconf);
         final DirectoryBundleOutput directoryBundleOutput = new DirectoryBundleOutput(pconf);
 
         // Run bundlers
-        BundlerUtil.writeBundleXML( pconf, directoryBundleOutput);
-        for ( final Class<IBundler> aClass : bundlers ) {
+        BundlerUtil.writeBundleXML(pconf, directoryBundleOutput);
+        for (final Class<IBundler> aClass : bundlers) {
 
             final IBundler bundler = aClass.newInstance();
-            confBundlers.add( bundler );
-            bundler.setConfig( pconf );
+            confBundlers.add(bundler);
+            bundler.setConfig(pconf);
             bundler.setPublisher(publisher);
-            final BundlerStatus bundlerStatus = new BundlerStatus( bundler.getClass().getName() );
+            final BundlerStatus bundlerStatus = new BundlerStatus(bundler.getClass().getName());
 
             //Generate the bundler
             Logger.info(PublisherTestUtil.class, "Start of Bundler: " + aClass.getSimpleName());
-            bundler.generate( directoryBundleOutput, bundlerStatus );
+            bundler.generate(directoryBundleOutput, bundlerStatus);
             Logger.info(PublisherTestUtil.class, "End of Bundler: " + aClass.getSimpleName());
         }
 
-        pconf.setBundlers( confBundlers );
+        pconf.setBundlers(confBundlers);
 
         //Compressing bundle
         final List<File> list = new ArrayList<File>();
-        list.add( bundleRoot );
-        final File bundle = new File( bundleRoot + File.separator + ".." + File.separator + pconf.getId() + ".tar.gz" );
+        list.add(bundleRoot);
+        final File bundle = new File(
+                bundleRoot + File.separator + ".." + File.separator + pconf.getId() + ".tar.gz");
 
         final Map<String, Object> bundleData = new HashMap<String, Object>();
-        bundleData.put( "id", bundleId );
-        bundleData.put( FILE, PushUtils.compressFiles( list, bundle, bundleRoot.getAbsolutePath() ) );
+        bundleData.put("id", bundleId);
+        bundleData.put(FILE, PushUtils.compressFiles(list, bundle, bundleRoot.getAbsolutePath()));
         return bundleData;
     }
-
 
 
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/HTMLPageAssetRenderedTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/services/HTMLPageAssetRenderedTest.java
@@ -82,10 +82,10 @@ public class HTMLPageAssetRenderedTest {
 
     private static ContentType contentGenericType;
     private static User systemUser;
-    private static final String contentFallbackProperty = "DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE";
-    private static final String pageFallbackProperty = "DEFAULT_PAGE_TO_DEFAULT_LANGUAGE";
-    private static  boolean contentFallbackDefaultValue ;
-    private static  boolean pageFallbackDefaultValue;
+    private static final String DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE = "DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE";
+    private static final String DEFAULT_PAGE_TO_DEFAULT_LANGUAGE = "DEFAULT_PAGE_TO_DEFAULT_LANGUAGE";
+    private static boolean contentFallbackDefaultValue;
+    private static boolean pageFallbackDefaultValue;
     private static Folder folder;
     private static final List<String> contentletsIds = new ArrayList<>();
     private static ContentletAPI contentletAPI;
@@ -97,9 +97,11 @@ public class HTMLPageAssetRenderedTest {
     private static Visitor visitor;
 
     @BeforeClass
-    public static void setConfigVariable (){
-        contentFallbackDefaultValue = Config.getBooleanProperty(contentFallbackProperty,false);
-        pageFallbackDefaultValue =Config.getBooleanProperty(pageFallbackProperty,true);
+    public static void setConfigVariable() {
+        contentFallbackDefaultValue = Config.getBooleanProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE,
+                false);
+        pageFallbackDefaultValue = Config.getBooleanProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE,
+                true);
     }
 
     @DataProvider
@@ -114,23 +116,26 @@ public class HTMLPageAssetRenderedTest {
         final Container fileContainer = createFileContainer();
         final Template templateFileContainer = createTemplate(fileContainer);
 
-        return new Object[][] {
-                { container, templateContainer },
-                { fileContainer, templateFileContainer}
+        return new Object[][]{
+                {container, templateContainer},
+                {fileContainer, templateFileContainer}
         };
     }
 
-    private static Template createTemplate(final Container container) throws DotSecurityException, WebAssetException, DotDataException {
+    private static Template createTemplate(final Container container)
+            throws DotSecurityException, WebAssetException, DotDataException {
         return createTemplate(new TestContainerUUID(container, UUID));
     }
 
-    private static Template createTemplate(final TestContainerUUID... containers) throws DotSecurityException, WebAssetException, DotDataException {
+    private static Template createTemplate(final TestContainerUUID... containers)
+            throws DotSecurityException, WebAssetException, DotDataException {
         final TemplateDataGen templateDataGen = new TemplateDataGen()
                 .title("PageContextBuilderTemplate" + System.currentTimeMillis())
                 .host(site);
 
         for (TestContainerUUID testContainerUUID : containers) {
-            templateDataGen.withContainer(testContainerUUID.container, testContainerUUID.UUID).nextPersisted();
+            templateDataGen.withContainer(testContainerUUID.container, testContainerUUID.UUID)
+                    .nextPersisted();
         }
 
         final Template template = templateDataGen.nextPersisted();
@@ -139,11 +144,13 @@ public class HTMLPageAssetRenderedTest {
         return template;
     }
 
-    private static Container createContainer() throws DotSecurityException, DotDataException, WebAssetException {
+    private static Container createContainer()
+            throws DotSecurityException, DotDataException, WebAssetException {
         return createContainer(5);
     }
 
-    private static Container createContainer(final int maxContentlet) throws DotSecurityException, DotDataException, WebAssetException {
+    private static Container createContainer(final int maxContentlet)
+            throws DotSecurityException, DotDataException, WebAssetException {
         Container container = new Container();
         final String containerName = "containerHTMLPageRenderedTest" + System.currentTimeMillis();
 
@@ -152,7 +159,7 @@ public class HTMLPageAssetRenderedTest {
         container.setOwner(systemUser.getUserId());
         container.setMaxContentlets(maxContentlet);
 
-        final List<ContainerStructure> csList = new ArrayList<ContainerStructure>();
+        final List<ContainerStructure> csList = new ArrayList<>();
         final ContainerStructure cs = new ContainerStructure();
         cs.setStructureId(contentGenericType.id());
         cs.setCode("$!{body}");
@@ -164,7 +171,8 @@ public class HTMLPageAssetRenderedTest {
         return container;
     }
 
-    private static FileAssetContainer createFileContainer() throws DotSecurityException, DotDataException, WebAssetException {
+    private static FileAssetContainer createFileContainer()
+            throws DotSecurityException, DotDataException, WebAssetException {
         return createFileContainer(site);
     }
 
@@ -178,9 +186,11 @@ public class HTMLPageAssetRenderedTest {
                 .contentType(contentGenericType, "$!{body}")
                 .nextPersisted();
 
-        container = (FileAssetContainer) APILocator.getContainerAPI().find(container.getInode(), systemUser, true);
+        container = (FileAssetContainer) APILocator.getContainerAPI()
+                .find(container.getInode(), systemUser, true);
 
-        final Folder folder = APILocator.getFolderAPI().findFolderByPath(container.getPath(), host, systemUser, true);
+        final Folder folder = APILocator.getFolderAPI()
+                .findFolderByPath(container.getPath(), host, systemUser, true);
         final List<FileAsset> containerFiles =
                 APILocator.getFileAssetAPI().findFileAssetsByFolder(folder, systemUser, true);
 
@@ -206,15 +216,16 @@ public class HTMLPageAssetRenderedTest {
 
         IntegrationTestInitService.getInstance().mockStrutsActionModule();
 
-        final Host  host = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
+        final Host host = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
 
-        persona = new PersonaDataGen().keyTag("persona"+System.currentTimeMillis()).hostFolder(host.getIdentifier()).nextPersisted();
+        persona = new PersonaDataGen().keyTag("persona" + System.currentTimeMillis())
+                .hostFolder(host.getIdentifier()).nextPersisted();
 
         visitor = mock(Visitor.class);
         when(visitor.getPersona()).thenReturn(persona);
     }
 
-    private static void createTestPage() throws Exception{
+    private static void createTestPage() throws Exception {
 
         site = new SiteDataGen().nextPersisted();
         //Create test folder
@@ -258,9 +269,10 @@ public class HTMLPageAssetRenderedTest {
         contentlet2English.setBoolProperty(Contentlet.IS_TEST_MODE, true);
         contentletAPI.publish(contentlet2English, systemUser, false);
 
-        Contentlet contentlet2Spanish = contentletAPI.checkout(contentlet2English.getInode(), systemUser, false);
-        contentlet2Spanish.setProperty("title","content2Spa");
-        contentlet2Spanish.setProperty("body","content2Spa");
+        Contentlet contentlet2Spanish = contentletAPI.checkout(contentlet2English.getInode(),
+                systemUser, false);
+        contentlet2Spanish.setProperty("title", "content2Spa");
+        contentlet2Spanish.setProperty("body", "content2Spa");
         contentlet2Spanish.setLanguageId(spanishLanguage.getId());
         contentlet2Spanish.setIndexPolicy(IndexPolicy.WAIT_FOR);
         contentlet2Spanish.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
@@ -309,83 +321,90 @@ public class HTMLPageAssetRenderedTest {
     }
 
 
-    private void  createMultiTree(final String pageId, final String containerId) throws DotDataException {
+    private void createMultiTree(final String pageId, final String containerId)
+            throws DotDataException {
         createMultiTree(pageId, containerId, UUID);
     }
 
 
-    private void  createMultiTree(final String pageId, final String containerId, final String UUID)
+    private void createMultiTree(final String pageId, final String containerId, final String UUID)
             throws DotDataException {
 
         final List<MultiTree> mTrees = new ArrayList<>();
         // english - content1
-        MultiTree multiTree = new MultiTree(pageId, containerId, contentletsIds.get(0),UUID,0);
+        MultiTree multiTree = new MultiTree(pageId, containerId, contentletsIds.get(0), UUID, 0);
         mTrees.add(multiTree);
 
         // english and spanish - content2/content2Spa
-        multiTree = new MultiTree(pageId, containerId, contentletsIds.get(1),UUID,0);
+        multiTree = new MultiTree(pageId, containerId, contentletsIds.get(1), UUID, 0);
         mTrees.add(multiTree);
 
         // spanish  - content3Spa
-        multiTree = new MultiTree(pageId, containerId, contentletsIds.get(2),UUID,0);
+        multiTree = new MultiTree(pageId, containerId, contentletsIds.get(2), UUID, 0);
         mTrees.add(multiTree);
 
         // english, custom persona - content4
-        final String personaTag  = persona.getKeyTag();
-        final String personalization = Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON + personaTag;
+        final String personaTag = persona.getKeyTag();
+        final String personalization =
+                Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON + personaTag;
 
-        multiTree = new MultiTree(pageId, containerId, contentletsIds.get(3),UUID,0, personalization);
+        multiTree = new MultiTree(pageId, containerId, contentletsIds.get(3), UUID, 0,
+                personalization);
         mTrees.add(multiTree);
 
         APILocator.getMultiTreeAPI().saveMultiTrees(mTrees);
     }
 
     @AfterClass
-    public static void restore() throws Exception{
+    public static void restore() throws Exception {
 
-        Config.setProperty(contentFallbackProperty, contentFallbackDefaultValue);
-        Config.setProperty(pageFallbackProperty, pageFallbackDefaultValue);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, contentFallbackDefaultValue);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, pageFallbackDefaultValue);
 
         //Deleting the folder will delete all the pages inside it
-        if(folder != null){
-            APILocator.getFolderAPI().delete(folder,systemUser,false);
+        if (folder != null) {
+            APILocator.getFolderAPI().delete(folder, systemUser, false);
         }
 
-        for(final String contentletId : contentletsIds){
-            final Contentlet contentlet = contentletAPI.findContentletByIdentifierAnyLanguage(contentletId);
-            if(null == contentlet){
-               continue;
+        for (final String contentletId : contentletsIds) {
+            final Contentlet contentlet = contentletAPI.findContentletByIdentifierAnyLanguage(
+                    contentletId);
+            if (null == contentlet) {
+                continue;
             }
 
             contentlet.setIndexPolicy(IndexPolicy.WAIT_FOR);
             contentlet.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
             contentlet.setBoolProperty(Contentlet.IS_TEST_MODE, true);
-            contentletAPI.destroy(contentlet, systemUser, false );
+            contentletAPI.destroy(contentlet, systemUser, false);
         }
 
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to true
-     *       And the page have version just in ENG
-     *       And the page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP version, content 3 is just in ESP version
-     * Should: Since the page is requests in ENG version it should be render with content1 and content2
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and
+     * DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to true And the page have version just in ENG And the
+     * page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP
+     * version, content 3 is just in ESP version Should: Since the page is requests in ENG version
+     * it should be render with content1 and content2
      */
     @Test
     @UseDataProvider("cases")
     public void ContentFallbackFalse_PageFallbackTrue_PageEnglish_ViewEnglishContent1And2_ViewSpanishContent2And3(
-            final Container container, final Template template) throws Exception{
+            final Container container, final Template template) throws Exception {
 
-        Config.setProperty(contentFallbackProperty,false);
-        Config.setProperty(pageFallbackProperty,true);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, true);
 
-        final String pageName = "test1Page-"+System.currentTimeMillis();
+        final String pageName = "test1Page-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
 
-        final List<MultiTree>  multiTrees = APILocator.getMultiTreeAPI().getMultiTrees(pageEnglishVersion, container);
+        final List<MultiTree> multiTrees = APILocator.getMultiTreeAPI()
+                .getMultiTrees(pageEnglishVersion, container);
         Assert.assertNotNull(multiTrees);
         Assert.assertEquals(4, multiTrees.size());
 
@@ -393,19 +412,23 @@ public class HTMLPageAssetRenderedTest {
         for (final MultiTree multiTree : multiTrees) {
             try {
 
-                final Contentlet contentletSpa = APILocator.getContentletAPI().findContentletByIdentifier(
-                        multiTree.getContentlet(), true, spanishLanguage.getId(), systemUser, false);
+                final Contentlet contentletSpa = APILocator.getContentletAPI()
+                        .findContentletByIdentifier(
+                                multiTree.getContentlet(), true, spanishLanguage.getId(),
+                                systemUser, false);
                 if (null != contentletSpa) {
                     contentletSpaCount += 1;
                 }
-            } catch (DotContentletStateException e) {}
+            } catch (DotContentletStateException e) {
+            }
         }
 
         Assert.assertEquals(2, contentletSpaCount);
 
         //request page ENG version
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -413,37 +436,41 @@ public class HTMLPageAssetRenderedTest {
         final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
         String html = APILocator.getHTMLPageAssetRenderedAPI().getPageHtml(
                 PageContextBuilder.builder()
-                    .setUser(systemUser)
-                    .setPageUri(pageEnglishVersion.getURI())
-                    .setPageMode(PageMode.LIVE)
-                    .build(),
+                        .setUser(systemUser)
+                        .setPageUri(pageEnglishVersion.getURI())
+                        .setPageMode(PageMode.LIVE)
+                        .build(),
                 mockRequest, mockResponse);
-        assertTrue("ENG = "+html , html.contains("content1") && html.contains("content2"));
+        assertTrue("ENG = " + html, html.contains("content1") && html.contains("content2"));
     }
 
     ///////
+
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * Given Scenario: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to true
-     *       And the page have version just in ENG
-     *       And the page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP version, content 3 is just in ESP version
-     *       And the current language (the request language, is spanish)
-     * ExpectedResult: Since the lang is spanish, the contents rendered will be only spanish content on the page.
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} Given Scenario: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and
+     * DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to true And the page have version just in ENG And the
+     * page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP
+     * version, content 3 is just in ESP version And the current language (the request language, is
+     * spanish) ExpectedResult: Since the lang is spanish, the contents rendered will be only
+     * spanish content on the page.
      */
     @Test
     @UseDataProvider("cases")
     public void render_spanish_contentlets_on_english_page(
-            final Container container, final Template template) throws Exception{
+            final Container container, final Template template) throws Exception {
 
-        Config.setProperty(contentFallbackProperty,false);
-        Config.setProperty(pageFallbackProperty,true);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, true);
 
-        final String pageName = "test1Page-"+System.currentTimeMillis();
+        final String pageName = "test1Page-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
 
-        final List<MultiTree>  multiTrees = APILocator.getMultiTreeAPI().getMultiTrees(pageEnglishVersion, container);
+        final List<MultiTree> multiTrees = APILocator.getMultiTreeAPI()
+                .getMultiTrees(pageEnglishVersion, container);
         Assert.assertNotNull(multiTrees);
         Assert.assertEquals(4, multiTrees.size());
 
@@ -451,12 +478,15 @@ public class HTMLPageAssetRenderedTest {
         for (final MultiTree multiTree : multiTrees) {
             try {
 
-                final Contentlet contentletSpa = APILocator.getContentletAPI().findContentletByIdentifier(
-                        multiTree.getContentlet(), true, spanishLanguage.getId(), systemUser, false);
+                final Contentlet contentletSpa = APILocator.getContentletAPI()
+                        .findContentletByIdentifier(
+                                multiTree.getContentlet(), true, spanishLanguage.getId(),
+                                systemUser, false);
                 if (null != contentletSpa) {
                     contentletSpaCount += 1;
                 }
-            } catch (DotContentletStateException e) {}
+            } catch (DotContentletStateException e) {
+            }
         }
 
         Assert.assertEquals(2, contentletSpaCount);
@@ -464,14 +494,17 @@ public class HTMLPageAssetRenderedTest {
         //request page ESP version
         final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         final HttpSession httpSession = mockRequest.getSession();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest
                 .setAttribute(WebKeys.HTMLPAGE_LANGUAGE, String.valueOf(spanishLanguage.getId()));
-        httpSession.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, String.valueOf(spanishLanguage.getId()));
-        httpSession.setAttribute(WebKeys.HTMLPAGE_LANGUAGE + ".current", String.valueOf(spanishLanguage.getId()));
+        httpSession.setAttribute(WebKeys.HTMLPAGE_LANGUAGE,
+                String.valueOf(spanishLanguage.getId()));
+        httpSession.setAttribute(WebKeys.HTMLPAGE_LANGUAGE + ".current",
+                String.valueOf(spanishLanguage.getId()));
         HttpServletRequestThreadLocal.INSTANCE.setRequest(mockRequest);
 
         CacheLocator.getBlockPageCache().clearCache();
@@ -485,13 +518,13 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue("ESP = "+html , html.contains("content2Spa") && html.contains("content3Spa"));
+        assertTrue("ESP = " + html, html.contains("content2Spa") && html.contains("content3Spa"));
     }
     ///////
 
     @NotNull
     private HTMLPageAsset createHtmlPageAsset(
-           final Template template,
+            final Template template,
             final String pageName,
             final long languageId)
 
@@ -508,7 +541,7 @@ public class HTMLPageAssetRenderedTest {
             throws DotSecurityException, DotDataException {
 
         final Folder folder = new FolderDataGen().site(host).nextPersisted();
-        final HTMLPageAsset pageEnglishVersion = new HTMLPageDataGen(folder,template)
+        final HTMLPageAsset pageEnglishVersion = new HTMLPageDataGen(folder, template)
                 .languageId(languageId)
                 .pageURL(pageName)
                 .title(pageName)
@@ -524,40 +557,45 @@ public class HTMLPageAssetRenderedTest {
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to true
-     *       And the page have version in ENG and ESP
-     *       And the page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP version, content 3 is just in ESP version
-     * Should: If the page is requests in ENG version it should be render with content1 and content2
-     *         If the page is requests in ESP version it should be render with content3 and content2 (both in ESP version)
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and
+     * DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to true And the page have version in ENG and ESP And
+     * the page have tree content, where: content1 is just in ENG version, content2 is in ENG and
+     * ESP version, content 3 is just in ESP version Should: If the page is requests in ENG version
+     * it should be render with content1 and content2 If the page is requests in ESP version it
+     * should be render with content3 and content2 (both in ESP version)
      */
     @Test
     @UseDataProvider("cases")
-    public void ContentFallbackFalse_PageFallbackTrue_PageEnglishAndSpanish_ViewEnglishContent1And2_ViewSpanishContent2And3(final Container container, final Template template) throws Exception{
+    public void ContentFallbackFalse_PageFallbackTrue_PageEnglishAndSpanish_ViewEnglishContent1And2_ViewSpanishContent2And3(
+            final Container container, final Template template) throws Exception {
 
-        Config.setProperty(contentFallbackProperty,false);
-        Config.setProperty(pageFallbackProperty,true);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, true);
 
-        final String pageName = "test2Page-"+System.currentTimeMillis();
+        final String pageName = "test2Page-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
-        Contentlet pageSpanishVersion = contentletAPI.checkout(pageEnglishVersion.getInode(),systemUser,false);
+        Contentlet pageSpanishVersion = contentletAPI.checkout(pageEnglishVersion.getInode(),
+                systemUser, false);
         pageSpanishVersion.setLanguageId(spanishLanguage.getId());
         pageSpanishVersion.setIndexPolicy(IndexPolicy.WAIT_FOR);
         pageSpanishVersion.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
         pageSpanishVersion.setBoolProperty(Contentlet.IS_TEST_MODE, true);
-        pageSpanishVersion = contentletAPI.checkin(pageSpanishVersion,systemUser,false);
+        pageSpanishVersion = contentletAPI.checkin(pageSpanishVersion, systemUser, false);
 
         pageSpanishVersion.setIndexPolicy(IndexPolicy.WAIT_FOR);
         pageSpanishVersion.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
         pageSpanishVersion.setBoolProperty(Contentlet.IS_TEST_MODE, true);
-        contentletAPI.publish(pageSpanishVersion,systemUser,false);
+        contentletAPI.publish(pageSpanishVersion, systemUser, false);
         addAnonymousPermissions(pageSpanishVersion);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
 
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -570,10 +608,11 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue("ENG = "+html , html.contains("content1") && html.contains("content2"));
+        assertTrue("ENG = " + html, html.contains("content1") && html.contains("content2"));
 
         mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest
@@ -586,31 +625,36 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue("ESP = "+html , html.contains("content2Spa") && html.contains("content3Spa"));
+        assertTrue("ESP = " + html, html.contains("content2Spa") && html.contains("content3Spa"));
 
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to true
-     *       And the page have version in ESP
-     *       And the page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP version, content 3 is just in ESP version
-     * Should: If the page is requests in ENG version it should be thrown a {@link HTMLPageAssetNotFoundException}
-     *         If the page is requests in ESP version it should be render with content3 and content2 (both in ESP version)
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and
+     * DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to true And the page have version in ESP And the page
+     * have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP
+     * version, content 3 is just in ESP version Should: If the page is requests in ENG version it
+     * should be thrown a {@link HTMLPageAssetNotFoundException} If the page is requests in ESP
+     * version it should be render with content3 and content2 (both in ESP version)
      */
     @UseDataProvider("cases")
-    public void ContentFallbackFalse_PageFallbackTrue_PageSpanish_ViewEnglish404_ViewSpanishContent2And3(final Container container, final Template template) throws Exception{
+    public void ContentFallbackFalse_PageFallbackTrue_PageSpanish_ViewEnglish404_ViewSpanishContent2And3(
+            final Container container, final Template template) throws Exception {
 
-        Config.setProperty(contentFallbackProperty,false);
-        Config.setProperty(pageFallbackProperty,true);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, true);
 
-        final String pageName = "test3Page-"+System.currentTimeMillis();
-        final HTMLPageAsset pageSpanishVersion = createHtmlPageAsset(template, pageName, spanishLanguage.getId());
+        final String pageName = "test3Page-" + System.currentTimeMillis();
+        final HTMLPageAsset pageSpanishVersion = createHtmlPageAsset(template, pageName,
+                spanishLanguage.getId());
 
         createMultiTree(pageSpanishVersion.getIdentifier(), container.getIdentifier());
 
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         mockRequest
                 .setAttribute(WebKeys.HTMLPAGE_LANGUAGE, String.valueOf(spanishLanguage.getId()));
@@ -623,10 +667,11 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue("ESP = "+html , html.contains("content3Spacontent2Spa"));
+        assertTrue("ESP = " + html, html.contains("content3Spacontent2Spa"));
 
         mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -642,32 +687,36 @@ public class HTMLPageAssetRenderedTest {
                     mockRequest, mockResponse);
 
             throw new AssertionError("HTMLPageAssetNotFoundException expected");
-        }catch(HTMLPageAssetNotFoundException e) {
+        } catch (HTMLPageAssetNotFoundException e) {
             //expected
         }
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to false
-     *       And the page have version in ENG
-     *       And the page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP version, content 3 is just in ESP version
-     * Should: If the page is requests in ENG version it should be render with content1 and content2
-     *         If the page is requests in ESP version it should be thrown a {@link HTMLPageAssetNotFoundException}
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and
+     * DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to false And the page have version in ENG And the
+     * page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP
+     * version, content 3 is just in ESP version Should: If the page is requests in ENG version it
+     * should be render with content1 and content2 If the page is requests in ESP version it should
+     * be thrown a {@link HTMLPageAssetNotFoundException}
      */
     @UseDataProvider("cases")
-    public void ContentFallbackFalse_PageFallbackFalse_PageEnglish_ViewEnglishContent1And2_ViewSpanish404(final Container container, final Template template) throws Exception{
+    public void ContentFallbackFalse_PageFallbackFalse_PageEnglish_ViewEnglishContent1And2_ViewSpanish404(
+            final Container container, final Template template) throws Exception {
 
-        Config.setProperty(contentFallbackProperty,false);
-        Config.setProperty(pageFallbackProperty,false);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, false);
 
-        final String pageName = "test4Page-"+System.currentTimeMillis();
+        final String pageName = "test4Page-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
 
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -680,10 +729,11 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue("ENG = "+html , html.contains("content2content1"));
+        assertTrue("ENG = " + html, html.contains("content2content1"));
 
         mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         mockRequest
                 .setAttribute(WebKeys.HTMLPAGE_LANGUAGE, String.valueOf(spanishLanguage.getId()));
@@ -691,22 +741,24 @@ public class HTMLPageAssetRenderedTest {
 
         try {
             APILocator.getHTMLPageAssetRenderedAPI().getPageHtml(
-                PageContextBuilder.builder()
-                        .setUser(systemUser)
-                        .setPageUri(pageEnglishVersion.getURI())
-                        .setPageMode(PageMode.LIVE)
-                        .build(),
-                mockRequest, mockResponse);
+                    PageContextBuilder.builder()
+                            .setUser(systemUser)
+                            .setPageUri(pageEnglishVersion.getURI())
+                            .setPageMode(PageMode.LIVE)
+                            .build(),
+                    mockRequest, mockResponse);
             throw new AssertionError("HTMLPageAssetNotFoundException expected");
-        }catch(HTMLPageAssetNotFoundException e) {
+        } catch (HTMLPageAssetNotFoundException e) {
             //expected
         }
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: A Page has a content that have a Image field and this content is using a FileAsset Image
-     * Should: the [field_variable]ImageURI variable should be equals to /contentAsset/raw-data/[content_id]/fileAsset?language_id=1
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: A Page has a content that have a Image field and this content is
+     * using a FileAsset Image Should: the [field_variable]ImageURI variable should be equals to
+     * /contentAsset/raw-data/[content_id]/fileAsset?language_id=1
      */
     @Test
     public void renderPageWithFileAssetImage()
@@ -760,7 +812,7 @@ public class HTMLPageAssetRenderedTest {
                 .nextPersisted();
         TemplateDataGen.publish(template);
 
-        final String pageName = "renderPageWithFileAssetImage-"+System.currentTimeMillis();
+        final String pageName = "renderPageWithFileAssetImage-" + System.currentTimeMillis();
         final HTMLPageAsset page = createHtmlPageAsset(template, pageName, 1);
 
         new MultiTreeDataGen()
@@ -771,7 +823,8 @@ public class HTMLPageAssetRenderedTest {
                 .nextPersisted();
 
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -789,14 +842,16 @@ public class HTMLPageAssetRenderedTest {
                 "/contentAsset/raw-data/%s/fileAsset?language_id=1",
                 imageContentlet.getIdentifier()
         );
-        assertTrue(html , html.contains(String.format("Image URI: %s", imageURIExpected)));
+        assertTrue(html, html.contains(String.format("Image URI: %s", imageURIExpected)));
     }
 
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: A Page has a content that have a Image field and this content is using a DotAsset Image
-     * Should: the [field_variable]ImageURI variable should be equals to /contentAsset/raw-data/[content_id]/fileAsset?language_id=1
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: A Page has a content that have a Image field and this content is
+     * using a DotAsset Image Should: the [field_variable]ImageURI variable should be equals to
+     * /contentAsset/raw-data/[content_id]/fileAsset?language_id=1
      */
     @Test
     public void renderPageWithDotAssetImage()
@@ -816,17 +871,18 @@ public class HTMLPageAssetRenderedTest {
         final File image = new File(Thread.currentThread().getContextClassLoader()
                 .getResource("images/test.jpg").getFile());
 
-        final ContentType dotAssetContentType = APILocator.getContentTypeAPI(APILocator.systemUser())
+        final ContentType dotAssetContentType = APILocator.getContentTypeAPI(
+                        APILocator.systemUser())
                 .save(ContentTypeBuilder.builder(DotAssetContentType.class)
-                .folder(FolderAPI.SYSTEM_FOLDER)
-                .host(Host.SYSTEM_HOST)
-                .name("name" + System.currentTimeMillis())
-                .owner(APILocator.systemUser().getUserId())
-                .build());
+                        .folder(FolderAPI.SYSTEM_FOLDER)
+                        .host(Host.SYSTEM_HOST)
+                        .name("name" + System.currentTimeMillis())
+                        .owner(APILocator.systemUser().getUserId())
+                        .build());
 
         final Contentlet imageContentlet = new ContentletDataGen(dotAssetContentType)
-            .setProperty(DotAssetContentType.ASSET_FIELD_VAR, image)
-            .nextPersisted();
+                .setProperty(DotAssetContentType.ASSET_FIELD_VAR, image)
+                .nextPersisted();
         ContentletDataGen.publish(imageContentlet);
 
         Contentlet contentlet = new ContentletDataGen(contentType)
@@ -858,7 +914,7 @@ public class HTMLPageAssetRenderedTest {
                 .nextPersisted();
         TemplateDataGen.publish(template);
 
-        final String pageName = "renderPageWithFileAssetImage-"+System.currentTimeMillis();
+        final String pageName = "renderPageWithFileAssetImage-" + System.currentTimeMillis();
         final HTMLPageAsset page = createHtmlPageAsset(template, pageName, 1);
 
         new MultiTreeDataGen()
@@ -869,7 +925,8 @@ public class HTMLPageAssetRenderedTest {
                 .nextPersisted();
 
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -887,43 +944,48 @@ public class HTMLPageAssetRenderedTest {
                 "dA/%s",
                 imageContentlet.getIdentifier()
         );
-        assertTrue(html , html.contains(String.format("Image URI: %s", imageURIExpected)));
+        assertTrue(html, html.contains(String.format("Image URI: %s", imageURIExpected)));
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to false
-     *       And the page have version in ENG and ESP
-     *       And the page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP version, content 3 is just in ESP version
-     * Should: If the page is requests in ENG version it should be render with content1 and content2
-     *         If the page is requests in ESP version it should be render with content3 and content2 (both in ESP version)
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to false and
+     * DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to false And the page have version in ENG and ESP And
+     * the page have tree content, where: content1 is just in ENG version, content2 is in ENG and
+     * ESP version, content 3 is just in ESP version Should: If the page is requests in ENG version
+     * it should be render with content1 and content2 If the page is requests in ESP version it
+     * should be render with content3 and content2 (both in ESP version)
      */
     @Test
     @UseDataProvider("cases")
-    public void ContentFallbackFalse_PageFallbackFalse_PageEnglishAndSpanish_ViewEnglishContent1And2_ViewSpanishContent2And3(final Container container, final Template template) throws Exception{
+    public void ContentFallbackFalse_PageFallbackFalse_PageEnglishAndSpanish_ViewEnglishContent1And2_ViewSpanishContent2And3(
+            final Container container, final Template template) throws Exception {
 
-        Config.setProperty(contentFallbackProperty,false);
-        Config.setProperty(pageFallbackProperty,false);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, false);
 
-        final String pageName = "test5Page-"+System.currentTimeMillis();
+        final String pageName = "test5Page-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
-        Contentlet pageSpanishVersion = contentletAPI.checkout(pageEnglishVersion.getInode(),systemUser,false);
+        Contentlet pageSpanishVersion = contentletAPI.checkout(pageEnglishVersion.getInode(),
+                systemUser, false);
         pageSpanishVersion.setLanguageId(spanishLanguage.getId());
         pageSpanishVersion.setIndexPolicy(IndexPolicy.WAIT_FOR);
         pageSpanishVersion.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
         pageSpanishVersion.setBoolProperty(Contentlet.IS_TEST_MODE, true);
-        pageSpanishVersion = contentletAPI.checkin(pageSpanishVersion,systemUser,false);
+        pageSpanishVersion = contentletAPI.checkin(pageSpanishVersion, systemUser, false);
         pageSpanishVersion.setIndexPolicy(IndexPolicy.WAIT_FOR);
         pageSpanishVersion.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
         pageSpanishVersion.setBoolProperty(Contentlet.IS_TEST_MODE, true);
-        contentletAPI.publish(pageSpanishVersion,systemUser,false);
+        contentletAPI.publish(pageSpanishVersion, systemUser, false);
         addAnonymousPermissions(pageSpanishVersion);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
 
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -936,10 +998,11 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue("ENG = "+html , html.contains("content1") && html.contains("content2"));
+        assertTrue("ENG = " + html, html.contains("content1") && html.contains("content2"));
 
         mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest
@@ -952,44 +1015,49 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue("ESP = "+html , html.contains("content2Spa") && html.contains("content3Spa"));
+        assertTrue("ESP = " + html, html.contains("content2Spa") && html.contains("content3Spa"));
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to true and DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to true
-     *       And the page have version in ENG and ESP
-     *       And the page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP version, content 3 is just in ESP version
-     * Should: If the page is requests in ENG version it should be render with content1 and content2
-     *         If the page is requests in ESP version it should be render with content1 (ENG version), content3 and content2 (both in ESP version)
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to true and
+     * DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to true And the page have version in ENG and ESP And
+     * the page have tree content, where: content1 is just in ENG version, content2 is in ENG and
+     * ESP version, content 3 is just in ESP version Should: If the page is requests in ENG version
+     * it should be render with content1 and content2 If the page is requests in ESP version it
+     * should be render with content1 (ENG version), content3 and content2 (both in ESP version)
      */
     @Test
     @UseDataProvider("cases")
-    public void ContentFallbackTrue_PageFallbackTrue_PageEnglishAndSpanish_ViewEnglishContent1And2_ViewSpanishContent1And2And3(final Container container, final Template template) throws Exception{
+    public void ContentFallbackTrue_PageFallbackTrue_PageEnglishAndSpanish_ViewEnglishContent1And2_ViewSpanishContent1And2And3(
+            final Container container, final Template template) throws Exception {
 
-        Config.setProperty(contentFallbackProperty,true);
-        Config.setProperty(pageFallbackProperty,true);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, true);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, true);
 
-        final String pageName = "test6Page-"+System.currentTimeMillis();
+        final String pageName = "test6Page-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
-        Contentlet pageSpanishVersion = contentletAPI.checkout(pageEnglishVersion.getInode(),systemUser,false);
+        Contentlet pageSpanishVersion = contentletAPI.checkout(pageEnglishVersion.getInode(),
+                systemUser, false);
 
         pageSpanishVersion.setLanguageId(spanishLanguage.getId());
         pageSpanishVersion.setIndexPolicy(IndexPolicy.WAIT_FOR);
         pageSpanishVersion.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
         pageEnglishVersion.setBoolProperty(Contentlet.IS_TEST_MODE, true);
-        pageSpanishVersion = contentletAPI.checkin(pageSpanishVersion,systemUser,false);
+        pageSpanishVersion = contentletAPI.checkin(pageSpanishVersion, systemUser, false);
 
         pageSpanishVersion.setIndexPolicy(IndexPolicy.WAIT_FOR);
         pageSpanishVersion.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
         pageEnglishVersion.setBoolProperty(Contentlet.IS_TEST_MODE, true);
-        contentletAPI.publish(pageSpanishVersion,systemUser,false);
+        contentletAPI.publish(pageSpanishVersion, systemUser, false);
         addAnonymousPermissions(pageSpanishVersion);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
 
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -1002,10 +1070,11 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue("ENG = "+html , html.contains("content1") && html.contains("content2"));
+        assertTrue("ENG = " + html, html.contains("content1") && html.contains("content2"));
 
         mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest
@@ -1018,31 +1087,35 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue("ESP = "+html , html.contains("content3Spa")
+        assertTrue("ESP = " + html, html.contains("content3Spa")
                 && html.contains("content2Spa") && html.contains("content1"));
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to true and DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to false
-     *       And the page have version just in ENG
-     *       And the page have tree content, where: content1 is just in ENG version, content2 is in ENG and ESP version, content 3 is just in ESP version
-     * Should: If the page is requests in ENG version it should be render with content1 and content2
-     *         If the page is requests in ESP version it should be thrown a {@link HTMLPageAssetNotFoundException}
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE is set to true and
+     * DEFAULT_PAGE_TO_DEFAULT_LANGUAGE is set to false And the page have version just in ENG And
+     * the page have tree content, where: content1 is just in ENG version, content2 is in ENG and
+     * ESP version, content 3 is just in ESP version Should: If the page is requests in ENG version
+     * it should be render with content1 and content2 If the page is requests in ESP version it
+     * should be thrown a {@link HTMLPageAssetNotFoundException}
      */
     @UseDataProvider("cases")
-    public void ContentFallbackTrue_PageFallbackFalse_PageEnglish_ViewEnglishContent1And2_ViewSpanish404(final Container container, final Template template) throws Exception{
+    public void ContentFallbackTrue_PageFallbackFalse_PageEnglish_ViewEnglishContent1And2_ViewSpanish404(
+            final Container container, final Template template) throws Exception {
 
-        Config.setProperty(contentFallbackProperty,true);
-        Config.setProperty(pageFallbackProperty,false);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, true);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, false);
 
-        final String pageName = "test7Page-"+System.currentTimeMillis();
+        final String pageName = "test7Page-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
 
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -1055,16 +1128,17 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue("ENG = "+html , html.contains("content2content1"));
+        assertTrue("ENG = " + html, html.contains("content2content1"));
 
         mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         mockRequest
                 .setAttribute(WebKeys.HTMLPAGE_LANGUAGE, String.valueOf(spanishLanguage.getId()));
         HttpServletRequestThreadLocal.INSTANCE.setRequest(mockRequest);
 
-        try{
+        try {
             APILocator.getHTMLPageAssetRenderedAPI().getPageHtml(
                     PageContextBuilder.builder()
                             .setUser(systemUser)
@@ -1074,21 +1148,22 @@ public class HTMLPageAssetRenderedTest {
                     mockRequest, mockResponse);
 
             throw new AssertionError("HTMLPageAssetNotFoundException expected");
-        }catch(HTMLPageAssetNotFoundException e) {
+        } catch (HTMLPageAssetNotFoundException e) {
             //expected
         }
     }
 
     /**
-     * This test creates a widget content type, sets a value for the widget code,
-     * creates a contentlet of this new widget and add it to a page.
-     * If you update the value widget code, and hit again the page the new value should show up.
+     * This test creates a widget content type, sets a value for the widget code, creates a
+     * contentlet of this new widget and add it to a page. If you update the value widget code, and
+     * hit again the page the new value should show up.
      *
      * @throws Exception
      */
     @Test
     @UseDataProvider("cases")
-    public void constantField_notUpdatedCache_whenChanged(final Container container, final Template template) throws Exception{
+    public void constantField_notUpdatedCache_whenChanged(final Container container,
+            final Template template) throws Exception {
 
         ContentType contentType = ContentTypeBuilder
                 .builder(BaseContentType.WIDGET.immutableClass())
@@ -1117,7 +1192,8 @@ public class HTMLPageAssetRenderedTest {
             addAnonymousPermissions(contentlet);
 
             final HTMLPageAsset pageEnglishVersion = new HTMLPageDataGen(folder, template)
-                    .languageId(1).pageURL("testPageWidget"+ System.currentTimeMillis()).title("testPageWidget")
+                    .languageId(1).pageURL("testPageWidget" + System.currentTimeMillis())
+                    .title("testPageWidget")
                     .nextPersisted();
             pageEnglishVersion.setIndexPolicy(IndexPolicy.WAIT_FOR);
             pageEnglishVersion.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
@@ -1125,12 +1201,14 @@ public class HTMLPageAssetRenderedTest {
             contentletAPI.publish(pageEnglishVersion, systemUser, false);
             addAnonymousPermissions(pageEnglishVersion);
 
-            final MultiTree multiTree = new MultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier(),
+            final MultiTree multiTree = new MultiTree(pageEnglishVersion.getIdentifier(),
+                    container.getIdentifier(),
                     contentlet.getIdentifier(), UUID, 0);
             APILocator.getMultiTreeAPI().saveMultiTree(multiTree);
 
             HttpServletRequest mockRequest = new MockSessionRequest(
-                    new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request())
+                    new MockAttributeRequest(
+                            new MockHttpRequestIntegrationTest("localhost", "/").request())
                             .request())
                     .request();
             when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
@@ -1156,7 +1234,8 @@ public class HTMLPageAssetRenderedTest {
             contentType = APILocator.getContentTypeAPI(systemUser).save(contentType);
 
             mockRequest = new MockSessionRequest(
-                    new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request())
+                    new MockAttributeRequest(
+                            new MockHttpRequestIntegrationTest("localhost", "/").request())
                             .request())
                     .request();
             when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
@@ -1171,16 +1250,15 @@ public class HTMLPageAssetRenderedTest {
                                     .build(),
                             mockRequest, mockResponse);
             assertTrue(html, html.contains("this has been changed"));
-        }finally {
+        } finally {
             APILocator.getContentTypeAPI(systemUser).delete(contentType);
         }
     }
 
     /**
-     * This test is for when you archived a container that is being used on page,
-     * the page needs to be resolved without issues. And when you unarchived and
-     * publish the container, the page needs to show the content related to the container.
-     *
+     * This test is for when you archived a container that is being used on page, the page needs to
+     * be resolved without issues. And when you unarchived and publish the container, the page needs
+     * to show the content related to the container.
      */
     @Test
     public void containerArchived_PageShouldResolve() throws Exception {
@@ -1201,7 +1279,8 @@ public class HTMLPageAssetRenderedTest {
             createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
 
             HttpServletRequest mockRequest = new MockSessionRequest(
-                    new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request())
+                    new MockAttributeRequest(
+                            new MockHttpRequestIntegrationTest("localhost", "/").request())
                             .request())
                     .request();
             when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
@@ -1223,7 +1302,8 @@ public class HTMLPageAssetRenderedTest {
             CacheLocator.getVeloctyResourceCache().clearCache();
 
             mockRequest = new MockSessionRequest(
-                    new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request())
+                    new MockAttributeRequest(
+                            new MockHttpRequestIntegrationTest("localhost", "/").request())
                             .request())
                     .request();
             when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
@@ -1244,7 +1324,8 @@ public class HTMLPageAssetRenderedTest {
             CacheLocator.getVeloctyResourceCache().clearCache();
 
             mockRequest = new MockSessionRequest(
-                    new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request())
+                    new MockAttributeRequest(
+                            new MockHttpRequestIntegrationTest("localhost", "/").request())
                             .request())
                     .request();
             when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
@@ -1259,7 +1340,7 @@ public class HTMLPageAssetRenderedTest {
                                     .build(),
                             mockRequest, mockResponse);
             assertTrue(html, html.contains("content1") && html.contains("content2"));
-        }finally {
+        } finally {
             if (!(container instanceof FileAssetContainer)) {
                 WebAssetFactory.unArchiveAsset(container);
                 WebAssetFactory.publishAsset(container, systemUser);
@@ -1268,18 +1349,21 @@ public class HTMLPageAssetRenderedTest {
     }
 
     /**
-     * Method to test: {@link com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetRenderedAPIImpl#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * Given Scenario: Create a page with three contents for default persona, and 1 content to another persona
-     * ExpectedResult: The page should return the content according to the persona set into the request
+     * Method to test:
+     * {@link
+     * com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetRenderedAPIImpl#getPageHtml(PageContext,
+     * HttpServletRequest, HttpServletResponse)} Given Scenario: Create a page with three contents
+     * for default persona, and 1 content to another persona ExpectedResult: The page should return
+     * the content according to the persona set into the request
      *
      * @throws Exception
      */
     @Test
     @UseDataProvider("cases")
-    public void shouldReturnPageHTMLForPersona(final Container container, final Template template) throws Exception{
+    public void shouldReturnPageHTMLForPersona(final Container container, final Template template)
+            throws Exception {
 
-
-        final String pageName = "test5Page-"+System.currentTimeMillis();
+        final String pageName = "test5Page-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
@@ -1303,7 +1387,7 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue(html , html.contains("content4"));
+        assertTrue(html, html.contains("content4"));
 
         when(session.getAttribute(WebKeys.VISITOR)).thenReturn(null);
 
@@ -1314,7 +1398,7 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        assertTrue(html , html.contains("content1") &&  html.contains("content2"));
+        assertTrue(html, html.contains("content1") && html.contains("content2"));
 
     }
 
@@ -1327,35 +1411,42 @@ public class HTMLPageAssetRenderedTest {
     }
 
     /**
-     * Method to test: {@link com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetRenderedAPIImpl#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * Given Scenario: Create a page with legacy UUID
+     * Method to test:
+     * {@link
+     * com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetRenderedAPIImpl#getPageHtml(PageContext,
+     * HttpServletRequest, HttpServletResponse)} Given Scenario: Create a page with legacy UUID
      * ExpectedResult: The page should return the right HTML
      *
      * @throws Exception
      */
     @Test
     @UseDataProvider("cases")
-    public void shouldReturnPageHTMLForLegacyUUID(final Container container, final Template templateTestCase) throws Exception {
+    public void shouldReturnPageHTMLForLegacyUUID(final Container container,
+            final Template templateTestCase) throws Exception {
 
         final String containerId = container.getIdentifier();
 
         //Create a Template
-        final Template template = new TemplateDataGen().title("PageContextBuilderTemplate"+System.currentTimeMillis())
+        final Template template = new TemplateDataGen().title(
+                        "PageContextBuilderTemplate" + System.currentTimeMillis())
                 .withContainer(containerId, ContainerUUID.UUID_LEGACY_VALUE).nextPersisted();
         PublishFactory.publishAsset(template, systemUser, false, false);
 
-        final String pageName = "testPage-"+System.currentTimeMillis();
-        final HTMLPageAsset page = new HTMLPageDataGen(folder,template).languageId(1).pageURL(pageName).title(pageName).nextPersisted();
+        final String pageName = "testPage-" + System.currentTimeMillis();
+        final HTMLPageAsset page = new HTMLPageDataGen(folder, template).languageId(1)
+                .pageURL(pageName).title(pageName).nextPersisted();
         page.setIndexPolicy(IndexPolicy.WAIT_FOR);
         page.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
         page.setBoolProperty(Contentlet.IS_TEST_MODE, true);
         contentletAPI.publish(page, systemUser, false);
 
         final String pageId = page.getIdentifier();
-        MultiTree multiTree = new MultiTree(pageId, containerId, contentletsIds.get(0), ContainerUUID.UUID_START_VALUE,0);
+        MultiTree multiTree = new MultiTree(pageId, containerId, contentletsIds.get(0),
+                ContainerUUID.UUID_START_VALUE, 0);
         APILocator.getMultiTreeAPI().saveMultiTreeAndReorder(multiTree);
 
-        multiTree = new MultiTree(pageId, containerId, contentletsIds.get(1), ContainerUUID.UUID_START_VALUE,0);
+        multiTree = new MultiTree(pageId, containerId, contentletsIds.get(1),
+                ContainerUUID.UUID_START_VALUE, 0);
         APILocator.getMultiTreeAPI().saveMultiTreeAndReorder(multiTree);
 
         final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
@@ -1381,34 +1472,41 @@ public class HTMLPageAssetRenderedTest {
     }
 
     /**
-     * Method to test: {@link com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetRenderedAPIImpl#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * Given Scenario: Create a page with legacy UUID and MultiTree
-     * ExpectedResult: The page should return the right HTML
+     * Method to test:
+     * {@link
+     * com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetRenderedAPIImpl#getPageHtml(PageContext,
+     * HttpServletRequest, HttpServletResponse)} Given Scenario: Create a page with legacy UUID and
+     * MultiTree ExpectedResult: The page should return the right HTML
      *
      * @throws Exception
      */
     @Test
     @UseDataProvider("cases")
-    public void shouldReturnPageHTMLForLegacyUUIDAndMultiTree(final Container container, final Template templateTestCase) throws Exception {
+    public void shouldReturnPageHTMLForLegacyUUIDAndMultiTree(final Container container,
+            final Template templateTestCase) throws Exception {
         final String containerId = container.getIdentifier();
 
         //Create a Template
-        final Template template = new TemplateDataGen().title("PageContextBuilderTemplate"+System.currentTimeMillis())
+        final Template template = new TemplateDataGen().title(
+                        "PageContextBuilderTemplate" + System.currentTimeMillis())
                 .withContainer(containerId, ContainerUUID.UUID_LEGACY_VALUE).nextPersisted();
         PublishFactory.publishAsset(template, systemUser, false, false);
 
-        final String pageName = "testPage-"+System.currentTimeMillis();
-        final HTMLPageAsset page = new HTMLPageDataGen(folder,template).languageId(1).pageURL(pageName).title(pageName).nextPersisted();
+        final String pageName = "testPage-" + System.currentTimeMillis();
+        final HTMLPageAsset page = new HTMLPageDataGen(folder, template).languageId(1)
+                .pageURL(pageName).title(pageName).nextPersisted();
         page.setIndexPolicy(IndexPolicy.WAIT_FOR);
         page.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
         page.setBoolProperty(Contentlet.IS_TEST_MODE, true);
         contentletAPI.publish(page, systemUser, false);
 
         final String pageId = page.getIdentifier();
-        MultiTree multiTree = new MultiTree(pageId, containerId, contentletsIds.get(0), ContainerUUID.UUID_LEGACY_VALUE,0);
+        MultiTree multiTree = new MultiTree(pageId, containerId, contentletsIds.get(0),
+                ContainerUUID.UUID_LEGACY_VALUE, 0);
         APILocator.getMultiTreeAPI().saveMultiTreeAndReorder(multiTree);
 
-        multiTree = new MultiTree(pageId, containerId, contentletsIds.get(1), ContainerUUID.UUID_LEGACY_VALUE,0);
+        multiTree = new MultiTree(pageId, containerId, contentletsIds.get(1),
+                ContainerUUID.UUID_LEGACY_VALUE, 0);
         APILocator.getMultiTreeAPI().saveMultiTreeAndReorder(multiTree);
 
         final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
@@ -1434,48 +1532,59 @@ public class HTMLPageAssetRenderedTest {
     }
 
     /**
-     * Method to test: {@link com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetRenderedAPIImpl#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * Given Scenario: Create a page with parseContainer directive into its template, and request the HTML in EDIT_MODE
-     * ExpectedResult: should return a UUID with the 'dotParser_' prefix
+     * Method to test:
+     * {@link
+     * com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetRenderedAPIImpl#getPageHtml(PageContext,
+     * HttpServletRequest, HttpServletResponse)} Given Scenario: Create a page with parseContainer
+     * directive into its template, and request the HTML in EDIT_MODE ExpectedResult: should return
+     * a UUID with the 'dotParser_' prefix
      *
      * @throws Exception
      */
     @Test
     @UseDataProvider("cases")
-    public void shouldReturnParserContainerUUID(final Container container, final Template template) throws Exception {
+    public void shouldReturnParserContainerUUID(final Container container, final Template template)
+            throws Exception {
 
-        Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", true);
-        final String pageName = "test5Page-"+System.currentTimeMillis();
-        final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
+        boolean defaultContentToDefaultLangOriginalValue =
+                Config.getBooleanProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
+        try {
+            Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, true);
+            final String pageName = "test5Page-" + System.currentTimeMillis();
+            final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
-        createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
+            createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier());
 
-        final HttpServletRequest mockRequest = createHttpServletRequest(pageEnglishVersion);
+            final HttpServletRequest mockRequest = createHttpServletRequest(pageEnglishVersion);
 
-        final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+            final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
 
-        final HttpSession session = createHttpSession(mockRequest);
+            final HttpSession session = createHttpSession(mockRequest);
 
-        when(session.getAttribute(WebKeys.VISITOR)).thenReturn(null);
+            when(session.getAttribute(WebKeys.VISITOR)).thenReturn(null);
 
-        systemUser.isBackendUser();
+            systemUser.isBackendUser();
 
-        final String html = APILocator.getHTMLPageAssetRenderedAPI().getPageHtml(
-                PageContextBuilder.builder()
-                        .setUser(systemUser)
-                        .setPageUri(pageEnglishVersion.getURI())
-                        .setPageMode(PageMode.EDIT_MODE)
-                        .build(),
-                mockRequest, mockResponse);
+            final String html = APILocator.getHTMLPageAssetRenderedAPI().getPageHtml(
+                    PageContextBuilder.builder()
+                            .setUser(systemUser)
+                            .setPageUri(pageEnglishVersion.getURI())
+                            .setPageMode(PageMode.EDIT_MODE)
+                            .build(),
+                    mockRequest, mockResponse);
 
-        final String regexExpected =
-                "<div data-dot-object=\"container\" .* data-dot-uuid=\"dotParser_.*\" .*>" +
-                    "<div data-dot-object=\"contentlet\" .*>.*</div>" +
-                    "<div data-dot-object=\"contentlet\" .*>.*</div>" +
-                    "<div data-dot-object=\"contentlet\" .*>.*</div>" +
-                "</div>";
+            final String regexExpected =
+                    "<div data-dot-object=\"container\" .* data-dot-uuid=\"dotParser_.*\" .*>" +
+                            "<div data-dot-object=\"contentlet\" .*>.*</div>" +
+                            "<div data-dot-object=\"contentlet\" .*>.*</div>" +
+                            "<div data-dot-object=\"contentlet\" .*>.*</div>" +
+                            "</div>";
 
-        assertTrue(html.replace(getNotExperimentJsCode(), "").matches(regexExpected));
+            assertTrue(html.replace(getNotExperimentJsCode(), "").matches(regexExpected));
+        } finally {
+            Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE,
+                    defaultContentToDefaultLangOriginalValue);
+        }
     }
 
 
@@ -1488,55 +1597,59 @@ public class HTMLPageAssetRenderedTest {
         final Function2<FileAssetContainer, Host, String> relativePath =
                 (FileAssetContainer container, Host host) -> container.getPath();
         final Function2<FileAssetContainer, Host, String> absolutePath =
-                (FileAssetContainer container, Host host) -> "//" + host.getName()  + container.getPath();
+                (FileAssetContainer container, Host host) -> "//" + host.getName()
+                        + container.getPath();
 
         final Function2<Host, String, Template> advanceTemplate =
-                (final Host templateHost, final String containerPath) -> createAdvancedTemplate(templateHost, containerPath);
+                (final Host templateHost, final String containerPath) -> createAdvancedTemplate(
+                        templateHost, containerPath);
         final Function2<Host, String, Template> drawedTemplate =
-                (final Host templateHost, final String containerPath) -> createDrawedTemplate(templateHost, containerPath);
+                (final Host templateHost, final String containerPath) -> createDrawedTemplate(
+                        templateHost, containerPath);
 
         final Host anotherHost = new SiteDataGen().nextPersisted();
-        final Host defaultHost = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), true);
+        final Host defaultHost = APILocator.getHostAPI()
+                .findDefaultHost(APILocator.systemUser(), true);
         final Host currentHost = site;
 
         final HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletRequestThreadLocal.INSTANCE.setRequest(request);
         when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(currentHost);
 
-        return new Object[][] {
-                { currentHost, currentHost, currentHost, relativePath, advanceTemplate, true},
-                { currentHost, currentHost, anotherHost, relativePath, advanceTemplate, false},
-                { currentHost, anotherHost, anotherHost, relativePath, advanceTemplate, false},
-                { currentHost, currentHost, defaultHost, relativePath, advanceTemplate, true},
-                { currentHost, anotherHost, defaultHost, relativePath, advanceTemplate, true},
+        return new Object[][]{
+                {currentHost, currentHost, currentHost, relativePath, advanceTemplate, true},
+                {currentHost, currentHost, anotherHost, relativePath, advanceTemplate, false},
+                {currentHost, anotherHost, anotherHost, relativePath, advanceTemplate, false},
+                {currentHost, currentHost, defaultHost, relativePath, advanceTemplate, true},
+                {currentHost, anotherHost, defaultHost, relativePath, advanceTemplate, true},
 
-                { currentHost, currentHost, currentHost, absolutePath, advanceTemplate, true},
-                { currentHost, currentHost, anotherHost, absolutePath, advanceTemplate, true},
-                { currentHost, anotherHost, anotherHost, absolutePath, advanceTemplate, true},
-                { currentHost, currentHost, defaultHost, absolutePath, advanceTemplate, true},
-                { currentHost, anotherHost, defaultHost, absolutePath, advanceTemplate, true},
+                {currentHost, currentHost, currentHost, absolutePath, advanceTemplate, true},
+                {currentHost, currentHost, anotherHost, absolutePath, advanceTemplate, true},
+                {currentHost, anotherHost, anotherHost, absolutePath, advanceTemplate, true},
+                {currentHost, currentHost, defaultHost, absolutePath, advanceTemplate, true},
+                {currentHost, anotherHost, defaultHost, absolutePath, advanceTemplate, true},
 
-                { currentHost, currentHost, currentHost, relativePath, drawedTemplate, true},
-                { currentHost, currentHost, anotherHost, relativePath, drawedTemplate, false},
-                { currentHost, anotherHost, anotherHost, relativePath, drawedTemplate, false},
-                { currentHost, currentHost, defaultHost, relativePath, drawedTemplate, true},
-                { currentHost, anotherHost, defaultHost, relativePath, drawedTemplate, true},
+                {currentHost, currentHost, currentHost, relativePath, drawedTemplate, true},
+                {currentHost, currentHost, anotherHost, relativePath, drawedTemplate, false},
+                {currentHost, anotherHost, anotherHost, relativePath, drawedTemplate, false},
+                {currentHost, currentHost, defaultHost, relativePath, drawedTemplate, true},
+                {currentHost, anotherHost, defaultHost, relativePath, drawedTemplate, true},
 
-                { currentHost, currentHost, currentHost, absolutePath, drawedTemplate, true},
-                { currentHost, currentHost, anotherHost, absolutePath, drawedTemplate, true},
-                { currentHost, anotherHost, anotherHost, absolutePath, drawedTemplate, true},
-                { currentHost, currentHost, defaultHost, absolutePath, drawedTemplate, true},
-                { currentHost, anotherHost, defaultHost, absolutePath, drawedTemplate, true}
+                {currentHost, currentHost, currentHost, absolutePath, drawedTemplate, true},
+                {currentHost, currentHost, anotherHost, absolutePath, drawedTemplate, true},
+                {currentHost, anotherHost, anotherHost, absolutePath, drawedTemplate, true},
+                {currentHost, currentHost, defaultHost, absolutePath, drawedTemplate, true},
+                {currentHost, anotherHost, defaultHost, absolutePath, drawedTemplate, true}
         };
     }
 
     /**
-     * Method to test: {@link com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetRenderedAPIImpl#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * Given Scenario:
-     *  - Template, FileContainer and Page in the same site or different site
-     *  - Using Advance Template or not Advance Template
-     *  - Using relative or absolute path
-     * ExpectedResult: should work
+     * Method to test:
+     * {@link
+     * com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetRenderedAPIImpl#getPageHtml(PageContext,
+     * HttpServletRequest, HttpServletResponse)} Given Scenario: - Template, FileContainer and Page
+     * in the same site or different site - Using Advance Template or not Advance Template - Using
+     * relative or absolute path ExpectedResult: should work
      *
      * @throws Exception
      */
@@ -1556,15 +1669,17 @@ public class HTMLPageAssetRenderedTest {
         final Template template = templateCreator.apply(templateHost, path);
         PublishFactory.publishAsset(template, systemUser, false, false);
 
-        final String pageName = "testPage-"+System.currentTimeMillis();
-        final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(pageHost, template, pageName, 1);
+        final String pageName = "testPage-" + System.currentTimeMillis();
+        final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(pageHost, template, pageName,
+                1);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier(),
                 template.isDrawed() ? ContainerUUID.UUID_START_VALUE :
                         ParseContainer.getDotParserContainerUUID(ContainerUUID.UUID_START_VALUE));
 
         final HttpServletRequest mockRequest = createHttpServletRequest(pageEnglishVersion);
-        when(mockRequest.getParameter(WebKeys.PAGE_MODE_PARAMETER)).thenReturn(PageMode.LIVE.toString());
+        when(mockRequest.getParameter(WebKeys.PAGE_MODE_PARAMETER)).thenReturn(
+                PageMode.LIVE.toString());
 
         final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
         final HttpSession session = createHttpSession(mockRequest);
@@ -1581,12 +1696,14 @@ public class HTMLPageAssetRenderedTest {
 
         if (shouldWork) {
             assertTrue(
-                    String.format("Should has content: using %s path and %s Template", path, template.isDrawed() ? "Drawed" : "Advanced"),
-                     html.contains("content1") && html.contains("content2")
+                    String.format("Should has content: using %s path and %s Template", path,
+                            template.isDrawed() ? "Drawed" : "Advanced"),
+                    html.contains("content1") && html.contains("content2")
             );
         } else {
             Assert.assertFalse(
-                    String.format("Should has content: using %s path and %s Template", path, template.isDrawed() ? "Drawed" : "Advanced"),
+                    String.format("Should has content: using %s path and %s Template", path,
+                            template.isDrawed() ? "Drawed" : "Advanced"),
                     html.contains("content1") && html.contains("content2")
             );
         }
@@ -1596,10 +1713,11 @@ public class HTMLPageAssetRenderedTest {
             final Host templateHost,
             final String containerPath) {
 
-        return new TemplateDataGen().title("PageContextBuilderTemplate"+System.currentTimeMillis())
-                    .host(templateHost)
-                    .withContainer(containerPath, ContainerUUID.UUID_START_VALUE)
-                    .nextPersisted();
+        return new TemplateDataGen().title(
+                        "PageContextBuilderTemplate" + System.currentTimeMillis())
+                .host(templateHost)
+                .withContainer(containerPath, ContainerUUID.UUID_START_VALUE)
+                .nextPersisted();
     }
 
     private static Template createDrawedTemplate(final Host host, final String containerPath) {
@@ -1609,7 +1727,7 @@ public class HTMLPageAssetRenderedTest {
 
         final Contentlet contentlet = new ThemeDataGen().nextPersisted();
         return new TemplateDataGen()
-                .title("PageContextBuilderTemplate"+System.currentTimeMillis())
+                .title("PageContextBuilderTemplate" + System.currentTimeMillis())
                 .host(host)
                 .drawedBody(templateLayout)
                 .theme(contentlet)
@@ -1619,7 +1737,7 @@ public class HTMLPageAssetRenderedTest {
     //Data Provider for the Widget Pre-execute code test
     @DataProvider
     public static Object[] dataProviderWidgetPreExecuteCode() {
-        return new Object[] {
+        return new Object[]{
                 new WidgetPreExecuteCodeTestCase(PageMode.EDIT_MODE),
                 new WidgetPreExecuteCodeTestCase(PageMode.PREVIEW_MODE),
                 new WidgetPreExecuteCodeTestCase(PageMode.LIVE),
@@ -1627,6 +1745,7 @@ public class HTMLPageAssetRenderedTest {
     }
 
     private static class WidgetPreExecuteCodeTestCase {
+
         final PageMode pageMode;
 
         public WidgetPreExecuteCodeTestCase(final PageMode pageMode) {
@@ -1636,62 +1755,80 @@ public class HTMLPageAssetRenderedTest {
 
     @Test
     @UseDataProvider("dataProviderWidgetPreExecuteCode")
-    public void test_WidgetPreExecuteCodeShowRegardlessPageMode(final WidgetPreExecuteCodeTestCase testCase) throws Exception {
+    public void test_WidgetPreExecuteCodeShowRegardlessPageMode(
+            final WidgetPreExecuteCodeTestCase testCase) throws Exception {
 
-        Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", true);
-        //Update the Preexecute Field to have some code in it
-        final String preExcuteCode = "PreExecute Code Displayed";
-        ContentType contentType = TestDataUtils.getWidgetLikeContentType();
-        final Field preExecuteField = APILocator.getContentTypeFieldAPI().byContentTypeIdAndVar(contentType.id(),WidgetContentType.WIDGET_PRE_EXECUTE_FIELD_VAR);
-        APILocator.getContentTypeFieldAPI()
-                .save(FieldBuilder.builder(preExecuteField).values(preExcuteCode).build(), systemUser);
-        // Assert that the widget has set the pre-execute field
-        assertTrue(APILocator.getContentTypeFieldAPI()
-                .byContentTypeIdAndVar(contentType.id(),WidgetContentType.WIDGET_PRE_EXECUTE_FIELD_VAR)
-                .values().equals(preExcuteCode));
+        boolean defaultContentToDefaultLangOriginalValue =
+                Config.getBooleanProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
+        try {
 
-        //Create Contentlet
-        final Contentlet widgetContentlet = TestDataUtils.getWidgetContent(true,1,contentType.id());
-        addAnonymousPermissions(widgetContentlet);
+            Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, true);
+            //Update the Preexecute Field to have some code in it
+            final String preExcuteCode = "PreExecute Code Displayed";
+            ContentType contentType = TestDataUtils.getWidgetLikeContentType();
+            final Field preExecuteField = APILocator.getContentTypeFieldAPI()
+                    .byContentTypeIdAndVar(contentType.id(),
+                            WidgetContentType.WIDGET_PRE_EXECUTE_FIELD_VAR);
+            APILocator.getContentTypeFieldAPI()
+                    .save(FieldBuilder.builder(preExecuteField).values(preExcuteCode).build(),
+                            systemUser);
+            // Assert that the widget has set the pre-execute field
+            assertTrue(APILocator.getContentTypeFieldAPI()
+                    .byContentTypeIdAndVar(contentType.id(),
+                            WidgetContentType.WIDGET_PRE_EXECUTE_FIELD_VAR)
+                    .values().equals(preExcuteCode));
 
-        //Create Container, Template and Page
-        final Container container = createContainer();
-        final Template template = createTemplate(container);
+            //Create Contentlet
+            final Contentlet widgetContentlet = TestDataUtils.getWidgetContent(true, 1,
+                    contentType.id());
+            addAnonymousPermissions(widgetContentlet);
 
-        final String pageName = "testPage-"+System.currentTimeMillis();
-        final HTMLPageAsset page = createHtmlPageAsset(template, pageName, 1);
+            //Create Container, Template and Page
+            final Container container = createContainer();
+            final Template template = createTemplate(container);
 
-        //Add contentlet to the page
-        MultiTree multiTree = new MultiTree(page.getIdentifier(), container.getIdentifier(),widgetContentlet.getIdentifier() ,UUID,0);
-        APILocator.getMultiTreeAPI().saveMultiTree(multiTree);
+            final String pageName = "testPage-" + System.currentTimeMillis();
+            final HTMLPageAsset page = createHtmlPageAsset(template, pageName, 1);
 
-        //Request page
-        final HttpServletRequest mockRequest = createHttpServletRequest(page);
-        final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
-        final HttpSession session = createHttpSession(mockRequest);
-        when(session.getAttribute(WebKeys.VISITOR)).thenReturn(null);
-        when(session.getAttribute(WebKeys.CMS_USER)).thenReturn(systemUser);
-        final String html = APILocator.getHTMLPageAssetRenderedAPI().getPageHtml(
-                PageContextBuilder.builder()
-                        .setUser(systemUser)
-                        .setPageUri(page.getURI())
-                        .setPageMode(testCase.pageMode)
-                        .build(),
-                mockRequest, mockResponse);
+            //Add contentlet to the page
+            MultiTree multiTree = new MultiTree(page.getIdentifier(), container.getIdentifier(),
+                    widgetContentlet.getIdentifier(), UUID, 0);
+            APILocator.getMultiTreeAPI().saveMultiTree(multiTree);
 
-        //Page html must contains the pre-execute code
-        assertTrue("Page Mode: " + testCase.pageMode + " html: " + html,html.contains(preExcuteCode));
+            //Request page
+            final HttpServletRequest mockRequest = createHttpServletRequest(page);
+            final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+            final HttpSession session = createHttpSession(mockRequest);
+            when(session.getAttribute(WebKeys.VISITOR)).thenReturn(null);
+            when(session.getAttribute(WebKeys.CMS_USER)).thenReturn(systemUser);
+            final String html = APILocator.getHTMLPageAssetRenderedAPI().getPageHtml(
+                    PageContextBuilder.builder()
+                            .setUser(systemUser)
+                            .setPageUri(page.getURI())
+                            .setPageMode(testCase.pageMode)
+                            .build(),
+                    mockRequest, mockResponse);
+
+            //Page html must contains the pre-execute code
+            assertTrue("Page Mode: " + testCase.pageMode + " html: " + html,
+                    html.contains(preExcuteCode));
+        } finally {
+            Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE",
+                    defaultContentToDefaultLangOriginalValue);
+        }
     }
 
     @NotNull
-    private HttpServletRequest createHttpServletRequest(HTMLPageAsset pageEnglishVersion) throws DotDataException {
+    private HttpServletRequest createHttpServletRequest(HTMLPageAsset pageEnglishVersion)
+            throws DotDataException {
         final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
         HttpServletRequestThreadLocal.INSTANCE.setRequest(mockRequest);
         when(mockRequest.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(site);
         when(mockRequest.getRequestURI()).thenReturn(pageEnglishVersion.getURI());
-        when(mockRequest.getParameter(WebKeys.PAGE_MODE_PARAMETER)).thenReturn(PageMode.EDIT_MODE.toString());
+        when(mockRequest.getParameter(WebKeys.PAGE_MODE_PARAMETER)).thenReturn(
+                PageMode.EDIT_MODE.toString());
         when(mockRequest.getAttribute(com.liferay.portal.util.WebKeys.USER)).thenReturn(systemUser);
         return mockRequest;
     }
@@ -1708,12 +1845,12 @@ public class HTMLPageAssetRenderedTest {
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: A container is add twice in a page
-     * Should: render the pge
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: A container is add twice in a page Should: render the pge
      */
     @Test
-    public void containerTwiceIntoPage() throws Exception{
+    public void containerTwiceIntoPage() throws Exception {
 
         final Container container = createFileContainer();
         final Template template = createTemplate(
@@ -1721,23 +1858,24 @@ public class HTMLPageAssetRenderedTest {
                 new TestContainerUUID(container, "2")
         );
 
-        Config.setProperty(contentFallbackProperty,false);
-        Config.setProperty(pageFallbackProperty,true);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, true);
 
-        final String pageName = "test1Page-"+System.currentTimeMillis();
+        final String pageName = "test1Page-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier(), "1");
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier(), "2");
 
-        final List<MultiTree>  multiTrees = APILocator.getMultiTreeAPI().getContainerMultiTrees(container.getIdentifier());
+        final List<MultiTree> multiTrees = APILocator.getMultiTreeAPI()
+                .getContainerMultiTrees(container.getIdentifier());
         Assert.assertNotNull(multiTrees);
         Assert.assertEquals(8, multiTrees.size());
 
-
         //request page ENG version
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -1750,16 +1888,17 @@ public class HTMLPageAssetRenderedTest {
                         .setPageMode(PageMode.LIVE)
                         .build(),
                 mockRequest, mockResponse);
-        Assert.assertEquals( html , getNotExperimentJsCode() + "content1content2content1content2");
+        Assert.assertEquals(html, getNotExperimentJsCode() + "content1content2content1content2");
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: A container is add twice in a page using a TemplateLayout
-     * Should: render the pge
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: A container is add twice in a page using a TemplateLayout Should:
+     * render the pge
      */
     @Test
-    public void containerTwiceIntoPageAndTemplateLayout() throws Exception{
+    public void containerTwiceIntoPageAndTemplateLayout() throws Exception {
 
         final FileAssetContainer container = createFileContainer();
         final TemplateLayout templateLayout = new TemplateLayoutDataGen()
@@ -1774,23 +1913,24 @@ public class HTMLPageAssetRenderedTest {
                 .theme(theme)
                 .nextPersisted();
 
-        Config.setProperty(contentFallbackProperty,false);
-        Config.setProperty(pageFallbackProperty,true);
+        Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
+        Config.setProperty(DEFAULT_PAGE_TO_DEFAULT_LANGUAGE, true);
 
-        final String pageName = "test1Page-"+System.currentTimeMillis();
+        final String pageName = "test1Page-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier(), "1");
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier(), "2");
 
-        final List<MultiTree>  multiTrees = APILocator.getMultiTreeAPI().getContainerMultiTrees(container.getIdentifier());
+        final List<MultiTree> multiTrees = APILocator.getMultiTreeAPI()
+                .getContainerMultiTrees(container.getIdentifier());
         Assert.assertNotNull(multiTrees);
         Assert.assertEquals(8, multiTrees.size());
 
-
         //request page ENG version
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -1807,7 +1947,7 @@ public class HTMLPageAssetRenderedTest {
     }
 
     @Test
-    public void pageWithSidebarShouldRender() throws Exception{
+    public void pageWithSidebarShouldRender() throws Exception {
 
         final FileAssetContainer container = createFileContainer();
         final TemplateLayout templateLayout = new TemplateLayoutDataGen()
@@ -1822,7 +1962,7 @@ public class HTMLPageAssetRenderedTest {
                 .theme(theme)
                 .nextPersisted();
 
-        final String pageName = "test_page_with_sidebar-"+System.currentTimeMillis();
+        final String pageName = "test_page_with_sidebar-" + System.currentTimeMillis();
         final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(template, pageName, 1);
 
         createMultiTree(pageEnglishVersion.getIdentifier(), container.getIdentifier(), "1");
@@ -1830,7 +1970,8 @@ public class HTMLPageAssetRenderedTest {
 
         //request page ENG version
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -1850,28 +1991,32 @@ public class HTMLPageAssetRenderedTest {
         final int secondIndex = html.indexOf(toFind, firstIndex + toFind.length());
         final int thirdIndex = html.indexOf(toFind, secondIndex + toFind.length());
 
-        assertTrue(firstIndex != -1 && secondIndex != -1 && firstIndex != secondIndex && thirdIndex == -1);
+        assertTrue(firstIndex != -1 && secondIndex != -1 && firstIndex != secondIndex
+                && thirdIndex == -1);
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: A page has a template that is a file template design
-     * Should: render the page
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: A page has a template that is a file template design Should:
+     * render the page
      */
     @Test
-    public void pageWithFileTemplateDesignShouldRender() throws Exception{
+    public void pageWithFileTemplateDesignShouldRender() throws Exception {
         final Host host = new SiteDataGen().nextPersisted();
 
         final FileAssetTemplate fileAssetTemplate = new TemplateAsFileDataGen()
                 .host(host)
                 .nextPersisted();
 
-        final String pageName = "test_page_with_filetemplatedesign-"+System.currentTimeMillis();
-        final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(host,fileAssetTemplate, pageName, 1);
+        final String pageName = "test_page_with_filetemplatedesign-" + System.currentTimeMillis();
+        final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(host, fileAssetTemplate,
+                pageName, 1);
 
         //request page ENG version
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(host.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -1889,12 +2034,13 @@ public class HTMLPageAssetRenderedTest {
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: A page has a template that is a file template advanced
-     * Should: render the page
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: A page has a template that is a file template advanced Should:
+     * render the page
      */
     @Test
-    public void pageWithFileTemplateAdvancedShouldRender() throws Exception{
+    public void pageWithFileTemplateAdvancedShouldRender() throws Exception {
         final Host host = new SiteDataGen().nextPersisted();
 
         final FileAssetTemplate fileAssetTemplate = new TemplateAsFileDataGen()
@@ -1902,12 +2048,14 @@ public class HTMLPageAssetRenderedTest {
                 .host(host)
                 .nextPersisted();
 
-        final String pageName = "test_page_with_filetemplateadvanced-"+System.currentTimeMillis();
-        final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(host,fileAssetTemplate, pageName, 1);
+        final String pageName = "test_page_with_filetemplateadvanced-" + System.currentTimeMillis();
+        final HTMLPageAsset pageEnglishVersion = createHtmlPageAsset(host, fileAssetTemplate,
+                pageName, 1);
 
         //request page ENG version
         HttpServletRequest mockRequest = new MockSessionRequest(
-                new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                 .request();
         when(mockRequest.getParameter("host_id")).thenReturn(host.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -1925,12 +2073,13 @@ public class HTMLPageAssetRenderedTest {
     }
 
     /**
-     * Method to test: {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest, HttpServletResponse)}
-     * When: A page has multiple personas version, and the container has a MAx contentlet equals to 1
-     * Should: render the page
+     * Method to test:
+     * {@link HTMLPageAssetRenderedAPI#getPageHtml(PageContext, HttpServletRequest,
+     * HttpServletResponse)} When: A page has multiple personas version, and the container has a MAx
+     * contentlet equals to 1 Should: render the page
      */
     @Test
-    public void pageWithMultiplePersona() throws Exception{
+    public void pageWithMultiplePersona() throws Exception {
 
         final Container container = createContainer(1);
 
@@ -1945,7 +2094,7 @@ public class HTMLPageAssetRenderedTest {
                 .theme(theme)
                 .nextPersisted();
 
-        final String pageName = "test1Page-"+System.currentTimeMillis();
+        final String pageName = "test1Page-" + System.currentTimeMillis();
         final HTMLPageAsset page = createHtmlPageAsset(template, pageName, 1);
 
         final Persona defaultPersona = APILocator.getPersonaAPI().getDefaultPersona();
@@ -1959,7 +2108,8 @@ public class HTMLPageAssetRenderedTest {
                 .setProperty("body", defaultPersona.getKeyTag())
                 .nextPersisted();
 
-        final Contentlet notDefaultPersonaContentlet = new ContentletDataGen(contentGenericType.id())
+        final Contentlet notDefaultPersonaContentlet = new ContentletDataGen(
+                contentGenericType.id())
                 .languageId(1)
                 .folder(folder)
                 .host(site)
@@ -1986,12 +2136,11 @@ public class HTMLPageAssetRenderedTest {
                 .setInstanceID("1")
                 .nextPersisted();
 
-
         //request page ENG version
         HttpServletRequest mockRequest = new MockSessionRequest(
                 new MockAttributeRequest(
                         new MockHttpRequestIntegrationTest("localhost", "/").request()).request()
-            ).request();
+        ).request();
 
         when(mockRequest.getParameter("host_id")).thenReturn(site.getIdentifier());
         mockRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
@@ -2011,17 +2160,19 @@ public class HTMLPageAssetRenderedTest {
         visitor.setPersona(notDefaultPersona);
         mockRequest.getSession().setAttribute(WebKeys.VISITOR, visitor);
 
-        final String htmlWithNoDefaultPersona = APILocator.getHTMLPageAssetRenderedAPI().getPageHtml(
-                PageContextBuilder.builder()
-                        .setUser(systemUser)
-                        .setPageUri(page.getURI())
-                        .setPageMode(PageMode.LIVE)
-                        .build(),
-                mockRequest, mockResponse);
+        final String htmlWithNoDefaultPersona = APILocator.getHTMLPageAssetRenderedAPI()
+                .getPageHtml(
+                        PageContextBuilder.builder()
+                                .setUser(systemUser)
+                                .setPageUri(page.getURI())
+                                .setPageMode(PageMode.LIVE)
+                                .build(),
+                        mockRequest, mockResponse);
         assertTrue(htmlWithNoDefaultPersona.contains(notDefaultPersona.getKeyTag()));
     }
 
-    private static class TestContainerUUID{
+    private static class TestContainerUUID {
+
         Container container;
         String UUID;
 
@@ -2031,7 +2182,7 @@ public class HTMLPageAssetRenderedTest {
         }
     }
 
-    private String getNotExperimentJsCode(){
+    private String getNotExperimentJsCode() {
         return "<SCRIPT>localStorage.removeItem('experiment_data');</SCRIPT>\n";
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/servlet/VelocityServletIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/servlet/VelocityServletIntegrationTest.java
@@ -126,8 +126,7 @@ public class VelocityServletIntegrationTest {
 
     /**
      * Method to test: {@link VelocityServlet#service(HttpServletRequest, HttpServletResponse)}
-     * when: There is exists a Content Type Url Map and is request
-     * Should: return 200 Http code
+     * when: There is exists a Content Type Url Map and is request Should: return 200 Http code
      *
      * @throws ServletException
      * @throws IOException
@@ -142,7 +141,8 @@ public class VelocityServletIntegrationTest {
         final Contentlet contentlet = createURLMapperContentType(newsPatternPrefix, host);
         ContentletDataGen.publish(contentlet);
 
-        final String contentletURLMap = newsPatternPrefix + contentlet.getStringProperty("urlTitle");
+        final String contentletURLMap =
+                newsPatternPrefix + contentlet.getStringProperty("urlTitle");
 
         when(request.getRequestURI()).thenReturn(contentletURLMap);
         when(request.getAttribute(WebKeys.CURRENT_HOST)).thenReturn(host);
@@ -155,14 +155,14 @@ public class VelocityServletIntegrationTest {
 
     /**
      * Method to test: {@link VelocityServlet#service(HttpServletRequest, HttpServletResponse)}
-     * when: There is exists a Content Type Url Map and is request
-     * Should: return 200 Http code
+     * when: There is exists a Content Type Url Map and is request Should: return 200 Http code
      *
      * @throws ServletException
      * @throws IOException
      */
     @Test
-    public void whenRequestVanityURL() throws ServletException, IOException, DotDataException, DotSecurityException {
+    public void whenRequestVanityURL()
+            throws ServletException, IOException, DotDataException, DotSecurityException {
 
         final VelocityServlet velocityServlet = new VelocityServlet();
 
@@ -190,22 +190,23 @@ public class VelocityServletIntegrationTest {
     private void createAndPublishVanityURL(final String forwardURL, final String VANITY_URI)
             throws DotDataException, DotSecurityException {
         final Language defaultLanguage = APILocator.getLanguageAPI().getDefaultLanguage();
-        final Contentlet vanityUrl = FiltersUtil.getInstance().createVanityUrl("test", host, VANITY_URI,
-                forwardURL, 200, 0, defaultLanguage.getId());
+        final Contentlet vanityUrl = FiltersUtil.getInstance()
+                .createVanityUrl("test", host, VANITY_URI,
+                        forwardURL, 200, 0, defaultLanguage.getId());
 
         FiltersUtil.getInstance().publishVanityUrl(vanityUrl);
     }
 
     /**
      * Method to test: {@link VelocityServlet#service(HttpServletRequest, HttpServletResponse)}
-     * when: There is exists a VanityURL that forward to a URL Map
-     * Should: return 200 Http code
+     * when: There is exists a VanityURL that forward to a URL Map Should: return 200 Http code
      *
      * @throws ServletException
      * @throws IOException
      */
     @Test
-    public void whenRequestURLMapAndVanityURLTogether() throws ServletException, IOException, DotSecurityException, DotDataException {
+    public void whenRequestURLMapAndVanityURLTogether()
+            throws ServletException, IOException, DotSecurityException, DotDataException {
 
         final VelocityServlet velocityServlet = new VelocityServlet();
 
@@ -215,8 +216,7 @@ public class VelocityServletIntegrationTest {
         ContentletDataGen.publish(contentlet);
 
         final String uri = "/vanityURL/" + contentlet.getStringProperty("urlTitle");
-        
-        
+
         when(request.getRequestURI()).thenReturn(uri);
 
         final String VANITY_URI = "/vanityURL/([a-zA-Z0-9-_]+)";
@@ -224,24 +224,27 @@ public class VelocityServletIntegrationTest {
 
         createAndPublishVanityURL(FORWARD_URL, VANITY_URI);
 
-        when(request.getRequestURI()).thenReturn("/vanityURL/" + contentlet.getStringProperty("urlTitle"));
+        when(request.getRequestURI()).thenReturn(
+                "/vanityURL/" + contentlet.getStringProperty("urlTitle"));
         final FilterChain chain = Mockito.mock(FilterChain.class);
 
         final VanityURLFilter vanityURLFilter = new VanityURLFilter();
         vanityURLFilter.doFilter(request, response, chain);
 
-        
-        assert(request.getAttribute(com.dotmarketing.filters.Constants.CMS_FILTER_URI_OVERRIDE)!=null);
-        final String vanity = (String) request.getAttribute(com.dotmarketing.filters.Constants.CMS_FILTER_URI_OVERRIDE);
-        
-        assertEquals("vanity rewritten", vanity,FORWARD_URL.replace("$1", contentlet.getStringProperty("urlTitle")));
+        assert (request.getAttribute(com.dotmarketing.filters.Constants.CMS_FILTER_URI_OVERRIDE)
+                != null);
+        final String vanity = (String) request.getAttribute(
+                com.dotmarketing.filters.Constants.CMS_FILTER_URI_OVERRIDE);
+
+        assertEquals("vanity rewritten", vanity,
+                FORWARD_URL.replace("$1", contentlet.getStringProperty("urlTitle")));
         velocityServlet.service(request, response);
 
         verify(servletOutputStream).write(getNotExperimentJsCode().getBytes());
         verify(response, never()).sendError(HttpServletResponse.SC_NOT_FOUND);
     }
 
-    private  Contentlet createURLMapperContentType(final String newsPatternPrefix, final Host host) {
+    private Contentlet createURLMapperContentType(final String newsPatternPrefix, final Host host) {
         final String urlMapPattern = newsPatternPrefix + "{urlTitle}";
         final HTMLPageAsset page = createPage();
 
@@ -257,7 +260,7 @@ public class VelocityServletIntegrationTest {
     }
 
 
-    private  HTMLPageAsset createPage(){
+    private HTMLPageAsset createPage() {
 
         final Folder folder = new FolderDataGen().site(host)
                 .nextPersisted();
@@ -268,23 +271,24 @@ public class VelocityServletIntegrationTest {
                 .title("news-detail")
                 .nextPersisted();
         ContentletDataGen.publish(htmlPageAsset);
-        return  htmlPageAsset;
+        return htmlPageAsset;
     }
 
     /**
      * Method to test: {@link VelocityServlet#service(HttpServletRequest, HttpServletResponse)}
-     *
-     * When: TimeMachine in running and request a existing Page
-     * Should: Return the page
+     * <p>
+     * When: TimeMachine in running and request a existing Page Should: Return the page
      */
     @Test
-    public void testingTimeMachine () throws Exception{
+    public void testingTimeMachine() throws Exception {
 
         final User systemUser = APILocator.systemUser();
-        final ContentType contentGenericType = APILocator.getContentTypeAPI(systemUser).find("webPageContent");
+        final ContentType contentGenericType = APILocator.getContentTypeAPI(systemUser)
+                .find("webPageContent");
 
         Container container = new ContainerDataGen().site(host).nextPersisted();
-        final Template template = new TemplateDataGen().site(host).withContainer(container.getIdentifier()).nextPersisted();
+        final Template template = new TemplateDataGen().site(host)
+                .withContainer(container.getIdentifier()).nextPersisted();
 
         final List<ContainerStructure> csList = new ArrayList<ContainerStructure>();
         final ContainerStructure containerStructure = new ContainerStructure();
@@ -296,7 +300,7 @@ public class VelocityServletIntegrationTest {
         PublishFactory.publishAsset(container, systemUser, false, false);
 
         final boolean defaultContentToDefaultLanguage = Config.getBooleanProperty(
-                "DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", true);
+                "DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", false);
         final boolean defaultPageToDefaultLanguage = Config.getBooleanProperty(
                 "DEFAULT_PAGE_TO_DEFAULT_LANGUAGE", true);
 
@@ -359,16 +363,20 @@ public class VelocityServletIntegrationTest {
             velocityServlet.service(mockRequest, mockResponse);
 
             verify(mockResponse, never()).sendError(anyInt());
-            verify(outputStream).write((getNotExperimentJsCode() + "<div>content1</div>").getBytes());
+            verify(outputStream).write(
+                    (getNotExperimentJsCode() + "<div>content1</div>").getBytes());
         } finally {
-            Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", defaultContentToDefaultLanguage);
+            Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE",
+                    defaultContentToDefaultLanguage);
             Config.setProperty("DEFAULT_PAGE_TO_DEFAULT_LANGUAGE", defaultPageToDefaultLanguage);
         }
     }
 
     /**
-     * Here were testing that a logged in user with FE and BE roles will But login in the Front end will get the Page Per SE and not the Edit Mode
-     * More context here: https://github.com/dotcms/core/issues/22124
+     * Here were testing that a logged in user with FE and BE roles will But login in the Front end
+     * will get the Page Per SE and not the Edit Mode More context here:
+     * https://github.com/dotcms/core/issues/22124
+     *
      * @throws Exception
      */
     @Test
@@ -389,6 +397,7 @@ public class VelocityServletIntegrationTest {
 
     /**
      * This is the actual test body
+     *
      * @param user
      * @param mode
      * @throws IOException
@@ -411,13 +420,17 @@ public class VelocityServletIntegrationTest {
         final ServletOutputStream outputStream = mock(ServletOutputStream.class);
         when(response.getOutputStream()).thenReturn(outputStream);
 
-        final HTMLPageAssetRenderedAPI pageAssetRenderedAPI = mock(HTMLPageAssetRenderedAPIImpl.class);
-        when(pageAssetRenderedAPI.getPageHtml(Mockito.any(PageContext.class),Mockito.any(HttpServletRequest.class), Mockito.any(HttpServletResponse.class))).thenReturn(
+        final HTMLPageAssetRenderedAPI pageAssetRenderedAPI = mock(
+                HTMLPageAssetRenderedAPIImpl.class);
+        when(pageAssetRenderedAPI.getPageHtml(Mockito.any(PageContext.class),
+                Mockito.any(HttpServletRequest.class),
+                Mockito.any(HttpServletResponse.class))).thenReturn(
                 pageContent);
 
-        final VelocityServlet velocityServlet = new VelocityServlet(WebAPILocator.getUserWebAPI(), pageAssetRenderedAPI);
+        final VelocityServlet velocityServlet = new VelocityServlet(WebAPILocator.getUserWebAPI(),
+                pageAssetRenderedAPI);
         velocityServlet.service(velocityRequest, response);
-        if(LoginMode.FE == mode){
+        if (LoginMode.FE == mode) {
             //Here we verify the page was served normally
             verify(outputStream, times(1)).write(pageContent.getBytes());
         } else {
@@ -426,7 +439,7 @@ public class VelocityServletIntegrationTest {
         }
     }
 
-    private String getNotExperimentJsCode(){
+    private String getNotExperimentJsCode() {
         return "<SCRIPT>localStorage.removeItem('experiment_data');</SCRIPT>\n";
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceIntegrationTest.java
@@ -94,6 +94,7 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.business.Role;
 import com.dotmarketing.business.RoleAPI;
+import com.dotmarketing.common.reindex.ReindexQueueAPI;
 import com.dotmarketing.common.reindex.ReindexThread;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.categories.model.Category;
@@ -153,6 +154,7 @@ import org.glassfish.jersey.media.multipart.BodyPart;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -179,7 +181,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     public static void prepare() throws Exception {
         //Setting web app environment
         IntegrationTestInitService.getInstance().init();
-        workflowAPI =  APILocator.getWorkflowAPI();
+        workflowAPI = APILocator.getWorkflowAPI();
         contentletAPI = APILocator.getContentletAPI();
         roleAPI = APILocator.getRoleAPI();
         final ContentHelper contentHelper = ContentHelper.getInstance();
@@ -187,7 +189,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                 SystemActionApiFireCommandFactory.getInstance();
         final PermissionAPI permissionAPI = APILocator.getPermissionAPI();
         final WorkflowImportExportUtil workflowImportExportUtil = getInstance();
-        final WorkflowHelper workflowHelper = new WorkflowHelper(workflowAPI, roleAPI, contentletAPI, permissionAPI,
+        final WorkflowHelper workflowHelper = new WorkflowHelper(workflowAPI, roleAPI,
+                contentletAPI, permissionAPI,
                 workflowImportExportUtil);
         final ResponseUtil responseUtil = ResponseUtil.INSTANCE;
 
@@ -201,11 +204,13 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         final InitDataObject dataObject = mock(InitDataObject.class);
         when(dataObject.getUser()).thenReturn(user);
         when(webResource
-                .init(nullable(String.class), any(HttpServletRequest.class), any(HttpServletResponse.class), anyBoolean(),
+                .init(nullable(String.class), any(HttpServletRequest.class),
+                        any(HttpServletResponse.class), anyBoolean(),
                         nullable(String.class))).thenReturn(dataObject);
 
         workflowResource = new WorkflowResource(workflowHelper, contentHelper, workflowAPI,
-                contentletAPI, responseUtil, permissionAPI, workflowImportExportUtil, new MultiPartUtils(), webResource,
+                contentletAPI, responseUtil, permissionAPI, workflowImportExportUtil,
+                new MultiPartUtils(), webResource,
                 systemActionApiFireCommandFactory);
 
         contentTypeAPI = APILocator.getContentTypeAPI(APILocator.systemUser());
@@ -257,12 +262,12 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     public void testImportScheme() throws DotDataException {
 
         final HttpServletRequest request = mock(HttpServletRequest.class);
-        final List<Permission> permissions                              = new ArrayList<>();
-        final List<WorkflowScheme> schemes                              = new ArrayList<>();
-        final WorkflowScheme       scheme                               = new WorkflowScheme();
-        final List<WorkflowStep>   steps                                = new ArrayList<>();
-        final List<WorkflowAction> actions                              = new ArrayList<>();
-        final List<Map<String, String>> actionSteps                     = new ArrayList<>();
+        final List<Permission> permissions = new ArrayList<>();
+        final List<WorkflowScheme> schemes = new ArrayList<>();
+        final WorkflowScheme scheme = new WorkflowScheme();
+        final List<WorkflowStep> steps = new ArrayList<>();
+        final List<WorkflowAction> actions = new ArrayList<>();
+        final List<Map<String, String>> actionSteps = new ArrayList<>();
 
         try {
 
@@ -295,7 +300,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             final WorkflowAction workflowAction1 = new WorkflowAction();
 
             workflowAction1.setId(UUIDGenerator.generateUuid());
-            workflowAction1.setShowOn(WorkflowState.LOCKED, WorkflowState.PUBLISHED, WorkflowState.UNPUBLISHED, WorkflowState.EDITING);
+            workflowAction1.setShowOn(WorkflowState.LOCKED, WorkflowState.PUBLISHED,
+                    WorkflowState.UNPUBLISHED, WorkflowState.EDITING);
             workflowAction1.setNextStep(workflowStep2.getId());
             workflowAction1.setNextAssign(roleAdmin().getId());
             workflowAction1.setSchemeId(scheme.getId());
@@ -307,7 +313,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             final WorkflowAction workflowAction2 = new WorkflowAction();
 
             workflowAction2.setId(UUIDGenerator.generateUuid());
-            workflowAction2.setShowOn(WorkflowState.LOCKED, WorkflowState.PUBLISHED, WorkflowState.UNPUBLISHED, WorkflowState.EDITING);
+            workflowAction2.setShowOn(WorkflowState.LOCKED, WorkflowState.PUBLISHED,
+                    WorkflowState.UNPUBLISHED, WorkflowState.EDITING);
             workflowAction2.setNextStep(workflowStep2.getId());
             workflowAction2.setNextAssign(roleAdmin().getId());
             workflowAction2.setSchemeId(scheme.getId());
@@ -319,7 +326,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             final WorkflowAction workflowAction3 = new WorkflowAction();
 
             workflowAction3.setId(UUIDGenerator.generateUuid());
-            workflowAction3.setShowOn(WorkflowState.LOCKED, WorkflowState.PUBLISHED, WorkflowState.EDITING);
+            workflowAction3.setShowOn(WorkflowState.LOCKED, WorkflowState.PUBLISHED,
+                    WorkflowState.EDITING);
             workflowAction3.setNextStep(WorkflowAction.CURRENT_STEP);
             workflowAction3.setNextAssign(roleAdmin().getId());
             workflowAction3.setSchemeId(scheme.getId());
@@ -361,24 +369,29 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             permission2.setPermission(1);
             permissions.add(permission2);
 
-
             final WorkflowSchemeImportObjectForm exportObjectForm =
                     new WorkflowSchemeImportObjectForm(
-                            new WorkflowSchemeImportExportObjectView(WorkflowResource.VERSION,schemes,steps,actions,actionSteps, Collections.emptyList(),
-                                    Collections.emptyList(),Collections.emptyList()),
+                            new WorkflowSchemeImportExportObjectView(WorkflowResource.VERSION,
+                                    schemes, steps, actions, actionSteps, Collections.emptyList(),
+                                    Collections.emptyList(), Collections.emptyList()),
                             permissions);
 
-            final Response importResponse = workflowResource.importScheme(request, new EmptyHttpResponse(), exportObjectForm);
+            final Response importResponse = workflowResource.importScheme(request,
+                    new EmptyHttpResponse(), exportObjectForm);
             assertEquals(Response.Status.OK.getStatusCode(), importResponse.getStatus());
 
-            final Response exportResponse = workflowResource.exportScheme(request, new EmptyHttpResponse(), scheme.getId());
+            final Response exportResponse = workflowResource.exportScheme(request,
+                    new EmptyHttpResponse(), scheme.getId());
             assertEquals(Response.Status.OK.getStatusCode(), importResponse.getStatus());
-            final ResponseEntityView exportEntityView = ResponseEntityView.class.cast(exportResponse.getEntity());
+            final ResponseEntityView exportEntityView = ResponseEntityView.class.cast(
+                    exportResponse.getEntity());
             final Map importSchemeMap = Map.class.cast(exportEntityView.getEntity());
             assertNotNull(importSchemeMap);
 
-            final WorkflowSchemeImportExportObjectView exportObject = (WorkflowSchemeImportExportObjectView) importSchemeMap.get("workflowObject");
-            final List<Permission> permissionsExported = (List<Permission>) importSchemeMap.get("permissions");
+            final WorkflowSchemeImportExportObjectView exportObject = (WorkflowSchemeImportExportObjectView) importSchemeMap.get(
+                    "workflowObject");
+            final List<Permission> permissionsExported = (List<Permission>) importSchemeMap.get(
+                    "permissions");
 
             assertNotNull(exportObject);
             assertNotNull(permissionsExported);
@@ -394,7 +407,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
             assertNotNull(exportObject.getActions());
             assertEquals(3, exportObject.getActions().size());
-            final Set<String> actionIdSet = exportObject.getActions().stream().map(WorkflowAction::getId).collect(Collectors.toSet());
+            final Set<String> actionIdSet = exportObject.getActions().stream()
+                    .map(WorkflowAction::getId).collect(Collectors.toSet());
             assertTrue(actionIdSet.contains(workflowAction1.getId()));
             assertTrue(actionIdSet.contains(workflowAction2.getId()));
             assertTrue(actionIdSet.contains(workflowAction3.getId()));
@@ -422,55 +436,62 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     }
 
     @Test
-    public void testAddSchemaThenFindIt(){
+    public void testAddSchemaThenFindIt() {
         final WorkflowScheme savedScheme = createScheme(workflowResource);
         assertNotNull(savedScheme);
         final List<WorkflowScheme> schemaList = findSchemes(workflowResource);
         boolean found = false;
-        for(WorkflowScheme scheme:schemaList){
+        for (WorkflowScheme scheme : schemaList) {
             found = savedScheme.getId().equals(scheme.getId());
-            if(found){
-               break;
+            if (found) {
+                break;
             }
         }
         assertTrue(found);
     }
 
     @Test
-    public void testUpdateSchema(){
+    public void testUpdateSchema() {
         final String updatedName = schemeName();
         final WorkflowScheme savedScheme = createScheme(workflowResource);
         assertNotNull(savedScheme);
         final HttpServletRequest request = mock(HttpServletRequest.class);
-        WorkflowSchemeForm form = new WorkflowSchemeForm.Builder().schemeDescription("lol").schemeArchived(false).schemeName(updatedName).build();
-        final Response updateResponse = workflowResource.updateScheme(request, new EmptyHttpResponse(), savedScheme.getId(), form);
+        WorkflowSchemeForm form = new WorkflowSchemeForm.Builder().schemeDescription("lol")
+                .schemeArchived(false).schemeName(updatedName).build();
+        final Response updateResponse = workflowResource.updateScheme(request,
+                new EmptyHttpResponse(), savedScheme.getId(), form);
         assertEquals(Response.Status.OK.getStatusCode(), updateResponse.getStatus());
-        final ResponseEntityView updateSchemeEntityView = ResponseEntityView.class.cast(updateResponse.getEntity());
-        final WorkflowScheme updatedScheme = WorkflowScheme.class.cast(updateSchemeEntityView.getEntity());
+        final ResponseEntityView updateSchemeEntityView = ResponseEntityView.class.cast(
+                updateResponse.getEntity());
+        final WorkflowScheme updatedScheme = WorkflowScheme.class.cast(
+                updateSchemeEntityView.getEntity());
         assertNotNull(updatedScheme);
     }
 
     @Test
-    public void testUpdateSchemaUsingDupeName(){
+    public void testUpdateSchemaUsingDupeName() {
         final WorkflowScheme savedScheme1 = createScheme(workflowResource);
         final WorkflowScheme savedScheme2 = createScheme(workflowResource);
         assertNotNull(savedScheme1);
         final String updatedName = savedScheme2.getName();
         final HttpServletRequest request = mock(HttpServletRequest.class);
-        WorkflowSchemeForm form = new WorkflowSchemeForm.Builder().schemeDescription("lol").schemeArchived(false).schemeName(updatedName).build();
-        final Response updateResponse = workflowResource.updateScheme(request, new EmptyHttpResponse(), savedScheme1.getId(), form);
+        WorkflowSchemeForm form = new WorkflowSchemeForm.Builder().schemeDescription("lol")
+                .schemeArchived(false).schemeName(updatedName).build();
+        final Response updateResponse = workflowResource.updateScheme(request,
+                new EmptyHttpResponse(), savedScheme1.getId(), form);
         assertEquals(Status.OK.getStatusCode(), updateResponse.getStatus());
     }
 
     @Test
-    public void testCreateSchemeThenAddStepsThenAddActions() throws Exception{
-        final Role adminRole =  roleAdmin();
+    public void testCreateSchemeThenAddStepsThenAddActions() throws Exception {
+        final Role adminRole = roleAdmin();
         final String adminRoleId = adminRole.getId();
         final WorkflowScheme savedScheme = createScheme(workflowResource);
         assertNotNull(savedScheme);
-        final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme,3);
+        final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme, 3);
         assertFalse(workflowSteps.isEmpty());
-        final List<WorkflowAction> actions = createWorkflowActions(workflowResource, savedScheme, adminRoleId, workflowSteps);
+        final List<WorkflowAction> actions = createWorkflowActions(workflowResource, savedScheme,
+                adminRoleId, workflowSteps);
         assertFalse(actions.isEmpty());
     }
 
@@ -485,11 +506,11 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
         final CountDownLatch countDownLatch = new CountDownLatch(workflowSteps.size());
         final AtomicInteger count = new AtomicInteger(0);
-        for(final WorkflowStep workflowStep: workflowSteps){
+        for (final WorkflowStep workflowStep : workflowSteps) {
             final AsyncResponse asyncResponse = new MockAsyncResponse((arg) -> {
 
                 countDownLatch.countDown();
-                final Response deleteStepResponse = (Response)arg;
+                final Response deleteStepResponse = (Response) arg;
                 assertEquals(Response.Status.OK.getStatusCode(), deleteStepResponse.getStatus());
                 count.addAndGet(1);
                 return true;
@@ -519,7 +540,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         final List<WorkflowStep> steps = findSteps(workflowResource, savedScheme);
         validateOrderedSteps(steps);
         assertTrue(steps.isEmpty());
-        addSteps(workflowResource, savedScheme,numSteps);
+        addSteps(workflowResource, savedScheme, numSteps);
         final List<WorkflowStep> afterAddingSteps = findSteps(workflowResource, savedScheme);
         assertEquals(numSteps, afterAddingSteps.size());
         validateOrderedSteps(afterAddingSteps);
@@ -533,16 +554,17 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         final WorkflowScheme savedScheme = createScheme(workflowResource);
         final List<WorkflowStep> steps = findSteps(workflowResource, savedScheme);
         assertTrue(steps.isEmpty());
-        final List<WorkflowStep> workflowStepsOriginalSetUp = addSteps(workflowResource, savedScheme, numSteps);
+        final List<WorkflowStep> workflowStepsOriginalSetUp = addSteps(workflowResource,
+                savedScheme, numSteps);
         final WorkflowStep firstWorkflowStep = workflowStepsOriginalSetUp.get(0);
-        reorderSteps(firstWorkflowStep.getId(),randomEntry);
+        reorderSteps(firstWorkflowStep.getId(), randomEntry);
 
         final List<WorkflowStep> afterReorderingSteps = findSteps(workflowResource, savedScheme);
         assertEquals(numSteps, afterReorderingSteps.size());
         final WorkflowStep rearrangedPosition = afterReorderingSteps.get(randomEntry);
 
-        assertEquals(rearrangedPosition.getMyOrder(),randomEntry);
-        assertEquals(rearrangedPosition.getId(),firstWorkflowStep.getId());
+        assertEquals(rearrangedPosition.getMyOrder(), randomEntry);
+        assertEquals(rearrangedPosition.getId(), firstWorkflowStep.getId());
         validateOrderedSteps(afterReorderingSteps);
     }
 
@@ -569,36 +591,43 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     }
 
     @Test
-    public void testUpdateStep(){
+    public void testUpdateStep() {
         final int numSteps = 3;
         final String updatedName = "LOL!";
-        final int newOrder = numSteps + 10; //We're sending an index outside the boundaries. See if we can break it.
+        final int newOrder = numSteps
+                + 10; //We're sending an index outside the boundaries. See if we can break it.
         final WorkflowScheme savedScheme = createScheme(workflowResource);
         assertNotNull(savedScheme);
         final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme, numSteps);
         assertFalse(workflowSteps.isEmpty());
         final WorkflowStep workflowStep = workflowSteps.get(0);
         final HttpServletRequest request = mock(HttpServletRequest.class);
-        final WorkflowStepUpdateForm updatedValuesForm = new WorkflowStepUpdateForm.Builder().enableEscalation(false).escalationAction("").escalationTime("0").enableEscalation(false).stepName(updatedName).stepOrder(newOrder).build();
-        final Response updateStepResponse = workflowResource.updateStep(request, new EmptyHttpResponse(), workflowStep.getId(), updatedValuesForm);
+        final WorkflowStepUpdateForm updatedValuesForm = new WorkflowStepUpdateForm.Builder().enableEscalation(
+                        false).escalationAction("").escalationTime("0").enableEscalation(false)
+                .stepName(updatedName).stepOrder(newOrder).build();
+        final Response updateStepResponse = workflowResource.updateStep(request,
+                new EmptyHttpResponse(), workflowStep.getId(), updatedValuesForm);
         assertEquals(Response.Status.OK.getStatusCode(), updateStepResponse.getStatus());
-        final ResponseEntityView updateResponseEv = ResponseEntityView.class.cast(updateStepResponse.getEntity());
-        final WorkflowStep updatedWorkflowStep = WorkflowStep.class.cast(updateResponseEv.getEntity());
+        final ResponseEntityView updateResponseEv = ResponseEntityView.class.cast(
+                updateStepResponse.getEntity());
+        final WorkflowStep updatedWorkflowStep = WorkflowStep.class.cast(
+                updateResponseEv.getEntity());
         assertEquals(updatedName, updatedWorkflowStep.getName());
-        assertEquals(numSteps -1 ,updatedWorkflowStep.getMyOrder());
+        assertEquals(numSteps - 1, updatedWorkflowStep.getMyOrder());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testSaveActionToStepThenFindActionsBySchemeThenFindByStep() throws Exception{
-        final Role adminRole =  roleAdmin();
+    public void testSaveActionToStepThenFindActionsBySchemeThenFindByStep() throws Exception {
+        final Role adminRole = roleAdmin();
         final String adminRoleId = adminRole.getId();
         final WorkflowScheme savedScheme = createScheme(workflowResource);
         assertNotNull(savedScheme);
-        final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme,2);
+        final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme, 2);
         assertFalse(workflowSteps.isEmpty());
         assertEquals(2, workflowSteps.size());
-        final List<WorkflowAction> actions = createWorkflowActions(workflowResource, savedScheme, adminRoleId, workflowSteps);
+        final List<WorkflowAction> actions = createWorkflowActions(workflowResource, savedScheme,
+                adminRoleId, workflowSteps);
         assertEquals(2, actions.size());
 
         final WorkflowStep secondStep = workflowSteps.get(1);
@@ -611,85 +640,108 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                 new WorkflowActionStepForm.Builder().actionId(firstAction.getId()).build()
         );
         assertEquals(200, saveActionToStepResponse.getStatus());
-        final ResponseEntityView updateResponseEv = ResponseEntityView.class.cast(saveActionToStepResponse.getEntity());
-        assertEquals(ResponseEntityView.OK,updateResponseEv.getEntity());
+        final ResponseEntityView updateResponseEv = ResponseEntityView.class.cast(
+                saveActionToStepResponse.getEntity());
+        assertEquals(ResponseEntityView.OK, updateResponseEv.getEntity());
 
         final HttpServletRequest request2 = mock(HttpServletRequest.class);
-        final Response actionsBySchemeResponse = workflowResource.findActionsByScheme(request2, new EmptyHttpResponse(), savedScheme.getId());
-        final ResponseEntityView findActionsResponseEv = ResponseEntityView.class.cast(actionsBySchemeResponse.getEntity());
-        final List<WorkflowAction> actionsByScheme = List.class.cast(findActionsResponseEv.getEntity());
+        final Response actionsBySchemeResponse = workflowResource.findActionsByScheme(request2,
+                new EmptyHttpResponse(), savedScheme.getId());
+        final ResponseEntityView findActionsResponseEv = ResponseEntityView.class.cast(
+                actionsBySchemeResponse.getEntity());
+        final List<WorkflowAction> actionsByScheme = List.class.cast(
+                findActionsResponseEv.getEntity());
         assertEquals(2, actionsByScheme.size());
 
         final HttpServletRequest request3 = mock(HttpServletRequest.class);
         //This returns 1 single action
-        final Response actionsByStepResponse = workflowResource.findActionByStep(request3, new EmptyHttpResponse(), secondStep.getId(), firstAction.getId());
-        final ResponseEntityView findActionsByStepResponseEv = ResponseEntityView.class.cast(actionsByStepResponse.getEntity());
-        final WorkflowAction actionByStep = WorkflowAction.class.cast(findActionsByStepResponseEv.getEntity());
+        final Response actionsByStepResponse = workflowResource.findActionByStep(request3,
+                new EmptyHttpResponse(), secondStep.getId(), firstAction.getId());
+        final ResponseEntityView findActionsByStepResponseEv = ResponseEntityView.class.cast(
+                actionsByStepResponse.getEntity());
+        final WorkflowAction actionByStep = WorkflowAction.class.cast(
+                findActionsByStepResponseEv.getEntity());
         assertNotNull(actionByStep);
-        assertEquals(firstAction.getId(),actionByStep.getId());
+        assertEquals(firstAction.getId(), actionByStep.getId());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testFindActionsByStepThenDeleteThem() throws Exception{
-        final Role adminRole =  roleAdmin();
+    public void testFindActionsByStepThenDeleteThem() throws Exception {
+        final Role adminRole = roleAdmin();
         final String adminRoleId = adminRole.getId();
         final WorkflowScheme savedScheme = createScheme(workflowResource);
         assertNotNull(savedScheme);
-        final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme,2);
+        final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme, 2);
         assertFalse(workflowSteps.isEmpty());
         assertEquals(2, workflowSteps.size());
-        final List<WorkflowAction> actions = createWorkflowActions(workflowResource, savedScheme, adminRoleId, workflowSteps);
+        final List<WorkflowAction> actions = createWorkflowActions(workflowResource, savedScheme,
+                adminRoleId, workflowSteps);
         assertEquals(2, actions.size());
 
         final HttpServletRequest request1 = mock(HttpServletRequest.class);
-        final Response actionsByStepResponse1 = workflowResource.findActionsByStep(request1, new EmptyHttpResponse(), workflowSteps.get(0).getId());
-        final ResponseEntityView findActionsByStepResponseEv1 = ResponseEntityView.class.cast(actionsByStepResponse1.getEntity());
-        final List<WorkflowAction> actionsByStep1 = List.class.cast(findActionsByStepResponseEv1.getEntity());
+        final Response actionsByStepResponse1 = workflowResource.findActionsByStep(request1,
+                new EmptyHttpResponse(), workflowSteps.get(0).getId());
+        final ResponseEntityView findActionsByStepResponseEv1 = ResponseEntityView.class.cast(
+                actionsByStepResponse1.getEntity());
+        final List<WorkflowAction> actionsByStep1 = List.class.cast(
+                findActionsByStepResponseEv1.getEntity());
         assertEquals(1, actionsByStep1.size());
 
         final HttpServletRequest request2 = mock(HttpServletRequest.class);
         //This returns a list actions
-        final Response actionsByStepResponse2 = workflowResource.findActionsByStep(request2, new EmptyHttpResponse(), workflowSteps.get(1).getId());
-        final ResponseEntityView findActionsByStepResponseEv2 = ResponseEntityView.class.cast(actionsByStepResponse2.getEntity());
-        final List<WorkflowAction> actionsByStep2 = List.class.cast(findActionsByStepResponseEv2.getEntity());
+        final Response actionsByStepResponse2 = workflowResource.findActionsByStep(request2,
+                new EmptyHttpResponse(), workflowSteps.get(1).getId());
+        final ResponseEntityView findActionsByStepResponseEv2 = ResponseEntityView.class.cast(
+                actionsByStepResponse2.getEntity());
+        final List<WorkflowAction> actionsByStep2 = List.class.cast(
+                findActionsByStepResponseEv2.getEntity());
         assertEquals(1, actionsByStep2.size());
 
         final HttpServletRequest request3 = mock(HttpServletRequest.class);
-        final Response deleteActionResponse1 = workflowResource.deleteAction(request3, new EmptyHttpResponse(), actionsByStep1.get(0).getId());
-        final ResponseEntityView deleteActionByResponseEv1 = ResponseEntityView.class.cast(deleteActionResponse1.getEntity());
-        final Response deleteActionResponse2 = workflowResource.deleteAction(request3, new EmptyHttpResponse(), actionsByStep2.get(0).getId());
-        final ResponseEntityView deleteActionByResponseEv2 = ResponseEntityView.class.cast(deleteActionResponse2.getEntity());
+        final Response deleteActionResponse1 = workflowResource.deleteAction(request3,
+                new EmptyHttpResponse(), actionsByStep1.get(0).getId());
+        final ResponseEntityView deleteActionByResponseEv1 = ResponseEntityView.class.cast(
+                deleteActionResponse1.getEntity());
+        final Response deleteActionResponse2 = workflowResource.deleteAction(request3,
+                new EmptyHttpResponse(), actionsByStep2.get(0).getId());
+        final ResponseEntityView deleteActionByResponseEv2 = ResponseEntityView.class.cast(
+                deleteActionResponse2.getEntity());
         final String ok1 = String.class.cast(deleteActionByResponseEv1.getEntity());
-        assertEquals(ResponseEntityView.OK,ok1);
+        assertEquals(ResponseEntityView.OK, ok1);
         final String ok2 = String.class.cast(deleteActionByResponseEv2.getEntity());
-        assertEquals(ResponseEntityView.OK,ok2);
+        assertEquals(ResponseEntityView.OK, ok2);
 
         final HttpServletRequest request4 = mock(HttpServletRequest.class);
-        final Response actionsBySchemeResponse = workflowResource.findActionsByScheme(request4, new EmptyHttpResponse(), savedScheme.getId());
-        final ResponseEntityView findActionsResponseEv = ResponseEntityView.class.cast(actionsBySchemeResponse.getEntity());
-        final List<WorkflowAction> actionsByScheme = List.class.cast(findActionsResponseEv.getEntity());
+        final Response actionsBySchemeResponse = workflowResource.findActionsByScheme(request4,
+                new EmptyHttpResponse(), savedScheme.getId());
+        final ResponseEntityView findActionsResponseEv = ResponseEntityView.class.cast(
+                actionsBySchemeResponse.getEntity());
+        final List<WorkflowAction> actionsByScheme = List.class.cast(
+                findActionsResponseEv.getEntity());
         assertEquals(0, actionsByScheme.size());
 
     }
 
     @Test
-    public void testUpdateAction() throws Exception{
-        final Role adminRole =  roleAdmin();
+    public void testUpdateAction() throws Exception {
+        final Role adminRole = roleAdmin();
         final String adminRoleId = adminRole.getId();
         final WorkflowScheme savedScheme = createScheme(workflowResource);
         assertNotNull(savedScheme);
-        final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme,1);
+        final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme, 1);
         assertFalse(workflowSteps.isEmpty());
         assertEquals(1, workflowSteps.size());
-        final List<WorkflowAction> actions = createWorkflowActions(workflowResource, savedScheme, adminRoleId, workflowSteps);
+        final List<WorkflowAction> actions = createWorkflowActions(workflowResource, savedScheme,
+                adminRoleId, workflowSteps);
         assertEquals(1, actions.size());
         final HttpServletRequest request = mock(HttpServletRequest.class);
 
         final Set<WorkflowState> states = WorkflowState.toSet(WorkflowState.values());
         final String actionNewName = actionName();
 
-        final WorkflowActionForm form = new WorkflowActionForm.Builder().schemeId(savedScheme.getId()).
+        final WorkflowActionForm form = new WorkflowActionForm.Builder().schemeId(
+                        savedScheme.getId()).
                 stepId(workflowSteps.get(0).getId()).
                 actionName(actionNewName).
                 showOn(states).
@@ -703,33 +755,40 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                 build();
 
         final String actionId = actions.get(0).getId();
-        final Response updateResponse = workflowResource.updateAction(request, new EmptyHttpResponse(), actionId, form);
-        final ResponseEntityView updateResponseEv = ResponseEntityView.class.cast(updateResponse.getEntity());
-        final WorkflowAction workflowAction = WorkflowAction.class.cast(updateResponseEv.getEntity());
-        assertEquals(actionNewName,workflowAction.getName());
+        final Response updateResponse = workflowResource.updateAction(request,
+                new EmptyHttpResponse(), actionId, form);
+        final ResponseEntityView updateResponseEv = ResponseEntityView.class.cast(
+                updateResponse.getEntity());
+        final WorkflowAction workflowAction = WorkflowAction.class.cast(
+                updateResponseEv.getEntity());
+        assertEquals(actionNewName, workflowAction.getName());
         final HttpServletRequest request2 = mock(HttpServletRequest.class);
-        final Response findActionResponse = workflowResource.findAction(request2, new EmptyHttpResponse(), actionId);
-        final ResponseEntityView findActionResponseEv = ResponseEntityView.class.cast(findActionResponse.getEntity());
+        final Response findActionResponse = workflowResource.findAction(request2,
+                new EmptyHttpResponse(), actionId);
+        final ResponseEntityView findActionResponseEv = ResponseEntityView.class.cast(
+                findActionResponse.getEntity());
         final WorkflowAction wa = WorkflowAction.class.cast(findActionResponseEv.getEntity());
         assertNotNull(wa);
-        assertEquals(actionNewName,wa.getName());
+        assertEquals(actionNewName, wa.getName());
     }
 
     /**
      * Test the delete scheme resource
+     *
      * @throws Exception
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testDeleteScheme() throws Exception{
-        final Role adminRole =  roleAdmin();
+    public void testDeleteScheme() throws Exception {
+        final Role adminRole = roleAdmin();
         final String adminRoleId = adminRole.getId();
         final WorkflowScheme savedScheme = createScheme(workflowResource);
         assertNotNull(savedScheme);
-        final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme,2);
+        final List<WorkflowStep> workflowSteps = addSteps(workflowResource, savedScheme, 2);
         assertFalse(workflowSteps.isEmpty());
         assertEquals(2, workflowSteps.size());
-        final List<WorkflowAction> actions = createWorkflowActions(workflowResource, savedScheme, adminRoleId, workflowSteps);
+        final List<WorkflowAction> actions = createWorkflowActions(workflowResource, savedScheme,
+                adminRoleId, workflowSteps);
         assertEquals(2, actions.size());
 
         final WorkflowStep secondStep = workflowSteps.get(1);
@@ -742,56 +801,68 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                 request1, new EmptyHttpResponse(), secondStep.getId(),
                 new WorkflowActionStepForm.Builder().actionId(firstAction.getId()).build()
         );
-        final ResponseEntityView updateResponseEv = ResponseEntityView.class.cast(saveActionToStepResponse.getEntity());
-        assertEquals(ResponseEntityView.OK,updateResponseEv.getEntity());
+        final ResponseEntityView updateResponseEv = ResponseEntityView.class.cast(
+                saveActionToStepResponse.getEntity());
+        assertEquals(ResponseEntityView.OK, updateResponseEv.getEntity());
 
         final HttpServletRequest request2 = mock(HttpServletRequest.class);
-        final Response actionsBySchemeResponse = workflowResource.findActionsByScheme(request2, new EmptyHttpResponse(), savedScheme.getId());
-        final ResponseEntityView findActionsResponseEv = ResponseEntityView.class.cast(actionsBySchemeResponse.getEntity());
-        final List<WorkflowAction> actionsByScheme = List.class.cast(findActionsResponseEv.getEntity());
+        final Response actionsBySchemeResponse = workflowResource.findActionsByScheme(request2,
+                new EmptyHttpResponse(), savedScheme.getId());
+        final ResponseEntityView findActionsResponseEv = ResponseEntityView.class.cast(
+                actionsBySchemeResponse.getEntity());
+        final List<WorkflowAction> actionsByScheme = List.class.cast(
+                findActionsResponseEv.getEntity());
         assertEquals(2, actionsByScheme.size());
 
         final HttpServletRequest request3 = mock(HttpServletRequest.class);
         //This returns 1 single action
-        final Response actionsByStepResponse = workflowResource.findActionByStep(request3, new EmptyHttpResponse(), secondStep.getId(), firstAction.getId());
-        final ResponseEntityView findActionsByStepResponseEv = ResponseEntityView.class.cast(actionsByStepResponse.getEntity());
-        final WorkflowAction actionByStep = WorkflowAction.class.cast(findActionsByStepResponseEv.getEntity());
+        final Response actionsByStepResponse = workflowResource.findActionByStep(request3,
+                new EmptyHttpResponse(), secondStep.getId(), firstAction.getId());
+        final ResponseEntityView findActionsByStepResponseEv = ResponseEntityView.class.cast(
+                actionsByStepResponse.getEntity());
+        final WorkflowAction actionByStep = WorkflowAction.class.cast(
+                findActionsByStepResponseEv.getEntity());
         assertNotNull(actionByStep);
-        assertEquals(firstAction.getId(),actionByStep.getId());
+        assertEquals(firstAction.getId(), actionByStep.getId());
 
         //test delete without archive
         final AsyncResponse asyncResponse = new MockAsyncResponse(
                 (arg) -> {
-            final Response deleteSchemeResponse = (Response)arg;
-            assertEquals(Status.FORBIDDEN.getStatusCode(), deleteSchemeResponse.getStatus());
+                    final Response deleteSchemeResponse = (Response) arg;
+                    assertEquals(Status.FORBIDDEN.getStatusCode(),
+                            deleteSchemeResponse.getStatus());
 
-            //test archive scheme
-            WorkflowSchemeForm form = new WorkflowSchemeForm.Builder().schemeDescription("Delete scheme").schemeArchived(true).schemeName(savedScheme.getName()).build();
-            final HttpServletRequest request5 = mock(HttpServletRequest.class);
-            final Response updateResponse = workflowResource.updateScheme(request5, new EmptyHttpResponse(), savedScheme.getId(), form);
-            assertEquals(Response.Status.OK.getStatusCode(), updateResponse.getStatus());
+                    //test archive scheme
+                    WorkflowSchemeForm form = new WorkflowSchemeForm.Builder().schemeDescription(
+                                    "Delete scheme").schemeArchived(true).schemeName(savedScheme.getName())
+                            .build();
+                    final HttpServletRequest request5 = mock(HttpServletRequest.class);
+                    final Response updateResponse = workflowResource.updateScheme(request5,
+                            new EmptyHttpResponse(), savedScheme.getId(), form);
+                    assertEquals(Response.Status.OK.getStatusCode(), updateResponse.getStatus());
 
-            //test delete scheme
-            final AsyncResponse asyncResponse2 = new MockAsyncResponse(
-                    arg2 -> {
-                        final Response deleteSchemeResponse2 =(Response) arg2;
-                        assertEquals(Status.OK.getStatusCode(), deleteSchemeResponse2.getStatus());
-                        return true;
-                    },
-                    (arg2) -> true
-            );
-            final HttpServletRequest request6 = mock(HttpServletRequest.class);
-            workflowResource.deleteScheme(request6, asyncResponse2, savedScheme.getId());
+                    //test delete scheme
+                    final AsyncResponse asyncResponse2 = new MockAsyncResponse(
+                            arg2 -> {
+                                final Response deleteSchemeResponse2 = (Response) arg2;
+                                assertEquals(Status.OK.getStatusCode(),
+                                        deleteSchemeResponse2.getStatus());
+                                return true;
+                            },
+                            (arg2) -> true
+                    );
+                    final HttpServletRequest request6 = mock(HttpServletRequest.class);
+                    workflowResource.deleteScheme(request6, asyncResponse2, savedScheme.getId());
 
-            return true;
-        }, (arg) -> true);
+                    return true;
+                }, (arg) -> true);
 
         final HttpServletRequest request4 = mock(HttpServletRequest.class);
         workflowResource.deleteScheme(request4, asyncResponse, savedScheme.getId());
     }
 
     @Test
-    public void Test_Get_Bulk_Actions_For_Query() throws Exception{
+    public void Test_Get_Bulk_Actions_For_Query() throws Exception {
 
         //We need to make sure at least one content for each Workflow exists in the database.
 
@@ -800,10 +871,13 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         //Document Workflow.
         TestDataUtils.getDocumentLikeContent(true, languageAPI.getDefaultLanguage().getId(), null);
 
-        final String luceneQuery = String.format("-contentType:Host -baseType:3 +(conhost:%s conhost:SYSTEM_HOST) +languageId:1 +deleted:false +working:true",host.getIdentifier());
+        final String luceneQuery = String.format(
+                "-contentType:Host -baseType:3 +(conhost:%s conhost:SYSTEM_HOST) +languageId:1 +deleted:false +working:true",
+                host.getIdentifier());
         final HttpServletRequest request = mock(HttpServletRequest.class);
         final BulkActionForm form = new BulkActionForm(null, luceneQuery);
-        final Response response = workflowResource.getBulkActions(request, new EmptyHttpResponse(), form);
+        final Response response = workflowResource.getBulkActions(request, new EmptyHttpResponse(),
+                form);
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         final ResponseEntityView entityView = ResponseEntityView.class.cast(response.getEntity());
         final BulkActionView wa = BulkActionView.class.cast(entityView.getEntity());
@@ -822,10 +896,12 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         assertTrue(systemWorkflowOptional.isPresent());
 
         final BulkWorkflowSchemeView documentManagementScheme = documentManagementOptional.get();
-        final List<WorkflowAction> documentActions = getAllWorkflowActions(documentManagementScheme);
+        final List<WorkflowAction> documentActions = getAllWorkflowActions(
+                documentManagementScheme);
 
         final Set<String> documentActionNames =
-                workflowAPI.findActions(workflowAPI.findSchemeByName(DM_WORKFLOW), systemUser).stream().map(WorkflowAction::getName).collect(Collectors.toSet());
+                workflowAPI.findActions(workflowAPI.findSchemeByName(DM_WORKFLOW), systemUser)
+                        .stream().map(WorkflowAction::getName).collect(Collectors.toSet());
 
         documentActions.forEach(action -> {
             assertTrue(documentActionNames.contains(action.getName()));
@@ -835,7 +911,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         final List<WorkflowAction> systemActions = getAllWorkflowActions(systemWorkflowScheme);
 
         final Set<String> systemActionNames =
-                workflowAPI.findActions(workflowAPI.findSystemWorkflowScheme(), systemUser).stream().map(WorkflowAction::getName).collect(Collectors.toSet());
+                workflowAPI.findActions(workflowAPI.findSystemWorkflowScheme(), systemUser).stream()
+                        .map(WorkflowAction::getName).collect(Collectors.toSet());
 
         systemActions.forEach(action -> {
             assertTrue(systemActionNames.contains(action.getName()));
@@ -846,14 +923,21 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     @Test
     public void Test_Get_Bulk_Actions_For_Contentlet_Ids() throws Exception {
         //This collects contents associated with a workflow.
-        final Map<WorkflowScheme, Map<ContentType, List<Contentlet>>> sampleContent = collectSampleContent(10);
+        final Map<WorkflowScheme, Map<ContentType, List<Contentlet>>> sampleContent = collectSampleContent(
+                10);
         final Set<WorkflowScheme> workflowSchemes = sampleContent.keySet();
+
+        ReindexQueueAPI queueAPI = APILocator.getReindexQueueAPI();
+        TestDataUtils.assertEmptyQueue();
+
         for (final WorkflowScheme scheme : workflowSchemes) {
+            Logger.warn(getClass(), "scheme id=" + scheme.getId() + " name=" + scheme.getName());
 
             final List<WorkflowStep> steps = workflowAPI.findSteps(scheme);
 
             final Set<String> availableActions =
-                    workflowAPI.findActions(steps, APILocator.systemUser()).stream().map(WorkflowAction::getId).collect(Collectors.toSet());
+                    workflowAPI.findActions(steps, APILocator.systemUser()).stream()
+                            .map(WorkflowAction::getId).collect(Collectors.toSet());
 
             final Map<ContentType, List<Contentlet>> contentsByType = sampleContent.get(scheme);
             final Set<ContentType> types = contentsByType.keySet();
@@ -862,36 +946,43 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                 final List<String> contentletIds = contentlets.stream().map(Contentlet::getInode)
                         .collect(Collectors.toList());
 
-                if(!UtilMethods.isSet(contentletIds)){
+                if (!UtilMethods.isSet(contentletIds)) {
                     // for some reason no contetlets of the current type were found.
-                   continue;
+                    continue;
                 }
 
                 final HttpServletRequest request = mock(HttpServletRequest.class);
                 final BulkActionForm form = new BulkActionForm(contentletIds, null);
-                final Response response = workflowResource.getBulkActions(request, new EmptyHttpResponse(), form);
+                final Response response = workflowResource.getBulkActions(request,
+                        new EmptyHttpResponse(), form);
                 assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
                 final ResponseEntityView entityView = ResponseEntityView.class
                         .cast(response.getEntity());
-                final BulkActionView bulkActionView = BulkActionView.class.cast(entityView.getEntity());
+                final BulkActionView bulkActionView = BulkActionView.class.cast(
+                        entityView.getEntity());
                 assertNotNull(bulkActionView);
                 final List<BulkWorkflowSchemeView> schemes = bulkActionView.getSchemes();
 
                 assertNotNull(schemes);
-                if(Host.HOST_VELOCITY_VAR_NAME.equals(contentType.name())){
+                if (Host.HOST_VELOCITY_VAR_NAME.equals(contentType.name())) {
 
                     // if we're sending contentlets of type Host then we should get nothing back
-                    assertTrue("Nothing should come back for CT Host ",schemes.isEmpty());
+                    assertTrue("Nothing should come back for CT Host ", schemes.isEmpty());
 
                 } else {
 
-                    assertFalse( "Everything else should have a WF. " , schemes.isEmpty());
+                    assertFalse("Everything else should have a WF. ", schemes.isEmpty());
                     // if the piece of content is associated with multiple WorkFlows we need to verify the response matches the one we're currently on.
                     boolean schemeMatches = false;
                     for (final BulkWorkflowSchemeView view : schemes) {
+                        Logger.warn(getClass(),
+                                "bulk scheme id=" + view.getScheme().getId() + " name="
+                                        + view.getScheme().getName());
+
                         schemeMatches = (scheme.getId().equals(view.getScheme().getId()));
                         if (schemeMatches) {
-                            assertFalse("Scheme is expected to have steps", view.getSteps().isEmpty());
+                            assertFalse("Scheme is expected to have steps",
+                                    view.getSteps().isEmpty());
                             assertEquals("Schema name does not match", scheme.getName(),
                                     view.getScheme().getName());
                             for (final BulkWorkflowStepView stepView : view.getSteps()) {
@@ -901,7 +992,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                                 );
                                 final List<CountWorkflowAction> workflowActions = stepView.getActions();
                                 for (final CountWorkflowAction workflowAction : workflowActions) {
-                                    assertTrue("Expected action " + workflowAction.getWorkflowAction()
+                                    assertTrue(
+                                            "Expected action " + workflowAction.getWorkflowAction()
                                                     .getName() + " Not found.",
                                             availableActions.contains(
                                                     workflowAction.getWorkflowAction().getId())
@@ -913,7 +1005,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                     }
 
                     //At least one scheme was matched
-                    assertTrue("no scheme was matched. ",schemeMatches);
+                    assertTrue("no scheme was matched. ", schemeMatches);
 
                 }
             }
@@ -924,49 +1016,57 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     @Test
     public void Test_Fire_Bulk_Actions_For_Contentlet_Id() throws Exception {
 
-        final Map<WorkflowScheme, Map<ContentType, List<Contentlet>>> sampleContent = collectSampleContent(3);
+        final Map<WorkflowScheme, Map<ContentType, List<Contentlet>>> sampleContent = collectSampleContent(
+                3);
         final Set<WorkflowScheme> workflowSchemes = sampleContent.keySet();
         for (final WorkflowScheme scheme : workflowSchemes) {
-            final Map<ContentType,List<Contentlet>> samples = sampleContent.get(scheme);
-            for(final ContentType ct: samples.keySet()){
-               final List<Contentlet> contentlets = samples.get(ct);
-               if(UtilMethods.isSet(contentlets)){
-                   final Contentlet contentlet = contentlets.get(0);
+            final Map<ContentType, List<Contentlet>> samples = sampleContent.get(scheme);
+            for (final ContentType ct : samples.keySet()) {
+                final List<Contentlet> contentlets = samples.get(ct);
+                if (UtilMethods.isSet(contentlets)) {
+                    final Contentlet contentlet = contentlets.get(0);
 //                   DateUtil.sleep(DateUtil.TWO_SECOND_MILLIS);
-                   workflowAPI.deleteWorkflowTaskByContentletIdAnyLanguage(contentlet, adminUser);
-                   contentlet.setIndexPolicy(IndexPolicy.WAIT_FOR);
-                   APILocator.getContentletIndexAPI().addContentToIndex(contentlet);
-                   final List<WorkflowStep> steps = workflowAPI.findStepsByContentlet(contentlet);
-                   Logger.info(this, "**** steps" + steps);
-                   final List<WorkflowAction> actions = workflowAPI.findActions(steps, APILocator.systemUser());
-                   Logger.info(this, "**** actions" + actions);
+                    workflowAPI.deleteWorkflowTaskByContentletIdAnyLanguage(contentlet, adminUser);
+                    contentlet.setIndexPolicy(IndexPolicy.WAIT_FOR);
+                    APILocator.getContentletIndexAPI().addContentToIndex(contentlet);
+                    final List<WorkflowStep> steps = workflowAPI.findStepsByContentlet(contentlet);
+                    Logger.info(this, "**** steps" + steps);
+                    final List<WorkflowAction> actions = workflowAPI.findActions(steps,
+                            APILocator.systemUser());
+                    Logger.info(this, "**** actions" + actions);
 
-                   final WorkflowAction action = actions.stream().findAny().get();
-                   final HttpServletRequest request = mock(HttpServletRequest.class);
-                   final FireBulkActionsForm form = new FireBulkActionsForm(null,
-                           Collections.singletonList(contentlet.getInode()), action.getId(), null
-                   );
+                    final WorkflowAction action = actions.stream().findAny().get();
+                    final HttpServletRequest request = mock(HttpServletRequest.class);
+                    final FireBulkActionsForm form = new FireBulkActionsForm(null,
+                            Collections.singletonList(contentlet.getInode()), action.getId(), null
+                    );
 
-                   final AsyncResponse asyncResponse = new MockAsyncResponse((arg) -> {
-                       final Response response = (Response) arg;
-                       final int code = response.getStatus();
-                       assertEquals(Status.OK.getStatusCode(), code);
-                       final ResponseEntityView entityView = ResponseEntityView.class.cast(response.getEntity());
-                       final BulkActionsResultView wa = BulkActionsResultView.class.cast(entityView.getEntity());
-                       assertNotNull(wa);
-                       return true;
-                   }, o -> true);
+                    final AsyncResponse asyncResponse = new MockAsyncResponse((arg) -> {
+                        final Response response = (Response) arg;
+                        final int code = response.getStatus();
+                        assertEquals(Status.OK.getStatusCode(), code);
+                        final ResponseEntityView entityView = ResponseEntityView.class.cast(
+                                response.getEntity());
+                        final BulkActionsResultView wa = BulkActionsResultView.class.cast(
+                                entityView.getEntity());
+                        assertNotNull(wa);
+                        return true;
+                    }, o -> true);
 
-                   Logger.info(getClass(), "Executing Action: '"+action.getName() + "' on contentlet: '" + contentlet.getName() + "'");
-                   workflowResource.fireBulkActions(request, asyncResponse, form);
-               }
+                    Logger.info(getClass(),
+                            "Executing Action: '" + action.getName() + "' on contentlet: '"
+                                    + contentlet.getName() + "'");
+                    workflowResource.fireBulkActions(request, asyncResponse, form);
+                }
             }
         }
     }
 
-    private List<WorkflowAction> validateDocumentManagement(final BulkWorkflowSchemeView documentManagementScheme){
+    private List<WorkflowAction> validateDocumentManagement(
+            final BulkWorkflowSchemeView documentManagementScheme) {
 
-        final List<WorkflowAction> documentActions = getAllWorkflowActions(documentManagementScheme);
+        final List<WorkflowAction> documentActions = getAllWorkflowActions(
+                documentManagementScheme);
 
         Logger.info(this, "documentActions: " + documentActions);
         //step 1 Document Management Actions.
@@ -981,7 +1081,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         return documentActions;
     }
 
-    private List<WorkflowAction> validateSystemWorkflow(final BulkWorkflowSchemeView systemWorkflowScheme){
+    private List<WorkflowAction> validateSystemWorkflow(
+            final BulkWorkflowSchemeView systemWorkflowScheme) {
 
         final List<WorkflowAction> systemActions = getAllWorkflowActions(systemWorkflowScheme);
 
@@ -993,6 +1094,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
     /**
      * Thread sleep that allows a few seconds for the index to finish indexing.
+     *
      * @throws Exception
      */
     private void indexNeedsToCatchup() {
@@ -1004,7 +1106,6 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     }
 
     /**
-     *
      * @param contentlet
      * @return
      * @throws Exception
@@ -1013,7 +1114,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
         try {
             return contentletAPI.findContentletByIdentifier(
-                    contentlet.getIdentifier(),false, contentlet.getLanguageId(), systemUser, false
+                    contentlet.getIdentifier(), false, contentlet.getLanguageId(), systemUser, false
             );
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -1022,10 +1123,11 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
     /**
      * Creates a custom contentType with a required field
+     *
      * @return
      * @throws Exception
      */
-    private ContentType createSampleContentType() throws Exception{
+    private ContentType createSampleContentType() throws Exception {
         ContentType contentType;
         final String ctPrefix = "TestContentType";
         final String newContentTypeName = ctPrefix + System.currentTimeMillis();
@@ -1041,7 +1143,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
         // Add fields to the contentType
         final Field field =
-                FieldBuilder.builder(TextField.class).name(REQUIRED_TEXT_FIELD_NAME).variable(REQUIRED_TEXT_FIELD_NAME)
+                FieldBuilder.builder(TextField.class).name(REQUIRED_TEXT_FIELD_NAME)
+                        .variable(REQUIRED_TEXT_FIELD_NAME)
                         .required(true)
                         .contentTypeId(contentType.id()).dataType(DataTypes.TEXT).build();
         contentType = contentTypeAPI.save(contentType, Collections.singletonList(field));
@@ -1054,18 +1157,20 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                 ).collect(Collectors.toSet())
         );
 
-        Logger.info(this, "findSchemesForContentType: " + workflowAPI.findSchemesForContentType(contentType));
+        Logger.info(this,
+                "findSchemesForContentType: " + workflowAPI.findSchemesForContentType(contentType));
 
         return contentType;
     }
 
     /**
      * Creates a contentlet based on the content type passed
+     *
      * @param contentType
      * @return
      * @throws Exception
      */
-    private Contentlet createSampleContent(final ContentType contentType) throws Exception{
+    private Contentlet createSampleContent(final ContentType contentType) throws Exception {
         Contentlet contentlet = null;
         // Create a content sample
         contentlet = new Contentlet();
@@ -1074,7 +1179,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         contentlet.setHost(host.getIdentifier());
         contentlet.setLanguageId(languageAPI.getDefaultLanguage().getId());
 
-        contentlet.setStringProperty(REQUIRED_TEXT_FIELD_NAME,"anyValue");
+        contentlet.setStringProperty(REQUIRED_TEXT_FIELD_NAME, "anyValue");
         contentlet.setIndexPolicy(IndexPolicy.FORCE);
 
         // Save the content
@@ -1117,7 +1222,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         assertTrue(editingStep.isPresent());
         final Map<String, Set<WorkflowState>> docWorkflowShowOn = new HashMap<>();
 
-        final List<WorkflowAction> dmWorkflowActions = workflowAPI.findActions(editingStep.get(), systemUser);
+        final List<WorkflowAction> dmWorkflowActions = workflowAPI.findActions(editingStep.get(),
+                systemUser);
         for (final WorkflowAction action : dmWorkflowActions) {
             docWorkflowShowOn
                     .computeIfAbsent(action.getId(), s -> new HashSet<>(action.getShowOn()));
@@ -1130,12 +1236,13 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             // We create a contentType that is associated with the two workflows that come out of the box.
             final ContentType contentType = createSampleContentType();
             //Then we create an instance
-            final Contentlet contentlet   = createSampleContent(contentType);
+            final Contentlet contentlet = createSampleContent(contentType);
             final String inode = contentlet.getInode();
 
             try {
 
-                workflowAPI.deleteWorkflowTaskByContentletIdAnyLanguage(contentlet, APILocator.systemUser());
+                workflowAPI.deleteWorkflowTaskByContentletIdAnyLanguage(contentlet,
+                        APILocator.systemUser());
                 contentlet.setIndexPolicy(IndexPolicy.FORCE);
                 APILocator.getContentletIndexAPI().addContentToIndex(contentlet);
 
@@ -1218,7 +1325,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                                 Collections.singletonList(inode), null
                         );
 
-                        final Response response2 = workflowResource.getBulkActions(request2, new EmptyHttpResponse(), form2);
+                        final Response response2 = workflowResource.getBulkActions(request2,
+                                new EmptyHttpResponse(), form2);
                         assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
                         final ResponseEntityView afterFireEntityView = ResponseEntityView.class
                                 .cast(response2.getEntity());
@@ -1240,7 +1348,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                         );
 
                         final Response response3 = workflowResource
-                                .getBulkActions(request3, new EmptyHttpResponse(), bulkActionFormAfterSave);
+                                .getBulkActions(request3, new EmptyHttpResponse(),
+                                        bulkActionFormAfterSave);
                         assertEquals(Response.Status.OK.getStatusCode(), response3.getStatus());
                         final ResponseEntityView afterFireEntityViewNewInode = ResponseEntityView.class
                                 .cast(response3.getEntity());
@@ -1276,7 +1385,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             } finally {
 
                 if (contentlet != null) {
-                    contentletAPI.destroy(contentlet, systemUser, false );
+                    contentletAPI.destroy(contentlet, systemUser, false);
                 }
                 if (contentType != null) {
                     contentTypeAPI.delete(contentType);
@@ -1339,15 +1448,17 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         try {
             final long langId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
             //Hand picked Form-like Widgets with a mandatory title field
-            final Contentlet candidate1 = TestDataUtils.getEmptyFormWithRequiredFieldsContent(langId);
-           // contentletAPI.findContentletByIdentifier(
-           //         "b4ae5fd4-c4c7-4590-8299-00569a9f13be", false, 1, systemUser, false
-           // );
+            final Contentlet candidate1 = TestDataUtils.getEmptyFormWithRequiredFieldsContent(
+                    langId);
+            // contentletAPI.findContentletByIdentifier(
+            //         "b4ae5fd4-c4c7-4590-8299-00569a9f13be", false, 1, systemUser, false
+            // );
 
-            final Contentlet candidate2 = TestDataUtils.getEmptyFormWithRequiredFieldsContent(langId);
-           // contentletAPI.findContentletByIdentifier(
-           //         "2f180f39-59c3-4225-9cca-5daf778f3f3e", false, 1, systemUser, false
-           // );
+            final Contentlet candidate2 = TestDataUtils.getEmptyFormWithRequiredFieldsContent(
+                    langId);
+            // contentletAPI.findContentletByIdentifier(
+            //         "2f180f39-59c3-4225-9cca-5daf778f3f3e", false, 1, systemUser, false
+            // );
 
             final List<Contentlet> contentlets = Arrays.asList(candidate1, candidate2);
 
@@ -1423,7 +1534,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                                 Collections.singletonList(inode), null
                         );
                         final HttpServletRequest request2 = mock(HttpServletRequest.class);
-                        final Response response2 = workflowResource.getBulkActions(request2, new EmptyHttpResponse(), form2);
+                        final Response response2 = workflowResource.getBulkActions(request2,
+                                new EmptyHttpResponse(), form2);
                         assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
 
                         final ResponseEntityView afterFireEntityView = ResponseEntityView.class
@@ -1484,30 +1596,31 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             // We create a contentType that is associated with the two workflows that comes out of the box.
             contentType = createSampleContentType();
             Contentlet brandNewContentlet = null;
-             try {
-                 //Save Action
-                 final FireActionForm.Builder builder1 = new FireActionForm.Builder();
-                 final Map <String,Object>contentletFormData = new HashMap<>();
-                 contentletFormData.put("stInode", contentType.inode());
-                 contentletFormData.put(REQUIRED_TEXT_FIELD_NAME, "value-1");
-                 builder1.contentlet(contentletFormData);
+            try {
+                //Save Action
+                final FireActionForm.Builder builder1 = new FireActionForm.Builder();
+                final Map<String, Object> contentletFormData = new HashMap<>();
+                contentletFormData.put("stInode", contentType.inode());
+                contentletFormData.put(REQUIRED_TEXT_FIELD_NAME, "value-1");
+                builder1.contentlet(contentletFormData);
 
                 final FireActionForm fireActionForm1 = new FireActionForm(builder1);
                 final HttpServletRequest request1 = getHttpRequest();
                 final Response response1 = workflowResource
-                        .fireActionSinglePart(request1, new EmptyHttpResponse(), saveAndPublishActionId, null, null, "FORCE", "-1",  fireActionForm1);
+                        .fireActionSinglePart(request1, new EmptyHttpResponse(),
+                                saveAndPublishActionId, null, null, "FORCE", "-1", fireActionForm1);
 
                 final int statusCode1 = response1.getStatus();
                 assertEquals(Status.OK.getStatusCode(), statusCode1);
                 final ResponseEntityView fireEntityView1 = ResponseEntityView.class
                         .cast(response1.getEntity());
-                brandNewContentlet = new Contentlet (Map.class.cast(fireEntityView1.getEntity()));
+                brandNewContentlet = new Contentlet(Map.class.cast(fireEntityView1.getEntity()));
                 assertNotNull(brandNewContentlet);
                 assertEquals("value-1", brandNewContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
 
-                 //Update Action
+                //Update Action
                 final FireActionForm.Builder builder2 = new FireActionForm.Builder();
-                final Map <String,Object>contentletFormData2 = new HashMap<>();
+                final Map<String, Object> contentletFormData2 = new HashMap<>();
                 contentletFormData2.put("stInode", contentType.inode());
                 contentletFormData2.put(REQUIRED_TEXT_FIELD_NAME, "value-2");
                 builder2.contentlet(contentletFormData2);
@@ -1515,74 +1628,77 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                 final FireActionForm fireActionForm2 = new FireActionForm(builder2);
                 final HttpServletRequest request2 = getHttpRequest();
                 final Response response2 = workflowResource
-                     .fireActionSinglePart(request2, new EmptyHttpResponse(), saveAndPublishActionId, brandNewContentlet.getInode(), null, "FORCE", "-1", fireActionForm2);
+                        .fireActionSinglePart(request2, new EmptyHttpResponse(),
+                                saveAndPublishActionId, brandNewContentlet.getInode(), null,
+                                "FORCE", "-1", fireActionForm2);
 
                 final int statusCode2 = response2.getStatus();
                 assertEquals(Status.OK.getStatusCode(), statusCode2);
                 final ResponseEntityView fireEntityView2 = ResponseEntityView.class
-                         .cast(response2.getEntity());
-                final Contentlet updatedContentlet = new Contentlet (Map.class.cast(fireEntityView2.getEntity()));
+                        .cast(response2.getEntity());
+                final Contentlet updatedContentlet = new Contentlet(
+                        Map.class.cast(fireEntityView2.getEntity()));
                 assertNotNull(updatedContentlet);
 
-                assertEquals(brandNewContentlet.getIdentifier(),updatedContentlet.getIdentifier());
+                assertEquals(brandNewContentlet.getIdentifier(), updatedContentlet.getIdentifier());
                 assertEquals("value-2", updatedContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
 
-             }finally {
-                if(null != brandNewContentlet){
-                    contentletAPI.destroy(brandNewContentlet, APILocator.systemUser(), false );
+            } finally {
+                if (null != brandNewContentlet) {
+                    contentletAPI.destroy(brandNewContentlet, APILocator.systemUser(), false);
                 }
             }
 
-        }finally {
-            if(null != contentType){
-              contentTypeAPI.delete(contentType);
+        } finally {
+            if (null != contentType) {
+                contentTypeAPI.delete(contentType);
             }
         }
     }
 
-    static ImmutableMap <Class, DataTypes> fieldTypesMetaDataMap = new ImmutableMap.Builder<Class, DataTypes>()
+    static ImmutableMap<Class, DataTypes> fieldTypesMetaDataMap = new ImmutableMap.Builder<Class, DataTypes>()
             //   .put(BinaryField.class, DataTypes.SYSTEM)
             //   .put(CategoryField.class, DataTypes.SYSTEM)
-                .put(CheckboxField.class, DataTypes.TEXT)
-                .put(CustomField.class, DataTypes.LONG_TEXT)
-                .put(DateField.class, DataTypes.DATE)
-                .put(DateTimeField.class, DataTypes.DATE)
+            .put(CheckboxField.class, DataTypes.TEXT)
+            .put(CustomField.class, DataTypes.LONG_TEXT)
+            .put(DateField.class, DataTypes.DATE)
+            .put(DateTimeField.class, DataTypes.DATE)
             //   .put(FileField.class, DataTypes.TEXT)
             //   .put(HiddenField.class, DataTypes.SYSTEM)
             //   .put(HostFolderField.class,DataTypes.SYSTEM)
-                .put(ImageField.class,DataTypes.TEXT)
-                .put(KeyValueField.class,DataTypes.LONG_TEXT)
+            .put(ImageField.class, DataTypes.TEXT)
+            .put(KeyValueField.class, DataTypes.LONG_TEXT)
             //   .put(LineDividerField.class,DataTypes.SYSTEM)
-                .put(MultiSelectField.class,DataTypes.LONG_TEXT)
+            .put(MultiSelectField.class, DataTypes.LONG_TEXT)
             //   .put(PermissionTabField.class,DataTypes.SYSTEM)
-                .put(RadioField.class,DataTypes.TEXT)
+            .put(RadioField.class, DataTypes.TEXT)
             //   .put(RelationshipField.class,DataTypes.SYSTEM)
             //   .put(RelationshipsTabField.class,  DataTypes.SYSTEM)
-                .put(SelectField.class, DataTypes.TEXT)
+            .put(SelectField.class, DataTypes.TEXT)
             //   .put(TabDividerField.class, DataTypes.SYSTEM)
             //   .put(TagField.class, DataTypes.SYSTEM)
-                .put(TextField.class, DataTypes.TEXT)
-                .put(TextAreaField.class, DataTypes.LONG_TEXT)
-                .put(TimeField.class, DataTypes.DATE)
-                .put(WysiwygField.class, DataTypes.LONG_TEXT)
-                .build();
+            .put(TextField.class, DataTypes.TEXT)
+            .put(TextAreaField.class, DataTypes.LONG_TEXT)
+            .put(TimeField.class, DataTypes.DATE)
+            .put(WysiwygField.class, DataTypes.LONG_TEXT)
+            .build();
 
 
     private static final String SAVE_ACTION_ID = "ceca71a0-deee-4999-bd47-b01baa1bcfc8";
     private static final String NON_REQUIRED_IMAGE_FIELD_NAME = "nonRequiredImageField";
-    private static final String NON_REQUIRED_IMAGE_VALUE= "/path/to/the/image/random.jpg";
+    private static final String NON_REQUIRED_IMAGE_VALUE = "/path/to/the/image/random.jpg";
 
     private static final String REQUIRED_TEXT_FIELD_NAME = "requiredTextField";
-    private static final String REQUIRED_TEXT_FIELD_VALUE= "This Value is Required";
+    private static final String REQUIRED_TEXT_FIELD_VALUE = "This Value is Required";
 
     private static final String NON_REQUIRED_TEXT_FIELD_NAME = "nonRequiredTextField";
-    private static final String NON_REQUIRED_TEXT_FIELD_VALUE= "This Value isn't required";
+    private static final String NON_REQUIRED_TEXT_FIELD_VALUE = "This Value isn't required";
 
     private static final String REQUIRED_NUMERIC_TEXT_FIELD_NAME = "requiredNumericTextField";
-    private static final String REQUIRED_NUMERIC_TEXT_FIELD_VALUE= "0";
+    private static final String REQUIRED_NUMERIC_TEXT_FIELD_VALUE = "0";
 
     private static final String NON_REQUIRED_NUMERIC_TEXT_FIELD_NAME = "nonRequiredNumericTextField";
-    private static final String NON_REQUIRED_NUMERIC_TEXT_FIELD_VALUE= "0";
+    private static final String NON_REQUIRED_NUMERIC_TEXT_FIELD_VALUE = "0";
     private static final String MULTIPART_JSON = "{\n" +
             "\t'contentlet': {\t\n" +
             "   \t\t\"contentType\":\"%s\",\n" +
@@ -1598,18 +1714,18 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     @Test
     public void test_Fire_Save_Content_Type_Binary_File() throws Exception {
 
-        final User sysUser      = APILocator.systemUser();
+        final User sysUser = APILocator.systemUser();
         final FieldAPI fieldAPI = APILocator.getContentTypeFieldAPI();
-        final String   fieldNameTitle = "title";
-        final String   fieldNameFile1 = "file1";
-        final String   fieldNameFile2 = "file2";
-        final String   inputFile1Text = "Text file 1";
-        final String   inputFile2Text = "Text file 2";
+        final String fieldNameTitle = "title";
+        final String fieldNameFile1 = "file1";
+        final String fieldNameFile2 = "file2";
+        final String inputFile1Text = "Text file 1";
+        final String inputFile2Text = "Text file 2";
         ContentType contentType = null;
 
         try {
             // We create a contentType that is associated with the two workflows that come out of the box.
-            contentType                   = createSampleContentType();
+            contentType = createSampleContentType();
             Contentlet brandNewContentlet = null;
 
             try {
@@ -1617,20 +1733,24 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                 //Lets add even more fields to the contentType.
                 final String uu1 = UUID.randomUUID().toString();
                 final Field binaryField1 = ImmutableBinaryField.builder().name("file1 binary field")
-                        .variable(fieldNameFile1).contentTypeId(contentType.id()).hint("my hint").id(uu1).build();
+                        .variable(fieldNameFile1).contentTypeId(contentType.id()).hint("my hint")
+                        .id(uu1).build();
 
                 final String uu2 = UUID.randomUUID().toString();
                 final Field binaryField2 = ImmutableBinaryField.builder().name("file2 binary field")
-                        .variable(fieldNameFile2).contentTypeId(contentType.id()).hint("my hint").id(uu2).build();
+                        .variable(fieldNameFile2).contentTypeId(contentType.id()).hint("my hint")
+                        .id(uu2).build();
 
                 final String uu3 = UUID.randomUUID().toString();
                 final Field textField = ImmutableTextField.builder().name("text field")
-                        .variable(fieldNameTitle).contentTypeId(contentType.id()).hint("my hint").id(uu3).build();
+                        .variable(fieldNameTitle).contentTypeId(contentType.id()).hint("my hint")
+                        .id(uu3).build();
 
-                final List<Field> fields = Stream.concat (
+                final List<Field> fields = Stream.concat(
                         Stream.of(fieldAPI.save(textField, sysUser),
                                 fieldAPI.save(binaryField1, sysUser),
-                                fieldAPI.save(binaryField2, sysUser)),contentType.fields().stream()).collect(
+                                fieldAPI.save(binaryField2, sysUser)),
+                        contentType.fields().stream()).collect(
                         CollectionsUtils.toImmutableList()
                 );
 
@@ -1638,75 +1758,87 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
                 //Save Action (Creates the initial content)
                 // body multi part with title, file1, file2
-                FormDataMultiPart formDataMultiPart = this.createFormMultiPart(contentType, inputFile1Text, inputFile2Text);
+                FormDataMultiPart formDataMultiPart = this.createFormMultiPart(contentType,
+                        inputFile1Text, inputFile2Text);
                 final HttpServletRequest request1 = getHttpRequest();
                 final Response response1 = workflowResource
-                        .fireActionMultipart(request1, new EmptyHttpResponse(), SAVE_ACTION_ID, null,null, "FORCE","-1", formDataMultiPart);
+                        .fireActionMultipart(request1, new EmptyHttpResponse(), SAVE_ACTION_ID,
+                                null, null, "FORCE", "-1", formDataMultiPart);
                 final int statusCode1 = response1.getStatus();
                 assertEquals(Status.OK.getStatusCode(), statusCode1);
                 final ResponseEntityView fireEntityView1 = ResponseEntityView.class
                         .cast(response1.getEntity());
                 brandNewContentlet = new Contentlet(Map.class.cast(fireEntityView1.getEntity()));
-                checkBrandNewContentlet(fieldNameTitle, fieldNameFile1, fieldNameFile2, brandNewContentlet);
+                checkBrandNewContentlet(fieldNameTitle, fieldNameFile1, fieldNameFile2,
+                        brandNewContentlet);
 
                 // update existing by content inode.
-                formDataMultiPart = this.createFormMultiPart(contentType, inputFile1Text,inputFile2Text);
+                formDataMultiPart = this.createFormMultiPart(contentType, inputFile1Text,
+                        inputFile2Text);
                 final HttpServletRequest request2 = getHttpRequest();
                 final Response response2 = workflowResource
-                        .fireActionMultipart(request2, new EmptyHttpResponse(), SAVE_ACTION_ID, brandNewContentlet.getInode(),null, "FORCE", "-1", formDataMultiPart);
+                        .fireActionMultipart(request2, new EmptyHttpResponse(), SAVE_ACTION_ID,
+                                brandNewContentlet.getInode(), null, "FORCE", "-1",
+                                formDataMultiPart);
                 final int statusCode2 = response2.getStatus();
                 assertEquals(Status.OK.getStatusCode(), statusCode2);
                 final ResponseEntityView fireEntityView2 = ResponseEntityView.class
                         .cast(response2.getEntity());
                 String identifier = brandNewContentlet.getIdentifier();
                 brandNewContentlet = new Contentlet(Map.class.cast(fireEntityView2.getEntity()));
-                checkBrandNewContentlet(fieldNameTitle, fieldNameFile1, fieldNameFile2, brandNewContentlet);
+                checkBrandNewContentlet(fieldNameTitle, fieldNameFile1, fieldNameFile2,
+                        brandNewContentlet);
                 assertEquals(identifier, brandNewContentlet.getIdentifier());
 
                 // update existing by identifier
-                formDataMultiPart = this.createFormMultiPart(contentType, inputFile1Text, inputFile2Text);
+                formDataMultiPart = this.createFormMultiPart(contentType, inputFile1Text,
+                        inputFile2Text);
                 final HttpServletRequest request3 = getHttpRequest();
                 identifier = brandNewContentlet.getIdentifier();
                 final Response response3 = workflowResource
-                        .fireActionMultipart(request3, new EmptyHttpResponse(), SAVE_ACTION_ID, null,identifier,"FORCE", "-1", formDataMultiPart);
+                        .fireActionMultipart(request3, new EmptyHttpResponse(), SAVE_ACTION_ID,
+                                null, identifier, "FORCE", "-1", formDataMultiPart);
                 final int statusCode3 = response3.getStatus();
                 assertEquals(Status.OK.getStatusCode(), statusCode3);
                 final ResponseEntityView fireEntityView3 = ResponseEntityView.class
                         .cast(response3.getEntity());
                 brandNewContentlet = new Contentlet(Map.class.cast(fireEntityView3.getEntity()));
-                checkBrandNewContentlet(fieldNameTitle, fieldNameFile1, fieldNameFile2, brandNewContentlet);
+                checkBrandNewContentlet(fieldNameTitle, fieldNameFile1, fieldNameFile2,
+                        brandNewContentlet);
                 assertEquals(identifier, brandNewContentlet.getIdentifier());
             } finally {
-                if(null != brandNewContentlet){
-                    contentletAPI.destroy(brandNewContentlet, APILocator.systemUser(), false );
+                if (null != brandNewContentlet) {
+                    contentletAPI.destroy(brandNewContentlet, APILocator.systemUser(), false);
                 }
             }
 
         } finally {
-            if(null != contentType){
+            if (null != contentType) {
                 contentTypeAPI.delete(contentType);
             }
         }
     }
 
-    private FormDataMultiPart createFormMultiPart(final ContentType contentType, final String inputFile1Text,
-                                                  final String inputFile2Text) {
-        final Charset           charset              = Charset.defaultCharset();
+    private FormDataMultiPart createFormMultiPart(final ContentType contentType,
+            final String inputFile1Text,
+            final String inputFile2Text) {
+        final Charset charset = Charset.defaultCharset();
 
-        final FormDataMultiPart formDataMultiPart    = mock(FormDataMultiPart.class);
+        final FormDataMultiPart formDataMultiPart = mock(FormDataMultiPart.class);
 
-        final BodyPart          bodyPart             = mock(BodyPart.class);
+        final BodyPart bodyPart = mock(BodyPart.class);
         final ContentDisposition contentDisposition1 = mock(ContentDisposition.class);
         final ContentDisposition contentDisposition2 = mock(ContentDisposition.class);
         final ContentDisposition contentDisposition3 = mock(ContentDisposition.class);
 
-        final ImmutableMap<String, String> params    = ImmutableMap.of("name", "json");
+        final ImmutableMap<String, String> params = ImmutableMap.of("name", "json");
 
-        final FormDataBodyPart formDataBodyPart1     = mock(FormDataBodyPart.class);
-        final FormDataBodyPart formDataBodyPart2     = mock(FormDataBodyPart.class);
+        final FormDataBodyPart formDataBodyPart1 = mock(FormDataBodyPart.class);
+        final FormDataBodyPart formDataBodyPart2 = mock(FormDataBodyPart.class);
 
         when(formDataMultiPart.getBodyParts()).thenReturn(Arrays.asList(bodyPart));
-        when(formDataMultiPart.getFields("file")).thenReturn(Arrays.asList(formDataBodyPart1, formDataBodyPart2));
+        when(formDataMultiPart.getFields("file")).thenReturn(
+                Arrays.asList(formDataBodyPart1, formDataBodyPart2));
 
         when(bodyPart.getContentDisposition()).thenReturn(contentDisposition1);
         when(bodyPart.getMediaType()).thenReturn(MediaType.APPLICATION_JSON_TYPE);
@@ -1731,7 +1863,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         return formDataMultiPart;
     }
 
-    private void checkBrandNewContentlet(String fieldNameTitle, String fieldNameFile1, String fieldNameFile2, Contentlet brandNewContentlet) throws IOException {
+    private void checkBrandNewContentlet(String fieldNameTitle, String fieldNameFile1,
+            String fieldNameFile2, Contentlet brandNewContentlet) throws IOException {
         assertNotNull(brandNewContentlet);
         assertNotNull(brandNewContentlet.getMap());
         assertTrue(brandNewContentlet.getMap().containsKey(fieldNameTitle));
@@ -1739,24 +1872,33 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         assertTrue(brandNewContentlet.getMap().containsKey(fieldNameFile2));
         assertEquals("Test", brandNewContentlet.getMap().get("title"));
 
-        final String dAPath1 =  (String)brandNewContentlet.get("file1");
-        final String dAPath2 =  (String)brandNewContentlet.get("file2");
+        final String dAPath1 = (String) brandNewContentlet.get("file1");
+        final String dAPath2 = (String) brandNewContentlet.get("file2");
 
         final String dAPathFormat = "/dA/%s/%s/%s";
 
-        assertEquals("File dAPath don't match",dAPath1,String.format(dAPathFormat, brandNewContentlet.getIdentifier(), "file1", FilenameUtils.getName(dAPath1)));
-        assertEquals("File dAPath don't match",dAPath2,String.format(dAPathFormat, brandNewContentlet.getIdentifier(), "file2", FilenameUtils.getName(dAPath2)));
+        assertEquals("File dAPath don't match", dAPath1,
+                String.format(dAPathFormat, brandNewContentlet.getIdentifier(), "file1",
+                        FilenameUtils.getName(dAPath1)));
+        assertEquals("File dAPath don't match", dAPath2,
+                String.format(dAPathFormat, brandNewContentlet.getIdentifier(), "file2",
+                        FilenameUtils.getName(dAPath2)));
 
-        final String dAPathVersion1 =  (String)brandNewContentlet.get("file1Version");
-        final String dAPathVersion2 =  (String)brandNewContentlet.get("file2Version");
+        final String dAPathVersion1 = (String) brandNewContentlet.get("file1Version");
+        final String dAPathVersion2 = (String) brandNewContentlet.get("file2Version");
 
-        assertEquals("Version file don't match",dAPathVersion1,String.format(dAPathFormat, brandNewContentlet.getInode(), "file1", FilenameUtils.getName(dAPathVersion1)));
-        assertEquals("Version file don't match",dAPathVersion2,String.format(dAPathFormat, brandNewContentlet.getInode(), "file2", FilenameUtils.getName(dAPathVersion2)));
+        assertEquals("Version file don't match", dAPathVersion1,
+                String.format(dAPathFormat, brandNewContentlet.getInode(), "file1",
+                        FilenameUtils.getName(dAPathVersion1)));
+        assertEquals("Version file don't match", dAPathVersion2,
+                String.format(dAPathFormat, brandNewContentlet.getInode(), "file2",
+                        FilenameUtils.getName(dAPathVersion2)));
 
     }
 
     @Test
-    public void Test_Fire_Save_Remove_Image_Then_Verify_Fields_Were_Cleared_Issue_15340() throws Exception {
+    public void Test_Fire_Save_Remove_Image_Then_Verify_Fields_Were_Cleared_Issue_15340()
+            throws Exception {
 
         final User sysUser = APILocator.systemUser();
         final FieldAPI fieldAPI = APILocator.getContentTypeFieldAPI();
@@ -1770,21 +1912,22 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
                 //Lets add even more fields to the contentType.
                 Field imageField =
-                        FieldBuilder.builder(ImageField.class).name(NON_REQUIRED_IMAGE_FIELD_NAME).variable(NON_REQUIRED_IMAGE_FIELD_NAME)
+                        FieldBuilder.builder(ImageField.class).name(NON_REQUIRED_IMAGE_FIELD_NAME)
+                                .variable(NON_REQUIRED_IMAGE_FIELD_NAME)
                                 .required(false)
                                 .contentTypeId(contentType.id()).dataType(DataTypes.TEXT).build();
 
                 imageField = fieldAPI.save(imageField, sysUser);
-                final List<Field> fields = Stream.concat (
-                        Stream.of(imageField),contentType.fields().stream()).collect(
-                                CollectionsUtils.toImmutableList()
-                        );
+                final List<Field> fields = Stream.concat(
+                        Stream.of(imageField), contentType.fields().stream()).collect(
+                        CollectionsUtils.toImmutableList()
+                );
 
                 contentType = contentTypeAPI.save(contentType, fields);
 
                 //Save Action (Creates the initial content)
                 final FireActionForm.Builder builder1 = new FireActionForm.Builder();
-                final Map <String,Object>contentletFormData = new HashMap<>();
+                final Map<String, Object> contentletFormData = new HashMap<>();
                 contentletFormData.put("stInode", contentType.inode());
                 contentletFormData.put(REQUIRED_TEXT_FIELD_NAME, REQUIRED_TEXT_FIELD_VALUE);
                 contentletFormData.put(NON_REQUIRED_IMAGE_FIELD_NAME, NON_REQUIRED_IMAGE_VALUE);
@@ -1793,7 +1936,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                 final FireActionForm fireActionForm1 = new FireActionForm(builder1);
                 final HttpServletRequest request1 = getHttpRequest();
                 final Response response1 = workflowResource
-                        .fireActionSinglePart(request1, new EmptyHttpResponse(), SAVE_ACTION_ID, null,null, "FORCE", "-1", fireActionForm1);
+                        .fireActionSinglePart(request1, new EmptyHttpResponse(), SAVE_ACTION_ID,
+                                null, null, "FORCE", "-1", fireActionForm1);
 
                 final int statusCode1 = response1.getStatus();
                 assertEquals(Status.OK.getStatusCode(), statusCode1);
@@ -1801,12 +1945,14 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                         .cast(response1.getEntity());
                 brandNewContentlet = new Contentlet(Map.class.cast(fireEntityView1.getEntity()));
                 assertNotNull(brandNewContentlet);
-                assertEquals(REQUIRED_TEXT_FIELD_VALUE, brandNewContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
-                assertEquals(NON_REQUIRED_IMAGE_VALUE, brandNewContentlet.getMap().get(NON_REQUIRED_IMAGE_FIELD_NAME));
+                assertEquals(REQUIRED_TEXT_FIELD_VALUE,
+                        brandNewContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
+                assertEquals(NON_REQUIRED_IMAGE_VALUE,
+                        brandNewContentlet.getMap().get(NON_REQUIRED_IMAGE_FIELD_NAME));
 
                 //Save Action (Creates the initial content)
                 final FireActionForm.Builder builder2 = new FireActionForm.Builder();
-                final Map <String,Object>contentletFormData2 = new HashMap<>();
+                final Map<String, Object> contentletFormData2 = new HashMap<>();
                 contentletFormData2.put("stInode", contentType.inode());
                 // We're not sending this property here so we can verify it comes back without any modifications.
                 //contentletFormData.put("requiredField", "value-1");
@@ -1817,33 +1963,41 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                 final FireActionForm fireActionForm2 = new FireActionForm(builder2);
                 final HttpServletRequest request2 = getHttpRequest();
                 final Response response2 = workflowResource
-                        .fireActionSinglePart(request2, new EmptyHttpResponse(), SAVE_ACTION_ID, brandNewContentlet.getInode(), null, "FORCE","-1", fireActionForm2);
+                        .fireActionSinglePart(request2, new EmptyHttpResponse(), SAVE_ACTION_ID,
+                                brandNewContentlet.getInode(), null, "FORCE", "-1",
+                                fireActionForm2);
 
                 final int statusCode2 = response2.getStatus();
                 assertEquals(Status.OK.getStatusCode(), statusCode2);
                 final ResponseEntityView fireEntityView2 = ResponseEntityView.class
                         .cast(response2.getEntity());
-                Contentlet fetchedContentlet = new Contentlet(Map.class.cast(fireEntityView2.getEntity()));
+                Contentlet fetchedContentlet = new Contentlet(
+                        Map.class.cast(fireEntityView2.getEntity()));
                 assertNotNull(fetchedContentlet);
-                assertEquals(REQUIRED_TEXT_FIELD_VALUE, fetchedContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
+                assertEquals(REQUIRED_TEXT_FIELD_VALUE,
+                        fetchedContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
 
-                assertNull(fetchedContentlet.getMap().get(NON_REQUIRED_IMAGE_FIELD_NAME)); // Image.. still should be gone!
+                assertNull(fetchedContentlet.getMap()
+                        .get(NON_REQUIRED_IMAGE_FIELD_NAME)); // Image.. still should be gone!
 
-                final Contentlet found = APILocator.getContentletAPI().find(fetchedContentlet.getInode(), sysUser,false);
+                final Contentlet found = APILocator.getContentletAPI()
+                        .find(fetchedContentlet.getInode(), sysUser, false);
                 assertNotNull(found);
 
-                assertEquals(REQUIRED_TEXT_FIELD_VALUE, found.getMap().get(REQUIRED_TEXT_FIELD_NAME));
-                assertNull(found.getMap().get(NON_REQUIRED_IMAGE_FIELD_NAME)); // Image.. still should be gone!
+                assertEquals(REQUIRED_TEXT_FIELD_VALUE,
+                        found.getMap().get(REQUIRED_TEXT_FIELD_NAME));
+                assertNull(found.getMap()
+                        .get(NON_REQUIRED_IMAGE_FIELD_NAME)); // Image.. still should be gone!
                 //if we send null we should get back null.
 
-            }finally {
-                if(null != brandNewContentlet){
-                    contentletAPI.destroy(brandNewContentlet, APILocator.systemUser(), false );
+            } finally {
+                if (null != brandNewContentlet) {
+                    contentletAPI.destroy(brandNewContentlet, APILocator.systemUser(), false);
                 }
             }
 
-        }finally {
-            if(null != contentType){
+        } finally {
+            if (null != contentType) {
                 contentTypeAPI.delete(contentType);
             }
         }
@@ -1862,11 +2016,11 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
             //Save Action (Creates the initial content)
             final FireActionForm.Builder builder1 = new FireActionForm.Builder();
-            final Map <String,Object>contentletFormData = new HashMap<>();
+            final Map<String, Object> contentletFormData = new HashMap<>();
             contentletFormData.put("stInode", contentType.inode());
-            for(final Field field : contentType.fields()){
+            for (final Field field : contentType.fields()) {
                 final Object value = generateValue(field);
-                if( null != value){
+                if (null != value) {
                     contentletFormData.put(field.variable(), value);
                 }
             }
@@ -1874,7 +2028,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             final FireActionForm fireActionForm1 = new FireActionForm(builder1);
             final HttpServletRequest request1 = getHttpRequest();
             final Response response1 = workflowResource
-                    .fireActionSinglePart(request1, new EmptyHttpResponse(), SAVE_ACTION_ID, null, null, "FORCE","-1", fireActionForm1);
+                    .fireActionSinglePart(request1, new EmptyHttpResponse(), SAVE_ACTION_ID, null,
+                            null, "FORCE", "-1", fireActionForm1);
 
             final int statusCode1 = response1.getStatus();
             assertEquals(Status.OK.getStatusCode(), statusCode1);
@@ -1883,31 +2038,33 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             brandNewContentlet = new Contentlet(Map.class.cast(fireEntityView1.getEntity()));
             assertNotNull(brandNewContentlet);
 
-            for(final Field field : contentType.fields()){
+            for (final Field field : contentType.fields()) {
                 assertNotNull(brandNewContentlet.get(field.variable()));
             }
 
             final FireActionForm.Builder builder2 = new FireActionForm.Builder();
-            final Map <String,Object>contentletFormData2 = new HashMap<>();
+            final Map<String, Object> contentletFormData2 = new HashMap<>();
             contentletFormData2.put("stInode", contentType.inode());
-            for(final Field field : contentType.fields()){
+            for (final Field field : contentType.fields()) {
                 contentletFormData2.put(field.variable(), null);
             }
             builder2.contentlet(contentletFormData2);
             final FireActionForm fireActionForm2 = new FireActionForm(builder2);
             final HttpServletRequest request2 = getHttpRequest();
             final Response response2 = workflowResource
-                    .fireActionSinglePart(request2, new EmptyHttpResponse(), SAVE_ACTION_ID, brandNewContentlet.getInode(), null, "FORCE","-1", fireActionForm2);
+                    .fireActionSinglePart(request2, new EmptyHttpResponse(), SAVE_ACTION_ID,
+                            brandNewContentlet.getInode(), null, "FORCE", "-1", fireActionForm2);
 
             final int statusCode2 = response2.getStatus();
             assertEquals(Status.OK.getStatusCode(), statusCode2);
 
             final ResponseEntityView fireEntityView2 = ResponseEntityView.class
                     .cast(response2.getEntity());
-            final Contentlet fetchedContentlet = new Contentlet(Map.class.cast(fireEntityView2.getEntity()));
+            final Contentlet fetchedContentlet = new Contentlet(
+                    Map.class.cast(fireEntityView2.getEntity()));
             assertNotNull(fetchedContentlet);
 
-            for(final Field field : contentType.fields()){
+            for (final Field field : contentType.fields()) {
                 assertNull(fetchedContentlet.get(field.variable()));
             }
 
@@ -1921,12 +2078,14 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
 
     /**
-     * This Test demostrates that the workflow resource is capable of performing an update on a subset of fields.
+     * This Test demostrates that the workflow resource is capable of performing an update on a
+     * subset of fields.
+     *
      * @throws Exception
      */
     @Test
     public void Test_Create_Instance_Of_Content_With_Mandatory_Fields_Then_Send_Partial_Number_Of_Required_Fields_Issue_15340()
-        throws Exception {
+            throws Exception {
         ContentType contentType = null;
         try {
             // This CT has a mix of required and non-required fields.
@@ -1935,7 +2094,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
             //Save Action (Creates the initial content)
             final FireActionForm.Builder builder1 = new FireActionForm.Builder();
-            final Map <String,Object>contentletFormData = new HashMap<>();
+            final Map<String, Object> contentletFormData = new HashMap<>();
             contentletFormData.put("stInode", contentType.inode());
             contentletFormData.put(REQUIRED_TEXT_FIELD_NAME, REQUIRED_TEXT_FIELD_VALUE);
             contentletFormData.put(NON_REQUIRED_TEXT_FIELD_NAME, NON_REQUIRED_TEXT_FIELD_VALUE);
@@ -1944,7 +2103,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             final FireActionForm fireActionForm1 = new FireActionForm(builder1);
             final HttpServletRequest request1 = getHttpRequest();
             final Response response1 = workflowResource
-                    .fireActionSinglePart(request1, new EmptyHttpResponse(), SAVE_ACTION_ID, null, null, "FORCE","-1", fireActionForm1);
+                    .fireActionSinglePart(request1, new EmptyHttpResponse(), SAVE_ACTION_ID, null,
+                            null, "FORCE", "-1", fireActionForm1);
 
             final int statusCode1 = response1.getStatus();
             assertEquals(Status.OK.getStatusCode(), statusCode1);
@@ -1959,7 +2119,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
             final String NON_REQUIRED_UPDATED_VALUE = "Non required updated value.";
 
-            final Map <String,Object>contentletFormData2 = new HashMap<>();
+            final Map<String, Object> contentletFormData2 = new HashMap<>();
             contentletFormData2.put("stInode", contentType.inode());
             contentletFormData2.put(NON_REQUIRED_TEXT_FIELD_NAME, NON_REQUIRED_UPDATED_VALUE);
             builder2.contentlet(contentletFormData2);
@@ -1967,7 +2127,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             final FireActionForm fireActionForm2 = new FireActionForm(builder2);
             final HttpServletRequest request2 = getHttpRequest();
             final Response response2 = workflowResource
-                    .fireActionSinglePart(request2, new EmptyHttpResponse(), SAVE_ACTION_ID, brandNewContentlet.getInode(), null, "FORCE","-1", fireActionForm2);
+                    .fireActionSinglePart(request2, new EmptyHttpResponse(), SAVE_ACTION_ID,
+                            brandNewContentlet.getInode(), null, "FORCE", "-1", fireActionForm2);
 
             final int statusCode2 = response2.getStatus();
             assertEquals(Status.OK.getStatusCode(), statusCode2);
@@ -1976,14 +2137,16 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
             final ResponseEntityView fireEntityView2 = ResponseEntityView.class
                     .cast(response2.getEntity());
-            final Contentlet fetchedContentlet = new Contentlet (Map.class.cast(fireEntityView2.getEntity()));
+            final Contentlet fetchedContentlet = new Contentlet(
+                    Map.class.cast(fireEntityView2.getEntity()));
             assertNotNull(fetchedContentlet);
 
             //This one got changed. It is expected since we are using the resource to modify its value.
-            assertEquals(NON_REQUIRED_UPDATED_VALUE, fetchedContentlet.getMap().get(NON_REQUIRED_TEXT_FIELD_NAME));
+            assertEquals(NON_REQUIRED_UPDATED_VALUE,
+                    fetchedContentlet.getMap().get(NON_REQUIRED_TEXT_FIELD_NAME));
             //This one should remain unchanged. since it never got send on the form.
-            assertEquals(REQUIRED_TEXT_FIELD_VALUE, fetchedContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
-
+            assertEquals(REQUIRED_TEXT_FIELD_VALUE,
+                    fetchedContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
 
             //Meaning the endpoint is flexible to modify a subset of fields. No need to send them all.
         } finally {
@@ -2013,7 +2176,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             final FireActionForm fireActionForm1 = new FireActionForm(builder1);
             final HttpServletRequest request1 = getHttpRequest();
             final Response response1 = workflowResource
-                    .fireActionSinglePart(request1, new EmptyHttpResponse(), SAVE_ACTION_ID, null, null, "FORCE","-1", fireActionForm1);
+                    .fireActionSinglePart(request1, new EmptyHttpResponse(), SAVE_ACTION_ID, null,
+                            null, "FORCE", "-1", fireActionForm1);
 
             final int statusCode1 = response1.getStatus();
             assertEquals(Status.OK.getStatusCode(), statusCode1);
@@ -2024,7 +2188,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             assertNotNull(brandNewContentlet);
 
             final FireActionForm.Builder builder2 = new FireActionForm.Builder();
-            final Map <String,Object>contentletFormData2 = new HashMap<>();
+            final Map<String, Object> contentletFormData2 = new HashMap<>();
             contentletFormData2.put("stInode", contentType.inode());
             contentletFormData2.put(REQUIRED_NUMERIC_TEXT_FIELD_NAME, null);
             contentletFormData2.put(NON_REQUIRED_NUMERIC_TEXT_FIELD_NAME, "0");
@@ -2033,12 +2197,16 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
             final FireActionForm fireActionForm2 = new FireActionForm(builder2);
             final HttpServletRequest request2 = getHttpRequest();
             final Response response2 = workflowResource
-                    .fireActionSinglePart(request2, new EmptyHttpResponse(), SAVE_ACTION_ID, brandNewContentlet.getInode(), null, "FORCE","-1", fireActionForm2);
+                    .fireActionSinglePart(request2, new EmptyHttpResponse(), SAVE_ACTION_ID,
+                            brandNewContentlet.getInode(), null, "FORCE", "-1", fireActionForm2);
 
             final int statusCode2 = response2.getStatus();
             assertEquals(Status.BAD_REQUEST.getStatusCode(), statusCode2);
-            final ResponseEntityView errorEntityView = ResponseEntityView.class.cast(response2.getEntity());
-            assertEquals(1, errorEntityView.getErrors().stream().filter(errorEntity -> "required".equals(ErrorEntity.class.cast(errorEntity).getErrorCode())).count());
+            final ResponseEntityView errorEntityView = ResponseEntityView.class.cast(
+                    response2.getEntity());
+            assertEquals(1, errorEntityView.getErrors().stream()
+                    .filter(errorEntity -> "required".equals(
+                            ErrorEntity.class.cast(errorEntity).getErrorCode())).count());
 
         } finally {
             if (null != contentType) {
@@ -2051,7 +2219,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     public void testFireActionDefault_ContentWithRelationships_Success() throws Exception {
         ContentType childContentType = null;
         ContentType parentContentType = null;
-        try{
+        try {
             //Create childContentType
             childContentType = createSampleContentType();
 
@@ -2060,46 +2228,58 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
             //Create child Content
             final FireActionForm.Builder builder1 = new FireActionForm.Builder();
-            final Map <String,Object>contentletFormData = new HashMap<>();
+            final Map<String, Object> contentletFormData = new HashMap<>();
             contentletFormData.put("stInode", childContentType.inode());
             contentletFormData.put(REQUIRED_TEXT_FIELD_NAME, REQUIRED_TEXT_FIELD_VALUE);
             builder1.contentlet(contentletFormData);
             final FireActionForm fireActionForm1 = new FireActionForm(builder1);
             final HttpServletRequest request1 = getHttpRequest();
             final Response response1 = workflowResource
-                    .fireActionDefaultSinglePart(request1, new EmptyHttpResponse(), null, null, "FORCE",
-                            String.valueOf(languageAPI.getDefaultLanguage().getId()), SystemAction.PUBLISH,  fireActionForm1);
+                    .fireActionDefaultSinglePart(request1, new EmptyHttpResponse(), null, null,
+                            "FORCE",
+                            String.valueOf(languageAPI.getDefaultLanguage().getId()),
+                            SystemAction.PUBLISH, fireActionForm1);
             final int statusCode1 = response1.getStatus();
             assertEquals(Status.OK.getStatusCode(), statusCode1);
             final ResponseEntityView fireEntityView1 = ResponseEntityView.class
                     .cast(response1.getEntity());
-            final Contentlet childContentlet = new Contentlet (Map.class.cast(fireEntityView1.getEntity()));
+            final Contentlet childContentlet = new Contentlet(
+                    Map.class.cast(fireEntityView1.getEntity()));
             assertNotNull(childContentlet);
-            assertEquals(REQUIRED_TEXT_FIELD_VALUE, childContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
+            assertEquals(REQUIRED_TEXT_FIELD_VALUE,
+                    childContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
 
             //Create parent Content
             final FireActionForm.Builder builder2 = new FireActionForm.Builder();
-            final Map <String,Object>contentletFormData2 = new HashMap<>();
+            final Map<String, Object> contentletFormData2 = new HashMap<>();
             contentletFormData2.put("stInode", parentContentType.inode());
             contentletFormData2.put(REQUIRED_TEXT_FIELD_NAME, REQUIRED_TEXT_FIELD_VALUE);
-            contentletFormData2.put(RELATIONSHIP_FIELD_NAME,childContentlet.getIdentifier());
+            contentletFormData2.put(RELATIONSHIP_FIELD_NAME, childContentlet.getIdentifier());
             builder2.contentlet(contentletFormData2);
             final FireActionForm fireActionForm2 = new FireActionForm(builder2);
             final HttpServletRequest request2 = getHttpRequest();
             final Response response2 = workflowResource
-                    .fireActionDefaultSinglePart(request2, new EmptyHttpResponse(), null, null, "FORCE",
-                            String.valueOf(languageAPI.getDefaultLanguage().getId()), SystemAction.PUBLISH,  fireActionForm2);
+                    .fireActionDefaultSinglePart(request2, new EmptyHttpResponse(), null, null,
+                            "FORCE",
+                            String.valueOf(languageAPI.getDefaultLanguage().getId()),
+                            SystemAction.PUBLISH, fireActionForm2);
             final int statusCode2 = response2.getStatus();
             assertEquals(Status.OK.getStatusCode(), statusCode2);
             final ResponseEntityView fireEntityView2 = ResponseEntityView.class
                     .cast(response2.getEntity());
-            final Contentlet parentContentlet = new Contentlet (Map.class.cast(fireEntityView2.getEntity()));
+            final Contentlet parentContentlet = new Contentlet(
+                    Map.class.cast(fireEntityView2.getEntity()));
             assertNotNull(parentContentlet);
-            assertEquals(REQUIRED_TEXT_FIELD_VALUE, parentContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
-            assertEquals(1,contentletAPI.getAllRelationships(parentContentlet).getRelationshipsRecords().size());
-            assertEquals(childContentlet.getIdentifier(),contentletAPI.getAllRelationships(parentContentlet).getRelationshipsRecords().get(0).getRecords().get(0).getIdentifier());
+            assertEquals(REQUIRED_TEXT_FIELD_VALUE,
+                    parentContentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
+            assertEquals(1,
+                    contentletAPI.getAllRelationships(parentContentlet).getRelationshipsRecords()
+                            .size());
+            assertEquals(childContentlet.getIdentifier(),
+                    contentletAPI.getAllRelationships(parentContentlet).getRelationshipsRecords()
+                            .get(0).getRecords().get(0).getIdentifier());
 
-        }finally {
+        } finally {
             if (null != childContentType) {
                 contentTypeAPI.delete(childContentType);
             }
@@ -2109,7 +2289,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         }
     }
 
-    private ContentType createRelationshipFieldContentType(final String childContentTypeVariable) throws Exception{
+    private ContentType createRelationshipFieldContentType(final String childContentTypeVariable)
+            throws Exception {
         ContentType contentType;
         final String ctPrefix = "TestContentType";
         final String newContentTypeName = ctPrefix + System.currentTimeMillis();
@@ -2122,13 +2303,16 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
         // Add fields to the contentType
         final Field textField =
-                FieldBuilder.builder(TextField.class).name(REQUIRED_TEXT_FIELD_NAME).variable(REQUIRED_TEXT_FIELD_NAME)
+                FieldBuilder.builder(TextField.class).name(REQUIRED_TEXT_FIELD_NAME)
+                        .variable(REQUIRED_TEXT_FIELD_NAME)
                         .required(true)
                         .contentTypeId(contentType.id()).dataType(DataTypes.TEXT).build();
 
         final Field relationshipField =
-                FieldBuilder.builder(RelationshipField.class).name(RELATIONSHIP_FIELD_NAME).contentTypeId(contentType.id())
-                        .values(String.valueOf(RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal())).relationType(childContentTypeVariable).build();
+                FieldBuilder.builder(RelationshipField.class).name(RELATIONSHIP_FIELD_NAME)
+                        .contentTypeId(contentType.id())
+                        .values(String.valueOf(RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal()))
+                        .relationType(childContentTypeVariable).build();
         contentType = contentTypeAPI.save(contentType, Arrays.asList(textField, relationshipField));
 
         // Assign contentType to Workflows
@@ -2145,10 +2329,14 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     @Test
     public void testFireActionDefault_ContentWithCategories_Success() throws Exception {
         ContentType categoryContentType = null;
-        try{
+        try {
             //Create Categories
-            final CategoryDataGen rootCategoryDataGen = new CategoryDataGen().setCategoryName("Bikes-"+System.currentTimeMillis()).setKey("Bikes").setKeywords("Bikes").setCategoryVelocityVarName("bikes");
-            final Category child1 = new CategoryDataGen().setCategoryName("RoadBike-"+System.currentTimeMillis()).setKey("RoadBike").setKeywords("RoadBike").setCategoryVelocityVarName("roadBike").next();
+            final CategoryDataGen rootCategoryDataGen = new CategoryDataGen().setCategoryName(
+                            "Bikes-" + System.currentTimeMillis()).setKey("Bikes").setKeywords("Bikes")
+                    .setCategoryVelocityVarName("bikes");
+            final Category child1 = new CategoryDataGen().setCategoryName(
+                            "RoadBike-" + System.currentTimeMillis()).setKey("RoadBike")
+                    .setKeywords("RoadBike").setCategoryVelocityVarName("roadBike").next();
 
             final Category root = rootCategoryDataGen.children(child1).nextPersisted();
 
@@ -2157,35 +2345,42 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
             //Create Content
             final FireActionForm.Builder builder1 = new FireActionForm.Builder();
-            final Map <String,Object>contentletFormData = new HashMap<>();
+            final Map<String, Object> contentletFormData = new HashMap<>();
             contentletFormData.put("stInode", categoryContentType.inode());
             contentletFormData.put(REQUIRED_TEXT_FIELD_NAME, REQUIRED_TEXT_FIELD_VALUE);
-            contentletFormData.put(CATEGORY_FIELD_NAME,child1.getInode());
+            contentletFormData.put(CATEGORY_FIELD_NAME, child1.getInode());
             builder1.contentlet(contentletFormData);
             final FireActionForm fireActionForm1 = new FireActionForm(builder1);
             final HttpServletRequest request1 = getHttpRequest();
             final Response response1 = workflowResource
-                    .fireActionDefaultSinglePart(request1, new EmptyHttpResponse(), null, null, "FORCE",
-                            String.valueOf(languageAPI.getDefaultLanguage().getId()), SystemAction.PUBLISH,  fireActionForm1);
+                    .fireActionDefaultSinglePart(request1, new EmptyHttpResponse(), null, null,
+                            "FORCE",
+                            String.valueOf(languageAPI.getDefaultLanguage().getId()),
+                            SystemAction.PUBLISH, fireActionForm1);
             final int statusCode1 = response1.getStatus();
             assertEquals(Status.OK.getStatusCode(), statusCode1);
             final ResponseEntityView fireEntityView1 = ResponseEntityView.class
                     .cast(response1.getEntity());
-            final Contentlet contentlet = new Contentlet (Map.class.cast(fireEntityView1.getEntity()));
+            final Contentlet contentlet = new Contentlet(
+                    Map.class.cast(fireEntityView1.getEntity()));
             assertNotNull(contentlet);
-            assertEquals(REQUIRED_TEXT_FIELD_VALUE, contentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
+            assertEquals(REQUIRED_TEXT_FIELD_VALUE,
+                    contentlet.getMap().get(REQUIRED_TEXT_FIELD_NAME));
             assertNotNull(APILocator.getCategoryAPI().getParents(contentlet, adminUser, true));
-            assertEquals(child1.getInode(),APILocator.getCategoryAPI().getParents(contentlet, adminUser, true).get(0).getInode());
+            assertEquals(child1.getInode(),
+                    APILocator.getCategoryAPI().getParents(contentlet, adminUser, true).get(0)
+                            .getInode());
 
 
-        }finally {
+        } finally {
             if (null != categoryContentType) {
                 contentTypeAPI.delete(categoryContentType);
             }
         }
     }
 
-    private ContentType createCategoryFieldContentType(final String parentCategoryInode) throws Exception{
+    private ContentType createCategoryFieldContentType(final String parentCategoryInode)
+            throws Exception {
         ContentType contentType;
         final String ctPrefix = "TestContentType";
         final String newContentTypeName = ctPrefix + System.currentTimeMillis();
@@ -2198,12 +2393,14 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
         // Add fields to the contentType
         final Field textField =
-                FieldBuilder.builder(TextField.class).name(REQUIRED_TEXT_FIELD_NAME).variable(REQUIRED_TEXT_FIELD_NAME)
+                FieldBuilder.builder(TextField.class).name(REQUIRED_TEXT_FIELD_NAME)
+                        .variable(REQUIRED_TEXT_FIELD_NAME)
                         .required(true)
                         .contentTypeId(contentType.id()).dataType(DataTypes.TEXT).build();
 
         final Field categoryField =
-                FieldBuilder.builder(CategoryField.class).name(CATEGORY_FIELD_NAME).contentTypeId(contentType.id()).indexed(true).required(true)
+                FieldBuilder.builder(CategoryField.class).name(CATEGORY_FIELD_NAME)
+                        .contentTypeId(contentType.id()).indexed(true).required(true)
                         .values(parentCategoryInode).build();
         contentType = contentTypeAPI.save(contentType, Arrays.asList(textField, categoryField));
 
@@ -2218,7 +2415,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         return contentType;
     }
 
-    private ContentType createNumericRequiredAndNonRequiredFieldsContentType() throws Exception{
+    private ContentType createNumericRequiredAndNonRequiredFieldsContentType() throws Exception {
         ContentType contentType;
         final String ctPrefix = "NumericRequiredAndNonRequiredFieldsContentType";
         final String newContentTypeName = ctPrefix + System.currentTimeMillis();
@@ -2237,7 +2434,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
         final Field nonRequiredField = FieldBuilder.builder(TextField.class)
                 .dataType(DataTypes.INTEGER)
-                .name(NON_REQUIRED_NUMERIC_TEXT_FIELD_NAME).variable(NON_REQUIRED_NUMERIC_TEXT_FIELD_NAME)
+                .name(NON_REQUIRED_NUMERIC_TEXT_FIELD_NAME)
+                .variable(NON_REQUIRED_NUMERIC_TEXT_FIELD_NAME)
                 .required(false)
                 .contentTypeId(contentType.id()).build();
 
@@ -2255,7 +2453,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         return contentType;
     }
 
-    private ContentType createMixedRequiredAndNonRequiredFieldsContentType() throws Exception{
+    private ContentType createMixedRequiredAndNonRequiredFieldsContentType() throws Exception {
         ContentType contentType;
         final String ctPrefix = "MixedRequiredAndNonRequiredFieldsContentType";
         final String newContentTypeName = ctPrefix + System.currentTimeMillis();
@@ -2267,10 +2465,10 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         final WorkflowScheme documentWorkflow = workflowAPI.findSchemeByName(DM_WORKFLOW);
 
         final Field requiredField = FieldBuilder.builder(TextField.class)
-                    .dataType(DataTypes.TEXT)
-                    .name(REQUIRED_TEXT_FIELD_NAME).variable(REQUIRED_TEXT_FIELD_NAME)
-                    .required(true)
-                    .contentTypeId(contentType.id()).build();
+                .dataType(DataTypes.TEXT)
+                .name(REQUIRED_TEXT_FIELD_NAME).variable(REQUIRED_TEXT_FIELD_NAME)
+                .required(true)
+                .contentTypeId(contentType.id()).build();
 
         final Field nonRequiredField = FieldBuilder.builder(TextField.class)
                 .dataType(DataTypes.TEXT)
@@ -2292,7 +2490,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         return contentType;
     }
 
-    private ContentType createLargeContentType(final boolean required) throws Exception{
+    private ContentType createLargeContentType(final boolean required) throws Exception {
         ContentType contentType;
         final String ctPrefix = "LargeTestContentType";
         final String newContentTypeName = ctPrefix + System.currentTimeMillis();
@@ -2312,7 +2510,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
                     .name(fieldName)
                     .required(required)
                     .contentTypeId(contentType.id()
-            ).build();
+                    ).build();
             fields.add(field);
         }
         contentType = contentTypeAPI.save(contentType, fields);
@@ -2328,24 +2526,24 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         return contentType;
     }
 
-    private Object generateValue(final Field field){
+    private Object generateValue(final Field field) {
 
-        if(field instanceof CategoryField){
+        if (field instanceof CategoryField) {
             return "Any";
         }
 
-        if(field instanceof KeyValueField){
+        if (field instanceof KeyValueField) {
             return "{key1:value, key2:value }";
         }
 
         final DataTypes dataType = field.dataType();
-        if(DataTypes.DATE == dataType){
+        if (DataTypes.DATE == dataType) {
             return new Date();
         }
-        if(DataTypes.LONG_TEXT == dataType) {
+        if (DataTypes.LONG_TEXT == dataType) {
             return RandomStringUtils.random(2500, true, false);
         }
-        if(DataTypes.TEXT == dataType) {
+        if (DataTypes.TEXT == dataType) {
             return RandomStringUtils.random(100, true, false);
         }
 
@@ -2356,11 +2554,14 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
     private static HttpServletRequest getHttpRequest() {
         MockHeaderRequest request = new MockHeaderRequest(
                 (
-                        new MockSessionRequest(new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
+                        new MockSessionRequest(new MockAttributeRequest(
+                                new MockHttpRequestIntegrationTest("localhost",
+                                        "/").request()).request())
                 ).request()
         );
 
-        request.setHeader("Authorization", "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+        request.setHeader("Authorization",
+                "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
 
         return request;
     }

--- a/dotCMS/src/integration-test/java/com/dotcms/util/IntegrationTestInitService.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/util/IntegrationTestInitService.java
@@ -1,5 +1,6 @@
 package com.dotcms.util;
 
+import com.dotcms.business.bytebuddy.ByteBuddyFactory;
 import com.dotcms.config.DotInitializationService;
 import com.dotcms.repackage.org.apache.struts.Globals;
 import com.dotcms.repackage.org.apache.struts.config.ModuleConfig;
@@ -10,9 +11,12 @@ import com.dotmarketing.business.FactoryLocator;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.liferay.util.SystemProperties;
+
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.felix.framework.OSGISystem;
+import org.awaitility.Awaitility;
+import org.awaitility.Duration;
 import org.mockito.Mockito;
 
 /**
@@ -33,12 +37,17 @@ public class IntegrationTestInitService {
     }
 
     public static IntegrationTestInitService getInstance() {
+        ByteBuddyFactory.init();
         return service;
     }
 
     public void init() throws Exception {
         try {
             if (initCompleted.compareAndSet(false, true)) {
+                Awaitility.setDefaultPollInterval(10, TimeUnit.MILLISECONDS);
+                Awaitility.setDefaultPollDelay(Duration.ZERO);
+                Awaitility.setDefaultTimeout(Duration.ONE_MINUTE);
+
                 ConfigTestHelper._setupFakeTestingContext();
 
                 CacheLocator.init();
@@ -57,7 +66,7 @@ public class IntegrationTestInitService {
                 // Init other dotCMS services.
                 DotInitializationService.getInstance().initialize();
             }
-        } catch(Exception e) {
+        } catch (Exception e) {
             Logger.error(this, "Error initializing Integration Test Init Service", e);
             throw e;
         }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/business/PermissionBitFactoryImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/business/PermissionBitFactoryImplTest.java
@@ -7,18 +7,20 @@ import static org.junit.Assert.assertTrue;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.ContentletDataGen;
+import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.datagen.UserDataGen;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Permission;
-import com.dotmarketing.beans.PermissionType;
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.reindex.ReindexQueueAPI;
+import com.dotmarketing.db.LocalTransaction;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.liferay.portal.model.User;
 import java.util.List;
 import java.util.Map;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class PermissionBitFactoryImplTest {
@@ -29,61 +31,79 @@ public class PermissionBitFactoryImplTest {
     }
 
     /**
-     * Method to test: {@link PermissionBitFactoryImpl#addPermissionsToCache(Permissionable)}
-     * When: Create a {@link ContentType} and two {@link Contentlet} and assign two new permission to the ContentType
-     * Should: Create a register for each COntentlet in dist_reindex_journal
+     * Method to test: {@link PermissionBitFactoryImpl#addPermissionsToCache(Permissionable)} When:
+     * Create a {@link ContentType} and two {@link Contentlet} and assign two new permission to the
+     * ContentType Should: Create a register for each COntentlet in dist_reindex_journal
      *
      * @throws DotDataException
      */
     @Test
-    public void assignPermissions() throws DotDataException {
+    public void assignPermissions() throws DotDataException, DotSecurityException {
+
+        ReindexQueueAPI queueAPI = APILocator.getReindexQueueAPI();
+        TestDataUtils.assertEmptyQueue();
 
         final User user = new UserDataGen().nextPersisted();
-        final PermissionBitFactoryImpl permissionBitFactory = new PermissionBitFactoryImpl(CacheLocator.getPermissionCache());
+        final PermissionBitFactoryImpl permissionBitFactory = new PermissionBitFactoryImpl(
+                CacheLocator.getPermissionCache());
 
         final ContentType contentType = new ContentTypeDataGen().nextPersisted();
         final Contentlet contentlet_1 = new ContentletDataGen(contentType).nextPersisted();
         final Contentlet contentlet_2 = new ContentletDataGen(contentType).nextPersisted();
-        final Role userRole = APILocator.getRoleAPI().getUserRole(user);
-        Permission readPermissions = new Permission( contentType.getPermissionId(),
-                userRole.getId(), PermissionAPI.PERMISSION_READ );
+        // Ensure contentlets indexed but not permissions
+        TestDataUtils.assertEmptyQueue();
 
-        Permission editPermissions = new Permission( contentType.getPermissionId(),
-                userRole.getId(), PermissionAPI.PERMISSION_EDIT );
+        LocalTransaction.wrap(() -> {
+            final Role userRole = APILocator.getRoleAPI().getUserRole(user);
+            Permission readPermissions = new Permission(contentType.getPermissionId(),
+                    userRole.getId(), PermissionAPI.PERMISSION_READ);
 
-        permissionBitFactory.assignPermissions(list(readPermissions, editPermissions), contentType);
+            Permission editPermissions = new Permission(contentType.getPermissionId(),
+                    userRole.getId(), PermissionAPI.PERMISSION_EDIT);
 
-        final List<Permission> permissions = APILocator.getPermissionAPI()
-                .getPermissions(contentType);
+            permissionBitFactory.assignPermissions(list(readPermissions, editPermissions),
+                    contentType);
 
-        assertEquals(2, permissions.size());
-        assertEquals(userRole.getId(), permissions.get(0).getRoleId());
-        assertEquals(userRole.getId(), permissions.get(1).getRoleId());
-        final boolean hasReadPermission = permissions.stream()
-                .anyMatch(permission -> PermissionAPI.PERMISSION_READ == permission.getPermission());
+            final List<Permission> permissions = APILocator.getPermissionAPI()
+                    .getPermissions(contentType);
 
-        final boolean hasEditPermission = permissions.stream()
-                .anyMatch(permission -> PermissionAPI.PERMISSION_EDIT == permission.getPermission());
+            assertEquals(2, permissions.size());
+            assertEquals(userRole.getId(), permissions.get(0).getRoleId());
+            assertEquals(userRole.getId(), permissions.get(1).getRoleId());
+            final boolean hasReadPermission = permissions.stream()
+                    .anyMatch(permission -> PermissionAPI.PERMISSION_READ
+                            == permission.getPermission());
 
-        assertTrue(hasReadPermission);
-        assertTrue(hasEditPermission);
+            final boolean hasEditPermission = permissions.stream()
+                    .anyMatch(permission -> PermissionAPI.PERMISSION_EDIT
+                            == permission.getPermission());
 
-        final String query = "SELECT * from dist_reindex_journal WHERE inode_to_index = ? OR inode_to_index = ?";
-        DotConnect dotConnect = new DotConnect();
-        dotConnect.setSQL(query);
-        dotConnect.addParam(contentlet_1.getIdentifier());
-        dotConnect.addParam(contentlet_2.getIdentifier());
+            assertTrue(hasReadPermission);
+            assertTrue(hasEditPermission);
+            // reindex jornal will clear after queue is unpaused after transsaction.
+            final String query = "SELECT * from dist_reindex_journal WHERE inode_to_index = ? OR inode_to_index = ?";
+            DotConnect dotConnect = new DotConnect();
+            dotConnect.setSQL(query);
+            dotConnect.addParam(contentlet_1.getIdentifier());
+            dotConnect.addParam(contentlet_2.getIdentifier());
 
-        final List<Map<String, Object>> maps = dotConnect.loadObjectResults();
+            final List<Map<String, Object>> maps = dotConnect.loadObjectResults();
 
-        assertEquals(maps.size(), 2);
+            assertEquals(2, maps.size());
 
-        final boolean hasContentlet1Permission = maps.stream()
-                .anyMatch(map -> map.get("inode_to_index").equals(contentlet_1.getIdentifier()));
-        final boolean hasContentlet2Permission = maps.stream()
-                .anyMatch(map -> map.get("inode_to_index").equals(contentlet_2.getIdentifier()));
+            final boolean hasContentlet1Permission = maps.stream()
+                    .anyMatch(
+                            map -> map.get("inode_to_index").equals(contentlet_1.getIdentifier()));
+            final boolean hasContentlet2Permission = maps.stream()
+                    .anyMatch(
+                            map -> map.get("inode_to_index").equals(contentlet_2.getIdentifier()));
 
-        assertTrue(hasContentlet1Permission);
-        assertTrue(hasContentlet2Permission);
+            assertTrue(hasContentlet1Permission);
+            assertTrue(hasContentlet2Permission);
+        });
+
+        // Ensure queue is cleared up.
+        TestDataUtils.assertEmptyQueue();
+
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/db/HibernateUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/db/HibernateUtilTest.java
@@ -1,7 +1,9 @@
 package com.dotmarketing.db;
 
+import static org.junit.Assert.assertEquals;
+
 import com.dotcms.datagen.SiteDataGen;
-import com.dotcms.repackage.net.sf.hibernate.HibernateException;
+import com.dotcms.repackage.net.sf.hibernate.Session;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.ContainerStructure;
 import com.dotmarketing.beans.Host;
@@ -9,96 +11,97 @@ import com.dotmarketing.beans.Inode;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotHibernateException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.UUIDGenerator;
 import com.liferay.portal.model.User;
-
-import java.sql.SQLException;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import junit.framework.Assert;
-import com.dotcms.repackage.net.sf.hibernate.Session;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
-
 @RunWith(DataProviderRunner.class)
 public class HibernateUtilTest {
-    
+
     static User user;
     static Host host;
-    
+
     @BeforeClass
     public static void init() throws Exception {
-    	 //Setting web app environment
+        //Setting web app environment
         IntegrationTestInitService.getInstance().init();
         user = APILocator.getUserAPI().getSystemUser();
         host = APILocator.getHostAPI().findDefaultHost(user, false);
     }
-    
+
     @After
     @Before
     public void prep() throws Exception {
-    	Session session = HibernateUtil.getSession();
-    	if (session != null) {
-    		session.clear();
-    	}
+        Session session = HibernateUtil.getSession();
+        if (session != null) {
+            session.clear();
+        }
         HibernateUtil.closeSession();
     }
-    
+
     /**
-     * This test detects if hibernate is saving objects that have change 
-     * in the hibernate session on session close/flush. Its commented as
-     * we haven't found a way to disable that behavior for hibernate2.
+     * This test detects if hibernate is saving objects that have change in the hibernate session on
+     * session close/flush. Its commented as we haven't found a way to disable that behavior for
+     * hibernate2.
+     *
      * @throws Exception
      */
     @Test
     public void updateOnDirtyObjectWhenFlush() throws Exception {
         HibernateUtil.startTransaction();
-        
+
         Container container = new Container();
-        String title = "Test container #"+UUIDGenerator.generateUuid();
+        String title = "Test container #" + UUIDGenerator.generateUuid();
         container.setTitle(title);
-        container.setPreLoop("pre"); container.setPostLoop("post");
-        
+        container.setPreLoop("pre");
+        container.setPostLoop("post");
+
         List<ContainerStructure> containerStructureList = new ArrayList<ContainerStructure>();
-        ContainerStructure cs=new ContainerStructure();
-        cs.setStructureId(CacheLocator.getContentTypeCache().getStructureByVelocityVarName("webPageContent").getInode());
+        ContainerStructure cs = new ContainerStructure();
+        cs.setStructureId(
+                CacheLocator.getContentTypeCache().getStructureByVelocityVarName("webPageContent")
+                        .getInode());
         cs.setCode("$body");
         containerStructureList.add(cs);
-        container = APILocator.getContainerAPI().save(container, containerStructureList, host, user, false);
-        String cInode=container.getInode();
-        
+        container = APILocator.getContainerAPI()
+                .save(container, containerStructureList, host, user, false);
+        String cInode = container.getInode();
+
         // clear cache lo ensure we load from hibernate
         CacheLocator.getCacheAdministrator().flushAll();
-        
-        container = (Container)HibernateUtil.load(Container.class, cInode);
-        
+
+        container = (Container) HibernateUtil.load(Container.class, cInode);
+
         container.setTitle("my dirty title");
-        
+
         HibernateUtil.closeSession();
-        
-        container = (Container)HibernateUtil.load(Container.class, cInode);
-        
-        Assert.assertEquals(title,container.getTitle());
+
+        container = (Container) HibernateUtil.load(Container.class, cInode);
+
+        Assert.assertEquals(title, container.getTitle());
     }
-    
+
     /**
-     * Test the problem with hibernate updating objects that have changed in the 
-     * session. ON A READ! at hibernateUtil we set in the session to never autoflush
-     * unless we close the session.
+     * Test the problem with hibernate updating objects that have changed in the session. ON A READ!
+     * at hibernateUtil we set in the session to never autoflush unless we close the session.
+     *
      * @throws Exception
      */
     @Test
@@ -108,45 +111,53 @@ public class HibernateUtilTest {
 
         // 1st
         Container container = new Container();
-        String title = "Test container #"+UUIDGenerator.generateUuid();
+        String title = "Test container #" + UUIDGenerator.generateUuid();
         container.setTitle(title);
-        container.setPreLoop("pre"); container.setPostLoop("post");
-        
+        container.setPreLoop("pre");
+        container.setPostLoop("post");
+
         List<ContainerStructure> containerStructureList = new ArrayList<ContainerStructure>();
-        ContainerStructure cs=new ContainerStructure();
-        cs.setStructureId(CacheLocator.getContentTypeCache().getStructureByVelocityVarName("webPageContent").getInode());
+        ContainerStructure cs = new ContainerStructure();
+        cs.setStructureId(
+                CacheLocator.getContentTypeCache().getStructureByVelocityVarName("webPageContent")
+                        .getInode());
         cs.setCode("$body");
         containerStructureList.add(cs);
-        container = APILocator.getContainerAPI().save(container, containerStructureList, newHost, user, false);
-        String cInode=container.getInode();
-        
-        
+        container = APILocator.getContainerAPI()
+                .save(container, containerStructureList, newHost, user, false);
+        String cInode = container.getInode();
+
         // 2nd
         container = new Container();
-        String title2 = "Test 2nd container #"+UUIDGenerator.generateUuid();
+        String title2 = "Test 2nd container #" + UUIDGenerator.generateUuid();
         container.setTitle(title2);
-        container.setPreLoop("pre"); container.setPostLoop("post");
+        container.setPreLoop("pre");
+        container.setPostLoop("post");
         containerStructureList = new ArrayList<ContainerStructure>();
-        cs=new ContainerStructure();
-        cs.setStructureId(CacheLocator.getContentTypeCache().getStructureByVelocityVarName("webPageContent").getInode());
-        cs.setCode("$body"); containerStructureList.add(cs);
-        container = APILocator.getContainerAPI().save(container, containerStructureList, newHost, user, false);
-        String cInode2=container.getInode();
+        cs = new ContainerStructure();
+        cs.setStructureId(
+                CacheLocator.getContentTypeCache().getStructureByVelocityVarName("webPageContent")
+                        .getInode());
+        cs.setCode("$body");
+        containerStructureList.add(cs);
+        container = APILocator.getContainerAPI()
+                .save(container, containerStructureList, newHost, user, false);
+        String cInode2 = container.getInode();
         container = null;
-        
+
         HibernateUtil.closeSession();
-        
+
         // load the first and make it dirty
-        Container fst = (Container)HibernateUtil.load(Container.class, cInode);
+        Container fst = (Container) HibernateUtil.load(Container.class, cInode);
         fst.setTitle("my dirty title 2");
-        
+
         // load the second. it might trigger an update on the first one
         HibernateUtil hh = new HibernateUtil(Container.class);
-        hh.setQuery("from "+Container.class.getName()+" c where c.inode=?");
+        hh.setQuery("from " + Container.class.getName() + " c where c.inode=?");
         hh.setParam(cInode2);
-        Container cc = (Container)hh.load();
+        Container cc = (Container) hh.load();
         Assert.assertEquals(title2, cc.getTitle());
-        
+
         // lets see if in the db it remains the same
         DotConnect dc = new DotConnect();
         dc.setSQL("select title from " + Inode.Type.CONTAINERS.getTableName() + " where inode=?");
@@ -157,13 +168,16 @@ public class HibernateUtilTest {
     @DataProvider
     public static Object[] testCases() {
 
-        final Runnable reindexRunnable=new ReindexRunnable(Collections.emptyList(), ReindexRunnable.Action.ADDING) {};
-
-        final Runnable flushCacheRunnable = new FlushCacheRunnable() {
-            public void run() {}
+        final Runnable reindexRunnable = new ReindexRunnable(Collections.emptyList(),
+                ReindexRunnable.Action.ADDING) {
         };
 
-        return new AddCommitListenerTestCase[] {
+        final Runnable flushCacheRunnable = new FlushCacheRunnable() {
+            public void run() {
+            }
+        };
+
+        return new AddCommitListenerTestCase[]{
                 new AddCommitListenerTestCase.Builder()
                         .asyncReindexCommitListeners(true)
                         .dotRunnable(reindexRunnable)
@@ -206,28 +220,32 @@ public class HibernateUtilTest {
 
     @Test
     @UseDataProvider("testCases")
-    public void testAddCommitListener(final AddCommitListenerTestCase testCase) throws DotHibernateException,
-            HibernateException, SQLException {
-        HibernateUtil.getSession().connection().setAutoCommit(false);
+    public void testAddCommitListener(final AddCommitListenerTestCase testCase)
+            throws DotHibernateException,
+            DotDataException, DotSecurityException {
 
-        final boolean originalAsyncReindexCommitListenersValue = Config.getBooleanProperty("ASYNC_REINDEX_COMMIT_LISTENERS", true);
-        final boolean originalAsyncCommitListenersValue = Config.getBooleanProperty("ASYNC_COMMIT_LISTENERS", true);
+        final boolean originalAsyncReindexCommitListenersValue = Config.getBooleanProperty(
+                "ASYNC_REINDEX_COMMIT_LISTENERS", true);
+        final boolean originalAsyncCommitListenersValue = Config.getBooleanProperty(
+                "ASYNC_COMMIT_LISTENERS", true);
 
-        Config.setProperty("ASYNC_REINDEX_COMMIT_LISTENERS", testCase.isAsyncReindexCommitListeners());
+        Config.setProperty("ASYNC_REINDEX_COMMIT_LISTENERS",
+                testCase.isAsyncReindexCommitListeners());
         Config.setProperty("ASYNC_COMMIT_LISTENERS", testCase.isAsyncCommitListeners());
 
         try {
+            LocalTransaction.wrap(() ->
+            {
+                HibernateUtil.addCommitListener(testCase.getDotRunnable());
 
-            HibernateUtil.addCommitListener(testCase.getDotRunnable());
-
-            final Map<String, Runnable> asyncCommitListeners = HibernateUtil.asyncCommitListeners.get();
-            final Map<String, Runnable> syncCommitListeners = HibernateUtil.syncCommitListeners.get();
-            assertEquals(testCase.getExpectedAsyncListeners(), asyncCommitListeners.size());
-            assertEquals(testCase.getExpectedSyncListeners(), syncCommitListeners.size());
-            HibernateUtil.getSession().connection().setAutoCommit(true);
-
+                final Map<String, Runnable> asyncCommitListeners = HibernateUtil.asyncCommitListeners.get();
+                final Map<String, Runnable> syncCommitListeners = HibernateUtil.syncCommitListeners.get();
+                assertEquals(testCase.getExpectedAsyncListeners(), asyncCommitListeners.size());
+                assertEquals(testCase.getExpectedSyncListeners(), syncCommitListeners.size());
+            });
         } finally {
-            Config.setProperty("ASYNC_REINDEX_COMMIT_LISTENERS", originalAsyncReindexCommitListenersValue);
+            Config.setProperty("ASYNC_REINDEX_COMMIT_LISTENERS",
+                    originalAsyncReindexCommitListenersValue);
             Config.setProperty("ASYNC_COMMIT_LISTENERS", originalAsyncCommitListenersValue);
         }
     }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -7,12 +7,11 @@ import static com.dotmarketing.business.APILocator.getContentTypeFieldAPI;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.VARIANT_ID;
 import static java.io.File.separator;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -150,6 +149,7 @@ import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.context.Context;
 import org.apache.velocity.context.InternalContextAdapterImpl;
 import org.apache.velocity.runtime.parser.node.SimpleNode;
+import org.awaitility.Awaitility;
 import org.elasticsearch.action.search.SearchResponse;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -159,27 +159,28 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
 /**
- * Created by Jonathan Gamba. 
- * Date: 3/20/12
- * Time: 12:12 PM
+ * Created by Jonathan Gamba. Date: 3/20/12 Time: 12:12 PM
  */
 
 @RunWith(DataProviderRunner.class)
 public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
-    public void testDotAsset_Checkin () throws DotDataException, DotSecurityException, IOException {
+    public void testDotAsset_Checkin() throws DotDataException, DotSecurityException, IOException {
 
         // 1) creates a dotasset for test
         final String variable = "testDotAsset" + System.currentTimeMillis();
         final ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(APILocator.systemUser());
-        ContentType dotAssetContentType     = contentTypeAPI
-                .save(ContentTypeBuilder.builder(DotAssetContentType.class).folder(FolderAPI.SYSTEM_FOLDER)
-                .host(Host.SYSTEM_HOST).name(variable)
-                .owner(user.getUserId()).build());
+        ContentType dotAssetContentType = contentTypeAPI
+                .save(ContentTypeBuilder.builder(DotAssetContentType.class)
+                        .folder(FolderAPI.SYSTEM_FOLDER)
+                        .host(Host.SYSTEM_HOST).name(variable)
+                        .owner(user.getUserId()).build());
         final Map<String, com.dotcms.contenttype.model.field.Field> fieldMap = dotAssetContentType.fieldMap();
-        com.dotcms.contenttype.model.field.Field binaryField           = fieldMap.get(DotAssetContentType.ASSET_FIELD_VAR);
-        final FieldVariable allowFileTypes = ImmutableFieldVariable.builder().key(BinaryField.ALLOWED_FILE_TYPES)
+        com.dotcms.contenttype.model.field.Field binaryField = fieldMap.get(
+                DotAssetContentType.ASSET_FIELD_VAR);
+        final FieldVariable allowFileTypes = ImmutableFieldVariable.builder()
+                .key(BinaryField.ALLOWED_FILE_TYPES)
                 .value("application/*, text/*").fieldId(binaryField.id()).build();
         binaryField.constructFieldVariables(Arrays.asList(allowFileTypes));
 
@@ -195,7 +196,8 @@ public class ContentletAPITest extends ContentletBaseTest {
         dotAssetContentlet.setLanguageId(languageAPI.getDefaultLanguage().getId());
         dotAssetContentlet.setModUser(user.getUserId());
         dotAssetContentlet.setHost(APILocator.systemHost().getIdentifier());
-        dotAssetContentlet.setStringProperty(Contentlet.BASE_TYPE_KEY, BaseContentType.DOTASSET.getAlternateName());
+        dotAssetContentlet.setStringProperty(Contentlet.BASE_TYPE_KEY,
+                BaseContentType.DOTASSET.getAlternateName());
         dotAssetContentlet.setBinary(binaryField, tempTestFile);
         dotAssetContentlet.setIndexPolicy(IndexPolicy.FORCE);
         dotAssetContentlet.setIndexPolicyDependencies(IndexPolicy.FORCE);
@@ -208,17 +210,20 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         final String contentletTitle = dotAssetContentlet.getTitle();
 
-        assertEquals("the contentlet title should be the binary field name", contentletTitle, tempTestFile.getName());
+        assertEquals("the contentlet title should be the binary field name", contentletTitle,
+                tempTestFile.getName());
 
         dotAssetContentlet.getMap().remove(Contentlet.TITTLE_KEY);
 
         final String contentletTitle2 = dotAssetContentlet.getTitle();
 
-        assertEquals("the contentlet title should be the binary field name", contentletTitle2, contentletTitle);
+        assertEquals("the contentlet title should be the binary field name", contentletTitle2,
+                contentletTitle);
     }
 
     @Test
-    public void testCheckinDefaultActionsSkipBySettingActionId () throws DotDataException, DotSecurityException {
+    public void testCheckinDefaultActionsSkipBySettingActionId()
+            throws DotDataException, DotSecurityException {
 
         final WorkflowAPI workflowAPI = APILocator.getWorkflowAPI();
         Contentlet contentletToDestroy = null;
@@ -227,14 +232,18 @@ public class ContentletAPITest extends ContentletBaseTest {
         try {
 
             //1) create a content type
-            final String velocityContentTypeName = "DefaultActionContentTypeSkip" + System.currentTimeMillis();
+            final String velocityContentTypeName =
+                    "DefaultActionContentTypeSkip" + System.currentTimeMillis();
             type = contentTypeAPI.save(
                     ContentTypeBuilder.builder(BaseContentType.CONTENT.immutableClass())
-                            .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER).host(Host.SYSTEM_HOST)
-                            .name("DefaultActionContentTypeSkip").owner(APILocator.systemUser().toString())
+                            .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER)
+                            .host(Host.SYSTEM_HOST)
+                            .name("DefaultActionContentTypeSkip")
+                            .owner(APILocator.systemUser().toString())
                             .variable(velocityContentTypeName).build());
 
-            final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(type.fields());
+            final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(
+                    type.fields());
 
             fields.add(FieldBuilder.builder(TextField.class).name("title").variable("title")
                     .contentTypeId(type.id()).dataType(DataTypes.TEXT).indexed(true).build());
@@ -244,13 +253,16 @@ public class ContentletAPITest extends ContentletBaseTest {
             final ContentType contentTypeSaved = contentTypeAPI.save(type, fields);
 
             final WorkflowScheme systemWorkflow = workflowAPI.findSystemWorkflowScheme();
-            workflowAPI.saveSchemeIdsForContentType(contentTypeSaved, CollectionsUtils.set(systemWorkflow.getId()));
-            final List<WorkflowScheme> contentTypeSchemes = workflowAPI.findSchemesForContentType(contentTypeSaved);
+            workflowAPI.saveSchemeIdsForContentType(contentTypeSaved,
+                    CollectionsUtils.set(systemWorkflow.getId()));
+            final List<WorkflowScheme> contentTypeSchemes = workflowAPI.findSchemesForContentType(
+                    contentTypeSaved);
             Assert.assertNotNull(contentTypeSchemes);
             Assert.assertEquals(1, contentTypeSchemes.size());
 
             //2) associated system workflow to the scheme
-            final WorkflowAction saveWorkflowAction = workflowAPI.findAction(SystemWorkflowConstants.WORKFLOW_SAVE_ACTION_ID, APILocator.systemUser());
+            final WorkflowAction saveWorkflowAction = workflowAPI.findAction(
+                    SystemWorkflowConstants.WORKFLOW_SAVE_ACTION_ID, APILocator.systemUser());
             Assert.assertNotNull(saveWorkflowAction);
             final SystemActionWorkflowActionMapping mapping = workflowAPI.mapSystemActionToWorkflowActionForContentType
                     (WorkflowAPI.SystemAction.NEW, saveWorkflowAction, contentTypeSaved);
@@ -279,7 +291,8 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             //4) check the contentlet is on the step unpublish
             final WorkflowStep unpublishStep = workflowAPI.findStepByContentlet(contentlet1);
-            Assert.assertEquals (SystemWorkflowConstants.WORKFLOW_PUBLISHED_STEP_ID, unpublishStep.getId());
+            Assert.assertEquals(SystemWorkflowConstants.WORKFLOW_PUBLISHED_STEP_ID,
+                    unpublishStep.getId());
         } finally {
 
             try {
@@ -305,7 +318,7 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     @Test
-    public void testCheckinDefaultActionsSkip () throws DotDataException, DotSecurityException {
+    public void testCheckinDefaultActionsSkip() throws DotDataException, DotSecurityException {
 
         final WorkflowAPI workflowAPI = APILocator.getWorkflowAPI();
         Contentlet contentletToDestroy = null;
@@ -314,14 +327,18 @@ public class ContentletAPITest extends ContentletBaseTest {
         try {
 
             //1) create a content type
-            final String velocityContentTypeName = "DefaultActionContentTypeSkip" + System.currentTimeMillis();
+            final String velocityContentTypeName =
+                    "DefaultActionContentTypeSkip" + System.currentTimeMillis();
             type = contentTypeAPI.save(
                     ContentTypeBuilder.builder(BaseContentType.CONTENT.immutableClass())
-                            .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER).host(Host.SYSTEM_HOST)
-                            .name("DefaultActionContentTypeSkip").owner(APILocator.systemUser().toString())
+                            .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER)
+                            .host(Host.SYSTEM_HOST)
+                            .name("DefaultActionContentTypeSkip")
+                            .owner(APILocator.systemUser().toString())
                             .variable(velocityContentTypeName).build());
 
-            final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(type.fields());
+            final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(
+                    type.fields());
 
             fields.add(FieldBuilder.builder(TextField.class).name("title").variable("title")
                     .contentTypeId(type.id()).dataType(DataTypes.TEXT).indexed(true).build());
@@ -331,13 +348,16 @@ public class ContentletAPITest extends ContentletBaseTest {
             final ContentType contentTypeSaved = contentTypeAPI.save(type, fields);
 
             final WorkflowScheme systemWorkflow = workflowAPI.findSystemWorkflowScheme();
-            workflowAPI.saveSchemeIdsForContentType(contentTypeSaved, CollectionsUtils.set(systemWorkflow.getId()));
-            final List<WorkflowScheme> contentTypeSchemes = workflowAPI.findSchemesForContentType(contentTypeSaved);
+            workflowAPI.saveSchemeIdsForContentType(contentTypeSaved,
+                    CollectionsUtils.set(systemWorkflow.getId()));
+            final List<WorkflowScheme> contentTypeSchemes = workflowAPI.findSchemesForContentType(
+                    contentTypeSaved);
             Assert.assertNotNull(contentTypeSchemes);
             Assert.assertEquals(1, contentTypeSchemes.size());
 
             //2) associated system workflow to the scheme
-            final WorkflowAction saveWorkflowAction = workflowAPI.findAction(SystemWorkflowConstants.WORKFLOW_SAVE_ACTION_ID, APILocator.systemUser());
+            final WorkflowAction saveWorkflowAction = workflowAPI.findAction(
+                    SystemWorkflowConstants.WORKFLOW_SAVE_ACTION_ID, APILocator.systemUser());
             Assert.assertNotNull(saveWorkflowAction);
             final SystemActionWorkflowActionMapping mapping = workflowAPI.mapSystemActionToWorkflowActionForContentType
                     (WorkflowAPI.SystemAction.NEW, saveWorkflowAction, contentTypeSaved);
@@ -366,7 +386,8 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             //4) check the contentlet is on the step unpublish
             final WorkflowStep unpublishStep = workflowAPI.findStepByContentlet(contentlet1);
-            Assert.assertEquals (SystemWorkflowConstants.WORKFLOW_NEW_STEP_ID, unpublishStep.getId());
+            Assert.assertEquals(SystemWorkflowConstants.WORKFLOW_NEW_STEP_ID,
+                    unpublishStep.getId());
         } finally {
 
             try {
@@ -392,7 +413,7 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     @Test
-    public void testCheckinDefaultActions () throws DotDataException, DotSecurityException {
+    public void testCheckinDefaultActions() throws DotDataException, DotSecurityException {
 
         final WorkflowAPI workflowAPI = APILocator.getWorkflowAPI();
         Contentlet contentletToDestroy = null;
@@ -404,11 +425,14 @@ public class ContentletAPITest extends ContentletBaseTest {
             final String velocityContentTypeName = "DefaultActionContentType";
             type = contentTypeAPI.save(
                     ContentTypeBuilder.builder(BaseContentType.CONTENT.immutableClass())
-                            .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER).host(Host.SYSTEM_HOST)
-                            .name("DefaultActionContentType").owner(APILocator.systemUser().toString())
+                            .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER)
+                            .host(Host.SYSTEM_HOST)
+                            .name("DefaultActionContentType")
+                            .owner(APILocator.systemUser().toString())
                             .variable(velocityContentTypeName).build());
 
-            final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(type.fields());
+            final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(
+                    type.fields());
 
             fields.add(FieldBuilder.builder(TextField.class).name("title").variable("title")
                     .contentTypeId(type.id()).dataType(DataTypes.TEXT).indexed(true).build());
@@ -418,13 +442,16 @@ public class ContentletAPITest extends ContentletBaseTest {
             final ContentType contentTypeSaved = contentTypeAPI.save(type, fields);
 
             final WorkflowScheme systemWorkflow = workflowAPI.findSystemWorkflowScheme();
-            workflowAPI.saveSchemeIdsForContentType(contentTypeSaved, CollectionsUtils.set(systemWorkflow.getId()));
-            final List<WorkflowScheme> contentTypeSchemes = workflowAPI.findSchemesForContentType(contentTypeSaved);
+            workflowAPI.saveSchemeIdsForContentType(contentTypeSaved,
+                    CollectionsUtils.set(systemWorkflow.getId()));
+            final List<WorkflowScheme> contentTypeSchemes = workflowAPI.findSchemesForContentType(
+                    contentTypeSaved);
             Assert.assertNotNull(contentTypeSchemes);
             Assert.assertEquals(1, contentTypeSchemes.size());
 
             //2) associated system workflow to the scheme
-            final WorkflowAction saveWorkflowAction = workflowAPI.findAction(SystemWorkflowConstants.WORKFLOW_SAVE_ACTION_ID, APILocator.systemUser());
+            final WorkflowAction saveWorkflowAction = workflowAPI.findAction(
+                    SystemWorkflowConstants.WORKFLOW_SAVE_ACTION_ID, APILocator.systemUser());
             Assert.assertNotNull(saveWorkflowAction);
             final SystemActionWorkflowActionMapping mapping = workflowAPI.mapSystemActionToWorkflowActionForContentType
                     (WorkflowAPI.SystemAction.NEW, saveWorkflowAction, contentTypeSaved);
@@ -452,7 +479,8 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             //4) check the contentlet is on the step unpublish
             final WorkflowStep unpublishStep = workflowAPI.findStepByContentlet(contentlet1);
-            Assert.assertEquals (SystemWorkflowConstants.WORKFLOW_UNPUBLISHED_STEP_ID, unpublishStep.getId());
+            Assert.assertEquals(SystemWorkflowConstants.WORKFLOW_UNPUBLISHED_STEP_ID,
+                    unpublishStep.getId());
         } finally {
 
             try {
@@ -471,14 +499,14 @@ public class ContentletAPITest extends ContentletBaseTest {
                         // quiet
                     }
                 }
-            }catch (Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }
     }
 
     @Test
-    public void testCheckinNoDefaultActions () throws DotDataException, DotSecurityException {
+    public void testCheckinNoDefaultActions() throws DotDataException, DotSecurityException {
 
         final WorkflowAPI workflowAPI = APILocator.getWorkflowAPI();
         Contentlet contentletToDestroy = null;
@@ -490,11 +518,14 @@ public class ContentletAPITest extends ContentletBaseTest {
             final String velocityContentTypeName = "NoDefaultActionContentType";
             type = contentTypeAPI.save(
                     ContentTypeBuilder.builder(BaseContentType.CONTENT.immutableClass())
-                            .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER).host(Host.SYSTEM_HOST)
-                            .name("NoDefaultActionContentType").owner(APILocator.systemUser().toString())
+                            .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER)
+                            .host(Host.SYSTEM_HOST)
+                            .name("NoDefaultActionContentType")
+                            .owner(APILocator.systemUser().toString())
                             .variable(velocityContentTypeName).build());
 
-            final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(type.fields());
+            final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(
+                    type.fields());
 
             fields.add(FieldBuilder.builder(TextField.class).name("title").variable("title")
                     .contentTypeId(type.id()).dataType(DataTypes.TEXT).indexed(true).build());
@@ -503,14 +534,18 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final ContentType contentTypeSaved = contentTypeAPI.save(type, fields);
 
-            final WorkflowScheme systemWorkflow = TestWorkflowUtils.getDocumentWorkflow("TestWF"+System.currentTimeMillis());
-            workflowAPI.saveSchemeIdsForContentType(contentTypeSaved, CollectionsUtils.set(systemWorkflow.getId()));
-            final List<WorkflowScheme> contentTypeSchemes = workflowAPI.findSchemesForContentType(contentTypeSaved);
+            final WorkflowScheme systemWorkflow = TestWorkflowUtils.getDocumentWorkflow(
+                    "TestWF" + System.currentTimeMillis());
+            workflowAPI.saveSchemeIdsForContentType(contentTypeSaved,
+                    CollectionsUtils.set(systemWorkflow.getId()));
+            final List<WorkflowScheme> contentTypeSchemes = workflowAPI.findSchemesForContentType(
+                    contentTypeSaved);
             Assert.assertNotNull(contentTypeSchemes);
             Assert.assertEquals(1, contentTypeSchemes.size());
 
             //2) associated system workflow to the scheme
-            final WorkflowAction saveWorkflowAction = workflowAPI.findAction(SystemWorkflowConstants.WORKFLOW_SAVE_ACTION_ID, APILocator.systemUser());
+            final WorkflowAction saveWorkflowAction = workflowAPI.findAction(
+                    SystemWorkflowConstants.WORKFLOW_SAVE_ACTION_ID, APILocator.systemUser());
             Assert.assertNotNull(saveWorkflowAction);
 
             //3) map the save content to the new
@@ -531,9 +566,9 @@ public class ContentletAPITest extends ContentletBaseTest {
             contentletToDestroy = contentlet1;
 
             //4) check the contentlet is on the step unpublish
-            final WorkflowStep firstStep  = workflowAPI.findFirstStep(systemWorkflow.getId()).get();
+            final WorkflowStep firstStep = workflowAPI.findFirstStep(systemWorkflow.getId()).get();
             final WorkflowStep currentStep = workflowAPI.findStepByContentlet(contentlet1);
-            Assert.assertEquals (firstStep.getId(), currentStep.getId());
+            Assert.assertEquals(firstStep.getId(), currentStep.getId());
         } finally {
 
             try {
@@ -552,7 +587,7 @@ public class ContentletAPITest extends ContentletBaseTest {
                         // quiet
                     }
                 }
-            }catch (Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }
@@ -562,32 +597,32 @@ public class ContentletAPITest extends ContentletBaseTest {
      * Testing {@link ContentletAPI#findAllContent(int, int)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
-    @Ignore ( "Not Ready to Run." )
+    @Ignore("Not Ready to Run.")
     @Test
-    public void findAllContent () throws DotDataException, DotSecurityException {
+    public void findAllContent() throws DotDataException, DotSecurityException {
 
         //Getting all contentlets live/working contentlets
-        List<Contentlet> contentlets = contentletAPI.findAllContent( 0, 5 );
+        List<Contentlet> contentlets = contentletAPI.findAllContent(0, 5);
 
         //Validations
-        assertTrue( contentlets != null && !contentlets.isEmpty() );
-        assertEquals( contentlets.size(), 5 );
+        assertTrue(contentlets != null && !contentlets.isEmpty());
+        assertEquals(contentlets.size(), 5);
 
         //Validate the integrity of the array
-        Contentlet contentlet = contentletAPI.find( contentlets.iterator().next().getInode(), user, false );
+        Contentlet contentlet = contentletAPI.find(contentlets.iterator().next().getInode(), user,
+                false);
 
         //Validations
-        assertTrue( contentlet != null && ( contentlet.getInode() != null && !contentlet.getInode().isEmpty() ) );
+        assertTrue(contentlet != null && (contentlet.getInode() != null && !contentlet.getInode()
+                .isEmpty()));
     }
 
     @Test
-    public void test_invalidate_shorty_cache () throws DotDataException, DotSecurityException {
+    public void test_invalidate_shorty_cache() throws DotDataException, DotSecurityException {
 
         Contentlet contentletToDestroy = null;
         ContentType type = null;
@@ -595,11 +630,13 @@ public class ContentletAPITest extends ContentletBaseTest {
             final String velocityContentTypeName = "InvalidateShortyCacheContentType";
             type = contentTypeAPI.save(
                     ContentTypeBuilder.builder(BaseContentType.CONTENT.immutableClass())
-                            .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER).host(Host.SYSTEM_HOST)
+                            .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER)
+                            .host(Host.SYSTEM_HOST)
                             .name("InvalidateShortyCache").owner(APILocator.systemUser().toString())
                             .variable(velocityContentTypeName).build());
 
-            final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(type.fields());
+            final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(
+                    type.fields());
 
             fields.add(FieldBuilder.builder(TextField.class).name("title").variable("title")
                     .contentTypeId(type.id()).dataType(DataTypes.TEXT).indexed(true).build());
@@ -627,7 +664,8 @@ public class ContentletAPITest extends ContentletBaseTest {
             final Optional<ShortyId> shortyId = shortyIdAPI.getShorty(contentlet1.getIdentifier());
             Assert.assertTrue(shortyId.isPresent());
             Assert.assertTrue(new ShortyIdCache().get(shortyId.get().shortId).isPresent());
-            final Contentlet contentletCheckout = contentletAPI.checkout(contentlet1.getInode(), user, false);
+            final Contentlet contentletCheckout = contentletAPI.checkout(contentlet1.getInode(),
+                    user, false);
             final String inode = contentletCheckout.getInode();
             this.contentletAPI.copyProperties(contentletCheckout, contentlet.getMap());
             contentletCheckout.setIdentifier(contentlet1.getIdentifier());
@@ -652,35 +690,39 @@ public class ContentletAPITest extends ContentletBaseTest {
                         // quiet
                     }
                 }
-            }catch (Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }
     }
 
-    @Ignore ( "Not Ready to Run." )
+    @Ignore("Not Ready to Run.")
     @Test
-    public void run_listener_after_save_result_called_all_listeners () throws DotDataException, DotSecurityException {
+    public void run_listener_after_save_result_called_all_listeners()
+            throws DotDataException, DotSecurityException {
 
         ContentType typeResult = null;
-        final int        numberOfContents    = 1000;//20000;
-        final CountDownLatch countDownLatch  = new CountDownLatch(numberOfContents);
-        DotSubmitter dotSubmitter = DotConcurrentFactory.getInstance().getSubmitter(DotConcurrentFactory.DOT_SYSTEM_THREAD_POOL);
+        final int numberOfContents = 1000;//20000;
+        final CountDownLatch countDownLatch = new CountDownLatch(numberOfContents);
+        DotSubmitter dotSubmitter = DotConcurrentFactory.getInstance()
+                .getSubmitter(DotConcurrentFactory.DOT_SYSTEM_THREAD_POOL);
         try {
 
-            final long       languageId          = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+            final long languageId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
             final String velocityContentTypeName = "RunListenerAfterSaveTest8";
-
 
             LocalTransaction.wrap(() -> {
 
                 final ContentType type = contentTypeAPI.save(
                         ContentTypeBuilder.builder(BaseContentType.CONTENT.immutableClass())
-                                .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER).host(Host.SYSTEM_HOST)
-                                .name("RunListenerAfterSaveTest").owner(APILocator.systemUser().toString())
+                                .expireDateVar(null).folder(FolderAPI.SYSTEM_FOLDER)
+                                .host(Host.SYSTEM_HOST)
+                                .name("RunListenerAfterSaveTest")
+                                .owner(APILocator.systemUser().toString())
                                 .variable(velocityContentTypeName).build());
 
-                final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(type.fields());
+                final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(
+                        type.fields());
 
                 fields.add(FieldBuilder.builder(TextField.class).name("title").variable("title")
                         .contentTypeId(type.id()).dataType(DataTypes.TEXT).indexed(true).build());
@@ -699,20 +741,23 @@ public class ContentletAPITest extends ContentletBaseTest {
 
                     try {
                         List<Contentlet> contentlets =
-                                APILocator.getContentletAPI().search("+type:" + velocityContentTypeName, 1000, 0, null, APILocator.systemUser(), false);
+                                APILocator.getContentletAPI()
+                                        .search("+type:" + velocityContentTypeName, 1000, 0, null,
+                                                APILocator.systemUser(), false);
                         if (UtilMethods.isSet(contentlets)) {
 
                             for (final Contentlet contentlet1 : contentlets) {
-                                APILocator.getContentletAPI().find(contentlet1.getInode(), APILocator.systemUser(), false);
+                                APILocator.getContentletAPI()
+                                        .find(contentlet1.getInode(), APILocator.systemUser(),
+                                                false);
                             }
                         }
-                    } catch (DotDataException  | DotSecurityException e) {
+                    } catch (DotDataException | DotSecurityException e) {
                         e.printStackTrace();
                     }
                 }));
 
                 LocalTransaction.wrapReturnWithListeners(() -> {
-
 
                     final Contentlet contentlet = new Contentlet();
                     final User user = APILocator.systemUser();
@@ -732,13 +777,17 @@ public class ContentletAPITest extends ContentletBaseTest {
                         HibernateUtil.addCommitListener(() -> {
 
                             try {
-                                assertTrue(APILocator.getContentletAPI().indexCount("+inode:" + contentlet1.getInode(), user, false) > 0);
+                                assertTrue(APILocator.getContentletAPI()
+                                        .indexCount("+inode:" + contentlet1.getInode(), user, false)
+                                        > 0);
                             } catch (DotDataException | DotSecurityException e) {
                                 fail(e.getMessage());
                             }
 
-                            if (APILocator.getContentletAPI().isInodeIndexed(contentlet1.getInode())) {
-                                ContentletSystemEventUtil.getInstance().pushSaveEvent(contentlet1, true);
+                            if (APILocator.getContentletAPI()
+                                    .isInodeIndexed(contentlet1.getInode())) {
+                                ContentletSystemEventUtil.getInstance()
+                                        .pushSaveEvent(contentlet1, true);
                             }
 
                             countDownLatch.countDown();
@@ -749,7 +798,7 @@ public class ContentletAPITest extends ContentletBaseTest {
                 });
             }
 
-            for (final Future future: futures) {
+            for (final Future future : futures) {
 
                 future.get();
                 countDownLatch.await(1, TimeUnit.SECONDS);
@@ -760,7 +809,7 @@ public class ContentletAPITest extends ContentletBaseTest {
                 countDownLatch.await(30, TimeUnit.SECONDS);
             }
 
-            assertEquals(0 , countDownLatch.getCount());
+            assertEquals(0, countDownLatch.getCount());
 
             typeResult = type;
         } catch (Exception e) {
@@ -770,7 +819,8 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             if (null != typeResult) {
 
-                ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(APILocator.systemUser());
+                ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(
+                        APILocator.systemUser());
                 contentTypeAPI.delete(typeResult);
             }
         }
@@ -782,55 +832,55 @@ public class ContentletAPITest extends ContentletBaseTest {
      * Testing {@link ContentletAPI#find(String, com.liferay.portal.model.User, boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void find () throws DotDataException, DotSecurityException {
+    public void find() throws DotDataException, DotSecurityException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Search the contentlet
-        Contentlet foundContentlet = contentletAPI.find( contentlet.getInode(), user, false );
+        Contentlet foundContentlet = contentletAPI.find(contentlet.getInode(), user, false);
 
         //Validations
-        assertNotNull( foundContentlet );
-        assertEquals( foundContentlet.getInode(), contentlet.getInode() );
+        assertNotNull(foundContentlet);
+        assertEquals(foundContentlet.getInode(), contentlet.getInode());
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User, boolean)}
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void test_findContentletByIdentifierOrFallback_non_existing_DotContentletStateException_expected () throws DotDataException, DotSecurityException {
+    public void test_findContentletByIdentifierOrFallback_non_existing_DotContentletStateException_expected()
+            throws DotDataException, DotSecurityException {
 
-
-        assertFalse(contentletAPI.findContentletByIdentifierOrFallback("noexisting", false, 1, user, false).isPresent());
+        assertFalse(contentletAPI.findContentletByIdentifierOrFallback("noexisting", false, 1, user,
+                false).isPresent());
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User, boolean)}
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test()
-    public void test_findContentletByIdentifierOrFallback_existing_DotContentletStateException_expected_true () throws DotDataException, DotSecurityException {
+    public void test_findContentletByIdentifierOrFallback_existing_DotContentletStateException_expected_true()
+            throws DotDataException, DotSecurityException {
 
         //Getting our test contentlet
         Contentlet contentletWidget = TestDataUtils
@@ -849,19 +899,20 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User, boolean)}
-     *
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
+     * <p>
      * English version, no Spanish, fallback true, request Spanish -> Return english
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test()
-    public void test_findContentletByIdentifierOrFallback_existing_English_version_no_Spanish_fallback_false_expecting_false () throws DotDataException, DotSecurityException {
+    public void test_findContentletByIdentifierOrFallback_existing_English_version_no_Spanish_fallback_false_expecting_false()
+            throws DotDataException, DotSecurityException {
 
         //Getting our test contentlet
         Contentlet genericContent = TestDataUtils.getGenericContentContent(true, 1);
@@ -876,19 +927,20 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User, boolean)}
-     *
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
+     * <p>
      * English version, with Spanish, fallback true, request Spanish -> Return Spanish
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test()
-    public void test_findContentletByIdentifierOrFallback_existing_EnglishSpanish_fallback_true_expecting_Spanish_true () throws DotDataException, DotSecurityException {
+    public void test_findContentletByIdentifierOrFallback_existing_EnglishSpanish_fallback_true_expecting_Spanish_true()
+            throws DotDataException, DotSecurityException {
 
         //Getting our test contentlet
         Contentlet contentletWidget = TestDataUtils.getPageContent(true, spanishLanguage.getId());
@@ -904,19 +956,20 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User, boolean)}
-     *
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
+     * <p>
      * English version, no Spanish, fallback false, request Spanish -> 404
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test()
-    public void test_findContentletByIdentifierOrFallback_existing_English_No_Spanish_fallback_false_expecting_False () throws DotDataException, DotSecurityException {
+    public void test_findContentletByIdentifierOrFallback_existing_English_No_Spanish_fallback_false_expecting_False()
+            throws DotDataException, DotSecurityException {
 
         //Getting our test contentlet
         Contentlet newsContentlet = TestDataUtils
@@ -934,19 +987,20 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User, boolean)}
-     *
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
+     * <p>
      * English version, with Spanish, fallback false, request Spanish -> Return Spanish
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test()
-    public void test_findContentletByIdentifierOrFallback_existing_EnglishSpanish_fallback_false_expecting_Spanish_true () throws DotDataException, DotSecurityException {
+    public void test_findContentletByIdentifierOrFallback_existing_EnglishSpanish_fallback_false_expecting_Spanish_true()
+            throws DotDataException, DotSecurityException {
 
         //Getting our test contentlet
         Contentlet newsContentlet = TestDataUtils
@@ -976,9 +1030,10 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long,
-     * User, boolean)}
-     *
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
+     * <p>
      * No English version, with Spanish, fallback true, request Spanish -> Return Spanish
      *
      * @see ContentletAPI
@@ -1002,19 +1057,20 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User, boolean)}
-     *
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
+     * <p>
      * No English version, with Spanish, fallback false, request Spanish -> Return Spanish
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test()
-    public void test_findContentletByIdentifierOrFallback_existing_NonEnglish_WithSpanish_fallback_false_expecting_Spanish_true () throws DotDataException, DotSecurityException, IOException {
+    public void test_findContentletByIdentifierOrFallback_existing_NonEnglish_WithSpanish_fallback_false_expecting_Spanish_true()
+            throws DotDataException, DotSecurityException, IOException {
 
         //Getting our test contentlet
         Contentlet spanishGenericContentContentlet = TestDataUtils.getGenericContentContent(true,
@@ -1031,19 +1087,21 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User, boolean)}
-     *
-     * English version LIVE, with Spanish WORKING, fallback true, request Spanish WORKING -> Return Spanish WORKING
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
+     * <p>
+     * English version LIVE, with Spanish WORKING, fallback true, request Spanish WORKING -> Return
+     * Spanish WORKING
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test()
-    public void test_findContentletByIdentifierOrFallback_existing_EnglishLive_WithSpanishWorking_fallback_true_expecting_SpanishWorking_true () throws DotDataException, DotSecurityException, IOException {
+    public void test_findContentletByIdentifierOrFallback_existing_EnglishLive_WithSpanishWorking_fallback_true_expecting_SpanishWorking_true()
+            throws DotDataException, DotSecurityException, IOException {
 
         //Getting our test contentlet
         Contentlet fileAssetContentletEngLive = TestDataUtils.getFileAssetContent(true,
@@ -1083,19 +1141,21 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User, boolean)}
-     *
-     * English version LIVE, with Spanish WORKING, fallback true, request Spanish LIVE -> Return English
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
+     * <p>
+     * English version LIVE, with Spanish WORKING, fallback true, request Spanish LIVE -> Return
+     * English
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test()
-    public void test_findContentletByIdentifierOrFallback_existing_EnglishLive_WithSpanishWorking_fallback_true_expecting_English_true () throws DotDataException, DotSecurityException, IOException {
+    public void test_findContentletByIdentifierOrFallback_existing_EnglishLive_WithSpanishWorking_fallback_true_expecting_English_true()
+            throws DotDataException, DotSecurityException, IOException {
 
         //Getting our test contentlet
         Contentlet fileAssetContentletEngLive = TestDataUtils.getFileAssetContent(true,
@@ -1136,19 +1196,20 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User, boolean)}
-     *
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifierOrFallback(String, boolean, long, User,
+     * boolean)}
+     * <p>
      * Only Spanish WORKING, fallback false, request English Working -> Return Empty
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test()
-    public void test_findContentletByIdentifierOrFallback_existing_OnlySpanishWorking_fallback_true_expecting_English_true () throws DotDataException, DotSecurityException, IOException {
+    public void test_findContentletByIdentifierOrFallback_existing_OnlySpanishWorking_fallback_true_expecting_English_true()
+            throws DotDataException, DotSecurityException, IOException {
 
         //Getting our test contentlet
         Contentlet newsContentletEng = TestDataUtils
@@ -1185,248 +1246,255 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletForLanguage(long, com.dotmarketing.beans.Identifier)}
+     * Testing
+     * {@link ContentletAPI#findContentletForLanguage(long, com.dotmarketing.beans.Identifier)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void findContentletForLanguage () throws DotDataException, DotSecurityException {
+    public void findContentletForLanguage() throws DotDataException, DotSecurityException {
 
         //Getting our test contentlet
         Contentlet contentletWithLanguage = null;
-        for ( Contentlet contentlet : contentlets ) {
+        for (Contentlet contentlet : contentlets) {
 
             //Verify if we have a contentlet with a language set
-            if ( contentlet.getLanguageId() != 0 ) {
+            if (contentlet.getLanguageId() != 0) {
                 contentletWithLanguage = contentlet;
                 break;
             }
         }
 
-        Identifier contentletIdentifier = APILocator.getIdentifierAPI().find( contentletWithLanguage );
+        Identifier contentletIdentifier = APILocator.getIdentifierAPI()
+                .find(contentletWithLanguage);
 
         //Search the contentlet
-        assertNotNull( contentletWithLanguage );
-        Contentlet foundContentlet = contentletAPI.findContentletForLanguage( contentletWithLanguage.getLanguageId(), contentletIdentifier );
+        assertNotNull(contentletWithLanguage);
+        Contentlet foundContentlet = contentletAPI.findContentletForLanguage(
+                contentletWithLanguage.getLanguageId(), contentletIdentifier);
 
         //Validations
-        assertNotNull( foundContentlet );
-        assertEquals( foundContentlet.getInode(), contentletWithLanguage.getInode() );
+        assertNotNull(foundContentlet);
+        assertEquals(foundContentlet.getInode(), contentletWithLanguage.getInode());
     }
 
     /**
-     * Testing {@link ContentletAPI#findByStructure(com.dotmarketing.portlets.structure.model.Structure, com.liferay.portal.model.User, boolean, int, int)}
+     * Testing
+     * {@link ContentletAPI#findByStructure(com.dotmarketing.portlets.structure.model.Structure,
+     * com.liferay.portal.model.User, boolean, int, int)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void findByStructure () throws DotSecurityException, DotDataException {
+    public void findByStructure() throws DotSecurityException, DotDataException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Search the contentlet
-        List<Contentlet> foundContentlets = contentletAPI.findByStructure( contentlet.getStructure(), user, false, 0, 0 );
+        List<Contentlet> foundContentlets = contentletAPI.findByStructure(contentlet.getStructure(),
+                user, false, 0, 0);
 
         //Validations
-        assertTrue( foundContentlets != null && !foundContentlets.isEmpty() );
+        assertTrue(foundContentlets != null && !foundContentlets.isEmpty());
     }
 
     /**
-     * Testing {@link ContentletAPI#findByStructure(String, com.liferay.portal.model.User, boolean, int, int)}
+     * Testing
+     * {@link ContentletAPI#findByStructure(String, com.liferay.portal.model.User, boolean, int,
+     * int)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void findByStructureInode () throws DotSecurityException, DotDataException {
+    public void findByStructureInode() throws DotSecurityException, DotDataException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Search the contentlets
-        List<Contentlet> foundContentlets = contentletAPI.findByStructure( contentlet.getStructureInode(), user, false, 0, 0 );
+        List<Contentlet> foundContentlets = contentletAPI.findByStructure(
+                contentlet.getStructureInode(), user, false, 0, 0);
 
         //Validations
-        assertTrue( foundContentlets != null && !foundContentlets.isEmpty() );
+        assertTrue(foundContentlets != null && !foundContentlets.isEmpty());
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletByIdentifier(String, boolean, long, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#findContentletByIdentifier(String, boolean, long,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void findContentletByIdentifier () throws DotSecurityException, DotDataException {
+    public void findContentletByIdentifier() throws DotSecurityException, DotDataException {
 
         //Getting our test contentlet
         Contentlet contentletWithLanguage = null;
-        for ( Contentlet contentlet : contentlets ) {
+        for (Contentlet contentlet : contentlets) {
 
             //Verify if we have a contentlet with a language set
-            if ( contentlet.getLanguageId() != 0 ) {
+            if (contentlet.getLanguageId() != 0) {
                 contentletWithLanguage = contentlet;
                 break;
             }
         }
 
         //Search the contentlet
-        assertNotNull( contentletWithLanguage );
-        Contentlet foundContentlet = contentletAPI.findContentletByIdentifier( contentletWithLanguage.getIdentifier(), false, contentletWithLanguage.getLanguageId(), user, false );
+        assertNotNull(contentletWithLanguage);
+        Contentlet foundContentlet = contentletAPI.findContentletByIdentifier(
+                contentletWithLanguage.getIdentifier(), false,
+                contentletWithLanguage.getLanguageId(), user, false);
 
         //Validations
-        assertNotNull( foundContentlet );
-        assertEquals( foundContentlet.getInode(), contentletWithLanguage.getInode() );
+        assertNotNull(foundContentlet);
+        assertEquals(foundContentlet.getInode(), contentletWithLanguage.getInode());
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletsByIdentifiers(String[], boolean, long, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#findContentletsByIdentifiers(String[], boolean, long,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void findContentletByIdentifiers () throws DotSecurityException, DotDataException {
+    public void findContentletByIdentifiers() throws DotSecurityException, DotDataException {
 
         //Getting our test contentlet
         Contentlet contentletWithLanguage = null;
-        for ( Contentlet contentlet : contentlets ) {
+        for (Contentlet contentlet : contentlets) {
 
             //Verify if we have a contentlet with a language set
-            if ( contentlet.getLanguageId() != 0 ) {
+            if (contentlet.getLanguageId() != 0) {
                 contentletWithLanguage = contentlet;
                 break;
             }
         }
 
         //Search the contentlet
-        assertNotNull( contentletWithLanguage );
-        List<Contentlet> foundContentlets = contentletAPI.findContentletsByIdentifiers( new String[]{ contentletWithLanguage.getIdentifier() }, false, contentletWithLanguage.getLanguageId(), user, false );
+        assertNotNull(contentletWithLanguage);
+        List<Contentlet> foundContentlets = contentletAPI.findContentletsByIdentifiers(
+                new String[]{contentletWithLanguage.getIdentifier()}, false,
+                contentletWithLanguage.getLanguageId(), user, false);
 
         //Validations
-        assertTrue( foundContentlets != null && !foundContentlets.isEmpty() );
+        assertTrue(foundContentlets != null && !foundContentlets.isEmpty());
     }
 
     /**
      * Testing {@link ContentletAPI#findContentlets(java.util.List)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void findContentlets () throws DotSecurityException, DotDataException {
+    public void findContentlets() throws DotSecurityException, DotDataException {
 
         //Getting our test inodes
         List<String> inodes = new ArrayList<>();
-        for ( Contentlet contentlet : contentlets ) {
-            inodes.add( contentlet.getInode() );
+        for (Contentlet contentlet : contentlets) {
+            inodes.add(contentlet.getInode());
         }
 
         //Search for the contentlets
-        List<Contentlet> foundContentlets = contentletAPI.findContentlets( inodes );
+        List<Contentlet> foundContentlets = contentletAPI.findContentlets(inodes);
 
         //Validations
-        assertTrue( foundContentlets != null && !foundContentlets.isEmpty() );
-        assertEquals( foundContentlets.size(), contentlets.size() );
+        assertTrue(foundContentlets != null && !foundContentlets.isEmpty());
+        assertEquals(foundContentlets.size(), contentlets.size());
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletsByFolder(com.dotmarketing.portlets.folders.model.Folder, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#findContentletsByFolder(com.dotmarketing.portlets.folders.model.Folder,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void findContentletsByFolder () throws DotDataException, DotSecurityException {
+    public void findContentletsByFolder() throws DotDataException, DotSecurityException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Getting the folder of the test contentlet
-        Folder folder = APILocator.getFolderAPI().find( contentlet.getFolder(), user, false );
+        Folder folder = APILocator.getFolderAPI().find(contentlet.getFolder(), user, false);
 
         //Search the contentlets
-        List<Contentlet> foundContentlets = contentletAPI.findContentletsByFolder( folder, user, false );
+        List<Contentlet> foundContentlets = contentletAPI.findContentletsByFolder(folder, user,
+                false);
 
         //Validations
-        assertTrue( foundContentlets != null && !foundContentlets.isEmpty() );
+        assertTrue(foundContentlets != null && !foundContentlets.isEmpty());
     }
 
     /**
-     * Testing {@link ContentletAPI#findContentletsByHost(com.dotmarketing.beans.Host, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#findContentletsByHost(com.dotmarketing.beans.Host,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void findContentletsByHost () throws DotDataException, DotSecurityException {
+    public void findContentletsByHost() throws DotDataException, DotSecurityException {
 
         //Search the contentlets
-        List<Contentlet> foundContentlets = contentletAPI.findContentletsByHost( defaultHost, user, false );
+        List<Contentlet> foundContentlets = contentletAPI.findContentletsByHost(defaultHost, user,
+                false);
 
         //Validations
-        assertTrue( foundContentlets != null && !foundContentlets.isEmpty() );
+        assertTrue(foundContentlets != null && !foundContentlets.isEmpty());
     }
 
     /**
-     * Testing {@link ContentletAPI#copyContentlet(com.dotmarketing.portlets.contentlet.model.Contentlet, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#copyContentlet(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void copyContentlet () throws DotSecurityException, DotDataException {
+    public void copyContentlet() throws DotSecurityException, DotDataException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Copy the test contentlet
-        Contentlet copyContentlet = contentletAPI.copyContentlet( contentlet, user, false );
+        Contentlet copyContentlet = contentletAPI.copyContentlet(contentlet, user, false);
 
         //validations
-        assertTrue( copyContentlet != null && !copyContentlet.getInode().isEmpty() );
+        assertTrue(copyContentlet != null && !copyContentlet.getInode().isEmpty());
         assertEquals(copyContentlet.getStructureInode(), contentlet.getStructureInode());
-        assertEquals( copyContentlet.getFolder(), contentlet.getFolder() );
-        assertEquals( copyContentlet.getHost(), contentlet.getHost() );
+        assertEquals(copyContentlet.getFolder(), contentlet.getFolder());
+        assertEquals(copyContentlet.getHost(), contentlet.getHost());
 
         try {
             contentletAPI.destroy(copyContentlet, user, false);
@@ -1436,237 +1504,256 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#copyContentlet(com.dotmarketing.portlets.contentlet.model.Contentlet, com.dotmarketing.portlets.folders.model.Folder, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#copyContentlet(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.dotmarketing.portlets.folders.model.Folder, com.liferay.portal.model.User, boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void copyContentletWithFolder () throws DotSecurityException, DotDataException {
+    public void copyContentletWithFolder() throws DotSecurityException, DotDataException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Getting the folder of the test contentlet
-        Folder folder = APILocator.getFolderAPI().find( contentlet.getFolder(), user, false );
+        Folder folder = APILocator.getFolderAPI().find(contentlet.getFolder(), user, false);
 
         //Copy the test contentlet
-        Contentlet copyContentlet = contentletAPI.copyContentlet( contentlet, folder, user, false );
+        Contentlet copyContentlet = contentletAPI.copyContentlet(contentlet, folder, user, false);
 
         //validations
-        assertTrue( copyContentlet != null && !copyContentlet.getInode().isEmpty() );
+        assertTrue(copyContentlet != null && !copyContentlet.getInode().isEmpty());
         assertEquals(copyContentlet.getStructureInode(), contentlet.getStructureInode());
-        assertEquals( copyContentlet.getFolder(), contentlet.getFolder() );
-        assertEquals( copyContentlet.get("junitTestWysiwyg"), contentlet.get("junitTestWysiwyg") );
+        assertEquals(copyContentlet.getFolder(), contentlet.getFolder());
+        assertEquals(copyContentlet.get("junitTestWysiwyg"), contentlet.get("junitTestWysiwyg"));
 
         contentletAPI.destroy(copyContentlet, user, false);
     }
 
     /**
-     * Testing {@link ContentletAPI#copyContentlet(com.dotmarketing.portlets.contentlet.model.Contentlet, com.dotmarketing.beans.Host, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#copyContentlet(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.dotmarketing.beans.Host, com.liferay.portal.model.User, boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void copyContentletWithHost () throws DotSecurityException, DotDataException {
+    public void copyContentletWithHost() throws DotSecurityException, DotDataException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Copy the test contentlet
-        Contentlet copyContentlet = contentletAPI.copyContentlet( contentlet, defaultHost, user, false );
+        Contentlet copyContentlet = contentletAPI.copyContentlet(contentlet, defaultHost, user,
+                false);
 
         //validations
-        assertTrue( copyContentlet != null && !copyContentlet.getInode().isEmpty() );
-        assertEquals( copyContentlet.getStructureInode(), contentlet.getStructureInode() );
-        assertEquals( copyContentlet.getFolder(), contentlet.getFolder() );
-        assertEquals( copyContentlet.get( "junitTestWysiwyg" ), contentlet.get( "junitTestWysiwyg" ) );
-        assertEquals( copyContentlet.getHost(), contentlet.getHost() );
+        assertTrue(copyContentlet != null && !copyContentlet.getInode().isEmpty());
+        assertEquals(copyContentlet.getStructureInode(), contentlet.getStructureInode());
+        assertEquals(copyContentlet.getFolder(), contentlet.getFolder());
+        assertEquals(copyContentlet.get("junitTestWysiwyg"), contentlet.get("junitTestWysiwyg"));
+        assertEquals(copyContentlet.getHost(), contentlet.getHost());
 
         try {
             contentletAPI.destroy(copyContentlet, user, false);
-        }catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-    
+
     /**
      * This tests that when a page is copied, we also include the personalized multitrees with it
      * See https://github.com/dotCMS/core/issues/16977
+     *
      * @throws Exception
      */
     @Test
-    public void TestCopyHTMLPageIncludesPersonalizedMultiTrees () throws Exception {
-      
-      final Template template = new TemplateDataGen().body("body").nextPersisted();
-      final Folder folder = new FolderDataGen().nextPersisted();
-      final HTMLPageAsset page = new HTMLPageDataGen(folder, template).nextPersisted();
-      final Structure structure = new StructureDataGen().nextPersisted();
-      final Container container = new ContainerDataGen().maxContentlets(1).withStructure(structure, "").nextPersisted();
-      final Contentlet content1 = new ContentletDataGen(structure.getInode()).nextPersisted();
-      final Contentlet content2 = new ContentletDataGen(structure.getInode()).nextPersisted();
+    public void TestCopyHTMLPageIncludesPersonalizedMultiTrees() throws Exception {
 
-      final Persona persona = new PersonaDataGen().keyTag(UUIDGenerator.shorty()).nextPersisted();
-      final String uniqueId = UUIDGenerator.shorty();
+        final Template template = new TemplateDataGen().body("body").nextPersisted();
+        final Folder folder = new FolderDataGen().nextPersisted();
+        final HTMLPageAsset page = new HTMLPageDataGen(folder, template).nextPersisted();
+        final Structure structure = new StructureDataGen().nextPersisted();
+        final Container container = new ContainerDataGen().maxContentlets(1)
+                .withStructure(structure, "").nextPersisted();
+        final Contentlet content1 = new ContentletDataGen(structure.getInode()).nextPersisted();
+        final Contentlet content2 = new ContentletDataGen(structure.getInode()).nextPersisted();
 
-      MultiTree multiTree = new MultiTree();
-      multiTree.setHtmlPage(page);
-      multiTree.setContainer(container);
-      multiTree.setContentlet(content1);
-      multiTree.setInstanceId(uniqueId);
-      multiTree.setPersonalization(MultiTree.DOT_PERSONALIZATION_DEFAULT);
-      multiTree.setTreeOrder(1);
-      APILocator.getMultiTreeAPI().saveMultiTree(multiTree);
+        final Persona persona = new PersonaDataGen().keyTag(UUIDGenerator.shorty()).nextPersisted();
+        final String uniqueId = UUIDGenerator.shorty();
 
-      multiTree = new MultiTree();
-      multiTree.setHtmlPage(page);
-      multiTree.setContainer(container);
-      multiTree.setContentlet(content2);
-      multiTree.setInstanceId(uniqueId);
-      multiTree.setPersonalization(persona.getKeyTag());
-      multiTree.setTreeOrder(1);
-      APILocator.getMultiTreeAPI().saveMultiTree(multiTree);
+        MultiTree multiTree = new MultiTree();
+        multiTree.setHtmlPage(page);
+        multiTree.setContainer(container);
+        multiTree.setContentlet(content1);
+        multiTree.setInstanceId(uniqueId);
+        multiTree.setPersonalization(MultiTree.DOT_PERSONALIZATION_DEFAULT);
+        multiTree.setTreeOrder(1);
+        APILocator.getMultiTreeAPI().saveMultiTree(multiTree);
 
-      Table<String, String, Set<PersonalizedContentlet>> pageContents = APILocator.getMultiTreeAPI().getPageMultiTrees(page, false);
+        multiTree = new MultiTree();
+        multiTree.setHtmlPage(page);
+        multiTree.setContainer(container);
+        multiTree.setContentlet(content2);
+        multiTree.setInstanceId(uniqueId);
+        multiTree.setPersonalization(persona.getKeyTag());
+        multiTree.setTreeOrder(1);
+        APILocator.getMultiTreeAPI().saveMultiTree(multiTree);
 
-      for (final String containerId : pageContents.rowKeySet()) {
-        assertEquals("containers match. Saved:" + container.getIdentifier() + ", got:" + containerId, containerId, container.getIdentifier());
+        Table<String, String, Set<PersonalizedContentlet>> pageContents = APILocator.getMultiTreeAPI()
+                .getPageMultiTrees(page, false);
 
-        for (final String uuid : pageContents.row(containerId).keySet()) {
-          assertEquals("containers uuids match. Saved:" + uniqueId + ", got:" + uuid, uniqueId, uuid);
-          Set<PersonalizedContentlet> personalizedContentletSet = pageContents.get(containerId, uniqueId);
+        for (final String containerId : pageContents.rowKeySet()) {
+            assertEquals(
+                    "containers match. Saved:" + container.getIdentifier() + ", got:" + containerId,
+                    containerId, container.getIdentifier());
 
-          assertTrue("container should have 2 personalized contents - got :" + personalizedContentletSet.size(),
-              personalizedContentletSet.size() == 2);
-          assertTrue("container should have contentlet for keyTag:" + MultiTree.DOT_PERSONALIZATION_DEFAULT, personalizedContentletSet
-              .contains(new PersonalizedContentlet(content1.getIdentifier(), MultiTree.DOT_PERSONALIZATION_DEFAULT)));
-          assertTrue("container should have contentlet for persona:" + persona.getKeyTag(),
-              personalizedContentletSet.contains(new PersonalizedContentlet(content2.getIdentifier(), persona.getKeyTag())));
+            for (final String uuid : pageContents.row(containerId).keySet()) {
+                assertEquals("containers uuids match. Saved:" + uniqueId + ", got:" + uuid,
+                        uniqueId, uuid);
+                Set<PersonalizedContentlet> personalizedContentletSet = pageContents.get(
+                        containerId, uniqueId);
+
+                assertTrue("container should have 2 personalized contents - got :"
+                                + personalizedContentletSet.size(),
+                        personalizedContentletSet.size() == 2);
+                assertTrue("container should have contentlet for keyTag:"
+                        + MultiTree.DOT_PERSONALIZATION_DEFAULT, personalizedContentletSet
+                        .contains(new PersonalizedContentlet(content1.getIdentifier(),
+                                MultiTree.DOT_PERSONALIZATION_DEFAULT)));
+                assertTrue("container should have contentlet for persona:" + persona.getKeyTag(),
+                        personalizedContentletSet.contains(
+                                new PersonalizedContentlet(content2.getIdentifier(),
+                                        persona.getKeyTag())));
+            }
+
         }
 
-      }
-      
-      HTMLPageAsset copyPage = APILocator.getHTMLPageAssetAPI().fromContentlet(APILocator.getContentletAPI().copyContentlet(page, user, false));
-      
-      
-      pageContents = APILocator.getMultiTreeAPI().getPageMultiTrees(copyPage, false);
-      for (final String containerId : pageContents.rowKeySet()) {
-        assertEquals("containers match. Saved:" + container.getIdentifier() + ", got:" + containerId, containerId, container.getIdentifier());
+        HTMLPageAsset copyPage = APILocator.getHTMLPageAssetAPI()
+                .fromContentlet(APILocator.getContentletAPI().copyContentlet(page, user, false));
 
-        for (final String uuid : pageContents.row(containerId).keySet()) {
-          assertEquals("containers uuids match. Saved:" + uniqueId + ", got:" + uuid, uniqueId, uuid);
-          Set<PersonalizedContentlet> personalizedContentletSet = pageContents.get(containerId, uniqueId);
+        pageContents = APILocator.getMultiTreeAPI().getPageMultiTrees(copyPage, false);
+        for (final String containerId : pageContents.rowKeySet()) {
+            assertEquals(
+                    "containers match. Saved:" + container.getIdentifier() + ", got:" + containerId,
+                    containerId, container.getIdentifier());
 
-          assertTrue("container should have 2 personalized contents - got :" + personalizedContentletSet.size(),
-              personalizedContentletSet.size() == 2);
-          assertTrue("container should have contentlet for keyTag:" + MultiTree.DOT_PERSONALIZATION_DEFAULT, personalizedContentletSet
-              .contains(new PersonalizedContentlet(content1.getIdentifier(), MultiTree.DOT_PERSONALIZATION_DEFAULT)));
-          assertTrue("container should have contentlet for persona:" + persona.getKeyTag(),
-              personalizedContentletSet.contains(new PersonalizedContentlet(content2.getIdentifier(), persona.getKeyTag())));
+            for (final String uuid : pageContents.row(containerId).keySet()) {
+                assertEquals("containers uuids match. Saved:" + uniqueId + ", got:" + uuid,
+                        uniqueId, uuid);
+                Set<PersonalizedContentlet> personalizedContentletSet = pageContents.get(
+                        containerId, uniqueId);
+
+                assertTrue("container should have 2 personalized contents - got :"
+                                + personalizedContentletSet.size(),
+                        personalizedContentletSet.size() == 2);
+                assertTrue("container should have contentlet for keyTag:"
+                        + MultiTree.DOT_PERSONALIZATION_DEFAULT, personalizedContentletSet
+                        .contains(new PersonalizedContentlet(content1.getIdentifier(),
+                                MultiTree.DOT_PERSONALIZATION_DEFAULT)));
+                assertTrue("container should have contentlet for persona:" + persona.getKeyTag(),
+                        personalizedContentletSet.contains(
+                                new PersonalizedContentlet(content2.getIdentifier(),
+                                        persona.getKeyTag())));
+            }
         }
-      }
-      
-      
+
+
     }
-    
+
     /**
-     * Testing {@link ContentletAPI#copyContentlet(com.dotmarketing.portlets.contentlet.model.Contentlet, com.dotmarketing.portlets.folders.model.Folder, com.liferay.portal.model.User, boolean, boolean)}
+     * Testing
+     * {@link ContentletAPI#copyContentlet(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.dotmarketing.portlets.folders.model.Folder, com.liferay.portal.model.User, boolean,
+     * boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void copyContentletWithFolderAppendCopy () throws DotSecurityException, DotDataException {
+    public void copyContentletWithFolderAppendCopy() throws DotSecurityException, DotDataException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Getting the folder of the test contentlet
-        Folder folder = APILocator.getFolderAPI().find( contentlet.getFolder(), user, false );
+        Folder folder = APILocator.getFolderAPI().find(contentlet.getFolder(), user, false);
 
         //Copy the test contentlet
-        Contentlet copyContentlet = contentletAPI.copyContentlet( contentlet, folder, user, true, false );
+        Contentlet copyContentlet = contentletAPI.copyContentlet(contentlet, folder, user, true,
+                false);
 
         //validations
-        assertTrue( copyContentlet != null && !copyContentlet.getInode().isEmpty() );
-        assertEquals( copyContentlet.getStructureInode(), contentlet.getStructureInode() );
-        assertEquals( copyContentlet.getFolder(), contentlet.getFolder() );
-        assertEquals( copyContentlet.get( "junitTestWysiwyg" ), contentlet.get( "junitTestWysiwyg" ) );
+        assertTrue(copyContentlet != null && !copyContentlet.getInode().isEmpty());
+        assertEquals(copyContentlet.getStructureInode(), contentlet.getStructureInode());
+        assertEquals(copyContentlet.getFolder(), contentlet.getFolder());
+        assertEquals(copyContentlet.get("junitTestWysiwyg"), contentlet.get("junitTestWysiwyg"));
 
         try {
             contentletAPI.destroy(copyContentlet, user, false);
-        }catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
-    
-    
-    
-    
-    
-    
-    
-    
-    
+
+
     @Test
     public void copyContentletWithSeveralVersionsOrderIssue() throws Exception {
-        long defLang=APILocator.getLanguageAPI().getDefaultLanguage().getId();
-        
-        Host host1=new Host();
-        host1.setHostname("copy.contentlet.t1."+System.currentTimeMillis());
+        long defLang = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+
+        Host host1 = new Host();
+        host1.setHostname("copy.contentlet.t1." + System.currentTimeMillis());
         host1.setDefault(false);
         host1.setLanguageId(defLang);
         host1.setIndexPolicy(IndexPolicy.FORCE);
         host1 = APILocator.getHostAPI().save(host1, user, false);
 
-        Host host2=new Host();
-        host2.setHostname("copy.contentlet.t2."+System.currentTimeMillis());
+        Host host2 = new Host();
+        host2.setHostname("copy.contentlet.t2." + System.currentTimeMillis());
         host2.setDefault(false);
         host2.setLanguageId(defLang);
         host2.setIndexPolicy(IndexPolicy.FORCE);
         host2 = APILocator.getHostAPI().save(host2, user, false);
 
-        
-        java.io.File bin=new java.io.File(APILocator.getFileAssetAPI().getRealAssetPathTmpBinary() + separator
-                + UUIDGenerator.generateUuid() + separator + "hello.txt");
+        java.io.File bin = new java.io.File(
+                APILocator.getFileAssetAPI().getRealAssetPathTmpBinary() + separator
+                        + UUIDGenerator.generateUuid() + separator + "hello.txt");
         bin.getParentFile().mkdirs();
-        
+
         bin.createNewFile();
         FileUtils.writeStringToFile(bin, "this is the content of the file");
-        
-        Contentlet file=new Contentlet();
+
+        Contentlet file = new Contentlet();
         file.setHost(host1.getIdentifier());
         file.setFolder("SYSTEM_FOLDER");
-        file.setStructureInode(CacheLocator.getContentTypeCache().getStructureByVelocityVarName("FileAsset").getInode());
+        file.setStructureInode(
+                CacheLocator.getContentTypeCache().getStructureByVelocityVarName("FileAsset")
+                        .getInode());
         file.setLanguageId(defLang);
-        file.setStringProperty(FileAssetAPI.TITLE_FIELD,"test copy");
+        file.setStringProperty(FileAssetAPI.TITLE_FIELD, "test copy");
         file.setStringProperty(FileAssetAPI.FILE_NAME_FIELD, "hello.txt");
         file.setBinary(FileAssetAPI.BINARY_FIELD, bin);
         file.setIndexPolicy(IndexPolicy.FORCE);
         file = contentletAPI.checkin(file, user, false);
         final String ident = file.getIdentifier();
-        
+
         // create 20 versions
-        for(int i=1; i<=20; i++) {
+        for (int i = 1; i <= 20; i++) {
             file = contentletAPI.findContentletByIdentifier(ident, false, defLang, user, false);
             file.setIndexPolicy(IndexPolicy.FORCE);
-            APILocator.getFileAssetAPI().renameFile(file, "hello"+i, user, false);
+            APILocator.getFileAssetAPI().renameFile(file, "hello" + i, user, false);
         }
-        
+
         file = contentletAPI.findContentletByIdentifier(ident, false, defLang, user, false);
 
         // the issue https://github.com/dotCMS/dotCMS/issues/5007 is caused by an order issue
@@ -1675,23 +1762,26 @@ public class ContentletAPITest extends ContentletBaseTest {
         // identifier and the data that will have the "working" (or live) version.
         Contentlet copy = contentletAPI.copyContentlet(file, host1, user, false);
         Identifier copyIdent = APILocator.getIdentifierAPI().find(copy);
-        
-        copy = contentletAPI.findContentletByIdentifier(copyIdent.getId(), false, defLang, user, false);
 
-        assertEquals("hello20_copy.txt",copyIdent.getAssetName());
-        assertEquals("hello20_copy.txt",copy.getStringProperty(FileAssetAPI.FILE_NAME_FIELD));
+        copy = contentletAPI.findContentletByIdentifier(copyIdent.getId(), false, defLang, user,
+                false);
+
+        assertEquals("hello20_copy.txt", copyIdent.getAssetName());
+        assertEquals("hello20_copy.txt", copy.getStringProperty(FileAssetAPI.FILE_NAME_FIELD));
         //FileAssetAPI.renameFile no longer renames the binary - so skipping assert
         //assertEquals("hello20_copy.txt",copy.getBinary(FileAssetAPI.BINARY_FIELD).getName());
-        assertEquals("this is the content of the file", FileUtils.readFileToString(copy.getBinary(FileAssetAPI.BINARY_FIELD)));
+        assertEquals("this is the content of the file",
+                FileUtils.readFileToString(copy.getBinary(FileAssetAPI.BINARY_FIELD)));
 
         Contentlet copy2 = contentletAPI.copyContentlet(file, host2, user, false);
         Identifier copyIdent2 = APILocator.getIdentifierAPI().find(copy2);
 
-        assertEquals("hello20.txt",copyIdent2.getAssetName());
-        assertEquals("hello20.txt",copy2.getStringProperty(FileAssetAPI.FILE_NAME_FIELD));
+        assertEquals("hello20.txt", copyIdent2.getAssetName());
+        assertEquals("hello20.txt", copy2.getStringProperty(FileAssetAPI.FILE_NAME_FIELD));
         //FileAssetAPI.renameFile no longer renames the binary - so skipping assert
         //assertEquals("hello20.txt",copy2.getBinary(FileAssetAPI.BINARY_FIELD).getName());
-        assertEquals("this is the content of the file", FileUtils.readFileToString(copy2.getBinary(FileAssetAPI.BINARY_FIELD)));
+        assertEquals("this is the content of the file",
+                FileUtils.readFileToString(copy2.getBinary(FileAssetAPI.BINARY_FIELD)));
 
         try {
             contentletAPI.destroy(file, user, false);
@@ -1705,85 +1795,93 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#search(String, int, int, String, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#search(String, int, int, String, com.liferay.portal.model.User,
+     * boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void search () throws DotSecurityException, DotDataException {
+    public void search() throws DotSecurityException, DotDataException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Create the lucene query
-        String luceneQuery = "+structureinode:" + contentlet.getStructureInode() + " +deleted:false";
+        String luceneQuery =
+                "+structureinode:" + contentlet.getStructureInode() + " +deleted:false";
 
         //Search the contentlets
-        List<Contentlet> foundContentlets = contentletAPI.search( luceneQuery, 1000, -1, "inode", user, false );
+        List<Contentlet> foundContentlets = contentletAPI.search(luceneQuery, 1000, -1, "inode",
+                user, false);
 
         //Validations
-        assertTrue( foundContentlets != null && !foundContentlets.isEmpty() );
+        assertTrue(foundContentlets != null && !foundContentlets.isEmpty());
     }
 
     /**
-     * Testing {@link ContentletAPI#search(String, int, int, String, com.liferay.portal.model.User, boolean, int)}
+     * Testing
+     * {@link ContentletAPI#search(String, int, int, String, com.liferay.portal.model.User, boolean,
+     * int)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void searchWithPermissions () throws DotSecurityException, DotDataException {
+    public void searchWithPermissions() throws DotSecurityException, DotDataException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Create the lucene query
-        String luceneQuery = "+structureinode:" + contentlet.getStructureInode() + " +deleted:false";
+        String luceneQuery =
+                "+structureinode:" + contentlet.getStructureInode() + " +deleted:false";
 
         //Search the contentlets
-        List<Contentlet> foundContentlets = contentletAPI.search( luceneQuery, 1000, -1, "inode", user, false, PermissionAPI.PERMISSION_READ );
+        List<Contentlet> foundContentlets = contentletAPI.search(luceneQuery, 1000, -1, "inode",
+                user, false, PermissionAPI.PERMISSION_READ);
 
         //Validations
-        assertTrue( foundContentlets != null && !foundContentlets.isEmpty() );
+        assertTrue(foundContentlets != null && !foundContentlets.isEmpty());
     }
 
     /**
-     * Testing {@link ContentletAPI#searchIndex(String, int, int, String, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#searchIndex(String, int, int, String, com.liferay.portal.model.User,
+     * boolean)}
      *
      * @throws com.dotmarketing.exception.DotDataException
-     *
      * @throws com.dotmarketing.exception.DotSecurityException
-     *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void searchIndex () throws DotDataException, DotSecurityException {
+    public void searchIndex() throws DotDataException, DotSecurityException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Create the lucene query
-        String luceneQuery = "+structureinode:" + contentlet.getStructureInode() + " +deleted:false";
+        String luceneQuery =
+                "+structureinode:" + contentlet.getStructureInode() + " +deleted:false";
 
         //Search the contentlets
-        List<ContentletSearch> foundContentlets = contentletAPI.searchIndex( luceneQuery, 1000, -1, "inode", user, false );
+        List<ContentletSearch> foundContentlets = contentletAPI.searchIndex(luceneQuery, 1000, -1,
+                "inode", user, false);
 
         //Validations
-        assertTrue( foundContentlets != null && !foundContentlets.isEmpty() );
+        assertTrue(foundContentlets != null && !foundContentlets.isEmpty());
     }
 
     /**
-     * Testing {@link ContentletAPI#publishRelatedHtmlPages(com.dotmarketing.portlets.contentlet.model.Contentlet)}
+     * Testing
+     * {@link
+     * ContentletAPI#publishRelatedHtmlPages(com.dotmarketing.portlets.contentlet.model.Contentlet)}
      *
      * @throws DotDataException
      * @throws DotSecurityException
@@ -1792,37 +1890,44 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void publishRelatedHtmlPages () throws DotDataException, DotSecurityException, DotCacheException {
+    public void publishRelatedHtmlPages()
+            throws DotDataException, DotSecurityException, DotCacheException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Making it live
-        APILocator.getVersionableAPI().setLive( contentlet );
+        APILocator.getVersionableAPI().setLive(contentlet);
 
         //Publish html pages for this contentlet
-        contentletAPI.publishRelatedHtmlPages( contentlet );
+        contentletAPI.publishRelatedHtmlPages(contentlet);
 
         //TODO: How to validate this???, good question, basically checking that the html page is not in cache basically the method publishRelatedHtmlPages(...) will just remove the htmlPage from cache
 
         //Get the contentlet Identifier to gather the related pages
-        Identifier identifier = APILocator.getIdentifierAPI().find( contentlet );
+        Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
         //Get the identifier's number of the related pages
-        List<MultiTree> multiTrees = APILocator.getMultiTreeAPI().getMultiTreesByChild( identifier.getId() );
-        for ( MultiTree multitree : multiTrees ) {
+        List<MultiTree> multiTrees = APILocator.getMultiTreeAPI()
+                .getMultiTreesByChild(identifier.getId());
+        for (MultiTree multitree : multiTrees) {
             //Get the Identifiers of the related pages
-            Identifier htmlPageIdentifier = APILocator.getIdentifierAPI().find( multitree.getParent1() );
+            Identifier htmlPageIdentifier = APILocator.getIdentifierAPI()
+                    .find(multitree.getParent1());
 
             //OK..., lets try to find this page in the cache...
-            HTMLPageAsset foundPage = ( HTMLPageAsset ) CacheLocator.getCacheAdministrator().get( "HTMLPageCache" + identifier, "HTMLPageCache" );
+            HTMLPageAsset foundPage = (HTMLPageAsset) CacheLocator.getCacheAdministrator()
+                    .get("HTMLPageCache" + identifier, "HTMLPageCache");
 
             //Validations
-            assertTrue( foundPage == null || ( foundPage.getInode() == null || foundPage.getInode().equals( "" ) ) );
+            assertTrue(foundPage == null || (foundPage.getInode() == null || foundPage.getInode()
+                    .equals("")));
         }
     }
 
     /**
-     * Testing {@link ContentletAPI#cleanField(com.dotmarketing.portlets.structure.model.Structure, com.dotmarketing.portlets.structure.model.Field, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#cleanField(com.dotmarketing.portlets.structure.model.Structure,
+     * com.dotmarketing.portlets.structure.model.Field, com.liferay.portal.model.User, boolean)}
      * with a binary field
      *
      * @throws DotDataException
@@ -1838,14 +1943,15 @@ public class ContentletAPITest extends ContentletBaseTest {
         Long identifier = uniqueIdentifier.get(structure.getName());
 
         //Search the contentlet for this structure
-        List<Contentlet> contentletList = contentletAPI.findByStructure(structure, user, false, 0, 0);
+        List<Contentlet> contentletList = contentletAPI.findByStructure(structure, user, false, 0,
+                0);
         Contentlet contentlet = contentletList.iterator().next();
 
         //Getting a known binary field for this structure
         //TODO: The definition of the method getFieldByName receive a parameter named "String:structureType", some examples I saw send the Inode, but actually what it needs is the structure name....
 
-        Field foundBinaryField = FieldFactory.getFieldByVariableName(structure.getInode(), "junitTestBinary" + identifier);
-
+        Field foundBinaryField = FieldFactory.getFieldByVariableName(structure.getInode(),
+                "junitTestBinary" + identifier);
 
         //Getting the current value for this field
         Object value = contentletAPI.getFieldValue(contentlet, foundBinaryField);
@@ -1861,7 +1967,9 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#cleanField(com.dotmarketing.portlets.structure.model.Structure, com.dotmarketing.portlets.structure.model.Field, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#cleanField(com.dotmarketing.portlets.structure.model.Structure,
+     * com.dotmarketing.portlets.structure.model.Field, com.liferay.portal.model.User, boolean)}
      * with a tag field
      *
      * @throws DotDataException
@@ -1878,34 +1986,39 @@ public class ContentletAPITest extends ContentletBaseTest {
         Long identifier = uniqueIdentifier.get(structure.getName());
 
         //Search the contentlet for this structure
-        List<Contentlet> contentletList = contentletAPI.findByStructure( structure, user, false, 0, 0 );
+        List<Contentlet> contentletList = contentletAPI.findByStructure(structure, user, false, 0,
+                0);
         Contentlet contentlet = contentletList.iterator().next();
 
         //Getting a known tag field for this structure
         //TODO: The definition of the method getFieldByName receive a parameter named "String:structureType", some examples I saw send the Inode, but actually what it needs is the structure name....
-        Field foundTagField = FieldFactory.getFieldByVariableName( structure.getInode(), "junitTestTag" + identifier );
+        Field foundTagField = FieldFactory.getFieldByVariableName(structure.getInode(),
+                "junitTestTag" + identifier);
 
         //Getting the current value for this field
-        List<Tag> value = tagAPI.getTagsByInodeAndFieldVarName(contentlet.getInode(), foundTagField.getVelocityVarName());
+        List<Tag> value = tagAPI.getTagsByInodeAndFieldVarName(contentlet.getInode(),
+                foundTagField.getVelocityVarName());
 
         //Validations
-        assertNotNull( value );
-        assertFalse( value.isEmpty() );
+        assertNotNull(value);
+        assertFalse(value.isEmpty());
 
         //Cleaning the tag field
-        contentletAPI.cleanField( structure, foundTagField, user, false );
+        contentletAPI.cleanField(structure, foundTagField, user, false);
 
         //Getting the current value for this field
-        List<Tag> value2 = tagAPI.getTagsByInodeAndFieldVarName(contentlet.getInode(), foundTagField.getVelocityVarName());
+        List<Tag> value2 = tagAPI.getTagsByInodeAndFieldVarName(contentlet.getInode(),
+                foundTagField.getVelocityVarName());
 
         //Validations
-        assertTrue( value2.isEmpty() );        
+        assertTrue(value2.isEmpty());
     }
 
     /**
      * Tests method {@link ContentletAPI#getContentletReferences(Contentlet, User, boolean)}.
      * <p>
-     * Checks that expected containers and pages (in the correct language) are returned by the method.
+     * Checks that expected containers and pages (in the correct language) are returned by the
+     * method.
      */
 
     @Test
@@ -1917,38 +2030,45 @@ public class ContentletAPITest extends ContentletBaseTest {
             HibernateUtil.startTransaction();
             final String UUID = UUIDGenerator.generateUuid();
             Structure structure = new StructureDataGen().nextPersisted();
-            Container container = new ContainerDataGen().withStructure(structure, "").nextPersisted();
-            Template template = new TemplateDataGen().withContainer(container.getIdentifier(),UUID).nextPersisted();
+            Container container = new ContainerDataGen().withStructure(structure, "")
+                    .nextPersisted();
+            Template template = new TemplateDataGen().withContainer(container.getIdentifier(), UUID)
+                    .nextPersisted();
             Folder folder = new FolderDataGen().nextPersisted();
 
             HTMLPageDataGen htmlPageDataGen = new HTMLPageDataGen(folder, template);
             HTMLPageAsset englishPage = htmlPageDataGen.languageId(english).nextPersisted();
-            HTMLPageAsset spanishPage = htmlPageDataGen.pageURL(englishPage.getPageUrl() + "SP").languageId(spanish)
-                .nextPersisted();
+            HTMLPageAsset spanishPage = htmlPageDataGen.pageURL(englishPage.getPageUrl() + "SP")
+                    .languageId(spanish)
+                    .nextPersisted();
 
             ContentletDataGen contentletDataGen = new ContentletDataGen(structure.getInode());
             Contentlet contentInEnglish = contentletDataGen.languageId(english).nextPersisted();
             Contentlet contentInSpanish = contentletDataGen.languageId(spanish).nextPersisted();
 
             // let's add the content to the page in english (create the page-container-content relationship)
-            MultiTree multiTreeEN = new MultiTree(englishPage.getIdentifier(), container.getIdentifier(),
-                contentInEnglish.getIdentifier(),UUID,0);
+            MultiTree multiTreeEN = new MultiTree(englishPage.getIdentifier(),
+                    container.getIdentifier(),
+                    contentInEnglish.getIdentifier(), UUID, 0);
             APILocator.getMultiTreeAPI().saveMultiTree(multiTreeEN);
 
             // let's add the content to the page in spanish (create the page-container-content relationship)
-            MultiTree multiTreeSP = new MultiTree(spanishPage.getIdentifier(), container.getIdentifier(),
-                contentInSpanish.getIdentifier(),UUID,0);
+            MultiTree multiTreeSP = new MultiTree(spanishPage.getIdentifier(),
+                    container.getIdentifier(),
+                    contentInSpanish.getIdentifier(), UUID, 0);
             APILocator.getMultiTreeAPI().saveMultiTree(multiTreeSP);
 
             // let's get the references for english content
-            List<Map<String, Object>> references = contentletAPI.getContentletReferences(contentInEnglish, user, false);
+            List<Map<String, Object>> references = contentletAPI.getContentletReferences(
+                    contentInEnglish, user, false);
 
             assertNotNull(references);
             assertTrue(!references.isEmpty());
             // let's check if the referenced page is in the expected language
             assertEquals(((IHTMLPage) references.get(0).get("page")).getLanguageId(), english);
             // let's check the referenced container is the expected
-            assertEquals(((Container) references.get(0).get("container")).getInode(), container.getInode());
+            assertEquals(((Container) references.get(0).get("container")).getInode(),
+                    container.getInode());
 
             // let's get the references for spanish content
             references = contentletAPI.getContentletReferences(contentInSpanish, user, false);
@@ -1958,7 +2078,8 @@ public class ContentletAPITest extends ContentletBaseTest {
             // let's check if the referenced page is in the expected language
             assertEquals(((IHTMLPage) references.get(0).get("page")).getLanguageId(), spanish);
             // let's check the referenced container is the expected
-            assertEquals(((Container) references.get(0).get("container")).getInode(), container.getInode());
+            assertEquals(((Container) references.get(0).get("container")).getInode(),
+                    container.getInode());
 
             ContentletDataGen.remove(contentInEnglish);
             ContentletDataGen.remove(contentInSpanish);
@@ -1977,9 +2098,10 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Method to test: {@link ContentletAPI#getContentletReferences(Contentlet, User, boolean)}
-     * Test case: Checks that the fallback page is returned by the method when there is no page for the source content in its language (Spanish)
-     * Expected result: The page in the fallback language (English) should be returned for the Spanish content
+     * Method to test: {@link ContentletAPI#getContentletReferences(Contentlet, User, boolean)} Test
+     * case: Checks that the fallback page is returned by the method when there is no page for the
+     * source content in its language (Spanish) Expected result: The page in the fallback language
+     * (English) should be returned for the Spanish content
      */
     @Test
     public void getContentletReferencesForMonolingualPages() throws Exception {
@@ -1990,8 +2112,10 @@ public class ContentletAPITest extends ContentletBaseTest {
             HibernateUtil.startTransaction();
             final String UUID = UUIDGenerator.generateUuid();
             Structure structure = new StructureDataGen().nextPersisted();
-            Container container = new ContainerDataGen().withStructure(structure, "").nextPersisted();
-            Template template = new TemplateDataGen().withContainer(container.getIdentifier(),UUID).nextPersisted();
+            Container container = new ContainerDataGen().withStructure(structure, "")
+                    .nextPersisted();
+            Template template = new TemplateDataGen().withContainer(container.getIdentifier(), UUID)
+                    .nextPersisted();
             Folder folder = new FolderDataGen().nextPersisted();
 
             HTMLPageDataGen htmlPageDataGen = new HTMLPageDataGen(folder, template);
@@ -2002,24 +2126,28 @@ public class ContentletAPITest extends ContentletBaseTest {
             Contentlet contentInSpanish = contentletDataGen.languageId(spanish).nextPersisted();
 
             // let's add the English content to the page in English (create the page-container-content relationship)
-            MultiTree multiTreeEN = new MultiTree(englishPage.getIdentifier(), container.getIdentifier(),
-                    contentInEnglish.getIdentifier(),UUID,0);
+            MultiTree multiTreeEN = new MultiTree(englishPage.getIdentifier(),
+                    container.getIdentifier(),
+                    contentInEnglish.getIdentifier(), UUID, 0);
             APILocator.getMultiTreeAPI().saveMultiTree(multiTreeEN);
 
             // let's add the Spanish content to the page in English (create the page-container-content relationship)
-            MultiTree multiTreeSP = new MultiTree(englishPage.getIdentifier(), container.getIdentifier(),
-                    contentInSpanish.getIdentifier(),UUID,0);
+            MultiTree multiTreeSP = new MultiTree(englishPage.getIdentifier(),
+                    container.getIdentifier(),
+                    contentInSpanish.getIdentifier(), UUID, 0);
             APILocator.getMultiTreeAPI().saveMultiTree(multiTreeSP);
 
             // let's get the references for english content
-            List<Map<String, Object>> references = contentletAPI.getContentletReferences(contentInEnglish, user, false);
+            List<Map<String, Object>> references = contentletAPI.getContentletReferences(
+                    contentInEnglish, user, false);
 
             assertNotNull(references);
             assertTrue(!references.isEmpty());
             // let's check if the referenced page is in the expected language
             assertEquals(((IHTMLPage) references.get(0).get("page")).getLanguageId(), english);
             // let's check the referenced container is the expected
-            assertEquals(((Container) references.get(0).get("container")).getInode(), container.getInode());
+            assertEquals(((Container) references.get(0).get("container")).getInode(),
+                    container.getInode());
 
             // let's get the references for spanish content
             references = contentletAPI.getContentletReferences(contentInSpanish, user, false);
@@ -2029,7 +2157,8 @@ public class ContentletAPITest extends ContentletBaseTest {
             // let's check if the referenced page is in the expected language
             assertEquals(english, ((IHTMLPage) references.get(0).get("page")).getLanguageId());
             // let's check the referenced container is the expected
-            assertEquals(container.getInode(),((Container) references.get(0).get("container")).getInode());
+            assertEquals(container.getInode(),
+                    ((Container) references.get(0).get("container")).getInode());
 
             ContentletDataGen.remove(contentInEnglish);
             ContentletDataGen.remove(contentInSpanish);
@@ -2047,9 +2176,9 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Method to test: {@link ContentletAPI#getContentletReferences(Contentlet, User, boolean)}
-     * Test case: References from pages in different language than the contentlet one
-     * Expected result: The multitree is excluded from the results
+     * Method to test: {@link ContentletAPI#getContentletReferences(Contentlet, User, boolean)} Test
+     * case: References from pages in different language than the contentlet one Expected result:
+     * The multitree is excluded from the results
      */
     @Test
     public void getContentletReferences_FilterOutReferencesByContentLang() throws Exception {
@@ -2059,7 +2188,8 @@ public class ContentletAPITest extends ContentletBaseTest {
         final String UUID = UUIDGenerator.generateUuid();
         Structure structure = new StructureDataGen().nextPersisted();
         Container container = new ContainerDataGen().withStructure(structure, "").nextPersisted();
-        Template template = new TemplateDataGen().withContainer(container.getIdentifier(),UUID).nextPersisted();
+        Template template = new TemplateDataGen().withContainer(container.getIdentifier(), UUID)
+                .nextPersisted();
         Folder folder = new FolderDataGen().nextPersisted();
 
         HTMLPageDataGen htmlPageDataGen = new HTMLPageDataGen(folder, template);
@@ -2069,9 +2199,10 @@ public class ContentletAPITest extends ContentletBaseTest {
         Contentlet contentInEnglish = contentletDataGen.languageId(english).nextPersisted();
         Contentlet contentInSpanish = contentletDataGen.languageId(spanish).nextPersisted();
 
-          // let's add the Spanish content to the page in Spanish (create the page-container-content relationship)
-        MultiTree multiTreeSP = new MultiTree(spanishPage.getIdentifier(), container.getIdentifier(),
-                contentInSpanish.getIdentifier(),UUID,0);
+        // let's add the Spanish content to the page in Spanish (create the page-container-content relationship)
+        MultiTree multiTreeSP = new MultiTree(spanishPage.getIdentifier(),
+                container.getIdentifier(),
+                contentInSpanish.getIdentifier(), UUID, 0);
         APILocator.getMultiTreeAPI().saveMultiTree(multiTreeSP);
 
         // let's get the references for english content
@@ -2083,9 +2214,9 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Method to test: {@link ContentletAPI#getContentletReferences(Contentlet, User, boolean)}
-     * Test case: References from pages in same language than the contentlet one
-     * Expected result: The multitree is present in the the results
+     * Method to test: {@link ContentletAPI#getContentletReferences(Contentlet, User, boolean)} Test
+     * case: References from pages in same language than the contentlet one Expected result: The
+     * multitree is present in the the results
      */
     @Test
     public void getContentletReferences_ReferencesByContentLang() throws Exception {
@@ -2095,7 +2226,8 @@ public class ContentletAPITest extends ContentletBaseTest {
         final String UUID = UUIDGenerator.generateUuid();
         Structure structure = new StructureDataGen().nextPersisted();
         Container container = new ContainerDataGen().withStructure(structure, "").nextPersisted();
-        Template template = new TemplateDataGen().withContainer(container.getIdentifier(),UUID).nextPersisted();
+        Template template = new TemplateDataGen().withContainer(container.getIdentifier(), UUID)
+                .nextPersisted();
         Folder folder = new FolderDataGen().nextPersisted();
 
         HTMLPageDataGen htmlPageDataGen = new HTMLPageDataGen(folder, template);
@@ -2106,8 +2238,9 @@ public class ContentletAPITest extends ContentletBaseTest {
         Contentlet contentInSpanish = contentletDataGen.languageId(spanish).nextPersisted();
 
         // let's add the Spanish content to the page in Spanish (create the page-container-content relationship)
-        MultiTree multiTreeSP = new MultiTree(spanishPage.getIdentifier(), container.getIdentifier(),
-                contentInSpanish.getIdentifier(),UUID,0);
+        MultiTree multiTreeSP = new MultiTree(spanishPage.getIdentifier(),
+                container.getIdentifier(),
+                contentInSpanish.getIdentifier(), UUID, 0);
         APILocator.getMultiTreeAPI().saveMultiTree(multiTreeSP);
 
         // let's get the references for spanish content
@@ -2116,14 +2249,15 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         assertNotNull(references);
         assertFalse(references.isEmpty());
-        assertTrue(references.stream().allMatch((ref)->((IHTMLPage)ref.get("page")).getIdentifier()
-                .equals(spanishPage.getIdentifier())));
+        assertTrue(
+                references.stream().allMatch((ref) -> ((IHTMLPage) ref.get("page")).getIdentifier()
+                        .equals(spanishPage.getIdentifier())));
     }
 
     /**
-     * Method to test: {@link ContentletAPI#getContentletReferences(Contentlet, User, boolean)}
-     * Test case: Reference from page for a certain Persona
-     * Expected result: The results include the Persona
+     * Method to test: {@link ContentletAPI#getContentletReferences(Contentlet, User, boolean)} Test
+     * case: Reference from page for a certain Persona Expected result: The results include the
+     * Persona
      */
     @Test
     public void getContentletReferences_PersonaIncluded() throws Exception {
@@ -2132,7 +2266,8 @@ public class ContentletAPITest extends ContentletBaseTest {
         final String UUID = UUIDGenerator.generateUuid();
         Structure structure = new StructureDataGen().nextPersisted();
         Container container = new ContainerDataGen().withStructure(structure, "").nextPersisted();
-        Template template = new TemplateDataGen().withContainer(container.getIdentifier(),UUID).nextPersisted();
+        Template template = new TemplateDataGen().withContainer(container.getIdentifier(), UUID)
+                .nextPersisted();
         Folder folder = new FolderDataGen().nextPersisted();
 
         HTMLPageDataGen htmlPageDataGen = new HTMLPageDataGen(folder, template);
@@ -2146,8 +2281,9 @@ public class ContentletAPITest extends ContentletBaseTest {
                 + persona.getKeyTag();
 
         // let's add the Spanish content to the page in Spanish (create the page-container-content relationship)
-        MultiTree multiTreeSP = new MultiTree(spanishPage.getIdentifier(), container.getIdentifier(),
-                contentInSpanish.getIdentifier(),UUID,0, personalization);
+        MultiTree multiTreeSP = new MultiTree(spanishPage.getIdentifier(),
+                container.getIdentifier(),
+                contentInSpanish.getIdentifier(), UUID, 0, personalization);
         APILocator.getMultiTreeAPI().saveMultiTree(multiTreeSP);
 
         // let's get the references for spanish content
@@ -2156,12 +2292,14 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         assertNotNull(references);
         assertFalse(references.isEmpty());
-        assertTrue(references.stream().allMatch((ref)-> ref.get("persona").
+        assertTrue(references.stream().allMatch((ref) -> ref.get("persona").
                 equals(persona.getName())));
     }
 
     /**
-     * Testing {@link ContentletAPI#getFieldValue(com.dotmarketing.portlets.contentlet.model.Contentlet, com.dotmarketing.portlets.structure.model.Field)}
+     * Testing
+     * {@link ContentletAPI#getFieldValue(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.dotmarketing.portlets.structure.model.Field)}
      *
      * @throws DotDataException
      * @throws DotSecurityException
@@ -2169,7 +2307,7 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void getFieldValue () throws DotSecurityException, DotDataException {
+    public void getFieldValue() throws DotSecurityException, DotDataException {
 
         //Getting a known structure
         Structure structure = structures.iterator().next();
@@ -2178,28 +2316,34 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         //Getting a know field for this structure
         //TODO: The definition of the method getFieldByName receive a parameter named "String:structureType", some examples I saw send the Inode, but actually what it needs is the structure name....
-        Field foundWysiwygField = FieldFactory.getFieldByVariableName( structure.getInode(), "junitTestWysiwyg" + identifier );
+        Field foundWysiwygField = FieldFactory.getFieldByVariableName(structure.getInode(),
+                "junitTestWysiwyg" + identifier);
 
         //Search the contentlets for this structure
-        List<Contentlet> contentletList = contentletAPI.findByStructure( structure, user, false, 0, 0 );
+        List<Contentlet> contentletList = contentletAPI.findByStructure(structure, user, false, 0,
+                0);
 
         //Getting the current value for this field
-        Object value = contentletAPI.getFieldValue( contentletList.iterator().next(), foundWysiwygField );
+        Object value = contentletAPI.getFieldValue(contentletList.iterator().next(),
+                foundWysiwygField);
 
         //Validations
-        assertNotNull( value );
-        assertTrue( !( ( String ) value ).isEmpty() );
+        assertNotNull(value);
+        assertTrue(!((String) value).isEmpty());
     }
 
     /**
-     * Testing {@link ContentletAPI#addLinkToContentlet(com.dotmarketing.portlets.contentlet.model.Contentlet, String, String, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link
+     * ContentletAPI#addLinkToContentlet(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * String, String, com.liferay.portal.model.User, boolean)}
      *
      * @throws Exception
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void addLinkToContentlet () throws Exception {
+    public void addLinkToContentlet() throws Exception {
 
         String RELATION_TYPE = new Link().getType();
 
@@ -2210,71 +2354,81 @@ public class ContentletAPITest extends ContentletBaseTest {
         Link menuLink = createMenuLink();
 
         //Search the contentlets for this structure
-        List<Contentlet> contentletList = contentletAPI.findByStructure( structure, user, false, 0, 0 );
+        List<Contentlet> contentletList = contentletAPI.findByStructure(structure, user, false, 0,
+                0);
         Contentlet contentlet = contentletList.iterator().next();
 
         //Add to this contentlet a link
-        contentletAPI.addLinkToContentlet( contentlet, menuLink.getInode(), RELATION_TYPE, user, false );
+        contentletAPI.addLinkToContentlet(contentlet, menuLink.getInode(), RELATION_TYPE, user,
+                false);
 
         //Verify if the link was associated
         //List<Link> relatedLinks = contentletAPI.getRelatedLinks( contentlet, user, false );//TODO: This method is not working but we are not testing it on this call....
 
         //Get the contentlet Identifier to gather the menu links
-        Identifier menuLinkIdentifier = APILocator.getIdentifierAPI().find( menuLink );
+        Identifier menuLinkIdentifier = APILocator.getIdentifierAPI().find(menuLink);
 
         //Verify if the relation was created
-        Tree tree = TreeFactory.getTree( contentlet.getInode(), menuLinkIdentifier.getId(), RELATION_TYPE );
+        Tree tree = TreeFactory.getTree(contentlet.getInode(), menuLinkIdentifier.getId(),
+                RELATION_TYPE);
 
         //Validations
-        assertNotNull( tree );
-        assertNotNull( tree.getParent() );
-        assertNotNull( tree.getChild() );
-        assertEquals( tree.getParent(), contentlet.getInode() );
-        assertEquals( tree.getChild(), menuLinkIdentifier.getId() );
-        assertEquals( tree.getRelationType(), RELATION_TYPE );
-        
-        try{
-        	HibernateUtil.startTransaction();
-            menuLinkAPI.delete( menuLink, user, false );
-        	HibernateUtil.closeAndCommitTransaction();
-        }catch(Exception e){
-        	HibernateUtil.rollbackTransaction();
-        	Logger.error(ContentletAPITest.class, e.getMessage());
+        assertNotNull(tree);
+        assertNotNull(tree.getParent());
+        assertNotNull(tree.getChild());
+        assertEquals(tree.getParent(), contentlet.getInode());
+        assertEquals(tree.getChild(), menuLinkIdentifier.getId());
+        assertEquals(tree.getRelationType(), RELATION_TYPE);
+
+        try {
+            HibernateUtil.startTransaction();
+            menuLinkAPI.delete(menuLink, user, false);
+            HibernateUtil.closeAndCommitTransaction();
+        } catch (Exception e) {
+            HibernateUtil.rollbackTransaction();
+            Logger.error(ContentletAPITest.class, e.getMessage());
         }
 
 
     }
 
     /**
-     * Testing {@link ContentletAPI#findPageContentlets(String, String, String, boolean, long, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#findPageContentlets(String, String, String, boolean, long,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @see ContentletAPI
      * @see Contentlet
      */
     @Test
-    public void findPageContentlets () throws DotDataException, DotSecurityException {
+    public void findPageContentlets() throws DotDataException, DotSecurityException {
 
         //Iterate throw the test contentles
-        for ( Contentlet contentlet : contentlets ) {
+        for (Contentlet contentlet : contentlets) {
 
             //Get the identifier for this contentlet
-            Identifier identifier = APILocator.getIdentifierAPI().find( contentlet );
+            Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
 
             //Search for related html pages and containers
-            List<MultiTree> multiTrees = APILocator.getMultiTreeAPI().getMultiTreesByChild( identifier.getId() );
-            if ( multiTrees != null && !multiTrees.isEmpty() ) {
+            List<MultiTree> multiTrees = APILocator.getMultiTreeAPI()
+                    .getMultiTreesByChild(identifier.getId());
+            if (multiTrees != null && !multiTrees.isEmpty()) {
 
-                for ( MultiTree multiTree : multiTrees ) {
+                for (MultiTree multiTree : multiTrees) {
 
                     //Getting the identifiers
-                    Identifier htmlPageIdentifier = APILocator.getIdentifierAPI().find( multiTree.getParent1() );
-                    Identifier containerPageIdentifier = APILocator.getIdentifierAPI().find( multiTree.getParent2() );
+                    Identifier htmlPageIdentifier = APILocator.getIdentifierAPI()
+                            .find(multiTree.getParent1());
+                    Identifier containerPageIdentifier = APILocator.getIdentifierAPI()
+                            .find(multiTree.getParent2());
 
                     //Find the related contentlets, at this point should return something....
-                    List<Contentlet> pageContentlets = contentletAPI.findPageContentlets( htmlPageIdentifier.getId(), containerPageIdentifier.getId(), null, true, -1, user, false );
+                    List<Contentlet> pageContentlets = contentletAPI.findPageContentlets(
+                            htmlPageIdentifier.getId(), containerPageIdentifier.getId(), null, true,
+                            -1, user, false);
 
                     //Validations
-                    assertTrue( pageContentlets != null && !pageContentlets.isEmpty() );
+                    assertTrue(pageContentlets != null && !pageContentlets.isEmpty());
                 }
 
                 break;
@@ -2283,139 +2437,180 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * This test is for ordering purposes.
-     * When you get the related content of a content, the ordering should be the same as it was stored.
+     * This test is for ordering purposes. When you get the related content of a content, the
+     * ordering should be the same as it was stored.
      */
     @Test
-    public void test_getAllRelationships_checkOrdering() throws DotSecurityException, DotDataException{
+    public void test_getAllRelationships_checkOrdering()
+            throws DotSecurityException, DotDataException {
         ContentType parentContentType = null;
         ContentType childContentType = null;
-        try{
-            parentContentType = createContentType("parentContentType",BaseContentType.CONTENT);
-            childContentType = createContentType("childContentType",BaseContentType.CONTENT);
+        try {
+            parentContentType = createContentType("parentContentType", BaseContentType.CONTENT);
+            childContentType = createContentType("childContentType", BaseContentType.CONTENT);
 
             //Create Relationship Field and Text Fields
-            createRelationshipField("testRelationship",parentContentType.id(),childContentType.variable());
+            createRelationshipField("testRelationship", parentContentType.id(),
+                    childContentType.variable());
             final String textFieldString = "title";
-            createTextField(textFieldString,parentContentType.id());
-            createTextField(textFieldString,childContentType.id());
+            createTextField(textFieldString, parentContentType.id());
+            createTextField(textFieldString, childContentType.id());
 
             //Create Contentlets
-            Contentlet contentletParent = new ContentletDataGen(parentContentType.id()).setProperty(textFieldString,"parent Contentlet").next();
-            final Contentlet contentletChild1 = new ContentletDataGen(childContentType.id()).setProperty(textFieldString,"child Contentlet").nextPersisted();
-            final Contentlet contentletChild2 = new ContentletDataGen(childContentType.id()).setProperty(textFieldString,"child Contentlet 2").nextPersisted();
-            final Contentlet contentletChild3 = new ContentletDataGen(childContentType.id()).setProperty(textFieldString,"child Contentlet 3").nextPersisted();
+            Contentlet contentletParent = new ContentletDataGen(parentContentType.id()).setProperty(
+                    textFieldString, "parent Contentlet").next();
+            final Contentlet contentletChild1 = new ContentletDataGen(
+                    childContentType.id()).setProperty(textFieldString, "child Contentlet")
+                    .nextPersisted();
+            final Contentlet contentletChild2 = new ContentletDataGen(
+                    childContentType.id()).setProperty(textFieldString, "child Contentlet 2")
+                    .nextPersisted();
+            final Contentlet contentletChild3 = new ContentletDataGen(
+                    childContentType.id()).setProperty(textFieldString, "child Contentlet 3")
+                    .nextPersisted();
 
             //Find Relationship
             final Relationship relationship = relationshipAPI.byParent(parentContentType).get(0);
 
             //Relate contentlets
             Map<Relationship, List<Contentlet>> relationshipListMap = Maps.newHashMap();
-            relationshipListMap.put(relationship,CollectionsUtils.list(contentletChild1,contentletChild2,contentletChild3));
+            relationshipListMap.put(relationship,
+                    CollectionsUtils.list(contentletChild1, contentletChild2, contentletChild3));
 
             //Checkin of the parent to save Relationships
-            contentletParent = contentletAPI.checkin(contentletParent,relationshipListMap,user,false);
+            contentletParent = contentletAPI.checkin(contentletParent, relationshipListMap, user,
+                    false);
 
             //Get All Relationships of the parent contentlet
-            ContentletRelationships cRelationships = contentletAPI.getAllRelationships(contentletParent);
+            ContentletRelationships cRelationships = contentletAPI.getAllRelationships(
+                    contentletParent);
 
             //Check that the content is related and the order of the related content (child1 - child2 - child3)
             assertNotNull(cRelationships);
-            assertEquals(contentletChild1,cRelationships.getRelationshipsRecords().get(0).getRecords().get(0));
-            assertEquals(contentletChild2,cRelationships.getRelationshipsRecords().get(0).getRecords().get(1));
-            assertEquals(contentletChild3,cRelationships.getRelationshipsRecords().get(0).getRecords().get(2));
+            assertEquals(contentletChild1,
+                    cRelationships.getRelationshipsRecords().get(0).getRecords().get(0));
+            assertEquals(contentletChild2,
+                    cRelationships.getRelationshipsRecords().get(0).getRecords().get(1));
+            assertEquals(contentletChild3,
+                    cRelationships.getRelationshipsRecords().get(0).getRecords().get(2));
 
             //Reorder Relationships
-            relationshipListMap.put(relationship,CollectionsUtils.list(contentletChild3,contentletChild1,contentletChild2));
+            relationshipListMap.put(relationship,
+                    CollectionsUtils.list(contentletChild3, contentletChild1, contentletChild2));
             contentletParent = contentletAPI.checkout(contentletParent.getInode(), user, false);
-            contentletParent = contentletAPI.checkin(contentletParent,relationshipListMap,user,false);
+            contentletParent = contentletAPI.checkin(contentletParent, relationshipListMap, user,
+                    false);
 
             //Get All Relationships of the parent contentlet
             cRelationships = contentletAPI.getAllRelationships(contentletParent);
 
             //Check that the content is related and the order of the related content (child3 - child1 - child2)
             assertNotNull(cRelationships);
-            assertEquals(contentletChild3,cRelationships.getRelationshipsRecords().get(0).getRecords().get(0));
-            assertEquals(contentletChild1,cRelationships.getRelationshipsRecords().get(0).getRecords().get(1));
-            assertEquals(contentletChild2,cRelationships.getRelationshipsRecords().get(0).getRecords().get(2));
-        }finally {
-            if(parentContentType != null){
+            assertEquals(contentletChild3,
+                    cRelationships.getRelationshipsRecords().get(0).getRecords().get(0));
+            assertEquals(contentletChild1,
+                    cRelationships.getRelationshipsRecords().get(0).getRecords().get(1));
+            assertEquals(contentletChild2,
+                    cRelationships.getRelationshipsRecords().get(0).getRecords().get(2));
+        } finally {
+            if (parentContentType != null) {
                 contentTypeAPI.delete(parentContentType);
             }
-            if(childContentType != null){
+            if (childContentType != null) {
                 contentTypeAPI.delete(childContentType);
             }
         }
     }
 
     /**
-     * This test is for ordering purposes.
-     * When you get the related content of a content, the ordering should be the same as it was stored.
-     * For selfRelated Content Types.
+     * This test is for ordering purposes. When you get the related content of a content, the
+     * ordering should be the same as it was stored. For selfRelated Content Types.
      */
     @Test
-    public void test_getAllRelationships_checkOrdering_selfRelatedContentType() throws DotSecurityException, DotDataException{
+    public void test_getAllRelationships_checkOrdering_selfRelatedContentType()
+            throws DotSecurityException, DotDataException {
         ContentType parentContentType = null;
-        try{
-            parentContentType = createContentType("parentContentType",BaseContentType.CONTENT);
+        try {
+            parentContentType = createContentType("parentContentType", BaseContentType.CONTENT);
 
             //Create Relationship Field and Text Fields
-            createRelationshipField("testRelationship",parentContentType.id(),parentContentType.variable());
+            createRelationshipField("testRelationship", parentContentType.id(),
+                    parentContentType.variable());
             final String textFieldString = "title";
-            createTextField(textFieldString,parentContentType.id());
+            createTextField(textFieldString, parentContentType.id());
 
             //Create Contentlets
-            Contentlet contentletParent = new ContentletDataGen(parentContentType.id()).setProperty(textFieldString,"parent Contentlet").next();
-            final Contentlet contentletChild1 = new ContentletDataGen(parentContentType.id()).setProperty(textFieldString,"child Contentlet").nextPersisted();
-            final Contentlet contentletChild2 = new ContentletDataGen(parentContentType.id()).setProperty(textFieldString,"child Contentlet 2").nextPersisted();
-            final Contentlet contentletChild3 = new ContentletDataGen(parentContentType.id()).setProperty(textFieldString,"child Contentlet 3").nextPersisted();
+            Contentlet contentletParent = new ContentletDataGen(parentContentType.id()).setProperty(
+                    textFieldString, "parent Contentlet").next();
+            final Contentlet contentletChild1 = new ContentletDataGen(
+                    parentContentType.id()).setProperty(textFieldString, "child Contentlet")
+                    .nextPersisted();
+            final Contentlet contentletChild2 = new ContentletDataGen(
+                    parentContentType.id()).setProperty(textFieldString, "child Contentlet 2")
+                    .nextPersisted();
+            final Contentlet contentletChild3 = new ContentletDataGen(
+                    parentContentType.id()).setProperty(textFieldString, "child Contentlet 3")
+                    .nextPersisted();
 
             //Find Relationship
             final Relationship relationship = relationshipAPI.byParent(parentContentType).get(0);
 
             //Relate contentlets
             Map<Relationship, List<Contentlet>> relationshipListMap = Maps.newHashMap();
-            relationshipListMap.put(relationship,CollectionsUtils.list(contentletChild1,contentletChild2,contentletChild3));
+            relationshipListMap.put(relationship,
+                    CollectionsUtils.list(contentletChild1, contentletChild2, contentletChild3));
 
             //Checkin of the parent to save Relationships
-            contentletParent = contentletAPI.checkin(contentletParent,relationshipListMap,user,false);
+            contentletParent = contentletAPI.checkin(contentletParent, relationshipListMap, user,
+                    false);
 
             //Get All Relationships of the parent contentlet
-            ContentletRelationships cRelationships = contentletAPI.getAllRelationships(contentletParent);
+            ContentletRelationships cRelationships = contentletAPI.getAllRelationships(
+                    contentletParent);
 
             //Check that the content is related and the order of the related content (child1 - child2 - child3)
             assertNotNull(cRelationships);
-            assertEquals(contentletChild1,cRelationships.getRelationshipsRecords().get(1).getRecords().get(0));
-            assertEquals(contentletChild2,cRelationships.getRelationshipsRecords().get(1).getRecords().get(1));
-            assertEquals(contentletChild3,cRelationships.getRelationshipsRecords().get(1).getRecords().get(2));
+            assertEquals(contentletChild1,
+                    cRelationships.getRelationshipsRecords().get(1).getRecords().get(0));
+            assertEquals(contentletChild2,
+                    cRelationships.getRelationshipsRecords().get(1).getRecords().get(1));
+            assertEquals(contentletChild3,
+                    cRelationships.getRelationshipsRecords().get(1).getRecords().get(2));
 
             //Reorder Relationships
-            relationshipListMap.put(relationship,CollectionsUtils.list(contentletChild3,contentletChild1,contentletChild2));
+            relationshipListMap.put(relationship,
+                    CollectionsUtils.list(contentletChild3, contentletChild1, contentletChild2));
             contentletParent = contentletAPI.checkout(contentletParent.getInode(), user, false);
-            contentletParent = contentletAPI.checkin(contentletParent,relationshipListMap,user,false);
+            contentletParent = contentletAPI.checkin(contentletParent, relationshipListMap, user,
+                    false);
 
             //Get All Relationships of the parent contentlet
             cRelationships = contentletAPI.getAllRelationships(contentletParent);
 
             //Check that the content is related and the order of the related content (child3 - child1 - child2)
             assertNotNull(cRelationships);
-            assertEquals(contentletChild3,cRelationships.getRelationshipsRecords().get(1).getRecords().get(0));
-            assertEquals(contentletChild1,cRelationships.getRelationshipsRecords().get(1).getRecords().get(1));
-            assertEquals(contentletChild2,cRelationships.getRelationshipsRecords().get(1).getRecords().get(2));
-        }finally {
-            if(parentContentType != null){
+            assertEquals(contentletChild3,
+                    cRelationships.getRelationshipsRecords().get(1).getRecords().get(0));
+            assertEquals(contentletChild1,
+                    cRelationships.getRelationshipsRecords().get(1).getRecords().get(1));
+            assertEquals(contentletChild2,
+                    cRelationships.getRelationshipsRecords().get(1).getRecords().get(2));
+        } finally {
+            if (parentContentType != null) {
                 contentTypeAPI.delete(parentContentType);
             }
         }
     }
 
-    private com.dotcms.contenttype.model.field.Field createRelationshipField(final String fieldName, final String parentContentTypeID, final String childContentTypeVariable)
+    private com.dotcms.contenttype.model.field.Field createRelationshipField(final String fieldName,
+            final String parentContentTypeID, final String childContentTypeVariable)
             throws DotDataException, DotSecurityException {
         final com.dotcms.contenttype.model.field.Field field = FieldBuilder.builder(
-                RelationshipField.class)
+                        RelationshipField.class)
                 .name(fieldName)
                 .contentTypeId(parentContentTypeID)
-                .values(String.valueOf(WebKeys.Relationship.RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal()))
+                .values(String.valueOf(
+                        WebKeys.Relationship.RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal()))
                 .indexed(true)
                 .listed(false)
                 .relationType(childContentTypeVariable)
@@ -2425,7 +2620,9 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#getAllRelationships(com.dotmarketing.portlets.contentlet.model.Contentlet)}
+     * Testing
+     * {@link
+     * ContentletAPI#getAllRelationships(com.dotmarketing.portlets.contentlet.model.Contentlet)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -2433,7 +2630,7 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void getAllRelationships () throws DotSecurityException, DotDataException {
+    public void getAllRelationships() throws DotSecurityException, DotDataException {
 
         Relationship testRelationship = null;
         try {
@@ -2452,7 +2649,7 @@ public class ContentletAPITest extends ContentletBaseTest {
             assertTrue(contentletRelationships.getRelationshipsRecords() != null
                     && !contentletRelationships.getRelationshipsRecords().isEmpty());
 
-        }finally{
+        } finally {
             if (testRelationship != null && testRelationship.getInode() != null) {
                 relationshipAPI.delete(testRelationship);
             }
@@ -2460,7 +2657,8 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     @Test
-    public void testCreateSelfJoinedRelationship_contentletAddedAsChild () throws DotDataException, DotSecurityException {
+    public void testCreateSelfJoinedRelationship_contentletAddedAsChild()
+            throws DotDataException, DotSecurityException {
 
         Contentlet parent = null;
         Contentlet child = null;
@@ -2533,7 +2731,9 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#getAllRelationships(com.dotmarketing.portlets.contentlet.model.Contentlet)}
+     * Testing
+     * {@link
+     * ContentletAPI#getAllRelationships(com.dotmarketing.portlets.contentlet.model.Contentlet)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -2541,9 +2741,9 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void getAllRelationshipsByContentlet () throws DotSecurityException, DotDataException {
+    public void getAllRelationshipsByContentlet() throws DotSecurityException, DotDataException {
 
-        Structure testStructure       = null;
+        Structure testStructure = null;
         Relationship testRelationship = null;
         try {
             //First lets create a test structure
@@ -2578,12 +2778,12 @@ public class ContentletAPITest extends ContentletBaseTest {
             assertNotNull(contentletRelationships);
             assertTrue(contentletRelationships.getRelationshipsRecords() != null
                     && !contentletRelationships.getRelationshipsRecords().isEmpty());
-        }finally{
+        } finally {
             if (testRelationship != null && testRelationship.getInode() != null) {
                 relationshipAPI.delete(testRelationship);
             }
 
-            if (testStructure != null && testStructure.getInode() != null){
+            if (testStructure != null && testStructure.getInode() != null) {
                 APILocator.getStructureAPI().delete(testStructure, user);
             }
         }
@@ -2591,7 +2791,9 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#getAllLanguages(com.dotmarketing.portlets.contentlet.model.Contentlet, Boolean, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#getAllLanguages(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * Boolean, com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -2599,46 +2801,55 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void getAllLanguages () throws DotSecurityException, DotDataException {
+    public void getAllLanguages() throws DotSecurityException, DotDataException {
 
-        Structure st=new Structure();
+        Structure st = new Structure();
         st.setStructureType(BaseContentType.CONTENT.getType());
-        st.setName("JUNIT-test-getAllLanguages"+System.currentTimeMillis());
-        st.setVelocityVarName("testAllLanguages"+System.currentTimeMillis());
+        st.setName("JUNIT-test-getAllLanguages" + System.currentTimeMillis());
+        st.setVelocityVarName("testAllLanguages" + System.currentTimeMillis());
         st.setHost(defaultHost.getIdentifier());
         StructureFactory.saveStructure(st);
 
-        Field ff=new Field("title",Field.FieldType.TEXT,Field.DataType.TEXT,st,true,true,true,1,false,false,true);
+        Field ff = new Field("title", Field.FieldType.TEXT, Field.DataType.TEXT, st, true, true,
+                true, 1, false, false, true);
         FieldFactory.saveField(ff);
 
-        String identifier=null;
-        List<Language> list=APILocator.getLanguageAPI().getLanguages();
-        Contentlet last=null;
-        for(Language ll : list) {
-            Contentlet con=new Contentlet();
+        String identifier = null;
+        List<Language> list = APILocator.getLanguageAPI().getLanguages();
+        Contentlet last = null;
+        for (Language ll : list) {
+            Contentlet con = new Contentlet();
             con.setStructureInode(st.getInode());
-            if(identifier!=null) con.setIdentifier(identifier);
-            con.setStringProperty(ff.getVelocityVarName(), "test text "+System.currentTimeMillis());
+            if (identifier != null) {
+                con.setIdentifier(identifier);
+            }
+            con.setStringProperty(ff.getVelocityVarName(),
+                    "test text " + System.currentTimeMillis());
             con.setLanguageId(ll.getId());
             con.setIndexPolicy(IndexPolicy.FORCE);
-            con=contentletAPI.checkin(con, user, false);
-            if(identifier==null) identifier=con.getIdentifier();
+            con = contentletAPI.checkin(con, user, false);
+            if (identifier == null) {
+                identifier = con.getIdentifier();
+            }
             APILocator.getVersionableAPI().setLive(con);
-            last=con;
+            last = con;
         }
 
         //Get all the contentles siblings for this contentlet (contentlet for all the languages)
-        List<Contentlet> forAllLanguages = contentletAPI.getAllLanguages( last, true, user, false );
+        List<Contentlet> forAllLanguages = contentletAPI.getAllLanguages(last, true, user, false);
 
         //Validations
-        assertNotNull( forAllLanguages );
-        assertTrue( !forAllLanguages.isEmpty() );
+        assertNotNull(forAllLanguages);
+        assertTrue(!forAllLanguages.isEmpty());
         assertEquals(list.size(), forAllLanguages.size());
 
     }
 
     /**
-     * Testing {@link ContentletAPI#isContentEqual(com.dotmarketing.portlets.contentlet.model.Contentlet, com.dotmarketing.portlets.contentlet.model.Contentlet, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#isContentEqual(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.dotmarketing.portlets.contentlet.model.Contentlet, com.liferay.portal.model.User,
+     * boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -2646,7 +2857,7 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void isContentEqual () throws DotDataException, DotSecurityException {
+    public void isContentEqual() throws DotDataException, DotSecurityException {
 
         Iterator<Contentlet> contentletIterator = contentlets.iterator();
 
@@ -2655,15 +2866,17 @@ public class ContentletAPITest extends ContentletBaseTest {
         Contentlet contentlet2 = contentletIterator.next();
 
         //Compare if the contentlets are equal
-        Boolean areEqual = contentletAPI.isContentEqual( contentlet1, contentlet2, user, false );
+        Boolean areEqual = contentletAPI.isContentEqual(contentlet1, contentlet2, user, false);
 
         //Validations
-        assertNotNull( areEqual );
-        assertFalse( areEqual );
+        assertNotNull(areEqual);
+        assertFalse(areEqual);
     }
 
     /**
-     * Testing {@link ContentletAPI#archive(com.dotmarketing.portlets.contentlet.model.Contentlet, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#archive(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -2671,28 +2884,29 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void archive () throws DotDataException, DotSecurityException {
+    public void archive() throws DotDataException, DotSecurityException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         try {
             //Archive this given contentlet (means it will be mark it as deleted)
-            contentletAPI.archive( contentlet, user, false );
+            contentletAPI.archive(contentlet, user, false);
 
             //Verify if it was deleted
-            Boolean isDeleted = APILocator.getVersionableAPI().isDeleted( contentlet );
+            Boolean isDeleted = APILocator.getVersionableAPI().isDeleted(contentlet);
 
             //Validations
-            assertNotNull( isDeleted );
-            assertTrue( isDeleted );
+            assertNotNull(isDeleted);
+            assertTrue(isDeleted);
         } finally {
-            contentletAPI.unarchive( contentlet, user, false );
+            contentletAPI.unarchive(contentlet, user, false);
         }
     }
 
     /**
      * https://github.com/dotCMS/core/issues/11716
+     *
      * @throws DotDataException
      * @throws DotSecurityException
      */
@@ -2706,7 +2920,6 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         //clean up old reindexed records
         new DotConnect().setSQL("delete from dist_reindex_journal").loadResult();
-
 
         final ContentType type = new ContentTypeDataGen().nextPersisted();
         List<Contentlet> origCons = new ArrayList<>();
@@ -2767,7 +2980,9 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Testing {@link ContentletAPI#delete(com.dotmarketing.portlets.contentlet.model.Contentlet, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#delete(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -2775,53 +2990,61 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void delete () throws Exception {
+    public void delete() throws Exception {
 
         //First lets create a test structure
-        Structure testStructure = createStructure( "JUnit Test Structure_" + String.valueOf( new Date().getTime() ), "junit_test_structure_" + String.valueOf( new Date().getTime() ) );
+        Structure testStructure = createStructure(
+                "JUnit Test Structure_" + String.valueOf(new Date().getTime()),
+                "junit_test_structure_" + String.valueOf(new Date().getTime()));
 
         //Now a new contentlet
-        Contentlet newContentlet = createContentlet( testStructure, null, false );
+        Contentlet newContentlet = createContentlet(testStructure, null, false);
 
         //Now we need to delete it
         contentletAPI.archive(newContentlet, user, false);
-        contentletAPI.delete( newContentlet, user, false );
+        contentletAPI.delete(newContentlet, user, false);
 
         //Try to find the deleted Contentlet
-        Contentlet foundContentlet = contentletAPI.find( newContentlet.getInode(), user, false );
+        Contentlet foundContentlet = contentletAPI.find(newContentlet.getInode(), user, false);
 
         //Validations
-        assertTrue( foundContentlet == null || foundContentlet.getInode() == null || foundContentlet.getInode().isEmpty() );
+        assertTrue(foundContentlet == null || foundContentlet.getInode() == null
+                || foundContentlet.getInode().isEmpty());
 
         // make sure the db is totally clean up
 
-        AssetUtil.assertDeleted(newContentlet.getInode(), newContentlet.getIdentifier(), "contentlet");
+        AssetUtil.assertDeleted(newContentlet.getInode(), newContentlet.getIdentifier(),
+                "contentlet");
 
         APILocator.getStructureAPI().delete(testStructure, user);
     }
 
     @Test
-    public void delete_GivenUnarchivedContentAndDontValidateMeInTrue_ShouldDeleteSuccessfully () throws Exception {
+    public void delete_GivenUnarchivedContentAndDontValidateMeInTrue_ShouldDeleteSuccessfully()
+            throws Exception {
         Structure testStructure = null;
         try {
-            testStructure = createStructure("JUnit Test Structure_" + String.valueOf(new Date().getTime()), "junit_test_structure_" + String.valueOf(new Date().getTime()));
+            testStructure = createStructure(
+                    "JUnit Test Structure_" + String.valueOf(new Date().getTime()),
+                    "junit_test_structure_" + String.valueOf(new Date().getTime()));
             final Contentlet newContentlet = createContentlet(testStructure, null, false);
             newContentlet.setStringProperty(Contentlet.DONT_VALIDATE_ME, "anarchy");
             contentletAPI.delete(newContentlet, user, false);
-            final Contentlet foundContentlet = contentletAPI.find(newContentlet.getInode(), user, false);
-            assertTrue( !UtilMethods.isSet(foundContentlet) || !UtilMethods.isSet(foundContentlet.getInode()) );
+            final Contentlet foundContentlet = contentletAPI.find(newContentlet.getInode(), user,
+                    false);
+            assertTrue(!UtilMethods.isSet(foundContentlet) || !UtilMethods.isSet(
+                    foundContentlet.getInode()));
 
-            AssetUtil.assertDeleted(newContentlet.getInode(), newContentlet.getIdentifier(), "contentlet");
+            AssetUtil.assertDeleted(newContentlet.getInode(), newContentlet.getIdentifier(),
+                    "contentlet");
         } finally {
             APILocator.getStructureAPI().delete(testStructure, user);
         }
     }
 
     /**
-     * Creates a content on english and spanish.
-     * Locked the english content by admin
-     * Tries to destroy spanish content
-     * Throws an exception
+     * Creates a content on english and spanish. Locked the english content by admin Tries to
+     * destroy spanish content Throws an exception
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -2829,18 +3052,22 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test(expected = DotLockException.class)
-    public void no_destroy_limited_content_locked_by_admin_by_limited_user () throws DotSecurityException, DotDataException {
+    public void no_destroy_limited_content_locked_by_admin_by_limited_user()
+            throws DotSecurityException, DotDataException {
 
-        final User     chrisPublisher  = TestUserUtils.getChrisPublisherUser();
-        final User     adminUser       = TestUserUtils.getAdminUser();
+        final User chrisPublisher = TestUserUtils.getChrisPublisherUser();
+        final User adminUser = TestUserUtils.getAdminUser();
         final LanguageCodeDataGen languageCodeDataGen = new LanguageCodeDataGen();
-        final String   languageCode1   = languageCodeDataGen.next();
-        final Language language1       = new LanguageDataGen().languageCode(languageCode1).countryCode("IT").nextPersisted();
-        final String   languageCode2   = languageCodeDataGen.next();
-        final Language language2       = new LanguageDataGen().languageCode(languageCode2).countryCode("IT").nextPersisted();
-        final Structure testStructure  = createStructure("JUnit Test Destroy Structure_" + new Date().getTime(),
+        final String languageCode1 = languageCodeDataGen.next();
+        final Language language1 = new LanguageDataGen().languageCode(languageCode1)
+                .countryCode("IT").nextPersisted();
+        final String languageCode2 = languageCodeDataGen.next();
+        final Language language2 = new LanguageDataGen().languageCode(languageCode2)
+                .countryCode("IT").nextPersisted();
+        final Structure testStructure = createStructure(
+                "JUnit Test Destroy Structure_" + new Date().getTime(),
                 "junit_test_destroy_structure_" + new Date().getTime());
-        Contentlet newContentlet1      = createContentlet(testStructure, language1, false);
+        Contentlet newContentlet1 = createContentlet(testStructure, language1, false);
 
         Contentlet anotherLanguage = contentletAPI.checkout(newContentlet1.getInode(), user, false);
         anotherLanguage.setLanguageId(language2.getId());
@@ -2866,14 +3093,12 @@ public class ContentletAPITest extends ContentletBaseTest {
         contentletAPI.lock(newContentlet1, adminUser, false);
 
         //  Tries to destroy by limited user
-        contentletAPI.destroy( anotherLanguage, chrisPublisher, false);
+        contentletAPI.destroy(anotherLanguage, chrisPublisher, false);
     }
 
     /**
-     * Creates a content on english and spanish.
-     * Locked the english content by admin
-     * Tries to destroy spanish content by admin
-     * Everything successfully destroyed
+     * Creates a content on english and spanish. Locked the english content by admin Tries to
+     * destroy spanish content by admin Everything successfully destroyed
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -2881,19 +3106,23 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test()
-    public void destroy_content_locked_by_admin_by_other_admin_user () throws DotSecurityException, DotDataException {
+    public void destroy_content_locked_by_admin_by_other_admin_user()
+            throws DotSecurityException, DotDataException {
 
-        final User     adminUser2      = TestUserUtils.getAdminUser();
-        final User     adminUser       = TestUserUtils.getAdminUser();
+        final User adminUser2 = TestUserUtils.getAdminUser();
+        final User adminUser = TestUserUtils.getAdminUser();
         final LanguageCodeDataGen languageCodeDataGen = new LanguageCodeDataGen();
-        final String   languageCode1   = languageCodeDataGen.next();
-        final Language language1       = new LanguageDataGen().languageCode(languageCode1).countryCode("IT").nextPersisted();
-        final String   languageCode2   = languageCodeDataGen.next();
-        final Language language2       = new LanguageDataGen().languageCode(languageCode2).countryCode("IT").nextPersisted();
-        final Structure testStructure  = createStructure("JUnit Test Destroy Structure_" + new Date().getTime(),
+        final String languageCode1 = languageCodeDataGen.next();
+        final Language language1 = new LanguageDataGen().languageCode(languageCode1)
+                .countryCode("IT").nextPersisted();
+        final String languageCode2 = languageCodeDataGen.next();
+        final Language language2 = new LanguageDataGen().languageCode(languageCode2)
+                .countryCode("IT").nextPersisted();
+        final Structure testStructure = createStructure(
+                "JUnit Test Destroy Structure_" + new Date().getTime(),
                 "junit_test_destroy_structure_" + new Date().getTime());
 
-        Contentlet newContentlet1      = createContentlet(testStructure, language1, false);
+        Contentlet newContentlet1 = createContentlet(testStructure, language1, false);
 
         Contentlet anotherLanguage = contentletAPI.checkout(newContentlet1.getInode(), user, false);
         anotherLanguage.setLanguageId(language2.getId());
@@ -2909,7 +3138,8 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         APILocator.getPermissionAPI().save(permission, newContentlet1, user, false);
 
-        final Identifier identifier = APILocator.getIdentifierAPI().find(newContentlet1.getIdentifier());
+        final Identifier identifier = APILocator.getIdentifierAPI()
+                .find(newContentlet1.getIdentifier());
         // new inode to create a new version
         final String newInode = UUIDGenerator.generateUuid();
         newContentlet1.setInode(newInode);
@@ -2920,16 +3150,18 @@ public class ContentletAPITest extends ContentletBaseTest {
         contentletAPI.lock(newContentlet1, adminUser, false);
 
         //  Tries to destroy by limited user
-        contentletAPI.destroy( anotherLanguage, adminUser2, false);
+        contentletAPI.destroy(anotherLanguage, adminUser2, false);
 
         final List<Contentlet> contentlets =
-                contentletAPI.findAllVersions(identifier, true, user , false);
+                contentletAPI.findAllVersions(identifier, true, user, false);
 
         assertFalse(UtilMethods.isSet(contentlets));
     }
 
     /**
-     * Testing {@link ContentletAPI#delete(com.dotmarketing.portlets.contentlet.model.Contentlet, com.liferay.portal.model.User, boolean, boolean)}
+     * Testing
+     * {@link ContentletAPI#delete(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.liferay.portal.model.User, boolean, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -2937,24 +3169,25 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void deleteForAllVersions () throws DotSecurityException, DotDataException {
+    public void deleteForAllVersions() throws DotSecurityException, DotDataException {
 
         Language language = APILocator.getLanguageAPI().getDefaultLanguage();
 
         //First lets create a test structure
-        Structure testStructure = createStructure( "JUnit Test Structure_" + String.valueOf( new Date().getTime() ), "junit_test_structure_" + String.valueOf( new Date().getTime() ) );
+        Structure testStructure = createStructure(
+                "JUnit Test Structure_" + String.valueOf(new Date().getTime()),
+                "junit_test_structure_" + String.valueOf(new Date().getTime()));
 
         //Now a new contentlet
-        Contentlet newContentlet = createContentlet( testStructure, language, false );
+        Contentlet newContentlet = createContentlet(testStructure, language, false);
 
         // new inode to create a new version
-        String newInode=UUIDGenerator.generateUuid();
+        String newInode = UUIDGenerator.generateUuid();
         newContentlet.setInode(newInode);
 
-
         List<Language> languages = APILocator.getLanguageAPI().getLanguages();
-        for ( Language localLanguage : languages ) {
-            if ( localLanguage.getId() != language.getId() ) {
+        for (Language localLanguage : languages) {
+            if (localLanguage.getId() != language.getId()) {
                 language = localLanguage;
                 break;
             }
@@ -2966,19 +3199,23 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         //Now we need to delete it
         contentletAPI.archive(newContentlet, user, false);
-        contentletAPI.delete( newContentlet, user, false, true );
+        contentletAPI.delete(newContentlet, user, false, true);
 
         //Try to find the deleted Contentlet
-        Identifier contentletIdentifier = APILocator.getIdentifierAPI().find( newContentlet.getIdentifier() );
-        List<Contentlet> foundContentlets = contentletAPI.findAllVersions(contentletIdentifier, user, false );
+        Identifier contentletIdentifier = APILocator.getIdentifierAPI()
+                .find(newContentlet.getIdentifier());
+        List<Contentlet> foundContentlets = contentletAPI.findAllVersions(contentletIdentifier,
+                user, false);
 
         //Validations
-        assertTrue( foundContentlets == null || foundContentlets.isEmpty() );
+        assertTrue(foundContentlets == null || foundContentlets.isEmpty());
         APILocator.getStructureAPI().delete(testStructure, user);
     }
 
     /**
-     * Testing {@link ContentletAPI#publish(com.dotmarketing.portlets.contentlet.model.Contentlet, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#publish(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -2986,24 +3223,25 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void publish () throws DotDataException, DotSecurityException {
+    public void publish() throws DotDataException, DotSecurityException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Publish the test contentlet
-        contentletAPI.publish( contentlet, user, false );
+        contentletAPI.publish(contentlet, user, false);
 
         //Verify if it was published
-        Boolean isLive = APILocator.getVersionableAPI().isLive( contentlet );
+        Boolean isLive = APILocator.getVersionableAPI().isLive(contentlet);
 
         //Validations
-        assertNotNull( isLive );
-        assertTrue( isLive );
+        assertNotNull(isLive);
+        assertTrue(isLive);
     }
 
     /**
-     * Testing {@link ContentletAPI#publish(java.util.List, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#publish(java.util.List, com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3011,24 +3249,26 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void publishCollection () throws DotDataException, DotSecurityException {
+    public void publishCollection() throws DotDataException, DotSecurityException {
 
         //Publish all the test contentlets
-        contentletAPI.publish( contentlets, user, false );
+        contentletAPI.publish(contentlets, user, false);
 
-        for ( Contentlet contentlet : contentlets ) {
+        for (Contentlet contentlet : contentlets) {
 
             //Verify if it was published
-            Boolean isLive = APILocator.getVersionableAPI().isLive( contentlet );
+            Boolean isLive = APILocator.getVersionableAPI().isLive(contentlet);
 
             //Validations
-            assertNotNull( isLive );
-            assertTrue( isLive );
+            assertNotNull(isLive);
+            assertTrue(isLive);
         }
     }
 
     /**
-     * Testing {@link ContentletAPI#unpublish(com.dotmarketing.portlets.contentlet.model.Contentlet, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#unpublish(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3036,38 +3276,39 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void unpublish () throws DotDataException, DotSecurityException {
+    public void unpublish() throws DotDataException, DotSecurityException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //Verify if it is published
-        Boolean isLive = APILocator.getVersionableAPI().isLive( contentlet );
-        if ( !isLive ) {
+        Boolean isLive = APILocator.getVersionableAPI().isLive(contentlet);
+        if (!isLive) {
             //Publish the test contentlet
-            contentletAPI.publish( contentlet, user, false );
+            contentletAPI.publish(contentlet, user, false);
 
             //Verify if it was published
-            isLive = APILocator.getVersionableAPI().isLive( contentlet );
+            isLive = APILocator.getVersionableAPI().isLive(contentlet);
 
             //Validations
-            assertNotNull( isLive );
-            assertTrue( isLive );
+            assertNotNull(isLive);
+            assertTrue(isLive);
         }
 
         //Unpublish the test contentlet
-        contentletAPI.unpublish( contentlet, user, false );
+        contentletAPI.unpublish(contentlet, user, false);
 
         //Verify if it was unpublished
-        isLive = APILocator.getVersionableAPI().isLive( contentlet );
+        isLive = APILocator.getVersionableAPI().isLive(contentlet);
 
         //Validations
-        assertNotNull( isLive );
-        assertFalse( isLive );
+        assertNotNull(isLive);
+        assertFalse(isLive);
     }
 
     /**
-     * Testing {@link ContentletAPI#unpublish(java.util.List, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#unpublish(java.util.List, com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3075,26 +3316,27 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void unpublishCollection () throws DotDataException, DotSecurityException {
+    public void unpublishCollection() throws DotDataException, DotSecurityException {
 
         contentletAPI.publish(contentlets, user, false);
 
         //Unpublish all the test contentlets
-        contentletAPI.unpublish( contentlets, user, false );
+        contentletAPI.unpublish(contentlets, user, false);
 
-        for ( Contentlet contentlet : contentlets ) {
+        for (Contentlet contentlet : contentlets) {
 
             //Verify if it was unpublished
-            Boolean isLive = APILocator.getVersionableAPI().isLive( contentlet );
+            Boolean isLive = APILocator.getVersionableAPI().isLive(contentlet);
 
             //Validations
-            assertNotNull( isLive );
-            assertFalse( isLive );
+            assertNotNull(isLive);
+            assertFalse(isLive);
         }
     }
 
     /**
-     * Testing {@link ContentletAPI#archive(java.util.List, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#archive(java.util.List, com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3102,28 +3344,29 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void archiveCollection () throws DotDataException, DotSecurityException {
+    public void archiveCollection() throws DotDataException, DotSecurityException {
 
         try {
             //Archive this given contentlet collection (means it will be mark them as deleted)
-            contentletAPI.archive( contentlets, user, false );
+            contentletAPI.archive(contentlets, user, false);
 
-            for ( Contentlet contentlet : contentlets ) {
+            for (Contentlet contentlet : contentlets) {
 
                 //Verify if it was deleted
-                Boolean isDeleted = APILocator.getVersionableAPI().isDeleted( contentlet );
+                Boolean isDeleted = APILocator.getVersionableAPI().isDeleted(contentlet);
 
                 //Validations
-                assertNotNull( isDeleted );
-                assertTrue( isDeleted );
+                assertNotNull(isDeleted);
+                assertTrue(isDeleted);
             }
         } finally {
-            contentletAPI.unarchive( contentlets, user, false );
+            contentletAPI.unarchive(contentlets, user, false);
         }
     }
 
     /**
-     * Testing {@link ContentletAPI#unarchive(java.util.List, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#unarchive(java.util.List, com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3131,27 +3374,29 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void unarchiveCollection () throws DotDataException, DotSecurityException {
+    public void unarchiveCollection() throws DotDataException, DotSecurityException {
 
         //First lets archive this given contentlet collection (means it will be mark them as deleted)
-        contentletAPI.archive( contentlets, user, false );
+        contentletAPI.archive(contentlets, user, false);
 
         //Now lets test the unarchive
-        contentletAPI.unarchive( contentlets, user, false );
+        contentletAPI.unarchive(contentlets, user, false);
 
-        for ( Contentlet contentlet : contentlets ) {
+        for (Contentlet contentlet : contentlets) {
 
             //Verify if it continues as deleted
-            Boolean isDeleted = APILocator.getVersionableAPI().isDeleted( contentlet );
+            Boolean isDeleted = APILocator.getVersionableAPI().isDeleted(contentlet);
 
             //Validations
-            assertNotNull( isDeleted );
-            assertFalse( isDeleted );
+            assertNotNull(isDeleted);
+            assertFalse(isDeleted);
         }
     }
 
     /**
-     * Testing {@link ContentletAPI#unarchive(com.dotmarketing.portlets.contentlet.model.Contentlet, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#unarchive(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3159,27 +3404,29 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void unarchive () throws DotDataException, DotSecurityException {
+    public void unarchive() throws DotDataException, DotSecurityException {
 
         //Getting a known contentlet
         Contentlet contentlet = contentlets.iterator().next();
 
         //First lets archive this given contentlet (means it will be mark it as deleted)
-        contentletAPI.archive( contentlet, user, false );
+        contentletAPI.archive(contentlet, user, false);
 
         //Now lets test the unarchive
-        contentletAPI.unarchive( contentlet, user, false );
+        contentletAPI.unarchive(contentlet, user, false);
 
         //Verify if it continues as deleted
-        Boolean isDeleted = APILocator.getVersionableAPI().isDeleted( contentlet );
+        Boolean isDeleted = APILocator.getVersionableAPI().isDeleted(contentlet);
 
         //Validations
-        assertNotNull( isDeleted );
-        assertFalse( isDeleted );
+        assertNotNull(isDeleted);
+        assertFalse(isDeleted);
     }
 
     /**
-     * Testing {@link ContentletAPI#deleteAllVersionsandBackup(java.util.List, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#deleteAllVersionsandBackup(java.util.List,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3187,26 +3434,30 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void deleteAllVersionsAndBackup () throws DotSecurityException, DotDataException {
+    public void deleteAllVersionsAndBackup() throws DotSecurityException, DotDataException {
 
         //First lets create a test structure
-        Structure testStructure = createStructure( "JUnit Test Structure_" + String.valueOf( new Date().getTime() ), "junit_test_structure_" + String.valueOf( new Date().getTime() ) );
+        Structure testStructure = createStructure(
+                "JUnit Test Structure_" + String.valueOf(new Date().getTime()),
+                "junit_test_structure_" + String.valueOf(new Date().getTime()));
 
         //Now a new contentlet
-        Contentlet newContentlet = createContentlet( testStructure, null, false );
-        Identifier contentletIdentifier = APILocator.getIdentifierAPI().find( newContentlet.getIdentifier() );
+        Contentlet newContentlet = createContentlet(testStructure, null, false);
+        Identifier contentletIdentifier = APILocator.getIdentifierAPI()
+                .find(newContentlet.getIdentifier());
 
         //Now test this delete
         List<Contentlet> testContentlets = new ArrayList<>();
-        testContentlets.add( newContentlet );
-        contentletAPI.deleteAllVersionsandBackup( testContentlets, user, false );
+        testContentlets.add(newContentlet);
+        contentletAPI.deleteAllVersionsandBackup(testContentlets, user, false);
 
         //Try to find the versions for this Contentlet (Must be only one version)
-        List<Contentlet> versions = contentletAPI.findAllVersions( contentletIdentifier, user, false );
+        List<Contentlet> versions = contentletAPI.findAllVersions(contentletIdentifier, user,
+                false);
 
         //Validations
-        assertNotNull( versions );
-        assertEquals( versions.size(), 1 );
+        assertNotNull(versions);
+        assertEquals(versions.size(), 1);
         APILocator.getStructureAPI().delete(testStructure, user);
     }
 
@@ -3219,30 +3470,35 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void deleteCollection () throws DotSecurityException, DotDataException {
+    public void deleteCollection() throws DotSecurityException, DotDataException {
 
         //First lets create a test structure
-        Structure testStructure = createStructure( "JUnit Test Structure_" + String.valueOf( new Date().getTime() ), "junit_test_structure_" + String.valueOf( new Date().getTime() ) );
+        Structure testStructure = createStructure(
+                "JUnit Test Structure_" + String.valueOf(new Date().getTime()),
+                "junit_test_structure_" + String.valueOf(new Date().getTime()));
 
         //Now a new contentlet
-        Contentlet newContentlet = createContentlet( testStructure, null, false );
+        Contentlet newContentlet = createContentlet(testStructure, null, false);
 
         //Now test this delete
         contentletAPI.archive(newContentlet, user, false);
         List<Contentlet> testContentlets = new ArrayList<>();
-        testContentlets.add( newContentlet );
-        contentletAPI.delete( testContentlets, user, false );
+        testContentlets.add(newContentlet);
+        contentletAPI.delete(testContentlets, user, false);
 
         //Try to find the deleted Contentlet
-        Contentlet foundContentlet = contentletAPI.find( newContentlet.getInode(), user, false );
+        Contentlet foundContentlet = contentletAPI.find(newContentlet.getInode(), user, false);
 
         //Validations
-        assertTrue( foundContentlet == null || foundContentlet.getInode() == null || foundContentlet.getInode().isEmpty() );
+        assertTrue(foundContentlet == null || foundContentlet.getInode() == null
+                || foundContentlet.getInode().isEmpty());
         APILocator.getStructureAPI().delete(testStructure, user);
     }
 
     /**
-     * Testing {@link ContentletAPI#delete(java.util.List, com.liferay.portal.model.User, boolean, boolean)}
+     * Testing
+     * {@link ContentletAPI#delete(java.util.List, com.liferay.portal.model.User, boolean,
+     * boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3250,26 +3506,28 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void deleteCollectionAllVersions () throws DotSecurityException, DotDataException {
+    public void deleteCollectionAllVersions() throws DotSecurityException, DotDataException {
 
         Language language = APILocator.getLanguageAPI().getDefaultLanguage();
 
         //First lets create a test structure
-        Structure testStructure = createStructure( "JUnit Test Structure_" + String.valueOf( new Date().getTime() ), "junit_test_structure_" + String.valueOf( new Date().getTime() ) );
+        Structure testStructure = createStructure(
+                "JUnit Test Structure_" + String.valueOf(new Date().getTime()),
+                "junit_test_structure_" + String.valueOf(new Date().getTime()));
 
         //Create a new contentlet with one version
-        Contentlet newContentlet1 = createContentlet( testStructure, language, false );
+        Contentlet newContentlet1 = createContentlet(testStructure, language, false);
 
         //Create a new contentlet with two versions
-        Contentlet newContentlet2 = createContentlet( testStructure, language, false );
+        Contentlet newContentlet2 = createContentlet(testStructure, language, false);
 
         // new inode to create the second version
-        String newInode=UUIDGenerator.generateUuid();
+        String newInode = UUIDGenerator.generateUuid();
         newContentlet2.setInode(newInode);
 
         List<Language> languages = APILocator.getLanguageAPI().getLanguages();
-        for ( Language localLanguage : languages ) {
-            if ( localLanguage.getId() != language.getId() ) {
+        for (Language localLanguage : languages) {
+            if (localLanguage.getId() != language.getId()) {
                 language = localLanguage;
                 break;
             }
@@ -3279,30 +3537,35 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         newContentlet2 = contentletAPI.checkin(newContentlet2, user, false);
 
-
         //Now test this delete
         List<Contentlet> testContentlets = new ArrayList<>();
-        testContentlets.add( newContentlet1 );
-        testContentlets.add( newContentlet2 );
-        contentletAPI.delete( testContentlets, user, false, true );
+        testContentlets.add(newContentlet1);
+        testContentlets.add(newContentlet2);
+        contentletAPI.delete(testContentlets, user, false, true);
 
         //Try to find the deleted Contentlets
-        Identifier contentletIdentifier = APILocator.getIdentifierAPI().find( newContentlet1.getIdentifier() );
-        List<Contentlet> foundContentlets = contentletAPI.findAllVersions(contentletIdentifier, user, false );
+        Identifier contentletIdentifier = APILocator.getIdentifierAPI()
+                .find(newContentlet1.getIdentifier());
+        List<Contentlet> foundContentlets = contentletAPI.findAllVersions(contentletIdentifier,
+                user, false);
 
         //Validations for newContentlet1
-        assertTrue( foundContentlets == null || foundContentlets.isEmpty() );
+        assertTrue(foundContentlets == null || foundContentlets.isEmpty());
 
-        contentletIdentifier = APILocator.getIdentifierAPI().find( newContentlet2.getIdentifier() );
-        foundContentlets = contentletAPI.findAllVersions(contentletIdentifier, user, false );
+        contentletIdentifier = APILocator.getIdentifierAPI().find(newContentlet2.getIdentifier());
+        foundContentlets = contentletAPI.findAllVersions(contentletIdentifier, user, false);
 
         //Validations for newContentlet2
-        assertTrue( foundContentlets == null || foundContentlets.isEmpty() );
+        assertTrue(foundContentlets == null || foundContentlets.isEmpty());
         APILocator.getStructureAPI().delete(testStructure, user);
     }
 
     /**
-     * Testing {@link ContentletAPI#deleteRelatedContent(com.dotmarketing.portlets.contentlet.model.Contentlet, com.dotmarketing.portlets.structure.model.Relationship, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link
+     * ContentletAPI#deleteRelatedContent(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.dotmarketing.portlets.structure.model.Relationship, com.liferay.portal.model.User,
+     * boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3310,7 +3573,7 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void deleteRelatedContent () throws DotSecurityException, DotDataException {
+    public void deleteRelatedContent() throws DotSecurityException, DotDataException {
 
         Structure testStructure = null;
         Relationship testRelationship = null;
@@ -3318,8 +3581,8 @@ public class ContentletAPITest extends ContentletBaseTest {
         try {
             //First lets create a test structure
             testStructure =
-                createStructure("JUnit Test Structure_" + String.valueOf(new Date().getTime()),
-                    "junit_test_structure_" + String.valueOf(new Date().getTime()));
+                    createStructure("JUnit Test Structure_" + String.valueOf(new Date().getTime()),
+                            "junit_test_structure_" + String.valueOf(new Date().getTime()));
 
             //Now a new test contentlets
             Contentlet baseContentlet = createContentlet(testStructure, null, false);
@@ -3327,49 +3590,58 @@ public class ContentletAPITest extends ContentletBaseTest {
             Contentlet contentToRelateAsParent = createContentlet(testStructure, null, false);
 
             //Create the relationship
-            testRelationship = createRelationShip(testStructure.getInode(), testStructure.getInode(),
-                false, 1);
+            testRelationship = createRelationShip(testStructure.getInode(),
+                    testStructure.getInode(),
+                    false, 1);
 
             //Relate content as child
             List<Contentlet> childrenList = new ArrayList<>();
             childrenList.add(contentToRelateAsChild);
-            ContentletRelationships childrenRelationships = createContentletRelationships(testRelationship,
-                baseContentlet, testStructure, childrenList, true);
+            ContentletRelationships childrenRelationships = createContentletRelationships(
+                    testRelationship,
+                    baseContentlet, testStructure, childrenList, true);
 
             //Relate content as parent
             List<Contentlet> parentList = new ArrayList<>();
             parentList.add(contentToRelateAsParent);
-            ContentletRelationships parentRelationshis = createContentletRelationships(testRelationship,
-                baseContentlet, testStructure, parentList, false);
+            ContentletRelationships parentRelationshis = createContentletRelationships(
+                    testRelationship,
+                    baseContentlet, testStructure, parentList, false);
 
             //Relate contents to our test contentlet
             for (final ContentletRelationships.ContentletRelationshipRecords contentletRelationshipRecords : childrenRelationships
-                .getRelationshipsRecords()) {
-                contentletAPI.relateContent(baseContentlet, contentletRelationshipRecords, user, false);
+                    .getRelationshipsRecords()) {
+                contentletAPI.relateContent(baseContentlet, contentletRelationshipRecords, user,
+                        false);
             }
 
             //Relate contents to our test contentlet
             for (ContentletRelationships.ContentletRelationshipRecords contentletRelationshipRecords : parentRelationshis
-                .getRelationshipsRecords()) {
-                contentletAPI.relateContent(baseContentlet, contentletRelationshipRecords, user, false);
+                    .getRelationshipsRecords()) {
+                contentletAPI.relateContent(baseContentlet, contentletRelationshipRecords, user,
+                        false);
             }
 
             // Let's delete only the children (1 child)
             contentletAPI.deleteRelatedContent(baseContentlet, testRelationship, true, user, false);
 
             // we should have only one content (1 parent) since we just deleted the one child
-            List<Contentlet> foundContentlets = relationshipAPI.dbRelatedContent(testRelationship, baseContentlet,
-                false);
+            List<Contentlet> foundContentlets = relationshipAPI.dbRelatedContent(testRelationship,
+                    baseContentlet,
+                    false);
             assertTrue(!foundContentlets.isEmpty() && foundContentlets.size() == 1);
 
             // Let's now delete the parent
-            contentletAPI.deleteRelatedContent(baseContentlet, testRelationship, false, user, false);
+            contentletAPI.deleteRelatedContent(baseContentlet, testRelationship, false, user,
+                    false);
 
             // we should get no content back for both hasParent `true` and `false` since the one child and one parent were deleted
-            foundContentlets = relationshipAPI.dbRelatedContent(testRelationship, baseContentlet, false);
+            foundContentlets = relationshipAPI.dbRelatedContent(testRelationship, baseContentlet,
+                    false);
             assertTrue(!UtilMethods.isSet(foundContentlets));
 
-            foundContentlets = relationshipAPI.dbRelatedContent(testRelationship, baseContentlet, true);
+            foundContentlets = relationshipAPI.dbRelatedContent(testRelationship, baseContentlet,
+                    true);
             assertTrue(!UtilMethods.isSet(foundContentlets));
         } finally {
             try {
@@ -3379,14 +3651,19 @@ public class ContentletAPITest extends ContentletBaseTest {
                 if (testStructure != null && testStructure != null) {
                     APILocator.getStructureAPI().delete(testStructure, user);
                 }
-            }catch (Exception e) {e.printStackTrace();}
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 
 
-
     /**
-     * Testing {@link ContentletAPI#deleteRelatedContent(com.dotmarketing.portlets.contentlet.model.Contentlet, com.dotmarketing.portlets.structure.model.Relationship, boolean, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link
+     * ContentletAPI#deleteRelatedContent(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.dotmarketing.portlets.structure.model.Relationship, boolean,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3394,9 +3671,9 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void deleteRelatedContentWithParent () throws DotSecurityException, DotDataException {
+    public void deleteRelatedContentWithParent() throws DotSecurityException, DotDataException {
 
-        Structure testStructure       = null;
+        Structure testStructure = null;
         Relationship testRelationship = null;
 
         try {
@@ -3438,19 +3715,22 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             //Validations
             assertTrue(foundContentlets == null || foundContentlets.isEmpty());
-        }finally{
+        } finally {
             if (testRelationship != null && testRelationship.getInode() != null) {
                 relationshipAPI.delete(testRelationship);
             }
 
-            if (testStructure != null && testStructure.getInode() != null){
+            if (testStructure != null && testStructure.getInode() != null) {
                 APILocator.getStructureAPI().delete(testStructure, user);
             }
         }
     }
 
     /**
-     * Testing {@link ContentletAPI#relateContent(Contentlet, ContentletRelationships.ContentletRelationshipRecords, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#relateContent(Contentlet,
+     * ContentletRelationships.ContentletRelationshipRecords, com.liferay.portal.model.User,
+     * boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3458,9 +3738,9 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void relateContent () throws DotSecurityException, DotDataException {
+    public void relateContent() throws DotSecurityException, DotDataException {
 
-        Structure testStructure       = null;
+        Structure testStructure = null;
         Relationship testRelationship = null;
         try {
             //First lets create a test structure
@@ -3502,19 +3782,22 @@ public class ContentletAPITest extends ContentletBaseTest {
             assertEquals(tree.getChild(), childContentlet.getIdentifier());
             assertEquals(tree.getRelationType(), testRelationship.getRelationTypeValue());
 
-        }finally {
-            if (testRelationship != null && testRelationship.getInode() != null){
+        } finally {
+            if (testRelationship != null && testRelationship.getInode() != null) {
                 relationshipAPI.delete(testRelationship);
             }
 
-            if (testStructure != null && testStructure.getInode() != null){
+            if (testStructure != null && testStructure.getInode() != null) {
                 APILocator.getStructureAPI().delete(testStructure, user);
             }
         }
     }
 
     /**
-     * Testing {@link ContentletAPI#relateContent(com.dotmarketing.portlets.contentlet.model.Contentlet, com.dotmarketing.portlets.structure.model.Relationship, java.util.List, com.liferay.portal.model.User, boolean)}
+     * Testing
+     * {@link ContentletAPI#relateContent(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * com.dotmarketing.portlets.structure.model.Relationship, java.util.List,
+     * com.liferay.portal.model.User, boolean)}
      *
      * @throws DotSecurityException
      * @throws DotDataException
@@ -3522,40 +3805,44 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void relateContentDirect () throws DotSecurityException, DotDataException {
+    public void relateContentDirect() throws DotSecurityException, DotDataException {
 
         Relationship testRelationship = null;
-        Structure testStructure       = null;
-        try{
+        Structure testStructure = null;
+        try {
             //First lets create a test structure
-            testStructure = createStructure( "JUnit Test Structure_" + String.valueOf( new Date().getTime() ), "junit_test_structure_" + String.valueOf( new Date().getTime() ) );
+            testStructure = createStructure(
+                    "JUnit Test Structure_" + String.valueOf(new Date().getTime()),
+                    "junit_test_structure_" + String.valueOf(new Date().getTime()));
 
             //Now a new test contentlets
-            Contentlet parentContentlet = createContentlet( testStructure, null, false );
-            Contentlet childContentlet = createContentlet( testStructure, null, false );
+            Contentlet parentContentlet = createContentlet(testStructure, null, false);
+            Contentlet childContentlet = createContentlet(testStructure, null, false);
 
             //Create the relationship
-            testRelationship = createRelationShip( testStructure, false );
+            testRelationship = createRelationShip(testStructure, false);
 
             //Create the contentlet relationships
             List<Contentlet> contentRelationships = new ArrayList<>();
-            contentRelationships.add( childContentlet );
+            contentRelationships.add(childContentlet);
 
             //Relate the content
-            contentletAPI.relateContent( parentContentlet, testRelationship, contentRelationships, user, false );
+            contentletAPI.relateContent(parentContentlet, testRelationship, contentRelationships,
+                    user, false);
 
             //Verify if the content was related
-            Tree tree = TreeFactory.getTree( parentContentlet.getIdentifier(), childContentlet.getIdentifier(), testRelationship.getRelationTypeValue() );
+            Tree tree = TreeFactory.getTree(parentContentlet.getIdentifier(),
+                    childContentlet.getIdentifier(), testRelationship.getRelationTypeValue());
 
             //Validations
-            assertNotNull( tree );
-            assertNotNull( tree.getParent() );
-            assertNotNull( tree.getChild() );
-            assertEquals( tree.getParent(), parentContentlet.getIdentifier() );
-            assertEquals( tree.getChild(), childContentlet.getIdentifier() );
-            assertEquals( tree.getRelationType(), testRelationship.getRelationTypeValue() );
+            assertNotNull(tree);
+            assertNotNull(tree.getParent());
+            assertNotNull(tree.getChild());
+            assertEquals(tree.getParent(), parentContentlet.getIdentifier());
+            assertEquals(tree.getChild(), childContentlet.getIdentifier());
+            assertEquals(tree.getRelationType(), testRelationship.getRelationTypeValue());
 
-        }finally {
+        } finally {
             try {
                 if (testRelationship != null && testRelationship.getInode() != null) {
                     relationshipAPI.delete(testRelationship);
@@ -3564,12 +3851,15 @@ public class ContentletAPITest extends ContentletBaseTest {
                 if (testStructure != null && testStructure.getInode() != null) {
                     APILocator.getStructureAPI().delete(testStructure, user);
                 }
-            }catch (Exception e) {e.printStackTrace();}
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 
     /**
-     * Testing {@link ContentletAPI#getRelatedContent(com.dotmarketing.portlets.contentlet.model.Contentlet,
+     * Testing
+     * {@link ContentletAPI#getRelatedContent(com.dotmarketing.portlets.contentlet.model.Contentlet,
      * com.dotmarketing.portlets.structure.model.Relationship, com.liferay.portal.model.User,
      * boolean)}
      *
@@ -3637,7 +3927,7 @@ public class ContentletAPITest extends ContentletBaseTest {
             //First lets create a test structure
             testStructure = createStructure(
                     "JUnit Test Structure_" + timeMillis,
-                    "junit_test_structure_" +timeMillis);
+                    "junit_test_structure_" + timeMillis);
 
             //Now a new test contentlets
             final Contentlet grandParentContentlet = createContentlet(testStructure, null, false);
@@ -3702,10 +3992,10 @@ public class ContentletAPITest extends ContentletBaseTest {
      * @see Contentlet
      */
     @Test
-    public void getRelatedContentPullByParent () throws DotSecurityException, DotDataException {
+    public void getRelatedContentPullByParent() throws DotSecurityException, DotDataException {
 
         Relationship testRelationship = null;
-        Structure testStructure       = null;
+        Structure testStructure = null;
         final long timeMillis = new Date().getTime();
         try {
             //First lets create a test structure
@@ -3746,43 +4036,45 @@ public class ContentletAPITest extends ContentletBaseTest {
             }
 
 
-        }finally {
-            if (testRelationship != null && testRelationship.getInode() != null){
+        } finally {
+            if (testRelationship != null && testRelationship.getInode() != null) {
                 relationshipAPI.delete(testRelationship);
             }
 
-            if (testStructure != null && testStructure.getInode() != null){
+            if (testStructure != null && testStructure.getInode() != null) {
                 APILocator.getStructureAPI().delete(testStructure, user);
             }
         }
     }
 
     /**
-     * Now we introduce the case when we wanna add content with
-     * the inode & identifier we set. The content should not exists
-     * for that inode nor the identifier.
+     * Now we introduce the case when we wanna add content with the inode & identifier we set. The
+     * content should not exists for that inode nor the identifier.
      *
      * @throws Exception if test fails
      */
     @Test
     public void saveContentWithExistingIdentifier() throws Exception {
-        Structure testStructure = createStructure( "JUnit Test Structure_" + String.valueOf( new Date().getTime() ) + "zzz", "junit_test_structure_" + String.valueOf( new Date().getTime() ) + "zzz" );
+        Structure testStructure = createStructure(
+                "JUnit Test Structure_" + String.valueOf(new Date().getTime()) + "zzz",
+                "junit_test_structure_" + String.valueOf(new Date().getTime()) + "zzz");
 
-        Field field = new Field( "JUnit Test Text", Field.FieldType.TEXT, Field.DataType.TEXT, testStructure, false, true, false, 1, false, false, false );
-        FieldFactory.saveField( field );
+        Field field = new Field("JUnit Test Text", Field.FieldType.TEXT, Field.DataType.TEXT,
+                testStructure, false, true, false, 1, false, false, false);
+        FieldFactory.saveField(field);
 
-        Contentlet cont=new Contentlet();
+        Contentlet cont = new Contentlet();
         cont.setStructureInode(testStructure.getInode());
         cont.setStringProperty(field.getVelocityVarName(), "a value");
-        cont.setStructureInode( testStructure.getInode() );
-        cont.setHost( defaultHost.getIdentifier() );
+        cont.setStructureInode(testStructure.getInode());
+        cont.setHost(defaultHost.getIdentifier());
 
         // here comes the existing inode and identifier
         // for this test we generate them using the normal
         // generator but the use case for this is when
         // the content comes from another dotCMS instance
-        String inode=UUIDGenerator.generateUuid();
-        String identifier=UUIDGenerator.generateUuid();
+        String inode = UUIDGenerator.generateUuid();
+        String identifier = UUIDGenerator.generateUuid();
         cont.setInode(inode);
         cont.setIdentifier(identifier);
 
@@ -3797,38 +4089,38 @@ public class ContentletAPITest extends ContentletBaseTest {
         CacheLocator.getContentletCache().clearCache();
 
         // now lets test with existing content
-        Contentlet existing=contentletAPI.find(inode, user, false);
+        Contentlet existing = contentletAPI.find(inode, user, false);
         assertEquals(inode, existing.getInode());
         assertEquals(identifier, existing.getIdentifier());
 
         // new inode to create a new version
-        String newInode=UUIDGenerator.generateUuid();
+        String newInode = UUIDGenerator.generateUuid();
         existing.setInode(newInode);
         existing.setIndexPolicy(IndexPolicy.FORCE);
 
-        saved=contentletAPI.checkin(existing, user, false);
-        
+        saved = contentletAPI.checkin(existing, user, false);
+
         assertEquals(newInode, saved.getInode());
         assertEquals(identifier, saved.getIdentifier());
 
         try {
             APILocator.getStructureAPI().delete(testStructure, user);
-        }catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
     /**
-     * Making sure we set pub/exp dates on identifier when saving content
-     * and we set them back to the content when reading.
-     *
+     * Making sure we set pub/exp dates on identifier when saving content and we set them back to
+     * the content when reading.
+     * <p>
      * https://github.com/dotCMS/dotCMS/issues/1763
      */
     @Test
     public void testUpdatePublishExpireDatesFromIdentifier() throws Exception {
         final boolean uniquePublishExpireDatePerLanguages = ContentletTransformer.isUniquePublishExpireDatePerLanguages();
         ContentletTransformer.setUniquePublishExpireDatePerLanguages(true);
-        
+
         try {
             final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
@@ -3937,37 +4229,43 @@ public class ContentletAPITest extends ContentletBaseTest {
             final long count = APILocator.getContentletAPI().indexCount(q, user, false);
             assertEquals(1, count);
         } finally {
-            ContentletTransformer.setUniquePublishExpireDatePerLanguages(uniquePublishExpireDatePerLanguages);
+            ContentletTransformer.setUniquePublishExpireDatePerLanguages(
+                    uniquePublishExpireDatePerLanguages);
         }
     }
 
     @Test
     public void rangeQuery() throws Exception {
         // https://github.com/dotCMS/dotCMS/issues/2630
-        Structure testStructure = createStructure( "JUnit Test Structure_" + String.valueOf( new Date().getTime() ) + "zzzvv", "junit_test_structure_" + String.valueOf( new Date().getTime() ) + "zzzvv" );
-        Field field = new Field( "JUnit Test Text", Field.FieldType.TEXT, Field.DataType.TEXT, testStructure, false, true, true, 1, false, false, false );
-        field = FieldFactory.saveField( field );
+        Structure testStructure = createStructure(
+                "JUnit Test Structure_" + String.valueOf(new Date().getTime()) + "zzzvv",
+                "junit_test_structure_" + String.valueOf(new Date().getTime()) + "zzzvv");
+        Field field = new Field("JUnit Test Text", Field.FieldType.TEXT, Field.DataType.TEXT,
+                testStructure, false, true, true, 1, false, false, false);
+        field = FieldFactory.saveField(field);
 
-        List<Contentlet> list=new ArrayList<>();
-        String[] letters={"a","b","c","d","e","f","g"};
-        for(String letter : letters) {
-            Contentlet conn=new Contentlet();
+        List<Contentlet> list = new ArrayList<>();
+        String[] letters = {"a", "b", "c", "d", "e", "f", "g"};
+        for (String letter : letters) {
+            Contentlet conn = new Contentlet();
             conn.setStructureInode(testStructure.getInode());
             conn.setStringProperty(field.getVelocityVarName(), letter);
             conn.setIndexPolicy(IndexPolicy.FORCE);
             conn = contentletAPI.checkin(conn, user, false);
             list.add(conn);
         }
-        String query = "+structurename:"+testStructure.getVelocityVarName()+
-                " +"+testStructure.getVelocityVarName()+"."+field.getVelocityVarName()+":[b   TO f ]";
-        String sort = testStructure.getVelocityVarName()+"."+field.getVelocityVarName()+" asc";
+        String query = "+structurename:" + testStructure.getVelocityVarName() +
+                " +" + testStructure.getVelocityVarName() + "." + field.getVelocityVarName()
+                + ":[b   TO f ]";
+        String sort =
+                testStructure.getVelocityVarName() + "." + field.getVelocityVarName() + " asc";
         List<Contentlet> search = contentletAPI.search(query, 100, 0, sort, user, false);
-        assertEquals(5,search.size());
-        assertEquals("b",search.get(0).getStringProperty(field.getVelocityVarName()));
-        assertEquals("c",search.get(1).getStringProperty(field.getVelocityVarName()));
-        assertEquals("d",search.get(2).getStringProperty(field.getVelocityVarName()));
-        assertEquals("e",search.get(3).getStringProperty(field.getVelocityVarName()));
-        assertEquals("f",search.get(4).getStringProperty(field.getVelocityVarName()));
+        assertEquals(5, search.size());
+        assertEquals("b", search.get(0).getStringProperty(field.getVelocityVarName()));
+        assertEquals("c", search.get(1).getStringProperty(field.getVelocityVarName()));
+        assertEquals("d", search.get(2).getStringProperty(field.getVelocityVarName()));
+        assertEquals("e", search.get(3).getStringProperty(field.getVelocityVarName()));
+        assertEquals("f", search.get(4).getStringProperty(field.getVelocityVarName()));
 
         try {
             contentletAPI.archive(list, user, false);
@@ -3981,117 +4279,139 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
     public void widgetInvalidateAllLang() throws Exception {
-        Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE",true);
 
-        HttpServletRequest requestProxy = new MockInternalRequest().request();
-        HttpServletResponse responseProxy = Mockito.mock(HttpServletResponse.class);
+        boolean defaultContentToDefaultLangOriginalValue =
+                Config.getBooleanProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", false);
+        try {
 
-        initMessages();
+            Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", true);
 
-        Language def=APILocator.getLanguageAPI().getDefaultLanguage();
-        Contentlet w = new Contentlet();
-        w.setStructureInode(simpleWidgetContentType.id());
-        w.setStringProperty("widgetTitle", "A testing widget "+UUIDGenerator.generateUuid());
-        w.setStringProperty("code", "Initial code");
-        w.setLanguageId(def.getId());
-        w.setIndexPolicy(IndexPolicy.FORCE);
-        w.setIndexPolicyDependencies(IndexPolicy.FORCE);
-        w = contentletAPI.checkin(w, user, false);
-        contentletAPI.publish(w, user, false);
+            HttpServletRequest requestProxy = new MockInternalRequest().request();
+            HttpServletResponse responseProxy = Mockito.mock(HttpServletResponse.class);
 
-        /*
-         * For every language we should get the same content and contentMap template code
-         */
-        VelocityEngine engine = VelocityUtil.getEngine();
-        SimpleNode contentTester = engine.getRuntimeServices().parse(new StringReader("code:$code"), "tester1");
+            initMessages();
 
-        contentTester.init(null, null);
+            Language def = APILocator.getLanguageAPI().getDefaultLanguage();
+            Contentlet w = new Contentlet();
+            w.setStructureInode(simpleWidgetContentType.id());
+            w.setStringProperty("widgetTitle", "A testing widget " + UUIDGenerator.generateUuid());
+            w.setStringProperty("code", "Initial code");
+            w.setLanguageId(def.getId());
+            w.setIndexPolicy(IndexPolicy.FORCE);
+            w.setIndexPolicyDependencies(IndexPolicy.FORCE);
+            w = contentletAPI.checkin(w, user, false);
+            contentletAPI.publish(w, user, false);
 
-        requestProxy.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
-        requestProxy.setAttribute(com.liferay.portal.util.WebKeys.USER,APILocator.getUserAPI().getSystemUser());
+            /*
+             * For every language we should get the same content and contentMap template code
+             */
+            VelocityEngine engine = VelocityUtil.getEngine();
+            SimpleNode contentTester = engine.getRuntimeServices()
+                    .parse(new StringReader("code:$code"), "tester1");
 
-        org.apache.velocity.Template teng1 = engine.getTemplate(
-                File.separator + PageMode.LIVE.name() + File.separator + w.getIdentifier() + "_1" +
-                        StringPool.UNDERLINE + VariantAPI.DEFAULT_VARIANT.name() + "."
-                        + VelocityType.CONTENT.fileExtension);
-        org.apache.velocity.Template tesp1 = engine.getTemplate(
-                File.separator + PageMode.LIVE.name() + File.separator + w.getIdentifier() + "_"
-                        + spanishLanguage.getId() + StringPool.UNDERLINE + VariantAPI.DEFAULT_VARIANT.name() + "."
-                        + VelocityType.CONTENT.fileExtension);
+            contentTester.init(null, null);
 
-        Context ctx = VelocityUtil.getWebContext(requestProxy, responseProxy);
-        StringWriter writer=new StringWriter();
-        teng1.merge(ctx, writer);
-        contentTester.render(new InternalContextAdapterImpl(ctx), writer);
-        assertEquals("code:Initial code",writer.toString());
-        ctx = VelocityUtil.getWebContext(requestProxy, responseProxy);
-        writer=new StringWriter();
-        tesp1.merge(ctx, writer);
-        contentTester.render(new InternalContextAdapterImpl(ctx), writer);
-        assertEquals("code:Initial code",writer.toString());
+            requestProxy.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
+            requestProxy.setAttribute(com.liferay.portal.util.WebKeys.USER,
+                    APILocator.getUserAPI().getSystemUser());
 
-        Contentlet w2=contentletAPI.checkout(w.getInode(), user, false);
-        w2.setStringProperty("code", "Modified Code to make templates different");
-        w2 = contentletAPI.checkin(w2, user, false);
-        contentletAPI.publish(w2, user, false);
-        contentletAPI.isInodeIndexed(w2.getInode(),true);
-        VelocityResourceKey key = new VelocityResourceKey(w2, PageMode.LIVE,
-                spanishLanguage.getId());
-        CacheLocator.getVeloctyResourceCache().remove(key);
+            org.apache.velocity.Template teng1 = engine.getTemplate(
+                    File.separator + PageMode.LIVE.name() + File.separator + w.getIdentifier()
+                            + "_1" +
+                            StringPool.UNDERLINE + VariantAPI.DEFAULT_VARIANT.name() + "."
+                            + VelocityType.CONTENT.fileExtension);
+            org.apache.velocity.Template tesp1 = engine.getTemplate(
+                    File.separator + PageMode.LIVE.name() + File.separator + w.getIdentifier() + "_"
+                            + spanishLanguage.getId() + StringPool.UNDERLINE
+                            + VariantAPI.DEFAULT_VARIANT.name() + "."
+                            + VelocityType.CONTENT.fileExtension);
 
-        // now if everything have been cleared correctly those should match again
-        org.apache.velocity.Template teng3 = engine.getTemplate(
-                File.separator + PageMode.LIVE.name() + File.separator + w.getIdentifier() + "_1"
-                        + StringPool.UNDERLINE + VariantAPI.DEFAULT_VARIANT.name() + "."
-                        + VelocityType.CONTENT.fileExtension);
-        org.apache.velocity.Template tesp3 = engine.getTemplate(
-                File.separator + PageMode.LIVE.name() + File.separator + w.getIdentifier() + "_"
-                        + spanishLanguage.getId() + StringPool.UNDERLINE + VariantAPI.DEFAULT_VARIANT.name() + "."
-                        + VelocityType.CONTENT.fileExtension);
-        ctx = VelocityUtil.getWebContext(requestProxy, responseProxy);
-        writer=new StringWriter();
-        teng3.merge(ctx, writer);
-        contentTester.render(new InternalContextAdapterImpl(ctx), writer);
-        assertEquals("code:Modified Code to make templates different",writer.toString());
-        ctx = VelocityUtil.getWebContext(requestProxy, responseProxy);
-        writer=new StringWriter();
-        tesp3.merge(ctx, writer);
-        contentTester.render(new InternalContextAdapterImpl(ctx), writer);
-        assertEquals("code:Modified Code to make templates different",writer.toString());
+            Context ctx = VelocityUtil.getWebContext(requestProxy, responseProxy);
+            StringWriter writer = new StringWriter();
+            teng1.merge(ctx, writer);
+            contentTester.render(new InternalContextAdapterImpl(ctx), writer);
+            assertEquals("code:Initial code", writer.toString());
+            ctx = VelocityUtil.getWebContext(requestProxy, responseProxy);
+            writer = new StringWriter();
+            tesp1.merge(ctx, writer);
+            contentTester.render(new InternalContextAdapterImpl(ctx), writer);
+            assertEquals("code:Initial code", writer.toString());
 
-        // clean up
-        Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE",false);
+            Contentlet w2 = contentletAPI.checkout(w.getInode(), user, false);
+            w2.setStringProperty("code", "Modified Code to make templates different");
+            w2 = contentletAPI.checkin(w2, user, false);
+            contentletAPI.publish(w2, user, false);
+            contentletAPI.isInodeIndexed(w2.getInode(), true);
+            VelocityResourceKey key = new VelocityResourceKey(w2, PageMode.LIVE,
+                    spanishLanguage.getId());
+            CacheLocator.getVeloctyResourceCache().remove(key);
+
+            // now if everything have been cleared correctly those should match again
+            org.apache.velocity.Template teng3 = engine.getTemplate(
+                    File.separator + PageMode.LIVE.name() + File.separator + w.getIdentifier()
+                            + "_1"
+                            + StringPool.UNDERLINE + VariantAPI.DEFAULT_VARIANT.name() + "."
+                            + VelocityType.CONTENT.fileExtension);
+            org.apache.velocity.Template tesp3 = engine.getTemplate(
+                    File.separator + PageMode.LIVE.name() + File.separator + w.getIdentifier() + "_"
+                            + spanishLanguage.getId() + StringPool.UNDERLINE
+                            + VariantAPI.DEFAULT_VARIANT.name() + "."
+                            + VelocityType.CONTENT.fileExtension);
+            ctx = VelocityUtil.getWebContext(requestProxy, responseProxy);
+            writer = new StringWriter();
+            teng3.merge(ctx, writer);
+            contentTester.render(new InternalContextAdapterImpl(ctx), writer);
+            assertEquals("code:Modified Code to make templates different", writer.toString());
+            ctx = VelocityUtil.getWebContext(requestProxy, responseProxy);
+            writer = new StringWriter();
+            tesp3.merge(ctx, writer);
+            contentTester.render(new InternalContextAdapterImpl(ctx), writer);
+            assertEquals("code:Modified Code to make templates different", writer.toString());
+
+            // clean up
+
+        } finally {
+            Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE",
+                    defaultContentToDefaultLangOriginalValue);
+        }
+
     }
+
     @Test
     public void testFileCopyOnSecondLanguageVersion()
             throws DotDataException, DotSecurityException {
 
         final String contentTypeName = "structure2709" + System.currentTimeMillis();
 
-    	// Structure
+        // Structure
         Structure testStructure = new Structure();
 
-        testStructure.setDefaultStructure( false );
+        testStructure.setDefaultStructure(false);
         testStructure.setDescription(contentTypeName);
-        testStructure.setFixed( false );
-        testStructure.setIDate( new Date() );
+        testStructure.setFixed(false);
+        testStructure.setIDate(new Date());
         testStructure.setName(contentTypeName);
-        testStructure.setOwner( user.getUserId() );
-        testStructure.setDetailPage( "" );
-        testStructure.setStructureType( BaseContentType.CONTENT.getType() );
-        testStructure.setType( "structure" );
+        testStructure.setOwner(user.getUserId());
+        testStructure.setDetailPage("");
+        testStructure.setStructureType(BaseContentType.CONTENT.getType());
+        testStructure.setType("structure");
         testStructure.setVelocityVarName(contentTypeName);
 
-        StructureFactory.saveStructure( testStructure );
+        StructureFactory.saveStructure(testStructure);
 
-        Permission permissionRead = new Permission( testStructure.getInode(), APILocator.getRoleAPI().loadCMSAnonymousRole().getId(), PermissionAPI.PERMISSION_READ );
-        Permission permissionEdit = new Permission( testStructure.getInode(), APILocator.getRoleAPI().loadCMSAnonymousRole().getId(), PermissionAPI.PERMISSION_EDIT );
-        Permission permissionWrite = new Permission( testStructure.getInode(), APILocator.getRoleAPI().loadCMSAnonymousRole().getId(), PermissionAPI.PERMISSION_WRITE );
+        Permission permissionRead = new Permission(testStructure.getInode(),
+                APILocator.getRoleAPI().loadCMSAnonymousRole().getId(),
+                PermissionAPI.PERMISSION_READ);
+        Permission permissionEdit = new Permission(testStructure.getInode(),
+                APILocator.getRoleAPI().loadCMSAnonymousRole().getId(),
+                PermissionAPI.PERMISSION_EDIT);
+        Permission permissionWrite = new Permission(testStructure.getInode(),
+                APILocator.getRoleAPI().loadCMSAnonymousRole().getId(),
+                PermissionAPI.PERMISSION_WRITE);
 
-        APILocator.getPermissionAPI().save( permissionRead, testStructure, user, false );
-        APILocator.getPermissionAPI().save( permissionEdit, testStructure, user, false );
-        APILocator.getPermissionAPI().save( permissionWrite, testStructure, user, false );
-
+        APILocator.getPermissionAPI().save(permissionRead, testStructure, user, false);
+        APILocator.getPermissionAPI().save(permissionEdit, testStructure, user, false);
+        APILocator.getPermissionAPI().save(permissionWrite, testStructure, user, false);
 
         // Fields
 
@@ -4108,7 +4428,7 @@ public class ContentletAPITest extends ContentletBaseTest {
         title.setVelocityVarName("testTitle2709");
         title.setIndexed(true);
         title.setFieldContentlet("text4");
-        FieldFactory.saveField( title );
+        FieldFactory.saveField(title);
 
         // file
         Field file = new Field();
@@ -4123,48 +4443,51 @@ public class ContentletAPITest extends ContentletBaseTest {
         file.setVelocityVarName("testFile2709");
         file.setIndexed(true);
         file.setFieldContentlet("text1");
-        FieldFactory.saveField( file );
+        FieldFactory.saveField(file);
 
         // ENGLISH CONTENT
         Contentlet englishContent = new Contentlet();
-        englishContent.setStructureInode( testStructure.getInode() );
+        englishContent.setStructureInode(testStructure.getInode());
         englishContent.setLanguageId(1);
 
         //Create a test file asset
         Contentlet fileA = TestDataUtils
                 .getFileAssetContent(true, languageAPI.getDefaultLanguage().getId());
 
-        contentletAPI.setContentletProperty( englishContent, title, "englishTitle2709" );
-        contentletAPI.setContentletProperty( englishContent, file, fileA.getInode() );
+        contentletAPI.setContentletProperty(englishContent, title, "englishTitle2709");
+        contentletAPI.setContentletProperty(englishContent, file, fileA.getInode());
 
-        englishContent = contentletAPI.checkin( englishContent, null, APILocator.getPermissionAPI().getPermissions( testStructure ), user, false );
+        englishContent = contentletAPI.checkin(englishContent, null,
+                APILocator.getPermissionAPI().getPermissions(testStructure), user, false);
 
         // SPANISH CONTENT
-		Contentlet spanishContent = new Contentlet();
-		spanishContent.setStructureInode(testStructure.getInode());
+        Contentlet spanishContent = new Contentlet();
+        spanishContent.setStructureInode(testStructure.getInode());
         spanishContent.setLanguageId(spanishLanguage.getId());
-		spanishContent.setIdentifier(englishContent.getIdentifier());
+        spanishContent.setIdentifier(englishContent.getIdentifier());
 
-		contentletAPI.setContentletProperty( spanishContent, title, "spanishTitle2709" );
-		contentletAPI.setContentletProperty( spanishContent, file, fileA.getInode() );
+        contentletAPI.setContentletProperty(spanishContent, title, "spanishTitle2709");
+        contentletAPI.setContentletProperty(spanishContent, file, fileA.getInode());
 
-		spanishContent = contentletAPI.checkin( spanishContent, null, APILocator.getPermissionAPI().getPermissions( testStructure ), user, false );
-		Object retrivedFile = spanishContent.get("testFile2709");
-		assertTrue(retrivedFile!=null);
-        try{
-        	HibernateUtil.startTransaction();
-        	APILocator.getStructureAPI().delete(testStructure, user);
-        	HibernateUtil.closeAndCommitTransaction();
-        }catch(Exception e){
-        	HibernateUtil.rollbackTransaction();
-        	Logger.error(ContentletAPITest.class, e.getMessage());
+        spanishContent = contentletAPI.checkin(spanishContent, null,
+                APILocator.getPermissionAPI().getPermissions(testStructure), user, false);
+        Object retrivedFile = spanishContent.get("testFile2709");
+        assertTrue(retrivedFile != null);
+        try {
+            HibernateUtil.startTransaction();
+            APILocator.getStructureAPI().delete(testStructure, user);
+            HibernateUtil.closeAndCommitTransaction();
+        } catch (Exception e) {
+            HibernateUtil.rollbackTransaction();
+            Logger.error(ContentletAPITest.class, e.getMessage());
         }
 
 
     }
 
     @Test
-    public void newFileAssetLanguageDifferentThanDefault() throws DotSecurityException, DotDataException, IOException {
+    public void newFileAssetLanguageDifferentThanDefault()
+            throws DotSecurityException, DotDataException, IOException {
         long spanish = spanishLanguage.getId();
         Folder folder = APILocator.getFolderAPI().findSystemFolder();
         java.io.File file = java.io.File.createTempFile("texto", ".txt");
@@ -4173,75 +4496,86 @@ public class ContentletAPITest extends ContentletBaseTest {
         FileAssetDataGen fileAssetDataGen = new FileAssetDataGen(folder, file);
         Contentlet fileInSpanish = fileAssetDataGen.languageId(spanish).nextPersisted();
         Contentlet
-            result =
-            contentletAPI.findContentletByIdentifier(fileInSpanish.getIdentifier(), false, spanish, user, false);
+                result =
+                contentletAPI.findContentletByIdentifier(fileInSpanish.getIdentifier(), false,
+                        spanish, user, false);
         assertEquals(fileInSpanish.getInode(), result.getInode());
 
         fileAssetDataGen.remove(fileInSpanish);
     }
-    
-    @Test
-    public void newVersionFileAssetLanguageDifferentThanDefault() throws DotDataException, IOException, DotSecurityException{
-    	int english = 1;
-        long spanish = spanishLanguage.getId();
-    	
-    	Folder folder = APILocator.getFolderAPI().findSystemFolder();
-    	java.io.File file = java.io.File.createTempFile("file", ".txt");
-        FileUtil.write(file, "helloworld");
-        
-    	FileAssetDataGen fileAssetDataGen = new FileAssetDataGen(folder,file);
-    	Contentlet fileAsset = fileAssetDataGen.languageId(english).nextPersisted();
-  	  
-    	Contentlet contentletSpanish = contentletAPI.findContentletByIdentifier(fileAsset.getIdentifier(), false, english, user, false);
-    	contentletSpanish = contentletAPI.checkout(contentletSpanish.getInode(), user, false);
-    	contentletSpanish.setLanguageId(spanish);
-    	contentletSpanish = contentletAPI.checkin(contentletSpanish, user, false);
-  	  
-    	Contentlet resultSpanish = contentletAPI.findContentletByIdentifier(fileAsset.getIdentifier(), false, spanish, user, false);
-    	assertNotNull( resultSpanish );
 
-        Contentlet resultEnglish = contentletAPI.findContentletByIdentifier(fileAsset.getIdentifier(), false, english, user, false);
-    	fileAssetDataGen.remove(resultSpanish);
+    @Test
+    public void newVersionFileAssetLanguageDifferentThanDefault()
+            throws DotDataException, IOException, DotSecurityException {
+        int english = 1;
+        long spanish = spanishLanguage.getId();
+
+        Folder folder = APILocator.getFolderAPI().findSystemFolder();
+        java.io.File file = java.io.File.createTempFile("file", ".txt");
+        FileUtil.write(file, "helloworld");
+
+        FileAssetDataGen fileAssetDataGen = new FileAssetDataGen(folder, file);
+        Contentlet fileAsset = fileAssetDataGen.languageId(english).nextPersisted();
+
+        Contentlet contentletSpanish = contentletAPI.findContentletByIdentifier(
+                fileAsset.getIdentifier(), false, english, user, false);
+        contentletSpanish = contentletAPI.checkout(contentletSpanish.getInode(), user, false);
+        contentletSpanish.setLanguageId(spanish);
+        contentletSpanish = contentletAPI.checkin(contentletSpanish, user, false);
+
+        Contentlet resultSpanish = contentletAPI.findContentletByIdentifier(
+                fileAsset.getIdentifier(), false, spanish, user, false);
+        assertNotNull(resultSpanish);
+
+        Contentlet resultEnglish = contentletAPI.findContentletByIdentifier(
+                fileAsset.getIdentifier(), false, english, user, false);
+        fileAssetDataGen.remove(resultSpanish);
         fileAssetDataGen.remove(resultEnglish);
     }
-    
+
     /**
      * Deletes a list of contents
+     *
      * @throws Exception
      */
     @Test
-    public void deleteMultipleContents() throws Exception { // https://github.com/dotCMS/core/issues/7678
+    public void deleteMultipleContents()
+            throws Exception { // https://github.com/dotCMS/core/issues/7678
 
-    	// languages
-    	int english = 1;
+        // languages
+        int english = 1;
         long spanish = spanishLanguage.getId();
 
         // new template
         Template template = new TemplateDataGen().nextPersisted();
         // new test folder
-		Folder testFolder = new FolderDataGen().nextPersisted();
-		// sample pages
-		HTMLPageAsset pageEnglish1 = new HTMLPageDataGen(testFolder, template).languageId(english).nextPersisted();
-		HTMLPageAsset pageEnglish2 = new HTMLPageDataGen(testFolder, template).languageId(english).nextPersisted();
-		contentletAPI.publish(pageEnglish1, user, false);
-		contentletAPI.publish(pageEnglish2, user, false);
+        Folder testFolder = new FolderDataGen().nextPersisted();
+        // sample pages
+        HTMLPageAsset pageEnglish1 = new HTMLPageDataGen(testFolder, template).languageId(english)
+                .nextPersisted();
+        HTMLPageAsset pageEnglish2 = new HTMLPageDataGen(testFolder, template).languageId(english)
+                .nextPersisted();
+        contentletAPI.publish(pageEnglish1, user, false);
+        contentletAPI.publish(pageEnglish2, user, false);
         // delete counter
         int deleted = 0;
         // Page list
         List<HTMLPageAsset> liveHTMLPages = new ArrayList<HTMLPageAsset>();
         // List of contentlets created for this test.
         List<Contentlet> contentletsCreated = new ArrayList<Contentlet>();
-        
+
         liveHTMLPages.add(pageEnglish1);
         liveHTMLPages.add(pageEnglish2);
-               
+
         //We need to create a new copy of pages for Spanish.
-        for(HTMLPageAsset liveHTMLPage : liveHTMLPages){
-            Contentlet htmlPageContentlet = APILocator.getContentletAPI().checkout( liveHTMLPage.getInode(), user, false );
+        for (HTMLPageAsset liveHTMLPage : liveHTMLPages) {
+            Contentlet htmlPageContentlet = APILocator.getContentletAPI()
+                    .checkout(liveHTMLPage.getInode(), user, false);
             htmlPageContentlet.getMap().put("languageId", new Long(spanish));
 
             //Checkin and Publish.
-            Contentlet working = APILocator.getContentletAPI().checkin(htmlPageContentlet, user, false);
+            Contentlet working = APILocator.getContentletAPI()
+                    .checkin(htmlPageContentlet, user, false);
             APILocator.getContentletAPI().publish(working, user, false);
             APILocator.getContentletAPI().isInodeIndexed(working.getInode(), true);
 
@@ -4252,38 +4586,38 @@ public class ContentletAPITest extends ContentletBaseTest {
         APILocator.getContentletAPI().unpublish(contentletsCreated, user, false);
         APILocator.getContentletAPI().archive(contentletsCreated, user, false);
         APILocator.getContentletAPI().delete(contentletsCreated, user, false);
-        
-        for(Contentlet contentlet: contentletsCreated){
-        	if(APILocator.getContentletAPI().find(contentlet.getInode(), user, false) == null){
-        		deleted++;
-        	}
+
+        for (Contentlet contentlet : contentletsCreated) {
+            if (APILocator.getContentletAPI().find(contentlet.getInode(), user, false) == null) {
+                deleted++;
+            }
         }
         // 2 Spanish pages created, 2 should have been deleted
         assertEquals(2, deleted);
-        
+
         List<Contentlet> liveEnglish = new ArrayList<Contentlet>();
-        for(IHTMLPage page:liveHTMLPages){
-        	liveEnglish.add(APILocator.getContentletAPI().find( page.getInode(), user, false ));
+        for (IHTMLPage page : liveHTMLPages) {
+            liveEnglish.add(APILocator.getContentletAPI().find(page.getInode(), user, false));
         }
-        
+
         APILocator.getContentletAPI().unpublish(liveEnglish, user, false);
         APILocator.getContentletAPI().archive(liveEnglish, user, false);
         APILocator.getContentletAPI().delete(liveEnglish, user, false);
-        
+
         deleted = 0;
-        for(Contentlet contentlet: liveEnglish){
-        	if(APILocator.getContentletAPI().find(contentlet.getInode(), user, false) == null){
-        		deleted++;
-        	}
+        for (Contentlet contentlet : liveEnglish) {
+            if (APILocator.getContentletAPI().find(contentlet.getInode(), user, false) == null) {
+                deleted++;
+            }
         }
-        
+
         // 2 English pages created, 2 should have been deleted
         assertEquals(2, deleted);
 
         // dispose other objects
-		FolderDataGen.remove(testFolder);
-		TemplateDataGen.remove(template);
-		
+        FolderDataGen.remove(testFolder);
+        TemplateDataGen.remove(template);
+
     }
 
     /*
@@ -4291,7 +4625,8 @@ public class ContentletAPITest extends ContentletBaseTest {
     should delete all the versions in Spanish not only the live/working version.
      */
     @Test
-    public void testDelete_GivenMultiLangMultiVersionContent_WhenDeletingOneSpanishVersion_ShouldDeleteAllSpanishVersions() throws Exception{
+    public void testDelete_GivenMultiLangMultiVersionContent_WhenDeletingOneSpanishVersion_ShouldDeleteAllSpanishVersions()
+            throws Exception {
         // languages
         int english = 1;
         long spanish = spanishLanguage.getId();
@@ -4335,44 +4670,49 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             textField2 = fieldAPI.save(textField2, user);
 
-            contentletEnglish = new ContentletDataGen(contentType.id()).languageId(english).nextPersisted();
+            contentletEnglish = new ContentletDataGen(contentType.id()).languageId(english)
+                    .nextPersisted();
             //new Version
-            contentletEnglish = contentletAPI.checkout(contentletEnglish.getInode(),user,false);
-            contentletEnglish = contentletAPI.checkin(contentletEnglish,user,false);
+            contentletEnglish = contentletAPI.checkout(contentletEnglish.getInode(), user, false);
+            contentletEnglish = contentletAPI.checkin(contentletEnglish, user, false);
             //new Version
-            contentletEnglish = contentletAPI.checkout(contentletEnglish.getInode(),user,false);
-            contentletEnglish = contentletAPI.checkin(contentletEnglish,user,false);
+            contentletEnglish = contentletAPI.checkout(contentletEnglish.getInode(), user, false);
+            contentletEnglish = contentletAPI.checkin(contentletEnglish, user, false);
 
-            Identifier contentletIdentifier = APILocator.getIdentifierAPI().find(contentletEnglish.getIdentifier());
+            Identifier contentletIdentifier = APILocator.getIdentifierAPI()
+                    .find(contentletEnglish.getIdentifier());
 
-            int quantityVersions = contentletAPI.findAllVersions(contentletIdentifier,user,false).size();
+            int quantityVersions = contentletAPI.findAllVersions(contentletIdentifier, user, false)
+                    .size();
 
-            assertEquals(3,quantityVersions);
+            assertEquals(3, quantityVersions);
 
-            contentletSpanish = contentletAPI.checkout(contentletEnglish.getInode(),user,false);
+            contentletSpanish = contentletAPI.checkout(contentletEnglish.getInode(), user, false);
             contentletSpanish.setLanguageId(spanish);
             contentletSpanish = contentletAPI.checkin(contentletSpanish, user, false);
             //new Version
-            contentletSpanish = contentletAPI.checkout(contentletSpanish.getInode(),user,false);
+            contentletSpanish = contentletAPI.checkout(contentletSpanish.getInode(), user, false);
             contentletSpanish.setLanguageId(spanish);
             contentletSpanish = contentletAPI.checkin(contentletSpanish, user, false);
             //new Version
-            contentletSpanish = contentletAPI.checkout(contentletSpanish.getInode(),user,false);
+            contentletSpanish = contentletAPI.checkout(contentletSpanish.getInode(), user, false);
             contentletSpanish.setLanguageId(spanish);
             contentletSpanish = contentletAPI.checkin(contentletSpanish, user, false);
 
-            quantityVersions = contentletAPI.findAllVersions(contentletIdentifier,user,false).size();
+            quantityVersions = contentletAPI.findAllVersions(contentletIdentifier, user, false)
+                    .size();
 
-            assertEquals(6,quantityVersions);
+            assertEquals(6, quantityVersions);
 
-            contentletAPI.archive(contentletSpanish,user,false);
-            contentletAPI.delete(contentletSpanish,user,false);
+            contentletAPI.archive(contentletSpanish, user, false);
+            contentletAPI.delete(contentletSpanish, user, false);
 
-            quantityVersions = contentletAPI.findAllVersions(contentletIdentifier,user,false).size();
+            quantityVersions = contentletAPI.findAllVersions(contentletIdentifier, user, false)
+                    .size();
 
-            assertEquals(3,quantityVersions);
+            assertEquals(3, quantityVersions);
 
-        }finally {
+        } finally {
             contentTypeAPI.delete(contentType);
         }
 
@@ -4380,13 +4720,9 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /**
      * This JUnit is to check the fix on Issue 10797 (https://github.com/dotCMS/core/issues/10797)
-     * It executes the following:
-     * 1) create a new structure
-     * 2) create a new field
-     * 3) create a contentlet
-     * 4) set the contentlet property
-     * 5) check the contentlet
-     * 6) deletes it all in the end
+     * It executes the following: 1) create a new structure 2) create a new field 3) create a
+     * contentlet 4) set the contentlet property 5) check the contentlet 6) deletes it all in the
+     * end
      *
      * @throws Exception Any exception that may happen
      */
@@ -4397,10 +4733,16 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         try {
             // Create test structure
-            testStructure = createStructure("Tab Divider Test Structure_" + String.valueOf(new Date().getTime()) + "tab_divider", "tab_divider_test_structure_" + String.valueOf(new Date().getTime()) + "tab_divider");
+            testStructure = createStructure(
+                    "Tab Divider Test Structure_" + String.valueOf(new Date().getTime())
+                            + "tab_divider",
+                    "tab_divider_test_structure_" + String.valueOf(new Date().getTime())
+                            + "tab_divider");
 
             // Create tab divider field
-            tabDividerField = new Field("JUnit Test TabDividerField", FieldType.TAB_DIVIDER, Field.DataType.SECTION_DIVIDER, testStructure, false, true, true, 1, false, false, false);
+            tabDividerField = new Field("JUnit Test TabDividerField", FieldType.TAB_DIVIDER,
+                    Field.DataType.SECTION_DIVIDER, testStructure, false, true, true, 1, false,
+                    false, false);
             tabDividerField = FieldFactory.saveField(tabDividerField);
 
             // Create the test contentlet
@@ -4408,13 +4750,16 @@ public class ContentletAPITest extends ContentletBaseTest {
             testContentlet.setStructureInode(testStructure.getInode());
 
             // Set the contentlet property
-            contentletAPI.setContentletProperty(testContentlet, tabDividerField, "tabDividerFieldValue");
+            contentletAPI.setContentletProperty(testContentlet, tabDividerField,
+                    "tabDividerFieldValue");
 
             // Checking the contentlet
             testContentlet.setIndexPolicy(IndexPolicy.FORCE);
             testContentlet = contentletAPI.checkin(testContentlet, user, false);
         } catch (Exception ex) {
-            Logger.error(this, "An error occurred during test_validateContentlet_contentWithTabDividerField", ex);
+            Logger.error(this,
+                    "An error occurred during test_validateContentlet_contentWithTabDividerField",
+                    ex);
             throw ex;
         } finally {
             try {
@@ -4542,7 +4887,7 @@ public class ContentletAPITest extends ContentletBaseTest {
     @Test
     @Ignore
     public void test_saveMultilingualFileAssetBasedOnLegacyFile_shouldKeepBinaryFile()
-        throws IOException, DotSecurityException, DotDataException {
+            throws IOException, DotSecurityException, DotDataException {
 
         ContentType contentType = null;
         com.dotcms.contenttype.model.field.Field textField = null;
@@ -4558,32 +4903,32 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             //Create Content Type.
             contentType = ContentTypeBuilder.builder(BaseContentType.CONTENT.immutableClass())
-                .description("ContentType for Legacy File")
-                .host(defaultHost.getIdentifier())
-                .name("ContentType for Legacy File")
-                .owner("owner")
-                .variable("testContentTypeForLegacyFile")
-                .build();
+                    .description("ContentType for Legacy File")
+                    .host(defaultHost.getIdentifier())
+                    .name("ContentType for Legacy File")
+                    .owner("owner")
+                    .variable("testContentTypeForLegacyFile")
+                    .build();
 
             contentType = contentTypeAPI.save(contentType);
 
             //Save Fields. 1. Text, 2. Binary
             //Creating Text Field.
             textField = ImmutableTextField.builder()
-                .name("Title")
-                .variable("title")
-                .contentTypeId(contentType.id())
-                .dataType(DataTypes.TEXT)
-                .build();
+                    .name("Title")
+                    .variable("title")
+                    .contentTypeId(contentType.id())
+                    .dataType(DataTypes.TEXT)
+                    .build();
 
             textField = fieldAPI.save(textField, user);
 
             //Creating First Binary Field.
             binaryField = ImmutableBinaryField.builder()
-                .name("File")
-                .variable("file")
-                .contentTypeId(contentType.id())
-                .build();
+                    .name("File")
+                    .variable("file")
+                    .contentTypeId(contentType.id())
+                    .build();
 
             binaryField = fieldAPI.save(binaryField, user);
 
@@ -4602,7 +4947,8 @@ public class ContentletAPITest extends ContentletBaseTest {
             initialContent = contentletAPI.checkin(initialContent, user, false);
 
             //File assets creation based on the initial content
-            fileAssetDataGen = new FileAssetDataGen(testFolder, initialContent.getBinary(binaryField.variable()));
+            fileAssetDataGen = new FileAssetDataGen(testFolder,
+                    initialContent.getBinary(binaryField.variable()));
 
             //Creating file asset content in Spanish
             spanishContent = fileAssetDataGen.languageId(spanishLanguage.getId()).nextPersisted();
@@ -4665,64 +5011,66 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /*
      * https://github.com/dotCMS/core/issues/11978
-     * 
-     * Creates a new Content Type with a DateTimeField and sets it as Expire Field, saves a new Content a checks that 
+     *
+     * Creates a new Content Type with a DateTimeField and sets it as Expire Field, saves a new Content a checks that
      * the value of the expire field is set and retrieve correctly
      */
     @Test
-    public void contentOnlyWithExpireFieldTest() throws Exception{
-    	ContentTypeAPIImpl contentTypeApi = (ContentTypeAPIImpl) APILocator.getContentTypeAPI(user);
-		long time = System.currentTimeMillis();
+    public void contentOnlyWithExpireFieldTest() throws Exception {
+        ContentTypeAPIImpl contentTypeApi = (ContentTypeAPIImpl) APILocator.getContentTypeAPI(user);
+        long time = System.currentTimeMillis();
 
-		ContentType contentType = ContentTypeBuilder.builder(BaseContentType.getContentTypeClass(BaseContentType.CONTENT.ordinal()))
-				.description("ContentTypeWithPublishExpireFields " + time).folder(FolderAPI.SYSTEM_FOLDER)
-				.host(Host.SYSTEM_HOST).name("ContentTypeWithPublishExpireFields " + time)
-				.owner(APILocator.systemUser().toString()).variable("CTVariable11").expireDateVar("expireDate").build();
-		contentType = contentTypeApi.save(contentType);
+        ContentType contentType = ContentTypeBuilder.builder(
+                        BaseContentType.getContentTypeClass(BaseContentType.CONTENT.ordinal()))
+                .description("ContentTypeWithPublishExpireFields " + time)
+                .folder(FolderAPI.SYSTEM_FOLDER)
+                .host(Host.SYSTEM_HOST).name("ContentTypeWithPublishExpireFields " + time)
+                .owner(APILocator.systemUser().toString()).variable("CTVariable11")
+                .expireDateVar("expireDate").build();
+        contentType = contentTypeApi.save(contentType);
 
-		assertThat("ContentType exists", contentTypeApi.find(contentType.inode()) != null);
+        assertThat("ContentType exists", contentTypeApi.find(contentType.inode()) != null);
 
-		List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(contentType.fields());
+        List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>(
+                contentType.fields());
 
-		com.dotcms.contenttype.model.field.Field fieldToSave = FieldBuilder.builder(DateTimeField.class).name("Expire Date").variable("expireDate")
-				.contentTypeId(contentType.id()).dataType(DataTypes.DATE).indexed(true).build();
-		fields.add(fieldToSave);
+        com.dotcms.contenttype.model.field.Field fieldToSave = FieldBuilder.builder(
+                        DateTimeField.class).name("Expire Date").variable("expireDate")
+                .contentTypeId(contentType.id()).dataType(DataTypes.DATE).indexed(true).build();
+        fields.add(fieldToSave);
 
-		contentType = contentTypeApi.save(contentType, fields);
-		
-		Contentlet contentlet = new Contentlet();
-		contentlet.setStructureInode(contentType.inode());
+        contentType = contentTypeApi.save(contentType, fields);
+
+        Contentlet contentlet = new Contentlet();
+        contentlet.setStructureInode(contentType.inode());
         contentlet.setLanguageId(languageAPI.getDefaultLanguage().getId());
 
-        contentlet.setDateProperty(fieldToSave.variable(), new Date(new Date().getTime()+60000L));
+        contentlet.setDateProperty(fieldToSave.variable(), new Date(new Date().getTime() + 60000L));
 
         contentlet.setIndexPolicy(IndexPolicy.FORCE);
         contentlet = contentletAPI.checkin(contentlet, user, false);
 
         contentlet = contentletAPI.find(contentlet.getInode(), user, false);
-		Date expireDate = contentlet.getDateProperty("expireDate");
-        
+        Date expireDate = contentlet.getDateProperty("expireDate");
+
         assertNotNull(expireDate);
-		
-		// Deleting content type.
-		contentTypeApi.delete(contentType);
+
+        // Deleting content type.
+        contentTypeApi.delete(contentType);
     }
 
     /**
-     * This test will:
-     * --- Create a content type called "Nested".
-     * --- Add  1 Text field called Title
-     * --- Add  1 Binary field called File
-     * --- Set an application/* as a {@link com.dotcms.contenttype.model.field.BinaryField#ALLOWED_FILE_TYPES}
-     * --- Upload a wrong file
-     * --- expects DotContentletValidationException
-     *
+     * This test will: --- Create a content type called "Nested". --- Add  1 Text field called Title
+     * --- Add  1 Binary field called File --- Set an application/* as a
+     * {@link com.dotcms.contenttype.model.field.BinaryField#ALLOWED_FILE_TYPES} --- Upload a wrong
+     * file --- expects DotContentletValidationException
      */
-    @Test (expected = DotContentletValidationException.class)
-    public void test_validateContentlet_wrong_size_expect_DotContentletValidationException() throws Exception {
+    @Test(expected = DotContentletValidationException.class)
+    public void test_validateContentlet_wrong_size_expect_DotContentletValidationException()
+            throws Exception {
 
         ContentType contentType = null;
-        com.dotcms.contenttype.model.field.Field textField   = null;
+        com.dotcms.contenttype.model.field.Field textField = null;
         com.dotcms.contenttype.model.field.Field binaryField = null;
 
         Contentlet contentletA = null;
@@ -4757,11 +5105,13 @@ public class ContentletAPITest extends ContentletBaseTest {
                 .contentTypeId(contentType.id())
                 .build();
 
-
         binaryField = fieldAPI.save(binaryField, user);
 
-        FieldVariable maxLength      = ImmutableFieldVariable.builder().key(BinaryField.MAX_FILE_LENGTH).value("10").fieldId(binaryField.id()).build();
-        FieldVariable allowFileTypes = ImmutableFieldVariable.builder().key(BinaryField.ALLOWED_FILE_TYPES).value("application/*, text/*").fieldId(binaryField.id()).build();
+        FieldVariable maxLength = ImmutableFieldVariable.builder().key(BinaryField.MAX_FILE_LENGTH)
+                .value("10").fieldId(binaryField.id()).build();
+        FieldVariable allowFileTypes = ImmutableFieldVariable.builder()
+                .key(BinaryField.ALLOWED_FILE_TYPES).value("application/*, text/*")
+                .fieldId(binaryField.id()).build();
         binaryField.constructFieldVariables(Arrays.asList(maxLength, allowFileTypes));
         fieldAPI.save(maxLength, user);
         fieldAPI.save(allowFileTypes, user);
@@ -4781,93 +5131,87 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * This test will:
-     * --- Create a content type called "Nested".
-     * --- Add  1 Text field called Title
-     * --- Add  1 Binary field called File
-     * --- Set an application/* as a {@link com.dotcms.contenttype.model.field.BinaryField#ALLOWED_FILE_TYPES}
-     * --- Upload a wrong file
-     * --- expects DotContentletValidationException
-     *
+     * This test will: --- Create a content type called "Nested". --- Add  1 Text field called Title
+     * --- Add  1 Binary field called File --- Set an application/* as a
+     * {@link com.dotcms.contenttype.model.field.BinaryField#ALLOWED_FILE_TYPES} --- Upload a wrong
+     * file --- expects DotContentletValidationException
      */
-    @Test (expected = DotContentletValidationException.class)
-    public void test_validateContentlet_wrong_mime_type_expect_DotContentletValidationException() throws Exception {
+    @Test(expected = DotContentletValidationException.class)
+    public void test_validateContentlet_wrong_mime_type_expect_DotContentletValidationException()
+            throws Exception {
 
         ContentType contentType = null;
-        com.dotcms.contenttype.model.field.Field textField   = null;
+        com.dotcms.contenttype.model.field.Field textField = null;
         com.dotcms.contenttype.model.field.Field binaryField = null;
 
         Contentlet contentletA = null;
 
-            // Create Content Type.
-            contentType = ContentTypeBuilder.builder(BaseContentType.CONTENT.immutableClass())
-                    .description("Nested" + System.currentTimeMillis())
-                    .host(defaultHost.getIdentifier())
-                    .name("Nested" + System.currentTimeMillis())
-                    .owner("owner")
-                    .variable("nested" + System.currentTimeMillis())
-                    .build();
+        // Create Content Type.
+        contentType = ContentTypeBuilder.builder(BaseContentType.CONTENT.immutableClass())
+                .description("Nested" + System.currentTimeMillis())
+                .host(defaultHost.getIdentifier())
+                .name("Nested" + System.currentTimeMillis())
+                .owner("owner")
+                .variable("nested" + System.currentTimeMillis())
+                .build();
 
-            contentType = contentTypeAPI.save(contentType);
+        contentType = contentTypeAPI.save(contentType);
 
-            // Save Fields. 1. Text
-            // Creating Text Field: Title.
-            textField = ImmutableTextField.builder()
-                    .name("Title")
-                    .variable("title")
-                    .contentTypeId(contentType.id())
-                    .dataType(DataTypes.TEXT)
-                    .build();
+        // Save Fields. 1. Text
+        // Creating Text Field: Title.
+        textField = ImmutableTextField.builder()
+                .name("Title")
+                .variable("title")
+                .contentTypeId(contentType.id())
+                .dataType(DataTypes.TEXT)
+                .build();
 
-            textField = fieldAPI.save(textField, user);
+        textField = fieldAPI.save(textField, user);
 
-            // Save Fields. 1. Binary
-            // Creating Text Field: File.
-            binaryField = ImmutableBinaryField.builder()
-                    .name("file")
-                    .variable("file")
-                    .contentTypeId(contentType.id())
-                    .build();
+        // Save Fields. 1. Binary
+        // Creating Text Field: File.
+        binaryField = ImmutableBinaryField.builder()
+                .name("file")
+                .variable("file")
+                .contentTypeId(contentType.id())
+                .build();
 
+        binaryField = fieldAPI.save(binaryField, user);
 
-            binaryField = fieldAPI.save(binaryField, user);
+        FieldVariable maxLength = ImmutableFieldVariable.builder().key(BinaryField.MAX_FILE_LENGTH)
+                .value("10").fieldId(binaryField.id()).build();
+        FieldVariable allowFileTypes = ImmutableFieldVariable.builder()
+                .key(BinaryField.ALLOWED_FILE_TYPES).value("application/*")
+                .fieldId(binaryField.id()).build();
+        binaryField.constructFieldVariables(Arrays.asList(maxLength, allowFileTypes));
+        fieldAPI.save(maxLength, user);
+        fieldAPI.save(allowFileTypes, user);
 
-            FieldVariable maxLength      = ImmutableFieldVariable.builder().key(BinaryField.MAX_FILE_LENGTH).value("10").fieldId(binaryField.id()).build();
-            FieldVariable allowFileTypes = ImmutableFieldVariable.builder().key(BinaryField.ALLOWED_FILE_TYPES).value("application/*").fieldId(binaryField.id()).build();
-            binaryField.constructFieldVariables(Arrays.asList(maxLength, allowFileTypes));
-            fieldAPI.save(maxLength, user);
-            fieldAPI.save(allowFileTypes, user);
+        final File tempTestFile = File
+                .createTempFile("csvTest_" + new Date().getTime(), ".txt");
+        FileUtils.writeStringToFile(tempTestFile, "Test");
 
-            final File tempTestFile = File
-                    .createTempFile("csvTest_" + new Date().getTime(), ".txt");
-            FileUtils.writeStringToFile(tempTestFile, "Test");
-
-            contentletA = new Contentlet();
-            contentletA.setStructureInode(contentType.inode());
-            contentletA.setLanguageId(languageAPI.getDefaultLanguage().getId());
-            contentletA.setStringProperty(textField.variable(), "A");
-            contentletA.setBinary(binaryField, tempTestFile);
-            contentletA.setIndexPolicy(IndexPolicy.FORCE);
-            contentletA.setIndexPolicyDependencies(IndexPolicy.FORCE);
-            contentletA = contentletAPI.checkin(contentletA, user, false);
+        contentletA = new Contentlet();
+        contentletA.setStructureInode(contentType.inode());
+        contentletA.setLanguageId(languageAPI.getDefaultLanguage().getId());
+        contentletA.setStringProperty(textField.variable(), "A");
+        contentletA.setBinary(binaryField, tempTestFile);
+        contentletA.setIndexPolicy(IndexPolicy.FORCE);
+        contentletA.setIndexPolicyDependencies(IndexPolicy.FORCE);
+        contentletA = contentletAPI.checkin(contentletA, user, false);
     }
 
     /**
-     * This test will:
-     * --- Create a content type called "Nested".
-     * --- Add only 1 Text field called Title
-     * --- Create a Content "A". Save/publish it.
-     * --- Create a Content "B". Save/publish it.
-     * --- Create a Content "C". Save/publish it.
-     * --- Create a 1:N Relationship, Parent and Child same Content Type: Nested
-     * --- Relate Content: Parent: A, Child B.
-     * --- Relate Content: Parent: B, Child C.
-     * --- Edit Content A, update title to "ABC"
-     *
+     * This test will: --- Create a content type called "Nested". --- Add only 1 Text field called
+     * Title --- Create a Content "A". Save/publish it. --- Create a Content "B". Save/publish it.
+     * --- Create a Content "C". Save/publish it. --- Create a 1:N Relationship, Parent and Child
+     * same Content Type: Nested --- Relate Content: Parent: A, Child B. --- Relate Content: Parent:
+     * B, Child C. --- Edit Content A, update title to "ABC"
+     * <p>
      * Before the fix we were getting an exception when editing content A because validateContentlet
-     * validates that if there's a 1-N relationship the parent content can't relate to a child
-     * that already has a parent; but we were pulling other related content, not just the parents.
-     *
+     * validates that if there's a 1-N relationship the parent content can't relate to a child that
+     * already has a parent; but we were pulling other related content, not just the parents.
+     * <p>
      * https://github.com/dotCMS/core/issues/10656
      */
     @Test
@@ -4992,27 +5336,36 @@ public class ContentletAPITest extends ContentletBaseTest {
         ContentType typeWithBinary = null;
 
         try {
-            typeWithBinary = createContentType("testCheckinWithoutVersioning", BaseContentType.CONTENT);
-            com.dotcms.contenttype.model.field.Field textField = createTextField("Title", typeWithBinary.id());
-            com.dotcms.contenttype.model.field.Field binaryField = createBinaryField("File", typeWithBinary.id());
+            typeWithBinary = createContentType("testCheckinWithoutVersioning",
+                    BaseContentType.CONTENT);
+            com.dotcms.contenttype.model.field.Field textField = createTextField("Title",
+                    typeWithBinary.id());
+            com.dotcms.contenttype.model.field.Field binaryField = createBinaryField("File",
+                    typeWithBinary.id());
             File textFileVersion1 = createTempFileWithText(FILE_V1_NAME, FILE_V1_NAME);
             Map<String, Object> fieldValues = map(textField.variable(), "contentV1",
                     binaryField.variable(), textFileVersion1);
-            Contentlet contentletWithBinary = createContentWithFieldValues(typeWithBinary.id(), fieldValues);
+            Contentlet contentletWithBinary = createContentWithFieldValues(typeWithBinary.id(),
+                    fieldValues);
 
             // let's verify that newly saved file exists
-            assertTrue(getBinaryAsset(contentletWithBinary.getInode(), binaryField.variable(), FILE_V1_NAME).exists());
+            assertTrue(getBinaryAsset(contentletWithBinary.getInode(), binaryField.variable(),
+                    FILE_V1_NAME).exists());
 
             File textFileVersion2 = createTempFileWithText(FILE_V2_NAME, FILE_V2_CONTENT);
             // replace old binary with new one
             contentletWithBinary.setBinary(binaryField.variable(), textFileVersion2);
-            Contentlet contentWithoutVersioning = contentletAPI.checkinWithoutVersioning(contentletWithBinary,
-                    new HashMap<>(), null, permissionAPI.getPermissions(contentletWithBinary), user, false);
+            Contentlet contentWithoutVersioning = contentletAPI.checkinWithoutVersioning(
+                    contentletWithBinary,
+                    new HashMap<>(), null, permissionAPI.getPermissions(contentletWithBinary), user,
+                    false);
 
             // we've just checkedIn without versioning, so old binary should not exist
-            assertFalse(getBinaryAsset(contentletWithBinary.getInode(), binaryField.variable(), FILE_V1_NAME).exists());
+            assertFalse(getBinaryAsset(contentletWithBinary.getInode(), binaryField.variable(),
+                    FILE_V1_NAME).exists());
 
-            File newBinary = getBinaryAsset(contentWithoutVersioning.getInode(), binaryField.variable(), FILE_V2_NAME);
+            File newBinary = getBinaryAsset(contentWithoutVersioning.getInode(),
+                    binaryField.variable(), FILE_V2_NAME);
             // new binary should exist
             assertTrue(newBinary.exists());
             // and content should be the expected
@@ -5021,7 +5374,9 @@ public class ContentletAPITest extends ContentletBaseTest {
             assertEquals(fileContent, FILE_V2_CONTENT);
 
         } finally {
-            if(typeWithBinary!=null) contentTypeAPI.delete(typeWithBinary);
+            if (typeWithBinary != null) {
+                contentTypeAPI.delete(typeWithBinary);
+            }
         }
     }
 
@@ -5033,24 +5388,32 @@ public class ContentletAPITest extends ContentletBaseTest {
         ContentType typeWithBinary = null;
 
         try {
-            typeWithBinary = createContentType("testCheckinWithoutVersioning", BaseContentType.CONTENT);
-            com.dotcms.contenttype.model.field.Field textField = createTextField("Title", typeWithBinary.id());
-            com.dotcms.contenttype.model.field.Field binaryField = createBinaryField("File", typeWithBinary.id());
+            typeWithBinary = createContentType("testCheckinWithoutVersioning",
+                    BaseContentType.CONTENT);
+            com.dotcms.contenttype.model.field.Field textField = createTextField("Title",
+                    typeWithBinary.id());
+            com.dotcms.contenttype.model.field.Field binaryField = createBinaryField("File",
+                    typeWithBinary.id());
             File textFileVersion1 = createTempFileWithText(BINARY_NAME, BINARY_CONTENT);
             Map<String, Object> fieldValues = map(textField.variable(), "contentV1",
                     binaryField.variable(), textFileVersion1);
-            Contentlet contentletWithBinary = createContentWithFieldValues(typeWithBinary.id(), fieldValues);
+            Contentlet contentletWithBinary = createContentWithFieldValues(typeWithBinary.id(),
+                    fieldValues);
 
             // let's verify that newly saved file exists
-            assertTrue(getBinaryAsset(contentletWithBinary.getInode(), binaryField.variable(), BINARY_NAME).exists());
+            assertTrue(getBinaryAsset(contentletWithBinary.getInode(), binaryField.variable(),
+                    BINARY_NAME).exists());
 
             //let's update a field different from the binary
             contentletWithBinary.setStringProperty(textField.variable(), "contentV2");
-            Contentlet contentWithoutVersioning = contentletAPI.checkinWithoutVersioning(contentletWithBinary,
-                    new HashMap<>(), null, permissionAPI.getPermissions(contentletWithBinary), user, false);
+            Contentlet contentWithoutVersioning = contentletAPI.checkinWithoutVersioning(
+                    contentletWithBinary,
+                    new HashMap<>(), null, permissionAPI.getPermissions(contentletWithBinary), user,
+                    false);
 
             // let's verify the binary is still in FS
-            File binaryFromAssetsDir = getBinaryAsset(contentWithoutVersioning.getInode(), binaryField.variable(), BINARY_NAME);
+            File binaryFromAssetsDir = getBinaryAsset(contentWithoutVersioning.getInode(),
+                    binaryField.variable(), BINARY_NAME);
             assertTrue(binaryFromAssetsDir.exists());
 
             // let's also verify file content remains the same
@@ -5063,7 +5426,9 @@ public class ContentletAPITest extends ContentletBaseTest {
             assertEquals(binaryFromContentlet.getName(), BINARY_NAME);
 
         } finally {
-            if(typeWithBinary!=null) contentTypeAPI.delete(typeWithBinary);
+            if (typeWithBinary != null) {
+                contentTypeAPI.delete(typeWithBinary);
+            }
         }
 
     }
@@ -5073,9 +5438,9 @@ public class ContentletAPITest extends ContentletBaseTest {
             throws DotDataException, DotSecurityException {
         String contentTypeName = "contentTypeTxtField" + System.currentTimeMillis();
         ContentType contentType = null;
-        try{
+        try {
             contentType = createContentType(contentTypeName, BaseContentType.CONTENT);
-            com.dotcms.contenttype.model.field.Field field =  ImmutableTextField.builder()
+            com.dotcms.contenttype.model.field.Field field = ImmutableTextField.builder()
                     .name("Whole Number Unique")
                     .contentTypeId(contentType.id())
                     .dataType(DataTypes.INTEGER)
@@ -5086,7 +5451,7 @@ public class ContentletAPITest extends ContentletBaseTest {
             Contentlet contentlet = new Contentlet();
             contentlet.setContentTypeId(contentType.inode());
             contentlet.setLanguageId(languageAPI.getDefaultLanguage().getId());
-            contentlet.setLongProperty(field.variable(),1);
+            contentlet.setLongProperty(field.variable(), 1);
             contentlet.setIndexPolicy(IndexPolicy.FORCE);
             contentlet = contentletAPI.checkin(contentlet, user, false);
             contentlet = contentletAPI.find(contentlet.getInode(), user, false);
@@ -5094,19 +5459,22 @@ public class ContentletAPITest extends ContentletBaseTest {
             Contentlet contentlet2 = new Contentlet();
             contentlet2.setContentTypeId(contentType.inode());
             contentlet2.setLanguageId(languageAPI.getDefaultLanguage().getId());
-            contentlet2.setLongProperty(field.variable(),1);
+            contentlet2.setLongProperty(field.variable(), 1);
             contentlet2 = contentletAPI.checkin(contentlet2, user, false);
 
 
-        }finally{
-            if(contentType != null) contentTypeAPI.delete(contentType);
+        } finally {
+            if (contentType != null) {
+                contentTypeAPI.delete(contentType);
+            }
         }
     }
 
-    private static class testCaseUniqueTextField{
+    private static class testCaseUniqueTextField {
+
         String fieldValue1;
 
-        testCaseUniqueTextField(final String fieldValue1){
+        testCaseUniqueTextField(final String fieldValue1) {
             this.fieldValue1 = fieldValue1;
         }
     }
@@ -5120,19 +5488,18 @@ public class ContentletAPITest extends ContentletBaseTest {
                 new testCaseUniqueTextField("aaa-bbb-ccc"),
                 new testCaseUniqueTextField("valid - field"),
                 new testCaseUniqueTextField("with \" quotes"),
-                new testCaseUniqueTextField("with special characters + [ ] { } * ( ) : && ! | ^ ~ ?"),
+                new testCaseUniqueTextField(
+                        "with special characters + [ ] { } * ( ) : && ! | ^ ~ ?"),
                 new testCaseUniqueTextField("CASEINSENSITIVE"),
                 new testCaseUniqueTextField("with chinese characters 好 心 面")
         };
     }
 
     /**
-     * This test is for the unique feature of a text field.
-     * It creates a content type with a text field marked as unique,
-     * and creates a contentlet in English, then a contentlet in Spanish
-     * (unique value does not matter the lang)
-     * and finally another contentlet in English and this is when it throws the exception
-     * (value it's in lowercase because needs to be case insentitive)
+     * This test is for the unique feature of a text field. It creates a content type with a text
+     * field marked as unique, and creates a contentlet in English, then a contentlet in Spanish
+     * (unique value does not matter the lang) and finally another contentlet in English and this is
+     * when it throws the exception (value it's in lowercase because needs to be case insentitive)
      */
     @Test(expected = DotContentletValidationException.class)
     @UseDataProvider("testCasesUniqueTextField")
@@ -5177,22 +5544,24 @@ public class ContentletAPITest extends ContentletBaseTest {
             contentlet3.setIndexPolicy(IndexPolicy.FORCE);
             contentlet3.setBoolProperty(Contentlet.DISABLE_WORKFLOW, true);
             contentlet3 = contentletAPI.checkin(contentlet3, user, false);
-        } catch(Exception e) {
+        } catch (Exception e) {
 
             if (ExceptionUtil.causedBy(e, DotContentletValidationException.class)) {
                 throw new DotContentletValidationException(e.getMessage());
             }
 
             fail(e.getMessage());
-        }finally{
-            if(contentType != null) contentTypeAPI.delete(contentType);
+        } finally {
+            if (contentType != null) {
+                contentTypeAPI.delete(contentType);
+            }
         }
     }
 
     /**
-     * Creates a contentlet with a working and a live version with diff values,
-     * and tries to create another contentlet with the live value this throws
-     * the exception (before we were only checking on the working index).
+     * Creates a contentlet with a working and a live version with diff values, and tries to create
+     * another contentlet with the live value this throws the exception (before we were only
+     * checking on the working index).
      *
      * @throws DotDataException
      * @throws DotSecurityException
@@ -5204,9 +5573,9 @@ public class ContentletAPITest extends ContentletBaseTest {
         final String fieldValueLive = "Live Value";
         final String fieldValueWorking = "Working Value";
         ContentType contentType = null;
-        try{
+        try {
             contentType = createContentType(contentTypeName, BaseContentType.CONTENT);
-            com.dotcms.contenttype.model.field.Field field =  ImmutableTextField.builder()
+            com.dotcms.contenttype.model.field.Field field = ImmutableTextField.builder()
                     .name("Text Unique")
                     .contentTypeId(contentType.id())
                     .dataType(DataTypes.TEXT)
@@ -5218,14 +5587,13 @@ public class ContentletAPITest extends ContentletBaseTest {
             Contentlet contentlet = new Contentlet();
             contentlet.setContentTypeId(contentType.inode());
             contentlet.setLanguageId(languageAPI.getDefaultLanguage().getId());
-            contentlet.setStringProperty(field.variable(),fieldValueLive);
+            contentlet.setStringProperty(field.variable(), fieldValueLive);
             contentlet.setIndexPolicy(IndexPolicy.WAIT_FOR);
             contentlet = contentletAPI.checkin(contentlet, user, false);
-            contentletAPI.publish(contentlet,user,false);
+            contentletAPI.publish(contentlet, user, false);
 
-
-            contentlet = contentletAPI.checkout(contentlet.getInode(),user,false);
-            contentlet.setStringProperty(field.variable(),fieldValueWorking);
+            contentlet = contentletAPI.checkout(contentlet.getInode(), user, false);
+            contentlet.setStringProperty(field.variable(), fieldValueWorking);
             contentlet.setIndexPolicy(IndexPolicy.WAIT_FOR);
             contentletAPI.checkin(contentlet, user, false);
 
@@ -5233,21 +5601,23 @@ public class ContentletAPITest extends ContentletBaseTest {
             Contentlet contentlet3 = new Contentlet();
             contentlet3.setContentTypeId(contentType.inode());
             contentlet3.setLanguageId(languageAPI.getDefaultLanguage().getId());
-            contentlet3.setStringProperty(field.variable(),fieldValueLive);
+            contentlet3.setStringProperty(field.variable(), fieldValueLive);
             contentlet3.setIndexPolicy(IndexPolicy.WAIT_FOR);
             contentletAPI.checkin(contentlet3, user, false);
 
-        }finally{
-            if(contentType != null) contentTypeAPI.delete(contentType);
+        } finally {
+            if (contentType != null) {
+                contentTypeAPI.delete(contentType);
+            }
         }
     }
 
     /**
      * This one tests the ContentletAPI.checkin with the following signature:
-     *
-     * checkin(Contentlet currentContentlet, ContentletRelationships relationshipsData, List<Category> cats,
-     * List<Permission> selectedPermissions, User user,	boolean respectFrontendRoles)
-     *
+     * <p>
+     * checkin(Contentlet currentContentlet, ContentletRelationships relationshipsData,
+     * List<Category> cats, List<Permission> selectedPermissions, User user,	boolean
+     * respectFrontendRoles)
      */
     @Test
     public void testCheckin1_ExistingContentWithCats_NullCats_ShouldKeepExistingCats()
@@ -5261,8 +5631,9 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final List<Category> categories = getACoupleOfCategories();
 
-            blogContent = contentletAPI.checkin(blogContent, (ContentletRelationships) null, categories,
-                null, user, false);
+            blogContent = contentletAPI.checkin(blogContent, (ContentletRelationships) null,
+                    categories,
+                    null, user, false);
 
             // let's check cats saved fine
             List<Category> contentCats = APILocator.getCategoryAPI().getParents(blogContent, user,
@@ -5270,13 +5641,16 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             assertTrue(contentCats.containsAll(categories));
 
-            Contentlet checkedoutBlogContent = contentletAPI.checkout(blogContent.getInode(), user, false);
+            Contentlet checkedoutBlogContent = contentletAPI.checkout(blogContent.getInode(), user,
+                    false);
 
-            Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutBlogContent, (ContentletRelationships) null,
-                null, null, user, false);
+            Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutBlogContent,
+                    (ContentletRelationships) null,
+                    null, null, user, false);
 
-            List<Category> existingCats = APILocator.getCategoryAPI().getParents(reCheckedinContent, user,
-                false);
+            List<Category> existingCats = APILocator.getCategoryAPI()
+                    .getParents(reCheckedinContent, user,
+                            false);
 
             assertTrue(existingCats.containsAll(categories));
         } finally {
@@ -5292,10 +5666,10 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /**
      * This one tests the ContentletAPI.checkin with the following signature:
-     *
-     * checkin(Contentlet currentContentlet, ContentletRelationships relationshipsData, List<Category> cats,
-     * List<Permission> selectedPermissions, User user, boolean respectFrontendRoles, boolean generateSystemEvent)
-     *
+     * <p>
+     * checkin(Contentlet currentContentlet, ContentletRelationships relationshipsData,
+     * List<Category> cats, List<Permission> selectedPermissions, User user, boolean
+     * respectFrontendRoles, boolean generateSystemEvent)
      */
     @Test
     public void testCheckin2_ExistingContentWithCats_NullCats_ShouldKeepExistingCats()
@@ -5310,16 +5684,19 @@ public class ContentletAPITest extends ContentletBaseTest {
             final List<Category> categories = getACoupleOfCategories();
 
             blogContent =
-                contentletAPI.checkin(blogContent, (Map<Relationship, List<Contentlet>>) null, categories,
-                    null, user, false);
+                    contentletAPI.checkin(blogContent, (Map<Relationship, List<Contentlet>>) null,
+                            categories,
+                            null, user, false);
 
-            Contentlet checkedoutBlogContent = contentletAPI.checkout(blogContent.getInode(), user, false);
+            Contentlet checkedoutBlogContent = contentletAPI.checkout(blogContent.getInode(), user,
+                    false);
 
             Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutBlogContent, null,
-                null, null, user, false, false);
+                    null, null, user, false, false);
 
-            List<Category> existingCats = APILocator.getCategoryAPI().getParents(reCheckedinContent, user,
-                false);
+            List<Category> existingCats = APILocator.getCategoryAPI()
+                    .getParents(reCheckedinContent, user,
+                            false);
 
             assertTrue(existingCats.containsAll(categories));
         } finally {
@@ -5335,10 +5712,9 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /**
      * This one tests the ContentletAPI.checkin with the following signature:
-     *
-     * checkin(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships, List<Category> cats ,
-     * List<Permission> permissions, User user,boolean respectFrontendRoles)
-     *
+     * <p>
+     * checkin(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships,
+     * List<Category> cats , List<Permission> permissions, User user,boolean respectFrontendRoles)
      */
     @Test
     public void testCheckin3_ExistingContentWithCats_NullCats_ShouldKeepExistingCats()
@@ -5352,16 +5728,19 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final List<Category> categories = getACoupleOfCategories();
 
-            blogContent = contentletAPI.checkin(blogContent, (Map<Relationship, List<Contentlet>>) null, categories,
-                null, user, false);
+            blogContent = contentletAPI.checkin(blogContent,
+                    (Map<Relationship, List<Contentlet>>) null, categories,
+                    null, user, false);
 
-            Contentlet checkedoutBlogContent = contentletAPI.checkout(blogContent.getInode(), user, false);
+            Contentlet checkedoutBlogContent = contentletAPI.checkout(blogContent.getInode(), user,
+                    false);
 
             Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutBlogContent,
-                (Map<Relationship, List<Contentlet>>) null, null, null, user, false);
+                    (Map<Relationship, List<Contentlet>>) null, null, null, user, false);
 
-            List<Category> existingCats = APILocator.getCategoryAPI().getParents(reCheckedinContent, user,
-                false);
+            List<Category> existingCats = APILocator.getCategoryAPI()
+                    .getParents(reCheckedinContent, user,
+                            false);
 
             assertTrue(existingCats.containsAll(categories));
         } finally {
@@ -5377,10 +5756,9 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /**
      * This one tests the ContentletAPI.checkin with the following signature:
-     *
-     * checkin(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships, List<Category> cats,
-     * User user,boolean respectFrontendRoles)
-     *
+     * <p>
+     * checkin(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships,
+     * List<Category> cats, User user,boolean respectFrontendRoles)
      */
     @Test
     public void testCheckin4_ExistingContentWithCats_NullCats_ShouldKeepExistingCats()
@@ -5394,16 +5772,19 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final List<Category> categories = getACoupleOfCategories();
 
-            blogContent = contentletAPI.checkin(blogContent, (Map<Relationship, List<Contentlet>>) null, categories,
-                null, user, false);
+            blogContent = contentletAPI.checkin(blogContent,
+                    (Map<Relationship, List<Contentlet>>) null, categories,
+                    null, user, false);
 
-            Contentlet checkedoutBlogContent = contentletAPI.checkout(blogContent.getInode(), user, false);
+            Contentlet checkedoutBlogContent = contentletAPI.checkout(blogContent.getInode(), user,
+                    false);
 
             Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutBlogContent,
-                (Map<Relationship, List<Contentlet>>) null, null, user, false);
+                    (Map<Relationship, List<Contentlet>>) null, null, user, false);
 
-            List<Category> existingCats = APILocator.getCategoryAPI().getParents(reCheckedinContent, user,
-                false);
+            List<Category> existingCats = APILocator.getCategoryAPI()
+                    .getParents(reCheckedinContent, user,
+                            false);
 
             assertTrue(existingCats.containsAll(categories));
         } finally {
@@ -5429,14 +5810,16 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final List<Category> categories = getACoupleOfCategories();
 
-            blogContent = contentletAPI.checkin(blogContent, (Map<Relationship, List<Contentlet>>) null, categories,
-                null, user, false);
+            blogContent = contentletAPI.checkin(blogContent,
+                    (Map<Relationship, List<Contentlet>>) null, categories,
+                    null, user, false);
 
             Contentlet reCheckedinContent = contentletAPI.checkinWithoutVersioning(blogContent,
-                (Map<Relationship, List<Contentlet>>) null, null, null, user, false);
+                    (Map<Relationship, List<Contentlet>>) null, null, null, user, false);
 
-            List<Category> existingCats = APILocator.getCategoryAPI().getParents(reCheckedinContent, user,
-                false);
+            List<Category> existingCats = APILocator.getCategoryAPI()
+                    .getParents(reCheckedinContent, user,
+                            false);
 
             assertTrue(existingCats.containsAll(categories));
         } finally {
@@ -5452,7 +5835,6 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /**
      * Test checkin with a non-existing contentlet identifier, that should fail
-     *
      */
     @Test(expected = DotDataException.class)
     public void testCheckin_Non_Existing_Identifier_With_Validate_Should_FAIL()
@@ -5467,21 +5849,24 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final List<Category> categories = getACoupleOfCategories();
 
-            newsContent = contentletAPI.checkin(newsContent, (ContentletRelationships) null, categories,
-                    null, user,false);
+            newsContent = contentletAPI.checkin(newsContent, (ContentletRelationships) null,
+                    categories,
+                    null, user, false);
 
             fail("Should throw a constrain exception for an unexisting id");
         } catch (Exception e) {
 
-            if (e instanceof DotDataException || ExceptionUtil.causedBy(e, DotDataException.class)) {
+            if (e instanceof DotDataException || ExceptionUtil.causedBy(e,
+                    DotDataException.class)) {
 
                 throw new DotDataException(e.getMessage());
             }
 
-            fail("The exception catch should: DotHibernateException and is: " + e.getClass() );
+            fail("The exception catch should: DotHibernateException and is: " + e.getClass());
         } finally {
             try {
-                if (newsContent != null && UtilMethods.isSet(newsContent.getIdentifier()) && UtilMethods.isSet(newsContent.getInode())) {
+                if (newsContent != null && UtilMethods.isSet(newsContent.getIdentifier())
+                        && UtilMethods.isSet(newsContent.getInode())) {
                     contentletAPI.destroy(newsContent, user, false);
                 }
             } catch (Exception e) {
@@ -5491,11 +5876,11 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Test checkin with a non-existing contentlet identifier, that should not fail since the non validate is activated
-     *
+     * Test checkin with a non-existing contentlet identifier, that should not fail since the non
+     * validate is activated
      */
     @Test
-        public void testCheckin_Non_Existing_Identifier_With_Not_Validate_Success()
+    public void testCheckin_Non_Existing_Identifier_With_Not_Validate_Success()
             throws DotDataException, DotSecurityException {
         Contentlet newsContent = null;
 
@@ -5511,18 +5896,19 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final List<Category> categories = getACoupleOfCategories();
 
-            final Contentlet newsContentReturned = contentletAPI.checkin(newsContent, (ContentletRelationships) null, categories,
-                    null, user,false);
+            final Contentlet newsContentReturned = contentletAPI.checkin(newsContent,
+                    (ContentletRelationships) null, categories,
+                    null, user, false);
 
             assertNotNull(newsContentReturned);
-            assertEquals (newsContentReturned.getIdentifier(), identifier);
+            assertEquals(newsContentReturned.getIdentifier(), identifier);
             newsContent = newsContentReturned;
-        }  finally {
+        } finally {
             try {
                 if (newsContent != null && UtilMethods.isSet(newsContent.getIdentifier())) {
                     contentletAPI.destroy(newsContent, user, false);
                 }
-            }catch (Exception e) {
+            } catch (Exception e) {
                 // quiet
             }
         }
@@ -5530,10 +5916,10 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /**
      * This one tests the ContentletAPI.checkin with the following signature:
-     *
-     * checkin(Contentlet currentContentlet, ContentletRelationships relationshipsData, List<Category> cats,
-     * List<Permission> selectedPermissions, User user,	boolean respectFrontendRoles)
-     *
+     * <p>
+     * checkin(Contentlet currentContentlet, ContentletRelationships relationshipsData,
+     * List<Category> cats, List<Permission> selectedPermissions, User user,	boolean
+     * respectFrontendRoles)
      */
     @Test
     public void testCheckin1_ExistingContentWithCats_EmptyCatsList_ShouldWipeExistingCats()
@@ -5547,18 +5933,22 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final List<Category> categories = getACoupleOfCategories();
 
-            newsContent = contentletAPI.checkin(newsContent, (ContentletRelationships) null, categories,
-                null, user,false);
+            newsContent = contentletAPI.checkin(newsContent, (ContentletRelationships) null,
+                    categories,
+                    null, user, false);
 
-            Contentlet checkedoutNewsContent = contentletAPI.checkout(newsContent.getInode(), user, false);
+            Contentlet checkedoutNewsContent = contentletAPI.checkout(newsContent.getInode(), user,
+                    false);
 
             checkedoutNewsContent.setIndexPolicy(IndexPolicy.FORCE);
             checkedoutNewsContent.setIndexPolicyDependencies(IndexPolicy.FORCE);
-            Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutNewsContent, (ContentletRelationships) null,
-                new ArrayList<>(), null, user, false);
+            Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutNewsContent,
+                    (ContentletRelationships) null,
+                    new ArrayList<>(), null, user, false);
 
-            List<Category> existingCats = APILocator.getCategoryAPI().getParents(reCheckedinContent, user,
-                false);
+            List<Category> existingCats = APILocator.getCategoryAPI()
+                    .getParents(reCheckedinContent, user,
+                            false);
 
             assertFalse(UtilMethods.isSet(existingCats));
         } finally {
@@ -5574,10 +5964,10 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /**
      * This one tests the ContentletAPI.checkin with the following signature:
-     *
-     * checkin(Contentlet currentContentlet, ContentletRelationships relationshipsData, List<Category> cats,
-     * List<Permission> selectedPermissions, User user, boolean respectFrontendRoles, boolean generateSystemEvent)
-     *
+     * <p>
+     * checkin(Contentlet currentContentlet, ContentletRelationships relationshipsData,
+     * List<Category> cats, List<Permission> selectedPermissions, User user, boolean
+     * respectFrontendRoles, boolean generateSystemEvent)
      */
     @Test
     public void testCheckin2_ExistingContentWithCats_EmptyCatsList_ShouldWipeExistingCats()
@@ -5592,15 +5982,17 @@ public class ContentletAPITest extends ContentletBaseTest {
             final List<Category> categories = getACoupleOfCategories();
 
             newsContent = contentletAPI.checkin(newsContent, null, categories,
-                null, user,false, false);
+                    null, user, false, false);
 
-            Contentlet checkedoutNewsContent = contentletAPI.checkout(newsContent.getInode(), user, false);
+            Contentlet checkedoutNewsContent = contentletAPI.checkout(newsContent.getInode(), user,
+                    false);
 
             Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutNewsContent, null,
-                new ArrayList<>(), null, user, false, false);
+                    new ArrayList<>(), null, user, false, false);
 
-            List<Category> existingCats = APILocator.getCategoryAPI().getParents(reCheckedinContent, user,
-                false);
+            List<Category> existingCats = APILocator.getCategoryAPI()
+                    .getParents(reCheckedinContent, user,
+                            false);
 
             assertFalse(UtilMethods.isSet(existingCats));
         } finally {
@@ -5616,10 +6008,9 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /**
      * This one tests the ContentletAPI.checkin with the following signature:
-     *
-     * checkin(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships, List<Category> cats ,
-     * List<Permission> permissions, User user,boolean respectFrontendRoles)
-     *
+     * <p>
+     * checkin(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships,
+     * List<Category> cats , List<Permission> permissions, User user,boolean respectFrontendRoles)
      */
     @Test
     public void testCheckin3_ExistingContentWithCats_EmptyCatsList_ShouldWipeExistingCats()
@@ -5633,18 +6024,22 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final List<Category> categories = getACoupleOfCategories();
 
-            newsContent = contentletAPI.checkin(newsContent, (Map<Relationship, List<Contentlet>>) null, categories,
-                null, user,false);
+            newsContent = contentletAPI.checkin(newsContent,
+                    (Map<Relationship, List<Contentlet>>) null, categories,
+                    null, user, false);
 
-            Contentlet checkedoutNewsContent = contentletAPI.checkout(newsContent.getInode(), user, false);
+            Contentlet checkedoutNewsContent = contentletAPI.checkout(newsContent.getInode(), user,
+                    false);
 
             checkedoutNewsContent.setIndexPolicy(IndexPolicy.FORCE);
             checkedoutNewsContent.setIndexPolicyDependencies(IndexPolicy.FORCE);
             Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutNewsContent,
-                (Map<Relationship, List<Contentlet>>) null, new ArrayList<>(), null, user, false);
+                    (Map<Relationship, List<Contentlet>>) null, new ArrayList<>(), null, user,
+                    false);
 
-            List<Category> existingCats = APILocator.getCategoryAPI().getParents(reCheckedinContent, user,
-                false);
+            List<Category> existingCats = APILocator.getCategoryAPI()
+                    .getParents(reCheckedinContent, user,
+                            false);
 
             assertFalse(UtilMethods.isSet(existingCats));
         } finally {
@@ -5660,10 +6055,9 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /**
      * This one tests the ContentletAPI.checkin with the following signature:
-     *
-     * checkin(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships, List<Category> cats,
-     * User user,boolean respectFrontendRoles)
-     *
+     * <p>
+     * checkin(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships,
+     * List<Category> cats, User user,boolean respectFrontendRoles)
      */
     @Test
     public void testCheckin4_ExistingContentWithCats_EmptyCatsList_ShouldWipeExistingCats()
@@ -5677,16 +6071,19 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final List<Category> categories = getACoupleOfCategories();
 
-            newsContent = contentletAPI.checkin(newsContent, (Map<Relationship, List<Contentlet>>) null, categories,
-                user,false);
+            newsContent = contentletAPI.checkin(newsContent,
+                    (Map<Relationship, List<Contentlet>>) null, categories,
+                    user, false);
 
-            Contentlet checkedoutNewsContent = contentletAPI.checkout(newsContent.getInode(), user, false);
+            Contentlet checkedoutNewsContent = contentletAPI.checkout(newsContent.getInode(), user,
+                    false);
 
             Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutNewsContent,
-                (Map<Relationship, List<Contentlet>>) null, new ArrayList<>(), user, false);
+                    (Map<Relationship, List<Contentlet>>) null, new ArrayList<>(), user, false);
 
-            List<Category> existingCats = APILocator.getCategoryAPI().getParents(reCheckedinContent, user,
-                false);
+            List<Category> existingCats = APILocator.getCategoryAPI()
+                    .getParents(reCheckedinContent, user,
+                            false);
 
             assertFalse(UtilMethods.isSet(existingCats));
         } finally {
@@ -5712,14 +6109,16 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             final List<Category> categories = getACoupleOfCategories();
 
-            newsContent = contentletAPI.checkin(newsContent, (Map<Relationship, List<Contentlet>>) null, categories, null, user,
-                false);
+            newsContent = contentletAPI.checkin(newsContent,
+                    (Map<Relationship, List<Contentlet>>) null, categories, null, user,
+                    false);
 
             Contentlet reCheckedinContent = contentletAPI.checkinWithoutVersioning(newsContent,
                     (ContentletRelationships) null, new ArrayList<>(), null, user, false);
 
-            List<Category> existingCats = APILocator.getCategoryAPI().getParents(reCheckedinContent, user,
-                false);
+            List<Category> existingCats = APILocator.getCategoryAPI()
+                    .getParents(reCheckedinContent, user,
+                            false);
 
             assertFalse(UtilMethods.isSet(existingCats));
         } finally {
@@ -5727,7 +6126,7 @@ public class ContentletAPITest extends ContentletBaseTest {
                 if (newsContent != null && UtilMethods.isSet(newsContent.getIdentifier())) {
                     contentletAPI.destroy(newsContent, user, false);
                 }
-            }catch (Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }
@@ -5776,8 +6175,8 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
     public void testCheckin1_ExistingContentWithChildAndParentRels_NullRels_ShouldKeepExistingRels()
-        throws DotDataException, DotSecurityException {
-        Contentlet blogContent    = null;
+            throws DotDataException, DotSecurityException {
+        Contentlet blogContent = null;
         Relationship relationship = null;
         List<Contentlet> relatedContent = null;
 
@@ -5787,7 +6186,8 @@ public class ContentletAPITest extends ContentletBaseTest {
                     .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
                             blogContentType.id());
 
-            final ContentletRelationships relationships = getACoupleOfParentAndChildrenSelfJoinRelationships(blogContent);
+            final ContentletRelationships relationships = getACoupleOfParentAndChildrenSelfJoinRelationships(
+                    blogContent);
             relationship = relationships.getRelationshipsRecords().get(0).getRelationship();
             relatedContent = relationships.getRelationshipsRecords().get(0).getRecords();
 
@@ -5795,20 +6195,24 @@ public class ContentletAPITest extends ContentletBaseTest {
             blogContent.setIndexPolicy(IndexPolicy.FORCE);
             blogContent.setIndexPolicyDependencies(IndexPolicy.FORCE);
             blogContent = contentletAPI.checkin(blogContent, relationships, categories, null, user,
-                false);
+                    false);
 
-            List<Contentlet> relatedContentFromDB = relationshipAPI.dbRelatedContent(relationship, blogContent,false);
+            List<Contentlet> relatedContentFromDB = relationshipAPI.dbRelatedContent(relationship,
+                    blogContent, false);
 
             assertTrue(relatedContentFromDB.containsAll(relatedContent));
 
-            Contentlet checkedoutBlogContent = contentletAPI.checkout(blogContent.getInode(), user, false);
+            Contentlet checkedoutBlogContent = contentletAPI.checkout(blogContent.getInode(), user,
+                    false);
 
             checkedoutBlogContent.setIndexPolicy(IndexPolicy.FORCE);
             checkedoutBlogContent.setIndexPolicyDependencies(IndexPolicy.FORCE);
-            Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutBlogContent, (ContentletRelationships) null,
-                null, null, user, false);
+            Contentlet reCheckedinContent = contentletAPI.checkin(checkedoutBlogContent,
+                    (ContentletRelationships) null,
+                    null, null, user, false);
 
-            List<Contentlet> existingRelationships = relationshipAPI.dbRelatedContent(relationship, reCheckedinContent, false);
+            List<Contentlet> existingRelationships = relationshipAPI.dbRelatedContent(relationship,
+                    reCheckedinContent, false);
 
             assertTrue(existingRelationships.containsAll(relatedContent));
         } finally {
@@ -5835,7 +6239,7 @@ public class ContentletAPITest extends ContentletBaseTest {
                 if (relationship != null && relationship.getInode() != null) {
                     relationshipAPI.delete(relationship);
                 }
-            }catch (Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }
@@ -5843,7 +6247,7 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
     public void testCheckin2_ExistingContentWithRels_NullRels_ShouldKeepExistingRels()
-        throws DotDataException, DotSecurityException {
+            throws DotDataException, DotSecurityException {
 
         Contentlet blogContent = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
@@ -5864,7 +6268,7 @@ public class ContentletAPITest extends ContentletBaseTest {
         checkedoutBlogContent.setIndexPolicyDependencies(IndexPolicy.FORCE);
         Contentlet reCheckedinContent = contentletAPI
                 .checkin(checkedoutBlogContent, (ContentletRelationships) null,
-                null, null, user, false, false);
+                        null, null, user, false, false);
 
         Relationship relationship = relationships.getRelationshipsRecords().get(0)
                 .getRelationship();
@@ -5881,7 +6285,7 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
     public void testCheckin3_ExistingContentWithRels_NullRels_ShouldKeepExistingRels()
-        throws DotDataException, DotSecurityException {
+            throws DotDataException, DotSecurityException {
 
         Contentlet blogContent = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
@@ -5897,7 +6301,7 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         blogContent.setIndexPolicy(IndexPolicy.FORCE);
         blogContent = contentletAPI.checkin(blogContent, relationshipsMap, categories,
-                null, user,false);
+                null, user, false);
 
         Contentlet checkedoutBlogContent = contentletAPI
                 .checkout(blogContent.getInode(), user, false);
@@ -5920,7 +6324,7 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
     public void testCheckin4_ExistingContentWithRels_NullRels_ShouldKeepExistingRels()
-        throws DotDataException, DotSecurityException {
+            throws DotDataException, DotSecurityException {
 
         Contentlet blogContent = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
@@ -5961,7 +6365,7 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
     public void testCheckinWithoutVersioning_ExistingContentWithRels_NullRels_ShouldKeepExistingRels()
-        throws DotDataException, DotSecurityException {
+            throws DotDataException, DotSecurityException {
 
         Contentlet blogContent = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
@@ -5998,7 +6402,7 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
     public void testCheckin3_ExistingContentWithRels_EmptyRels_ShouldWipeExistingRels()
-        throws DotDataException, DotSecurityException {
+            throws DotDataException, DotSecurityException {
 
         Contentlet blogContent = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
@@ -6019,7 +6423,7 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         blogContent.setIndexPolicy(IndexPolicy.FORCE);
         blogContent = contentletAPI.checkin(blogContent, relationshipsMap, categories,
-                null, user,false);
+                null, user, false);
 
         Contentlet checkedoutBlogContent = contentletAPI
                 .checkout(blogContent.getInode(), user, false);
@@ -6040,7 +6444,7 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
     public void testCheckin4_ExistingContentWithRels_EmptyRels_ShouldWipeExistingRels()
-        throws DotDataException, DotSecurityException {
+            throws DotDataException, DotSecurityException {
 
         Contentlet blogContent = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
@@ -6078,7 +6482,7 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
     public void testCheckinWithoutVersioning_ExistingContentWithRels_EmptyRels_ShouldWipeExistingRels()
-        throws DotDataException, DotSecurityException {
+            throws DotDataException, DotSecurityException {
 
         Contentlet blogContent = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
@@ -6112,15 +6516,16 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     @Test
     public void testCopyProperties_TypeWithTagField_shouldCopyTagFieldValue()
-        throws DotSecurityException, DotDataException {
+            throws DotSecurityException, DotDataException {
         Contentlet newsContent = null;
         try {
             newsContent = TestDataUtils
                     .getNewsContent(false, languageAPI.getDefaultLanguage().getId(),
                             newsContentType.id());
             Map<String, Object> innerMap = new HashMap<>(newsContent.getMap());
-            newsContent = contentletAPI.checkin(newsContent, user,false);
-            Contentlet checkedoutNewsContent = contentletAPI.checkout(newsContent.getInode(), user, false);
+            newsContent = contentletAPI.checkin(newsContent, user, false);
+            Contentlet checkedoutNewsContent = contentletAPI.checkout(newsContent.getInode(), user,
+                    false);
             assertEquals(checkedoutNewsContent.getStringProperty("tags"), innerMap.get("tags"));
             innerMap.put("tags", "newTag");
             contentletAPI.copyProperties(checkedoutNewsContent, innerMap);
@@ -6137,8 +6542,9 @@ public class ContentletAPITest extends ContentletBaseTest {
         }
     }
 
-    private ContentletRelationships getACoupleOfParentAndChildrenSelfJoinRelationships(final Contentlet contentlet)
-        throws DotDataException, DotSecurityException {
+    private ContentletRelationships getACoupleOfParentAndChildrenSelfJoinRelationships(
+            final Contentlet contentlet)
+            throws DotDataException, DotSecurityException {
 
         final Relationship selfJoinRelationship = new Relationship();
         selfJoinRelationship.setRelationTypeValue("ParentBlog-ChildBlog");
@@ -6149,39 +6555,47 @@ public class ContentletAPITest extends ContentletBaseTest {
         selfJoinRelationship.setChildRelationName("ChildBlog");
         relationshipAPI.save(selfJoinRelationship);
 
-        final ContentletRelationships contentletRelationships = new ContentletRelationships(contentlet);
+        final ContentletRelationships contentletRelationships = new ContentletRelationships(
+                contentlet);
 
         final ContentletRelationships.ContentletRelationshipRecords parentRecords =
-            contentletRelationships.new ContentletRelationshipRecords(selfJoinRelationship, false);
+                contentletRelationships.new ContentletRelationshipRecords(selfJoinRelationship,
+                        false);
         Contentlet parentBlog1 = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
                         blogContentType.id());
-        parentBlog1 = contentletAPI.checkin(parentBlog1, new HashMap<>(), getACoupleOfCategories(),  user, false);
+        parentBlog1 = contentletAPI.checkin(parentBlog1, new HashMap<>(), getACoupleOfCategories(),
+                user, false);
         Contentlet parentBlog2 = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
                         blogContentType.id());
-        parentBlog2 = contentletAPI.checkin(parentBlog2, new HashMap<>(), getACoupleOfCategories(), user, false);
+        parentBlog2 = contentletAPI.checkin(parentBlog2, new HashMap<>(), getACoupleOfCategories(),
+                user, false);
         parentRecords.setRecords(Arrays.asList(parentBlog1, parentBlog2));
 
         final ContentletRelationships.ContentletRelationshipRecords childRecords =
-            contentletRelationships.new ContentletRelationshipRecords(selfJoinRelationship, true);
+                contentletRelationships.new ContentletRelationshipRecords(selfJoinRelationship,
+                        true);
         Contentlet childBlog1 = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
                         blogContentType.id());
-        childBlog1 = contentletAPI.checkin(childBlog1, new HashMap<>(), getACoupleOfCategories(), user, false);
+        childBlog1 = contentletAPI.checkin(childBlog1, new HashMap<>(), getACoupleOfCategories(),
+                user, false);
         Contentlet childBlog2 = TestDataUtils
                 .getBlogContent(false, APILocator.getLanguageAPI().getDefaultLanguage().getId(),
                         blogContentType.id());
-        childBlog2 = contentletAPI.checkin(childBlog2, new HashMap<>(), getACoupleOfCategories(), user, false);
+        childBlog2 = contentletAPI.checkin(childBlog2, new HashMap<>(), getACoupleOfCategories(),
+                user, false);
         childRecords.setRecords(Arrays.asList(childBlog1, childBlog2));
 
-        contentletRelationships.setRelationshipsRecords(new ArrayList<>(Arrays.asList(parentRecords, childRecords)));
+        contentletRelationships.setRelationshipsRecords(
+                new ArrayList<>(Arrays.asList(parentRecords, childRecords)));
 
         return contentletRelationships;
     }
 
     private ContentletRelationships getACoupleOfChildRelationships(Contentlet contentlet)
-        throws DotDataException, DotSecurityException {
+            throws DotDataException, DotSecurityException {
 
         ContentletRelationships relationships = new ContentletRelationships(contentlet);
 
@@ -6202,7 +6616,7 @@ public class ContentletAPITest extends ContentletBaseTest {
         }
 
         ContentletRelationships.ContentletRelationshipRecords records =
-            relationships.new ContentletRelationshipRecords(blogComments, true);
+                relationships.new ContentletRelationshipRecords(blogComments, true);
 
         Contentlet comment1 = new Contentlet();
         comment1.setContentTypeId(commentsContentType.id());
@@ -6243,13 +6657,13 @@ public class ContentletAPITest extends ContentletBaseTest {
     @Test
     public void testDeletePageDefinedAsDetailPage() throws DotSecurityException, DotDataException {
 
-        long time              = System.currentTimeMillis();
-        ContentType type       = null;
-        Folder testFolder      = null;
+        long time = System.currentTimeMillis();
+        ContentType type = null;
+        Folder testFolder = null;
         HTMLPageAsset htmlPage = null;
-        Template template      = null;
+        Template template = null;
 
-        try{
+        try {
             // new template
             template = new TemplateDataGen().nextPersisted();
 
@@ -6276,8 +6690,8 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             try {
                 contentletAPI.delete(htmlPage, user, false);
-                assertTrue("DotWorkflowException expected", false );
-            }  catch (DotWorkflowException e) {
+                assertTrue("DotWorkflowException expected", false);
+            } catch (DotWorkflowException e) {
                 //Expected
             }
 
@@ -6286,15 +6700,15 @@ public class ContentletAPITest extends ContentletBaseTest {
             assertEquals(htmlPage.getIdentifier(), type.detailPage());
             assertEquals("/mapPatternForTesting", type.urlMapPattern());
         } finally {
-            if (type != null){
+            if (type != null) {
                 contentTypeAPI.delete(type);
             }
 
-            if (testFolder != null){
+            if (testFolder != null) {
                 FolderDataGen.remove(testFolder);
             }
 
-            if (template != null){
+            if (template != null) {
                 TemplateDataGen.remove(template);
             }
         }
@@ -6316,7 +6730,7 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         assertTrue(result.stream().anyMatch(contentlet -> {
             final String fileName = contentlet.getStringProperty("fileName").toLowerCase();
-               return fileName.endsWith("jpg") ||  fileName.endsWith("jpeg");
+            return fileName.endsWith("jpg") || fileName.endsWith("jpeg");
         }));
     }
 
@@ -6326,22 +6740,22 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         Contentlet spanishPage = null;
         Container container = null;
-        Folder folder       = null;
+        Folder folder = null;
         Structure structure = null;
 
-        Template englishTemplate  = null;
-        Template spanishTemplate  = null;
+        Template englishTemplate = null;
+        Template spanishTemplate = null;
 
         final String UUID = UUIDGenerator.generateUuid();
 
-        try{
+        try {
             structure = new StructureDataGen().nextPersisted();
             container = new ContainerDataGen().withStructure(structure, "")
                     .nextPersisted();
             englishTemplate = new TemplateDataGen().title("English Template")
-                    .withContainer(container.getIdentifier(),UUID).nextPersisted();
+                    .withContainer(container.getIdentifier(), UUID).nextPersisted();
             spanishTemplate = new TemplateDataGen().title("Spanish Template")
-                    .withContainer(container.getIdentifier(),UUID).nextPersisted();
+                    .withContainer(container.getIdentifier(), UUID).nextPersisted();
             folder = new FolderDataGen().nextPersisted();
 
             //Create a page in English
@@ -6352,13 +6766,15 @@ public class ContentletAPITest extends ContentletBaseTest {
             spanishPage = HTMLPageDataGen.checkout(englishPage);
 
             spanishPage.setLanguageId(spanishLanguage.getId());
-            spanishPage.setProperty(HTMLPageAssetAPI.TEMPLATE_FIELD, spanishTemplate.getIdentifier());
+            spanishPage.setProperty(HTMLPageAssetAPI.TEMPLATE_FIELD,
+                    spanishTemplate.getIdentifier());
             spanishPage.setProperty(HTMLPageAssetAPI.URL_FIELD, englishPage.getPageUrl() + "SP");
 
             spanishPage = HTMLPageDataGen.checkin(spanishPage);
 
             //Verify that both pages have the same template
-            assertEquals(spanishPage.get(HTMLPageAssetAPI.TEMPLATE_FIELD), spanishTemplate.getIdentifier());
+            assertEquals(spanishPage.get(HTMLPageAssetAPI.TEMPLATE_FIELD),
+                    spanishTemplate.getIdentifier());
 
             //Verify that the initial English version was not modified
             assertEquals(englishTemplate.getIdentifier(),
@@ -6378,7 +6794,7 @@ public class ContentletAPITest extends ContentletBaseTest {
                             .get(HTMLPageAssetAPI.TEMPLATE_FIELD));
 
 
-        } finally{
+        } finally {
 
             //Clean up environment
             try {
@@ -6388,11 +6804,13 @@ public class ContentletAPITest extends ContentletBaseTest {
                     FolderDataGen.remove(folder);
                 }
 
-                if (UtilMethods.isSet(spanishTemplate) && UtilMethods.isSet(spanishTemplate.getInode())) {
+                if (UtilMethods.isSet(spanishTemplate) && UtilMethods.isSet(
+                        spanishTemplate.getInode())) {
                     TemplateDataGen.remove(spanishTemplate);
                 }
 
-                if (UtilMethods.isSet(englishTemplate) && UtilMethods.isSet(englishTemplate.getInode())) {
+                if (UtilMethods.isSet(englishTemplate) && UtilMethods.isSet(
+                        englishTemplate.getInode())) {
                     TemplateDataGen.remove(englishTemplate);
                 }
 
@@ -6403,7 +6821,7 @@ public class ContentletAPITest extends ContentletBaseTest {
                 if (UtilMethods.isSet(structure) && UtilMethods.isSet(structure.getInode())) {
                     StructureDataGen.remove(structure);
                 }
-            }catch (Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }
@@ -6414,23 +6832,23 @@ public class ContentletAPITest extends ContentletBaseTest {
     public void testSetTemplateForAPageMustKeepTheSameTemplateForWorkingVersionsNoLive()
             throws Exception {
 
-        Contentlet result   = null;
+        Contentlet result = null;
         Container container = null;
-        Folder folder       = null;
+        Folder folder = null;
         Structure structure = null;
 
-        Template englishTemplate  = null;
-        Template spanishTemplate  = null;
+        Template englishTemplate = null;
+        Template spanishTemplate = null;
         final String UUID = UUIDGenerator.generateUuid();
 
-        try{
+        try {
             structure = new StructureDataGen().nextPersisted();
             container = new ContainerDataGen().withStructure(structure, "")
                     .nextPersisted();
             englishTemplate = new TemplateDataGen().title("English Template")
-                    .withContainer(container.getIdentifier(),UUID).nextPersisted();
+                    .withContainer(container.getIdentifier(), UUID).nextPersisted();
             spanishTemplate = new TemplateDataGen().title("Spanish Template")
-                    .withContainer(container.getIdentifier(),UUID).nextPersisted();
+                    .withContainer(container.getIdentifier(), UUID).nextPersisted();
             folder = new FolderDataGen().nextPersisted();
 
             //Create a page in English
@@ -6444,13 +6862,15 @@ public class ContentletAPITest extends ContentletBaseTest {
             Contentlet spanishPage = HTMLPageDataGen.checkout(englishPage);
 
             spanishPage.setLanguageId(spanishLanguage.getId());
-            spanishPage.setProperty(HTMLPageAssetAPI.TEMPLATE_FIELD, spanishTemplate.getIdentifier());
+            spanishPage.setProperty(HTMLPageAssetAPI.TEMPLATE_FIELD,
+                    spanishTemplate.getIdentifier());
             spanishPage.setProperty(HTMLPageAssetAPI.URL_FIELD, englishPage.getPageUrl() + "SP");
 
             result = HTMLPageDataGen.checkin(spanishPage);
 
             //Verify that the Spanish page has the same template
-            assertEquals(result.get(HTMLPageAssetAPI.TEMPLATE_FIELD), spanishTemplate.getIdentifier());
+            assertEquals(result.get(HTMLPageAssetAPI.TEMPLATE_FIELD),
+                    spanishTemplate.getIdentifier());
 
             //Verify that the initial English version was not modified
             assertEquals(englishTemplate.getIdentifier(),
@@ -6470,7 +6890,7 @@ public class ContentletAPITest extends ContentletBaseTest {
                     contentletAPI.find(newEnglishInode, user, false)
                             .get(HTMLPageAssetAPI.TEMPLATE_FIELD));
 
-        } finally{
+        } finally {
 
             try {
                 //Clean up environment
@@ -6480,11 +6900,13 @@ public class ContentletAPITest extends ContentletBaseTest {
                     FolderDataGen.remove(folder);
                 }
 
-                if (UtilMethods.isSet(spanishTemplate) && UtilMethods.isSet(spanishTemplate.getInode())) {
+                if (UtilMethods.isSet(spanishTemplate) && UtilMethods.isSet(
+                        spanishTemplate.getInode())) {
                     TemplateDataGen.remove(spanishTemplate);
                 }
 
-                if (UtilMethods.isSet(englishTemplate) && UtilMethods.isSet(englishTemplate.getInode())) {
+                if (UtilMethods.isSet(englishTemplate) && UtilMethods.isSet(
+                        englishTemplate.getInode())) {
                     TemplateDataGen.remove(englishTemplate);
                 }
 
@@ -6495,7 +6917,7 @@ public class ContentletAPITest extends ContentletBaseTest {
                 if (UtilMethods.isSet(structure) && UtilMethods.isSet(structure.getInode())) {
                     StructureDataGen.remove(structure);
                 }
-            }catch (Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }
@@ -6580,14 +7002,17 @@ public class ContentletAPITest extends ContentletBaseTest {
                     .getRelationshipFromField(parentField, user);
 
             final ContentletDataGen dataGen = new ContentletDataGen(parentContentType.id());
-            Contentlet childContent = dataGen.languageId(languageAPI.getDefaultLanguage().getId()).nextPersisted();
+            Contentlet childContent = dataGen.languageId(languageAPI.getDefaultLanguage().getId())
+                    .nextPersisted();
 
-            Contentlet parentContent = dataGen.languageId(languageAPI.getDefaultLanguage().getId()).next();
+            Contentlet parentContent = dataGen.languageId(languageAPI.getDefaultLanguage().getId())
+                    .next();
 
             parentContent = contentletAPI.checkin(parentContent, CollectionsUtils
                     .map(relationship, CollectionsUtils.list(childContent)), user, false);
 
-            List<Contentlet> relatedContent = relationshipAPI.dbRelatedContent(relationship, parentContent, true);
+            List<Contentlet> relatedContent = relationshipAPI.dbRelatedContent(relationship,
+                    parentContent, true);
 
             assertEquals(1, relatedContent.size());
             assertEquals(childContent.getIdentifier(), relatedContent.get(0).getIdentifier());
@@ -6629,7 +7054,8 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             //Setting the other side of the relationship childContentType --> parentContentType
             com.dotcms.contenttype.model.field.Field childField = createRelationshipField("parent",
-                    childContentType.id(), parentContentType.variable() + StringPool.PERIOD + parentField.variable());
+                    childContentType.id(),
+                    parentContentType.variable() + StringPool.PERIOD + parentField.variable());
 
             //Removing parent field
             fieldAPI.delete(parentField, user);
@@ -6694,7 +7120,8 @@ public class ContentletAPITest extends ContentletBaseTest {
 
             //Setting the other side of the relationship parentContentType --> parentContentType (self-related as child)
             com.dotcms.contenttype.model.field.Field childField = createRelationshipField("parent",
-                    parentContentType.id(), parentContentType.variable() + StringPool.PERIOD + parentField.variable());
+                    parentContentType.id(),
+                    parentContentType.variable() + StringPool.PERIOD + parentField.variable());
 
             //Removing parent field
             fieldAPI.delete(parentField, user);
@@ -6703,14 +7130,17 @@ public class ContentletAPITest extends ContentletBaseTest {
                     .getRelationshipFromField(childField, user);
 
             final ContentletDataGen dataGen = new ContentletDataGen(parentContentType.id());
-            Contentlet parentContent = dataGen.languageId(languageAPI.getDefaultLanguage().getId()).nextPersisted();
+            Contentlet parentContent = dataGen.languageId(languageAPI.getDefaultLanguage().getId())
+                    .nextPersisted();
 
-            Contentlet childContent = dataGen.languageId(languageAPI.getDefaultLanguage().getId()).next();
+            Contentlet childContent = dataGen.languageId(languageAPI.getDefaultLanguage().getId())
+                    .next();
             childContent.setRelated(childField.variable(), CollectionsUtils.list(parentContent));
 
             childContent = contentletAPI.checkin(childContent, user, false);
 
-            List<Contentlet> relatedContent = relationshipAPI.dbRelatedContent(relationship, childContent, false);
+            List<Contentlet> relatedContent = relationshipAPI.dbRelatedContent(relationship,
+                    childContent, false);
 
             assertEquals(1, relatedContent.size());
             assertEquals(parentContent.getIdentifier(), relatedContent.get(0).getIdentifier());
@@ -6741,13 +7171,15 @@ public class ContentletAPITest extends ContentletBaseTest {
                 languageAPI.getDefaultLanguage().getId());
         assertNotNull(beforeTouch);
 
-        final Set<String> inodes = Stream.of(beforeTouch).map(Contentlet::getInode).collect(Collectors.toSet());
+        final Set<String> inodes = Stream.of(beforeTouch).map(Contentlet::getInode)
+                .collect(Collectors.toSet());
         contentletAPI.updateModDate(inodes, user);
 
-        final Contentlet afterTouch = contentletAPI.find(beforeTouch.getInode(), APILocator.getUserAPI().getSystemUser(),false);
+        final Contentlet afterTouch = contentletAPI.find(beforeTouch.getInode(),
+                APILocator.getUserAPI().getSystemUser(), false);
         assertEquals(beforeTouch.getInode(), afterTouch.getInode());
         assertNotEquals(afterTouch.getModDate(), beforeTouch.getModDate());
-        assertEquals(user.getUserId(),afterTouch.getModUser());
+        assertEquals(user.getUserId(), afterTouch.getModUser());
     }
 
     @DataProvider
@@ -6800,7 +7232,6 @@ public class ContentletAPITest extends ContentletBaseTest {
                     }
                 };
 
-
         // case 3 setBoolProperty
         final TestCaseNullFieldvalues case3 = new TestCaseNullFieldvalues();
         case3.fieldType = RadioField.class;
@@ -6848,7 +7279,7 @@ public class ContentletAPITest extends ContentletBaseTest {
                     }
                 };
 
-        return new TestCaseNullFieldvalues[] {
+        return new TestCaseNullFieldvalues[]{
                 case1,
                 case2,
                 case3,
@@ -6858,6 +7289,7 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     private static class TestCaseNullFieldvalues {
+
         Consumer<Tuple2<String, String>> assertion;
         Class<? extends com.dotcms.contenttype.model.field.Field> fieldType;
         DataTypes dataType;
@@ -6967,13 +7399,14 @@ public class ContentletAPITest extends ContentletBaseTest {
         return binaryFromAssetsFolder;
     }
 
-    private Contentlet createContentWithFieldValues(String contentTypeId, Map<String, Object> fieldValues)
+    private Contentlet createContentWithFieldValues(String contentTypeId,
+            Map<String, Object> fieldValues)
             throws DotSecurityException, DotDataException {
         Contentlet contentlet = new Contentlet();
         contentlet.setContentTypeId(contentTypeId);
         contentlet.setLanguageId(languageAPI.getDefaultLanguage().getId());
 
-        for(String fieldVariable : fieldValues.keySet()) {
+        for (String fieldVariable : fieldValues.keySet()) {
             contentlet.setProperty(fieldVariable, fieldValues.get(fieldVariable));
         }
 
@@ -6998,9 +7431,10 @@ public class ContentletAPITest extends ContentletBaseTest {
         return contentTypeAPI.save(contentType);
     }
 
-    private com.dotcms.contenttype.model.field.Field createTextField(String name, String contentTypeId)
+    private com.dotcms.contenttype.model.field.Field createTextField(String name,
+            String contentTypeId)
             throws DotSecurityException, DotDataException {
-        com.dotcms.contenttype.model.field.Field field =  ImmutableTextField.builder()
+        com.dotcms.contenttype.model.field.Field field = ImmutableTextField.builder()
                 .name(name)
                 .contentTypeId(contentTypeId)
                 .dataType(DataTypes.TEXT)
@@ -7009,7 +7443,8 @@ public class ContentletAPITest extends ContentletBaseTest {
         return fieldAPI.save(field, user);
     }
 
-    private com.dotcms.contenttype.model.field.Field createBinaryField(String name, String contentTypeId)
+    private com.dotcms.contenttype.model.field.Field createBinaryField(String name,
+            String contentTypeId)
             throws DotSecurityException, DotDataException {
         com.dotcms.contenttype.model.field.Field field = ImmutableBinaryField.builder()
                 .name(name)
@@ -7022,7 +7457,7 @@ public class ContentletAPITest extends ContentletBaseTest {
     /**
      * Util method to write dummy text into a file.
      *
-     * @param file that we need to write. File should be empty.
+     * @param file        that we need to write. File should be empty.
      * @param textToWrite text that we are going to write into the file.
      */
     private void writeTextIntoFile(File file, final String textToWrite) {
@@ -7036,30 +7471,28 @@ public class ContentletAPITest extends ContentletBaseTest {
     @Test
     public void test_findInDb_returns_properly() throws Exception {
 
-
         ContentType type = new ContentTypeDataGen()
                 .fields(ImmutableList
-                        .of(ImmutableTextField.builder().name("Title").variable("title").searchable(true).listed(true).build()))
+                        .of(ImmutableTextField.builder().name("Title").variable("title")
+                                .searchable(true).listed(true).build()))
                 .nextPersisted();
 
-
         // test null value
-        Optional<Contentlet> conOpt= contentletAPI.findInDb(null);
-        assert(conOpt.isPresent()==false);
-
+        Optional<Contentlet> conOpt = contentletAPI.findInDb(null);
+        assert (conOpt.isPresent() == false);
 
         // test non-existing
-        conOpt= contentletAPI.findInDb("not-here");
-        assert(conOpt.isPresent()==false);
+        conOpt = contentletAPI.findInDb("not-here");
+        assert (conOpt.isPresent() == false);
 
-        final Contentlet contentlet = new ContentletDataGen(type.id()).setProperty("title", "contentTest " + System.currentTimeMillis()).nextPersisted();
+        final Contentlet contentlet = new ContentletDataGen(type.id()).setProperty("title",
+                "contentTest " + System.currentTimeMillis()).nextPersisted();
         contentlet.setStringProperty("title", "nope");
 
-        conOpt= contentletAPI.findInDb(contentlet.getInode());
-        assert(conOpt.isPresent());
+        conOpt = contentletAPI.findInDb(contentlet.getInode());
+        assert (conOpt.isPresent());
 
         assertNotEquals(conOpt.get().getTitle(), contentlet.getTitle());
-
 
 
     }
@@ -7081,16 +7514,16 @@ public class ContentletAPITest extends ContentletBaseTest {
             contentlet = contentletAPI.checkin(contentlet, user, false);
 
             assertEquals(contentType.host(), contentlet.getHost());
-        }finally {
-            if (contentType != null){
+        } finally {
+            if (contentType != null) {
                 contentTypeAPI.delete(contentType);
             }
         }
     }
 
     /**
-     * This test creates one content with versions in English and Spanish
-     * when one of these versions is deleted should be removed from the index.
+     * This test creates one content with versions in English and Spanish when one of these versions
+     * is deleted should be removed from the index.
      *
      * @throws DotDataException
      * @throws DotSecurityException
@@ -7103,38 +7536,52 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         try {
             contentType = new ContentTypeDataGen()
-                    .name("testRemoveContentFromIndexMultilingualContent"+System.currentTimeMillis())
+                    .name("testRemoveContentFromIndexMultilingualContent"
+                            + System.currentTimeMillis())
                     .fields(ImmutableList
                             .of(ImmutableTextField.builder().name("Title").variable("title")
                                     .build()))
                     .nextPersisted();
 
             final ContentletDataGen contentletDataGen = new ContentletDataGen(contentType.id());
-            final Contentlet contentInEnglish = contentletDataGen.languageId(languageAPI.getDefaultLanguage().getId()).nextPersisted();
+            final Contentlet contentInEnglish = contentletDataGen.languageId(
+                    languageAPI.getDefaultLanguage().getId()).nextPersisted();
             Contentlet contentInSpanish = ContentletDataGen.checkout(contentInEnglish);
             contentInSpanish.setLanguageId(spanishLanguage.getId());
             contentInSpanish = ContentletDataGen.checkin(contentInSpanish);
 
-            
-            
-            
-            
+            Logger.info(this, "searching after create");
+
             assertEquals(2,
-                    contentletAPI.searchIndex("+identifier:"+contentInEnglish.getIdentifier()  + " " + UUIDGenerator.uuid(),-1,0,"",user,true).size());
+                    contentletAPI.searchIndex(
+                            "+identifier:" + contentInEnglish.getIdentifier() + " "
+                                    + UUIDGenerator.uuid(), -1, 0, "", user, true).size());
 
             contentInSpanish.setIndexPolicy(IndexPolicy.FORCE);
             ContentletDataGen.archive(contentInSpanish);
             ContentletDataGen.delete(contentInSpanish);
 
+            Logger.info(this, "searching after delete spanish");
+
             assertEquals(1,
-                    contentletAPI.searchIndex("+identifier:"+contentInEnglish.getIdentifier() + " " + UUIDGenerator.uuid(),-1,0,"",user,true).size());
+                    contentletAPI.searchIndex(
+                            "+identifier:" + contentInEnglish.getIdentifier() + " "
+                                    + UUIDGenerator.uuid(), -1, 0, "", user, true).size());
 
             contentInEnglish.setIndexPolicy(IndexPolicy.FORCE);
             ContentletDataGen.archive(contentInEnglish);
             ContentletDataGen.delete(contentInEnglish);
 
-            assertEquals(0,
-                    contentletAPI.searchIndex("+identifier:"+contentInEnglish.getIdentifier() + " " + UUIDGenerator.uuid(),-1,0,"",user,true).size());
+            Logger.info(this, "searching after delete english");
+
+            int size = Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .until(() -> contentletAPI.searchIndex(
+                                    "+identifier:" + contentInEnglish.getIdentifier() + " "
+                                            + UUIDGenerator.uuid(), -1, 0, "", user, true).size(),
+                            equalTo(0));
+
+            assertEquals(0, size);
 
         } finally {
             if (contentType != null) {
@@ -7200,7 +7647,7 @@ public class ContentletAPITest extends ContentletBaseTest {
         final Language language = APILocator.getLanguageAPI().getDefaultLanguage();
         final WorkflowAPI workflowAPI = APILocator.getWorkflowAPI();
 
-        Contentlet contentlet    = null;
+        Contentlet contentlet = null;
         Contentlet newContentlet = null;
 
         try {
@@ -7258,12 +7705,12 @@ public class ContentletAPITest extends ContentletBaseTest {
                     .isSet(workflowAPI
                             .findWorkflowTaskFilesAsContent(newWorkflowTask, systemUser)));
 
-        }finally{
-            if (contentlet != null && contentlet.getInode() != null){
+        } finally {
+            if (contentlet != null && contentlet.getInode() != null) {
                 ContentletDataGen.destroy(contentlet);
             }
 
-            if (newContentlet != null && newContentlet.getInode() != null){
+            if (newContentlet != null && newContentlet.getInode() != null) {
                 ContentletDataGen.destroy(newContentlet);
             }
         }
@@ -7275,28 +7722,31 @@ public class ContentletAPITest extends ContentletBaseTest {
             throws DotDataException, DotSecurityException {
         //Create Contentlet
         final Contentlet originalContentlet = TestDataUtils.getGenericContentContent(true, 1);
-        contentletAPI.publish(originalContentlet,user,false);
+        contentletAPI.publish(originalContentlet, user, false);
 
         //Copy contentlet
-        final Contentlet copyContentletPublished = contentletAPI.copyContentlet(originalContentlet,user,false);
+        final Contentlet copyContentletPublished = contentletAPI.copyContentlet(originalContentlet,
+                user, false);
         //Check that the copy Contentlet is published
         assertTrue(copyContentletPublished.isLive());
 
         //Archive original Contentlet
-        contentletAPI.unpublish(originalContentlet,user,false);
-        contentletAPI.archive(originalContentlet,user,false);
+        contentletAPI.unpublish(originalContentlet, user, false);
+        contentletAPI.archive(originalContentlet, user, false);
         assertTrue(originalContentlet.isArchived());
 
         //Copy Contentlet
-        final Contentlet copyContentletArchived = contentletAPI.copyContentlet(originalContentlet,user,false);
+        final Contentlet copyContentletArchived = contentletAPI.copyContentlet(originalContentlet,
+                user, false);
         //Check that the copy Contentlet is published
         assertTrue(copyContentletArchived.isArchived());
     }
 
     /**
-     * Method to test: {@link ContentletAPI#checkin(Contentlet, User, boolean)}
-     * Given scenario: We create a file asset add some custom attributes to it then we create a new version
-     * Expected result: After creating a newer version the custom meta is still there.
+     * Method to test: {@link ContentletAPI#checkin(Contentlet, User, boolean)} Given scenario: We
+     * create a file asset add some custom attributes to it then we create a new version Expected
+     * result: After creating a newer version the custom meta is still there.
+     *
      * @throws Exception
      */
     @Test
@@ -7306,11 +7756,12 @@ public class ContentletAPITest extends ContentletBaseTest {
         final String fileAsset = FileAssetAPI.BINARY_FIELD;
         final FileMetadataAPI fileMetadataAPI = APILocator.getFileMetadataAPI();
         //Create Contentlet
-        final Contentlet originalContentlet = TestDataUtils.getFileAssetContent(true,1L, TestFile.GIF );
+        final Contentlet originalContentlet = TestDataUtils.getFileAssetContent(true, 1L,
+                TestFile.GIF);
 
         fileMetadataAPI.putCustomMetadataAttributes(originalContentlet,
                 ImmutableMap.of(fileAsset,
-                      ImmutableMap.of("focalPoint","2.66,2.44", "foo","bar", "bar", "foo")
+                        ImmutableMap.of("focalPoint", "2.66,2.44", "foo", "bar", "bar", "foo")
                 )
         );
 
@@ -7326,10 +7777,10 @@ public class ContentletAPITest extends ContentletBaseTest {
         final Metadata metadata1 = v2.getBinaryMetadata(fileAsset);
         assertNotNull(metadata1);
         final Map<String, Serializable> customMeta = metadata1.getCustomMeta();
-        assertEquals(customMeta.get("focalPoint"),"2.66,2.44");
-        assertEquals(customMeta.get("foo"),"bar");
-        assertEquals(customMeta.get("bar"),"foo");
-        
+        assertEquals(customMeta.get("focalPoint"), "2.66,2.44");
+        assertEquals(customMeta.get("foo"), "bar");
+        assertEquals(customMeta.get("bar"), "foo");
+
 
     }
 
@@ -7351,15 +7802,18 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         assertTrue(fileAsContentOptional.isPresent());
         assertNotNull(fileAsContentOptional.get().getMap().get("fileName"));
-        assertTrue(((String)fileAsContentOptional.get().getMap().get("fileName")).startsWith("testMissingProps"));
+        assertTrue(((String) fileAsContentOptional.get().getMap().get("fileName")).startsWith(
+                "testMissingProps"));
 
     }
 
 
     /**
-     * Method to test: {@link ContentletAPI#checkin(Contentlet, User, boolean)}
-     * Given scenario: We create a file asset under the default site then we update the site/folder then we call checkin again
-     * Expected result: After the checkin the contentlet should have been moved properly.
+     * Method to test: {@link ContentletAPI#checkin(Contentlet, User, boolean)} Given scenario: We
+     * create a file asset under the default site then we update the site/folder then we call
+     * checkin again Expected result: After the checkin the contentlet should have been moved
+     * properly.
+     *
      * @throws Exception
      */
     @Test
@@ -7370,7 +7824,8 @@ public class ContentletAPITest extends ContentletBaseTest {
         final Folder nextFolder = new FolderDataGen().site(nextSite).name("any").nextPersisted();
 
         //Create Contentlet
-        final Contentlet originalContentlet = TestDataUtils.getFileAssetContent(true,1L, TestFile.GIF );
+        final Contentlet originalContentlet = TestDataUtils.getFileAssetContent(true, 1L,
+                TestFile.GIF);
 
         final Contentlet checkout1 = contentletAPI
                 .checkout(originalContentlet.getInode(), user, false);
@@ -7380,15 +7835,18 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         Contentlet moved = contentletAPI.checkin(checkout1, user, false);
         final Identifier identifier = APILocator.getIdentifierAPI().find(moved.getIdentifier());
-        assertEquals(nextSite.getIdentifier(),identifier.getHostId());
-        moved = APILocator.getContentletAPI().find(moved.getInode(),APILocator.systemUser(),false);
-        assertEquals(moved.getHost(),identifier.getHostId());
+        assertEquals(nextSite.getIdentifier(), identifier.getHostId());
+        moved = APILocator.getContentletAPI()
+                .find(moved.getInode(), APILocator.systemUser(), false);
+        assertEquals(moved.getHost(), identifier.getHostId());
     }
 
     /**
-     * Method to test: {@link ContentletAPI#checkin(Contentlet, User, boolean)}
-     * Given scenario: We create CT that holds a keyValue then we create two instances. First one takes a well-formed json second one is messed up.
-     * Expected result: This test validates that messed-up json dont break stuff. when keyValues are returned.
+     * Method to test: {@link ContentletAPI#checkin(Contentlet, User, boolean)} Given scenario: We
+     * create CT that holds a keyValue then we create two instances. First one takes a well-formed
+     * json second one is messed up. Expected result: This test validates that messed-up json dont
+     * break stuff. when keyValues are returned.
+     *
      * @throws Exception
      */
     @Test
@@ -7470,27 +7928,32 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Method to test {@link ContentletAPI#loadField(String, com.dotcms.contenttype.model.field.Field)}
-     * Basically we're testing this method works on both types of saved contentlets. using json scheme or the columns
+     * Method to test
+     * {@link ContentletAPI#loadField(String, com.dotcms.contenttype.model.field.Field)} Basically
+     * we're testing this method works on both types of saved contentlets. using json scheme or the
+     * columns
+     *
      * @throws DotDataException
      * @throws DotSecurityException
      */
     @Test
-    public void Test_Load_Field_Works_On_Contentlet_Saved_as_Json_Or_Saved_As_Columns() throws DotDataException, DotSecurityException {
+    public void Test_Load_Field_Works_On_Contentlet_Saved_as_Json_Or_Saved_As_Columns()
+            throws DotDataException, DotSecurityException {
         //Test when contet is saved as json
         testLoadFieldWontReturnNull(true);
         //Test when contet is saved as columns
         testLoadFieldWontReturnNull(false);
     }
 
-    private void testLoadFieldWontReturnNull(final boolean saveAsJson) throws DotDataException, DotSecurityException {
+    private void testLoadFieldWontReturnNull(final boolean saveAsJson)
+            throws DotDataException, DotSecurityException {
 
         final DotConnect dotConnect = new DotConnect();
 
         final ContentletAPI contentletAPI = APILocator.getContentletAPI();
         final boolean defaultValue = Config.getBooleanProperty(SAVE_CONTENTLET_AS_JSON, true);
         Config.setProperty(SAVE_CONTENTLET_AS_JSON, saveAsJson);
-        try{
+        try {
             String contentTypeName = "SavedInColumnsCT" + System.currentTimeMillis();
 
             final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>();
@@ -7510,34 +7973,38 @@ public class ContentletAPITest extends ContentletBaseTest {
                     .fields(fields)
                     .nextPersisted();
 
-             Contentlet contentlet = new ContentletDataGen(contentType)
+            Contentlet contentlet = new ContentletDataGen(contentType)
                     .languageId(1)
                     .setProperty("title", "lol")
                     .nextPersisted();
 
-             //Verify stuff is getting saved as we suppose it is
-             String contentletAsJson = dotConnect.setSQL("select c.contentlet_as_json as json from contentlet c where c.inode = ?").addParam(contentlet.getInode()).getString("json");
+            //Verify stuff is getting saved as we suppose it is
+            String contentletAsJson = dotConnect.setSQL(
+                            "select c.contentlet_as_json as json from contentlet c where c.inode = ?")
+                    .addParam(contentlet.getInode()).getString("json");
 
-             if(saveAsJson){
-                 assertTrue(UtilMethods.isSet(contentletAsJson));
-             } else {
-                 assertTrue(UtilMethods.isNotSet(contentletAsJson));
-             }
+            if (saveAsJson) {
+                assertTrue(UtilMethods.isSet(contentletAsJson));
+            } else {
+                assertTrue(UtilMethods.isNotSet(contentletAsJson));
+            }
 
             final Optional<com.dotcms.contenttype.model.field.Field> titleField = contentlet
                     .getContentType().fields().stream()
                     .filter(field -> "titleField".equals(field.variable())).findFirst();
 
             assertTrue(titleField.isPresent());
-            assertNotNull(contentletAPI.loadField(contentlet.getInode(),titleField.get()));
+            assertNotNull(contentletAPI.loadField(contentlet.getInode(), titleField.get()));
 
             final Template template = new TemplateDataGen().body("body").nextPersisted();
             final Folder folder = new FolderDataGen().nextPersisted();
             final HTMLPageAsset page = new HTMLPageDataGen(folder, template).nextPersisted();
 
             //Verify stuff is getting saved as we suppose it is
-            contentletAsJson = dotConnect.setSQL("select c.contentlet_as_json as json from contentlet c where c.inode = ?").addParam(page.getInode()).getString("json");
-            if(saveAsJson){
+            contentletAsJson = dotConnect.setSQL(
+                            "select c.contentlet_as_json as json from contentlet c where c.inode = ?")
+                    .addParam(page.getInode()).getString("json");
+            if (saveAsJson) {
                 assertTrue(UtilMethods.isSet(contentletAsJson));
             } else {
                 assertTrue(UtilMethods.isNotSet(contentletAsJson));
@@ -7548,17 +8015,16 @@ public class ContentletAPITest extends ContentletBaseTest {
                     .filter(field -> "template".equals(field.variable())).findFirst();
 
             assertTrue(templateField.isPresent());
-            assertNotNull(contentletAPI.loadField(page.getInode(),templateField.get()));
+            assertNotNull(contentletAPI.loadField(page.getInode(), templateField.get()));
 
-        }finally {
+        } finally {
             Config.setProperty(SAVE_CONTENTLET_AS_JSON, defaultValue);
         }
     }
 
     /**
-     * Given scenario: Contentlet with a {@link JSONField} and a VALID value for the field
-     * Expected result: should persist the contentlet with the provided value
-     *
+     * Given scenario: Contentlet with a {@link JSONField} and a VALID value for the field Expected
+     * result: should persist the contentlet with the provided value
      */
     @Test
     public void saveContentWithValidJSONField_ShouldSucceed() throws Exception {
@@ -7583,7 +8049,6 @@ public class ContentletAPITest extends ContentletBaseTest {
     /**
      * Given scenario: Contentlet with a {@link JSONField} and a INVALID value for the field
      * Expected result: should throw ValidationException
-     *
      */
     @Test(expected = DotContentletValidationException.class)
     public void saveContentWithInvalidJSONField_ShouldThrowException() throws Exception {
@@ -7602,7 +8067,7 @@ public class ContentletAPITest extends ContentletBaseTest {
         try {
             final Contentlet contentletWithJSON = new ContentletDataGen(typeWithJSONField)
                     .setProperty(jsonField.variable(), testJSON).nextPersisted();
-        } catch(Exception e) {
+        } catch (Exception e) {
             if (ExceptionUtil.causedBy(e, DotContentletValidationException.class)) {
                 throw new DotContentletValidationException(e.getMessage());
             }
@@ -7619,9 +8084,8 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Given scenario: Contentlet with a {@link JSONField} with value "{} {}"
-     * Expected result: should save as "{}"
-     *
+     * Given scenario: Contentlet with a {@link JSONField} with value "{} {}" Expected result:
+     * should save as "{}"
      */
     @Test
     @UseDataProvider("testCasesJSON")
@@ -7646,10 +8110,8 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Method to test: checkIn content
-     * Given scenario: given indexed content in different variants
+     * Method to test: checkIn content Given scenario: given indexed content in different variants
      * Expected result: each document contain the proper variant in the id
-     *
      */
     @Test
     public void test_variant_present_in_document_id() throws Exception {
@@ -7673,11 +8135,10 @@ public class ContentletAPITest extends ContentletBaseTest {
                         .setProperty(VARIANT_ID, newVariant.name())
                         .nextPersisted();
 
-
         final String queryContentOnDefaultVariant = "{"
                 + "query: {"
                 + "   query_string: {"
-                + "        query: \"+identifier: "+contentDefaultVariant.getIdentifier()+"\""
+                + "        query: \"+identifier: " + contentDefaultVariant.getIdentifier() + "\""
                 + "     }"
                 + "  },"
                 + "}";
@@ -7688,13 +8149,14 @@ public class ContentletAPITest extends ContentletBaseTest {
                 false, APILocator.systemUser(), false);
 
         assertEquals(contentDefaultVariant.getIdentifier() + "_"
-                        + contentDefaultVariant.getLanguageId() + "_" + contentDefaultVariant.getVariantId(),
+                        + contentDefaultVariant.getLanguageId() + "_"
+                        + contentDefaultVariant.getVariantId(),
                 responseDefaultVariant.getHits().iterator().next().getId());
 
         final String queryContentOnNewVariant = "{"
                 + "query: {"
                 + "   query_string: {"
-                + "        query: \"+identifier: "+contentNewVariant.getIdentifier()+"\""
+                + "        query: \"+identifier: " + contentNewVariant.getIdentifier() + "\""
                 + "     }"
                 + "  },"
                 + "}";
@@ -7716,9 +8178,8 @@ public class ContentletAPITest extends ContentletBaseTest {
 
     /**
      * Given scenario: Contentlet with a {@link DateTimeField} where it was initially saved with
-     * correct value, and then it was tried to be cleared.
-     * Expected result: the field should be properly cleared
-     *
+     * correct value, and then it was tried to be cleared. Expected result: the field should be
+     * properly cleared
      */
     @Test
     @UseDataProvider("testCasesDateTime")
@@ -7744,9 +8205,10 @@ public class ContentletAPITest extends ContentletBaseTest {
     }
 
     /**
-     * Method to test: {@link ESContentletAPIImpl#publish(Contentlet, User, boolean)}
-     * When: You have a Contentlet with two different version in different {@link Variant}
-     * Should: Publish each version by its own
+     * Method to test: {@link ESContentletAPIImpl#publish(Contentlet, User, boolean)} When: You have
+     * a Contentlet with two different version in different {@link Variant} Should: Publish each
+     * version by its own
+     *
      * @throws DotDataException
      */
     @Test

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionletTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/workflows/actionlet/FourEyeApproverActionletTest.java
@@ -1,5 +1,7 @@
 package com.dotmarketing.portlets.workflows.actionlet;
 
+import static com.dotmarketing.util.WebKeys.DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE;
+
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.model.field.DataTypes;
 import com.dotcms.contenttype.model.field.Field;
@@ -152,8 +154,10 @@ public class FourEyeApproverActionletTest extends BaseWorkflowIntegrationTest {
 
         Contentlet contentletToCleanUp = null;
 
+        final boolean defaultContentToDefaultLanguage = Config.getBooleanProperty(
+                DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, false);
         try {
-            Config.setProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", true);
+            Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE, true);
             // Create a contentlet first and save it
             final long languageId = languageAPI.getDefaultLanguage().getId();
             final Contentlet cont = new Contentlet();
@@ -238,6 +242,8 @@ public class FourEyeApproverActionletTest extends BaseWorkflowIntegrationTest {
 
                 contentletAPI.destroy(contentletToCleanUp, systemUser, false);
             }
+            Config.setProperty(DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE,
+                    defaultContentToDefaultLanguage);
         }
 
     }

--- a/dotCMS/src/integration-test/resources/it-dotmarketing-config.properties
+++ b/dotCMS/src/integration-test/resources/it-dotmarketing-config.properties
@@ -1,6 +1,14 @@
 ## CUSTOM STUFF
 INDEX_POLICY_SINGLE_CONTENT=FORCE
 NETWORK_CACHE_FLUSH_DELAY=10
+
+#Integration test Helpers
+USE_TEST_TRANSACTION_TRACKER=true
+TEST_TRANSACTION_TRACKER_AUTO_CLOSE_TYPE=rollback
+USE_CONFIG_TEST_OVERRIDE_TRACKER=true
+USE_TEST_INDEXER_TRACKER=true
+
+
 #LISTENER POOL
 dotListenerSubmitterdotcms.concurrent.poolsize=100
 dotListenerSubmitterdotcms.concurrent.maxpoolsize=250

--- a/dotCMS/src/main/java/com/dotcms/api/system/event/SystemEventType.java
+++ b/dotCMS/src/main/java/com/dotcms/api/system/event/SystemEventType.java
@@ -63,6 +63,11 @@ public enum SystemEventType {
 	ARCHIVE_SITE,
 
 	/**
+	 * When a site is deleted
+	 */
+	DELETE_SITE,
+
+	/**
 	 * When a site is unarchived
 	 */
 	UN_ARCHIVE_SITE,

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -114,19 +114,23 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
 
     public synchronized void getRidOfOldIndex() throws DotDataException {
         IndiciesInfo idxs = APILocator.getIndiciesAPI().loadIndicies();
-        if (idxs.getWorking() != null)
+        if (idxs.getWorking() != null) {
             delete(idxs.getWorking());
-        if (idxs.getLive() != null)
+        }
+        if (idxs.getLive() != null) {
             delete(idxs.getLive());
-        if (idxs.getReindexWorking() != null)
+        }
+        if (idxs.getReindexWorking() != null) {
             delete(idxs.getReindexWorking());
-        if (idxs.getReindexLive() != null)
+        }
+        if (idxs.getReindexLive() != null) {
             delete(idxs.getReindexLive());
+        }
     }
 
     /**
      * Tells if at least we have a "working_XXXXXX" index
-     * 
+     *
      * @return
      * @throws DotDataException
      */
@@ -141,15 +145,17 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     public synchronized void checkAndInitialiazeIndex() {
         try {
             // if we don't have a working index, create it
-            if (!indexReady())
+            if (!indexReady()) {
                 initIndex();
+            }
         } catch (Exception e) {
             Logger.fatal("ESUil.checkAndInitializeIndex", e.getMessage());
 
         }
     }
 
-    public synchronized boolean createContentIndex(String indexName) throws ElasticsearchException, IOException {
+    public synchronized boolean createContentIndex(String indexName)
+            throws ElasticsearchException, IOException {
         boolean result = createContentIndex(indexName, 0);
         ESMappingUtilHelper.getInstance().addCustomMapping(indexName);
 
@@ -157,7 +163,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     @Override
-    public synchronized boolean createContentIndex(String indexName, int shards) throws ElasticsearchException, IOException {
+    public synchronized boolean createContentIndex(String indexName, int shards)
+            throws ElasticsearchException, IOException {
         String settings = null;
 
         try {
@@ -184,24 +191,24 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
 
-
     /**
-     * Creates new indexes /working_TIMESTAMP (aliases working_read, working_write and workinglive) and
-     * /live_TIMESTAMP with (aliases live_read, live_write, workinglive)
+     * Creates new indexes /working_TIMESTAMP (aliases working_read, working_write and workinglive)
+     * and /live_TIMESTAMP with (aliases live_read, live_write, workinglive)
      *
      * @return the timestamp string used as suffix for indices
      * @throws ElasticsearchException if Murphy comes around
      * @throws DotDataException
      */
     private synchronized String initIndex() throws ElasticsearchException, DotDataException {
-        if (indexReady())
+        if (indexReady()) {
             return "";
+        }
         try {
 
             final IndiciesInfo.Builder builder = new IndiciesInfo.Builder();
             final IndiciesInfo oldInfo = APILocator.getIndiciesAPI().loadIndicies();
 
-            if (oldInfo != null && oldInfo.getSiteSearch() != null){
+            if (oldInfo != null && oldInfo.getSiteSearch() != null) {
                 builder.setSiteSearch(oldInfo.getSiteSearch());
             }
 
@@ -221,23 +228,24 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
 
     }
+
     /**
-     * Stops the current re-indexation process and switches the current index to the new one. The main
-     * goal of this method is to allow users to switch to the new index even if one or more contents
-     * could not be re-indexed.
+     * Stops the current re-indexation process and switches the current index to the new one. The
+     * main goal of this method is to allow users to switch to the new index even if one or more
+     * contents could not be re-indexed.
      * <p>
-     * This is very useful because the new index can be created and used immediately. The user can have
-     * the new re-indexed content available and then work on the conflicting contents, which can be
-     * either fixed or removed from the database.
+     * This is very useful because the new index can be created and used immediately. The user can
+     * have the new re-indexed content available and then work on the conflicting contents, which
+     * can be either fixed or removed from the database.
      * </p>
      *
-     * @throws SQLException An error occurred when interacting with the database.
-     * @throws DotDataException The process to switch to the new failed.
+     * @throws SQLException         An error occurred when interacting with the database.
+     * @throws DotDataException     The process to switch to the new failed.
      * @throws InterruptedException The established pauses to switch to the new index failed.
      */
     @Override
     @CloseDBIfOpened
-    public void stopFullReindexationAndSwitchover() throws  DotDataException {
+    public void stopFullReindexationAndSwitchover() throws DotDataException {
         try {
             ReindexThread.pause();
             queueApi.deleteReindexRecords();
@@ -248,17 +256,17 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     /**
-     * Switches the current index structure to the new re-indexed data. This method also allows users to
-     * switch to the new re-indexed data even if there are still remaining contents in the
+     * Switches the current index structure to the new re-indexed data. This method also allows
+     * users to switch to the new re-indexed data even if there are still remaining contents in the
      * {@code dist_reindex_journal} table.
      *
-     * @param forceSwitch - If {@code true}, the new index will be used, even if there are contents that
-     *        could not be processed. Otherwise, set to {@code false} and the index switch will only
-     *        happen if ALL contents were re-indexed.
-     * @throws SQLException An error occurred when interacting with the database.
-     * @throws DotDataException The process to switch to the new failed.
-     * @throws InterruptedException The established pauses to switch to the new index failed.
+     * @param forceSwitch - If {@code true}, the new index will be used, even if there are contents
+     *                    that could not be processed. Otherwise, set to {@code false} and the index
+     *                    switch will only happen if ALL contents were re-indexed.
      * @return
+     * @throws SQLException         An error occurred when interacting with the database.
+     * @throws DotDataException     The process to switch to the new failed.
+     * @throws InterruptedException The established pauses to switch to the new index failed.
      */
     @Override
     @CloseDBIfOpened
@@ -278,8 +286,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     /**
-     * creates new working and live indexes with reading aliases pointing to old index and write aliases
-     * pointing to both old and new indexes
+     * creates new working and live indexes with reading aliases pointing to old index and write
+     * aliases pointing to both old and new indexes
      *
      * @return the timestamp string used as suffix for indices
      * @throws DotDataException
@@ -298,7 +306,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
                 builder.setSiteSearch(oldInfo.getSiteSearch());
 
                 final IndiciesInfo info = builder.build();
-                final String timeStamp = info.createNewIndiciesName(IndexType.REINDEX_WORKING, IndexType.REINDEX_LIVE);
+                final String timeStamp = info.createNewIndiciesName(IndexType.REINDEX_WORKING,
+                        IndexType.REINDEX_LIVE);
 
                 createContentIndex(info.getReindexWorking(), 0);
                 createContentIndex(info.getReindexLive(), 0);
@@ -312,14 +321,16 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
             } catch (Exception e) {
                 throw new ElasticsearchException(e.getMessage(), e);
             }
-        } else
+        } else {
             return initIndex();
+        }
     }
 
     @CloseDBIfOpened
     public boolean isInFullReindex() throws DotDataException {
         IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
-        return queueApi.hasReindexRecords() || (info.getReindexWorking() != null && info.getReindexLive() != null);
+        return queueApi.hasReindexRecords() || (info.getReindexWorking() != null
+                && info.getReindexLive() != null);
 
     }
 
@@ -329,19 +340,21 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     /**
-     * This will drop old index and will point read aliases to new index. This method should be called
-     * after call to {@link #fullReindexStart()}
+     * This will drop old index and will point read aliases to new index. This method should be
+     * called after call to {@link #fullReindexStart()}
      *
      * @return
      */
     @CloseDBIfOpened
     public boolean fullReindexSwitchover(Connection conn, final boolean forceSwitch) {
 
-
-        if(reindexTimeElapsedInLong()<Config.getLongProperty("REINDEX_THREAD_MINIMUM_RUNTIME_IN_SEC", 30)*1000) {
-            if(reindexTimeElapsed().isPresent()){
-                Logger.info(this.getClass(), "Reindex has been running only " +reindexTimeElapsed().get() + ". Letting the reindex settle.");
-            }else{
+        if (reindexTimeElapsedInLong()
+                < Config.getLongProperty("REINDEX_THREAD_MINIMUM_RUNTIME_IN_SEC", 30) * 1000) {
+            if (reindexTimeElapsed().isPresent()) {
+                Logger.info(this.getClass(),
+                        "Reindex has been running only " + reindexTimeElapsed().get()
+                                + ". Letting the reindex settle.");
+            } else {
                 Logger.info(this.getClass(), "Reindex Time Elapsed not set.");
             }
             ThreadUtils.sleep(3000);
@@ -349,7 +362,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
         try {
             final IndiciesInfo oldInfo = APILocator.getIndiciesAPI().loadIndicies();
-            final String luckyServer = Try.of(() -> APILocator.getServerAPI().getOldestServer()).getOrElse(ConfigUtils.getServerId());
+            final String luckyServer = Try.of(() -> APILocator.getServerAPI().getOldestServer())
+                    .getOrElse(ConfigUtils.getServerId());
             if (!forceSwitch) {
                 if (!isInFullReindex()) {
                     return false;
@@ -378,31 +392,31 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
                     Logger.info(this.getClass(), "Updating and optimizing ElasticSearch Indexes");
                     optimize(ImmutableList.of(newInfo.getWorking(), newInfo.getLive()));
                 } catch (Exception e) {
-                    Logger.warnAndDebug(this.getClass(), "unable to expand ES replicas:" + e.getMessage(), e);
+                    Logger.warnAndDebug(this.getClass(),
+                            "unable to expand ES replicas:" + e.getMessage(), e);
                 }
             });
 
             long failedRecords = queueApi.getFailedReindexRecords().size();
-            if(failedRecords > 0) {
+            if (failedRecords > 0) {
                 final SystemMessageBuilder systemMessageBuilder = new SystemMessageBuilder();
 
-                final String message = LanguageUtil.get(APILocator.getCompanyAPI().getDefaultCompany(), "Contents-Failed-Reindex-message").replace("{0}", String.valueOf(failedRecords));
+                final String message = LanguageUtil.get(
+                                APILocator.getCompanyAPI().getDefaultCompany(),
+                                "Contents-Failed-Reindex-message")
+                        .replace("{0}", String.valueOf(failedRecords));
 
-                
-                
                 SystemMessage systemMessage = systemMessageBuilder.setMessage(message)
-                     .setType(MessageType.SIMPLE_MESSAGE)
-                     .setSeverity(MessageSeverity.WARNING)
-                     .setLife(3600000)
-                     .create();
-                 List<String> users = APILocator.getRoleAPI().findUserIdsForRole(APILocator.getRoleAPI().loadCMSAdminRole());
-                 SystemMessageEventUtil.getInstance().pushMessage(systemMessage, users);
+                        .setType(MessageType.SIMPLE_MESSAGE)
+                        .setSeverity(MessageSeverity.WARNING)
+                        .setLife(3600000)
+                        .create();
+                List<String> users = APILocator.getRoleAPI()
+                        .findUserIdsForRole(APILocator.getRoleAPI().loadCMSAdminRole());
+                SystemMessageEventUtil.getInstance().pushMessage(systemMessage, users);
             }
-            
-            
-            
-            
-            
+
+
         } catch (Exception e) {
             throw new DotRuntimeException(e.getMessage(), e);
         }
@@ -424,32 +438,33 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
 
+    @Override
+    public Optional<String> reindexTimeElapsed() {
+        try {
 
-
-  @Override
-  public Optional<String> reindexTimeElapsed() {
-    try {
-
-      long elapsedTime = reindexTimeElapsedInLong();
-      if (elapsedTime > 0) {
-        return Optional.of(DateUtil.humanReadableFormat(Duration.ofMillis(reindexTimeElapsedInLong())).toLowerCase());
-      }
-    } catch (Exception e) {
-      Logger.debug(this, "unable to parse time:" + e, e);
+            long elapsedTime = reindexTimeElapsedInLong();
+            if (elapsedTime > 0) {
+                return Optional.of(
+                        DateUtil.humanReadableFormat(Duration.ofMillis(reindexTimeElapsedInLong()))
+                                .toLowerCase());
+            }
+        } catch (Exception e) {
+            Logger.debug(this, "unable to parse time:" + e, e);
+        }
+        return Optional.empty();
     }
-    return Optional.empty();
-  }
 
     private void logSwitchover(final IndiciesInfo oldInfo, final String luckyServer) {
         Logger.info(this, "-------------------------------");
-        final String myServerId=APILocator.getServerAPI().readServerId();
+        final String myServerId = APILocator.getServerAPI().readServerId();
         final Optional<String> duration = reindexTimeElapsed();
         if (duration.isPresent()) {
-            Logger.info(this, "Reindex took        : " + duration.get() );
+            Logger.info(this, "Reindex took        : " + duration.get());
         }
-        
-        Logger.info(this, "Switching Server Id : " + luckyServer + (luckyServer.equals(myServerId) ? " (this server) " : " (NOT this server)") );
-        
+
+        Logger.info(this, "Switching Server Id : " + luckyServer + (luckyServer.equals(myServerId)
+                ? " (this server) " : " (NOT this server)"));
+
         Logger.info(this, "Old indicies        : [" + esIndexApi
                 .removeClusterIdFromName(oldInfo.getWorking()) + "," + esIndexApi
                 .removeClusterIdFromName(oldInfo.getLive()) + "]");
@@ -474,16 +489,18 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     @Override
-    public void addContentToIndex(final Contentlet parentContenlet, final boolean includeDependencies)
+    public void addContentToIndex(final Contentlet parentContenlet,
+            final boolean includeDependencies)
             throws DotDataException {
 
         if (null == parentContenlet || !UtilMethods.isSet(parentContenlet.getIdentifier())) {
             return;
         }
 
-        Logger.info(this, "Indexing: " + parentContenlet.getIdentifier() + " : " + parentContenlet.getTitle()
-                + ", includeDependencies: " + includeDependencies +
-                ", policy: " + parentContenlet.getIndexPolicy());
+        Logger.info(this,
+                "Indexing: " + parentContenlet.getIdentifier() + " : " + parentContenlet.getTitle()
+                        + ", includeDependencies: " + includeDependencies +
+                        ", policy: " + parentContenlet.getIndexPolicy());
 
         final List<Contentlet> contentToIndex = includeDependencies
                 ? ImmutableList.<Contentlet>builder()
@@ -491,17 +508,17 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
                 .addAll(
                         loadDeps(parentContenlet)
                                 .stream()
-                                .peek((dep)-> dep.setIndexPolicy(parentContenlet.getIndexPolicyDependencies()))
+                                .peek((dep) -> dep.setIndexPolicy(
+                                        parentContenlet.getIndexPolicyDependencies()))
                                 .collect(Collectors.toList()))
                 .build()
                 : ImmutableList.of(parentContenlet);
-
 
         if (ElasticReadOnlyCommand.getInstance().isIndexOrClusterReadOnly()) {
             ElasticReadOnlyCommand.getInstance().sendReadOnlyMessage();
         }
 
-        if(parentContenlet.getIndexPolicy()==IndexPolicy.DEFER) {
+        if (parentContenlet.getIndexPolicy() == IndexPolicy.DEFER) {
             queueApi.addContentletsReindex(contentToIndex);
         } else if (!DbConnectionFactory.inTransaction()) {
             addContentToIndex(contentToIndex);
@@ -511,8 +528,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     /**
-     * Stops the full re-indexation process. This means clearing up the content queue and the reindex
-     * journal.
+     * Stops the full re-indexation process. This means clearing up the content queue and the
+     * reindex journal.
      *
      * @throws DotDataException
      */
@@ -534,7 +551,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         // split the list on three possible subset, one with the default refresh strategy, second one is the
         // wait for and finally the immediate
         final List<List<Contentlet>> partitions =
-                CollectionsUtils.partition(contentToIndex, contentlet -> contentlet.getIndexPolicy() == IndexPolicy.DEFER,
+                CollectionsUtils.partition(contentToIndex,
+                        contentlet -> contentlet.getIndexPolicy() == IndexPolicy.DEFER,
                         contentlet -> contentlet.getIndexPolicy() == IndexPolicy.WAIT_FOR,
                         contentlet -> contentlet.getIndexPolicy() == IndexPolicy.FORCE);
 
@@ -582,19 +600,21 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
                     RestHighLevelClientProvider.getInstance()
                             .getClient().bulkAsync(bulkRequest, RequestOptions.DEFAULT, listener);
                 } else {
-                    BulkResponse response = Sneaky.sneak(() -> RestHighLevelClientProvider.getInstance().getClient()
-                            .bulk(bulkRequest, RequestOptions.DEFAULT));
+                    BulkResponse response = Sneaky.sneak(
+                            () -> RestHighLevelClientProvider.getInstance().getClient()
+                                    .bulk(bulkRequest, RequestOptions.DEFAULT));
 
                     if (response != null && response.hasFailures()) {
                         Logger.error(this,
                                 "Erro" +
-                                        "r reindexing (" + response.getItems().length + ") content(s) "
+                                        "r reindexing (" + response.getItems().length
+                                        + ") content(s) "
                                         + response.buildFailureMessage());
                     }
                 }
             }
         } catch (final Exception e) {
-            if(ExceptionUtil.causedBy(e, IllegalStateException.class)) {
+            if (ExceptionUtil.causedBy(e, IllegalStateException.class)) {
                 ContentletFactory.rebuildRestHighLevelClientIfNeeded(e);
             }
             Logger.warnAndDebug(ContentletIndexAPIImpl.class, e);
@@ -619,7 +639,7 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         final BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.setRefreshPolicy(RefreshPolicy.NONE);
         return bulkRequest;
-        
+
     }
 
     public BulkProcessor createBulkProcessor(final BulkProcessorListener bulkProcessorListener) {
@@ -630,21 +650,24 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
                 bulkProcessorListener);
 
         // if running in a cluster reduce the number of concurrent requests in order to not overtax ES
-        final int numberToReindexInRequest = Try.of(()-> ReindexThread.ELASTICSEARCH_BULK_ACTIONS / APILocator.getServerAPI().getReindexingServers().size()).getOrElse(10);
-        
-        
-        
+        final int numberToReindexInRequest = Try.of(
+                () -> ReindexThread.ELASTICSEARCH_BULK_ACTIONS / APILocator.getServerAPI()
+                        .getReindexingServers().size()).getOrElse(10);
+
         builder.setBulkActions(numberToReindexInRequest)
-                        .setBulkSize(new ByteSizeValue(ReindexThread.ELASTICSEARCH_BULK_SIZE, ByteSizeUnit.MB))
-                        .setConcurrentRequests(ELASTICSEARCH_CONCURRENT_REQUESTS)
-                        .setBackoffPolicy(BackoffPolicy.constantBackoff(TimeValue.timeValueSeconds(
-                                        ReindexThread.BACKOFF_POLICY_TIME_IN_SECONDS), ReindexThread.BACKOFF_POLICY_MAX_RETRYS));
+                .setBulkSize(
+                        new ByteSizeValue(ReindexThread.ELASTICSEARCH_BULK_SIZE, ByteSizeUnit.MB))
+                .setConcurrentRequests(ELASTICSEARCH_CONCURRENT_REQUESTS)
+                .setBackoffPolicy(BackoffPolicy.constantBackoff(TimeValue.timeValueSeconds(
+                                ReindexThread.BACKOFF_POLICY_TIME_IN_SECONDS),
+                        ReindexThread.BACKOFF_POLICY_MAX_RETRYS));
 
         return builder.build();
     }
 
     @Override
-    public BulkRequest appendBulkRequest(final BulkRequest bulkRequest, final Collection<ReindexEntry> idxs)
+    public BulkRequest appendBulkRequest(final BulkRequest bulkRequest,
+            final Collection<ReindexEntry> idxs)
             throws DotDataException {
 
         for (ReindexEntry idx : idxs) {
@@ -662,7 +685,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     @Override
-    public BulkRequest appendBulkRequest(BulkRequest bulkRequest, final ReindexEntry idx)  throws DotDataException {
+    public BulkRequest appendBulkRequest(BulkRequest bulkRequest, final ReindexEntry idx)
+            throws DotDataException {
         bulkRequest = (bulkRequest == null) ? createBulkRequest() : bulkRequest;
         Logger.debug(this, "Indexing document " + idx.getIdentToIndex());
 
@@ -676,36 +700,43 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     /**
-     * Generates an ES bulk request that adds the specified {@link ReindexEntry} to the ElasticSearch index.
+     * Generates an ES bulk request that adds the specified {@link ReindexEntry} to the
+     * ElasticSearch index.
      *
      * @param bulk The {@link BulkIndexWrapper} object containing the Bulk Index Request.
      * @param idx  The entry containing the information of the Contentlet that will be indexed.
-     *
      * @throws DotDataException An error occurred when processing this request.
      */
     @CloseDBIfOpened
-    public void appendBulkRequest(final BulkIndexWrapper bulk, final ReindexEntry idx) throws DotDataException {
-        final List<ContentletVersionInfo> versions = APILocator.getVersionableAPI().findContentletVersionInfos(idx.getIdentToIndex());
+    public void appendBulkRequest(final BulkIndexWrapper bulk, final ReindexEntry idx)
+            throws DotDataException {
+        final List<ContentletVersionInfo> versions = APILocator.getVersionableAPI()
+                .findContentletVersionInfos(idx.getIdentToIndex());
         final Map<String, Contentlet> inodes = new HashMap<>();
         try {
             for (final ContentletVersionInfo cvi : versions) {
                 final String workingInode = cvi.getWorkingInode();
                 final String liveInode = cvi.getLiveInode();
-                inodes.put(workingInode, APILocator.getContentletAPI().findInDb(workingInode).orElse(null));
+                inodes.put(workingInode,
+                        APILocator.getContentletAPI().findInDb(workingInode).orElse(null));
                 if (UtilMethods.isSet(liveInode) && !inodes.containsKey(liveInode)) {
-                    inodes.put(liveInode, APILocator.getContentletAPI().findInDb(liveInode).orElse(null));
+                    inodes.put(liveInode,
+                            APILocator.getContentletAPI().findInDb(liveInode).orElse(null));
                 }
             }
             inodes.values().removeIf(Objects::isNull);
             if (inodes.isEmpty()) {
                 // If there is no content for this entry, it should be deleted to avoid future attempts that will fail also
                 APILocator.getReindexQueueAPI().deleteReindexEntry(idx);
-                Logger.debug(this, String.format("Unable to find versions for content id: '%s'. Deleting content " +
-                        "reindex entry.", idx.getIdentToIndex()));
+                Logger.debug(this, String.format(
+                        "Unable to find versions for content id: '%s'. Deleting content " +
+                                "reindex entry.", idx.getIdentToIndex()));
             }
             for (final Contentlet contentlet : inodes.values()) {
-                Logger.debug(this, String.format("Indexing id: '%s', priority: '%s'", contentlet.getInode(), idx
-                        .getPriority()));
+                Logger.debug(this,
+                        String.format("Indexing id: '%s', priority: '%s'", contentlet.getInode(),
+                                idx
+                                        .getPriority()));
                 contentlet.setIndexPolicy(IndexPolicy.DEFER);
                 addBulkRequest(bulk, ImmutableList.of(contentlet), idx.isReindex());
             }
@@ -715,7 +746,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
     }
 
-    public BulkProcessor appendToBulkProcessor(BulkProcessor bulk, final ReindexEntry idx) throws DotDataException {
+    public BulkProcessor appendToBulkProcessor(BulkProcessor bulk, final ReindexEntry idx)
+            throws DotDataException {
         Logger.debug(this, "Indexing document " + idx.getIdentToIndex());
 
         BulkIndexWrapper bulkIndexWrapper = new BulkIndexWrapper(bulk);
@@ -728,7 +760,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         return bulkIndexWrapper.getBulkProcessor();
     }
 
-    private void appendBulkRequest(final BulkIndexWrapper bulk, final List<Contentlet> contentToIndex) {
+    private void appendBulkRequest(final BulkIndexWrapper bulk,
+            final List<Contentlet> contentToIndex) {
         this.addBulkRequest(bulk, contentToIndex, false);
     }
 
@@ -767,8 +800,10 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
 
                 if (this.isWorking(contentlet)) {
 
-                    mapping = Try.of(()->objectMapper.writeValueAsString(mappingAPI.toMap(contentlet))).getOrElseThrow(
-                            DotRuntimeException::new);
+                    mapping = Try.of(
+                                    () -> objectMapper.writeValueAsString(mappingAPI.toMap(contentlet)))
+                            .getOrElseThrow(
+                                    DotRuntimeException::new);
                     if (!forReindex || info.getReindexWorking() == null) {
                         bulk.add(new IndexRequest(info.getWorking(), "_doc", id)
                                 .source(mapping, XContentType.JSON));
@@ -781,8 +816,10 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
 
                 if (this.isLive(contentlet)) {
                     if (mapping == null) {
-                        mapping = Try.of(()->objectMapper.writeValueAsString(mappingAPI.toMap(contentlet))).getOrElseThrow(
-                                DotRuntimeException::new);
+                        mapping = Try.of(
+                                        () -> objectMapper.writeValueAsString(mappingAPI.toMap(contentlet)))
+                                .getOrElseThrow(
+                                        DotRuntimeException::new);
                     }
                     if (!forReindex || info.getReindexLive() == null) {
                         bulk.add(new IndexRequest(info.getLive(), "_doc", id)
@@ -804,13 +841,13 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
     }
 
-    private boolean isWorking (final Contentlet contentlet) {
+    private boolean isWorking(final Contentlet contentlet) {
 
         boolean isWorking = false;
 
         try {
             isWorking = contentlet.isWorking();
-        }catch (Exception e) {
+        } catch (Exception e) {
             Logger.debug(this, e.getMessage(), e);
             Logger.warn(this, e.getMessage(), e);
             isWorking = false;
@@ -819,13 +856,13 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         return isWorking;
     }
 
-    private boolean isLive (final Contentlet contentlet) {
+    private boolean isLive(final Contentlet contentlet) {
 
         boolean isLive = false;
 
         try {
             isLive = contentlet.isLive();
-        }catch (Exception e) {
+        } catch (Exception e) {
             Logger.debug(this, e.getMessage(), e);
             Logger.warn(this, e.getMessage(), e);
             isLive = false;
@@ -839,12 +876,14 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     private List<Contentlet> loadDeps(final Contentlet parentContentlet) {
 
         final List<Contentlet> contentToIndex = new ArrayList<Contentlet>();
-        final List<String> depsIdentifiers = Sneaky.sneak(() -> this.mappingAPI.dependenciesLeftToReindex(parentContentlet));
+        final List<String> depsIdentifiers = Sneaky.sneak(
+                () -> this.mappingAPI.dependenciesLeftToReindex(parentContentlet));
         for (final String identifier : depsIdentifiers) {
 
             // get working and live version for all languages based on the identifier
             final List<Map<String, String>> versionInfoMapResults =
-                    Sneaky.sneak(() -> new DotConnect().setSQL(SELECT_CONTENTLET_VERSION_INFO).addParam(identifier).loadResults());
+                    Sneaky.sneak(() -> new DotConnect().setSQL(SELECT_CONTENTLET_VERSION_INFO)
+                            .addParam(identifier).loadResults());
             final List<String> inodes = new ArrayList<>();
             for (final Map<String, String> versionInfoMap : versionInfoMapResults) {
 
@@ -859,7 +898,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
             for (final String inode : inodes) {
 
                 final Contentlet contentlet =
-                        Sneaky.sneak(() -> APILocator.getContentletAPI().find(inode, APILocator.getUserAPI().getSystemUser(), false));
+                        Sneaky.sneak(() -> APILocator.getContentletAPI()
+                                .find(inode, APILocator.getUserAPI().getSystemUser(), false));
                 contentlet.setIndexPolicy(IndexPolicy.DEFER);
                 contentToIndex.add(contentlet);
             }
@@ -880,9 +920,10 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         // delete for every language and in every index
         for (Language language : languages) {
             for (final String index : info.asMap().values()) {
-                for(final Variant variant: variants) {
-                    final String id = entry.getIdentToIndex() + StringPool.UNDERLINE + language.getId()
-                            + StringPool.UNDERLINE + variant.name();
+                for (final Variant variant : variants) {
+                    final String id =
+                            entry.getIdentToIndex() + StringPool.UNDERLINE + language.getId()
+                                    + StringPool.UNDERLINE + variant.name();
 
                     System.err.println("deleting:" + id);
                     bulk.add(new DeleteRequest(index, "_doc", id));
@@ -900,13 +941,16 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         return bulkIndexWrapper.getRequestBuilder();
     }
 
-    public BulkProcessor appendBulkRemoveRequest(final BulkProcessor bulk, final ReindexEntry entry) throws DotDataException {
+    public BulkProcessor appendBulkRemoveRequest(final BulkProcessor bulk, final ReindexEntry entry)
+            throws DotDataException {
         final BulkIndexWrapper bulkIndexWrapper = new BulkIndexWrapper(bulk);
         appendBulkRemoveRequest(bulkIndexWrapper, entry);
         return bulkIndexWrapper.getBulkProcessor();
     }
 
-    private void removeContentFromIndex(final Contentlet content, final boolean onlyLive, final List<Relationship> relationships)
+    @WrapInTransaction
+    private void removeContentFromIndex(final Contentlet content, final boolean onlyLive,
+            final List<Relationship> relationships)
             throws DotHibernateException {
 
         final boolean indexIsNotDefer = IndexPolicy.DEFER != content.getIndexPolicy();
@@ -919,7 +963,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
             } else {
                 // add a commit listener to index the contentlet if the entire
                 // transaction finish clean
-                HibernateUtil.addCommitListener(content.getInode() + ReindexRunnable.Action.REMOVING,
+                HibernateUtil.addCommitListener(
+                        content.getInode() + ReindexRunnable.Action.REMOVING,
                         new RemoveReindexRunnable(content, onlyLive, relationships));
             }
         } catch (DotDataException | DotSecurityException | DotMappingException e1) {
@@ -927,10 +972,12 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
     } // removeContentFromIndex.
 
-    private void handleRemoveIndexNotDefer(final Contentlet content, final boolean onlyLive, final List<Relationship> relationships)
+    private void handleRemoveIndexNotDefer(final Contentlet content, final boolean onlyLive,
+            final List<Relationship> relationships)
             throws DotSecurityException, DotMappingException, DotDataException {
 
-        removeContentAndProcessDependencies(content, relationships, onlyLive, content.getIndexPolicy(),
+        removeContentAndProcessDependencies(content, relationships, onlyLive,
+                content.getIndexPolicy(),
                 content.getIndexPolicyDependencies());
     } // handleRemoveIndexNotDefer.
 
@@ -943,7 +990,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         private final boolean onlyLive;
         private final List<Relationship> relationships;
 
-        public RemoveReindexRunnable(final Contentlet contentlet, final boolean onlyLive, final List<Relationship> relationships) {
+        public RemoveReindexRunnable(final Contentlet contentlet, final boolean onlyLive,
+                final List<Relationship> relationships) {
 
             super(contentlet, ReindexRunnable.Action.REMOVING);
             this.contentlet = contentlet;
@@ -954,7 +1002,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         public void run() {
 
             try {
-                removeContentAndProcessDependencies(this.contentlet, this.relationships, this.onlyLive, IndexPolicy.DEFER,
+                removeContentAndProcessDependencies(this.contentlet, this.relationships,
+                        this.onlyLive, IndexPolicy.DEFER,
                         IndexPolicy.DEFER);
             } catch (Exception ex) {
                 throw new ElasticsearchException(ex.getMessage(), ex);
@@ -962,8 +1011,10 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
     }
 
-    private void removeContentAndProcessDependencies(final Contentlet contentlet, final List<Relationship> relationships,
-            final boolean onlyLive, final IndexPolicy indexPolicy, final IndexPolicy indexPolicyDependencies)
+    private void removeContentAndProcessDependencies(final Contentlet contentlet,
+            final List<Relationship> relationships,
+            final boolean onlyLive, final IndexPolicy indexPolicy,
+            final IndexPolicy indexPolicyDependencies)
             throws DotDataException, DotSecurityException, DotMappingException {
 
         final String id = builder(contentlet.getIdentifier(), StringPool.UNDERLINE,
@@ -1001,7 +1052,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
             // content to be deleted. Those contentlets are reindexed
             // to avoid left those fields making noise in the index
             if (UtilMethods.isSet(relationships)) {
-                reindexDependenciesForDeletedContent(contentlet, relationships, indexPolicyDependencies);
+                reindexDependenciesForDeletedContent(contentlet, relationships,
+                        indexPolicyDependencies);
             }
 
             bulkRequest.add(new DeleteRequest(info.getWorking(), "_doc", id));
@@ -1011,28 +1063,41 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
 
         bulkRequest.timeout(TimeValue.timeValueMillis(INDEX_OPERATIONS_TIMEOUT_IN_MS));
-        Sneaky.sneak(() -> RestHighLevelClientProvider.getInstance().getClient()
-                .bulk(bulkRequest, RequestOptions.DEFAULT));
-        
+        BulkResponse response = Sneaky.sneak(
+                () -> RestHighLevelClientProvider.getInstance().getClient()
+                        .bulk(bulkRequest, RequestOptions.DEFAULT));
+
+        if (response.hasFailures()) {
+            Logger.error(this,
+                    "Failed to remove content from index: " + response.buildFailureMessage());
+        }
+
         //Delete query cache when a new content has been reindexed
         CacheLocator.getESQueryCache().clearCache();
     }
 
-    private void reindexDependenciesForDeletedContent(final Contentlet contentlet, final List<Relationship> relationships,
+    private void reindexDependenciesForDeletedContent(final Contentlet contentlet,
+            final List<Relationship> relationships,
             final IndexPolicy indexPolicy)
             throws DotDataException, DotSecurityException, DotMappingException {
 
         for (final Relationship relationship : relationships) {
 
-            final boolean isSameStructRelationship = APILocator.getRelationshipAPI().sameParentAndChild(relationship);
+            final boolean isSameStructRelationship = APILocator.getRelationshipAPI()
+                    .sameParentAndChild(relationship);
 
             final String query = (isSameStructRelationship)
-                    ? builder("+type:content +(", relationship.getRelationTypeValue(), "-parent:", contentlet.getIdentifier(),
-                            StringPool.SPACE, relationship.getRelationTypeValue(), "-child:", contentlet.getIdentifier(), ") ").toString()
-                    : builder("+type:content +", relationship.getRelationTypeValue(), ":", contentlet.getIdentifier()).toString();
+                    ? builder("+type:content +(", relationship.getRelationTypeValue(), "-parent:",
+                    contentlet.getIdentifier(),
+                    StringPool.SPACE, relationship.getRelationTypeValue(), "-child:",
+                    contentlet.getIdentifier(), ") ").toString()
+                    : builder("+type:content +", relationship.getRelationTypeValue(), ":",
+                            contentlet.getIdentifier()).toString();
 
             final List<Contentlet> related =
-                    APILocator.getContentletAPI().search(query, -1, 0, null, APILocator.getUserAPI().getSystemUser(), false);
+                    APILocator.getContentletAPI()
+                            .search(query, -1, 0, null, APILocator.getUserAPI().getSystemUser(),
+                                    false);
 
             switch (indexPolicy) {
 
@@ -1048,13 +1113,16 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
     }
 
-    @CloseDBIfOpened
-    public void removeContentFromIndex(final Contentlet content, final boolean onlyLive) throws DotHibernateException {
+    @WrapInTransaction
+    public void removeContentFromIndex(final Contentlet content, final boolean onlyLive)
+            throws DotHibernateException {
 
-        if (content == null || !UtilMethods.isSet(content.getIdentifier()))
+        if (content == null || !UtilMethods.isSet(content.getIdentifier())) {
             return;
+        }
 
-        List<Relationship> relationships = APILocator.getRelationshipAPI().byContentType(content.getStructure());
+        List<Relationship> relationships = APILocator.getRelationshipAPI()
+                .byContentType(content.getStructure());
 
         // add a commit listener to index the contentlet if the entire
         // transaction finish clean
@@ -1069,9 +1137,11 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     @CloseDBIfOpened
     public void removeContentFromIndexByStructureInode(final String structureInode)
             throws DotDataException, DotSecurityException {
-        final ContentType contentType = APILocator.getContentTypeAPI(APILocator.getUserAPI().getSystemUser()).find(structureInode);
-        if(contentType==null){
-            throw new DotDataException("ContentType with Inode or VarName: " + structureInode + "not found");
+        final ContentType contentType = APILocator.getContentTypeAPI(
+                APILocator.getUserAPI().getSystemUser()).find(structureInode);
+        if (contentType == null) {
+            throw new DotDataException(
+                    "ContentType with Inode or VarName: " + structureInode + "not found");
         }
         final String structureName = contentType.variable();
         final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
@@ -1080,31 +1150,35 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         final List<String> idxs = new ArrayList<>();
         idxs.add(info.getWorking());
         idxs.add(info.getLive());
-        if (info.getReindexWorking() != null)
+        if (info.getReindexWorking() != null) {
             idxs.add(info.getReindexWorking());
-        if (info.getReindexLive() != null)
+        }
+        if (info.getReindexLive() != null) {
             idxs.add(info.getReindexLive());
+        }
         String[] idxsArr = new String[idxs.size()];
         idxsArr = idxs.toArray(idxsArr);
 
         DeleteByQueryRequest request = new DeleteByQueryRequest(idxsArr);
-        request.setQuery(QueryBuilders.matchQuery("contenttype",structureName.toLowerCase()));
+        request.setQuery(QueryBuilders.matchQuery("contenttype", structureName.toLowerCase()));
         request.setTimeout(new TimeValue(INDEX_OPERATIONS_TIMEOUT_IN_MS));
 
-        BulkByScrollResponse response = Sneaky.sneak(() -> RestHighLevelClientProvider.getInstance().getClient()
-                .deleteByQuery(request, RequestOptions.DEFAULT));
+        BulkByScrollResponse response = Sneaky.sneak(
+                () -> RestHighLevelClientProvider.getInstance().getClient()
+                        .deleteByQuery(request, RequestOptions.DEFAULT));
 
         Logger.info(this, "Records deleted: " +
                 response.getDeleted() + " from contentType: " + structureName);
-        
+
         //Delete query cache when a new content has been reindexed
         CacheLocator.getESQueryCache().clearCache();
     }
 
     public void fullReindexAbort() {
         try {
-            if (!isInFullReindex())
+            if (!isInFullReindex()) {
                 return;
+            }
 
             IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
 
@@ -1129,12 +1203,12 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
     public List<String> listDotCMSClosedIndices() {
-       return esIndexApi.getClosedIndexes();
+        return esIndexApi.getClosedIndexes();
     }
 
     /**
      * Returns a list of dotcms working and live indices.
-     * 
+     *
      * @return
      */
     @SuppressWarnings("unchecked")
@@ -1144,25 +1218,24 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     }
 
 
-
     public void activateIndex(final String indexName) throws DotDataException {
         final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
         final IndiciesInfo.Builder builder = IndiciesInfo.Builder.copy(info);
-        if(indexName==null) {
+        if (indexName == null) {
             throw new DotRuntimeException("Index cannot be null");
         }
         if (IndexType.WORKING.is(indexName)) {
             builder.setWorking(esIndexApi.getNameWithClusterIDPrefix(indexName));
-            if(esIndexApi.getNameWithClusterIDPrefix(indexName).equals(info.getReindexWorking())) {
+            if (esIndexApi.getNameWithClusterIDPrefix(indexName).equals(info.getReindexWorking())) {
                 builder.setReindexWorking(null);
             }
         } else if (IndexType.LIVE.is(indexName)) {
             builder.setLive(esIndexApi.getNameWithClusterIDPrefix(indexName));
-            if(esIndexApi.getNameWithClusterIDPrefix(indexName).equals(info.getReindexLive())) {
+            if (esIndexApi.getNameWithClusterIDPrefix(indexName).equals(info.getReindexLive())) {
                 builder.setReindexLive(null);
             }
         }
-        
+
         APILocator.getIndiciesAPI().point(builder.build());
     }
 
@@ -1209,10 +1282,12 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         final List<String> newIdx = new ArrayList<String>();
         final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
 
-        if (info.getReindexWorking() != null)
+        if (info.getReindexWorking() != null) {
             newIdx.add(esIndexApi.removeClusterIdFromName(info.getReindexWorking()));
-        if (info.getReindexLive() != null)
+        }
+        if (info.getReindexLive() != null) {
             newIdx.add(esIndexApi.removeClusterIdFromName(info.getReindexLive()));
+        }
         return newIdx;
     }
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -226,7 +226,6 @@ import static com.dotmarketing.portlets.personas.business.PersonaAPI.DEFAULT_PER
  * @author Jason Tesser
  * @author David Torres
  * @since 1.5
- *
  */
 public class ESContentletAPIImpl implements ContentletAPI {
 
@@ -609,16 +608,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
     public Contentlet findContentletByIdentifier(String identifier, boolean live, long languageId,
             String variantId, User user, boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException, DotContentletStateException {
-        if(languageId<=0) {
-            languageId=APILocator.getLanguageAPI().getDefaultLanguage().getId();
+        if (languageId <= 0) {
+            languageId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
         }
 
         try {
-            Optional<ContentletVersionInfo> clvi = APILocator.getVersionableAPI().getContentletVersionInfo(identifier, languageId, variantId);
+            Optional<ContentletVersionInfo> clvi = APILocator.getVersionableAPI()
+                    .getContentletVersionInfo(identifier, languageId, variantId);
             String liveInode = null;
             String workingInode = null;
 
-            if(clvi.isPresent()) {
+            if (clvi.isPresent()) {
                 liveInode = clvi.get().getLiveInode();
                 workingInode = clvi.get().getWorkingInode();
             }
@@ -628,69 +628,83 @@ public class ESContentletAPIImpl implements ContentletAPI {
             } else {
                 return find(workingInode, user, respectFrontendRoles);
             }
-        }catch (DotSecurityException se) {
+        } catch (DotSecurityException se) {
             throw se;
-        }catch (Exception e) {
-            throw new DotContentletStateException("Can't find contentlet: " + identifier + " lang:" + languageId + " live:" + live,e);
+        } catch (Exception e) {
+            throw new DotContentletStateException(
+                    "Can't find contentlet: " + identifier + " lang:" + languageId + " live:"
+                            + live, e);
         }
     }
 
     @CloseDBIfOpened
     @Override
-    public Contentlet findContentletByIdentifier(String identifier, boolean live, long languageId, User user, boolean respectFrontendRoles)throws DotDataException, DotSecurityException, DotContentletStateException {
-        return findContentletByIdentifier(identifier, live, languageId, VariantAPI.DEFAULT_VARIANT.name(), user, respectFrontendRoles);
+    public Contentlet findContentletByIdentifier(String identifier, boolean live, long languageId,
+            User user, boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
+        return findContentletByIdentifier(identifier, live, languageId,
+                VariantAPI.DEFAULT_VARIANT.name(), user, respectFrontendRoles);
 
     }
 
 
     @CloseDBIfOpened
     @Override
-    public Optional<Contentlet> findContentletByIdentifierOrFallback(final String identifier, final boolean live,
+    public Optional<Contentlet> findContentletByIdentifierOrFallback(final String identifier,
+            final boolean live,
             final long incomingLangId, final User user, final boolean respectFrontendRoles) {
 
         final long defaultLanguageId = this.languageAPI.getDefaultLanguage().getId();
-        final long tryLanguage       = incomingLangId <= 0? defaultLanguageId : incomingLangId;
-        boolean    fallback          = false;
+        final long tryLanguage = incomingLangId <= 0 ? defaultLanguageId : incomingLangId;
+        boolean fallback = false;
 
         try {
 
             // try the user language
             Optional<ContentletVersionInfo> contentletVersionInfo =
-                    APILocator.getVersionableAPI().getContentletVersionInfo(identifier, tryLanguage);
+                    APILocator.getVersionableAPI()
+                            .getContentletVersionInfo(identifier, tryLanguage);
 
             // try the fallback if does not exists
             if (tryLanguage != defaultLanguageId && (!contentletVersionInfo.isPresent()
                     || (live && contentletVersionInfo.get().getLiveInode() == null))) {
-                fallback              = true;  // using the fallback
-                contentletVersionInfo = APILocator.getVersionableAPI().getContentletVersionInfo(identifier, defaultLanguageId);
+                fallback = true;  // using the fallback
+                contentletVersionInfo = APILocator.getVersionableAPI()
+                        .getContentletVersionInfo(identifier, defaultLanguageId);
             }
 
             if (!contentletVersionInfo.isPresent()) {
                 return Optional.empty();
             }
 
-            final Contentlet contentlet =  live?
-                    this.find(contentletVersionInfo.get().getLiveInode(), user, respectFrontendRoles) :
-                    this.find(contentletVersionInfo.get().getWorkingInode(), user, respectFrontendRoles);
+            final Contentlet contentlet = live ?
+                    this.find(contentletVersionInfo.get().getLiveInode(), user,
+                            respectFrontendRoles) :
+                    this.find(contentletVersionInfo.get().getWorkingInode(), user,
+                            respectFrontendRoles);
 
             if (null == contentlet) {
                 return Optional.empty();
             }
 
             // if we are using the fallback, and it is not allowed, return empty
-            if (fallback && tryLanguage != defaultLanguageId && !contentlet.getContentType().languageFallback()) {
+            if (fallback && tryLanguage != defaultLanguageId && !contentlet.getContentType()
+                    .languageFallback()) {
                 return Optional.empty();
             }
 
             return Optional.of(contentlet);
         } catch (Exception e) {
-            throw new DotContentletStateException("Can't find contentlet: " + identifier + " lang:" + incomingLangId + " live:" + live, e);
+            throw new DotContentletStateException(
+                    "Can't find contentlet: " + identifier + " lang:" + incomingLangId + " live:"
+                            + live, e);
         }
     }
 
     @CloseDBIfOpened
     @Override
-    public Contentlet findContentletByIdentifierAnyLanguage(final String identifier, final boolean includeDeleted) throws DotDataException {
+    public Contentlet findContentletByIdentifierAnyLanguage(final String identifier,
+            final boolean includeDeleted) throws DotDataException {
         try {
             return contentFactory.findContentletByIdentifierAnyLanguage(identifier, includeDeleted);
 
@@ -701,7 +715,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public Contentlet findContentletByIdentifierAnyLanguage(final String identifier) throws DotDataException {
+    public Contentlet findContentletByIdentifierAnyLanguage(final String identifier)
+            throws DotDataException {
         try {
             return contentFactory.findContentletByIdentifierAnyLanguage(identifier);
 
@@ -712,7 +727,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public Contentlet findContentletByIdentifierAnyLanguage(final String identifier, final String variant) throws DotDataException {
+    public Contentlet findContentletByIdentifierAnyLanguage(final String identifier,
+            final String variant) throws DotDataException {
         try {
             return contentFactory.findContentletByIdentifierAnyLanguage(identifier, variant);
         } catch (Exception e) {
@@ -722,13 +738,16 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findContentletsByIdentifiers(final String[] identifiers, final boolean live, final long languageId, final User user, final boolean respectFrontendRoles)
+    public List<Contentlet> findContentletsByIdentifiers(final String[] identifiers,
+            final boolean live, final long languageId, final User user,
+            final boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException, DotContentletStateException {
         final List<Contentlet> contentlets = new ArrayList<>();
 
-        for(final String identifier : identifiers) {
+        for (final String identifier : identifiers) {
 
-            final Contentlet contentlet = findContentletByIdentifier(identifier.trim(), live, languageId, user, respectFrontendRoles);
+            final Contentlet contentlet = findContentletByIdentifier(identifier.trim(), live,
+                    languageId, user, respectFrontendRoles);
             contentlets.add(contentlet);
         }
 
@@ -737,16 +756,21 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findContentlets(List<String> inodes)throws DotDataException, DotSecurityException {
+    public List<Contentlet> findContentlets(List<String> inodes)
+            throws DotDataException, DotSecurityException {
         return contentFactory.findContentlets(inodes);
     }
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findContentletsByFolder(Folder parentFolder, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+    public List<Contentlet> findContentletsByFolder(Folder parentFolder, User user,
+            boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
 
         try {
-            return permissionAPI.filterCollection(search("+conFolder:" + parentFolder.getInode(), -1, 0, null , user, respectFrontendRoles), PermissionAPI.PERMISSION_READ, respectFrontendRoles, user);
+            return permissionAPI.filterCollection(
+                    search("+conFolder:" + parentFolder.getInode(), -1, 0, null, user,
+                            respectFrontendRoles), PermissionAPI.PERMISSION_READ,
+                    respectFrontendRoles, user);
         } catch (Exception e) {
             Logger.error(this.getClass(), e.getMessage(), e);
             throw new DotRuntimeException(e.getMessage(), e);
@@ -756,9 +780,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findContentletsByHost(Host parentHost, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+    public List<Contentlet> findContentletsByHost(Host parentHost, User user,
+            boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
         try {
-            return permissionAPI.filterCollection(search("+conHost:" + parentHost.getIdentifier() + " +working:true", -1, 0, null , user, respectFrontendRoles), PermissionAPI.PERMISSION_READ, respectFrontendRoles, user);
+            return permissionAPI.filterCollection(
+                    search("+conHost:" + parentHost.getIdentifier() + " +working:true", -1, 0, null,
+                            user, respectFrontendRoles), PermissionAPI.PERMISSION_READ,
+                    respectFrontendRoles, user);
         } catch (Exception e) {
             Logger.error(this.getClass(), e.getMessage(), e);
             throw new DotRuntimeException(e.getMessage(), e);
@@ -767,7 +795,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public PaginatedContentlets findContentletsPaginatedByHost(Host parentHost, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+    public PaginatedContentlets findContentletsPaginatedByHost(Host parentHost, User user,
+            boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
         return findContentletsPaginatedByHost(parentHost, null, null, user, respectFrontendRoles);
     }
 
@@ -790,12 +819,16 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findContentletsByHost(Host parentHost, List<Integer> includingContentTypes, List<Integer> excludingContentTypes, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+    public List<Contentlet> findContentletsByHost(Host parentHost,
+            List<Integer> includingContentTypes, List<Integer> excludingContentTypes, User user,
+            boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
         try {
             final String query = getContentletByHostQuery(parentHost, includingContentTypes,
                     excludingContentTypes);
 
-            return permissionAPI.filterCollection(search(query, -1, 0, null , user, respectFrontendRoles), PermissionAPI.PERMISSION_READ, respectFrontendRoles, user);
+            return permissionAPI.filterCollection(
+                    search(query, -1, 0, null, user, respectFrontendRoles),
+                    PermissionAPI.PERMISSION_READ, respectFrontendRoles, user);
         } catch (Exception e) {
             Logger.error(this.getClass(), e.getMessage(), e);
             throw new DotRuntimeException(e.getMessage(), e);
@@ -808,30 +841,37 @@ public class ESContentletAPIImpl implements ContentletAPI {
         query.append("+conHost:").append(parentHost.getIdentifier()).append(" +working:true");
 
         // Including content types
-        if(includingContentTypes != null && !includingContentTypes.isEmpty()) {
-            query.append(" +structureType:(").append(StringUtils.join(includingContentTypes, " ")).append(")");
+        if (includingContentTypes != null && !includingContentTypes.isEmpty()) {
+            query.append(" +structureType:(").append(StringUtils.join(includingContentTypes, " "))
+                    .append(")");
         }
 
         // Excluding content types
-        if(excludingContentTypes != null && !excludingContentTypes.isEmpty()) {
-            query.append(" -structureType:(").append(StringUtils.join(excludingContentTypes, " ")).append(")");
+        if (excludingContentTypes != null && !excludingContentTypes.isEmpty()) {
+            query.append(" -structureType:(").append(StringUtils.join(excludingContentTypes, " "))
+                    .append(")");
         }
         return query.toString();
     }
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findContentletsByHostBaseType(Host parentHost, List<Integer> includingBaseTypes, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+    public List<Contentlet> findContentletsByHostBaseType(Host parentHost,
+            List<Integer> includingBaseTypes, User user, boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException {
         try {
             StringBuilder query = new StringBuilder();
             query.append("+conHost:").append(parentHost.getIdentifier()).append(" +working:true");
 
             // Including content types
-            if(includingBaseTypes != null && !includingBaseTypes.isEmpty()) {
-                query.append(" +baseType:(").append(StringUtils.join(includingBaseTypes, " ")).append(")");
+            if (includingBaseTypes != null && !includingBaseTypes.isEmpty()) {
+                query.append(" +baseType:(").append(StringUtils.join(includingBaseTypes, " "))
+                        .append(")");
             }
 
-            return permissionAPI.filterCollection(search(query.toString(), -1, 0, null , user, respectFrontendRoles), PermissionAPI.PERMISSION_READ, respectFrontendRoles, user);
+            return permissionAPI.filterCollection(
+                    search(query.toString(), -1, 0, null, user, respectFrontendRoles),
+                    PermissionAPI.PERMISSION_READ, respectFrontendRoles, user);
         } catch (Exception e) {
             Logger.error(this.getClass(), e.getMessage(), e);
             throw new DotRuntimeException(e.getMessage(), e);
@@ -841,21 +881,30 @@ public class ESContentletAPIImpl implements ContentletAPI {
     // note: is not annotated with WrapInTransaction b/c it handles his own transaction locally in the method
     @WrapInTransaction
     @Override
-    public void publish(final Contentlet contentlet, final User userIn, final boolean respectFrontendRoles) throws DotSecurityException, DotDataException, DotStateException {
-        final User user = (userIn!=null) ? userIn : APILocator.getUserAPI().getAnonymousUser();
-        String contentPushPublishDate = contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE);
-        String contentPushExpireDate  = contentlet.getStringProperty("wfExpireDate");
+    public void publish(final Contentlet contentlet, final User userIn,
+            final boolean respectFrontendRoles)
+            throws DotSecurityException, DotDataException, DotStateException {
+        final User user = (userIn != null) ? userIn : APILocator.getUserAPI().getAnonymousUser();
+        String contentPushPublishDate = contentlet.getStringProperty(
+                Contentlet.WORKFLOW_PUBLISH_DATE);
+        String contentPushExpireDate = contentlet.getStringProperty("wfExpireDate");
 
-        contentPushPublishDate = UtilMethods.isSet(contentPushPublishDate)?contentPushPublishDate:"N/D";
-        contentPushExpireDate  = UtilMethods.isSet(contentPushExpireDate)?contentPushExpireDate:  "N/D";
+        contentPushPublishDate =
+                UtilMethods.isSet(contentPushPublishDate) ? contentPushPublishDate : "N/D";
+        contentPushExpireDate =
+                UtilMethods.isSet(contentPushExpireDate) ? contentPushExpireDate : "N/D";
 
-        ActivityLogger.logInfo(getClass(), "Publishing Content", "StartDate: " +contentPushPublishDate+ "; "
-                + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+        ActivityLogger.logInfo(getClass(), "Publishing Content",
+                "StartDate: " + contentPushPublishDate + "; "
+                        + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                        ? user.getUserId() : "Unknown")
+                        + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier()
+                        : "Unknown"), contentlet.getHost());
 
         try {
 
-            final Optional<Contentlet> contentletOpt = this.checkAndRunPublishAsWorkflow(contentlet, user, respectFrontendRoles);
+            final Optional<Contentlet> contentletOpt = this.checkAndRunPublishAsWorkflow(contentlet,
+                    user, respectFrontendRoles);
             if (contentletOpt.isPresent()) {
 
                 Logger.info(this, "A Workflow has been run instead of a simple publish: " +
@@ -867,63 +916,77 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             this.internalPublish(contentlet, user, respectFrontendRoles);
-        } catch(DotDataException | DotStateException | DotSecurityException e) {
+        } catch (DotDataException | DotStateException | DotSecurityException e) {
 
-            ActivityLogger.logInfo(getClass(), "Error Publishing Content", "StartDate: " +contentPushPublishDate+ "; "
-                    + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                    + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+            ActivityLogger.logInfo(getClass(), "Error Publishing Content",
+                    "StartDate: " + contentPushPublishDate + "; "
+                            + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                            ? user.getUserId() : "Unknown")
+                            + "; ContentIdentifier: " + (contentlet != null
+                            ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
             throw e;
         }
 
-        ActivityLogger.logInfo(getClass(), "Content Published", "StartDate: " + contentPushPublishDate + "; "
-                + "EndDate: " + contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+        ActivityLogger.logInfo(getClass(), "Content Published",
+                "StartDate: " + contentPushPublishDate + "; "
+                        + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                        ? user.getUserId() : "Unknown")
+                        + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier()
+                        : "Unknown"), contentlet.getHost());
 
         //Generate a System Event for this publish operation
         HibernateUtil.addCommitListener(
                 () -> this.contentletSystemEventUtil.pushPublishEvent(contentlet), 1000);
     }
 
-    private void internalPublish(final Contentlet contentlet, final User user, final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+    private void internalPublish(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
 
-        if(StringPool.BLANK.equals(contentlet.getInode())) {
+        if (StringPool.BLANK.equals(contentlet.getInode())) {
 
             throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
         }
 
-        if(!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_PUBLISH, user, respectFrontendRoles)) {
+        if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_PUBLISH,
+                user, respectFrontendRoles)) {
 
-            Logger.debug(PublishFactory.class, ()-> "publishAsset: user = " + (user != null ? user.getEmailAddress() : "Unknown")
-                    + ", don't have permissions to publish: " + (contentlet != null ? contentlet.getInode() : "Unknown"));
+            Logger.debug(PublishFactory.class,
+                    () -> "publishAsset: user = " + (user != null ? user.getEmailAddress()
+                            : "Unknown")
+                            + ", don't have permissions to publish: " + (contentlet != null
+                            ? contentlet.getInode() : "Unknown"));
 
             //If the contentlet has CMS Owner Publish permission on it, the user creating the new contentlet is allowed to publish
             final List<Role> roles = permissionAPI.getRoles(contentlet.getPermissionId(),
                     PermissionAPI.PERMISSION_PUBLISH, "CMS Owner", 0, -1);
             final Role cmsOwner = APILocator.getRoleAPI().loadCMSOwnerRole();
 
-            if(roles.size() > 0){
+            if (roles.size() > 0) {
                 final boolean isCMSOwner = roles.stream().anyMatch(cmsOwner::equals);
 
-                if(!isCMSOwner) {
+                if (!isCMSOwner) {
 
-                    throw new DotSecurityException("User " + (user != null ? user.getUserId() : "Unknown")
-                            + "does not have permission to publish contentlet with inode "
-                            + (contentlet != null ? contentlet.getInode() : "Unknown"));
+                    throw new DotSecurityException(
+                            "User " + (user != null ? user.getUserId() : "Unknown")
+                                    + "does not have permission to publish contentlet with inode "
+                                    + (contentlet != null ? contentlet.getInode() : "Unknown"));
                 }
             } else {
-                throw new DotSecurityException("User " + (user != null ? user.getUserId() : "Unknown")
-                        + "does not have permission to publish contentlet with inode "
-                        + (contentlet != null ? contentlet.getInode() : "Unknown"));
+                throw new DotSecurityException(
+                        "User " + (user != null ? user.getUserId() : "Unknown")
+                                + "does not have permission to publish contentlet with inode "
+                                + (contentlet != null ? contentlet.getInode() : "Unknown"));
             }
         }
 
         WorkflowProcessor workflow = null;
         // to run a workflow we need an action id set, not be part of a workflow already and do not desired disable it
-        if(contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW)==null &&
+        if (contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW) == null &&
                 UtilMethods.isSet(contentlet.getActionId()) &&
                 (null == contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS) ||
-                        Boolean.FALSE.equals(contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS))
-                ))  {
+                        Boolean.FALSE.equals(
+                                contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS))
+                )) {
             workflow = APILocator.getWorkflowAPI().fireWorkflowPreCheckin(contentlet, user);
         }
 
@@ -934,24 +997,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         publishAssociated(contentlet, false);
 
-        if(null != workflow) {
+        if (null != workflow) {
 
             workflow.setContentlet(contentlet);
             APILocator.getWorkflowAPI().fireWorkflowPostCheckin(workflow);
         }
 
-        if(contentlet.isFileAsset()) {
+        if (contentlet.isFileAsset()) {
 
             cleanFileAssetCache(contentlet, user, respectFrontendRoles);
         }
 
         //"Enable" and/or create a tag for this Persona key tag
-        if ( Structure.STRUCTURE_TYPE_PERSONA == contentlet.getStructure().getStructureType() ) {
+        if (Structure.STRUCTURE_TYPE_PERSONA == contentlet.getStructure().getStructureType()) {
             //If not exist create a tag based on this persona key tag
             APILocator.getPersonaAPI().enableDisablePersonaTag(contentlet, true);
         }
 
-        if(contentlet.isVanityUrl()) {
+        if (contentlet.isVanityUrl()) {
             APILocator.getVanityUrlAPI().invalidateVanityUrl(contentlet);
         }
 
@@ -969,7 +1032,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public void publishAssociated(Contentlet contentlet, boolean isNew) throws DotSecurityException, DotDataException,
+    public void publishAssociated(Contentlet contentlet, boolean isNew)
+            throws DotSecurityException, DotDataException,
             DotContentletStateException, DotStateException {
         publishAssociated(contentlet, isNew, true);
 
@@ -977,7 +1041,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public void publishAssociated(final Contentlet contentlet, final boolean isNew, final boolean isNewVersion) throws
+    public void publishAssociated(final Contentlet contentlet, final boolean isNew,
+            final boolean isNewVersion) throws
             DotSecurityException, DotDataException, DotStateException {
 
         if (!contentlet.isWorking()) {
@@ -985,10 +1050,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
             throw new DotContentletStateException("Only the working version can be published");
         }
 
-        ThreadContextUtil.ifReindex(()->indexAPI.addContentToIndex(contentlet, INCLUDE_DEPENDENCIES), INCLUDE_DEPENDENCIES);
+        ThreadContextUtil.ifReindex(
+                () -> indexAPI.addContentToIndex(contentlet, INCLUDE_DEPENDENCIES),
+                INCLUDE_DEPENDENCIES);
 
         // Publishes the files associated with the Contentlet
-        final List<Field> fields = FieldsCache.getFieldsByStructureInode(contentlet.getStructureInode());
+        final List<Field> fields = FieldsCache.getFieldsByStructureInode(
+                contentlet.getStructureInode());
         final Language defaultLang = languageAPI.getDefaultLanguage();
         final User systemUser = APILocator.getUserAPI().getSystemUser();
 
@@ -1010,28 +1078,31 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                         // First we want to find the LIVE File Asset with same language of the parent Contentlet.
                         try {
-                            findContentletByIdentifier( id.getId(), true, contentlet.getLanguageId(),
-                                    systemUser, false );
-                        } catch ( DotContentletStateException seLive ) {
+                            findContentletByIdentifier(id.getId(), true, contentlet.getLanguageId(),
+                                    systemUser, false);
+                        } catch (DotContentletStateException seLive) {
                             // If we don't have results, we try to find the WORKING File Asset
                             // with same language of the parent Contentlet.
-                            try{
-                                fileAssetCont = findContentletByIdentifier( id.getId(), false, contentlet.getLanguageId(),
-                                        systemUser, false );
-                                publish( fileAssetCont, systemUser, false );
-                            } catch ( DotContentletStateException seWorking ) {
+                            try {
+                                fileAssetCont = findContentletByIdentifier(id.getId(), false,
+                                        contentlet.getLanguageId(),
+                                        systemUser, false);
+                                publish(fileAssetCont, systemUser, false);
+                            } catch (DotContentletStateException seWorking) {
                                 // Now, if we still don't have resutls we should try to find de LIVE File Asset but
                                 // with DEFAULT language. Note: no need to do repeat this is the language previously
                                 // serched was already the default.
-                                if ( defaultLang.getId() != contentlet.getLanguageId() ){
+                                if (defaultLang.getId() != contentlet.getLanguageId()) {
                                     try {
-                                        findContentletByIdentifier( id.getId(), true, defaultLang.getId(),
-                                                systemUser, false );
-                                    } catch ( DotContentletStateException se ) {
+                                        findContentletByIdentifier(id.getId(), true,
+                                                defaultLang.getId(),
+                                                systemUser, false);
+                                    } catch (DotContentletStateException se) {
                                         // Again, if we don't find anything LIVE, we try WORKING File Asset + DEFAULT lang.
-                                        fileAssetCont = findContentletByIdentifier( id.getId(), false, defaultLang.getId(),
-                                                systemUser, false );
-                                        publish( fileAssetCont, systemUser, false );
+                                        fileAssetCont = findContentletByIdentifier(id.getId(),
+                                                false, defaultLang.getId(),
+                                                systemUser, false);
+                                        publish(fileAssetCont, systemUser, false);
                                     }
                                 } else {
                                     // If we already were using the default language we need to throw
@@ -1042,9 +1113,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                         }
                     }
-                } catch ( Exception ex ) {
-                    Logger.debug( this, ex.getMessage(), ex );
-                    throw new DotStateException( "Problem occurred while publishing file", ex );
+                } catch (Exception ex) {
+                    Logger.debug(this, ex.getMessage(), ex);
+                    throw new DotStateException("Problem occurred while publishing file", ex);
                 }
             }
         }
@@ -1074,38 +1145,45 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         for (Link link : links) {
 
-            Logger.debug(this, "*****I'm a Contentlet -- Publishing my Link Child=" + link.getInode());
+            Logger.debug(this,
+                    "*****I'm a Contentlet -- Publishing my Link Child=" + link.getInode());
             try {
 
                 PublishFactory.publishAsset(link, systemUser, false, isNewVersion);
             } catch (DotSecurityException e) {
-                Logger.debug(this, "User has permissions to publish the content = " + contentlet.getIdentifier()
+                Logger.debug(this, "User has permissions to publish the content = "
+                        + contentlet.getIdentifier()
                         + " but not the related link = " + link.getIdentifier());
-                throw new DotStateException("Problem occured while publishing link: " + e.getMessage(), e);
+                throw new DotStateException(
+                        "Problem occured while publishing link: " + e.getMessage(), e);
             } catch (Exception e) {
-                throw new DotStateException("Problem occured while publishing file: " + e.getMessage(), e);
+                throw new DotStateException(
+                        "Problem occured while publishing file: " + e.getMessage(), e);
             }
         }
     } // publishRelatedLinks.
 
     @Override
-    public List<Contentlet> search(String luceneQuery, int limit, int offset,String sortBy, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
-        return search(luceneQuery, limit, offset, sortBy, user, respectFrontendRoles, PermissionAPI.PERMISSION_READ);
+    public List<Contentlet> search(String luceneQuery, int limit, int offset, String sortBy,
+            User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+        return search(luceneQuery, limit, offset, sortBy, user, respectFrontendRoles,
+                PermissionAPI.PERMISSION_READ);
     }
 
     @Override
-    public List<Contentlet> search(String luceneQuery, int limit, int offset, String sortBy, User user, boolean respectFrontendRoles, int requiredPermission) throws DotDataException,DotSecurityException {
+    public List<Contentlet> search(String luceneQuery, int limit, int offset, String sortBy,
+            User user, boolean respectFrontendRoles, int requiredPermission)
+            throws DotDataException, DotSecurityException {
         PaginatedArrayList<Contentlet> contents = new PaginatedArrayList<Contentlet>();
         ArrayList<String> inodes = new ArrayList<String>();
 
-
-        PaginatedArrayList <ContentletSearch> list =(PaginatedArrayList)searchIndex(luceneQuery, limit, offset, sortBy, user, respectFrontendRoles);
+        PaginatedArrayList<ContentletSearch> list = (PaginatedArrayList) searchIndex(luceneQuery,
+                limit, offset, sortBy, user, respectFrontendRoles);
         contents.setTotalResults(list.getTotalResults());
-        for(ContentletSearch conwrap: list){
+        for (ContentletSearch conwrap : list) {
 
             inodes.add(conwrap.getInode());
         }
-
 
         List<Contentlet> contentlets = findContentlets(inodes);
         Map<String, Contentlet> map = new HashMap<String, Contentlet>(contentlets.size());
@@ -1113,62 +1191,77 @@ public class ESContentletAPIImpl implements ContentletAPI {
             map.put(contentlet.getInode(), contentlet);
         }
         for (String inode : inodes) {
-            if(map.get(inode) != null)
+            if (map.get(inode) != null) {
                 contents.add(map.get(inode));
+            }
         }
         return contents;
 
     }
 
     @Override
-    public List<Contentlet> searchByIdentifier(String luceneQuery, int limit, int offset,String sortBy, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
-        return searchByIdentifier(luceneQuery, limit, offset, sortBy, user, respectFrontendRoles, PermissionAPI.PERMISSION_READ);
+    public List<Contentlet> searchByIdentifier(String luceneQuery, int limit, int offset,
+            String sortBy, User user, boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException {
+        return searchByIdentifier(luceneQuery, limit, offset, sortBy, user, respectFrontendRoles,
+                PermissionAPI.PERMISSION_READ);
     }
 
     @Override
-    public List<Contentlet> searchByIdentifier(String luceneQuery, int limit, int offset, String sortBy, User user, boolean respectFrontendRoles, int requiredPermission) throws DotDataException,DotSecurityException {
-        return searchByIdentifier(luceneQuery, limit, offset, sortBy, user, respectFrontendRoles, requiredPermission, false);
+    public List<Contentlet> searchByIdentifier(String luceneQuery, int limit, int offset,
+            String sortBy, User user, boolean respectFrontendRoles, int requiredPermission)
+            throws DotDataException, DotSecurityException {
+        return searchByIdentifier(luceneQuery, limit, offset, sortBy, user, respectFrontendRoles,
+                requiredPermission, false);
     }
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> searchByIdentifier(String luceneQuery, int limit, int offset, String sortBy, User user, boolean respectFrontendRoles, int requiredPermission, boolean anyLanguage) throws DotDataException,DotSecurityException {
+    public List<Contentlet> searchByIdentifier(String luceneQuery, int limit, int offset,
+            String sortBy, User user, boolean respectFrontendRoles, int requiredPermission,
+            boolean anyLanguage) throws DotDataException, DotSecurityException {
         PaginatedArrayList<Contentlet> contents = new PaginatedArrayList<>();
-        PaginatedArrayList <ContentletSearch> list =(PaginatedArrayList)searchIndex(luceneQuery, limit, offset, sortBy, user, respectFrontendRoles);
+        PaginatedArrayList<ContentletSearch> list = (PaginatedArrayList) searchIndex(luceneQuery,
+                limit, offset, sortBy, user, respectFrontendRoles);
         contents.setTotalResults(list.getTotalResults());
 
         List<String> identifierList = new ArrayList<>();
-        for(ContentletSearch conwrap: list){
-            String ident=conwrap.getIdentifier();
-            Identifier ii=APILocator.getIdentifierAPI().find(ident);
-            if(ii!=null && UtilMethods.isSet(ii.getId()))
+        for (ContentletSearch conwrap : list) {
+            String ident = conwrap.getIdentifier();
+            Identifier ii = APILocator.getIdentifierAPI().find(ident);
+            if (ii != null && UtilMethods.isSet(ii.getId())) {
                 identifierList.add(ident);
+            }
         }
-        String[] identifiers=new String[identifierList.size()];
-        identifiers=identifierList.toArray(identifiers);
+        String[] identifiers = new String[identifierList.size()];
+        identifiers = identifierList.toArray(identifiers);
 
         List<Contentlet> contentlets = new ArrayList<>();
-        if(anyLanguage){
-            for(String identifier : identifierList){
-                for(Language lang : APILocator.getLanguageAPI().getLanguages()){
-                    try{
+        if (anyLanguage) {
+            for (String identifier : identifierList) {
+                for (Language lang : APILocator.getLanguageAPI().getLanguages()) {
+                    try {
                         Contentlet languageContentlet = null;
-                        try{
-                            languageContentlet = findContentletByIdentifier(identifier, false, lang.getId(), user, respectFrontendRoles);
-                        }catch (DotContentletStateException e) {
-                            Logger.debug(this,e.getMessage(),e);
+                        try {
+                            languageContentlet = findContentletByIdentifier(identifier, false,
+                                    lang.getId(), user, respectFrontendRoles);
+                        } catch (DotContentletStateException e) {
+                            Logger.debug(this, e.getMessage(), e);
                         }
-                        if(languageContentlet != null && UtilMethods.isSet(languageContentlet.getInode())){
+                        if (languageContentlet != null && UtilMethods.isSet(
+                                languageContentlet.getInode())) {
                             contentlets.add(languageContentlet);
                             break;
                         }
-                    }catch(DotContentletStateException se){
+                    } catch (DotContentletStateException se) {
                         Logger.debug(this, se.getMessage());
                     }
                 }
             }
-        }else{
-            contentlets = findContentletsByIdentifiers(identifiers, false, APILocator.getLanguageAPI().getDefaultLanguage().getId(), user, respectFrontendRoles);
+        } else {
+            contentlets = findContentletsByIdentifiers(identifiers, false,
+                    APILocator.getLanguageAPI().getDefaultLanguage().getId(), user,
+                    respectFrontendRoles);
         }
 
         Map<String, Contentlet> map = new HashMap<>(contentlets.size());
@@ -1176,7 +1269,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             map.put(contentlet.getIdentifier(), contentlet);
         }
         for (String identifier : identifiers) {
-            if(map.get(identifier) != null && !contents.contains(map.get(identifier))){
+            if (map.get(identifier) != null && !contents.contains(map.get(identifier))) {
                 contents.add(map.get(identifier));
             }
         }
@@ -1186,10 +1279,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @Override
     public List<Contentlet> getAllContentByVariants(final User user,
-            final boolean respectFrontendRoles, final String...variantNames) throws DotDataException, DotStateException,
+            final boolean respectFrontendRoles, final String... variantNames)
+            throws DotDataException, DotStateException,
             DotSecurityException {
 
-        final String queryWithoutParenthesis = Arrays.stream(variantNames).map((variant)->"variant:"+variant)
+        final String queryWithoutParenthesis = Arrays.stream(variantNames)
+                .map((variant) -> "variant:" + variant)
                 .collect(Collectors.joining(" OR "));
 
         final String query = "+(" + queryWithoutParenthesis + ")";
@@ -1199,11 +1294,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public void addPermissionsToQuery(StringBuffer buffy, User user, List<Role> roles, boolean respectFrontendRoles) throws DotSecurityException, DotDataException  {
-        if(user != null)
+    public void addPermissionsToQuery(StringBuffer buffy, User user, List<Role> roles,
+            boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
+        if (user != null) {
             buffy.append(" +((+owner:" + user.getUserId() + " +ownerCanRead:true) ");
-        else
+        } else {
             buffy.append(" +(");
+        }
         if (0 < roles.size()) {
             buffy.append(" (");
             for (Role role : roles) {
@@ -1211,15 +1308,18 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
             buffy.append(") ");
         }
-        if(respectFrontendRoles) {
-            buffy.append("(permissions:p" + APILocator.getRoleAPI().loadCMSAnonymousRole().getId() + ".1p*) ");
+        if (respectFrontendRoles) {
+            buffy.append("(permissions:p" + APILocator.getRoleAPI().loadCMSAnonymousRole().getId()
+                    + ".1p*) ");
             if (user != null && user.isFrontendUser()) {
-                buffy.append("(permissions:p" + APILocator.getRoleAPI().loadLoggedinSiteRole().getId() + ".1p*)");
+                buffy.append(
+                        "(permissions:p" + APILocator.getRoleAPI().loadLoggedinSiteRole().getId()
+                                + ".1p*)");
             }
         }
         buffy.append(")");
 
-        if(user==null || !user.isBackendUser()) {
+        if (user == null || !user.isBackendUser()) {
             buffy.append(" +live:true ");
         }
 
@@ -1227,40 +1327,46 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public List <ContentletSearch> searchIndex(String luceneQuery, int limit, int offset, String sortBy, User user, boolean respectFrontendRoles)throws DotSecurityException, DotDataException {
+    public List<ContentletSearch> searchIndex(String luceneQuery, int limit, int offset,
+            String sortBy, User user, boolean respectFrontendRoles)
+            throws DotSecurityException, DotDataException {
         boolean isAdmin = false;
         List<Role> roles = new ArrayList<Role>();
-        if(user == null && !respectFrontendRoles){
-            throw new DotSecurityException("You must specify a user if you are not respecting frontend roles");
+        if (user == null && !respectFrontendRoles) {
+            throw new DotSecurityException(
+                    "You must specify a user if you are not respecting frontend roles");
         }
-        if(user != null){
-            if (!APILocator.getRoleAPI().doesUserHaveRole(user, APILocator.getRoleAPI().loadCMSAdminRole())) {
+        if (user != null) {
+            if (!APILocator.getRoleAPI()
+                    .doesUserHaveRole(user, APILocator.getRoleAPI().loadCMSAdminRole())) {
                 roles = APILocator.getRoleAPI().loadRolesForUser(user.getUserId());
-            }else{
+            } else {
                 isAdmin = true;
             }
         }
         final StringBuffer buffy = new StringBuffer(luceneQuery);
 
         // Permissions in the query
-        if (!isAdmin)
+        if (!isAdmin) {
             addPermissionsToQuery(buffy, user, roles, respectFrontendRoles);
-
-        if(UtilMethods.isSet(sortBy) && sortBy.trim().equalsIgnoreCase("random")){
-            sortBy="random";
         }
 
-        if(limit <=0){
+        if (UtilMethods.isSet(sortBy) && sortBy.trim().equalsIgnoreCase("random")) {
+            sortBy = "random";
+        }
+
+        if (limit <= 0) {
             limit = MAX_LIMIT;
         }
 
-        if(limit<=MAX_LIMIT) {
-            final SearchHits searchHits = contentFactory.indexSearch(buffy.toString(), limit, offset, sortBy);
-            final PaginatedArrayList <ContentletSearch> list=new PaginatedArrayList<>();
+        if (limit <= MAX_LIMIT) {
+            final SearchHits searchHits = contentFactory.indexSearch(buffy.toString(), limit,
+                    offset, sortBy);
+            final PaginatedArrayList<ContentletSearch> list = new PaginatedArrayList<>();
             list.setTotalResults(searchHits.getTotalHits().value);
 
             for (final SearchHit searchHit : searchHits.getHits()) {
-                try{
+                try {
                     final Map<String, Object> sourceMap = searchHit.getSourceAsMap();
                     final ContentletSearch conWrapper = new ContentletSearch();
                     conWrapper.setId(searchHit.getId());
@@ -1270,9 +1376,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     conWrapper.setScore(searchHit.getScore());
 
                     list.add(conWrapper);
-                }
-                catch(Exception e){
-                    Logger.error(this,e.getMessage(),e);
+                } catch (Exception e) {
+                    Logger.error(this, e.getMessage(), e);
                 }
             }
             return list;
@@ -1284,39 +1389,44 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public void publishRelatedHtmlPages(final Contentlet contentlet) throws DotStateException, DotDataException{
-        if(StringUtils.EMPTY.equals(contentlet.getInode())) {
+    public void publishRelatedHtmlPages(final Contentlet contentlet)
+            throws DotStateException, DotDataException {
+        if (StringUtils.EMPTY.equals(contentlet.getInode())) {
             throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
         }
         //Get the contentlet Identifier to gather the related pages
         final Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
         //Get the identifier's number of the related pages
-        final List<MultiTree> multitrees = APILocator.getMultiTreeAPI().getMultiTreesByChild(identifier.getId());
+        final List<MultiTree> multitrees = APILocator.getMultiTreeAPI()
+                .getMultiTreesByChild(identifier.getId());
 
-        for(MultiTree multitree : multitrees)
-        {
+        for (MultiTree multitree : multitrees) {
             //Get the Identifiers of the related pages
-            final Identifier htmlPageIdentifier = APILocator.getIdentifierAPI().find(multitree.getParent1());
+            final Identifier htmlPageIdentifier = APILocator.getIdentifierAPI()
+                    .find(multitree.getParent1());
             Long languageId = -1L;
             IHTMLPage page = null;
             //Get the pages
-            try{
+            try {
 
                 //Get the contenlet language in order to find the proper language page to invalidate
                 languageId = contentlet.getLanguageId();
                 //Search for the page with a given identifier and for a given language (in case of Pages as content)
-                page = loadPageByIdentifier(htmlPageIdentifier.getId(), true, languageId, APILocator.getUserAPI().getSystemUser(), false);
+                page = loadPageByIdentifier(htmlPageIdentifier.getId(), true, languageId,
+                        APILocator.getUserAPI().getSystemUser(), false);
 
-                if(null != page && page.isLive()){
+                if (null != page && page.isLive()) {
                     //Rebuild the pages' files
                     new PageLoader().invalidate(page);
 
                 }
-            } catch(Exception e) {
-                final String htmlPageIdentifierId = null != htmlPageIdentifier ? htmlPageIdentifier.getId() : null;
+            } catch (Exception e) {
+                final String htmlPageIdentifierId =
+                        null != htmlPageIdentifier ? htmlPageIdentifier.getId() : null;
                 final String pageInode = null != page ? page.getInode() : null;
                 Logger.warn(this.getClass(),
-                        "Cannot publish related HTML Pages" + ". htmlPageIdentifier.getId() = [" + htmlPageIdentifierId
+                        "Cannot publish related HTML Pages" + ". htmlPageIdentifier.getId() = ["
+                                + htmlPageIdentifierId
                                 + "], languageId = [" + languageId + "], pageInode = [" + pageInode
                                 + "]. This might happen if contents are being imported in batch.");
             }
@@ -1324,55 +1434,70 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
 
         // if it showOnMenu is checked changing publish status should remove nav on that folder
-        if((contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_FILEASSET
-                || contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_HTMLPAGE)
+        if ((contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_FILEASSET
+                || contentlet.getStructure().getStructureType()
+                == Structure.STRUCTURE_TYPE_HTMLPAGE)
                 && contentlet.getStringProperty("showOnMenu") != null
                 && contentlet.getStringProperty("showOnMenu").contains("true")) {
 
-            CacheLocator.getNavToolCache().removeNavByPath(identifier.getHostId(), identifier.getParentPath());
+            CacheLocator.getNavToolCache()
+                    .removeNavByPath(identifier.getHostId(), identifier.getParentPath());
         }
     }
 
     @WrapInTransaction
     @Override
-    public void cleanField(final Structure structure, final Date deletionDate, final Field oldField, final User user,
+    public void cleanField(final Structure structure, final Date deletionDate, final Field oldField,
+            final User user,
             final boolean respectFrontendRoles)
             throws DotSecurityException, DotDataException {
-        if (!permissionAPI.doesUserHavePermission(structure, PermissionAPI.PERMISSION_PUBLISH, user, respectFrontendRoles)) {
-            throw new DotSecurityException("Must be able to publish structure to clean all the fields with user: "
-                    + (user != null ? user.getUserId() : "Unknown"));
+        if (!permissionAPI.doesUserHavePermission(structure, PermissionAPI.PERMISSION_PUBLISH, user,
+                respectFrontendRoles)) {
+            throw new DotSecurityException(
+                    "Must be able to publish structure to clean all the fields with user: "
+                            + (user != null ? user.getUserId() : "Unknown"));
         }
 
-        com.dotcms.contenttype.model.field.Field field = new LegacyFieldTransformer(oldField).from();
+        com.dotcms.contenttype.model.field.Field field = new LegacyFieldTransformer(
+                oldField).from();
 
         // Binary fields have nothing to do with database.
         if (field instanceof BinaryField) {
-            int batchSize=500;
-            int offset=0;
+            int batchSize = 500;
+            int offset = 0;
             final List<Contentlet> contentlets = new ArrayList<>();
-            contentlets.addAll(contentFactory.findByStructure(structure.getInode(), deletionDate, batchSize, offset));
-            while(!contentlets.isEmpty()) {
+            contentlets.addAll(
+                    contentFactory.findByStructure(structure.getInode(), deletionDate, batchSize,
+                            offset));
+            while (!contentlets.isEmpty()) {
                 final List<Contentlet> finalList = new ArrayList<>();
                 finalList.addAll(contentlets);
                 HibernateUtil.addCommitListener(() -> moveBinaryFilesToTrash(finalList, oldField));
-                offset+=batchSize;
+                offset += batchSize;
                 contentlets.clear();
-                contentlets.addAll(contentFactory.findByStructure(structure.getInode(), deletionDate, batchSize, offset));
+                contentlets.addAll(
+                        contentFactory.findByStructure(structure.getInode(), deletionDate,
+                                batchSize, offset));
             }
         } else if (field instanceof TagField) {
-            int batchSize=500;
-            int offset=0;
+            int batchSize = 500;
+            int offset = 0;
             final List<Contentlet> contentlets = new ArrayList<>();
-            contentlets.addAll(contentFactory.findByStructure(structure.getInode(), deletionDate, batchSize, offset));
-            while(!contentlets.isEmpty()) {
-                for(Contentlet contentlet : contentlets) {
-                    tagAPI.deleteTagInodesByInodeAndFieldVarName(contentlet.getInode(), field.variable());
+            contentlets.addAll(
+                    contentFactory.findByStructure(structure.getInode(), deletionDate, batchSize,
+                            offset));
+            while (!contentlets.isEmpty()) {
+                for (Contentlet contentlet : contentlets) {
+                    tagAPI.deleteTagInodesByInodeAndFieldVarName(contentlet.getInode(),
+                            field.variable());
                 }
-                offset+=batchSize;
+                offset += batchSize;
                 contentlets.clear();
-                contentlets.addAll(contentFactory.findByStructure(structure.getInode(), deletionDate, batchSize, offset));
+                contentlets.addAll(
+                        contentFactory.findByStructure(structure.getInode(), deletionDate,
+                                batchSize, offset));
             }
-        }else if(field.dataType() == DataTypes.SYSTEM || field.dataType()== DataTypes.NONE) {
+        } else if (field.dataType() == DataTypes.SYSTEM || field.dataType() == DataTypes.NONE) {
             return;
         } else {
 
@@ -1382,14 +1507,15 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @Override
     @WrapInTransaction
-    public void cleanField(Structure structure, Field oldField, User user, boolean respectFrontendRoles)
+    public void cleanField(Structure structure, Field oldField, User user,
+            boolean respectFrontendRoles)
             throws DotSecurityException, DotDataException {
         cleanField(structure, null, oldField, user, respectFrontendRoles);
     }
 
     /**
-     * Searches for a HTML Page with a given identifier and a given languageId, the languageId will be use only
-     * the new HTML Pages (pages as content).
+     * Searches for a HTML Page with a given identifier and a given languageId, the languageId will
+     * be use only the new HTML Pages (pages as content).
      *
      * @param ident
      * @param live
@@ -1401,31 +1527,39 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotContentletStateException
      * @throws DotSecurityException
      */
-    private IHTMLPage loadPageByIdentifier ( String ident, boolean live, Long languageId, User user, boolean frontRoles ) throws DotDataException, DotContentletStateException, DotSecurityException {
+    private IHTMLPage loadPageByIdentifier(String ident, boolean live, Long languageId, User user,
+            boolean frontRoles)
+            throws DotDataException, DotContentletStateException, DotSecurityException {
 
-
-        return APILocator.getHTMLPageAssetAPI().fromContentlet(this.findContentletByIdentifier(ident, live, languageId, user, frontRoles));
+        return APILocator.getHTMLPageAssetAPI().fromContentlet(
+                this.findContentletByIdentifier(ident, live, languageId, user, frontRoles));
 
     }
 
     /**
-     * @deprecated As of 2016-05-16, replaced by {@link #loadPageByIdentifier(String, boolean, Long, User, boolean)}
+     * @deprecated As of 2016-05-16, replaced by
+     * {@link #loadPageByIdentifier(String, boolean, Long, User, boolean)}
      */
-    private IHTMLPage loadPageByIdentifier ( String ident, boolean live, User user, boolean frontRoles ) throws DotDataException, DotContentletStateException, DotSecurityException {
+    private IHTMLPage loadPageByIdentifier(String ident, boolean live, User user,
+            boolean frontRoles)
+            throws DotDataException, DotContentletStateException, DotSecurityException {
         return loadPageByIdentifier(ident, live, 0L, user, frontRoles);
     }
 
     @CloseDBIfOpened
     @Override
-    public List<Map<String, Object>> getContentletReferences(final Contentlet contentlet, final User user, final boolean respectFrontendRoles)
+    public List<Map<String, Object>> getContentletReferences(final Contentlet contentlet,
+            final User user, final boolean respectFrontendRoles)
             throws DotSecurityException, DotDataException, DotContentletStateException {
 
         final List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
-        if(contentlet == null || !InodeUtils.isSet(contentlet.getInode())){
+        if (contentlet == null || !InodeUtils.isSet(contentlet.getInode())) {
             throw new DotContentletStateException("Contentlet must exist");
         }
-        if(!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_READ, user, respectFrontendRoles)){
-            throw new DotSecurityException("User " + (user != null ? user.getUserId() : "Unknown") + " cannot read Contentlet");
+        if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_READ, user,
+                respectFrontendRoles)) {
+            throw new DotSecurityException("User " + (user != null ? user.getUserId() : "Unknown")
+                    + " cannot read Contentlet");
         }
 
         final Identifier id = APILocator.getIdentifierAPI().find(contentlet);
@@ -1457,7 +1591,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                         results.add(map);
                     }
                 }
-            } catch(DoesNotExistException e) {
+            } catch (DoesNotExistException e) {
                 Logger.debug(this, "Page not available in the requested language. This is ok");
             }
         }
@@ -1465,22 +1599,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public Optional<Integer> getAllContentletReferencesCount(final String contentletId) throws DotDataException {
+    public Optional<Integer> getAllContentletReferencesCount(final String contentletId)
+            throws DotDataException {
         return Optional.of(this.multiTreeAPI.get().getAllContentletReferencesCount(contentletId));
     }
 
-    private String getPersonaNameByMultitree(final MultiTree tree) throws DotSecurityException, DotDataException {
-        final Supplier<String> defaultPersonaSupplier = () -> Try.of(()->
+    private String getPersonaNameByMultitree(final MultiTree tree)
+            throws DotSecurityException, DotDataException {
+        final Supplier<String> defaultPersonaSupplier = () -> Try.of(() ->
                 LanguageUtil.get(DEFAULT_PERSONA_NAME_KEY)).getOrElse("Default Visitor");
 
-        String personaTag = Try.of(()-> tree.getPersonalization()
-                .substring((Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON).length()))
+        String personaTag = Try.of(() -> tree.getPersonalization()
+                        .substring((Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON).length()))
                 .getOrElse("");
         Optional<Persona> personaOpt = APILocator.getPersonaAPI()
                 .findPersonaByTag(personaTag,
                         APILocator.systemUser(), false);
 
-        return personaOpt.isPresent()? personaOpt.get().getName(): defaultPersonaSupplier.get();
+        return personaOpt.isPresent() ? personaOpt.get().getName() : defaultPersonaSupplier.get();
     }
 
     @CloseDBIfOpened
@@ -1493,7 +1629,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
     @CloseDBIfOpened
     @Override
     public Object getFieldValue(final Contentlet contentlet,
-            final com.dotcms.contenttype.model.field.Field theField, final User user, final boolean respectFrontEndRoles) {
+            final com.dotcms.contenttype.model.field.Field theField, final User user,
+            final boolean respectFrontEndRoles) {
         try {
             User currentUser = user;
             if (currentUser == null) {
@@ -1510,22 +1647,22 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     return contentlet.getFolder();
                 }
             } else if (theField instanceof CategoryField) {
-                final Category categoryField = this.categoryAPI.find(theField.values(), currentUser, respectFrontEndRoles);
+                final Category categoryField = this.categoryAPI.find(theField.values(), currentUser,
+                        respectFrontEndRoles);
                 // Get all the Contentlets Categories
                 final List<Category> selectedCategories = this.categoryAPI
                         .getParents(contentlet, currentUser, respectFrontEndRoles);
-                if(selectedCategories.isEmpty()) {
+                if (selectedCategories.isEmpty()) {
                     return List.of();
                 }
                 final List<Category> availableCategories = this.categoryAPI
                         .getAllChildren(categoryField, APILocator.systemUser(), false);
-                if(availableCategories.isEmpty()) {
+                if (availableCategories.isEmpty()) {
                     return List.of();
                 }
                 selectedCategories.retainAll(availableCategories);
-                
+
                 return selectedCategories;
-                
 
 
             } else if (theField instanceof RelationshipField) {
@@ -1538,7 +1675,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 final ContentletRelationshipRecords records = contentletRelationships.new ContentletRelationshipRecords(
                         relationship, isChildField);
                 records.setRecords(contentlet
-                        .getRelated(theField.variable(), currentUser, respectFrontEndRoles, isChildField,
+                        .getRelated(theField.variable(), currentUser, respectFrontEndRoles,
+                                isChildField,
                                 contentlet.getLanguageId(), null));
                 contentletRelationships.setRelationshipsRecords(CollectionsUtils.list(records));
                 return contentletRelationships;
@@ -1552,7 +1690,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * @param theField a legacy field from the contentlet's parent Content Type
-     * @deprecated Use {@link ESContentletAPIImpl#getFieldValue(Contentlet,
+     * @deprecated Use
+     * {@link ESContentletAPIImpl#getFieldValue(Contentlet,
      * com.dotcms.contenttype.model.field.Field)} instead
      */
     @CloseDBIfOpened
@@ -1569,26 +1708,34 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public void addLinkToContentlet(Contentlet contentlet, String linkInode, String relationName, User user, boolean respectFrontendRoles)throws DotSecurityException, DotDataException {
-        if(contentlet.getInode().equals(""))
+    public void addLinkToContentlet(Contentlet contentlet, String linkInode, String relationName,
+            User user, boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
+        if (contentlet.getInode().equals("")) {
             throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
+        }
         if (InodeUtils.isSet(linkInode)) {
             Link link = (Link) InodeFactory.getInode(linkInode, Link.class);
             Identifier identifier = APILocator.getIdentifierAPI().find(link);
-            relationshipAPI.addRelationship(contentlet.getInode(),identifier.getInode(), relationName);
+            relationshipAPI.addRelationship(contentlet.getInode(), identifier.getInode(),
+                    relationName);
             new ContentletLoader().invalidate(contentlet);
         }
     }
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findPageContentlets(String HTMLPageIdentifier,String containerIdentifier, String orderby, boolean working, long languageId, User user, boolean respectFrontendRoles)    throws DotSecurityException, DotDataException {
-        List<Contentlet> contentlets = contentFactory.findPageContentlets(HTMLPageIdentifier, containerIdentifier, orderby, working, languageId);
-        return permissionAPI.filterCollection(contentlets, PermissionAPI.PERMISSION_READ, respectFrontendRoles, user);
+    public List<Contentlet> findPageContentlets(String HTMLPageIdentifier,
+            String containerIdentifier, String orderby, boolean working, long languageId, User user,
+            boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
+        List<Contentlet> contentlets = contentFactory.findPageContentlets(HTMLPageIdentifier,
+                containerIdentifier, orderby, working, languageId);
+        return permissionAPI.filterCollection(contentlets, PermissionAPI.PERMISSION_READ,
+                respectFrontendRoles, user);
     }
 
     /**
      * Get all relationships in a contentlet given its inode
+     *
      * @param contentletInode
      * @param user
      * @param respectFrontendRoles
@@ -1605,6 +1752,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * Get all relationships in a contentlet
+     *
      * @param contentlet
      * @return
      * @throws DotDataException
@@ -1618,6 +1766,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * Get all relationships in a contentlet
+     *
      * @param contentlet
      * @param cRelationships If this param is set, all relationships on this object will be ignored
      * @return
@@ -1665,10 +1814,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
         return cRelationships;
     }
 
-    private void pullRelated(Contentlet contentlet, ContentletRelationships cRelationships, Relationship relationship, boolean hasParent)
+    private void pullRelated(Contentlet contentlet, ContentletRelationships cRelationships,
+            Relationship relationship, boolean hasParent)
             throws DotDataException {
 
-        final boolean selfRelated = APILocator.getRelationshipAPI().sameParentAndChild(relationship);
+        final boolean selfRelated = APILocator.getRelationshipAPI()
+                .sameParentAndChild(relationship);
 
         final List<Contentlet> contentletList = new ArrayList<>();
         final ContentletRelationshipRecords records = cRelationships.new ContentletRelationshipRecords(
@@ -1678,7 +1829,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             if (selfRelated) {
                 contentletList.addAll(getRelatedContent(contentlet, relationship, hasParent,
                         APILocator.getUserAPI().getSystemUser(), true));
-            }else{
+            } else {
                 contentletList.addAll(getRelatedContent(contentlet, relationship,
                         APILocator.getUserAPI().getSystemUser(), true));
             }
@@ -1691,75 +1842,96 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> getAllLanguages(Contentlet contentlet, Boolean isLiveContent, User user, boolean respectFrontendRoles)
+    public List<Contentlet> getAllLanguages(Contentlet contentlet, Boolean isLiveContent, User user,
+            boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException {
 
-        if(!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_READ, user, respectFrontendRoles)){
-            throw new DotSecurityException("User: "+ (user != null ? user.getUserId() : "Unknown")+" cannot read Contentlet");
+        if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_READ, user,
+                respectFrontendRoles)) {
+            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
+                    + " cannot read Contentlet");
         }
 
-        List<Contentlet> contentletList =  null;
+        List<Contentlet> contentletList = null;
 
-
-        if(isLiveContent != null){
-            contentletList = contentFactory.getContentletsByIdentifier(contentlet.getIdentifier(), isLiveContent);
-        }else{
-            contentletList = contentFactory.getContentletsByIdentifier(contentlet.getIdentifier(), null);
+        if (isLiveContent != null) {
+            contentletList = contentFactory.getContentletsByIdentifier(contentlet.getIdentifier(),
+                    isLiveContent);
+        } else {
+            contentletList = contentFactory.getContentletsByIdentifier(contentlet.getIdentifier(),
+                    null);
         }
         return contentletList;
     }
 
     @WrapInTransaction
     @Override
-    public void unlock(final Contentlet contentlet, final User user, final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+    public void unlock(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
 
-        if(contentlet == null) {
+        if (contentlet == null) {
 
             throw new DotContentletStateException("The contentlet cannot Be null");
         }
 
-        final String contentPushPublishDate = UtilMethods.get(contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE), ND_SUPPLIER);
-        final String contentPushExpireDate  = UtilMethods.get(contentlet.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE),  ND_SUPPLIER);
+        final String contentPushPublishDate = UtilMethods.get(
+                contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE), ND_SUPPLIER);
+        final String contentPushExpireDate = UtilMethods.get(
+                contentlet.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE), ND_SUPPLIER);
 
-        ActivityLogger.logInfo(getClass(), "Unlocking Content", "StartDate: " +contentPushPublishDate+ "; "
-                + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+        ActivityLogger.logInfo(getClass(), "Unlocking Content",
+                "StartDate: " + contentPushPublishDate + "; "
+                        + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                        ? user.getUserId() : "Unknown")
+                        + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier()
+                        : "Unknown"), contentlet.getHost());
 
         try {
             canLock(contentlet, user, respectFrontendRoles);
 
-            if(contentlet.isLocked() ){
+            if (contentlet.isLocked()) {
                 // persists the webasset
                 APILocator.getVersionableAPI().setLocked(contentlet, false, user);
-                ThreadContextUtil.ifReindex(()-> indexAPI.addContentToIndex(contentlet, false));
+                ThreadContextUtil.ifReindex(() -> indexAPI.addContentToIndex(contentlet, false));
             }
 
-        } catch(DotDataException | DotStateException| DotSecurityException e) {
+        } catch (DotDataException | DotStateException | DotSecurityException e) {
 
-            ActivityLogger.logInfo(getClass(), "Error Unlocking Content", "StartDate: " +contentPushPublishDate+ "; "
-                    + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                    + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+            ActivityLogger.logInfo(getClass(), "Error Unlocking Content",
+                    "StartDate: " + contentPushPublishDate + "; "
+                            + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                            ? user.getUserId() : "Unknown")
+                            + "; ContentIdentifier: " + (contentlet != null
+                            ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
             throw e;
         }
 
-        ActivityLogger.logInfo(getClass(), "Content Unlocked", "StartDate: " +contentPushPublishDate+ "; "
-                + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+        ActivityLogger.logInfo(getClass(), "Content Unlocked",
+                "StartDate: " + contentPushPublishDate + "; "
+                        + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                        ? user.getUserId() : "Unknown")
+                        + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier()
+                        : "Unknown"), contentlet.getHost());
     }
 
     @CloseDBIfOpened
     @Override
-    public Identifier getRelatedIdentifier(Contentlet contentlet,String relationshipType, User user, boolean respectFrontendRoles)throws DotDataException, DotSecurityException {
-        if(!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_READ, user, respectFrontendRoles)){
-            throw new DotSecurityException("User: "+ (user != null ? user.getUserId() : "Unknown") +" cannot read Contentlet");
+    public Identifier getRelatedIdentifier(Contentlet contentlet, String relationshipType,
+            User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+        if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_READ, user,
+                respectFrontendRoles)) {
+            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
+                    + " cannot read Contentlet");
         }
         return contentFactory.getRelatedIdentifier(contentlet, relationshipType);
     }
 
     @CloseDBIfOpened
     @Override
-    public List<Link> getRelatedLinks(Contentlet contentlet, User user, boolean respectFrontendRoles) throws DotDataException,DotSecurityException {
-        return permissionAPI.filterCollection(contentFactory.getRelatedLinks(contentlet), PermissionAPI.PERMISSION_READ, respectFrontendRoles, user);
+    public List<Link> getRelatedLinks(Contentlet contentlet, User user,
+            boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+        return permissionAPI.filterCollection(contentFactory.getRelatedLinks(contentlet),
+                PermissionAPI.PERMISSION_READ, respectFrontendRoles, user);
     }
 
 
@@ -1772,7 +1944,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
         Logger.warn(this,
                 "This implementation of ContentletAPI.filterRelatedContent is deprecated and no longer respects the sort. "
                         + "Please, use any of the getRelatedContent implementations existing in the ContentletAPI instead ");
-        return filterRelatedContent(contentlet, rel, user, respectFrontendRoles, pullByParent, limit, offset);
+        return filterRelatedContent(contentlet, rel, user, respectFrontendRoles, pullByParent,
+                limit, offset);
     }
 
     @VisibleForTesting
@@ -1792,7 +1965,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             if (pullByParent == null) {
                 return (List<Contentlet>) CollectionsUtils
                         .join(getRelatedChildren(contentlet, rel, user, respectFrontendRoles, limit,
-                                offset),
+                                        offset),
                                 getRelatedParents(contentlet, rel, user, respectFrontendRoles,
                                         limit, offset)).stream()
                         .filter(Objects::nonNull)
@@ -1810,7 +1983,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
         } else {
             if (rel.getChildStructureInode().equals(contentlet.getContentTypeId())) {
-                return getRelatedParents(contentlet, rel, user, respectFrontendRoles, limit, offset);
+                return getRelatedParents(contentlet, rel, user, respectFrontendRoles, limit,
+                        offset);
             } else {
                 return getRelatedChildren(contentlet, rel, user, respectFrontendRoles, limit,
                         offset);
@@ -1819,14 +1993,16 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public List<Contentlet> getRelatedContent(final Contentlet contentlet, final Relationship rel, final User user,
+    public List<Contentlet> getRelatedContent(final Contentlet contentlet, final Relationship rel,
+            final User user,
             final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
         try {
             return getRelatedContent(contentlet, rel, null, user, respectFrontendRoles);
         } catch (final Exception e) {
             final String errorMessage = String.format("Related content for contentlet with " +
-                    "identifier '%s', title '%s', Relationship Name '%s' was not found: %s", contentlet.getIdentifier(), contentlet
-                    .getTitle(), rel.getRelationTypeValue(), e.getMessage());
+                            "identifier '%s', title '%s', Relationship Name '%s' was not found: %s",
+                    contentlet.getIdentifier(), contentlet
+                            .getTitle(), rel.getRelationTypeValue(), e.getMessage());
             if (e instanceof SearchPhaseExecutionException || e
                     .getCause() instanceof SearchPhaseExecutionException) {
                 Logger.warnAndDebug(ESContentletAPIImpl.class,
@@ -1838,30 +2014,35 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * Returns the list of child Contentlets related to the specified Contentlet based on a given Relationship.
+     * Returns the list of child Contentlets related to the specified Contentlet based on a given
+     * Relationship.
      *
-     * @param contentlet           The {@link Contentlet} whose child Contentlets will be retrieved.
+     * @param contentlet           The {@link Contentlet} whose child Contentlets will be
+     *                             retrieved.
      * @param rel                  The {@link Relationship} used to get the child Contentlets.
      * @param user                 The {@link User} performing this action.
-     * @param respectFrontendRoles If the User executing this action has the front-end role, or if front-end roles must
-     *                             be validated against this user, set to {@code true}. Otherwise, set to {@code
-     *                             false}.
-     * @param limitParam                The limit to the amount of results that will be returned.
-     * @param offset               The offset applied to the result, mostly for pagination purposes.
-     *
-     * @return The list of {@link Contentlet} objects that are the children of the specified Contentlet.
-     *
-     * @throws DotSecurityException The user executing this action does not have the required permissions.
+     * @param respectFrontendRoles If the User executing this action has the front-end role, or if
+     *                             front-end roles must be validated against this user, set to
+     *                             {@code true}. Otherwise, set to {@code false}.
+     * @param limitParam           The limit to the amount of results that will be returned.
+     * @param offset               The offset applied to the result, mostly for pagination
+     *                             purposes.
+     * @return The list of {@link Contentlet} objects that are the children of the specified
+     * Contentlet.
+     * @throws DotSecurityException The user executing this action does not have the required
+     *                              permissions.
      * @throws DotDataException     An error occurred when interacting with the data source.
      */
     private List<Contentlet> getRelatedChildren(final Contentlet contentlet, final Relationship rel,
-            final User user, final boolean respectFrontendRoles, final int limitParam, final int offset)
+            final User user, final boolean respectFrontendRoles, final int limitParam,
+            final int offset)
             throws DotSecurityException, DotDataException {
         final boolean HAS_PARENT = Boolean.TRUE;
         final boolean WORKING_VERSION = Boolean.FALSE;
         if (rel.isRelationshipField() && GET_RELATED_CONTENT_FROM_DB) {
             return FactoryLocator.getRelationshipFactory()
-                    .dbRelatedContent(rel, contentlet, HAS_PARENT, WORKING_VERSION, "tree_order", limitParam, offset);
+                    .dbRelatedContent(rel, contentlet, HAS_PARENT, WORKING_VERSION, "tree_order",
+                            limitParam, offset);
         } else {
 
             final List<Contentlet> result = new ArrayList<>();
@@ -1874,12 +2055,14 @@ public class ESContentletAPIImpl implements ContentletAPI {
             //Search for related content in existing contentlet
             if (UtilMethods.isSet(contentlet.getInode())) {
                 response = APILocator.getEsSearchAPI()
-                        .esSearchRelated(contentlet, relationshipName, DONT_PULL_PARENTS, WORKING_VERSION, user,
+                        .esSearchRelated(contentlet, relationshipName, DONT_PULL_PARENTS,
+                                WORKING_VERSION, user,
                                 respectFrontendRoles, limit, offset, null);
             } else {
                 //Search for related content in other versions of the same contentlet
                 response = APILocator.getEsSearchAPI()
-                        .esSearchRelated(contentlet.getIdentifier(), relationshipName, DONT_PULL_PARENTS, WORKING_VERSION, user,
+                        .esSearchRelated(contentlet.getIdentifier(), relationshipName,
+                                DONT_PULL_PARENTS, WORKING_VERSION, user,
                                 respectFrontendRoles, limit, offset, null);
             }
 
@@ -1890,7 +2073,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
             for (final SearchHit sh : response.getHits()) {
                 final Map<String, Object> sourceMap = sh.getSourceAsMap();
                 if (sourceMap.get(relationshipName) != null) {
-                    List<String> relatedIdentifiers = ((ArrayList<String>) sourceMap.get(relationshipName));
+                    List<String> relatedIdentifiers = ((ArrayList<String>) sourceMap.get(
+                            relationshipName));
 
                     if (limit > 0 && offset >= 0 && (offset + limit) <= relatedIdentifiers.size()) {
                         relatedIdentifiers = ((ArrayList<String>) sourceMap.get(relationshipName))
@@ -1899,17 +2083,22 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                     relatedIdentifiers.stream().forEach(child -> {
                         try {
-                            final Contentlet mappedContentlet = findContentletByIdentifierAnyLanguage(child, true);
-                            if (null != mappedContentlet && UtilMethods.isSet(mappedContentlet.getIdentifier())) {
+                            final Contentlet mappedContentlet = findContentletByIdentifierAnyLanguage(
+                                    child, true);
+                            if (null != mappedContentlet && UtilMethods.isSet(
+                                    mappedContentlet.getIdentifier())) {
                                 result.add(mappedContentlet);
                             } else {
-                                Logger.warn(this, String.format("Child Contentlet with ID '%s' for relationship '%s' " +
-                                                "was not found. Verify that it exists in the database", child,
+                                Logger.warn(this, String.format(
+                                        "Child Contentlet with ID '%s' for relationship '%s' " +
+                                                "was not found. Verify that it exists in the database",
+                                        child,
                                         rel.getRelationTypeValue()));
                             }
                         } catch (final Exception e) {
-                            throw new RuntimeException(String.format("An error occurred when mapping Child related " +
-                                    "content '%s': %s", child, e.getMessage()), e);
+                            throw new RuntimeException(
+                                    String.format("An error occurred when mapping Child related " +
+                                            "content '%s': %s", child, e.getMessage()), e);
                         }
                     });
                 }
@@ -1920,20 +2109,23 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * Returns the list of parent Contentlets related to the specified Contentlet based on a given Relationship.
+     * Returns the list of parent Contentlets related to the specified Contentlet based on a given
+     * Relationship.
      *
-     * @param contentlet           The {@link Contentlet} whose parent Contentlets will be retrieved.
+     * @param contentlet           The {@link Contentlet} whose parent Contentlets will be
+     *                             retrieved.
      * @param rel                  The {@link Relationship} used to get the parent Contentlets.
      * @param user                 The {@link User} performing this action.
-     * @param respectFrontendRoles If the User executing this action has the front-end role, or if front-end roles must
-     *                             be validated against this user, set to {@code true}. Otherwise, set to {@code
-     *                             false}.
-     * @param limitParam                The limit to the amount of results that will be returned.
-     * @param offset               The offset applied to the result, mostly for pagination purposes.
-     *
-     * @return The list of {@link Contentlet} objects that are the parents of the specified Contentlet.
-     *
-     * @throws DotSecurityException The user executing this action does not have the required permissions.
+     * @param respectFrontendRoles If the User executing this action has the front-end role, or if
+     *                             front-end roles must be validated against this user, set to
+     *                             {@code true}. Otherwise, set to {@code false}.
+     * @param limitParam           The limit to the amount of results that will be returned.
+     * @param offset               The offset applied to the result, mostly for pagination
+     *                             purposes.
+     * @return The list of {@link Contentlet} objects that are the parents of the specified
+     * Contentlet.
+     * @throws DotSecurityException The user executing this action does not have the required
+     *                              permissions.
      * @throws DotDataException     An error occurred when interacting with the data source.
      */
     private List<Contentlet> getRelatedParents(final Contentlet contentlet, final Relationship rel,
@@ -1943,7 +2135,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
         final boolean WORKING_VERSION = Boolean.FALSE;
         if (rel.isRelationshipField() && GET_RELATED_CONTENT_FROM_DB) {
             return FactoryLocator.getRelationshipFactory()
-                    .dbRelatedContent(rel, contentlet, HAS_NO_PARENT, WORKING_VERSION, "tree_order", limitParam, offset);
+                    .dbRelatedContent(rel, contentlet, HAS_NO_PARENT, WORKING_VERSION, "tree_order",
+                            limitParam, offset);
         } else {
             final Map<String, Contentlet> relatedMap = new HashMap<>();
             final String relationshipName = rel.getRelationTypeValue().toLowerCase();
@@ -1955,11 +2148,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
             //Search for related content in existing contentlet
             if (UtilMethods.isSet(contentlet.getInode())) {
                 response = APILocator.getEsSearchAPI()
-                        .esSearchRelated(contentlet, relationshipName, PULL_PARENTS, WORKING_VERSION, user,
+                        .esSearchRelated(contentlet, relationshipName, PULL_PARENTS,
+                                WORKING_VERSION, user,
                                 respectFrontendRoles, limit, offset, null);
             } else {
                 response = APILocator.getEsSearchAPI()
-                        .esSearchRelated(contentlet.getIdentifier(), relationshipName, PULL_PARENTS, WORKING_VERSION, user,
+                        .esSearchRelated(contentlet.getIdentifier(), relationshipName, PULL_PARENTS,
+                                WORKING_VERSION, user,
                                 respectFrontendRoles, limit, offset, null);
             }
 
@@ -1968,12 +2163,16 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     final Map<String, Object> sourceMap = sh.getSourceAsMap();
                     final String identifier = (String) sourceMap.get("identifier");
                     if (identifier != null && !relatedMap.containsKey(identifier)) {
-                        final Contentlet mappedContentlet = findContentletByIdentifierAnyLanguage(identifier, true);
-                        if (null != mappedContentlet && UtilMethods.isSet(mappedContentlet.getIdentifier())) {
+                        final Contentlet mappedContentlet = findContentletByIdentifierAnyLanguage(
+                                identifier, true);
+                        if (null != mappedContentlet && UtilMethods.isSet(
+                                mappedContentlet.getIdentifier())) {
                             relatedMap.put(identifier, mappedContentlet);
                         } else {
-                            Logger.warn(this, String.format("Parent Contentlet with ID '%s' for relationship '%s' was" +
-                                            " not found. Verify that it exists in the database", identifier,
+                            Logger.warn(this, String.format(
+                                    "Parent Contentlet with ID '%s' for relationship '%s' was" +
+                                            " not found. Verify that it exists in the database",
+                                    identifier,
                                     rel.getRelationTypeValue()));
                         }
                     }
@@ -1988,13 +2187,15 @@ public class ESContentletAPIImpl implements ContentletAPI {
     public List<Contentlet> getRelatedContent(Contentlet contentlet, Relationship rel,
             Boolean pullByParent, User user, boolean respectFrontendRoles, int limit, int offset,
             String sortBy) throws DotDataException {
-        return getRelatedContent(contentlet, rel, pullByParent, user, respectFrontendRoles, limit, offset, sortBy, -1, null);
+        return getRelatedContent(contentlet, rel, pullByParent, user, respectFrontendRoles, limit,
+                offset, sortBy, -1, null);
     }
 
     @CloseDBIfOpened
     @Override
     public List<Contentlet> getRelatedContent(final Contentlet contentlet, final Relationship rel,
-            final Boolean pullByParent, final User user, final boolean respectFrontendRoles, final int limit, final int offset,
+            final Boolean pullByParent, final User user, final boolean respectFrontendRoles,
+            final int limit, final int offset,
             final String sortBy, final long language, final Boolean live)
             throws DotDataException {
         String fieldVariable = rel.getRelationTypeValue();
@@ -2012,13 +2213,16 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 }
             }
 
-            return getRelatedContent(contentlet, fieldVariable, user, respectFrontendRoles, pullByParent, limit,
+            return getRelatedContent(contentlet, fieldVariable, user, respectFrontendRoles,
+                    pullByParent, limit,
                     offset, sortBy, language, live);
         } catch (final Exception e) {
-            final String id = contentlet!=null ? contentlet.getIdentifier() : "null";
-            final String relName = rel!=null ? rel.getRelationTypeValue() : "null";
-            final String errorMessage = String.format("Unable to look up related content for contentlet with " +
-                    "identifier '%s', Relationship name '%s'(%s): %s", id, relName, fieldVariable, e.getMessage());
+            final String id = contentlet != null ? contentlet.getIdentifier() : "null";
+            final String relName = rel != null ? rel.getRelationTypeValue() : "null";
+            final String errorMessage = String.format(
+                    "Unable to look up related content for contentlet with " +
+                            "identifier '%s', Relationship name '%s'(%s): %s", id, relName,
+                    fieldVariable, e.getMessage());
 
             if (e instanceof SearchPhaseExecutionException || e
                     .getCause() instanceof SearchPhaseExecutionException) {
@@ -2033,7 +2237,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @Override
     public List<Contentlet> getRelatedContent(Contentlet contentlet, Relationship rel,
-            Boolean pullByParent, User user, boolean respectFrontendRoles, final long language, final Boolean live)
+            Boolean pullByParent, User user, boolean respectFrontendRoles, final long language,
+            final Boolean live)
             throws DotDataException, DotSecurityException {
         return getRelatedContent(contentlet, rel, pullByParent, user, respectFrontendRoles, -1, -1,
                 null, language, live);
@@ -2048,7 +2253,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * @deprecated Use {@link ContentletAPI#getRelatedContent(Contentlet, Relationship, Boolean, User, boolean)} instead
      * @param contentlet
      * @param rel
      * @param pullByParent
@@ -2057,21 +2261,29 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @return
      * @throws DotDataException
      * @throws DotSecurityException
+     * @deprecated Use
+     * {@link ContentletAPI#getRelatedContent(Contentlet, Relationship, Boolean, User, boolean)}
+     * instead
      */
     @Deprecated
-    public List<Contentlet> getRelatedContentFromIndex(final Contentlet contentlet, final Relationship rel, final boolean pullByParent,
+    public List<Contentlet> getRelatedContentFromIndex(final Contentlet contentlet,
+            final Relationship rel, final boolean pullByParent,
             final User user, final boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException {
 
         try {
-            return getRelatedContent(contentlet, rel, pullByParent, user, respectFrontendRoles, -1, -1, null);
+            return getRelatedContent(contentlet, rel, pullByParent, user, respectFrontendRoles, -1,
+                    -1, null);
         } catch (final Exception e) {
-            final String errorMessage = String.format("Unable to look up related content for contentlet from Index " +
-                    "with identifier '%s', Relationship Name '%s': %s", contentlet.getIdentifier(), rel.getRelationTypeValue
-                    (), e.getMessage());
+            final String errorMessage = String.format(
+                    "Unable to look up related content for contentlet from Index " +
+                            "with identifier '%s', Relationship Name '%s': %s",
+                    contentlet.getIdentifier(), rel.getRelationTypeValue
+                            (), e.getMessage());
             if (e instanceof SearchPhaseExecutionException || e
                     .getCause() instanceof SearchPhaseExecutionException) {
-                Logger.warnAndDebug(ESContentletAPIImpl.class, errorMessage + ". An empty list will be returned", e);
+                Logger.warnAndDebug(ESContentletAPIImpl.class,
+                        errorMessage + ". An empty list will be returned", e);
                 return Collections.emptyList();
             }
             throw new DotDataException(errorMessage, e);
@@ -2080,6 +2292,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * check if a workflow may be run instead of the delete api call itself.
+     *
      * @param contentletIn
      * @param user
      * @param respectFrontendRoles
@@ -2087,7 +2300,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotSecurityException
      * @throws DotDataException
      */
-    private Optional<Boolean> checkAndRunDeleteAsWorkflow(final Contentlet contentletIn, final User user,
+    private Optional<Boolean> checkAndRunDeleteAsWorkflow(final Contentlet contentletIn,
+            final User user,
             final boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
 
         // if already on workflow or has an actionid skip this method.
@@ -2106,7 +2320,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         if (workflowActionOpt.isPresent()) {
 
-            final String title    = contentletIn.getTitle();
+            final String title = contentletIn.getTitle();
             final String actionId = workflowActionOpt.get().getId();
 
             // if the default action is in the avalable actions for the content.
@@ -2114,29 +2328,34 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 return Optional.empty();
             }
 
-            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier() + " hasn't action id set"
+            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier()
+                    + " hasn't action id set"
                     + " using the default action: " + actionId);
 
             // if the action has a save action, we skip the current checkin
             if (workflowActionOpt.get().hasDeleteActionlet()) {
 
-                Logger.info(this, () -> "The action: " + actionId + " has a delete contentlet actionlet"
-                        + " so firing a workflow and skipping the current delete for the contentlet: " + contentletIn.getIdentifier());
+                Logger.info(this,
+                        () -> "The action: " + actionId + " has a delete contentlet actionlet"
+                                + " so firing a workflow and skipping the current delete for the contentlet: "
+                                + contentletIn.getIdentifier());
 
                 contentletIn.setActionId(actionId);
                 contentletIn.setProperty(Contentlet.WORKFLOW_IN_PROGRESS, Boolean.TRUE);
 
-                final WorkflowProcessor processor = workflowAPI.fireWorkflowPreCheckin(contentletIn, user);
+                final WorkflowProcessor processor = workflowAPI.fireWorkflowPreCheckin(contentletIn,
+                        user);
                 workflowAPI.fireWorkflowPostCheckin(processor);
                 if (processor.getContextMap().containsKey("deleted")) {
 
-                    return Optional.ofNullable((Boolean)processor.getContextMap().get("deleted"));
+                    return Optional.ofNullable((Boolean) processor.getContextMap().get("deleted"));
                 }
 
                 return Optional.ofNullable(false);
             }
 
-            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier() + " hasn't a delete contentlet actionlet"
+            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier()
+                    + " hasn't a delete contentlet actionlet"
                     + " so including just the action to the contentlet: " + title);
 
             contentletIn.setActionId(actionId);
@@ -2146,9 +2365,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public boolean delete(final Contentlet contentlet, final User user, final boolean respectFrontendRoles) throws DotDataException,DotSecurityException {
+    public boolean delete(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
 
-        final Optional<Boolean> deleteOpt = this.checkAndRunDeleteAsWorkflow(contentlet, user, respectFrontendRoles);
+        final Optional<Boolean> deleteOpt = this.checkAndRunDeleteAsWorkflow(contentlet, user,
+                respectFrontendRoles);
         if (deleteOpt.isPresent()) {
 
             Logger.info(this, "A Workflow has been ran instead of delete the contentlet: " +
@@ -2165,8 +2386,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             deleted = delete(contentlets, user, respectFrontendRoles);
             HibernateUtil.addCommitListener
-                    (()-> this.localSystemEventsAPI.notify(new ContentletDeletedEvent(contentlet, user)));
-        } catch(DotDataException | DotSecurityException e) {
+                    (() -> this.localSystemEventsAPI.notify(
+                            new ContentletDeletedEvent(contentlet, user)));
+        } catch (DotDataException | DotSecurityException e) {
 
             logContentletActivity(contentlets, "Error Deleting Content", user);
             throw e;
@@ -2176,7 +2398,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public boolean delete(final Contentlet contentlet, final User user, final boolean respectFrontendRoles, final boolean allVersions) throws DotDataException,DotSecurityException {
+    public boolean delete(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles, final boolean allVersions)
+            throws DotDataException, DotSecurityException {
 
         final List<Contentlet> contentlets = new ArrayList<>();
         contentlets.add(contentlet);
@@ -2185,8 +2409,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             this.delete(contentlets, user, respectFrontendRoles, allVersions);
             HibernateUtil.addCommitListener
-                    (()-> this.localSystemEventsAPI.notify(new ContentletDeletedEvent(contentlet, user)));
-        } catch(DotDataException | DotSecurityException e) {
+                    (() -> this.localSystemEventsAPI.notify(
+                            new ContentletDeletedEvent(contentlet, user)));
+        } catch (DotDataException | DotSecurityException e) {
             logContentletActivity(contentlets, "Error Deleting Content", user);
             throw e;
         }
@@ -2197,23 +2422,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public boolean deleteByHost(final Host host, final User user, final boolean respectFrontendRoles)
+    public boolean deleteByHost(final Host host, final User user,
+            final boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException {
-
 
         final DotConnect db = new DotConnect();
 
-        List<String> deleteMe = db.setSQL("select working_inode  from identifier, contentlet_version_info where identifier.id = contentlet_version_info.identifier and host_inode=? and asset_type='contentlet'")
+        List<String> deleteMe = db.setSQL(
+                        "select working_inode  from identifier, contentlet_version_info where identifier.id = contentlet_version_info.identifier and host_inode=? and asset_type='contentlet'")
                 .addParam(host.getIdentifier())
                 .setMaxRows(200)
                 .loadObjectResults()
                 .stream()
-                .map(map->(String)map.get("working_inode"))
+                .map(map -> (String) map.get("working_inode"))
                 .collect(Collectors.toList());
 
-        while(deleteMe.size()>0) {
+        while (deleteMe.size() > 0) {
             final List<String> ids = deleteMe;
-            LocalTransaction.wrapNoException(() ->{
+            LocalTransaction.wrap(() -> {
 
                 try {
 
@@ -2226,12 +2452,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 }
             });
 
-            deleteMe = db.setSQL("select working_inode  from identifier, contentlet_version_info where identifier.id = contentlet_version_info.identifier and host_inode=? and asset_type='contentlet'")
+            deleteMe = db.setSQL(
+                            "select working_inode  from identifier, contentlet_version_info where identifier.id = contentlet_version_info.identifier and host_inode=? and asset_type='contentlet'")
                     .addParam(host.getIdentifier())
                     .setMaxRows(200)
                     .loadObjectResults()
                     .stream()
-                    .map(map->(String)map.get("working_inode"))
+                    .map(map -> (String) map.get("working_inode"))
                     .collect(Collectors.toList());
         }
         return true;
@@ -2240,7 +2467,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public boolean delete(final List<Contentlet> contentlets, final User user, final boolean respectFrontendRoles)
+    public boolean delete(final List<Contentlet> contentlets, final User user,
+            final boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException {
 
         return deleteContentlets(contentlets, user, respectFrontendRoles, false);
@@ -2248,6 +2476,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * check if a workflow may be run instead of the destroy api call itself.
+     *
      * @param contentletIn
      * @param user
      * @param respectFrontendRoles
@@ -2255,7 +2484,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotSecurityException
      * @throws DotDataException
      */
-    private Optional<Boolean> checkAndRunDestroyAsWorkflow(final Contentlet contentletIn, final User user,
+    private Optional<Boolean> checkAndRunDestroyAsWorkflow(final Contentlet contentletIn,
+            final User user,
             final boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
 
         // if already on workflow or has an actionid skip this method.
@@ -2274,7 +2504,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         if (workflowActionOpt.isPresent()) {
 
-            final String title    = contentletIn.getTitle();
+            final String title = contentletIn.getTitle();
             final String actionId = workflowActionOpt.get().getId();
 
             // if the default action is in the avalable actions for the content.
@@ -2282,29 +2512,34 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 return Optional.empty();
             }
 
-            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier() + " hasn't action id set"
+            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier()
+                    + " hasn't action id set"
                     + " using the default action: " + actionId);
 
             // if the action has a destroy action, we skip the current checkin
             if (workflowActionOpt.get().hasDestroyActionlet()) {
 
-                Logger.info(this, () -> "The action: " + actionId + " has a destroy contentlet actionlet"
-                        + " so firing a workflow and skipping the current destroy for the contentlet: " + contentletIn.getIdentifier());
+                Logger.info(this,
+                        () -> "The action: " + actionId + " has a destroy contentlet actionlet"
+                                + " so firing a workflow and skipping the current destroy for the contentlet: "
+                                + contentletIn.getIdentifier());
 
                 contentletIn.setActionId(actionId);
                 contentletIn.setProperty(Contentlet.WORKFLOW_IN_PROGRESS, Boolean.TRUE);
 
-                final WorkflowProcessor processor = workflowAPI.fireWorkflowPreCheckin(contentletIn, user);
+                final WorkflowProcessor processor = workflowAPI.fireWorkflowPreCheckin(contentletIn,
+                        user);
                 workflowAPI.fireWorkflowPostCheckin(processor);
                 if (processor.getContextMap().containsKey("destroy")) {
 
-                    return Optional.ofNullable((Boolean)processor.getContextMap().get("destroy"));
+                    return Optional.ofNullable((Boolean) processor.getContextMap().get("destroy"));
                 }
 
                 return Optional.ofNullable(false);
             }
 
-            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier() + " hasn't a destroy contentlet actionlet"
+            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier()
+                    + " hasn't a destroy contentlet actionlet"
                     + " so including just the action to the contentlet: " + title);
 
             contentletIn.setActionId(actionId);
@@ -2314,9 +2549,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public boolean destroy(final Contentlet contentlet, final User user, final boolean respectFrontendRoles) throws DotDataException,DotSecurityException {
+    public boolean destroy(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
 
-        final Optional<Boolean> deleteOpt = this.checkAndRunDestroyAsWorkflow(contentlet, user, respectFrontendRoles);
+        final Optional<Boolean> deleteOpt = this.checkAndRunDestroyAsWorkflow(contentlet, user,
+                respectFrontendRoles);
         if (deleteOpt.isPresent()) {
 
             Logger.info(this, "A Workflow has been ran instead of destroy the contentlet: " +
@@ -2330,7 +2567,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         try {
 
             return this.destroy(contentlets, user, respectFrontendRoles);
-        } catch(DotDataException | DotSecurityException e) {
+        } catch (DotDataException | DotSecurityException e) {
 
             this.logContentletActivity(contentlets, "Error Destroying Content", user);
             throw e;
@@ -2339,7 +2576,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public boolean destroy(final List<Contentlet> contentlets, final User user, final boolean respectFrontendRoles) throws DotDataException,
+    public boolean destroy(final List<Contentlet> contentlets, final User user,
+            final boolean respectFrontendRoles) throws DotDataException,
             DotSecurityException {
 
         boolean destroyed = false;
@@ -2353,7 +2591,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
         final List<Contentlet> contentletsToDelete = new ArrayList<>();
         for (final Contentlet contentlet : contentlets) {
 
-            final Optional<Boolean> deleteOpt = this.checkAndRunDestroyAsWorkflow(contentlet, user, respectFrontendRoles);
+            final Optional<Boolean> deleteOpt = this.checkAndRunDestroyAsWorkflow(contentlet, user,
+                    respectFrontendRoles);
             if (!deleteOpt.isPresent()) {
 
                 contentletsToDelete.add(contentlet);
@@ -2365,11 +2604,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
         }
 
-        return  !contentletsToDelete.isEmpty()?
-                this.internalDestroy(contentletsToDelete, user, respectFrontendRoles):destroyed;
+        return !contentletsToDelete.isEmpty() ?
+                this.internalDestroy(contentletsToDelete, user, respectFrontendRoles) : destroyed;
     }
 
-    private boolean internalDestroy (final List<Contentlet> contentlets, final User user, final boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
+    private boolean internalDestroy(final List<Contentlet> contentlets, final User user,
+            final boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
 
         this.logContentletActivity(contentlets, "Destroying Content", user);
 
@@ -2381,8 +2621,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
             }
 
-            final boolean bringOldVersions  = false;  // we do not want old version in order to be more efficient
-            final List<Contentlet> versions =  this.findAllVersions(APILocator.getIdentifierAPI().find(contentlet.getIdentifier()), bringOldVersions,
+            final boolean bringOldVersions = false;  // we do not want old version in order to be more efficient
+            final List<Contentlet> versions = this.findAllVersions(
+                    APILocator.getIdentifierAPI().find(contentlet.getIdentifier()),
+                    bringOldVersions,
                     user, respectFrontendRoles);
 
             for (final Contentlet version : versions) {
@@ -2390,7 +2632,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
         }
 
-        final List<Contentlet> filterContentlets = this.permissionAPI.filterCollection(contentlets, PermissionAPI.PERMISSION_PUBLISH,
+        final List<Contentlet> filterContentlets = this.permissionAPI.filterCollection(contentlets,
+                PermissionAPI.PERMISSION_PUBLISH,
                 respectFrontendRoles, user);
 
         if (filterContentlets.size() != contentlets.size()) {
@@ -2403,11 +2646,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
         return this.destroyContentlets(contentlets, user, respectFrontendRoles);
     }
 
-    private void forceUnpublishArchive (final Contentlet contentlet, final User user)
+    private void forceUnpublishArchive(final Contentlet contentlet, final User user)
             throws DotSecurityException, DotDataException {
 
         // Force unpublishing and archiving the contentlet
-        try{
+        try {
             if (contentlet.isLive()) {
                 unpublish(contentlet, user, false, 0);
             }
@@ -2417,12 +2660,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
         // make destroy more robust if we cannot find ContentletVersionInfo
         // keep going
-        catch(DotStateException e){
+        catch (DotStateException e) {
             Logger.debug(this, e.getMessage());
         }
     }
 
-    private void deleteRelationships(final Contentlet contentlet, final User user, final boolean respectFrontendRoles)
+    private void deleteRelationships(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles)
             throws DotSecurityException, DotDataException {
 
         final List<Relationship> relationships =
@@ -2433,13 +2677,16 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
     }
 
-    private void deleteMultitrees(final Contentlet contentlet, final User user) throws DotDataException, DotSecurityException {
+    private void deleteMultitrees(final Contentlet contentlet, final User user)
+            throws DotDataException, DotSecurityException {
 
-        final List<MultiTree> multiTrees = APILocator.getMultiTreeAPI().getMultiTreesByChild(contentlet.getIdentifier());
+        final List<MultiTree> multiTrees = APILocator.getMultiTreeAPI()
+                .getMultiTreesByChild(contentlet.getIdentifier());
 
         for (final MultiTree multiTree : multiTrees) {
 
-            final Identifier pageIdentifier = APILocator.getIdentifierAPI().find(multiTree.getHtmlPage());
+            final Identifier pageIdentifier = APILocator.getIdentifierAPI()
+                    .find(multiTree.getHtmlPage());
             if (pageIdentifier != null && UtilMethods.isSet(pageIdentifier.getInode())) {
 
                 try {
@@ -2450,9 +2697,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                         new PageLoader().invalidate(page);
                     }
-                } catch(DotStateException dcse) {
+                } catch (DotStateException dcse) {
 
-                    Logger.warn(this.getClass(), "Page with id:" +pageIdentifier.getId() +" does not exist" );
+                    Logger.warn(this.getClass(),
+                            "Page with id:" + pageIdentifier.getId() + " does not exist");
                 }
             }
 
@@ -2461,59 +2709,62 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * Completely destroys the given list of {@link Contentlet} objects
-     * (versions, relationships, associated contents, binary files) in all of
-     * their languages.
+     * Completely destroys the given list of {@link Contentlet} objects (versions, relationships,
+     * associated contents, binary files) in all of their languages.
      *
-     * @param contentlets
-     *            - The list of contentlets that will be completely destroyed.
-     * @param user
-     *            - The {@link User} performing this action.
-     * @param respectFrontendRoles
-     *            -
-     * @return If the contentlets were successfully destroyed, returns
-     *         {@code true}. Otherwise, returns {@code false}.
-     * @throws DotDataException
-     *             An error occurred when deleting the information from the
-     *             database.
-     * @throws DotSecurityException
-     *             The specified user does not have the required permissions to
-     *             perform this action.
+     * @param contentlets          - The list of contentlets that will be completely destroyed.
+     * @param user                 - The {@link User} performing this action.
+     * @param respectFrontendRoles -
+     * @return If the contentlets were successfully destroyed, returns {@code true}. Otherwise,
+     * returns {@code false}.
+     * @throws DotDataException     An error occurred when deleting the information from the
+     *                              database.
+     * @throws DotSecurityException The specified user does not have the required permissions to
+     *                              perform this action.
      */
-    private boolean destroyContentlets(final List<Contentlet> contentlets, final User user, final boolean respectFrontendRoles)
+    private boolean destroyContentlets(final List<Contentlet> contentlets, final User user,
+            final boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException {
 
         boolean noErrors = true;
-        final List<Contentlet> contentletsVersion     = new ArrayList<>();
+        final List<Contentlet> contentletsVersion = new ArrayList<>();
         // Log contentlet identifiers that we are going to destroy
         AdminLogger.log(this.getClass(), "destroy",
                 "User trying to destroy the following contents: " +
-                        contentlets.stream().map(Contentlet::getIdentifier).collect(Collectors.toSet()), user);
+                        contentlets.stream().map(Contentlet::getIdentifier)
+                                .collect(Collectors.toSet()), user);
         final Iterator<Contentlet> contentletIterator = contentlets.iterator();
         while (contentletIterator.hasNext()) {
 
             final Contentlet contentlet = contentletIterator.next();
             contentlet.getMap().put(Contentlet.DONT_VALIDATE_ME, true);
             this.forceUnpublishArchiveOnDestroy(user, contentlet);
-            APILocator.getWorkflowAPI().deleteWorkflowTaskByContentletIdAnyLanguage(contentlet, user);
+            APILocator.getWorkflowAPI()
+                    .deleteWorkflowTaskByContentletIdAnyLanguage(contentlet, user);
 
             // Remove Rules with this contentlet as Parent.
             try {
 
-                APILocator.getRulesAPI().deleteRulesByParent(contentlet, user, respectFrontendRoles);
+                APILocator.getRulesAPI()
+                        .deleteRulesByParent(contentlet, user, respectFrontendRoles);
             } catch (InvalidLicenseException ilexp) {
 
                 Logger.warn(this, "An enterprise license is required to delete rules under pages.");
             }
 
             // Remove category associations
-            this.categoryAPI.removeChildren(contentlet, APILocator.getUserAPI().getSystemUser(), true);
-            this.categoryAPI.removeParents(contentlet, APILocator.getUserAPI().getSystemUser(), true);
+            this.categoryAPI.removeChildren(contentlet, APILocator.getUserAPI().getSystemUser(),
+                    true);
+            this.categoryAPI.removeParents(contentlet, APILocator.getUserAPI().getSystemUser(),
+                    true);
             this.deleteRelationships(contentlet, user, respectFrontendRoles);
 
-            contentletsVersion.addAll(findAllVersions(APILocator.getIdentifierAPI().find(contentlet.getIdentifier()), user,
-                    respectFrontendRoles));
-            contentletsVersion.forEach(contentletLanguage -> contentletLanguage.setIndexPolicy(contentlet.getIndexPolicy()));
+            contentletsVersion.addAll(
+                    findAllVersions(APILocator.getIdentifierAPI().find(contentlet.getIdentifier()),
+                            user,
+                            respectFrontendRoles));
+            contentletsVersion.forEach(contentletLanguage -> contentletLanguage.setIndexPolicy(
+                    contentlet.getIndexPolicy()));
             // Remove page contents (if the content is a Content Page)
             this.deleteMultitrees(contentlet, user);
             this.logContentletActivity(contentlet, "Content Destroyed", user);
@@ -2538,26 +2789,29 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * at destroying/deleting time this will take care of removing all metadata entries
+     *
      * @param contentlets
      */
-    private void destroyMetadata(final List<Contentlet> contentlets){
-        for (final Contentlet contentlet:contentlets){
+    private void destroyMetadata(final List<Contentlet> contentlets) {
+        for (final Contentlet contentlet : contentlets) {
             fileMetadataAPI.removeMetadata(contentlet);
-            Logger.debug(ESContentletAPIImpl.class,String.format("metadata removed for %s",contentlet.getIdentifier()));
+            Logger.debug(ESContentletAPIImpl.class,
+                    String.format("metadata removed for %s", contentlet.getIdentifier()));
         }
-        Logger.debug(ESContentletAPIImpl.class,String.format("Done removing metadata for %d elements.",contentlets.size()));
+        Logger.debug(ESContentletAPIImpl.class,
+                String.format("Done removing metadata for %d elements.", contentlets.size()));
     }
 
     private void forceUnpublishArchiveOnDestroy(final User user, final Contentlet contentlet)
             throws DotSecurityException, DotDataException {
 
         // it could be into a step, so we do not want to move.
-        final Optional<Boolean> disableWorkflowOpt = this.getDisableWorkflow (contentlet);
+        final Optional<Boolean> disableWorkflowOpt = this.getDisableWorkflow(contentlet);
         contentlet.getMap().put(Contentlet.DISABLE_WORKFLOW, true);
         this.forceUnpublishArchive(contentlet, user);
 
-        contentlet.getMap().put(Contentlet.DISABLE_WORKFLOW, disableWorkflowOpt.isPresent()?
-                disableWorkflowOpt.get(): null);
+        contentlet.getMap().put(Contentlet.DISABLE_WORKFLOW, disableWorkflowOpt.isPresent() ?
+                disableWorkflowOpt.get() : null);
     }
 
     private Optional<Boolean> getDisableWorkflow(final Contentlet contentlet) {
@@ -2567,7 +2821,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             return Optional.empty();
         }
 
-        return Optional.ofNullable((boolean)contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW));
+        return Optional.ofNullable((boolean) contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW));
     }
 
     private void deleteElementFromPublishQueueTable(final List<Contentlet> contentlets) {
@@ -2576,12 +2830,15 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             try {
 
-                PublisherAPI.getInstance().deleteElementFromPublishQueueTable(contentlet.getIdentifier());
+                PublisherAPI.getInstance()
+                        .deleteElementFromPublishQueueTable(contentlet.getIdentifier());
             } catch (DotPublisherException e) {
                 Logger.error(getClass(),
-                        "Error destroying Contentlet from Publishing Queue with Identifier: " + contentlet.getIdentifier());
+                        "Error destroying Contentlet from Publishing Queue with Identifier: "
+                                + contentlet.getIdentifier());
                 Logger.debug(getClass(),
-                        "Error destroying Contentlet from Publishing Queue with Identifier: " + contentlet.getIdentifier(),
+                        "Error destroying Contentlet from Publishing Queue with Identifier: "
+                                + contentlet.getIdentifier(),
                         e);
             }
         }
@@ -2601,7 +2858,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             for (final Contentlet contentlet : contentlets) {
 
                 final Structure structure = contentlet.getStructure();
-                final List<Field> fields  = structure.getFields();
+                final List<Field> fields = structure.getFields();
                 final List<File> filelist = new ArrayList<>();
 
                 File file = null;
@@ -2610,7 +2867,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     if (field.getFieldType().equals(FieldType.BINARY.toString())) {
                         try {
 
-                            file = getBinaryFile(contentlet.getInode(), field.getVelocityVarName(), user);
+                            file = getBinaryFile(contentlet.getInode(), field.getVelocityVarName(),
+                                    user);
                         } catch (Exception ex) {
                             Logger.debug(this, ex.getMessage(), ex);
                         }
@@ -2622,63 +2880,58 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     }
                 }
 
-                final File filePath =  new File(backupPath + File.separator
+                final File filePath = new File(backupPath + File.separator
                         + contentlet.getIdentifier());
                 filePath.mkdirs();
 
-                final File _writingwbin = new File(filePath,  contentlet.getIdentifier().toString()  + ".xml");
+                final File _writingwbin = new File(filePath,
+                        contentlet.getIdentifier().toString() + ".xml");
 
                 try (BufferedOutputStream bufferedOutputStream = new BufferedOutputStream
                         (Files.newOutputStream(_writingwbin.toPath()))) {
 
                     xstream.toXML(contentlet, bufferedOutputStream);
-                    for(final File fileChild : filelist) {
+                    for (final File fileChild : filelist) {
 
                         final File child = new File(filePath, fileChild.getName());
-                        FileUtil.move(fileChild,child );
+                        FileUtil.move(fileChild, child);
                     }
                 } catch (IOException e) {
                     Logger.error(this,
-                            "Error processing the file for contentlet with Identifier: " + contentlet.getIdentifier(), e);
+                            "Error processing the file for contentlet with Identifier: "
+                                    + contentlet.getIdentifier(), e);
                 }
             }
         }
     } // backupDestroyedContentlets.
 
     /**
-     * Deletes the specified list of {@link Contentlet} objects ONLY in the
-     * specified language. If any of the specified contentlets is not archived,
-     * an exception will be thrown. If there's only one language for a given
-     * contentlet, the object will be destroyed.
+     * Deletes the specified list of {@link Contentlet} objects ONLY in the specified language. If
+     * any of the specified contentlets is not archived, an exception will be thrown. If there's
+     * only one language for a given contentlet, the object will be destroyed.
      *
-     * @param contentlets
-     *            - The list of contentlets that will be deleted.
-     * @param user
-     *            - The {@link User} performing this action.
-     * @param respectFrontendRoles
-     *            -
-     * @param isDeletingAHost
-     *            - If the code calling this method is trying to delete a given
-     *            Site (host), set to {@code true}. Otherwise, set to
-     *            {@code false}.
-     * @return If the contentlets were successfully deleted, returns
-     *         {@code true}. Otherwise, returns {@code false}.
-     * @throws DotDataException
-     *             An error occurred when deleting the information from the
-     *             database.
-     * @throws DotSecurityException
-     *             The specified user does not have the required permissions to
-     *             perform this action.
-     * @throws DotStateException
-     *             One of the specified contentlets is not archived.
+     * @param contentlets          - The list of contentlets that will be deleted.
+     * @param user                 - The {@link User} performing this action.
+     * @param respectFrontendRoles -
+     * @param isDeletingAHost      - If the code calling this method is trying to delete a given
+     *                             Site (host), set to {@code true}. Otherwise, set to
+     *                             {@code false}.
+     * @return If the contentlets were successfully deleted, returns {@code true}. Otherwise,
+     * returns {@code false}.
+     * @throws DotDataException     An error occurred when deleting the information from the
+     *                              database.
+     * @throws DotSecurityException The specified user does not have the required permissions to
+     *                              perform this action.
+     * @throws DotStateException    One of the specified contentlets is not archived.
      */
     private boolean deleteContentlets(final List<Contentlet> contentlets, final User user,
-            final boolean respectFrontendRoles, final boolean isDeletingAHost) throws DotDataException,
+            final boolean respectFrontendRoles, final boolean isDeletingAHost)
+            throws DotDataException,
             DotSecurityException {
 
         boolean noErrors = true;
 
-        if(contentlets == null || contentlets.size() == 0) {
+        if (contentlets == null || contentlets.size() == 0) {
 
             Logger.info(this, "No contents passed to delete so returning");
             noErrors = false;
@@ -2690,24 +2943,25 @@ public class ESContentletAPIImpl implements ContentletAPI {
         final List<Contentlet> filteredContentlets = this.validateAndFilterContentletsToDelete(
                 contentlets, user, respectFrontendRoles);
 
-        if(filteredContentlets.size() != contentlets.size()) {
+        if (filteredContentlets.size() != contentlets.size()) {
 
             this.logContentletActivity(contentlets, "Error Deleting Content", user);
-            throw new DotSecurityException("User: "+ (user != null ? user.getUserId() : "Unknown")
-                    +" does not have permission to delete some or all of the contentlets");
+            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
+                    + " does not have permission to delete some or all of the contentlets");
         }
 
         // Log contentlet identifiers that we are going to delete
-        final HashSet<String> contentletIdentifiers   = new HashSet<>();
+        final HashSet<String> contentletIdentifiers = new HashSet<>();
         for (final Contentlet contentlet : contentlets) {
 
             contentletIdentifiers.add(contentlet.getIdentifier());
         }
 
-        AdminLogger.log(this.getClass(), "delete", "User trying to delete the following contents: " +
-                contentletIdentifiers.toString(), user);
+        AdminLogger.log(this.getClass(), "delete",
+                "User trying to delete the following contents: " +
+                        contentletIdentifiers.toString(), user);
 
-        final HashSet<String> deletedIdentifiers      = new HashSet();
+        final HashSet<String> deletedIdentifiers = new HashSet();
         final Iterator<Contentlet> contentletIterator = filteredContentlets.iterator();
         while (contentletIterator.hasNext()) {
 
@@ -2718,7 +2972,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
         return noErrors;
     }
 
-    private void deleteContentlet(final List<Contentlet> contentlets, final User user, final boolean isDeletingAHost,
+    private void deleteContentlet(final List<Contentlet> contentlets, final User user,
+            final boolean isDeletingAHost,
             final HashSet<String> deletedIdentifiers, final Contentlet contentletToDelete)
             throws DotDataException, DotSecurityException {
 
@@ -2727,7 +2982,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         if (isDeletingAHost) {
             //We need to make sure that we only destroy a identifier once.
             //If the contentlet has several languages we could send same identifier several times.
-            if(!deletedIdentifiers.contains(contentletToDelete.getIdentifier())) {
+            if (!deletedIdentifiers.contains(contentletToDelete.getIdentifier())) {
 
                 contentletToDelete.setProperty(Contentlet.DONT_VALIDATE_ME, true);
                 this.destroyContentlets(Lists.newArrayList(contentletToDelete), user, false);
@@ -2743,43 +2998,57 @@ public class ESContentletAPIImpl implements ContentletAPI {
             // on the amount of languages of each contentlet.
 
             // Find all multi-language working contentlets
-            final List<Contentlet> otherLanguageCons = this.contentFactory.getContentletsByIdentifier(contentletToDelete.getIdentifier());
+            final List<Contentlet> otherLanguageCons = this.contentFactory.getContentletsByIdentifier(
+                    contentletToDelete.getIdentifier());
             if (otherLanguageCons.size() == 1) {
 
                 this.destroyContentlets(Lists.newArrayList(contentletToDelete), user, false);
             } else if (otherLanguageCons.size() > 1) {
 
-                if(!contentletToDelete.isArchived() && contentletToDelete.getMap().get(Contentlet.DONT_VALIDATE_ME) == null) {
+                if (!contentletToDelete.isArchived()
+                        && contentletToDelete.getMap().get(Contentlet.DONT_VALIDATE_ME) == null) {
 
                     this.logContentletActivity(contentletToDelete, "Error Deleting Content", user);
                     final String errorMsg = "Contentlet with Inode " + contentletToDelete.getInode()
                             + " cannot be deleted because it's not archived. Please archive it first before deleting it.";
                     Logger.error(this, errorMsg);
                     APILocator
-                            .getNotificationAPI().generateNotification(errorMsg, NotificationLevel.INFO, user.getUserId());
+                            .getNotificationAPI()
+                            .generateNotification(errorMsg, NotificationLevel.INFO,
+                                    user.getUserId());
                     throw new DotStateException(errorMsg);
                 }
 
                 //TODO we still have several things that need cleaning here:
                 //TODO https://github.com/dotCMS/core/issues/9146
-                final Identifier identifier                      = APILocator.getIdentifierAPI().find(contentletToDelete.getIdentifier());
-                final List<Contentlet> allVersionsList           = this.findAllVersions(identifier, user,false);
-                final List <Contentlet> contentletsLanguageList  = allVersionsList.stream().
-                        filter(contentlet -> contentlet.getLanguageId() == contentletToDelete.getLanguageId())
+                final Identifier identifier = APILocator.getIdentifierAPI()
+                        .find(contentletToDelete.getIdentifier());
+                final List<Contentlet> allVersionsList = this.findAllVersions(identifier, user,
+                        false);
+                final List<Contentlet> contentletsLanguageList = allVersionsList.stream().
+                        filter(contentlet -> contentlet.getLanguageId()
+                                == contentletToDelete.getLanguageId())
                         .collect(Collectors.toList());
-                contentletsLanguageList.forEach(contentletLanguage -> contentletLanguage.setIndexPolicy(contentletToDelete.getIndexPolicy()));
+                contentletsLanguageList.forEach(
+                        contentletLanguage -> contentletLanguage.setIndexPolicy(
+                                contentletToDelete.getIndexPolicy()));
                 this.contentFactory.delete(contentletsLanguageList, false);
 
                 for (final Contentlet contentlet : contentlets) {
 
                     try {
 
-                        PublisherAPI.getInstance().deleteElementFromPublishQueueTable(contentlet.getIdentifier(),
-                                contentlet.getLanguageId());
+                        PublisherAPI.getInstance()
+                                .deleteElementFromPublishQueueTable(contentlet.getIdentifier(),
+                                        contentlet.getLanguageId());
                     } catch (DotPublisherException e) {
 
-                        Logger.error(getClass(), "Error deleting Contentlet from Publishing Queue with Identifier: " + contentlet.getIdentifier());
-                        Logger.debug(getClass(), "Error deleting Contentlet from Publishing Queue with Identifier: " + contentlet.getIdentifier(), e);
+                        Logger.error(getClass(),
+                                "Error deleting Contentlet from Publishing Queue with Identifier: "
+                                        + contentlet.getIdentifier());
+                        Logger.debug(getClass(),
+                                "Error deleting Contentlet from Publishing Queue with Identifier: "
+                                        + contentlet.getIdentifier(), e);
                     }
                 }
             }
@@ -2789,19 +3058,22 @@ public class ESContentletAPIImpl implements ContentletAPI {
         this.sendDeleteEvent(contentletToDelete);
     }
 
-    private List<Contentlet> validateAndFilterContentletsToDelete(final List<Contentlet> contentlets,
-            final User user, final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+    private List<Contentlet> validateAndFilterContentletsToDelete(
+            final List<Contentlet> contentlets,
+            final User user, final boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException {
 
         for (final Contentlet contentlet : contentlets) {
 
-            if(!contentlet.isArchived() && contentlet.validateMe()) {
+            if (!contentlet.isArchived() && contentlet.validateMe()) {
 
                 throw new DotContentletStateException(
-                        getLocalizedMessageOrDefault(user, "Failed-to-delete-unarchived-content", FAILED_TO_DELETE_UNARCHIVED_CONTENT, getClass())
+                        getLocalizedMessageOrDefault(user, "Failed-to-delete-unarchived-content",
+                                FAILED_TO_DELETE_UNARCHIVED_CONTENT, getClass())
                 );
             }
 
-            if(contentlet.getInode().equals("")) {
+            if (contentlet.getInode().equals("")) {
 
                 logContentletActivity(contentlet, "Error Deleting Content", user);
                 throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
@@ -2814,25 +3086,28 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 PermissionAPI.PERMISSION_PUBLISH, respectFrontendRoles, user);
     }
 
-    private void sendDeleteEvent (final Contentlet contentlet) throws DotHibernateException {
-        HibernateUtil.addCommitListener(() -> this.contentletSystemEventUtil.pushDeleteEvent(contentlet), 1000);
+    private void sendDeleteEvent(final Contentlet contentlet) throws DotHibernateException {
+        HibernateUtil.addCommitListener(
+                () -> this.contentletSystemEventUtil.pushDeleteEvent(contentlet), 1000);
     }
 
     /**
      * Verifies if a page is being used as a detail page for any content type
+     *
      * @param user
      * @param c
      * @throws DotDataException
      * @throws LanguageException
      */
     private void unlinkRelatedContentType(User user, Contentlet c)
-            throws DotDataException{
+            throws DotDataException {
         ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(user);
-        List<ContentType> relatedContentTypes = contentTypeAPI.search("page_detail='" + c.getIdentifier() + "'");
+        List<ContentType> relatedContentTypes = contentTypeAPI.search(
+                "page_detail='" + c.getIdentifier() + "'");
         HTMLPageAssetAPI htmlPageAssetAPI = APILocator.getHTMLPageAssetAPI();
         String uri = htmlPageAssetAPI.fromContentlet(c).getURI();
         //Verifies if the page is related to any content type
-        if (UtilMethods.isSet(relatedContentTypes)){
+        if (UtilMethods.isSet(relatedContentTypes)) {
 
             //Unlinking url map and detail page
             relatedContentTypes.forEach((ContentType contentType) -> {
@@ -2852,10 +3127,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             relatedPagesMessage.append(relatedContentTypes.stream()
-                    .map((ContentType t)  -> t.name() + " - Detail Page: " + uri)
+                    .map((ContentType t) -> t.name() + " - Detail Page: " + uri)
                     .collect(Collectors.joining("<br/>")));
-
-
 
             Logger.warn(this, relatedPagesMessage.toString());
         }
@@ -2863,35 +3136,42 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public void deleteAllVersionsandBackup(List<Contentlet> contentlets, User user, boolean respectFrontendRoles) throws DotDataException,DotSecurityException {
-        if(contentlets == null || contentlets.size() == 0){
+    public void deleteAllVersionsandBackup(List<Contentlet> contentlets, User user,
+            boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+        if (contentlets == null || contentlets.size() == 0) {
             Logger.info(this, "No contents passed to delete so returning");
             return;
         }
-        for (Contentlet con : contentlets)
-            if(con.getInode().equals(""))
+        for (Contentlet con : contentlets) {
+            if (con.getInode().equals("")) {
                 throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
-        List<Contentlet> perCons = permissionAPI.filterCollection(contentlets, PermissionAPI.PERMISSION_PUBLISH, respectFrontendRoles, user);
+            }
+        }
+        List<Contentlet> perCons = permissionAPI.filterCollection(contentlets,
+                PermissionAPI.PERMISSION_PUBLISH, respectFrontendRoles, user);
         List<Contentlet> contentletsVersion = new ArrayList<Contentlet>();
         contentletsVersion.addAll(contentlets);
 
-        if(perCons.size() != contentlets.size()){
-            throw new DotSecurityException("User: "+ (user != null ? user.getUserId() : "Unknown")
-                    +" does not have permission to delete some or all of the contentlets");
+        if (perCons.size() != contentlets.size()) {
+            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
+                    + " does not have permission to delete some or all of the contentlets");
         }
         for (Contentlet con : contentlets) {
             categoryAPI.removeChildren(con, APILocator.getUserAPI().getSystemUser(), true);
             categoryAPI.removeParents(con, APILocator.getUserAPI().getSystemUser(), true);
-            List<Relationship> rels = APILocator.getRelationshipAPI().byContentType(con.getStructure());
-            for(Relationship relationship :  rels){
-                deleteRelatedContent(con,relationship,user,respectFrontendRoles);
+            List<Relationship> rels = APILocator.getRelationshipAPI()
+                    .byContentType(con.getStructure());
+            for (Relationship relationship : rels) {
+                deleteRelatedContent(con, relationship, user, respectFrontendRoles);
             }
 
-            contentletsVersion.addAll(findAllVersions(APILocator.getIdentifierAPI().find(con.getIdentifier()), user, respectFrontendRoles));
+            contentletsVersion.addAll(
+                    findAllVersions(APILocator.getIdentifierAPI().find(con.getIdentifier()), user,
+                            respectFrontendRoles));
         }
 
         List<String> contentletInodes = new ArrayList<String>();
-        for (Iterator<Contentlet> iter = contentletsVersion.iterator(); iter.hasNext();) {
+        for (Iterator<Contentlet> iter = contentletsVersion.iterator(); iter.hasNext(); ) {
             Contentlet element = iter.next();
             contentletInodes.add(element.getInode());
         }
@@ -2914,14 +3194,16 @@ public class ESContentletAPIImpl implements ContentletAPI {
             if (!backupFolder.exists()) {
                 backupFolder.mkdirs();
             }
-            _writing = new File(backupPath + File.separator + lastmoddate + "_" + "deletedcontentlets" + ".xml");
+            _writing = new File(
+                    backupPath + File.separator + lastmoddate + "_" + "deletedcontentlets"
+                            + ".xml");
 
             BufferedOutputStream _bout = null;
             try {
                 _bout = new BufferedOutputStream(Files.newOutputStream(_writing.toPath()));
             } catch (IOException e) {
                 Logger.error(this, e.getMessage());
-            } finally{
+            } finally {
                 try {
                     _bout.close();
                 } catch (IOException e) {
@@ -2930,41 +3212,45 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
             _xstream.toXML(contentlets, _bout);
         }
-        deleteBinaryFiles(contentletsVersion,null);
+        deleteBinaryFiles(contentletsVersion, null);
 
     }
 
     @WrapInTransaction
     @Override
-    public void delete(List<Contentlet> contentlets, User user, boolean respectFrontendRoles, boolean allVersions) throws DotDataException,DotSecurityException {
-        for (Contentlet con : contentlets){
-            if(con.getInode().equals("")) {
+    public void delete(List<Contentlet> contentlets, User user, boolean respectFrontendRoles,
+            boolean allVersions) throws DotDataException, DotSecurityException {
+        for (Contentlet con : contentlets) {
+            if (con.getInode().equals("")) {
                 throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
             }
-            if(!canLock(con, user)){
-                throw new DotContentletStateException("Content Object is locked and cannot be deleted:" + con.getIdentifier());
+            if (!canLock(con, user)) {
+                throw new DotContentletStateException(
+                        "Content Object is locked and cannot be deleted:" + con.getIdentifier());
             }
         }
-        List<Contentlet> perCons = permissionAPI.filterCollection(contentlets, PermissionAPI.PERMISSION_PUBLISH, respectFrontendRoles, user);
+        List<Contentlet> perCons = permissionAPI.filterCollection(contentlets,
+                PermissionAPI.PERMISSION_PUBLISH, respectFrontendRoles, user);
         List<Contentlet> contentletsVersion = new ArrayList<Contentlet>();
         contentletsVersion.addAll(contentlets);
 
-        if(perCons.size() != contentlets.size()){
-            throw new DotSecurityException("User: "+ (user != null ? user.getUserId() : "Unknown")
+        if (perCons.size() != contentlets.size()) {
+            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
                     + " does not have permission to delete some or all of the contentlets");
         }
         for (Contentlet con : contentlets) {
             categoryAPI.removeChildren(con, APILocator.getUserAPI().getSystemUser(), true);
             categoryAPI.removeParents(con, APILocator.getUserAPI().getSystemUser(), true);
-            List<Relationship> rels = APILocator.getRelationshipAPI().byContentType(con.getStructure());
-            for(Relationship relationship :  rels){
-                deleteRelatedContent(con,relationship,user,respectFrontendRoles);
+            List<Relationship> rels = APILocator.getRelationshipAPI()
+                    .byContentType(con.getStructure());
+            for (Relationship relationship : rels) {
+                deleteRelatedContent(con, relationship, user, respectFrontendRoles);
             }
 
         }
 
         List<String> contentletInodes = new ArrayList<String>();
-        for (Iterator<Contentlet> iter = contentletsVersion.iterator(); iter.hasNext();) {
+        for (Iterator<Contentlet> iter = contentletsVersion.iterator(); iter.hasNext(); ) {
             Contentlet element = iter.next();
             contentletInodes.add(element.getInode());
         }
@@ -2976,21 +3262,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
             CacheLocator.getIdentifierCache().removeFromCacheByVersionable(contentlet);
         }
 
-        deleteBinaryFiles(contentletsVersion,null);
+        deleteBinaryFiles(contentletsVersion, null);
 
     }
 
     @WrapInTransaction
     @Override
-    public void deleteVersion(Contentlet contentlet, User user,boolean respectFrontendRoles) throws DotDataException,DotSecurityException {
-        if(contentlet == null){
+    public void deleteVersion(Contentlet contentlet, User user, boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException {
+        if (contentlet == null) {
             Logger.info(this, "No contents passed to delete so returning");
             return;
         }
-        if(contentlet.getInode().equals(""))
+        if (contentlet.getInode().equals("")) {
             throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
-        if(!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_PUBLISH, user)){
-            throw new DotSecurityException("User: "+ (user != null ? user.getUserId() : "Unknown")
+        }
+        if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_PUBLISH,
+                user)) {
+            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
                     + " does not have permission to delete some or all of the contentlets");
         }
 
@@ -2998,10 +3287,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
         contentlets.add(contentlet);
         contentFactory.deleteVersion(contentlet);
 
-        Optional<ContentletVersionInfo> cinfo=APILocator.getVersionableAPI().getContentletVersionInfo(
-                contentlet.getIdentifier(), contentlet.getLanguageId());
+        Optional<ContentletVersionInfo> cinfo = APILocator.getVersionableAPI()
+                .getContentletVersionInfo(
+                        contentlet.getIdentifier(), contentlet.getLanguageId());
 
-        if(cinfo.isPresent() && (cinfo.get().getWorkingInode().equals(contentlet.getInode()) ||
+        if (cinfo.isPresent() && (cinfo.get().getWorkingInode().equals(contentlet.getInode()) ||
                 (InodeUtils.isSet(cinfo.get().getLiveInode())
                         && cinfo.get().getLiveInode().equals(contentlet.getInode())))) {
             // we remove from index if it is the working or live version
@@ -3010,7 +3300,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         CacheLocator.getIdentifierCache().removeFromCacheByVersionable(contentlet);
 
-        deleteBinaryFiles(contentlets,null);
+        deleteBinaryFiles(contentlets, null);
 
         fileMetadataAPI.removeVersionMetadata(contentlet);
 
@@ -3018,7 +3308,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public void archive(final Contentlet contentlet, final User user, final boolean respectFrontendRoles)
+    public void archive(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException, DotContentletStateException {
 
         archive(contentlet, user, respectFrontendRoles, false);
@@ -3026,6 +3317,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * check if a workflow may be run instead of the archive api call itself.
+     *
      * @param contentletIn
      * @param user
      * @param respectFrontendRoles
@@ -3033,7 +3325,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotSecurityException
      * @throws DotDataException
      */
-    private Optional<Contentlet> checkAndRunArchiveAsWorkflow(final Contentlet contentletIn, final User user,
+    private Optional<Contentlet> checkAndRunArchiveAsWorkflow(final Contentlet contentletIn,
+            final User user,
             final boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
 
         // if already on workflow or has an actionid skip this method.
@@ -3052,7 +3345,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         if (workflowActionOpt.isPresent()) {
 
-            final String title    = contentletIn.getTitle();
+            final String title = contentletIn.getTitle();
             final String actionId = workflowActionOpt.get().getId();
 
             // if the default action is in the avalable actions for the content.
@@ -3060,14 +3353,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 return Optional.empty();
             }
 
-            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier() + " hasn't action id set"
+            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier()
+                    + " hasn't action id set"
                     + " using the default action: " + actionId);
 
             // if the action has a save action, we skip the current checkin
             if (workflowActionOpt.get().hasArchiveActionlet()) {
 
-                Logger.info(this, () -> "The action: " + actionId + " has an archive contentlet actionlet"
-                        + " so firing a workflow and skipping the current archive for the contentlet: " + contentletIn.getIdentifier());
+                Logger.info(this,
+                        () -> "The action: " + actionId + " has an archive contentlet actionlet"
+                                + " so firing a workflow and skipping the current archive for the contentlet: "
+                                + contentletIn.getIdentifier());
 
                 return Optional.ofNullable(workflowAPI.fireContentWorkflow(contentletIn,
                         new ContentletDependencies.Builder().workflowActionId(actionId)
@@ -3077,7 +3373,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 ));
             }
 
-            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier() + " hasn't a archive contentlet actionlet"
+            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier()
+                    + " hasn't a archive contentlet actionlet"
                     + " so including just the action to the contentlet: " + title);
 
             contentletIn.setActionId(actionId);
@@ -3086,19 +3383,21 @@ public class ESContentletAPIImpl implements ContentletAPI {
         return Optional.empty();
     }
 
-    private void archive(final Contentlet contentlet, final User user, final boolean respectFrontendRoles, final boolean isDestroy)
-            throws DotDataException,DotSecurityException, DotContentletStateException {
+    private void archive(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles, final boolean isDestroy)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
 
         this.logContentletActivity(contentlet, "Archiving Content", user);
 
         try {
 
-            if(contentlet.getInode().equals(StringPool.BLANK)) {
+            if (contentlet.getInode().equals(StringPool.BLANK)) {
 
                 throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
             }
 
-            final Optional<Contentlet> contentletOpt = this.checkAndRunArchiveAsWorkflow(contentlet, user, respectFrontendRoles);
+            final Optional<Contentlet> contentletOpt = this.checkAndRunArchiveAsWorkflow(contentlet,
+                    user, respectFrontendRoles);
             if (contentletOpt.isPresent()) {
 
                 Logger.info(this, "A Workflow has been ran instead of archive the contentlet: " +
@@ -3110,10 +3409,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             internalArchive(contentlet, user, respectFrontendRoles, isDestroy);
-        } catch(DotDataException | DotStateException| DotSecurityException e) {
+        } catch (DotDataException | DotStateException | DotSecurityException e) {
 
-            final String errorMsg = "Error archiving content with Identifier [" + contentlet.getIdentifier() + "]: "
-                    + e.getMessage();
+            final String errorMsg =
+                    "Error archiving content with Identifier [" + contentlet.getIdentifier() + "]: "
+                            + e.getMessage();
             Logger.warn(this, errorMsg);
             logContentletActivity(contentlet, errorMsg, user);
             throw e;
@@ -3122,21 +3422,26 @@ public class ESContentletAPIImpl implements ContentletAPI {
         logContentletActivity(contentlet, "Content Archived", user);
     }
 
-    private void internalArchive(final Contentlet contentlet, final User user, final boolean respectFrontendRoles,
+    private void internalArchive(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles,
             final boolean isDestroy) throws DotDataException, DotSecurityException {
 
-        if(!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT, user, respectFrontendRoles)) {
+        if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT, user,
+                respectFrontendRoles)) {
 
-            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown") + " does not " +
-                    "have permission to edit the contentlet with Identifier [" + contentlet.getIdentifier() + "]");
+            throw new DotSecurityException(
+                    "User: " + (user != null ? user.getUserId() : "Unknown") + " does not " +
+                            "have permission to edit the contentlet with Identifier ["
+                            + contentlet.getIdentifier() + "]");
         }
 
-        final IndexPolicy indexPolicy              = contentlet.getIndexPolicy();
-        final IndexPolicy  indexPolicyDependencies = contentlet.getIndexPolicyDependencies();
+        final IndexPolicy indexPolicy = contentlet.getIndexPolicy();
+        final IndexPolicy indexPolicyDependencies = contentlet.getIndexPolicyDependencies();
         final Contentlet workingContentlet = findContentletByIdentifier(contentlet.getIdentifier(),
-                false, contentlet.getLanguageId(), contentlet.getVariantId(), user, respectFrontendRoles);
+                false, contentlet.getLanguageId(), contentlet.getVariantId(), user,
+                respectFrontendRoles);
 
-        if(workingContentlet==null) {
+        if (workingContentlet == null) {
             return;
         }
 
@@ -3144,35 +3449,41 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         try {
 
-            liveContentlet = findContentletByIdentifier(contentlet.getIdentifier(), true, contentlet.getLanguageId(), user, respectFrontendRoles);
+            liveContentlet = findContentletByIdentifier(contentlet.getIdentifier(), true,
+                    contentlet.getLanguageId(), user, respectFrontendRoles);
         } catch (DotContentletStateException ce) {
 
-            Logger.debug(this,"No live contentlet found for identifier = " + contentlet.getIdentifier());
+            Logger.debug(this,
+                    "No live contentlet found for identifier = " + contentlet.getIdentifier());
         }
 
         this.canLock(contentlet, user);
         final User modUser = getModUser(workingContentlet);
 
-        if(modUser != null) {
+        if (modUser != null) {
 
             workingContentlet.setModUser(modUser.getUserId());
         }
 
         // If the user calling this method is System, no other condition is required.
         // Note: no need to validate this on DELETE SITE/HOST.
-        if (contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME) != null || this.canLock(contentlet, user)) {
+        if (contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME) != null || this.canLock(contentlet,
+                user)) {
 
             this.internalArchive(contentlet, user, respectFrontendRoles, isDestroy, indexPolicy,
                     indexPolicyDependencies, workingContentlet, liveContentlet);
         } else {
 
-            throw new DotContentletStateException("Contentlet with Identifier '" + contentlet.getIdentifier() +
-                    "' must be unlocked before being archived");
+            throw new DotContentletStateException(
+                    "Contentlet with Identifier '" + contentlet.getIdentifier() +
+                            "' must be unlocked before being archived");
         }
     } // internalArchive.
 
-    private void internalArchive(final Contentlet contentlet, final User user, final boolean respectFrontendRoles,
-            final boolean isDestroy, final IndexPolicy indexPolicy, final IndexPolicy indexPolicyDependencies,
+    private void internalArchive(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles,
+            final boolean isDestroy, final IndexPolicy indexPolicy,
+            final IndexPolicy indexPolicyDependencies,
             final Contentlet workingContentlet, final Contentlet liveContentlet)
             throws DotDataException, DotSecurityException {
 
@@ -3208,24 +3519,28 @@ public class ESContentletAPIImpl implements ContentletAPI {
             CacheLocator.getHTMLPageCache().remove(contentlet.getInode());
         }
 
-        HibernateUtil.addCommitListener(() -> this.contentletSystemEventUtil.pushArchiveEvent(workingContentlet), 1000);
-        HibernateUtil.addCommitListener(() -> localSystemEventsAPI.notify(new ContentletArchiveEvent(contentlet, user, true)));
+        HibernateUtil.addCommitListener(
+                () -> this.contentletSystemEventUtil.pushArchiveEvent(workingContentlet), 1000);
+        HibernateUtil.addCommitListener(() -> localSystemEventsAPI.notify(
+                new ContentletArchiveEvent(contentlet, user, true)));
     } // internalArchive.
 
-    private void archiveFileAsset(final Contentlet contentlet, final User user, final boolean respectFrontendRoles)
+    private void archiveFileAsset(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException {
 
-        if(contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_FILEASSET) {
+        if (contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_FILEASSET) {
 
             final Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
             CacheLocator.getCSSCache().remove(identifier.getHostId(), identifier.getPath(), true);
             CacheLocator.getCSSCache().remove(identifier.getHostId(), identifier.getPath(), false);
             //remove from navtoolcache
             final IFileAsset fileAsset = APILocator.getFileAssetAPI().fromContentlet(contentlet);
-            if(fileAsset.isShowOnMenu()) {
+            if (fileAsset.isShowOnMenu()) {
 
-                final Folder folder = APILocator.getFolderAPI().findFolderByPath(identifier.getParentPath(),
-                        identifier.getHostId() , user, respectFrontendRoles);
+                final Folder folder = APILocator.getFolderAPI()
+                        .findFolderByPath(identifier.getParentPath(),
+                                identifier.getHostId(), user, respectFrontendRoles);
                 RefreshMenus.deleteMenu(folder);
                 CacheLocator.getNavToolCache().removeNav(identifier.getHostId(), folder.getInode());
             }
@@ -3238,13 +3553,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         try {
 
-            modUser    = APILocator.getUserAPI().loadUserById(workingContentlet.getModUser(),
-                    APILocator.systemUser(),false);
-        } catch(Exception ex) {
+            modUser = APILocator.getUserAPI().loadUserById(workingContentlet.getModUser(),
+                    APILocator.systemUser(), false);
+        } catch (Exception ex) {
 
-            if(ex instanceof NoSuchUserException) {
+            if (ex instanceof NoSuchUserException) {
 
-                modUser =  APILocator.systemUser();
+                modUser = APILocator.systemUser();
             }
         }
         return modUser;
@@ -3252,23 +3567,25 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     // todo: everything should be in a transaction>????
     @Override
-    public void archive(final List<Contentlet> contentlets, final User user, final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+    public void archive(final List<Contentlet> contentlets, final User user,
+            final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
 
         boolean stateError = false;
         for (final Contentlet contentlet : contentlets) {
             try {
 
                 this.archive(contentlet, user, respectFrontendRoles);
-            }catch (DotContentletStateException e) {
+            } catch (DotContentletStateException e) {
 
                 Logger.error(this, e.getMessage(), e);
                 stateError = true;
             }
         }
 
-        if(stateError) {
+        if (stateError) {
 
-            throw new DotContentletStateException("Unable to archive contentlets because one or more are locked");
+            throw new DotContentletStateException(
+                    "Unable to archive contentlets because one or more are locked");
         }
 
     }
@@ -3277,23 +3594,29 @@ public class ESContentletAPIImpl implements ContentletAPI {
     // the Transaction will place only on the setLocked, the rest of the method is ok to be just closeable.
     @CloseDBIfOpened
     @Override
-    public void lock(final Contentlet contentlet, final User user,  boolean respectFrontendRoles) throws DotContentletStateException, DotDataException, DotSecurityException {
+    public void lock(final Contentlet contentlet, final User user, boolean respectFrontendRoles)
+            throws DotContentletStateException, DotDataException, DotSecurityException {
 
-        if(contentlet == null) {
+        if (contentlet == null) {
 
             throw new DotContentletStateException("The contentlet cannot Be null");
         }
 
-        final String contentPushPublishDate = UtilMethods.get(contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE), ND_SUPPLIER);
-        final String contentPushExpireDate  = UtilMethods.get(contentlet.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE),  ND_SUPPLIER);
+        final String contentPushPublishDate = UtilMethods.get(
+                contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE), ND_SUPPLIER);
+        final String contentPushExpireDate = UtilMethods.get(
+                contentlet.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE), ND_SUPPLIER);
 
-        ActivityLogger.logInfo(getClass(), "Locking Content", "StartDate: " +contentPushPublishDate+ "; "
-                + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+        ActivityLogger.logInfo(getClass(), "Locking Content",
+                "StartDate: " + contentPushPublishDate + "; "
+                        + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                        ? user.getUserId() : "Unknown")
+                        + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier()
+                        : "Unknown"), contentlet.getHost());
 
         try {
 
-            if(StringPool.BLANK.equals(contentlet.getInode())) {
+            if (StringPool.BLANK.equals(contentlet.getInode())) {
 
                 throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
             }
@@ -3302,38 +3625,45 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             // persists the webasset
             APILocator.getVersionableAPI().setLocked(contentlet, true, user);
-            ThreadContextUtil.ifReindex(()-> indexAPI.addContentToIndex(contentlet, false));
-        } catch(DotDataException | DotStateException| DotSecurityException e) {
-            ActivityLogger.logInfo(getClass(), "Error Locking Content", "StartDate: " +contentPushPublishDate+ "; "
-                    + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                    + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+            ThreadContextUtil.ifReindex(() -> indexAPI.addContentToIndex(contentlet, false));
+        } catch (DotDataException | DotStateException | DotSecurityException e) {
+            ActivityLogger.logInfo(getClass(), "Error Locking Content",
+                    "StartDate: " + contentPushPublishDate + "; "
+                            + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                            ? user.getUserId() : "Unknown")
+                            + "; ContentIdentifier: " + (contentlet != null
+                            ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
             throw e;
         }
 
-        ActivityLogger.logInfo(getClass(), "Content Locked", "StartDate: " +contentPushPublishDate+ "; "
-                + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+        ActivityLogger.logInfo(getClass(), "Content Locked",
+                "StartDate: " + contentPushPublishDate + "; "
+                        + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                        ? user.getUserId() : "Unknown")
+                        + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier()
+                        : "Unknown"), contentlet.getHost());
     }
 
     @Override
-    public void reindex()throws DotReindexStateException {
+    public void reindex() throws DotReindexStateException {
         refreshAllContent();
     }
 
     @WrapInTransaction
     @Override
-    public void reindex(Structure structure)throws DotReindexStateException {
+    public void reindex(Structure structure) throws DotReindexStateException {
         try {
-            final ContentTypeTransformer contentTypeTransformer = new StructureTransformer(structure);
+            final ContentTypeTransformer contentTypeTransformer = new StructureTransformer(
+                    structure);
             reindexQueueAPI.addStructureReindexEntries(contentTypeTransformer.from());
         } catch (DotDataException e) {
             Logger.error(this, e.getMessage(), e);
-            throw new DotReindexStateException("Unable to complete reindex: " + e.getMessage(),e);
+            throw new DotReindexStateException("Unable to complete reindex: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public void reindex(Contentlet contentlet)throws DotReindexStateException, DotDataException{
+    public void reindex(Contentlet contentlet) throws DotReindexStateException, DotDataException {
         indexAPI.addContentToIndex(contentlet);
     }
 
@@ -3341,12 +3671,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
     @Override
     public void refresh(Structure structure) throws DotReindexStateException {
         try {
-            final ContentTypeTransformer contentTypeTransformer = new StructureTransformer(structure);
+            final ContentTypeTransformer contentTypeTransformer = new StructureTransformer(
+                    structure);
             reindexQueueAPI.addStructureReindexEntries(contentTypeTransformer.from());
             //CacheLocator.getContentletCache().clearCache();
         } catch (DotDataException e) {
             Logger.error(this, e.getMessage(), e);
-            throw new DotReindexStateException("Unable to complete reindex: " + e.getMessage(),e);
+            throw new DotReindexStateException("Unable to complete reindex: " + e.getMessage(), e);
         }
 
     }
@@ -3359,12 +3690,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
             //CacheLocator.getContentletCache().clearCache();
         } catch (DotDataException e) {
             Logger.error(this, e.getMessage(), e);
-            throw new DotReindexStateException("Unable to complete reindex: " + e.getMessage(),e);
+            throw new DotReindexStateException("Unable to complete reindex: " + e.getMessage(), e);
         }
 
     }
+
     /**
-     *
      * @param contentlet
      * @throws DotReindexStateException
      * @throws DotDataException
@@ -3374,6 +3705,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         indexAPI.addContentToIndex(contentlet, false);
 
     }
+
     @CloseDBIfOpened
     @Override
     public void refresh(Contentlet contentlet) throws DotReindexStateException,
@@ -3386,7 +3718,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
     @Override
     public void refreshAllContent() throws DotReindexStateException {
         try {
-            if(indexAPI.isInFullReindex()){
+            if (indexAPI.isInFullReindex()) {
                 return;
             }
             // we prepare the new index and aliases to point both old and new
@@ -3399,7 +3731,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             reindexQueueAPI.addAllToReindexQueue();
 
         } catch (Exception e) {
-            throw new DotReindexStateException(e.getMessage(),e);
+            throw new DotReindexStateException(e.getMessage(), e);
         }
 
     }
@@ -3411,7 +3743,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             reindexQueueAPI.refreshContentUnderHost(host);
         } catch (DotDataException e) {
             Logger.error(this, e.getMessage(), e);
-            throw new DotReindexStateException("Unable to complete reindex: " + e.getMessage(),e);
+            throw new DotReindexStateException("Unable to complete reindex: " + e.getMessage(), e);
         }
 
     }
@@ -3423,41 +3755,47 @@ public class ESContentletAPIImpl implements ContentletAPI {
             reindexQueueAPI.refreshContentUnderFolder(folder);
         } catch (DotDataException e) {
             Logger.error(this, e.getMessage(), e);
-            throw new DotReindexStateException("Unable to complete reindex " + e.getMessage(),e);
+            throw new DotReindexStateException("Unable to complete reindex " + e.getMessage(), e);
         }
 
     }
 
     @WrapInTransaction
     @Override
-    public void refreshContentUnderFolderPath ( String hostId, String folderPath ) throws DotReindexStateException {
+    public void refreshContentUnderFolderPath(String hostId, String folderPath)
+            throws DotReindexStateException {
         try {
             reindexQueueAPI.refreshContentUnderFolderPath(hostId, folderPath);
-        } catch ( DotDataException e ) {
+        } catch (DotDataException e) {
             Logger.error(this, e.getMessage(), e);
-            throw new DotReindexStateException("Unable to complete reindex " + e.getMessage(),e);
+            throw new DotReindexStateException("Unable to complete reindex " + e.getMessage(), e);
         }
     }
 
     @WrapInTransaction
     @Override
-    public void unpublish(final Contentlet contentlet, final User user, final boolean respectFrontendRoles) throws DotDataException,DotSecurityException, DotContentletStateException {
+    public void unpublish(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
 
-        if(StringPool.BLANK.equals(contentlet.getInode())) {
+        if (StringPool.BLANK.equals(contentlet.getInode())) {
 
             throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
         }
 
-        if(!this.permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_PUBLISH, user, respectFrontendRoles)) {
+        if (!this.permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_PUBLISH,
+                user, respectFrontendRoles)) {
 
-            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown") + " cannot unpublish Contentlet");
+            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
+                    + " cannot unpublish Contentlet");
         }
 
-        unpublish(contentlet, user, respectFrontendRoles, ThreadContextUtil.isReindex()?-1:0);
+        unpublish(contentlet, user, respectFrontendRoles, ThreadContextUtil.isReindex() ? -1 : 0);
     }
 
     /**
      * check if a workflow may be run instead of the unpublish api call itself.
+     *
      * @param contentletIn
      * @param user
      * @param respectFrontendRoles
@@ -3465,7 +3803,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotSecurityException
      * @throws DotDataException
      */
-    private Optional<Contentlet> checkAndRunUnpublishAsWorkflow(final Contentlet contentletIn, final User user,
+    private Optional<Contentlet> checkAndRunUnpublishAsWorkflow(final Contentlet contentletIn,
+            final User user,
             final boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
 
         // if already on workflow or has an actionid skip this method.
@@ -3484,7 +3823,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         if (workflowActionOpt.isPresent()) {
 
-            final String title    = contentletIn.getTitle();
+            final String title = contentletIn.getTitle();
             final String actionId = workflowActionOpt.get().getId();
 
             // if the default action is in the avalable actions for the content.
@@ -3492,14 +3831,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 return Optional.empty();
             }
 
-            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier() + " hasn't action id set"
+            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier()
+                    + " hasn't action id set"
                     + " using the default action: " + actionId);
 
             // if the action has a save action, we skip the current checkin
             if (workflowActionOpt.get().hasUnpublishActionlet()) {
 
-                Logger.info(this, () -> "The action: " + actionId + " has an unpublish contentlet actionlet"
-                        + " so firing a workflow and skipping the current publish for the contentlet: " + contentletIn.getIdentifier());
+                Logger.info(this,
+                        () -> "The action: " + actionId + " has an unpublish contentlet actionlet"
+                                + " so firing a workflow and skipping the current publish for the contentlet: "
+                                + contentletIn.getIdentifier());
 
                 return Optional.ofNullable(workflowAPI.fireContentWorkflow(contentletIn,
                         new ContentletDependencies.Builder().workflowActionId(actionId)
@@ -3509,7 +3851,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 ));
             }
 
-            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier() + " hasn't a unpublish contentlet actionlet"
+            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier()
+                    + " hasn't a unpublish contentlet actionlet"
                     + " so including just the action to the contentlet: " + title);
 
             contentletIn.setActionId(actionId);
@@ -3518,23 +3861,31 @@ public class ESContentletAPIImpl implements ContentletAPI {
         return Optional.empty();
     }
 
-    private void unpublish(final Contentlet contentlet, final User user, final boolean respectFrontendRoles, final int reindex) throws DotDataException,DotSecurityException, DotContentletStateException {
+    private void unpublish(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles, final int reindex)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
 
-        if(contentlet == null || !UtilMethods.isSet(contentlet.getInode())) {
+        if (contentlet == null || !UtilMethods.isSet(contentlet.getInode())) {
 
             throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
         }
 
-        final String contentPushPublishDate = UtilMethods.get(contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE), ND_SUPPLIER);
-        final String contentPushExpireDate  = UtilMethods.get(contentlet.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE),  ND_SUPPLIER);
+        final String contentPushPublishDate = UtilMethods.get(
+                contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE), ND_SUPPLIER);
+        final String contentPushExpireDate = UtilMethods.get(
+                contentlet.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE), ND_SUPPLIER);
 
-        ActivityLogger.logInfo(getClass(), "Unpublishing Content", "StartDate: " +contentPushPublishDate+ "; "
-                + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+        ActivityLogger.logInfo(getClass(), "Unpublishing Content",
+                "StartDate: " + contentPushPublishDate + "; "
+                        + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                        ? user.getUserId() : "Unknown")
+                        + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier()
+                        : "Unknown"), contentlet.getHost());
 
         try {
 
-            final Optional<Contentlet> contentletOpt = this.checkAndRunUnpublishAsWorkflow(contentlet, user, respectFrontendRoles);
+            final Optional<Contentlet> contentletOpt = this.checkAndRunUnpublishAsWorkflow(
+                    contentlet, user, respectFrontendRoles);
             if (contentletOpt.isPresent()) {
 
                 Logger.info(this, "A Workflow has been ran instead of unpublish the contentlet: " +
@@ -3547,24 +3898,31 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             this.internalUnpublish(contentlet, user, reindex);
 
-            HibernateUtil.addCommitListener(() -> this.contentletSystemEventUtil.pushUnpublishEvent(contentlet), 1000);
+            HibernateUtil.addCommitListener(
+                    () -> this.contentletSystemEventUtil.pushUnpublishEvent(contentlet), 1000);
             /*
             Triggers a local system event when this contentlet commit listener is executed,
             anyone who need it can subscribed to this commit listener event, on this case will be
             mostly use it in order to invalidate this contentlet cache.
              */
             triggerCommitListenerEvent(contentlet, user, false);
-        } catch(DotDataException | DotStateException| DotSecurityException e) {
+        } catch (DotDataException | DotStateException | DotSecurityException e) {
 
-            ActivityLogger.logInfo(getClass(), "Error Unpublishing Content", "StartDate: " +contentPushPublishDate+ "; "
-                    + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                    + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+            ActivityLogger.logInfo(getClass(), "Error Unpublishing Content",
+                    "StartDate: " + contentPushPublishDate + "; "
+                            + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                            ? user.getUserId() : "Unknown")
+                            + "; ContentIdentifier: " + (contentlet != null
+                            ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
             throw e;
         }
 
-        ActivityLogger.logInfo(getClass(), "Content Unpublished", "StartDate: " +contentPushPublishDate+ "; "
-                + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+        ActivityLogger.logInfo(getClass(), "Content Unpublished",
+                "StartDate: " + contentPushPublishDate + "; "
+                        + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                        ? user.getUserId() : "Unknown")
+                        + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier()
+                        : "Unknown"), contentlet.getHost());
     }
 
     private void internalUnpublish(final Contentlet contentlet, final User user, final int reindex)
@@ -3572,11 +3930,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         WorkflowProcessor workflow = null;
         // to run a workflow we need an action id set, not be part of a workflow already and do not desired disable it
-        if(contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW)==null &&
+        if (contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW) == null &&
                 UtilMethods.isSet(contentlet.getActionId()) &&
                 (null == contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS) ||
-                        Boolean.FALSE.equals(contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS))
-                ))  {
+                        Boolean.FALSE.equals(
+                                contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS))
+                )) {
             workflow = APILocator.getWorkflowAPI().fireWorkflowPreCheckin(contentlet, user);
         }
 
@@ -3585,12 +3944,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
         APILocator.getVersionableAPI().removeLive(contentlet);
 
         //"Disable" the tag created for this Persona key tag
-        if ( Structure.STRUCTURE_TYPE_PERSONA == contentlet.getStructure().getStructureType() ) {
+        if (Structure.STRUCTURE_TYPE_PERSONA == contentlet.getStructure().getStructureType()) {
             //Mark the tag created based in the Persona tag key as a regular tag
             APILocator.getPersonaAPI().enableDisablePersonaTag(contentlet, false);
         }
 
-        if(null != workflow) {
+        if (null != workflow) {
 
             workflow.setContentlet(contentlet);
             APILocator.getWorkflowAPI().fireWorkflowPostCheckin(workflow);
@@ -3603,7 +3962,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         this.indexAPI.removeContentFromLiveIndex(contentlet);
 
-        if(contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_FILEASSET) {
+        if (contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_FILEASSET) {
 
             this.cleanFileAssetCache(contentlet, user, false);
         }
@@ -3613,11 +3972,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
         final Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
         CacheLocator.getCSSCache().remove(identifier.getHostId(), identifier.getPath(), true);
         CacheLocator.getCSSCache().remove(identifier.getHostId(), identifier.getPath(), false);
-        if(contentlet.isVanityUrl()) {
+        if (contentlet.isVanityUrl()) {
             APILocator.getVanityUrlAPI().invalidateVanityUrl(contentlet);
         }
         publishRelatedHtmlPages(contentlet);
-        if(contentlet.isHTMLPage()){
+        if (contentlet.isHTMLPage()) {
             CacheLocator.getNavToolCache().removeNav(
                     contentlet.getHost(), contentlet.getFolder(),
                     contentlet.getLanguageId());
@@ -3625,14 +3984,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     private void cleanFileAssetCache(final Contentlet contentlet, final User user,
-            final boolean respectFrontEndPermissions) throws DotDataException, DotSecurityException {
+            final boolean respectFrontEndPermissions)
+            throws DotDataException, DotSecurityException {
 
         final Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
         CacheLocator.getCSSCache().remove(identifier.getHostId(), identifier.getPath(), true);
         //remove from navCache
         final IFileAsset fileAsset = APILocator.getFileAssetAPI().fromContentlet(contentlet);
         if (fileAsset.isShowOnMenu()) {
-            final Folder folder = APILocator.getFolderAPI().findFolderByPath(identifier.getParentPath(), identifier.getHostId(), user, respectFrontEndPermissions);
+            final Folder folder = APILocator.getFolderAPI()
+                    .findFolderByPath(identifier.getParentPath(), identifier.getHostId(), user,
+                            respectFrontEndPermissions);
             RefreshMenus.deleteMenu(folder);
             CacheLocator.getNavToolCache().removeNav(identifier.getHostId(), folder.getInode());
         }
@@ -3640,7 +4002,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     // todo:should be in a transaction?
     @Override
-    public void unpublish(final List<Contentlet> contentlets, final User user, final boolean respectFrontendRoles)
+    public void unpublish(final List<Contentlet> contentlets, final User user,
+            final boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException, DotContentletStateException {
 
         boolean stateError = false;
@@ -3657,23 +4020,27 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
         }
 
-        if(stateError){
+        if (stateError) {
 
             Logger.error(this, "Unable to unpublish one or more contentlets because it is locked");
-            throw new DotContentletStateException("Unable to unpublish one or more contentlets because it is locked");
+            throw new DotContentletStateException(
+                    "Unable to unpublish one or more contentlets because it is locked");
         }
     }
 
     /**
      * check if a workflow may be run instead of the unarchive api call itself.
+     *
      * @param contentletIn
      * @param user
      * @param respectFrontendRoles
-     * @return Optional Contentlet, if present means the workflow ran, returns the contentlet unarchived
+     * @return Optional Contentlet, if present means the workflow ran, returns the contentlet
+     * unarchived
      * @throws DotSecurityException
      * @throws DotDataException
      */
-    private Optional<Contentlet> checkAndRunUnarchiveAsWorkflow(final Contentlet contentletIn, final User user,
+    private Optional<Contentlet> checkAndRunUnarchiveAsWorkflow(final Contentlet contentletIn,
+            final User user,
             final boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
 
         // if already on workflow or has an actionid skip this method.
@@ -3692,7 +4059,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         if (workflowActionOpt.isPresent()) {
 
-            final String title    = contentletIn.getTitle();
+            final String title = contentletIn.getTitle();
             final String actionId = workflowActionOpt.get().getId();
 
             // if the default action is in the avalable actions for the content.
@@ -3700,14 +4067,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 return Optional.empty();
             }
 
-            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier() + " hasn't action id set"
+            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier()
+                    + " hasn't action id set"
                     + " using the default action: " + actionId);
 
             // if the action has a save action, we skip the current checkin
             if (workflowActionOpt.get().hasUnarchiveActionlet()) {
 
-                Logger.info(this, () -> "The action: " + actionId + " has an unarchive contentlet actionlet"
-                        + " so firing a workflow and skipping the current unarchive for the contentlet: " + contentletIn.getIdentifier());
+                Logger.info(this,
+                        () -> "The action: " + actionId + " has an unarchive contentlet actionlet"
+                                + " so firing a workflow and skipping the current unarchive for the contentlet: "
+                                + contentletIn.getIdentifier());
 
                 return Optional.ofNullable(workflowAPI.fireContentWorkflow(contentletIn,
                         new ContentletDependencies.Builder().workflowActionId(actionId)
@@ -3717,7 +4087,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 ));
             }
 
-            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier() + " hasn't a unarchive contentlet actionlet"
+            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier()
+                    + " hasn't a unarchive contentlet actionlet"
                     + " so including just the action to the contentlet: " + title);
 
             contentletIn.setActionId(actionId);
@@ -3728,29 +4099,39 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public void unarchive(final Contentlet contentlet, final User user, final boolean respectFrontendRoles)
-            throws DotDataException,DotSecurityException, DotContentletStateException {
+    public void unarchive(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
 
-        final String contentPushPublishDate = UtilMethods.get(contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE), ND_SUPPLIER);
-        final String contentPushExpireDate  = UtilMethods.get(contentlet.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE),  ND_SUPPLIER);
+        final String contentPushPublishDate = UtilMethods.get(
+                contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE), ND_SUPPLIER);
+        final String contentPushExpireDate = UtilMethods.get(
+                contentlet.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE), ND_SUPPLIER);
 
-        ActivityLogger.logInfo(getClass(), "Unarchiving Content", "StartDate: " +contentPushPublishDate+ "; "
-                + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+        ActivityLogger.logInfo(getClass(), "Unarchiving Content",
+                "StartDate: " + contentPushPublishDate + "; "
+                        + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                        ? user.getUserId() : "Unknown")
+                        + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier()
+                        : "Unknown"), contentlet.getHost());
 
         try {
 
-            if(StringPool.BLANK.equals(contentlet.getInode())) {
+            if (StringPool.BLANK.equals(contentlet.getInode())) {
 
                 throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
             }
 
-            if(!this.permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_PUBLISH, user, respectFrontendRoles)) {
+            if (!this.permissionAPI.doesUserHavePermission(contentlet,
+                    PermissionAPI.PERMISSION_PUBLISH, user, respectFrontendRoles)) {
 
-                throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown") + " cannot unpublish Contentlet");
+                throw new DotSecurityException(
+                        "User: " + (user != null ? user.getUserId() : "Unknown")
+                                + " cannot unpublish Contentlet");
             }
 
-            final Optional<Contentlet> contentletOpt = this.checkAndRunUnarchiveAsWorkflow(contentlet, user, respectFrontendRoles);
+            final Optional<Contentlet> contentletOpt = this.checkAndRunUnarchiveAsWorkflow(
+                    contentlet, user, respectFrontendRoles);
             if (contentletOpt.isPresent()) {
 
                 Logger.info(this, "A Workflow has been ran instead of unarchive the contentlet: " +
@@ -3762,25 +4143,33 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             this.internalUnarchive(contentlet, user, respectFrontendRoles);
-        } catch(DotDataException | DotStateException| DotSecurityException e) {
+        } catch (DotDataException | DotStateException | DotSecurityException e) {
 
-            ActivityLogger.logInfo(getClass(), "Error Unarchiving Content", "StartDate: " +contentPushPublishDate+ "; "
-                    + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                    + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+            ActivityLogger.logInfo(getClass(), "Error Unarchiving Content",
+                    "StartDate: " + contentPushPublishDate + "; "
+                            + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                            ? user.getUserId() : "Unknown")
+                            + "; ContentIdentifier: " + (contentlet != null
+                            ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
             throw e;
         }
 
-        ActivityLogger.logInfo(getClass(), "Content Unarchived", "StartDate: " +contentPushPublishDate+ "; "
-                + "EndDate: " +contentPushExpireDate + "; User:" + (user != null ? user.getUserId() : "Unknown")
-                + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"), contentlet.getHost());
+        ActivityLogger.logInfo(getClass(), "Content Unarchived",
+                "StartDate: " + contentPushPublishDate + "; "
+                        + "EndDate: " + contentPushExpireDate + "; User:" + (user != null
+                        ? user.getUserId() : "Unknown")
+                        + "; ContentIdentifier: " + (contentlet != null ? contentlet.getIdentifier()
+                        : "Unknown"), contentlet.getHost());
     }
 
-    private void internalUnarchive(final Contentlet contentlet, final User user, final boolean respectFrontendRoles)
+    private void internalUnarchive(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException {
 
-        final Contentlet workingContentlet = this.findContentletByIdentifier(contentlet.getIdentifier(),
+        final Contentlet workingContentlet = this.findContentletByIdentifier(
+                contentlet.getIdentifier(),
                 false, contentlet.getLanguageId(), user, respectFrontendRoles);
-        Contentlet liveContentlet         = null;
+        Contentlet liveContentlet = null;
 
         this.canLock(contentlet, user);
 
@@ -3790,10 +4179,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     contentlet.getLanguageId(), user, respectFrontendRoles);
         } catch (DotContentletStateException ce) {
 
-            Logger.debug(this,()->"No live contentlet found for identifier = " + contentlet.getIdentifier());
+            Logger.debug(this, () -> "No live contentlet found for identifier = "
+                    + contentlet.getIdentifier());
         }
 
-        if(liveContentlet != null && liveContentlet.getInode().equalsIgnoreCase(workingContentlet.getInode())
+        if (liveContentlet != null && liveContentlet.getInode()
+                .equalsIgnoreCase(workingContentlet.getInode())
                 && !workingContentlet.isArchived()) {
 
             throw new DotContentletStateException("Contentlet is unarchivable");
@@ -3804,7 +4195,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         this.indexAPI.addContentToIndex(workingContentlet);
 
         // we don't want to reindex this twice when it is the same version
-        if(liveContentlet!=null && UtilMethods.isSet(liveContentlet.getInode())
+        if (liveContentlet != null && UtilMethods.isSet(liveContentlet.getInode())
                 && !liveContentlet.getInode().equalsIgnoreCase(workingContentlet.getInode())) {
 
             this.indexAPI.addContentToIndex(liveContentlet);
@@ -3814,11 +4205,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
         CacheLocator.getContentletCache().remove(contentlet.getInode());
         publishRelatedHtmlPages(contentlet);
 
-        HibernateUtil.addCommitListener(() -> this.sendUnArchiveContentSystemEvent(contentlet), 1000);
-        HibernateUtil.addCommitListener(() -> localSystemEventsAPI.notify(new ContentletArchiveEvent(contentlet, user, false)));
+        HibernateUtil.addCommitListener(() -> this.sendUnArchiveContentSystemEvent(contentlet),
+                1000);
+        HibernateUtil.addCommitListener(() -> localSystemEventsAPI.notify(
+                new ContentletArchiveEvent(contentlet, user, false)));
     }
 
-    private void sendUnArchiveContentSystemEvent (final Contentlet contentlet) {
+    private void sendUnArchiveContentSystemEvent(final Contentlet contentlet) {
 
         this.contentletSystemEventUtil.pushUnArchiveEvent(contentlet);
     }
@@ -3826,7 +4219,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
     // todo: should be in a transaction.
     @Override
     public void unarchive(final List<Contentlet> contentlets, final User user,
-            final boolean respectFrontendRoles) throws DotDataException,DotSecurityException, DotContentletStateException {
+            final boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
 
         boolean stateError = false;
 
@@ -3842,9 +4236,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
         }
 
-        if(stateError) {
+        if (stateError) {
 
-            throw new DotContentletStateException("Unable to unarchive one or more contentlets because it is locked");
+            throw new DotContentletStateException(
+                    "Unable to unarchive one or more contentlets because it is locked");
         }
     } // unarchive.
 
@@ -3859,14 +4254,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @Override
     public void deleteRelatedContent(final Contentlet contentlet, final Relationship relationship,
-            final boolean hasParent, final User user, final boolean respectFrontendRoles) throws DotDataException, DotSecurityException, DotContentletStateException {
-        deleteRelatedContent(contentlet, relationship, hasParent, user, respectFrontendRoles, Collections.emptyList());
+            final boolean hasParent, final User user, final boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
+        deleteRelatedContent(contentlet, relationship, hasParent, user, respectFrontendRoles,
+                Collections.emptyList());
     }
 
     @WrapInTransaction
     @Override
     public void deleteRelatedContent(final Contentlet contentlet, final Relationship relationship,
-            final boolean hasParent, final User user, final boolean respectFrontendRoles, final List<Contentlet> contentletsToBeRelated)
+            final boolean hasParent, final User user, final boolean respectFrontendRoles,
+            final List<Contentlet> contentletsToBeRelated)
             throws DotDataException, DotSecurityException, DotContentletStateException {
 
         if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT, user,
@@ -3893,7 +4291,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 TreeFactory.deleteTreesByParentAndChildAndRelationType(contentlet.getIdentifier(),
                         relatedContent.getIdentifier(), relationship.getRelationTypeValue());
             } else {
-                TreeFactory.deleteTreesByParentAndChildAndRelationType(relatedContent.getIdentifier(),
+                TreeFactory.deleteTreesByParentAndChildAndRelationType(
+                        relatedContent.getIdentifier(),
                         contentlet.getIdentifier(), relationship.getRelationTypeValue());
             }
         }
@@ -3959,10 +4358,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public List<Contentlet> getRelatedContent(final Contentlet contentlet, final String variableName,
+    public List<Contentlet> getRelatedContent(final Contentlet contentlet,
+            final String variableName,
             final User user,
             final boolean respectFrontendRoles, Boolean pullByParents, final int limit,
-            final int offset, final String sortBy){
+            final int offset, final String sortBy) {
         return getRelatedContent(contentlet, variableName, user, respectFrontendRoles,
                 pullByParents, limit, offset, sortBy, -1, null);
     }
@@ -3975,7 +4375,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             final boolean respectFrontendRoles, Boolean pullByParents, final int limit,
             final int offset, final String sortBy, final long language, final Boolean live) {
 
-        if (variableName == null){
+        if (variableName == null) {
             return Collections.EMPTY_LIST;
         }
 
@@ -4002,9 +4402,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
         try {
             User currentUser;
 
-            if (user != null){
+            if (user != null) {
                 currentUser = user;
-            } else{
+            } else {
                 currentUser = APILocator.getUserAPI().getAnonymousUser();
             }
 
@@ -4012,24 +4412,27 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             if (relatedIds.containsKey(variableName)) {
                 relatedContentlet = getCachedRelatedContentlets(relatedIds, variableName, language,
-                        currentUser.equals(APILocator.getUserAPI().getAnonymousUser()) ? Boolean.TRUE
+                        currentUser.equals(APILocator.getUserAPI().getAnonymousUser())
+                                ? Boolean.TRUE
                                 : live);
             } else {
                 relatedContentlet = getNonCachedRelatedContentlets(contentlet, relatedIds,
                         variableName, pullByParents,
                         limit, offset, language,
-                        currentUser.equals(APILocator.getUserAPI().getAnonymousUser()) ? Boolean.TRUE
+                        currentUser.equals(APILocator.getUserAPI().getAnonymousUser())
+                                ? Boolean.TRUE
                                 : live);
             }
 
-            if (UtilMethods.isSet(sortBy)){
+            if (UtilMethods.isSet(sortBy)) {
                 Collections.sort(relatedContentlet, new ContentMapComparator(sortBy));
             }
 
             //Restricts contentlet according to user permissions
-            return APILocator.getPermissionAPI().filterCollection(relatedContentlet, PermissionAPI.PERMISSION_READ,
-                    currentUser.equals(APILocator.getUserAPI().getAnonymousUser())
-                            ? true : respectFrontendRoles, currentUser);
+            return APILocator.getPermissionAPI()
+                    .filterCollection(relatedContentlet, PermissionAPI.PERMISSION_READ,
+                            currentUser.equals(APILocator.getUserAPI().getAnonymousUser())
+                                    ? true : respectFrontendRoles, currentUser);
 
         } catch (DotDataException | DotSecurityException e) {
             Logger.warn(this, "Error getting related content for field " + variableName, e);
@@ -4038,27 +4441,27 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * Retrieves the Contentlets that are associated to a specific piece of Content through a specific Relationship
-     * field. This method is executed for Relationships that are not currently cached by dotCMS, and must be looked up
-     * from scratch.
+     * Retrieves the Contentlets that are associated to a specific piece of Content through a
+     * specific Relationship field. This method is executed for Relationships that are not currently
+     * cached by dotCMS, and must be looked up from scratch.
      *
-     * @param contentlet   The {@link Contentlet} object whose related Contentlets will be retrieved.
+     * @param contentlet   The {@link Contentlet} object whose related Contentlets will be
+     *                     retrieved.
      * @param relatedIds   The data structure that will store the related Contentlets.
-     * @param variableName The Velocity Variable name of the Relationship field for the Content Type that the {@code
-     *                     contentlet} object belongs to.
+     * @param variableName The Velocity Variable name of the Relationship field for the Content Type
+     *                     that the {@code contentlet} object belongs to.
      * @param pullByParent
      * @param limit        Pagination parameter for the total number of results to return.
      * @param offset       Pagination parameter for the offset.
-     *
      * @return The list of related {@link Contentlet} objects.
-     *
      * @throws DotDataException     An error occurred when interacting with the data source.
      * @throws DotSecurityException
      */
     @Nullable
     private List<Contentlet> getNonCachedRelatedContentlets(final Contentlet contentlet,
             final Map<String, List<String>> relatedIds, final String variableName,
-            final Boolean pullByParent, final int limit, final int offset, final long language, final Boolean live)
+            final Boolean pullByParent, final int limit, final int offset, final long language,
+            final Boolean live)
             throws DotDataException, DotSecurityException {
 
         final User systemUser = APILocator.getUserAPI().getSystemUser();
@@ -4076,15 +4479,19 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
 
         if (null == relationship) {
-            throw new DotStateException(String.format("Relationship field '%s' in Content Type ID '%s' was not found." +
-                    " Make sure that the relationship table points to the correct field.", variableName, contentlet
-                    .getContentTypeId()));
+            throw new DotStateException(
+                    String.format("Relationship field '%s' in Content Type ID '%s' was not found." +
+                                    " Make sure that the relationship table points to the correct field.",
+                            variableName, contentlet
+                                    .getContentTypeId()));
         }
-        final List<Contentlet> relatedList = filterRelatedContent(contentlet, relationship, systemUser, false,
+        final List<Contentlet> relatedList = filterRelatedContent(contentlet, relationship,
+                systemUser, false,
                 pullByParent, limit, offset);
 
         // Get unique identifiers to avoid duplicates (used to save on cache and filter the final list if needed
-        final List<String> uniqueIdentifiers = relatedList.stream().map(Contentlet::getIdentifier).distinct()
+        final List<String> uniqueIdentifiers = relatedList.stream().map(Contentlet::getIdentifier)
+                .distinct()
                 .collect(CollectionsUtils.toImmutableList());
 
         //Cache related content only if it is a relationship field and there is no filter
@@ -4098,23 +4505,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 relatedIds.put(variableName, Collections.emptyList());
             }
             //refreshing cache when related content map is updated
-            CacheLocator.getRelationshipCache().putRelatedContentMap(contentlet.getIdentifier(), relatedIds);
+            CacheLocator.getRelationshipCache()
+                    .putRelatedContentMap(contentlet.getIdentifier(), relatedIds);
         }
 
         if (live == null && language == -1) {
             return relatedList;
-        } else{
+        } else {
             /*Filter by live and/or language if set
               If live=true, for each content, it needs to return the live version.
               Otherwise, it would return the working one*/
             return uniqueIdentifiers.stream()
-                    .flatMap(identifier -> filterRelatedContentByLiveAndLanguage(language, live, identifier))
+                    .flatMap(identifier -> filterRelatedContentByLiveAndLanguage(language, live,
+                            identifier))
                     .collect(Collectors.toList());
         }
     }
 
     /**
-     *
      * @param relatedIds
      * @param variableName
      * @return
@@ -4125,18 +4533,19 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         return relatedIds
                 .get(variableName).stream()
-                .flatMap(identifier -> filterRelatedContentByLiveAndLanguage(language, live, identifier))
+                .flatMap(identifier -> filterRelatedContentByLiveAndLanguage(language, live,
+                        identifier))
                 .collect(Collectors.toList());
     }
 
     /**
-     *
      * @param language
      * @param live
      * @param identifier
      * @return
      */
-    private Stream<? extends Contentlet> filterRelatedContentByLiveAndLanguage(final long language, final Boolean live,
+    private Stream<? extends Contentlet> filterRelatedContentByLiveAndLanguage(final long language,
+            final Boolean live,
             final String identifier) {
 
         final List<Contentlet> relatedContentList = new ArrayList<>();
@@ -4147,7 +4556,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                         Collectors.toList());
 
         for (Long currentLanguage : languages) {
-            try{
+            try {
                 Contentlet currentContent = findContentletByIdentifier(
                         identifier, live == null ? false : live,
                         currentLanguage, APILocator.getUserAPI().getSystemUser(),
@@ -4174,21 +4583,23 @@ public class ESContentletAPIImpl implements ContentletAPI {
             final User user, boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException, DotContentletStateException {
 
-        final Structure structure = CacheLocator.getContentTypeCache().getStructureByInode(contentlet.getStructureInode());
+        final Structure structure = CacheLocator.getContentTypeCache()
+                .getStructureByInode(contentlet.getStructureInode());
         final boolean hasParent = APILocator.getRelationshipAPI().isParent(rel, structure);
-        final ContentletRelationshipRecords related = new ContentletRelationships(contentlet).new ContentletRelationshipRecords(rel, hasParent);
+        final ContentletRelationshipRecords related = new ContentletRelationships(
+                contentlet).new ContentletRelationshipRecords(rel, hasParent);
         related.setRecords(records);
         relateContent(contentlet, related, user, respectFrontendRoles);
     }
 
     @CloseDBIfOpened
-    private List<Relationship> getRelationships (final ContentTypeIf type) throws DotDataException {
+    private List<Relationship> getRelationships(final ContentTypeIf type) throws DotDataException {
 
         return APILocator.getRelationshipAPI().byContentType(type);
     }
 
     @CloseDBIfOpened
-    private List<Tree> getContentParents (final String inode) throws DotDataException {
+    private List<Tree> getContentParents(final String inode) throws DotDataException {
 
         return TreeFactory.getTreesByChild(inode);
     }
@@ -4202,14 +4613,16 @@ public class ESContentletAPIImpl implements ContentletAPI {
             final boolean respectFrontendRoles)
             throws DotDataException, DotSecurityException, DotContentletStateException {
 
-        if(!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT, user, respectFrontendRoles)) {
+        if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT, user,
+                respectFrontendRoles)) {
 
             throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
-                    + " cannot edit Contentlet: " + (contentlet != null ? contentlet.getInode() : "Unknown"));
+                    + " cannot edit Contentlet: " + (contentlet != null ? contentlet.getInode()
+                    : "Unknown"));
         }
 
         //do not perform any changes on related records
-        if (related.getRecords() == null){
+        if (related.getRecords() == null) {
             return;
         }
 
@@ -4217,7 +4630,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         final List<Relationship> relationships = this.getRelationships(contentType);
         final Relationship relationship = related.getRelationship();
 
-        if(!relationships.contains(related.getRelationship())) {
+        if (!relationships.contains(related.getRelationship())) {
 
             throw new DotContentletStateException(
                     "Error adding relationships in contentlet:  " + (contentlet != null ? contentlet
@@ -4232,13 +4645,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
 
         boolean localTransaction = false;
-        final boolean isNewConnection    = !DbConnectionFactory.connectionExists();
-        try{
+        final boolean isNewConnection = !DbConnectionFactory.connectionExists();
+        try {
             try {
                 localTransaction = HibernateUtil.startLocalTransactionIfNeeded();
-            }
-            catch(Exception e){
-                throw new DotDataException(e.getMessage(),e);
+            } catch (Exception e) {
+                throw new DotDataException(e.getMessage(), e);
             }
 
             deleteRelatedContent(contentlet, relationship, related.isHasParent(), user,
@@ -4247,32 +4659,37 @@ public class ESContentletAPIImpl implements ContentletAPI {
             Tree newTree;
             Set<Tree> uniqueRelationshipSet = new HashSet<>();
 
-            List<Contentlet> conRels = getRelatedContentFromIndex(contentlet,relationship,
-                    related.isHasParent(), user,respectFrontendRoles) ;
+            List<Contentlet> conRels = getRelatedContentFromIndex(contentlet, relationship,
+                    related.isHasParent(), user, respectFrontendRoles);
 
-            int treePosition = (conRels != null && conRels.size() != 0) ? conRels.size() : 1 ;
+            int treePosition = (conRels != null && conRels.size() != 0) ? conRels.size() : 1;
             int positionInParent = 1;
 
             for (Contentlet c : related.getRecords()) {
                 if (child) {
-                    for (Tree currentTree: contentParents) {
-                        if (currentTree.getRelationType().equals(relationship.getRelationTypeValue()) && c.getIdentifier().equals(currentTree.getParent())) {
+                    for (Tree currentTree : contentParents) {
+                        if (currentTree.getRelationType()
+                                .equals(relationship.getRelationTypeValue()) && c.getIdentifier()
+                                .equals(currentTree.getParent())) {
                             positionInParent = currentTree.getTreeOrder();
                         }
                     }
 
-                    newTree = new Tree(c.getIdentifier(), contentlet.getIdentifier(), relationship.getRelationTypeValue(), positionInParent);
+                    newTree = new Tree(c.getIdentifier(), contentlet.getIdentifier(),
+                            relationship.getRelationTypeValue(), positionInParent);
                 } else {
-                    newTree = new Tree(contentlet.getIdentifier(), c.getIdentifier(), relationship.getRelationTypeValue(), treePosition);
+                    newTree = new Tree(contentlet.getIdentifier(), c.getIdentifier(),
+                            relationship.getRelationTypeValue(), treePosition);
                 }
-                positionInParent=positionInParent+1;
+                positionInParent = positionInParent + 1;
 
-                if( uniqueRelationshipSet.add(newTree) ) {
+                if (uniqueRelationshipSet.add(newTree)) {
                     final int newTreePosition = newTree.getTreeOrder();
                     final Tree treeToUpdate = TreeFactory.getTree(newTree);
                     treeToUpdate.setTreeOrder(newTreePosition);
 
-                    TreeFactory.saveTree(treeToUpdate != null && UtilMethods.isSet(treeToUpdate.getRelationType())?treeToUpdate:newTree);
+                    TreeFactory.saveTree(treeToUpdate != null && UtilMethods.isSet(
+                            treeToUpdate.getRelationType()) ? treeToUpdate : newTree);
 
                     treePosition++;
                 }
@@ -4282,17 +4699,18 @@ public class ESContentletAPIImpl implements ContentletAPI {
             //If relationship field, related content cache must be invalidated
             invalidateRelatedContentCache(contentlet, relationship, related.isHasParent());
 
-            if(localTransaction){
+            if (localTransaction) {
                 HibernateUtil.commitTransaction();
             }
-        } catch(Exception exception){
-            Logger.debug(this.getClass(), "Failed to relate content. : " + exception.toString(), exception);
-            if(localTransaction){
+        } catch (Exception exception) {
+            Logger.debug(this.getClass(), "Failed to relate content. : " + exception.toString(),
+                    exception);
+            if (localTransaction) {
                 HibernateUtil.rollbackTransaction();
             }
             throw new DotDataException(exception.getMessage(), exception);
         } finally {
-            if(localTransaction && isNewConnection){
+            if (localTransaction && isNewConnection) {
                 HibernateUtil.closeSessionSilently();
             }
         }
@@ -4300,32 +4718,39 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     // todo: should be in a transaction.????
     @Override
-    public void publish(List<Contentlet> contentlets, User user,    boolean respectFrontendRoles) throws DotSecurityException,DotDataException, DotContentletStateException {
+    public void publish(List<Contentlet> contentlets, User user, boolean respectFrontendRoles)
+            throws DotSecurityException, DotDataException, DotContentletStateException {
         boolean stateError = false;
         for (Contentlet contentlet : contentlets) {
-            try{
+            try {
                 publish(contentlet, user, respectFrontendRoles);
-            }catch (DotContentletStateException e) {
+            } catch (DotContentletStateException e) {
                 stateError = true;
             }
         }
-        if(stateError){
-            throw new DotContentletStateException("Unable to publish one or more contentlets because it is locked");
+        if (stateError) {
+            throw new DotContentletStateException(
+                    "Unable to publish one or more contentlets because it is locked");
         }
     }
 
     @CloseDBIfOpened
     @Override
-    public boolean isContentEqual(Contentlet contentlet1,Contentlet contentlet2, User user, boolean respectFrontendRoles)throws DotSecurityException, DotDataException {
-        if(!permissionAPI.doesUserHavePermission(contentlet1, PermissionAPI.PERMISSION_READ, user, respectFrontendRoles)){
+    public boolean isContentEqual(Contentlet contentlet1, Contentlet contentlet2, User user,
+            boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
+        if (!permissionAPI.doesUserHavePermission(contentlet1, PermissionAPI.PERMISSION_READ, user,
+                respectFrontendRoles)) {
             throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
-                    + " cannot read Contentlet: " + (contentlet1 != null ? contentlet1.getInode() : "Unknown"));
+                    + " cannot read Contentlet: " + (contentlet1 != null ? contentlet1.getInode()
+                    : "Unknown"));
         }
-        if(!permissionAPI.doesUserHavePermission(contentlet2, PermissionAPI.PERMISSION_READ, user, respectFrontendRoles)){
+        if (!permissionAPI.doesUserHavePermission(contentlet2, PermissionAPI.PERMISSION_READ, user,
+                respectFrontendRoles)) {
             throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
-                    + " cannot read Contentlet: " + (contentlet2 != null ? contentlet1.getInode() : "Unknown"));
+                    + " cannot read Contentlet: " + (contentlet2 != null ? contentlet1.getInode()
+                    : "Unknown"));
         }
-        if(contentlet1.getInode().equalsIgnoreCase(contentlet2.getInode())){
+        if (contentlet1.getInode().equalsIgnoreCase(contentlet2.getInode())) {
             return true;
         }
         return false;
@@ -4333,18 +4758,21 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> getSiblings(String identifier)throws DotDataException, DotSecurityException {
-        List<Contentlet> contentletList = contentFactory.getContentletsByIdentifier(identifier );
+    public List<Contentlet> getSiblings(String identifier)
+            throws DotDataException, DotSecurityException {
+        List<Contentlet> contentletList = contentFactory.getContentletsByIdentifier(identifier);
 
         return contentletList;
     }
 
     @CloseDBIfOpened
     @Override
-    public Contentlet checkin(Contentlet contentlet, List<Category> cats, List<Permission> permissions, User user,
+    public Contentlet checkin(Contentlet contentlet, List<Category> cats,
+            List<Permission> permissions, User user,
             boolean respectFrontendRoles)
-            throws IllegalArgumentException,DotDataException, DotSecurityException,DotContentletStateException {
-        return checkin(contentlet, (Map<Relationship, List<Contentlet>>) null, cats, permissions, user,
+            throws IllegalArgumentException, DotDataException, DotSecurityException, DotContentletStateException {
+        return checkin(contentlet, (Map<Relationship, List<Contentlet>>) null, cats, permissions,
+                user,
                 respectFrontendRoles);
     }
 
@@ -4352,21 +4780,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
     @Override
     public Contentlet checkin(Contentlet contentlet, List<Permission> permissions, User user,
             boolean respectFrontendRoles)
-            throws IllegalArgumentException,DotDataException, DotSecurityException,DotContentletStateException {
-        return checkin(contentlet, (ContentletRelationships) null, null, permissions, user, respectFrontendRoles);
+            throws IllegalArgumentException, DotDataException, DotSecurityException, DotContentletStateException {
+        return checkin(contentlet, (ContentletRelationships) null, null, permissions, user,
+                respectFrontendRoles);
     }
 
     @CloseDBIfOpened
     @Override
-    public Contentlet checkin(Contentlet contentlet,Map<Relationship, List<Contentlet>> contentRelationships,
+    public Contentlet checkin(Contentlet contentlet,
+            Map<Relationship, List<Contentlet>> contentRelationships,
             List<Category> cats, User user, boolean respectFrontendRoles)
-            throws IllegalArgumentException, DotDataException,DotSecurityException, DotContentletStateException {
+            throws IllegalArgumentException, DotDataException, DotSecurityException, DotContentletStateException {
         return checkin(contentlet, contentRelationships, cats, user, respectFrontendRoles, false);
     }
 
     @CloseDBIfOpened
     @Override
-    public Contentlet checkin(Contentlet contentlet,Map<Relationship, List<Contentlet>> contentRelationships,User user,
+    public Contentlet checkin(Contentlet contentlet,
+            Map<Relationship, List<Contentlet>> contentRelationships, User user,
             boolean respectFrontendRoles)
             throws IllegalArgumentException, DotDataException, DotSecurityException, DotContentletStateException {
         return checkin(contentlet, contentRelationships, null, user, respectFrontendRoles);
@@ -4374,10 +4805,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public Contentlet checkin(Contentlet contentlet, User user,boolean respectFrontendRoles)
-            throws IllegalArgumentException,DotDataException, DotSecurityException {
+    public Contentlet checkin(Contentlet contentlet, User user, boolean respectFrontendRoles)
+            throws IllegalArgumentException, DotDataException, DotSecurityException {
 
-        user = (user==null) ? APILocator.getUserAPI().getAnonymousUser() : user;
+        user = (user == null) ? APILocator.getUserAPI().getAnonymousUser() : user;
 
         return checkin(contentlet, (ContentletRelationships) null, null, null, user,
                 respectFrontendRoles, false);
@@ -4385,21 +4816,22 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public Contentlet checkin(Contentlet contentlet, User user,boolean respectFrontendRoles, List<Category> cats)
-            throws IllegalArgumentException, DotDataException,DotSecurityException {
+    public Contentlet checkin(Contentlet contentlet, User user, boolean respectFrontendRoles,
+            List<Category> cats)
+            throws IllegalArgumentException, DotDataException, DotSecurityException {
         return checkin(contentlet, null, cats, user, respectFrontendRoles);
     }
 
     @Override
-    public Contentlet checkin(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships,
-            List<Category> cats , List<Permission> permissions, User user,
+    public Contentlet checkin(Contentlet contentlet,
+            Map<Relationship, List<Contentlet>> contentRelationships,
+            List<Category> cats, List<Permission> permissions, User user,
             boolean respectFrontendRoles)
-            throws DotDataException,DotSecurityException, DotContentletStateException, DotContentletValidationException {
+            throws DotDataException, DotSecurityException, DotContentletStateException, DotContentletValidationException {
         return checkin(contentlet, contentRelationships, cats, user, respectFrontendRoles, false);
     }
 
     /**
-     *
      * @param contentlet
      * @param contentRelationships
      * @param cats
@@ -4413,21 +4845,26 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotContentletValidationException
      */
     @CloseDBIfOpened
-    private Contentlet checkin(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships,
+    private Contentlet checkin(Contentlet contentlet,
+            Map<Relationship, List<Contentlet>> contentRelationships,
             List<Category> cats, User user, boolean respectFrontendRoles,
             boolean generateSystemEvent)
             throws DotDataException, DotSecurityException, DotContentletStateException {
 
-        ContentletRelationships relationshipsData = getContentletRelationshipsFromMap(contentlet, contentRelationships);
+        ContentletRelationships relationshipsData = getContentletRelationshipsFromMap(contentlet,
+                contentRelationships);
 
-        return checkin(contentlet, relationshipsData, cats, user, respectFrontendRoles, true, generateSystemEvent);
+        return checkin(contentlet, relationshipsData, cats, user, respectFrontendRoles, true,
+                generateSystemEvent);
     }
 
     @Override
-    public Contentlet checkin(Contentlet contentlet, ContentletRelationships contentRelationships, List<Category> cats,
-            List<Permission> permissions, User user,boolean respectFrontendRoles)
-            throws DotDataException,DotSecurityException, DotContentletStateException {
-        return checkin(contentlet, contentRelationships, cats, user, respectFrontendRoles, true, false);
+    public Contentlet checkin(Contentlet contentlet, ContentletRelationships contentRelationships,
+            List<Category> cats,
+            List<Permission> permissions, User user, boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
+        return checkin(contentlet, contentRelationships, cats, user, respectFrontendRoles, true,
+                false);
     }
 
     private ContentletRelationships getContentletRelationshipsFromMap(final Contentlet contentlet,
@@ -4438,9 +4875,14 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public Contentlet checkinWithoutVersioning(Contentlet contentlet, Map<Relationship, List<Contentlet>> contentRelationships, List<Category> cats ,List<Permission> permissions, User user,boolean respectFrontendRoles) throws DotDataException,DotSecurityException, DotContentletStateException, DotContentletValidationException {
-        ContentletRelationships relationshipsData = getContentletRelationshipsFromMap(contentlet, contentRelationships);
-        return checkin(contentlet, relationshipsData, cats , user, respectFrontendRoles, false, false);
+    public Contentlet checkinWithoutVersioning(Contentlet contentlet,
+            Map<Relationship, List<Contentlet>> contentRelationships, List<Category> cats,
+            List<Permission> permissions, User user, boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException, DotContentletValidationException {
+        ContentletRelationships relationshipsData = getContentletRelationshipsFromMap(contentlet,
+                contentRelationships);
+        return checkin(contentlet, relationshipsData, cats, user, respectFrontendRoles, false,
+                false);
     }
 
     @CloseDBIfOpened
@@ -4454,7 +4896,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     *
      * @param contentletIn
      * @param contentRelationships
      * @param categories
@@ -4468,24 +4909,29 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotContentletValidationException
      */
     @WrapInTransaction
-    private Contentlet checkin(final Contentlet contentletIn, final ContentletRelationships contentRelationships,
+    private Contentlet checkin(final Contentlet contentletIn,
+            final ContentletRelationships contentRelationships,
             final List<Category> categories, final User user, boolean respectFrontendRoles,
-            final boolean createNewVersion,  final boolean generateSystemEvent) throws DotDataException, DotSecurityException {
+            final boolean createNewVersion, final boolean generateSystemEvent)
+            throws DotDataException, DotSecurityException {
 
         Contentlet contentletOut = null;
-        Boolean autoAssign       = null;
+        Boolean autoAssign = null;
 
         try {
 
             String wfPublishDate = contentletIn.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE);
-            String wfExpireDate  = contentletIn.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE);
+            String wfExpireDate = contentletIn.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE);
             final boolean isWorkflowInProgress = contentletIn.isWorkflowInProgress();
-            final String contentPushPublishDateBefore = UtilMethods.isSet(wfPublishDate) ? wfPublishDate : "N/D";
-            final String contentPushExpireDateBefore  = UtilMethods.isSet(wfExpireDate) ? wfExpireDate : "N/D";
+            final String contentPushPublishDateBefore =
+                    UtilMethods.isSet(wfPublishDate) ? wfPublishDate : "N/D";
+            final String contentPushExpireDateBefore =
+                    UtilMethods.isSet(wfExpireDate) ? wfExpireDate : "N/D";
 
             ActivityLogger.logInfo(getClass(), "Saving Content",
                     "StartDate: " + contentPushPublishDateBefore + "; "
-                            + "EndDate: " + contentPushExpireDateBefore + "; User:" + (user != null ? user
+                            + "EndDate: " + contentPushExpireDateBefore + "; User:" + (user != null
+                            ? user
                             .getUserId() : "Unknown")
                             + "; ContentIdentifier: " + (contentletIn != null ? contentletIn
                             .getIdentifier() : "Unknown"), contentletIn.getHost());
@@ -4498,17 +4944,20 @@ public class ESContentletAPIImpl implements ContentletAPI {
             try {
 
                 final Optional<Contentlet> workflowContentletOpt =
-                        this.validateWorkflowStateOrRunAsWorkflow(contentletIn, contentRelationships,
-                                categories, user, respectFrontendRoles, createNewVersion, generateSystemEvent);
+                        this.validateWorkflowStateOrRunAsWorkflow(contentletIn,
+                                contentRelationships,
+                                categories, user, respectFrontendRoles, createNewVersion,
+                                generateSystemEvent);
 
                 if (workflowContentletOpt.isPresent()) {
 
-                    Logger.info(this, "A Workflow has been ran instead of checkin the contentlet: " +
-                            workflowContentletOpt.get().getIdentifier());
+                    Logger.info(this,
+                            "A Workflow has been ran instead of checkin the contentlet: " +
+                                    workflowContentletOpt.get().getIdentifier());
                     return workflowContentletOpt.get();
                 }
 
-                autoAssign = (Boolean)contentletIn.getMap().get(Contentlet.AUTO_ASSIGN_WORKFLOW);
+                autoAssign = (Boolean) contentletIn.getMap().get(Contentlet.AUTO_ASSIGN_WORKFLOW);
                 contentletOut = lockManager.tryLock(lockKey,
                         () -> internalCheckin(
                                 contentletIn, contentRelationships, categories, user,
@@ -4516,7 +4965,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                         )
                 ); // end synchronized block
             } catch (final Throwable t) {
-                Logger.warn(getClass(),t.getMessage(),t);
+                Logger.warn(getClass(), t.getMessage(), t);
                 bubbleUpException(t);
             }
 
@@ -4528,26 +4977,29 @@ public class ESContentletAPIImpl implements ContentletAPI {
             wfPublishDate = contentletOut.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE);
             wfExpireDate = contentletOut.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE);
 
-            final String contentPushPublishDateAfter = UtilMethods.isSet(wfPublishDate) ? wfPublishDate : "N/D";
-            final String contentPushExpireDateAfter = UtilMethods.isSet(wfExpireDate) ? wfExpireDate : "N/D";
+            final String contentPushPublishDateAfter =
+                    UtilMethods.isSet(wfPublishDate) ? wfPublishDate : "N/D";
+            final String contentPushExpireDateAfter =
+                    UtilMethods.isSet(wfExpireDate) ? wfExpireDate : "N/D";
 
             ActivityLogger.logInfo(getClass(), "Content Saved",
                     "StartDate: " + contentPushPublishDateAfter + "; "
-                            + "EndDate: " + contentPushExpireDateAfter + "; User:" + (user != null ? user
+                            + "EndDate: " + contentPushExpireDateAfter + "; User:" + (user != null
+                            ? user
                             .getUserId() : "Unknown")
                             + "; ContentIdentifier: " + contentletOut.getIdentifier(),
                     contentletOut.getHost());
 
-            if(isWorkflowInProgress){
+            if (isWorkflowInProgress) {
                 autoAssign = false;
             }
 
             // Creates the Local System event
-            if ( null != autoAssign ) {
+            if (null != autoAssign) {
                 contentletOut.setBoolProperty(Contentlet.AUTO_ASSIGN_WORKFLOW, autoAssign);
             }
 
-            this.createLocalCheckinEvent (contentletOut, user, createNewVersion);
+            this.createLocalCheckinEvent(contentletOut, user, createNewVersion);
 
             //Create a System event for this contentlet
             if (generateSystemEvent) {
@@ -4571,25 +5023,29 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 baseTypeOpt.isPresent()) {
 
             final BaseContentType baseContentType = baseTypeOpt.get();
-            final Optional<BaseTypeToContentTypeStrategy>  typeStrategy =
+            final Optional<BaseTypeToContentTypeStrategy> typeStrategy =
                     this.baseTypeToContentTypeStrategyResolver.get(baseContentType);
 
             if (typeStrategy.isPresent()) {
 
-                final Host host = Try.of(()->APILocator.getHostAPI().find(
+                final Host host = Try.of(() -> APILocator.getHostAPI().find(
                         contentletIn.getHost(), user, false)).getOrNull();
                 if (null != host) {
 
                     final HttpServletRequest request = HttpServletRequestThreadLocal.INSTANCE.getRequest();
-                    final String sessionId = request!=null && request.getSession(false)!=null? request.getSession().getId() : null;
-                    final List<String> accessingList = null != request?
-                            Arrays.asList(user.getUserId(), APILocator.getTempFileAPI().getRequestFingerprint(request), sessionId):
+                    final String sessionId = request != null && request.getSession(false) != null
+                            ? request.getSession().getId() : null;
+                    final List<String> accessingList = null != request ?
+                            Arrays.asList(user.getUserId(),
+                                    APILocator.getTempFileAPI().getRequestFingerprint(request),
+                                    sessionId) :
                             Arrays.asList(user.getUserId(), sessionId);
 
-
-                    final Optional<ContentType> contentTypeOpt = typeStrategy.get().apply(baseContentType,
-                            CollectionsUtils.map("user", user, "host", host,
-                                    "contentletMap", contentletIn.getMap(), "accessingList", accessingList));
+                    final Optional<ContentType> contentTypeOpt = typeStrategy.get()
+                            .apply(baseContentType,
+                                    CollectionsUtils.map("user", user, "host", host,
+                                            "contentletMap", contentletIn.getMap(), "accessingList",
+                                            accessingList));
 
                     if (contentTypeOpt.isPresent()) {
                         contentletIn.setContentType(contentTypeOpt.get());
@@ -4601,6 +5057,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * check if a workflow may be run instead of the publish api call itself.
+     *
      * @param contentletIn
      * @param user
      * @param respectFrontendRoles
@@ -4608,7 +5065,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotSecurityException
      * @throws DotDataException
      */
-    private Optional<Contentlet> checkAndRunPublishAsWorkflow(final Contentlet contentletIn, final User user,
+    private Optional<Contentlet> checkAndRunPublishAsWorkflow(final Contentlet contentletIn,
+            final User user,
             final boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
 
         // if already on workflow or has an actionid skip this method.
@@ -4627,7 +5085,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         if (workflowActionOpt.isPresent()) {
 
-            final String title    = contentletIn.getTitle();
+            final String title = contentletIn.getTitle();
             final String actionId = workflowActionOpt.get().getId();
 
             // if the default action is in the avalable actions for the content.
@@ -4635,14 +5093,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 return Optional.empty();
             }
 
-            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier() + " hasn't action id set"
+            Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier()
+                    + " hasn't action id set"
                     + " using the default action: " + actionId);
 
             // if the action has a save action, we skip the current checkin
             if (workflowActionOpt.get().hasPublishActionlet()) {
 
-                Logger.info(this, () -> "The action: " + actionId + " has a publish contentlet actionlet"
-                        + " so firing a workflow and skipping the current publish for the contentlet: " + contentletIn.getIdentifier());
+                Logger.info(this,
+                        () -> "The action: " + actionId + " has a publish contentlet actionlet"
+                                + " so firing a workflow and skipping the current publish for the contentlet: "
+                                + contentletIn.getIdentifier());
 
                 return Optional.ofNullable(workflowAPI.fireContentWorkflow(contentletIn,
                         new ContentletDependencies.Builder().workflowActionId(actionId)
@@ -4652,7 +5113,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 ));
             }
 
-            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier() + " hasn't a publish contentlet actionlet"
+            Logger.info(this, () -> "The action: " + contentletIn.getIdentifier()
+                    + " hasn't a publish contentlet actionlet"
                     + " so including just the action to the contentlet: " + title);
 
             contentletIn.setActionId(actionId);
@@ -4672,17 +5134,18 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
 
         Logger.info(this, () -> "The contentlet: " + contentletIn.getIdentifier()
-                + " has the action: " + actionId + " but the this is not an available action for it");
+                + " has the action: " + actionId
+                + " but the this is not an available action for it");
         return false;
     }
 
-    private Optional<Contentlet> validateWorkflowStateOrRunAsWorkflow(final Contentlet contentletIn, final ContentletRelationships contentRelationships,
+    private Optional<Contentlet> validateWorkflowStateOrRunAsWorkflow(final Contentlet contentletIn,
+            final ContentletRelationships contentRelationships,
             final List<Category> categories, final User userIn,
             final boolean respectFrontendRoles, final boolean createNewVersion,
             boolean generateSystemEvent) throws DotSecurityException, DotDataException {
 
-        final User user = (userIn==null) ? APILocator.getUserAPI().getAnonymousUser() : userIn;
-
+        final User user = (userIn == null) ? APILocator.getUserAPI().getAnonymousUser() : userIn;
 
         // if already on workflow or has an actionid skip this method.
         if (this.isDisableWorkflow(contentletIn)
@@ -4698,7 +5161,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
         // in the future if the contentlet exist, EDIT should be catch
         final Optional<WorkflowAction> workflowActionOpt =
                 workflowAPI.findActionMappedBySystemActionContentlet
-                        (contentletIn, contentletIn.isNew()?WorkflowAPI.SystemAction.NEW:WorkflowAPI.SystemAction.EDIT, user);
+                        (contentletIn, contentletIn.isNew() ? WorkflowAPI.SystemAction.NEW
+                                : WorkflowAPI.SystemAction.EDIT, user);
 
         if (workflowActionOpt.isPresent()) {
 
@@ -4716,20 +5180,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
             // if the action has a save action, we skip the current checkin
             if (workflowActionOpt.get().hasSaveActionlet()) {
 
-                Logger.info(this, () -> "The action: " + actionId + " has a save contentlet actionlet"
-                        + " so firing a workflow and skipping the current checkin for the contentlet: " + title);
+                Logger.info(this,
+                        () -> "The action: " + actionId + " has a save contentlet actionlet"
+                                + " so firing a workflow and skipping the current checkin for the contentlet: "
+                                + title);
 
                 return Optional.ofNullable(workflowAPI.fireContentWorkflow(contentletIn,
                         new ContentletDependencies.Builder().workflowActionId(actionId)
-                                .modUser(user).categories(categories).relationships(contentRelationships)
+                                .modUser(user).categories(categories)
+                                .relationships(contentRelationships)
                                 .respectAnonymousPermissions(respectFrontendRoles)
                                 .generateSystemEvent(generateSystemEvent)
                                 .build()
                 ));
             }
 
-            Logger.info(this, () -> "The action: " + actionId + " hasn't a save contentlet actionlet"
-                    + " so including just the action to the contentlet: " + title);
+            Logger.info(this,
+                    () -> "The action: " + actionId + " hasn't a save contentlet actionlet"
+                            + " so including just the action to the contentlet: " + title);
 
             contentletIn.setActionId(actionId);
         }
@@ -4746,7 +5214,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         return contentlet.isDisableWorkflow();
     }
 
-    private boolean isWorkflowInProgress (final Contentlet contentlet) {
+    private boolean isWorkflowInProgress(final Contentlet contentlet) {
         return contentlet.isWorkflowInProgress();
     }
 
@@ -4757,39 +5225,44 @@ public class ESContentletAPIImpl implements ContentletAPI {
             boolean createNewVersion
     ) throws DotDataException, DotSecurityException {
 
-        final User user = (incomingUser!=null) ? incomingUser : APILocator.getUserAPI().getAnonymousUser();
+        final User user =
+                (incomingUser != null) ? incomingUser : APILocator.getUserAPI().getAnonymousUser();
 
-        if(user.isAnonymousUser() && AnonymousAccess.systemSetting() != AnonymousAccess.WRITE) {
-            throw new DotSecurityException("CONTENT_APIS_ALLOW_ANONYMOUS setting does not allow anonymous content WRITEs");
+        if (user.isAnonymousUser() && AnonymousAccess.systemSetting() != AnonymousAccess.WRITE) {
+            throw new DotSecurityException(
+                    "CONTENT_APIS_ALLOW_ANONYMOUS setting does not allow anonymous content WRITEs");
         }
 
-        if(contentRelationships == null) {
+        if (contentRelationships == null) {
 
             //Obtain all relationships
-            contentRelationships =  getContentletRelationships(contentlet, user);
+            contentRelationships = getContentletRelationships(contentlet, user);
 
-            if (contentRelationships!=null) {
+            if (contentRelationships != null) {
                 getAllRelationships(contentlet, contentRelationships);
             }
         }
 
-        if (!isCheckInSafe(contentRelationships)){
+        if (!isCheckInSafe(contentRelationships)) {
 
             if (contentlet.getBoolProperty(Contentlet.IS_TEST_MODE)) {
                 this.elasticReadOnlyCommand.executeCheck();
             } else {
-                DotConcurrentFactory.getInstance().getSingleSubmitter().submit(() -> this.elasticReadOnlyCommand.executeCheck());
+                DotConcurrentFactory.getInstance().getSingleSubmitter()
+                        .submit(() -> this.elasticReadOnlyCommand.executeCheck());
             }
 
             final String contentletIdentifier =
-                    null != contentlet && null != contentlet.getIdentifier()? contentlet.getIdentifier(): StringPool.NULL;
+                    null != contentlet && null != contentlet.getIdentifier()
+                            ? contentlet.getIdentifier() : StringPool.NULL;
 
             throw new DotContentletStateException(
-                    "Content cannot be saved at this moment. Reason: Elastic Search cluster is in read only mode. Contentlet Id: " +
+                    "Content cannot be saved at this moment. Reason: Elastic Search cluster is in read only mode. Contentlet Id: "
+                            +
                             contentletIdentifier);
         }
 
-        if(categories == null) {
+        if (categories == null) {
             categories = getExistingContentCategories(contentlet);
         }
         final ContentType contentType = contentlet.getContentType();
@@ -4799,44 +5272,47 @@ public class ESContentletAPIImpl implements ContentletAPI {
         Contentlet workingContentlet = contentlet;
         try {
 
-
             // if we have incoming temp files set as binaryFields, lets populate the contentlet with them
-            for ( com.dotcms.contenttype.model.field.Field field : contentType.fields(BinaryField.class) ) {
+            for (com.dotcms.contenttype.model.field.Field field : contentType.fields(
+                    BinaryField.class)) {
                 final Object fileObject = contentlet.get(field.variable());
-                if(fileObject instanceof String && tempApi.isTempResource(contentlet.getStringProperty(field.variable()))) {
+                if (fileObject instanceof String && tempApi.isTempResource(
+                        contentlet.getStringProperty(field.variable()))) {
 
                     final HttpServletRequest request = HttpServletRequestThreadLocal.INSTANCE.getRequest();
 
-                    final DotTempFile tempFile = tempApi.getTempFile(request, contentlet.getStringProperty(field.variable())).get();
+                    final DotTempFile tempFile = tempApi.getTempFile(request,
+                            contentlet.getStringProperty(field.variable())).get();
                     contentlet.setBinary(field, tempFile.file);
                 }
             }
-
 
             String oldHostId = null;
 
             if (createNewVersion && contentlet != null && InodeUtils.isSet(contentlet.getInode())) {
                 // maybe the user want to save new content with existing inode & identifier comming from somewhere
                 // we need to check that the inode doesn't exists
-                DotConnect dc=new DotConnect();
+                DotConnect dc = new DotConnect();
                 dc.setSQL("select inode from contentlet where inode=?");
                 dc.addParam(contentlet.getInode());
-                if(dc.loadResults().size()>0){
-                    if(contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME) != null){
-                        Logger.debug(this, "forcing checking with no version as the _dont_validate_me is set and inode exists");
+                if (dc.loadResults().size() > 0) {
+                    if (contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME) != null) {
+                        Logger.debug(this,
+                                "forcing checking with no version as the _dont_validate_me is set and inode exists");
                         createNewVersion = false;
-                    }else{
+                    } else {
                         throw new DotContentletStateException("Contentlet must not exist already");
                     }
                 } else {
 
-                    existingInode=contentlet.getInode();
+                    existingInode = contentlet.getInode();
                     contentlet.setInode(null);
 
-                    Identifier ident=APILocator.getIdentifierAPI().find(contentlet.getIdentifier());
+                    Identifier ident = APILocator.getIdentifierAPI()
+                            .find(contentlet.getIdentifier());
 
-                    if(ident==null || !UtilMethods.isSet(ident.getId())) {
-                        existingIdentifier=contentlet.getIdentifier();
+                    if (ident == null || !UtilMethods.isSet(ident.getId())) {
+                        existingIdentifier = contentlet.getIdentifier();
                         contentlet.setIdentifier(null);
                     }
                 }
@@ -4851,10 +5327,15 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 }
             }
 
-            if (!createNewVersion && contentlet != null && !InodeUtils.isSet(contentlet.getInode()))
+            if (!createNewVersion && contentlet != null && !InodeUtils.isSet(
+                    contentlet.getInode())) {
                 throw new DotContentletStateException("Contentlet must exist already");
-            if (contentlet != null && contentlet.isArchived() && contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME) == null)
-                throw new DotContentletStateException("Unable to checkin an archived piece of content, please un-archive first");
+            }
+            if (contentlet != null && contentlet.isArchived()
+                    && contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME) == null) {
+                throw new DotContentletStateException(
+                        "Unable to checkin an archived piece of content, please un-archive first");
+            }
 
             checkPermission(contentlet, respectFrontendRoles, user);
 
@@ -4864,34 +5345,38 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             // note: we do this in this way in order to invoke hooks if they are
-            APILocator.getContentletAPI().validateContentlet(contentlet, contentRelationships, categories);
+            APILocator.getContentletAPI()
+                    .validateContentlet(contentlet, contentRelationships, categories);
 
-            if(contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME) == null) {
+            if (contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME) == null) {
                 canLock(contentlet, user, respectFrontendRoles);
             }
             contentlet.setModUser(user.getUserId());
             // start up workflow
-            final WorkflowAPI workflowAPI  = APILocator.getWorkflowAPI();
-            WorkflowProcessor workflow=null;
+            final WorkflowAPI workflowAPI = APILocator.getWorkflowAPI();
+            WorkflowProcessor workflow = null;
 
-            if(contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW)==null &&
+            if (contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW) == null &&
                     UtilMethods.isSet(contentlet.getActionId()) &&
                     (null == contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS) ||
-                            Boolean.FALSE.equals(contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS))
-                    ))  {
-                workflow = workflowAPI.fireWorkflowPreCheckin(contentlet,user);
+                            Boolean.FALSE.equals(
+                                    contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS))
+                    )) {
+                workflow = workflowAPI.fireWorkflowPreCheckin(contentlet, user);
             }
 
             workingContentlet = contentlet;
-            if(createNewVersion){
+            if (createNewVersion) {
                 workingContentlet = findWorkingContentlet(contentlet);
             }
-            String workingContentletInode = (workingContentlet==null) ? "" : workingContentlet.getInode();
+            String workingContentletInode =
+                    (workingContentlet == null) ? "" : workingContentlet.getInode();
 
             boolean priority = contentlet.isLowIndexPriority();
 
-            Boolean dontValidateMe = (Boolean)contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME);
-            Boolean disableWorkflow = (Boolean)contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW);
+            Boolean dontValidateMe = (Boolean) contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME);
+            Boolean disableWorkflow = (Boolean) contentlet.getMap()
+                    .get(Contentlet.DISABLE_WORKFLOW);
 
             final boolean isNewContent = !InodeUtils.isSet(workingContentletInode);
 
@@ -4912,24 +5397,31 @@ public class ESContentletAPIImpl implements ContentletAPI {
             //While the original contentlet first will get stuff marked for delete and then refreshed after saved in the database.
             final Contentlet contentletRaw = populateHost(contentlet);
 
-            if ( contentlet.getMap().get( "_use_mod_date" ) != null ) {
+            if (contentlet.getMap().get("_use_mod_date") != null) {
                     /*
                      When a content is sent using the remote push publishing we want to respect the modification
                      dates the content already had.
                      */
-                contentlet.setModDate( (Date) contentlet.getMap().get( "_use_mod_date" ) );
+                contentlet.setModDate((Date) contentlet.getMap().get("_use_mod_date"));
             } else {
-                contentlet.setModDate( new Date() );
+                contentlet.setModDate(new Date());
             }
 
             // Keep the 5 properties BEFORE store the contentlet on DB.
-            final String contentPushPublishDate = contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE);
-            final String contentPushPublishTime = contentlet.getStringProperty(Contentlet.WORKFLOW_PUBLISH_TIME);
-            final String contentPushPublishTimeZoneId = contentlet.getStringProperty(Contentlet.WORKFLOW_TIMEZONE_ID);
-            final String contentPushExpireDate = contentlet.getStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE);
-            final String contentPushExpireTime = contentlet.getStringProperty(Contentlet.WORKFLOW_EXPIRE_TIME);
-            final String contentPushNeverExpire = contentlet.getStringProperty(Contentlet.WORKFLOW_NEVER_EXPIRE);
-            final String contentWhereToSend = contentlet.getStringProperty(Contentlet.WHERE_TO_SEND);
+            final String contentPushPublishDate = contentlet.getStringProperty(
+                    Contentlet.WORKFLOW_PUBLISH_DATE);
+            final String contentPushPublishTime = contentlet.getStringProperty(
+                    Contentlet.WORKFLOW_PUBLISH_TIME);
+            final String contentPushPublishTimeZoneId = contentlet.getStringProperty(
+                    Contentlet.WORKFLOW_TIMEZONE_ID);
+            final String contentPushExpireDate = contentlet.getStringProperty(
+                    Contentlet.WORKFLOW_EXPIRE_DATE);
+            final String contentPushExpireTime = contentlet.getStringProperty(
+                    Contentlet.WORKFLOW_EXPIRE_TIME);
+            final String contentPushNeverExpire = contentlet.getStringProperty(
+                    Contentlet.WORKFLOW_NEVER_EXPIRE);
+            final String contentWhereToSend = contentlet.getStringProperty(
+                    Contentlet.WHERE_TO_SEND);
             final String filterKey = contentlet.getStringProperty(Contentlet.FILTER_KEY);
             final String iWantTo = contentlet.getStringProperty(Contentlet.I_WANT_TO);
             final String pathToMove = contentlet.getStringProperty(Contentlet.PATH_TO_MOVE);
@@ -4941,11 +5433,11 @@ public class ESContentletAPIImpl implements ContentletAPI {
                  */
             String htmlPageURL = null;
 
-            if ( contentlet.isHTMLPage() ) {
+            if (contentlet.isHTMLPage()) {
                 //Getting the URL saved on the contentlet form
-                htmlPageURL = contentletRaw.getStringProperty( HTMLPageAssetAPI.URL_FIELD );
+                htmlPageURL = contentletRaw.getStringProperty(HTMLPageAssetAPI.URL_FIELD);
                 //Clean-up the contentlet object, we don' want to persist this URL in the db
-                removeURLFromContentlet( contentlet );
+                removeURLFromContentlet(contentlet);
 
                 try {
                     //Verify if the template needs to be update for all versions of the content page
@@ -4959,22 +5451,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             //Preparing the tags info to be related to this contentlet
             final HashMap<String, String> tagsValues = new HashMap<>();
-            final String tagsHost = prepareTags(contentlet, user, contentType, structureHasAHostField,
+            final String tagsHost = prepareTags(contentlet, user, contentType,
+                    structureHasAHostField,
                     tagsValues);
 
-            final IndexPolicy indexPolicy             = contentlet.getIndexPolicy();
+            final IndexPolicy indexPolicy = contentlet.getIndexPolicy();
             final IndexPolicy indexPolicyDependencies = contentlet.getIndexPolicyDependencies();
 
-            boolean changedURI = addOrUpdateContentletIdentifier(contentlet, contentletRaw, existingIdentifier, existingInode, htmlPageURL);
+            boolean changedURI = addOrUpdateContentletIdentifier(contentlet, contentletRaw,
+                    existingIdentifier, existingInode, htmlPageURL);
 
-            if(shouldRemoveOldHostCache(contentlet, oldHostId)) {
+            if (shouldRemoveOldHostCache(contentlet, oldHostId)) {
                 CacheLocator.getVanityURLCache().remove(oldHostId, contentlet.getLanguageId());
             }
 
             contentlet = applyNullProperties(contentlet);
 
             //This is executed first hand to create the inode-contentlet relationship.
-            if(InodeUtils.isSet(existingInode)) {
+            if (InodeUtils.isSet(existingInode)) {
                 contentlet = contentFactory.save(contentlet, existingInode);
             } else {
                 contentlet = contentFactory.save(contentlet);
@@ -4987,17 +5481,18 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             APILocator.getVersionableAPI().setWorking(contentlet);
 
-
             if (workingContentlet == null) {
                 workingContentlet = contentlet;
             }
 
-            final boolean movedContentDependencies = (createNewVersion || contentRelationships != null
+            final boolean movedContentDependencies = (createNewVersion
+                    || contentRelationships != null
                     || categories != null);
 
             if (movedContentDependencies) {
                 contentlet.setBoolProperty(CHECKIN_IN_PROGRESS, Boolean.TRUE);
-                moveContentDependencies(workingContentlet, contentlet, contentRelationships, categories, user, respectFrontendRoles);
+                moveContentDependencies(workingContentlet, contentlet, contentRelationships,
+                        categories, user, respectFrontendRoles);
             }
 
             // Refreshing permissions
@@ -5011,27 +5506,30 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             //set again the don't validate me and disable workflow properties
             //if they were set
-            if(dontValidateMe != null){
+            if (dontValidateMe != null) {
                 contentlet.setProperty(Contentlet.DONT_VALIDATE_ME, dontValidateMe);
             }
 
-            if(disableWorkflow != null){
+            if (disableWorkflow != null) {
                 contentlet.setProperty(Contentlet.DISABLE_WORKFLOW, disableWorkflow);
             }
 
-            handleBinaries(contentlet, createNewVersion, contentType, workingContentlet, contentletRaw);
+            handleBinaries(contentlet, createNewVersion, contentType, workingContentlet,
+                    contentletRaw);
 
             updatePublishAndExpireDates(contentlet, systemUser, contentletRaw);
 
-            final Structure hostStructure = CacheLocator.getContentTypeCache().getStructureByVelocityVarName("Host");
+            final Structure hostStructure = CacheLocator.getContentTypeCache()
+                    .getStructureByVelocityVarName("Host");
             if (InodeUtils.isSet(contentlet.getIdentifier()) && contentlet.getStructureInode()
                     .equals(hostStructure.getInode())) {
                 final HostAPI hostAPI = APILocator.getHostAPI();
                 hostAPI.updateCache(new Host(contentlet));
 
                 final ContentletCache cc = CacheLocator.getContentletCache();
-                final Identifier ident=APILocator.getIdentifierAPI().find(contentlet);
-                final List<Contentlet> contentlets = findAllVersions(ident, systemUser, respectFrontendRoles);
+                final Identifier ident = APILocator.getIdentifierAPI().find(contentlet);
+                final List<Contentlet> contentlets = findAllVersions(ident, systemUser,
+                        respectFrontendRoles);
                 for (final Contentlet c : contentlets) {
                     final Host h = new Host(c);
                     cc.remove(h.getHostname());
@@ -5042,15 +5540,16 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                 //update tag references
                 String oldTagStorageId = "SYSTEM_HOST";
-                if(workingContentlet.getMap().get("tagStorage")!=null) {
+                if (workingContentlet.getMap().get("tagStorage") != null) {
                     oldTagStorageId = workingContentlet.getMap().get("tagStorage").toString();
                 }
 
                 String newTagStorageId = "SYSTEM_HOST";
-                if(contentlet.getMap().get("tagStorage")!=null) {
+                if (contentlet.getMap().get("tagStorage") != null) {
                     newTagStorageId = contentlet.getMap().get("tagStorage").toString();
                 }
-                tagAPI.updateTagReferences(contentlet.getIdentifier(), oldTagStorageId, newTagStorageId);
+                tagAPI.updateTagReferences(contentlet.getIdentifier(), oldTagStorageId,
+                        newTagStorageId);
             }
 
             flushMenuCacheIfNeeded(contentlet, workingContentlet, isNewContent, systemUser);
@@ -5062,7 +5561,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
             // Set the properties again after the store on DB and before the fire on an Actionlet.
             contentlet.setStringProperty(Contentlet.WORKFLOW_PUBLISH_DATE, contentPushPublishDate);
             contentlet.setStringProperty(Contentlet.WORKFLOW_PUBLISH_TIME, contentPushPublishTime);
-            contentlet.setStringProperty(Contentlet.WORKFLOW_TIMEZONE_ID, contentPushPublishTimeZoneId);
+            contentlet.setStringProperty(Contentlet.WORKFLOW_TIMEZONE_ID,
+                    contentPushPublishTimeZoneId);
             contentlet.setStringProperty(Contentlet.WORKFLOW_EXPIRE_DATE, contentPushExpireDate);
             contentlet.setStringProperty(Contentlet.WORKFLOW_EXPIRE_TIME, contentPushExpireTime);
             contentlet.setStringProperty(Contentlet.WORKFLOW_NEVER_EXPIRE, contentPushNeverExpire);
@@ -5074,7 +5574,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             //workflowAPI.
-            if(workflow!=null) {
+            if (workflow != null) {
                 workflow.setContentlet(contentlet);
                 workflowAPI.fireWorkflowPostCheckin(workflow);
             }
@@ -5082,13 +5582,14 @@ public class ESContentletAPIImpl implements ContentletAPI {
             new ContentletLoader().invalidate(contentlet);
 
         } catch (Exception e) {
-            if(createNewVersion && workingContentlet!= null && UtilMethods.isSet(workingContentlet.getInode())){
+            if (createNewVersion && workingContentlet != null && UtilMethods.isSet(
+                    workingContentlet.getInode())) {
                 APILocator.getVersionableAPI().setWorking(workingContentlet);
             }
 
-            if (e instanceof DotContentletValidationException){
+            if (e instanceof DotContentletValidationException) {
                 Logger.warnAndDebug(this.getClass(), e.getMessage(), e);
-            } else{
+            } else {
                 Logger.error(this, e.getMessage(), e);
             }
 
@@ -5106,34 +5607,41 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
 
     /**
-     * if we're not provided with an identifier this will attempt generating one.
-     * In case an identifier already exists, it will be updated if needed. For example: when a folder path or host is changed
-     * The inode is also generated here. For it is used internally to avoid collisions on the identifier table generating a unique asset name.
-     * We're taking advantage of the exising logic on {@link ESContentFactoryImpl}'s save method.
-     * That always explore the given contentlet trying to find a provided inode.
-     * Like this:
+     * if we're not provided with an identifier this will attempt generating one. In case an
+     * identifier already exists, it will be updated if needed. For example: when a folder path or
+     * host is changed The inode is also generated here. For it is used internally to avoid
+     * collisions on the identifier table generating a unique asset name. We're taking advantage of
+     * the exising logic on {@link ESContentFactoryImpl}'s save method. That always explore the
+     * given contentlet trying to find a provided inode. Like this:
      * <pre>
      * {@code
      *     final String inode = getInode(existingInode, contentlet);
      * }
      * </pre>
-     * @param contentlet the modified copy contentlet we want to save. After this method execution, this contentlet will contain the new identifier and inode (if applies)
-     * @param contentletRaw the incoming copy that holds every value passed from the front-end
-     * @param existingIdentifier if internalCheckin decides we need to use an existing identifier we will use it
-     * @param existingInode if internalCheckin decides we need to use an existing inode we will use it
-     * @param htmlPageURL for pages we use the url to generate a unique asset name wen saving into the the contentlet table
+     *
+     * @param contentlet         the modified copy contentlet we want to save. After this method
+     *                           execution, this contentlet will contain the new identifier and
+     *                           inode (if applies)
+     * @param contentletRaw      the incoming copy that holds every value passed from the front-end
+     * @param existingIdentifier if internalCheckin decides we need to use an existing identifier we
+     *                           will use it
+     * @param existingInode      if internalCheckin decides we need to use an existing inode we will
+     *                           use it
+     * @param htmlPageURL        for pages we use the url to generate a unique asset name wen saving
+     *                           into the the contentlet table
      * @return A boolean indicating if the contentlet's URI changed
      * @throws DotSecurityException
      * @throws DotDataException
      */
-    private boolean addOrUpdateContentletIdentifier(final Contentlet contentlet, final Contentlet contentletRaw,
+    private boolean addOrUpdateContentletIdentifier(final Contentlet contentlet,
+            final Contentlet contentletRaw,
             final String existingIdentifier, final String existingInode, final String htmlPageURL)
             throws DotSecurityException, DotDataException {
 
         final FolderAPI folderAPI = APILocator.getFolderAPI();
-        final HostAPI hostAPI     = APILocator.getHostAPI();
+        final HostAPI hostAPI = APILocator.getHostAPI();
         final IdentifierAPI identifierAPI = APILocator.getIdentifierAPI();
-        final User systemUser     = APILocator.systemUser();
+        final User systemUser = APILocator.systemUser();
 
         Identifier identifier;
         if (!InodeUtils.isSet(contentlet.getIdentifier())) {
@@ -5166,7 +5674,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                         identifierAPI.createNew(asset, parent);
 
                 contentlet.setIdentifier(identifier.getId());
-            }finally {
+            } finally {
                 //Clean-up the contentlet object again..., we don' want to persist this URL in the db
                 removeURLFromContentlet(contentlet);
             }
@@ -5175,8 +5683,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
             //Existing contentlet getting updated.
             identifier = identifierAPI.find(contentlet);
 
-            if (null == identifier || !UtilMethods.isSet(identifier.getId())){
-                throw new DotDataException(String.format("Contentlet with ID '%s' has not been found.", contentlet.getIdentifier()));
+            if (null == identifier || !UtilMethods.isSet(identifier.getId())) {
+                throw new DotDataException(
+                        String.format("Contentlet with ID '%s' has not been found.",
+                                contentlet.getIdentifier()));
             }
 
             final String oldURI = identifier.getURI();
@@ -5187,16 +5697,22 @@ public class ESContentletAPIImpl implements ContentletAPI {
             CacheLocator.getIdentifierCache().removeFromCacheByVersionable(contentlet);
             // Once the contentlet is saved, it gets refresh from the db. for which the incoming data gets lost.
             // Therefore here we need to make sure we use the original contentlet that comes with the info passed from the ui.
-            final String hostId = UtilMethods.isSet(contentletRaw.getHost()) ? contentletRaw.getHost() : contentlet.getHost();
+            final String hostId =
+                    UtilMethods.isSet(contentletRaw.getHost()) ? contentletRaw.getHost()
+                            : contentlet.getHost();
             identifier.setHostId(hostId);
-            if(contentlet.isFileAsset()){
+            if (contentlet.isFileAsset()) {
                 try {
-                    if(contentletRaw.getBinary(FileAssetAPI.BINARY_FIELD) == null){
-                        final String binaryIdentifier = contentletRaw.getIdentifier() != null ? contentletRaw.getIdentifier() : StringPool.BLANK;
-                        final String binaryNode = contentletRaw.getInode() != null ? contentletRaw.getInode() : StringPool.BLANK;
-                        throw new FileAssetValidationException("Unable to validate field: " + FileAssetAPI.BINARY_FIELD
-                                + " identifier: " + binaryIdentifier
-                                + " inode: " + binaryNode);
+                    if (contentletRaw.getBinary(FileAssetAPI.BINARY_FIELD) == null) {
+                        final String binaryIdentifier = contentletRaw.getIdentifier() != null
+                                ? contentletRaw.getIdentifier() : StringPool.BLANK;
+                        final String binaryNode =
+                                contentletRaw.getInode() != null ? contentletRaw.getInode()
+                                        : StringPool.BLANK;
+                        throw new FileAssetValidationException(
+                                "Unable to validate field: " + FileAssetAPI.BINARY_FIELD
+                                        + " identifier: " + binaryIdentifier
+                                        + " inode: " + binaryNode);
                     } else {
                         //We no longer use the old BinaryField to recover the file name.
                         //From now on we'll recover such value from the field "fileName" presented on the screen.
@@ -5210,13 +5726,14 @@ public class ESContentletAPIImpl implements ContentletAPI {
                         );
                     }
                 } catch (IOException e) {
-                    Logger.error( this.getClass(), "Error handling Binary Field.", e );
+                    Logger.error(this.getClass(), "Error handling Binary Field.", e);
                 }
-            } else if ( contentlet.isHTMLPage() ) {
+            } else if (contentlet.isHTMLPage()) {
                 //For HTML Pages - The asset name maps to the page URL
-                identifier.setAssetName( htmlPageURL );
+                identifier.setAssetName(htmlPageURL);
             }
-            if(UtilMethods.isSet(contentletRaw.getFolder()) && !contentletRaw.getFolder().equals(FolderAPI.SYSTEM_FOLDER)){
+            if (UtilMethods.isSet(contentletRaw.getFolder()) && !contentletRaw.getFolder()
+                    .equals(FolderAPI.SYSTEM_FOLDER)) {
                 final Folder folder = folderAPI.find(contentletRaw.getFolder(), systemUser, false);
                 if (null != folder) {
                     Identifier folderIdent = identifierAPI.find(folder.getIdentifier());
@@ -5233,15 +5750,18 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
 
     /**
-     * This takes the incoming contentlet makes a copy out of it and includes all the system fields in it so they can be used to generate a sound json representation of the contentlet
-     * System fields are required to generate a json representation of the contentlet
+     * This takes the incoming contentlet makes a copy out of it and includes all the system fields
+     * in it so they can be used to generate a sound json representation of the contentlet System
+     * fields are required to generate a json representation of the contentlet
+     *
      * @param contentlet
      * @param contentletRaw
      * @param tagsValues
      * @return
      */
     private Contentlet includeSystemFields(final Contentlet contentlet,
-            final Contentlet contentletRaw, final Map<String, String> tagsValues, final List<Category> categories, final User user) {
+            final Contentlet contentletRaw, final Map<String, String> tagsValues,
+            final List<Category> categories, final User user) {
         final ContentType contentType = contentlet.getContentType();
         final Contentlet systemFieldsInclusiveContentlet = new Contentlet(contentlet);
         final Map<String, Object> map = systemFieldsInclusiveContentlet.getMap();
@@ -5257,16 +5777,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 }
                 continue;
             }
-            if(systemField instanceof CategoryField){
+            if (systemField instanceof CategoryField) {
                 //This is a bit obscure logic. In order to find if a category belongs into a category-field we need to extract the value stored in the field it self
                 final List<String> selectedCategories = new ArrayList<>();
-                final Category parent = Try.of(()->categoryAPI.find(systemField.values(), user, false)).getOrNull();
-                if(null != parent){
-                   for(final Category child:categories){
-                       if(categoryAPI.isParent(child, parent, user)){
-                           selectedCategories.add(child.getCategoryVelocityVarName());
-                       }
-                   }
+                final Category parent = Try.of(
+                        () -> categoryAPI.find(systemField.values(), user, false)).getOrNull();
+                if (null != parent) {
+                    for (final Category child : categories) {
+                        if (categoryAPI.isParent(child, parent, user)) {
+                            selectedCategories.add(child.getCategoryVelocityVarName());
+                        }
+                    }
                 }
                 map.put(systemField.variable(), selectedCategories);
                 continue;
@@ -5278,8 +5799,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * Invalidate the respective caches depending on the type of contentlet passed down
-     * And call the reindex
+     * Invalidate the respective caches depending on the type of contentlet passed down And call the
+     * reindex
+     *
      * @param contentlet
      * @param createNewVersion
      * @param user
@@ -5290,8 +5812,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    private void invalidateThenReindex(final Contentlet contentlet, final boolean createNewVersion, final User user,
-            final boolean changedURI, final boolean isNewContent, final boolean structureHasAHostField,
+    private void invalidateThenReindex(final Contentlet contentlet, final boolean createNewVersion,
+            final User user,
+            final boolean changedURI, final boolean isNewContent,
+            final boolean structureHasAHostField,
             final boolean movedContentDependencies) throws DotDataException, DotSecurityException {
         boolean isLive = false;
         if (contentlet.isHTMLPage()) {
@@ -5326,12 +5850,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
         }
 
-        if(contentlet.isVanityUrl()){
+        if (contentlet.isVanityUrl()) {
             //remove from cache
             APILocator.getVanityUrlAPI().invalidateVanityUrl(contentlet);
         }
 
-        if(contentlet.isKeyValue()){
+        if (contentlet.isKeyValue()) {
             //remove from cache
             CacheLocator.getKeyValueCache().remove(contentlet);
         }
@@ -5343,26 +5867,27 @@ public class ESContentletAPIImpl implements ContentletAPI {
             });
         }
 
-        if(structureHasAHostField && changedURI) {
+        if (structureHasAHostField && changedURI) {
             final DotConnect dc = new DotConnect();
-            dc.setSQL("select working_inode,live_inode from contentlet_version_info where identifier=? and lang<>?");
+            dc.setSQL(
+                    "select working_inode,live_inode from contentlet_version_info where identifier=? and lang<>?");
             dc.addParam(contentlet.getIdentifier());
             dc.addParam(contentlet.getLanguageId());
-            final List<Map<String,Object>> others = dc.loadResults();
-            for(final Map<String,Object> other : others) {
-                final String workingInode=(String)other.get("working_inode");
-                indexAPI.addContentToIndex(find(workingInode, user,false));
-                final String liveInode=(String)other.get("live_inode");
-                if(UtilMethods.isSet(liveInode) && !liveInode.equals(workingInode)){
-                    indexAPI.addContentToIndex(find(liveInode, user,false));
+            final List<Map<String, Object>> others = dc.loadResults();
+            for (final Map<String, Object> other : others) {
+                final String workingInode = (String) other.get("working_inode");
+                indexAPI.addContentToIndex(find(workingInode, user, false));
+                final String liveInode = (String) other.get("live_inode");
+                if (UtilMethods.isSet(liveInode) && !liveInode.equals(workingInode)) {
+                    indexAPI.addContentToIndex(find(liveInode, user, false));
                 }
             }
         }
     }
 
     /**
-     * Prepare Tags Info so they can be related later on
-     * We expect tagsValues and tagsHost
+     * Prepare Tags Info so they can be related later on We expect tagsValues and tagsHost
+     *
      * @param contentlet
      * @param user
      * @param contentType
@@ -5370,27 +5895,28 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @param tagsValues
      * @return tagsHost
      */
-    private String prepareTags(final Contentlet contentlet, final User user, final ContentType contentType,
+    private String prepareTags(final Contentlet contentlet, final User user,
+            final ContentType contentType,
             final boolean structureHasAHostField, final HashMap<String, String> tagsValues) {
         String tagsHost = Host.SYSTEM_HOST;
 
-        for ( com.dotcms.contenttype.model.field.Field field : contentType.fields(TagField.class) ) {
+        for (com.dotcms.contenttype.model.field.Field field : contentType.fields(TagField.class)) {
             String value = null;
-            if ( contentlet.getStringProperty(field.variable()) != null ) {
+            if (contentlet.getStringProperty(field.variable()) != null) {
                 value = contentlet.getStringProperty(field.variable()).trim();
             }
 
-            if ( UtilMethods.isSet(value) ) {
+            if (UtilMethods.isSet(value)) {
 
-                if ( structureHasAHostField || UtilMethods.isSet(contentlet.getHost())) {
+                if (structureHasAHostField || UtilMethods.isSet(contentlet.getHost())) {
                     Host host = null;
                     try {
                         host = APILocator.getHostAPI().find(contentlet.getHost(), user, true);
-                    } catch ( Exception e ) {
+                    } catch (Exception e) {
                         Logger.error(this, "Unable to get contentlet host", e);
                     }
-                    if ( (!UtilMethods.isSet(host) || !UtilMethods.isSet(host.getInode()))
-                            || host.getIdentifier().equals(Host.SYSTEM_HOST) ) {
+                    if ((!UtilMethods.isSet(host) || !UtilMethods.isSet(host.getInode()))
+                            || host.getIdentifier().equals(Host.SYSTEM_HOST)) {
                         tagsHost = Host.SYSTEM_HOST;
                     } else {
                         tagsHost = host.getIdentifier();
@@ -5402,7 +5928,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                 //We should not store the tags inside the field, the relation must only exist on the tag_inode table (Unless we want to save it as json)
                 contentlet.setStringProperty(field.variable(), "");
-            } else if(value!=null && value.equals("")) { // empty string means wiping out the tags
+            } else if (value != null && value.equals(
+                    "")) { // empty string means wiping out the tags
                 tagsValues.put(field.variable(), value);
             }
         }
@@ -5411,6 +5938,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * Pages and file need menu cache flush
+     *
      * @param contentlet
      * @param workingContentlet
      * @param isNewContent
@@ -5418,30 +5946,35 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    private void flushMenuCacheIfNeeded(final Contentlet contentlet, final Contentlet workingContentlet,
+    private void flushMenuCacheIfNeeded(final Contentlet contentlet,
+            final Contentlet workingContentlet,
             final boolean isNewContent, final User systemUser)
             throws DotDataException, DotSecurityException {
         // both file & page as content might trigger a menu cache flush
-        if(contentlet.isFileAsset() || contentlet.isHTMLPage() ) {
+        if (contentlet.isFileAsset() || contentlet.isHTMLPage()) {
             final Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
             final Host host = APILocator.getHostAPI().find(
                     identifier.getHostId(), APILocator.getUserAPI().getSystemUser(), false);
-            final Folder folder = APILocator.getFolderAPI().findFolderByPath(identifier.getParentPath(), host ,
-                    systemUser, false);
+            final Folder folder = APILocator.getFolderAPI()
+                    .findFolderByPath(identifier.getParentPath(), host,
+                            systemUser, false);
 
-            final boolean shouldRefresh=
+            final boolean shouldRefresh =
                     (contentlet.isFileAsset()
-                            && RefreshMenus.shouldRefreshMenus(APILocator.getFileAssetAPI().fromContentlet(
-                            workingContentlet)
-                            ,APILocator.getFileAssetAPI().fromContentlet(contentlet), isNewContent))
+                            && RefreshMenus.shouldRefreshMenus(
+                            APILocator.getFileAssetAPI().fromContentlet(
+                                    workingContentlet)
+                            , APILocator.getFileAssetAPI().fromContentlet(contentlet),
+                            isNewContent))
                             ||
                             (contentlet.isHTMLPage()
-                                    && RefreshMenus.shouldRefreshMenus(APILocator.getHTMLPageAssetAPI().fromContentlet(
-                                    workingContentlet)
-                                    ,APILocator.getHTMLPageAssetAPI().fromContentlet(contentlet),
+                                    && RefreshMenus.shouldRefreshMenus(
+                                    APILocator.getHTMLPageAssetAPI().fromContentlet(
+                                            workingContentlet)
+                                    , APILocator.getHTMLPageAssetAPI().fromContentlet(contentlet),
                                     isNewContent));
 
-            if(shouldRefresh){
+            if (shouldRefresh) {
                 RefreshMenus.deleteMenu(folder);
                 CacheLocator.getNavToolCache().removeNav(host.getIdentifier(), folder.getInode());
             }
@@ -5450,50 +5983,61 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * Update System Publish and Expire Dates
+     *
      * @param contentlet
      * @param systemUser
      * @param contentletRaw
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    private void updatePublishAndExpireDates(final Contentlet contentlet, final User systemUser, final Contentlet contentletRaw)
+    private void updatePublishAndExpireDates(final Contentlet contentlet, final User systemUser,
+            final Contentlet contentletRaw)
             throws DotDataException, DotSecurityException {
         // lets update identifier's sysPubDate & sysExpireDate
         if ((contentlet != null) && InodeUtils.isSet(contentlet.getIdentifier())) {
-            final Structure st= contentlet.getStructure();
-            if(UtilMethods.isSet(st.getPublishDateVar()) || UtilMethods.isSet(st.getExpireDateVar())) {
-                Identifier ident=APILocator.getIdentifierAPI().find(contentlet);
-                boolean save=false;
-                if(UtilMethods.isSet(st.getPublishDateVar())) {
-                    Date pdate= contentletRaw.getDateProperty(st.getPublishDateVar());
+            final Structure st = contentlet.getStructure();
+            if (UtilMethods.isSet(st.getPublishDateVar()) || UtilMethods.isSet(
+                    st.getExpireDateVar())) {
+                Identifier ident = APILocator.getIdentifierAPI().find(contentlet);
+                boolean save = false;
+                if (UtilMethods.isSet(st.getPublishDateVar())) {
+                    Date pdate = contentletRaw.getDateProperty(st.getPublishDateVar());
                     contentlet.setDateProperty(st.getPublishDateVar(), pdate);
-                    if((ident.getSysPublishDate()==null && pdate!=null) || // was null and now we have a value
-                            (ident.getSysPublishDate()!=null && //wasn't null and now is null or different
-                                    (pdate==null || !pdate.equals(ident.getSysPublishDate())))) {
+                    if ((ident.getSysPublishDate() == null && pdate != null) ||
+                            // was null and now we have a value
+                            (ident.getSysPublishDate() != null &&
+                                    //wasn't null and now is null or different
+                                    (pdate == null || !pdate.equals(ident.getSysPublishDate())))) {
                         ident.setSysPublishDate(pdate);
-                        save=true;
+                        save = true;
                     }
                 }
-                if(UtilMethods.isSet(st.getExpireDateVar())) {
-                    Date edate= contentletRaw.getDateProperty(st.getExpireDateVar());
+                if (UtilMethods.isSet(st.getExpireDateVar())) {
+                    Date edate = contentletRaw.getDateProperty(st.getExpireDateVar());
                     contentlet.setDateProperty(st.getExpireDateVar(), edate);
-                    if((ident.getSysExpireDate()==null && edate!=null) || // was null and now we have a value
-                            (ident.getSysExpireDate()!=null && //wasn't null and now is null or different
-                                    (edate==null || !edate.equals(ident.getSysExpireDate())))) {
+                    if ((ident.getSysExpireDate() == null && edate != null) ||
+                            // was null and now we have a value
+                            (ident.getSysExpireDate() != null &&
+                                    //wasn't null and now is null or different
+                                    (edate == null || !edate.equals(ident.getSysExpireDate())))) {
                         ident.setSysExpireDate(edate);
-                        save=true;
+                        save = true;
                     }
                 }
-                if (!contentlet.isLive() && UtilMethods.isSet( st.getExpireDateVar() ) ) {//Verify if the structure have a Expire Date Field set
-                    if(contentlet
-                            .getMap().get(Contentlet.DONT_VALIDATE_ME) == null || !(Boolean) contentlet
-                            .getMap().get(Contentlet.DONT_VALIDATE_ME)){
-                        if(UtilMethods.isSet(ident.getSysExpireDate()) && ident.getSysExpireDate().before( new Date())) {
-                            throw new DotContentletValidationException( "message.contentlet.expired" );
+                if (!contentlet.isLive() && UtilMethods.isSet(
+                        st.getExpireDateVar())) {//Verify if the structure have a Expire Date Field set
+                    if (contentlet
+                            .getMap().get(Contentlet.DONT_VALIDATE_ME) == null
+                            || !(Boolean) contentlet
+                            .getMap().get(Contentlet.DONT_VALIDATE_ME)) {
+                        if (UtilMethods.isSet(ident.getSysExpireDate()) && ident.getSysExpireDate()
+                                .before(new Date())) {
+                            throw new DotContentletValidationException(
+                                    "message.contentlet.expired");
                         }
                     }
                 }
-                if(save) {
+                if (save) {
 
                     // publish/expire dates changed
                     APILocator.getIdentifierAPI().save(ident);
@@ -5504,16 +6048,18 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             .findContentletVersionInfos(ident.getId());
 
                     final List<String> inodes = new ArrayList<>();
-                    for(final ContentletVersionInfo cvi : list) {
+                    for (final ContentletVersionInfo cvi : list) {
                         inodes.add(cvi.getWorkingInode());
-                        if(UtilMethods.isSet(cvi.getLiveInode()) && !cvi.getWorkingInode().equals(cvi.getLiveInode())){
+                        if (UtilMethods.isSet(cvi.getLiveInode()) && !cvi.getWorkingInode()
+                                .equals(cvi.getLiveInode())) {
                             inodes.add(cvi.getLiveInode());
                         }
                     }
-                    for(final String inode : inodes) {
+                    for (final String inode : inodes) {
                         CacheLocator.getContentletCache().remove(inode);
-                        final Contentlet ct = APILocator.getContentletAPI().find(inode, systemUser, false);
-                        APILocator.getContentletIndexAPI().addContentToIndex(ct,false);
+                        final Contentlet ct = APILocator.getContentletAPI()
+                                .find(inode, systemUser, false);
+                        APILocator.getContentletIndexAPI().addContentToIndex(ct, false);
                     }
                 }
             }
@@ -5521,11 +6067,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * Takes the original contentlet passed down from internalCheckin
-     * Relate the tags using the respective api and add the related tags back into the original contentlet that was passed down
+     * Takes the original contentlet passed down from internalCheckin Relate the tags using the
+     * respective api and add the related tags back into the original contentlet that was passed
+     * down
+     *
      * @param contentlet contetlet reference
      * @param tagsValues prepared tags
-     * @param tagsHost prepared
+     * @param tagsHost   prepared
      * @return mutated contentlet
      * @throws DotSecurityException
      * @throws DotDataException
@@ -5533,24 +6081,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
     private Contentlet relateTags(final Contentlet contentlet, final Map<String, String> tagsValues,
             final String tagsHost) throws DotSecurityException, DotDataException {
         //Relate the tags with the saved contentlet
-        for (final Entry<String, String> tagEntry : tagsValues.entrySet() ) {
+        for (final Entry<String, String> tagEntry : tagsValues.entrySet()) {
             //From the given CSV tags names list search for the tag objects and if does not exist create them
             final List<Tag> tagList = tagAPI.getTagsInText(tagEntry.getValue(), tagsHost);
 
             // empty string for tag field value wipes out existing tags
-            if(UtilMethods.isSet(tagList) || StringPool.BLANK.equals(tagEntry.getValue())) {
+            if (UtilMethods.isSet(tagList) || StringPool.BLANK.equals(tagEntry.getValue())) {
                 tagAPI.deleteTagInodesByInodeAndFieldVarName(contentlet.getInode(),
                         tagEntry.getKey());
             }
 
-            for (final Tag tag : tagList ) {
+            for (final Tag tag : tagList) {
                 //Relate the found/created tag with this contentlet
                 tagAPI.addContentletTagInode(tag, contentlet.getInode(), tagEntry.getKey());
             }
             //Adding tags back as field to be returned
-            if (tagEntry.getValue()!=null && !StringPool.BLANK.equals(tagEntry.getValue())) {
+            if (tagEntry.getValue() != null && !StringPool.BLANK.equals(tagEntry.getValue())) {
                 contentlet.setProperty(tagEntry.getKey(), tagEntry.getValue());
-            } else{
+            } else {
                 contentlet.setProperty(tagEntry.getKey(), null);
             }
         }
@@ -5558,22 +6106,25 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     *
-     * @param contentlet Just Saved contentlet it is supposed to have at least an inode
+     * @param contentlet        Just Saved contentlet it is supposed to have at least an inode
      * @param createNewVersion
-     * @param contentType ContentType
-     * @param workingContentlet Working version of our content. If different from the actual then it has prior version's inode
-     * @param contentletRaw incoming content loaded from the ui. This one has all the files
+     * @param contentType       ContentType
+     * @param workingContentlet Working version of our content. If different from the actual then it
+     *                          has prior version's inode
+     * @param contentletRaw     incoming content loaded from the ui. This one has all the files
      * @return bool that says whether or not there were files to process
      * @throws DotDataException
      */
-    private boolean handleBinaries(final Contentlet contentlet, final boolean createNewVersion, final ContentType contentType, final Contentlet workingContentlet, final Contentlet contentletRaw) throws DotDataException {
+    private boolean handleBinaries(final Contentlet contentlet, final boolean createNewVersion,
+            final ContentType contentType, final Contentlet workingContentlet,
+            final Contentlet contentletRaw) throws DotDataException {
 
         // http://jira.dotmarketing.net/browse/DOTCMS-1073
         // storing binary files in file system.
         Logger.debug(this, "ContentletAPIImpl : storing binary files in file system.");
 
-        final boolean validateEmptyFile = UtilMethods.isSetOrGet(contentlet.getBoolProperty(Contentlet.VALIDATE_EMPTY_FILE), true);
+        final boolean validateEmptyFile = UtilMethods.isSetOrGet(
+                contentlet.getBoolProperty(Contentlet.VALIDATE_EMPTY_FILE), true);
 
         // Binary Files
         final String newInode = contentlet.getInode();
@@ -5586,7 +6137,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         newDir.mkdirs();
 
         File oldDir = null;
-        if(UtilMethods.isSet(oldInode)) {
+        if (UtilMethods.isSet(oldInode)) {
             oldDir = new File(APILocator.getFileAssetAPI().getRealAssetsRootPath()
                     + File.separator + oldInode.charAt(0)
                     + File.separator + oldInode.charAt(1)
@@ -5594,7 +6145,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
 
         File tmpDir = null;
-        if(UtilMethods.isSet(oldInode)) {
+        if (UtilMethods.isSet(oldInode)) {
             tmpDir = new File(APILocator.getFileAssetAPI().getRealAssetPathTmpBinary()
                     + File.separator + oldInode.charAt(0)
                     + File.separator + oldInode.charAt(1)
@@ -5606,56 +6157,67 @@ public class ESContentletAPIImpl implements ContentletAPI {
         // loop over the new field values
         // if we have a new temp file or a deleted file
         // do it to the new inode directory
-        for ( com.dotcms.contenttype.model.field.Field field : contentType.fields(BinaryField.class) ) {
+        for (com.dotcms.contenttype.model.field.Field field : contentType.fields(
+                BinaryField.class)) {
             try {
 
                 final String velocityVarNm = field.variable();
                 File incomingFile = contentletRaw.getBinary(velocityVarNm);
-                if(validateEmptyFile && incomingFile!=null && incomingFile.length()==0 && !Config.getBooleanProperty("CONTENT_ALLOW_ZERO_LENGTH_FILES", false)){
-                    throw new DotContentletStateException("Cannot checkin 0 length file: " + incomingFile );
+                if (validateEmptyFile && incomingFile != null && incomingFile.length() == 0
+                        && !Config.getBooleanProperty("CONTENT_ALLOW_ZERO_LENGTH_FILES", false)) {
+                    throw new DotContentletStateException(
+                            "Cannot checkin 0 length file: " + incomingFile);
                 }
-                final File binaryFieldFolder = new File(newDir.getAbsolutePath() + File.separator + velocityVarNm);
-
+                final File binaryFieldFolder = new File(
+                        newDir.getAbsolutePath() + File.separator + velocityVarNm);
 
                 // if the user has removed this file via ui
-                if (incomingFile == null  || incomingFile.getAbsolutePath().contains("-removed-")){
+                if (incomingFile == null || incomingFile.getAbsolutePath().contains("-removed-")) {
                     FileUtil.deltree(binaryFieldFolder);
                     contentlet.setBinary(velocityVarNm, null);
 
                     //For removed files we should cleanup any existing metadata.
-                    if(contentlet.isFileAsset()){
+                    if (contentlet.isFileAsset()) {
                         fileMetadataAPI.removeMetadata(contentlet);
                     }
 
                 } else { // if we have an incoming file
-                    if (incomingFile.exists() ){
+                    if (incomingFile.exists()) {
 
                         //If the incoming file is temp resource we need to find out if there is any metadata associated
-                        final Optional<String> tempResourceId = tempApi.getTempResourceId(incomingFile);
+                        final Optional<String> tempResourceId = tempApi.getTempResourceId(
+                                incomingFile);
 
                         //The physical file name is preserved across versions.
                         //No need to update the name. We will only reference the file through the logical asset-name
-                        final String oldFileName  = incomingFile.getName();
+                        final String oldFileName = incomingFile.getName();
 
                         File oldFile = null;
-                        if(UtilMethods.isSet(oldInode)) {
+                        if (UtilMethods.isSet(oldInode)) {
                             //get old file
-                            oldFile = new File(oldDir.getAbsolutePath()  + File.separator + velocityVarNm + File.separator +  oldFileName);
+                            oldFile = new File(
+                                    oldDir.getAbsolutePath() + File.separator + velocityVarNm
+                                            + File.separator + oldFileName);
 
                             // do we have an inline edited file, if so use that
-                            File editedFile = new File(tmpDir.getAbsolutePath()  + File.separator + velocityVarNm + File.separator + WebKeys.TEMP_FILE_PREFIX + oldFileName);
-                            if(editedFile.exists()){
+                            File editedFile = new File(
+                                    tmpDir.getAbsolutePath() + File.separator + velocityVarNm
+                                            + File.separator + WebKeys.TEMP_FILE_PREFIX
+                                            + oldFileName);
+                            if (editedFile.exists()) {
                                 incomingFile = editedFile;
                             }
                         }
 
                         //The file name must be preserved so it remains the same across versions.
-                        final File newFile = new File(newDir.getAbsolutePath()  + File.separator + velocityVarNm + File.separator +  oldFileName);
+                        final File newFile = new File(
+                                newDir.getAbsolutePath() + File.separator + velocityVarNm
+                                        + File.separator + oldFileName);
                         binaryFieldFolder.mkdirs();
 
                         // we move files that have been newly uploaded or edited
-                        if(oldFile==null || !oldFile.equals(incomingFile)){
-                            if(!createNewVersion){
+                        if (oldFile == null || !oldFile.equals(incomingFile)) {
+                            if (!createNewVersion) {
                                 // If we're calling a checkinWithoutVersioning method,
                                 // then folder needs to be cleaned up in order to add the new file in it.
                                 // Otherwise we will have the old file and incoming file at the same time
@@ -5677,30 +6239,37 @@ public class ESContentletAPIImpl implements ContentletAPI {
                                     validateEmptyFile);
                         }
 
-                        if(workingContentlet != contentlet){
+                        if (workingContentlet != contentlet) {
                             //This copies the metadata from version to version so we don't lose any any custom attribute previously added
                             fileMetadataAPI.copyCustomMetadata(workingContentlet, contentlet);
-                            Logger.debug(ESContentletAPIImpl.class,String.format("Metadata copied from inode: `%s` to  inode `%s` ", workingContentlet
-                                    .getInode(), contentlet.getInode()));
+                            Logger.debug(ESContentletAPIImpl.class, String.format(
+                                    "Metadata copied from inode: `%s` to  inode `%s` ",
+                                    workingContentlet
+                                            .getInode(), contentlet.getInode()));
                         }
 
                         contentlet.setBinary(velocityVarNm, newFile);
                         binaryHandled = true;
 
                         //This copies the metadata associated with the temp resource passed if any.
-                        if(tempResourceId.isPresent()){
-                            final Optional<Metadata> optionalMetadata = fileMetadataAPI.getMetadata(tempResourceId.get());
-                            if(optionalMetadata.isPresent()){
+                        if (tempResourceId.isPresent()) {
+                            final Optional<Metadata> optionalMetadata = fileMetadataAPI.getMetadata(
+                                    tempResourceId.get());
+                            if (optionalMetadata.isPresent()) {
                                 final Metadata tempMeta = optionalMetadata.get();
                                 fileMetadataAPI.putCustomMetadataAttributes(
-                                        contentlet, ImmutableMap.of(velocityVarNm, tempMeta.getCustomMeta()));
-                                Logger.debug(ESContentletAPIImpl.class,String.format("Metadata copied from temp resource: `%s` ", tempResourceId.get()));
+                                        contentlet,
+                                        ImmutableMap.of(velocityVarNm, tempMeta.getCustomMeta()));
+                                Logger.debug(ESContentletAPIImpl.class,
+                                        String.format("Metadata copied from temp resource: `%s` ",
+                                                tempResourceId.get()));
                             }
                         }
                     }
                 }
             } catch (IOException e) {
-                throw new DotContentletValidationException("Error occurred while processing the file:" + e.getMessage(),e);
+                throw new DotContentletValidationException(
+                        "Error occurred while processing the file:" + e.getMessage(), e);
             }
         }
         return binaryHandled;
@@ -5713,8 +6282,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         DotPreconditions.checkNotNull(contentlet);
 
-        if (InodeUtils.isSet(contentlet.getIdentifier())){
-            if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_WRITE, user, respectFrontendRoles)) {
+        if (InodeUtils.isSet(contentlet.getIdentifier())) {
+            if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_WRITE,
+                    user, respectFrontendRoles)) {
                 this.throwSecurityException(contentlet, user);
             }
         } else if (!permissionAPI.doesUserHavePermission(contentlet.getContentType(),
@@ -5724,9 +6294,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * Method that verifies if a check in operation can be executed.
-     * It is safe to execute a checkin if write operations can be performed on the ES cluster.
-     * Otherwise, check in will be allowed only if the contentlet to be saved does not have legacy relationships
+     * Method that verifies if a check in operation can be executed. It is safe to execute a checkin
+     * if write operations can be performed on the ES cluster. Otherwise, check in will be allowed
+     * only if the contentlet to be saved does not have legacy relationships
+     *
      * @param relationships ContentletRelationships with the records to be saved
      * @return
      */
@@ -5749,13 +6320,14 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * Given a ContentletRelationships object, verifies if there is any legacy relationship on it
+     *
      * @param relationships
      * @return
      */
     private boolean hasLegacyRelationships(ContentletRelationships relationships) {
         for (ContentletRelationshipRecords records : relationships
                 .getRelationshipsRecords()) {
-            if (!records.getRelationship().isRelationshipField()){
+            if (!records.getRelationship().isRelationshipField()) {
                 return true;
             }
         }
@@ -5764,6 +6336,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * Return a ContentletRelationships with all relationships found on the contentlet map
+     *
      * @param contentlet
      * @param user
      * @return
@@ -5790,7 +6363,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             .getRelationshipFromField(field, user);
                     final boolean hasParent = relationshipAPI.isChildField(relationship, field);
 
-                    if (contentRelationships == null){
+                    if (contentRelationships == null) {
                         contentRelationships = new ContentletRelationships(contentlet);
                     }
                     final ContentletRelationshipRecords relationshipRecords = contentRelationships.new ContentletRelationshipRecords(
@@ -5805,7 +6378,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         return contentRelationships;
     }
 
-    private void cleanupCacheOnChangedURI(final Contentlet contentlet){
+    private void cleanupCacheOnChangedURI(final Contentlet contentlet) {
         CacheLocator.getIdentifierCache().removeFromCacheByIdentifier(contentlet.getIdentifier());
         //Need both live and working contentlets for they all need to be evicted from cache.
         try {
@@ -5828,98 +6401,117 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     private void cleanup(final Contentlet contentlet) {
-        if(null != contentlet){
+        if (null != contentlet) {
             contentlet.getMap().remove(CHECKIN_IN_PROGRESS);
             contentlet.cleanup();
         }
     }
 
-    private void createLocalCheckinEvent(final Contentlet contentlet, final User user, final boolean createNewVersion) throws DotHibernateException {
+    private void createLocalCheckinEvent(final Contentlet contentlet, final User user,
+            final boolean createNewVersion) throws DotHibernateException {
 
         HibernateUtil.addCommitListener(
-                ()-> this.localSystemEventsAPI.notify(new ContentletCheckinEvent<>(contentlet, createNewVersion, user))
+                () -> this.localSystemEventsAPI.notify(
+                        new ContentletCheckinEvent<>(contentlet, createNewVersion, user))
         );
     }
 
     /**
-     * Updates the Template of the specified Contentlet - in case it's an HTML Page - in all of its existing language
-     * versions, only if its value is different from the current one. This update operation can be overridden by setting
-     * the configuration parameter {@code DO_NOT_UPDATE_TEMPLATES} as {@code true}.
+     * Updates the Template of the specified Contentlet - in case it's an HTML Page - in all of its
+     * existing language versions, only if its value is different from the current one. This update
+     * operation can be overridden by setting the configuration parameter
+     * {@code DO_NOT_UPDATE_TEMPLATES} as {@code true}.
      *
      * @param contentlet The {@link Contentlet} whose Template will be updated, if necessary
      * @param user       The {@link User} performing this action.
-     *
      * @throws DotDataException     An error occurred when interacting with the data source.
-     * @throws DotSecurityException The specified user does not have the required permissions to perform this action.
+     * @throws DotSecurityException The specified user does not have the required permissions to
+     *                              perform this action.
      */
     private void updateTemplateInAllLanguageVersions(final Contentlet contentlet, final User user)
-            throws DotDataException, DotSecurityException{
+            throws DotDataException, DotSecurityException {
         final boolean DONT_RESPECT_FRONTEND_ROLES = Boolean.FALSE;
-        final String DO_NOT_UPDATE_TEMPLATES= "DO_NOT_UPDATE_TEMPLATES";
+        final String DO_NOT_UPDATE_TEMPLATES = "DO_NOT_UPDATE_TEMPLATES";
 
-        if(contentlet.getBoolProperty(DO_NOT_UPDATE_TEMPLATES)){
+        if (contentlet.getBoolProperty(DO_NOT_UPDATE_TEMPLATES)) {
             return;
         }
-        if (UtilMethods.isSet(contentlet.getIdentifier())){
+        if (UtilMethods.isSet(contentlet.getIdentifier())) {
 
             final Optional<com.dotcms.contenttype.model.field.Field> templateField = contentlet
                     .getContentType().fields().stream()
                     .filter(field -> HTMLPageAssetAPI.TEMPLATE_FIELD.equals(field.variable()))
                     .findFirst();
 
-            if(templateField.isPresent()){
+            if (templateField.isPresent()) {
                 final String identifier = contentlet.getIdentifier();
-                final String newTemplate = contentlet.get(HTMLPageAssetAPI.TEMPLATE_FIELD).toString();
-                final Contentlet contentInAnyLang = findContentletByIdentifierAnyLanguage(contentlet.getIdentifier(), contentlet.getVariantId());
+                final String newTemplate = contentlet.get(HTMLPageAssetAPI.TEMPLATE_FIELD)
+                        .toString();
+                final Contentlet contentInAnyLang = findContentletByIdentifierAnyLanguage(
+                        contentlet.getIdentifier(), contentlet.getVariantId());
 
-                if (null == contentInAnyLang || !UtilMethods.isSet(contentInAnyLang.getIdentifier())) {
+                if (null == contentInAnyLang || !UtilMethods.isSet(
+                        contentInAnyLang.getIdentifier())) {
                     final Contentlet contentletByIdentifierAnyLanguageArchived = findContentletByIdentifierAnyLanguage(
                             contentlet.getIdentifier(), true);
 
-                    if (null == contentletByIdentifierAnyLanguageArchived || !UtilMethods.isSet(contentletByIdentifierAnyLanguageArchived.getIdentifier())) {
+                    if (null == contentletByIdentifierAnyLanguageArchived || !UtilMethods.isSet(
+                            contentletByIdentifierAnyLanguageArchived.getIdentifier())) {
                         throw new NotFoundInDbException(String.format(
-                                "Contentlet with ID '%s' has not been found: ", contentlet.getIdentifier()));
+                                "Contentlet with ID '%s' has not been found: ",
+                                contentlet.getIdentifier()));
                     } else if (contentletByIdentifierAnyLanguageArchived.isArchived()) {
                         throw new DotDataException(String.format(
-                                "Contentlet is currently marked as 'Archived'.", contentlet.getIdentifier()));
+                                "Contentlet is currently marked as 'Archived'.",
+                                contentlet.getIdentifier()));
                     } else {
                         return;
                     }
                 }
 
-                final String existingTemplate = loadField(contentInAnyLang.getInode(), templateField.get()).toString();
-                if (!existingTemplate.equals(newTemplate)){
-                    final List<ContentletVersionInfo> contentletVersions = APILocator.getVersionableAPI().findContentletVersionInfos(identifier, contentlet.getVariantId());
+                final String existingTemplate = loadField(contentInAnyLang.getInode(),
+                        templateField.get()).toString();
+                if (!existingTemplate.equals(newTemplate)) {
+                    final List<ContentletVersionInfo> contentletVersions = APILocator.getVersionableAPI()
+                            .findContentletVersionInfos(identifier, contentlet.getVariantId());
 
                     for (final ContentletVersionInfo version : contentletVersions) {
-                        final Contentlet contentVersion = find(version.getWorkingInode(), user, DONT_RESPECT_FRONTEND_ROLES);
+                        final Contentlet contentVersion = find(version.getWorkingInode(), user,
+                                DONT_RESPECT_FRONTEND_ROLES);
                         if (contentlet.getInode().equals(contentVersion.getInode())) {
                             continue;
                         }
 
                         //Create a new working version with the template when the page version is live and working
-                        final Contentlet newPageVersion = checkout(contentVersion.getInode(), user, DONT_RESPECT_FRONTEND_ROLES);
+                        final Contentlet newPageVersion = checkout(contentVersion.getInode(), user,
+                                DONT_RESPECT_FRONTEND_ROLES);
                         newPageVersion.setBoolProperty(DO_NOT_UPDATE_TEMPLATES, true);
-                        newPageVersion.setStringProperty(HTMLPageAssetAPI.TEMPLATE_FIELD, newTemplate);
+                        newPageVersion.setStringProperty(HTMLPageAssetAPI.TEMPLATE_FIELD,
+                                newTemplate);
                         newPageVersion.setBoolProperty(Contentlet.DONT_VALIDATE_ME, true);
 
                         if (contentlet.getMap().containsKey(Contentlet.DISABLE_WORKFLOW)) {
-                            newPageVersion.getMap().put(Contentlet.DISABLE_WORKFLOW, contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW));
+                            newPageVersion.getMap().put(Contentlet.DISABLE_WORKFLOW,
+                                    contentlet.getMap().get(Contentlet.DISABLE_WORKFLOW));
                         }
                         if (contentlet.getMap().containsKey(Contentlet.WORKFLOW_IN_PROGRESS)) {
-                            newPageVersion.getMap().put(Contentlet.WORKFLOW_IN_PROGRESS, contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS));
+                            newPageVersion.getMap().put(Contentlet.WORKFLOW_IN_PROGRESS,
+                                    contentlet.getMap().get(Contentlet.WORKFLOW_IN_PROGRESS));
                         }
 
-                        checkin(newPageVersion,  user, DONT_RESPECT_FRONTEND_ROLES);
+                        checkin(newPageVersion, user, DONT_RESPECT_FRONTEND_ROLES);
                     }
                 }
             }
         }
     }
 
-    private void pushSaveEvent (final Contentlet eventContentlet, final boolean eventCreateNewVersion) throws DotHibernateException {
+    private void pushSaveEvent(final Contentlet eventContentlet,
+            final boolean eventCreateNewVersion) throws DotHibernateException {
 
-        HibernateUtil.addCommitListener(() -> this.contentletSystemEventUtil.pushSaveEvent(eventContentlet, eventCreateNewVersion), 100);
+        HibernateUtil.addCommitListener(
+                () -> this.contentletSystemEventUtil.pushSaveEvent(eventContentlet,
+                        eventCreateNewVersion), 100);
     }
 
     private List<Category> getExistingContentCategories(Contentlet contentlet)
@@ -5927,8 +6519,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
         List<Category> cats = new ArrayList<>();
         Contentlet workingCon = findWorkingContentlet(contentlet);
 
-        if(workingCon!=null) {
-            cats = categoryAPI.getParents(workingCon, APILocator.getUserAPI().getSystemUser(), true);
+        if (workingCon != null) {
+            cats = categoryAPI.getParents(workingCon, APILocator.getUserAPI().getSystemUser(),
+                    true);
         }
         return cats;
     }
@@ -5937,16 +6530,19 @@ public class ESContentletAPIImpl implements ContentletAPI {
             final User user) throws DotSecurityException {
 
         final String userName = (user != null ? user.getUserId() : "Unknown");
-        final String message  = UtilMethods.isSet(contentlet.getIdentifier())?
-                "User: " + userName +" doesn't have write permissions to Contentlet: " + contentlet.getIdentifier():
-                "User: " + userName +" doesn't have write permissions to create the Contentlet";
+        final String message = UtilMethods.isSet(contentlet.getIdentifier()) ?
+                "User: " + userName + " doesn't have write permissions to Contentlet: "
+                        + contentlet.getIdentifier() :
+                "User: " + userName + " doesn't have write permissions to create the Contentlet";
 
         throw new DotSecurityException(message);
     }
 
     // todo: should be this in a transaction???
     @Override
-    public List<Contentlet> checkout(List<Contentlet> contentlets, User user,   boolean respectFrontendRoles) throws DotDataException,DotSecurityException, DotContentletStateException {
+    public List<Contentlet> checkout(List<Contentlet> contentlets, User user,
+            boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
         List<Contentlet> result = new ArrayList<Contentlet>();
         for (Contentlet contentlet : contentlets) {
             result.add(checkout(contentlet.getInode(), user, respectFrontendRoles));
@@ -5956,7 +6552,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     // todo: should be this in a transaction???
     @Override
-    public List<Contentlet> checkoutWithQuery(String luceneQuery, User user,boolean respectFrontendRoles) throws DotDataException,DotSecurityException, DotContentletStateException {
+    public List<Contentlet> checkoutWithQuery(String luceneQuery, User user,
+            boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
         List<Contentlet> result = new ArrayList<Contentlet>();
         List<Contentlet> cons = search(luceneQuery, 0, -1, "", user, respectFrontendRoles);
         for (Contentlet contentlet : cons) {
@@ -5967,7 +6565,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     // todo: should be this in a transaction???
     @Override
-    public List<Contentlet> checkout(String luceneQuery, User user,boolean respectFrontendRoles, int offset, int limit) throws DotDataException,DotSecurityException, DotContentletStateException {
+    public List<Contentlet> checkout(String luceneQuery, User user, boolean respectFrontendRoles,
+            int offset, int limit)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
         List<Contentlet> result = new ArrayList<Contentlet>();
         List<Contentlet> cons = search(luceneQuery, limit, offset, "", user, respectFrontendRoles);
         for (Contentlet contentlet : cons) {
@@ -5978,7 +6578,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public Contentlet checkout(final String contentletInode, final User user, final boolean respectFrontendRoles) throws DotDataException,DotSecurityException, DotContentletStateException {
+    public Contentlet checkout(final String contentletInode, final User user,
+            final boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
         //return new version
         final Contentlet contentlet = find(contentletInode, user, respectFrontendRoles);
 
@@ -6003,7 +6605,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
             final Identifier htmlPageIdentifier = APILocator.getIdentifierAPI()
                     .find(workingContentlet.getIdentifier());
             workingContentlet
-                    .setStringProperty(HTMLPageAssetAPI.URL_FIELD, htmlPageIdentifier.getAssetName());
+                    .setStringProperty(HTMLPageAssetAPI.URL_FIELD,
+                            htmlPageIdentifier.getAssetName());
         }
 
         return workingContentlet;
@@ -6011,6 +6614,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * This method moves categories and relationships dependencies
+     *
      * @param fromContentlet
      * @param toContentlet
      * @param contentRelationships
@@ -6020,7 +6624,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    private void moveContentDependencies(final Contentlet fromContentlet, final Contentlet toContentlet, ContentletRelationships contentRelationships, List<Category> categories, final User user, final boolean respect) throws DotDataException, DotSecurityException{
+    private void moveContentDependencies(final Contentlet fromContentlet,
+            final Contentlet toContentlet, ContentletRelationships contentRelationships,
+            List<Category> categories, final User user, final boolean respect)
+            throws DotDataException, DotSecurityException {
 
         //Handles Categories
         moveContentCategories(fromContentlet, toContentlet, categories, user, respect);
@@ -6030,7 +6637,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     *
      * @param fromContentlet
      * @param toContentlet
      * @param contentRelationships
@@ -6038,7 +6644,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    private void moveContentRelationships(final Contentlet fromContentlet, final Contentlet toContentlet,
+    private void moveContentRelationships(final Contentlet fromContentlet,
+            final Contentlet toContentlet,
             ContentletRelationships contentRelationships, final User user)
             throws DotDataException, DotSecurityException {
 
@@ -6063,7 +6670,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * This method keeps relationships as they are but also includes restricted content to the list to avoid deleting it
+     * This method keeps relationships as they are but also includes restricted content to the list
+     * to avoid deleting it
+     *
      * @param fromContentlet
      * @param contentRelationships
      * @param user
@@ -6073,7 +6682,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotSecurityException
      */
     private void addRestrictedContentForLimitedUser(final Contentlet fromContentlet,
-            final ContentletRelationships contentRelationships, final User user, final ContentType contentType,
+            final ContentletRelationships contentRelationships, final User user,
+            final ContentType contentType,
             final RelationshipAPI relationshipAPI) throws DotDataException, DotSecurityException {
         for (ContentletRelationshipRecords contentletRelationshipRecords : contentRelationships
                 .getRelationshipsRecords()) {
@@ -6109,15 +6719,18 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * This method creates a list of all relationships that will be wiped out
+     *
      * @param contentRelationships
      * @param contentType
      * @param relationshipAPI
      * @throws DotDataException
      */
     private void getWipeOutRelationships(final ContentletRelationships contentRelationships,
-            final ContentType contentType, final RelationshipAPI relationshipAPI) throws DotDataException {
+            final ContentType contentType, final RelationshipAPI relationshipAPI)
+            throws DotDataException {
         //wipe out all relationships
-        final List<Relationship> relationships = APILocator.getRelationshipAPI().byContentType(contentType);
+        final List<Relationship> relationships = APILocator.getRelationshipAPI()
+                .byContentType(contentType);
         relationships.forEach(relationship -> {
             //add empty list to each relationship
             if (relationshipAPI.sameParentAndChild(relationship)) {
@@ -6140,6 +6753,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * This method adds restricted content to the list of related content to be updated
+     *
      * @param user
      * @param contentletRelationshipRecords
      * @param relatedContentlets
@@ -6149,7 +6763,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
             List<Contentlet> relatedContentlets) {
 
         //consider immutable collections
-        contentletRelationshipRecords.setRecords(new ArrayList<>(contentletRelationshipRecords.getRecords()));
+        contentletRelationshipRecords.setRecords(
+                new ArrayList<>(contentletRelationshipRecords.getRecords()));
         contentletRelationshipRecords.getRecords()
                 .addAll(relatedContentlets.stream()
                         .filter(contentlet -> {
@@ -6165,7 +6780,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     *
      * @param fromContentlet
      * @param toContentlet
      * @param categories
@@ -6174,25 +6788,28 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    private void moveContentCategories(final Contentlet fromContentlet, final Contentlet toContentlet,
+    private void moveContentCategories(final Contentlet fromContentlet,
+            final Contentlet toContentlet,
             List<Category> categories, final User user, final boolean respect)
             throws DotDataException, DotSecurityException {
         final List<Category> categoriesUserCannotRemove = new ArrayList<>();
-        if(categories == null){
+        if (categories == null) {
             categories = new ArrayList<>();
         }
 
         //Find categories which the user can't use.  A user cannot remove a category they cannot use
-        final List<Category> cats = categoryAPI.getParents(fromContentlet, APILocator.getUserAPI().getSystemUser(), true);
+        final List<Category> cats = categoryAPI.getParents(fromContentlet,
+                APILocator.getUserAPI().getSystemUser(), true);
         for (final Category category : cats) {
-            if(!categoryAPI.canUseCategory(category, user, false)){
-                if(!categories.contains(category)){
+            if (!categoryAPI.canUseCategory(category, user, false)) {
+                if (!categories.contains(category)) {
                     categoriesUserCannotRemove.add(category);
                 }
             }
         }
 
-        categories = permissionAPI.filterCollection(categories, PermissionAPI.PERMISSION_USE, respect, user);
+        categories = permissionAPI.filterCollection(categories, PermissionAPI.PERMISSION_USE,
+                respect, user);
         categories.addAll(categoriesUserCannotRemove);
 
         // we have already validated permissions on the content object, no need to do it again
@@ -6201,18 +6818,23 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public void restoreVersion(Contentlet contentlet, User user,boolean respectFrontendRoles) throws DotSecurityException, DotContentletStateException, DotDataException {
-        if(contentlet.getInode().equals(""))
+    public void restoreVersion(Contentlet contentlet, User user, boolean respectFrontendRoles)
+            throws DotSecurityException, DotContentletStateException, DotDataException {
+        if (contentlet.getInode().equals("")) {
             throw new DotContentletStateException(CAN_T_CHANGE_STATE_OF_CHECKED_OUT_CONTENT);
-        if(!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT, user, respectFrontendRoles)){
-            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
-                    + " cannot edit Contentlet: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"));
         }
-        if(contentlet == null){
+        if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT, user,
+                respectFrontendRoles)) {
+            throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
+                    + " cannot edit Contentlet: " + (contentlet != null ? contentlet.getIdentifier()
+                    : "Unknown"));
+        }
+        if (contentlet == null) {
             throw new DotContentletStateException("The contentlet was null");
         }
         canLock(contentlet, user);
-        Contentlet currentWorkingCon = findContentletByIdentifier(contentlet.getIdentifier(), false, contentlet.getLanguageId(), user, respectFrontendRoles);
+        Contentlet currentWorkingCon = findContentletByIdentifier(contentlet.getIdentifier(), false,
+                contentlet.getLanguageId(), user, respectFrontendRoles);
         APILocator.getVersionableAPI().setWorking(contentlet);
         // Updating lucene index
         new ContentletLoader().invalidate(contentlet);
@@ -6223,13 +6845,18 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findAllUserVersions(Identifier identifier,User user, boolean respectFrontendRoles) throws DotSecurityException, DotDataException, DotStateException {
+    public List<Contentlet> findAllUserVersions(Identifier identifier, User user,
+            boolean respectFrontendRoles)
+            throws DotSecurityException, DotDataException, DotStateException {
         List<Contentlet> contentlets = contentFactory.findAllUserVersions(identifier);
-        if(contentlets.isEmpty())
+        if (contentlets.isEmpty()) {
             return new ArrayList<Contentlet>();
-        if(!permissionAPI.doesUserHavePermission(contentlets.get(0), PermissionAPI.PERMISSION_READ, user, respectFrontendRoles)){
+        }
+        if (!permissionAPI.doesUserHavePermission(contentlets.get(0), PermissionAPI.PERMISSION_READ,
+                user, respectFrontendRoles)) {
             throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
-                    + " cannot read Contentlet: "+ (identifier != null ? identifier.getId() : "Unknown")
+                    + " cannot read Contentlet: " + (identifier != null ? identifier.getId()
+                    : "Unknown")
                     + ".So Unable to View Versions");
         }
         return contentlets;
@@ -6237,31 +6864,41 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findAllVersions(Identifier identifier, User user, boolean respectFrontendRoles) throws DotSecurityException,DotDataException, DotStateException {
+    public List<Contentlet> findAllVersions(Identifier identifier, User user,
+            boolean respectFrontendRoles)
+            throws DotSecurityException, DotDataException, DotStateException {
         return findAllVersions(identifier, true, user, respectFrontendRoles);
     }
 
     @CloseDBIfOpened
     @Override
-    public List<Contentlet> findAllVersions(Identifier identifier, boolean bringOldVersions, User user, boolean respectFrontendRoles) throws DotSecurityException,DotDataException, DotStateException {
+    public List<Contentlet> findAllVersions(Identifier identifier, boolean bringOldVersions,
+            User user, boolean respectFrontendRoles)
+            throws DotSecurityException, DotDataException, DotStateException {
         List<Contentlet> contentlets = contentFactory.findAllVersions(identifier, bringOldVersions);
-        if(contentlets.isEmpty())
+        if (contentlets.isEmpty()) {
             return new ArrayList<Contentlet>();
-        if(!permissionAPI.doesUserHavePermission(contentlets.get(0), PermissionAPI.PERMISSION_READ, user, respectFrontendRoles)){
-            throw new DotSecurityException("User: " + (identifier != null ? identifier.getId() : "Unknown")
-                    + " cannot read Contentlet So Unable to View Versions");
+        }
+        if (!permissionAPI.doesUserHavePermission(contentlets.get(0), PermissionAPI.PERMISSION_READ,
+                user, respectFrontendRoles)) {
+            throw new DotSecurityException(
+                    "User: " + (identifier != null ? identifier.getId() : "Unknown")
+                            + " cannot read Contentlet So Unable to View Versions");
         }
         return contentlets;
     }
 
     @CloseDBIfOpened
     @Override
-    public String getName(final Contentlet contentlet, final User user, final boolean respectFrontendRoles) throws DotSecurityException,DotContentletStateException, DotDataException {
+    public String getName(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles)
+            throws DotSecurityException, DotContentletStateException, DotDataException {
 
         Preconditions.checkNotNull(contentlet, "The contentlet is null");
 
-        if(!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_READ, user, respectFrontendRoles)){
-            Logger.error(this.getClass(),"User: " + (user != null ? user.getUserId() : "Unknown")
+        if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_READ, user,
+                respectFrontendRoles)) {
+            Logger.error(this.getClass(), "User: " + (user != null ? user.getUserId() : "Unknown")
                     + " cannot read Contentlet: " + contentlet.getIdentifier());
             throw new DotSecurityException("User: " + (user != null ? user.getUserId() : "Unknown")
                     + " cannot read Contentlet: " + contentlet.getIdentifier());
@@ -6271,27 +6908,35 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * This is the original method that copy the properties of one contentlet to another, this is tge original firm and call the overloaded firm with checkIsUnique false
+     * This is the original method that copy the properties of one contentlet to another, this is
+     * tge original firm and call the overloaded firm with checkIsUnique false
      */
     @Override
-    public void copyProperties(Contentlet contentlet,Map<String, Object> properties) throws DotContentletStateException,DotSecurityException {
+    public void copyProperties(Contentlet contentlet, Map<String, Object> properties)
+            throws DotContentletStateException, DotSecurityException {
         boolean checkIsUnique = false;
-        copyProperties(contentlet,properties, checkIsUnique);
+        copyProperties(contentlet, properties, checkIsUnique);
     }
 
     /**
-     * This is the new method of the copyProperties that copy one contentlet to another, the checkIsUnique should be by default false, it check if a String value is
-     * unique and add a (Copy) string to the end of the field value, this method is called several times, so is important to call it with checkIsUnique false all the times
-     * @param contentlet the new contentlet to the filled
-     * @param properties the map with the fields and values of the old contentlet
-     * @param checkIsUnique the variable that establish if the unique string values should be modified or not
+     * This is the new method of the copyProperties that copy one contentlet to another, the
+     * checkIsUnique should be by default false, it check if a String value is unique and add a
+     * (Copy) string to the end of the field value, this method is called several times, so is
+     * important to call it with checkIsUnique false all the times
+     *
+     * @param contentlet    the new contentlet to the filled
+     * @param properties    the map with the fields and values of the old contentlet
+     * @param checkIsUnique the variable that establish if the unique string values should be
+     *                      modified or not
      * @throws DotContentletStateException
      * @throws DotSecurityException
      */
     @CloseDBIfOpened
-    public void copyProperties(final Contentlet contentlet, final Map<String, Object> properties, boolean checkIsUnique) throws DotContentletStateException,DotSecurityException {
-        if(!InodeUtils.isSet(contentlet.getStructureInode())){
-            Logger.warn(this,"Cannot copy properties to contentlet where structure inode < 1 : You must set the structure's inode");
+    public void copyProperties(final Contentlet contentlet, final Map<String, Object> properties,
+            boolean checkIsUnique) throws DotContentletStateException, DotSecurityException {
+        if (!InodeUtils.isSet(contentlet.getStructureInode())) {
+            Logger.warn(this,
+                    "Cannot copy properties to contentlet where structure inode < 1 : You must set the structure's inode");
             return;
         }
         List<Field> fields = FieldsCache.getFieldsByStructureInode(contentlet.getStructureInode());
@@ -6299,110 +6944,124 @@ public class ESContentletAPIImpl implements ContentletAPI {
         Map<String, Field> velFieldmap = new HashMap<String, Field>();
 
         for (Field field : fields) {
-            if(!field.getFieldType().equals(Field.FieldType.LINE_DIVIDER.toString()) && !field.getFieldType().equals(Field.FieldType.TAB_DIVIDER.toString())){
+            if (!field.getFieldType().equals(Field.FieldType.LINE_DIVIDER.toString())
+                    && !field.getFieldType().equals(Field.FieldType.TAB_DIVIDER.toString())) {
                 fieldNames.add(field.getFieldName());
-                velFieldmap.put(field.getVelocityVarName(),field);
+                velFieldmap.put(field.getVelocityVarName(), field);
             }
         }
         for (final Map.Entry<String, Object> property : properties.entrySet()) {
 
-            if(fieldNames.contains(property.getKey())) {
+            if (fieldNames.contains(property.getKey())) {
 
                 Logger.debug(this, "The map found a field not within the contentlet's structure");
             }
 
-            if(property.getValue() == null) {
+            if (property.getValue() == null) {
                 continue;
             }
 
-            if((!property.getKey().equals("recurrence")) &&
+            if ((!property.getKey().equals("recurrence")) &&
                     !(
-                            property.getValue() instanceof Set   || property.getValue() instanceof Map        || property.getValue() instanceof String || property.getValue() instanceof Boolean || property.getValue() instanceof File ||
-                                    property.getValue() instanceof Float || property.getValue() instanceof Integer    || property.getValue() instanceof Date   || property.getValue() instanceof Long    ||
-                                    property.getValue() instanceof List  || property.getValue() instanceof BigDecimal || property.getValue() instanceof Short  || property.getValue() instanceof Double
+                            property.getValue() instanceof Set || property.getValue() instanceof Map
+                                    || property.getValue() instanceof String
+                                    || property.getValue() instanceof Boolean
+                                    || property.getValue() instanceof File ||
+                                    property.getValue() instanceof Float
+                                    || property.getValue() instanceof Integer
+                                    || property.getValue() instanceof Date
+                                    || property.getValue() instanceof Long ||
+                                    property.getValue() instanceof List
+                                    || property.getValue() instanceof BigDecimal
+                                    || property.getValue() instanceof Short
+                                    || property.getValue() instanceof Double
                     )
-            ){
-                throw new DotContentletStateException("The map contains an invalid value: " + property.getValue().getClass());
+            ) {
+                throw new DotContentletStateException(
+                        "The map contains an invalid value: " + property.getValue().getClass());
             }
         }
-
 
         for (Map.Entry<String, Object> property : properties.entrySet()) {
             String conVariable = property.getKey();
             Object value = property.getValue();
-            try{
-                if(conVariable.equals(Contentlet.NULL_PROPERTIES)) {
+            try {
+                if (conVariable.equals(Contentlet.NULL_PROPERTIES)) {
                     continue;
                 }
-                if(conVariable.equals(Contentlet.INODE_KEY)){
-                    contentlet.setInode((String)value);
-                }else if(conVariable.equals(Contentlet.LANGUAGEID_KEY)){
+                if (conVariable.equals(Contentlet.INODE_KEY)) {
+                    contentlet.setInode((String) value);
+                } else if (conVariable.equals(Contentlet.LANGUAGEID_KEY)) {
                     contentlet.setLanguageId(ConversionUtils.toLong(value, 0L));
-                }else if(conVariable.equals(Contentlet.STRUCTURE_INODE_KEY)){
-                    contentlet.setStructureInode((String)value);
-                }else if(conVariable.equals(Contentlet.DISABLED_WYSIWYG_KEY)){
-                    contentlet.setDisabledWysiwyg((List<String>)value);
-                }else if(conVariable.equals(Contentlet.MOD_DATE_KEY)){
-                    contentlet.setModDate((Date)value);
-                }else if(conVariable.equals(Contentlet.MOD_USER_KEY)){
-                    contentlet.setModUser((String)value);
-                }else if(conVariable.equals(Contentlet.OWNER_KEY)){
-                    contentlet.setOwner((String)value);
-                }else if(conVariable.equals(Contentlet.IDENTIFIER_KEY)){
-                    contentlet.setIdentifier((String)value);
-                }else if(conVariable.equals(Contentlet.SORT_ORDER_KEY)){
+                } else if (conVariable.equals(Contentlet.STRUCTURE_INODE_KEY)) {
+                    contentlet.setStructureInode((String) value);
+                } else if (conVariable.equals(Contentlet.DISABLED_WYSIWYG_KEY)) {
+                    contentlet.setDisabledWysiwyg((List<String>) value);
+                } else if (conVariable.equals(Contentlet.MOD_DATE_KEY)) {
+                    contentlet.setModDate((Date) value);
+                } else if (conVariable.equals(Contentlet.MOD_USER_KEY)) {
+                    contentlet.setModUser((String) value);
+                } else if (conVariable.equals(Contentlet.OWNER_KEY)) {
+                    contentlet.setOwner((String) value);
+                } else if (conVariable.equals(Contentlet.IDENTIFIER_KEY)) {
+                    contentlet.setIdentifier((String) value);
+                } else if (conVariable.equals(Contentlet.SORT_ORDER_KEY)) {
                     contentlet.setSortOrder(ConversionUtils.toLong(value, 0L));
-                }else if(conVariable.equals(Contentlet.HOST_KEY)){
-                    contentlet.setHost((String)value);
-                }else if(conVariable.equals(Contentlet.FOLDER_KEY)){
-                    contentlet.setFolder((String)value);
-                }else if(isSetPropertyVariable(conVariable)){
+                } else if (conVariable.equals(Contentlet.HOST_KEY)) {
+                    contentlet.setHost((String) value);
+                } else if (conVariable.equals(Contentlet.FOLDER_KEY)) {
+                    contentlet.setFolder((String) value);
+                } else if (isSetPropertyVariable(conVariable)) {
                     contentlet.setProperty(conVariable, value);
-                } else if(conVariable.equals(Contentlet.VARIANT_ID)) {
+                } else if (conVariable.equals(Contentlet.VARIANT_ID)) {
                     contentlet.setVariantId(value.toString());
-                } else if(velFieldmap.get(conVariable) != null){
+                } else if (velFieldmap.get(conVariable) != null) {
                     Field field = velFieldmap.get(conVariable);
-                    if(isFieldTypeString(field))
-                    {
-                        if(checkIsUnique && field.isUnique())
-                        {
+                    if (isFieldTypeString(field)) {
+                        if (checkIsUnique && field.isUnique()) {
                             value = value +
                                     new StringBuilder(" (COPY_")
-                                            .append(System.currentTimeMillis()).append(')').toString();
+                                            .append(System.currentTimeMillis()).append(')')
+                                            .toString();
                         }
 
                         if (value instanceof CharSequence) {
-                            contentlet.setStringProperty(conVariable, value != null ? value.toString() : null);
+                            contentlet.setStringProperty(conVariable,
+                                    value != null ? value.toString() : null);
                         } else {
                             contentlet.setProperty(conVariable, value);
                         }
-                    }else if(isFieldTypeBoolean(field)){
-                        contentlet.setBoolProperty(conVariable, ConversionUtils.toBooleanFromDb(value));
-                    }else if(isFieldTypeFloat(field)){
+                    } else if (isFieldTypeBoolean(field)) {
+                        contentlet.setBoolProperty(conVariable,
+                                ConversionUtils.toBooleanFromDb(value));
+                    } else if (isFieldTypeFloat(field)) {
                         contentlet.setFloatProperty(conVariable, ConversionUtils.toFloat(value, 0));
-                    }else if(isFieldTypeDate(field)){
-                        contentlet.setDateProperty(conVariable,value != null ? (Date)value : null);
-                    }else if(isFieldTypeLong(field)){
+                    } else if (isFieldTypeDate(field)) {
+                        contentlet.setDateProperty(conVariable,
+                                value != null ? (Date) value : null);
+                    } else if (isFieldTypeLong(field)) {
                         contentlet.setLongProperty(conVariable, ConversionUtils.toLong(value, 0L));
-                    }else if(isFieldTypeBinary(field)){
-                        final File myFile = (value instanceof String) ? new File(String.valueOf(value)) : (File) value;
-                        contentlet.setBinary(conVariable,myFile);
+                    } else if (isFieldTypeBinary(field)) {
+                        final File myFile =
+                                (value instanceof String) ? new File(String.valueOf(value))
+                                        : (File) value;
+                        contentlet.setBinary(conVariable, myFile);
                     } else {
                         contentlet.setProperty(conVariable, value);
                     }
-                }else{
-                    Logger.debug(this,"Value " + value + " in map cannot be set to contentlet");
+                } else {
+                    Logger.debug(this, "Value " + value + " in map cannot be set to contentlet");
                 }
-            }catch (ClassCastException cce) {
-                Logger.error(this,"Value in map cannot be set to contentlet", cce);
+            } catch (ClassCastException cce) {
+                Logger.error(this, "Value in map cannot be set to contentlet", cce);
             } catch (IOException ioe) {
-                Logger.error(this,"IO Error in copying Binary File object ", ioe);
+                Logger.error(this, "IO Error in copying Binary File object ", ioe);
             }
 
         }
 
         //if we have a nullProperties variable, it needs to be the last one set
-        if(UtilMethods.isSet(properties.get(Contentlet.NULL_PROPERTIES))) {
+        if (UtilMethods.isSet(properties.get(Contentlet.NULL_PROPERTIES))) {
             contentlet.setProperty(Contentlet.NULL_PROPERTIES,
                     properties.get(Contentlet.NULL_PROPERTIES));
         }
@@ -6454,161 +7113,184 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public List<Contentlet> find(Category category, long languageId,boolean live,String orderBy,User user, boolean respectFrontendRoles) throws DotDataException,DotContentletStateException, DotSecurityException {
-        List<Category> cats  = new ArrayList<Category>();
-        return find(cats,languageId, live, orderBy, user, respectFrontendRoles);
+    public List<Contentlet> find(Category category, long languageId, boolean live, String orderBy,
+            User user, boolean respectFrontendRoles)
+            throws DotDataException, DotContentletStateException, DotSecurityException {
+        List<Category> cats = new ArrayList<Category>();
+        return find(cats, languageId, live, orderBy, user, respectFrontendRoles);
     }
 
     @Override
-    public List<Contentlet> find(List<Category> categories,long languageId, boolean live, String orderBy, User user, boolean respectFrontendRoles)  throws DotDataException, DotContentletStateException,DotSecurityException {
-        if(categories == null || categories.size() < 1)
+    public List<Contentlet> find(List<Category> categories, long languageId, boolean live,
+            String orderBy, User user, boolean respectFrontendRoles)
+            throws DotDataException, DotContentletStateException, DotSecurityException {
+        if (categories == null || categories.size() < 1) {
             return new ArrayList<Contentlet>();
+        }
         StringBuffer buffy = new StringBuffer();
         buffy.append("+type:content +deleted:false");
-        if(live)
+        if (live) {
             buffy.append(" +live:true");
-        else
+        } else {
             buffy.append(" +working:true");
-        if(languageId > 0)
+        }
+        if (languageId > 0) {
             buffy.append(" +languageId:" + languageId);
+        }
         for (Category category : categories) {
             buffy.append(" +c" + category.getInode() + "c:on");
         }
         try {
             return search(buffy.toString(), 0, -1, orderBy, user, respectFrontendRoles);
         } catch (Exception pe) {
-            Logger.error(this,"Unable to search for contentlets" ,pe);
-            throw new DotContentletStateException("Unable to search for contentlets: " + pe.getMessage(), pe);
+            Logger.error(this, "Unable to search for contentlets", pe);
+            throw new DotContentletStateException(
+                    "Unable to search for contentlets: " + pe.getMessage(), pe);
         }
     }
 
 
-
     @Override
-    public void setContentletProperty(Contentlet contentlet,Field field, Object value)throws DotContentletStateException {
+    public void setContentletProperty(Contentlet contentlet, Field field, Object value)
+            throws DotContentletStateException {
 
-        final String[] dateFormats = Config.getStringArrayProperty("dotcontentlet_dateformats", DEFAULT_DATE_FORMATS);
+        final String[] dateFormats = Config.getStringArrayProperty("dotcontentlet_dateformats",
+                DEFAULT_DATE_FORMATS);
 
-        if(contentlet == null){
+        if (contentlet == null) {
             throw new DotContentletValidationException("The contentlet must not be null");
         }
         String contentTypeInode = contentlet.getContentTypeId();
-        if(!InodeUtils.isSet(contentTypeInode)){
-            throw new DotContentletValidationException("The contentlet's Content Type Inode must be set");
+        if (!InodeUtils.isSet(contentTypeInode)) {
+            throw new DotContentletValidationException(
+                    "The contentlet's Content Type Inode must be set");
         }
 
-        if(value == null || !UtilMethods.isSet(value.toString())) {
+        if (value == null || !UtilMethods.isSet(value.toString())) {
             contentlet.setProperty(field.getVelocityVarName(), null);
             return;
         }
 
-        if(field.getFieldType().equals(Field.FieldType.CATEGORY.toString()) || field.getFieldType().equals(Field.FieldType.CATEGORIES_TAB.toString())){
+        if (field.getFieldType().equals(Field.FieldType.CATEGORY.toString()) || field.getFieldType()
+                .equals(Field.FieldType.CATEGORIES_TAB.toString())) {
 
-        }else if(fieldAPI.isElementConstant(field)){
-            Logger.debug(this, "Cannot set contentlet field value on field type constant. Value is saved to the field not the contentlet");
-        }else if(field.getFieldContentlet().startsWith("text") &&
-                !FieldType.JSON_FIELD.toString().equals(field.getFieldType())){
-            try{
-                contentlet.setStringProperty(field.getVelocityVarName(), (String)value);
-            }catch (Exception e) {
-                contentlet.setStringProperty(field.getVelocityVarName(),value.toString());
+        } else if (fieldAPI.isElementConstant(field)) {
+            Logger.debug(this,
+                    "Cannot set contentlet field value on field type constant. Value is saved to the field not the contentlet");
+        } else if (field.getFieldContentlet().startsWith("text") &&
+                !FieldType.JSON_FIELD.toString().equals(field.getFieldType())) {
+            try {
+                contentlet.setStringProperty(field.getVelocityVarName(), (String) value);
+            } catch (Exception e) {
+                contentlet.setStringProperty(field.getVelocityVarName(), value.toString());
             }
-        }else if(field.getFieldContentlet().startsWith("long_text")){
-            try{
-                contentlet.setStringProperty(field.getVelocityVarName(), (String)value);
-            }catch (Exception e) {
-                contentlet.setStringProperty(field.getVelocityVarName(),value.toString());
+        } else if (field.getFieldContentlet().startsWith("long_text")) {
+            try {
+                contentlet.setStringProperty(field.getVelocityVarName(), (String) value);
+            } catch (Exception e) {
+                contentlet.setStringProperty(field.getVelocityVarName(), value.toString());
             }
-        }else if(field.getFieldContentlet().startsWith("date")){
-            if(value instanceof Date){
-                contentlet.setDateProperty(field.getVelocityVarName(), (Date)value);
-            }else if(value instanceof String){
-                if(((String) value).trim().length()>0) {
+        } else if (field.getFieldContentlet().startsWith("date")) {
+            if (value instanceof Date) {
+                contentlet.setDateProperty(field.getVelocityVarName(), (Date) value);
+            } else if (value instanceof String) {
+                if (((String) value).trim().length() > 0) {
                     try {
                         final String trimmedValue = ((String) value).trim();
-                        if(trimmedValue.equals("+0000") || trimmedValue.equals("00:00 +0000")) {
+                        if (trimmedValue.equals("+0000") || trimmedValue.equals("00:00 +0000")) {
                             contentlet.setDateProperty(field.getVelocityVarName(),
                                     null);
                         } else {
                             contentlet.setDateProperty(field.getVelocityVarName(),
                                     DateUtil.convertDate((String) value, dateFormats));
                         }
-                    }catch (Exception e) {
-                        throw new DotContentletStateException("Unable to convert string to date " + value);
+                    } catch (Exception e) {
+                        throw new DotContentletStateException(
+                                "Unable to convert string to date " + value);
                     }
-                }
-                else {
+                } else {
                     contentlet.setDateProperty(field.getVelocityVarName(), null);
                 }
-            }else if(field.isRequired() && value==null){
-                throw new DotContentletStateException("Date fields must either be of type String or Date");
+            } else if (field.isRequired() && value == null) {
+                throw new DotContentletStateException(
+                        "Date fields must either be of type String or Date");
             }
-        }else if(field.getFieldContentlet().startsWith("bool")){
-            if(value instanceof Boolean){
-                contentlet.setBoolProperty(field.getVelocityVarName(), (Boolean)value);
-            }else if(value instanceof String){
-                try{
+        } else if (field.getFieldContentlet().startsWith("bool")) {
+            if (value instanceof Boolean) {
+                contentlet.setBoolProperty(field.getVelocityVarName(), (Boolean) value);
+            } else if (value instanceof String) {
+                try {
                     String auxValue = (String) value;
-                    Boolean auxBoolean = (auxValue.equalsIgnoreCase("1") || auxValue.equalsIgnoreCase("true") || auxValue.equalsIgnoreCase("t")) ? Boolean.TRUE : Boolean.FALSE;
+                    Boolean auxBoolean =
+                            (auxValue.equalsIgnoreCase("1") || auxValue.equalsIgnoreCase("true")
+                                    || auxValue.equalsIgnoreCase("t")) ? Boolean.TRUE
+                                    : Boolean.FALSE;
                     contentlet.setBoolProperty(field.getVelocityVarName(), auxBoolean);
-                }catch (Exception e) {
-                    throw new DotContentletStateException("Unable to set string value as a Boolean");
+                } catch (Exception e) {
+                    throw new DotContentletStateException(
+                            "Unable to set string value as a Boolean");
                 }
-            }else{
-                throw new DotContentletStateException("Boolean fields must either be of type String or Boolean");
+            } else {
+                throw new DotContentletStateException(
+                        "Boolean fields must either be of type String or Boolean");
             }
-        }else if(field.getFieldContentlet().startsWith("float")){
-            if(value instanceof Number){
-                contentlet.setFloatProperty(field.getVelocityVarName(),((Number)value).floatValue());
-            }else if(value instanceof String){
-                try{
-                    contentlet.setFloatProperty(field.getVelocityVarName(),new Float((String)value));
-                }catch (Exception e) {
-                    if(value != null && value.toString().length() != 0){
-                        contentlet.getMap().put(field.getVelocityVarName(),(String)value);
+        } else if (field.getFieldContentlet().startsWith("float")) {
+            if (value instanceof Number) {
+                contentlet.setFloatProperty(field.getVelocityVarName(),
+                        ((Number) value).floatValue());
+            } else if (value instanceof String) {
+                try {
+                    contentlet.setFloatProperty(field.getVelocityVarName(),
+                            new Float((String) value));
+                } catch (Exception e) {
+                    if (value != null && value.toString().length() != 0) {
+                        contentlet.getMap().put(field.getVelocityVarName(), (String) value);
                     }
                     throw new DotContentletStateException("Unable to set string value as a Float");
                 }
             }
-        }else if(field.getFieldContentlet().startsWith("integer")){
-            if(value instanceof Number){
-                contentlet.setLongProperty(field.getVelocityVarName(),((Number)value).longValue());
-            }else if(value instanceof String){
-                try{
-                    contentlet.setLongProperty(field.getVelocityVarName(),new Long((String)value));
-                }catch (Exception e) {
+        } else if (field.getFieldContentlet().startsWith("integer")) {
+            if (value instanceof Number) {
+                contentlet.setLongProperty(field.getVelocityVarName(),
+                        ((Number) value).longValue());
+            } else if (value instanceof String) {
+                try {
+                    contentlet.setLongProperty(field.getVelocityVarName(),
+                            new Long((String) value));
+                } catch (Exception e) {
                     //If we throw this exception here.. the contentlet will never get to the validateContentlet Method
                     throw new DotContentletStateException("Unable to set string value as a Long");
                 }
             }
             // setBinary
-        }else if(Field.FieldType.BINARY.toString().equals(field.getFieldType())){
-            try{
-
+        } else if (Field.FieldType.BINARY.toString().equals(field.getFieldType())) {
+            try {
 
                 // only if the value is a file or a tempFile
-                if(value.getClass()==File.class){
+                if (value.getClass() == File.class) {
                     contentlet.setBinary(field.getVelocityVarName(), (java.io.File) value);
                 }
                 // if this value is a String and a temp resource, use it to populate the
                 // binary field
-                else if(value instanceof String && tempApi.isTempResource((String) value)) {
+                else if (value instanceof String && tempApi.isTempResource((String) value)) {
                     final HttpServletRequest request = HttpServletRequestThreadLocal.INSTANCE.getRequest();
                     // we use the session to verify access to the temp resource
-                    final Optional<DotTempFile> tempFileOptional =  tempApi
+                    final Optional<DotTempFile> tempFileOptional = tempApi
                             .getTempFile(request, (String) value);
 
-                    if(tempFileOptional.isPresent()) {
-                        contentlet.setBinary(field.getVelocityVarName(), tempFileOptional.get().file);
+                    if (tempFileOptional.isPresent()) {
+                        contentlet.setBinary(field.getVelocityVarName(),
+                                tempFileOptional.get().file);
                     } else {
                         throw new DotStateException("Invalid Temp File provided");
                     }
 
                 }
-            }catch (IOException e) {
-                throw new DotContentletStateException("Unable to set binary file Object: " + e.getMessage(),e);
+            } catch (IOException e) {
+                throw new DotContentletStateException(
+                        "Unable to set binary file Object: " + e.getMessage(), e);
             }
-        }else if(field.getFieldContentlet().startsWith("system_field")) {
+        } else if (field.getFieldContentlet().startsWith("system_field")) {
             if (value.getClass() == java.lang.String.class) {
                 try {
                     contentlet.setStringProperty(field.getVelocityVarName(), (String) value);
@@ -6616,19 +7298,21 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     contentlet.setStringProperty(field.getVelocityVarName(), value.toString());
                 }
             }
-        } else if(FieldType.JSON_FIELD.toString().equals(field.getFieldType())) {
-            if((value instanceof String) && (JsonUtil.isValidJSON((String)value))){
+        } else if (FieldType.JSON_FIELD.toString().equals(field.getFieldType())) {
+            if ((value instanceof String) && (JsonUtil.isValidJSON((String) value))) {
                 contentlet.setStringProperty(field.getVelocityVarName(), Try.of(
-                        ()->JsonUtil.JSON_MAPPER.readTree((String)value).toString()).getOrElse("{}"));
-            } else if(value instanceof Map){
+                                () -> JsonUtil.JSON_MAPPER.readTree((String) value).toString())
+                        .getOrElse("{}"));
+            } else if (value instanceof Map) {
                 contentlet.setStringProperty(field.getVelocityVarName(),
-                        Try.of(()->JsonUtil.getJsonAsString((Map<String, Object>) value))
+                        Try.of(() -> JsonUtil.getJsonAsString((Map<String, Object>) value))
                                 .getOrElse("{}"));
             } else {
-                throw new DotContentletStateException("Invalid JSON field provided. Field variable: " +
-                        field.getVelocityVarName());
+                throw new DotContentletStateException(
+                        "Invalid JSON field provided. Field variable: " +
+                                field.getVelocityVarName());
             }
-        } else{
+        } else {
             throw new DotContentletStateException("Unable to set value : Unknown field type");
         }
     }
@@ -6636,52 +7320,61 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * This method takes the incoming contentlet and determines if the new fileName we're receiving
-     * is the same already stored on the identifier.fileAsset
-     * This So we enforce validation only of new incoming files
+     * is the same already stored on the identifier.fileAsset This So we enforce validation only of
+     * new incoming files
+     *
      * @param contentletIn
      * @return
      * @throws DotDataException
      * @throws DotSecurityException
      * @throws IOException
      */
-    private boolean hasNewIncomingFile(final Contentlet contentletIn) throws DotContentletStateException{
-        if(!contentletIn.isFileAsset()){
+    private boolean hasNewIncomingFile(final Contentlet contentletIn)
+            throws DotContentletStateException {
+        if (!contentletIn.isFileAsset()) {
             throw new IllegalArgumentException("Contentlet isn't a subtype of FileAsset");
         }
         try {
             final String identifierStr = contentletIn.getIdentifier();
-            if(!UtilMethods.isSet(identifierStr)){
+            if (!UtilMethods.isSet(identifierStr)) {
                 // if no identifier is set, we're dealing with a brand new contentlet then we enforce validation
                 return true;
             }
 
             final Identifier identifier = APILocator.getIdentifierAPI().find(identifierStr);
             final File incomingFile = contentletIn.getBinary(FileAssetAPI.BINARY_FIELD);
-            String incomingFileName = null != incomingFile ? incomingFile.getName() : StringPool.BLANK;
-            if(UtilMethods.isSet(contentletIn.getStringProperty(FileAssetAPI.FILE_NAME_FIELD))){
+            String incomingFileName =
+                    null != incomingFile ? incomingFile.getName() : StringPool.BLANK;
+            if (UtilMethods.isSet(contentletIn.getStringProperty(FileAssetAPI.FILE_NAME_FIELD))) {
                 incomingFileName = contentletIn.getStringProperty(FileAssetAPI.FILE_NAME_FIELD);
             }
             return !incomingFileName.equals(identifier.getAssetName());
         } catch (Exception e) {
-            throw new DotContentletStateException("Exception trying to determine if there's a new incoming file:" + e.getMessage(),e);
+            throw new DotContentletStateException(
+                    "Exception trying to determine if there's a new incoming file:"
+                            + e.getMessage(), e);
         }
     }
 
     @CloseDBIfOpened
     @Override
-    public void validateContentlet(final Contentlet contentlet, final List<Category> cats)throws DotContentletValidationException {
-        if(null == contentlet){
+    public void validateContentlet(final Contentlet contentlet, final List<Category> cats)
+            throws DotContentletValidationException {
+        if (null == contentlet) {
             throw new DotContentletValidationException("The contentlet must not be null.");
         }
         final String contentTypeId = contentlet.getContentTypeId();
-        final String contentIdentifier = (UtilMethods.isSet(contentlet.getIdentifier()) ? contentlet.getIdentifier()
+        final String contentIdentifier = (UtilMethods.isSet(contentlet.getIdentifier())
+                ? contentlet.getIdentifier()
                 : "Unknown/New");
-        if(!InodeUtils.isSet(contentTypeId)){
-            throw new DotContentletValidationException("Contentlet [" + contentIdentifier + "] is not associated to " +
-                    "any Content Type.");
+        if (!InodeUtils.isSet(contentTypeId)) {
+            throw new DotContentletValidationException(
+                    "Contentlet [" + contentIdentifier + "] is not associated to " +
+                            "any Content Type.");
         }
-        final ContentType contentType = Sneaky.sneak(() -> APILocator.getContentTypeAPI(APILocator.systemUser()).find
-                (contentTypeId));
+        final ContentType contentType = Sneaky.sneak(
+                () -> APILocator.getContentTypeAPI(APILocator.systemUser()).find
+                        (contentTypeId));
         if (BaseContentType.FILEASSET.getType() == contentType.baseType().getType()) {
             this.validateFileAsset(contentlet, contentIdentifier, contentType);
         }
@@ -6689,148 +7382,171 @@ public class ESContentletAPIImpl implements ContentletAPI {
         if (BaseContentType.HTMLPAGE.getType() == contentType.baseType().getType()) {
             this.validateHtmlPage(contentlet, contentIdentifier, contentType);
         }
-        if(contentlet.isHost()){
+        if (contentlet.isHost()) {
             this.validateSite(contentlet);
         }
         boolean hasError = false;
         final DotContentletValidationException cve = new DotContentletValidationException(
-                String.format("Contentlet with id:`%s` and title:`%s` has invalid / missing field(s).", contentIdentifier, contentlet.getTitle())
+                String.format(
+                        "Contentlet with id:`%s` and title:`%s` has invalid / missing field(s).",
+                        contentIdentifier, contentlet.getTitle())
         );
         final List<Field> fields = FieldsCache.getFieldsByStructureInode(contentTypeId);
         final Map<String, Object> contentletMap = contentlet.getMap();
         final Set<String> nullValueProperties = contentlet.getNullProperties();
         for (final Field field : fields) {
-            final Object fieldValue = (nullValueProperties.contains(field.getVelocityVarName()) ? null : contentletMap.get(field.getVelocityVarName()));
-            final com.dotcms.contenttype.model.field.Field newField = LegacyFieldTransformer.from(field);
+            final Object fieldValue = (nullValueProperties.contains(field.getVelocityVarName())
+                    ? null : contentletMap.get(field.getVelocityVarName()));
+            final com.dotcms.contenttype.model.field.Field newField = LegacyFieldTransformer.from(
+                    field);
             // Validate Field Type
-            if(fieldValue != null){
-                if(isFieldTypeString(field) && !(newField instanceof JSONField)){
+            if (fieldValue != null) {
+                if (isFieldTypeString(field) && !(newField instanceof JSONField)) {
 
-                    if(fieldValue instanceof Map && FieldType.KEY_VALUE.toString().equals(field.getFieldType())){
+                    if (fieldValue instanceof Map && FieldType.KEY_VALUE.toString()
+                            .equals(field.getFieldType())) {
                         //That's fine we're handling now keyValues directly as maps
                         continue;
                     }
 
-                    if(!(fieldValue instanceof String)){
+                    if (!(fieldValue instanceof String)) {
                         cve.addBadTypeField(field);
-                        Logger.warn(this, "Value of field [" + field.getVelocityVarName() + "] must be of type String");
+                        Logger.warn(this, "Value of field [" + field.getVelocityVarName()
+                                + "] must be of type String");
                         hasError = true;
                         continue;
                     }
-                }else if(isFieldTypeDate(field)){
-                    if(!(fieldValue instanceof Date)){
+                } else if (isFieldTypeDate(field)) {
+                    if (!(fieldValue instanceof Date)) {
                         cve.addBadTypeField(field);
-                        Logger.warn(this, "Value of field [" + field.getVelocityVarName() + "] must be of type Date");
+                        Logger.warn(this, "Value of field [" + field.getVelocityVarName()
+                                + "] must be of type Date");
                         hasError = true;
                         continue;
                     }
-                }else if(isFieldTypeBoolean(field)){
-                    if(!(fieldValue instanceof Boolean)){
+                } else if (isFieldTypeBoolean(field)) {
+                    if (!(fieldValue instanceof Boolean)) {
                         cve.addBadTypeField(field);
-                        Logger.warn(this, "Value of field [" + field.getVelocityVarName() + "] must be of type Boolean");
+                        Logger.warn(this, "Value of field [" + field.getVelocityVarName()
+                                + "] must be of type Boolean");
                         hasError = true;
                         continue;
                     }
-                }else if(isFieldTypeFloat(field)){
-                    if(!(fieldValue instanceof Float)){
+                } else if (isFieldTypeFloat(field)) {
+                    if (!(fieldValue instanceof Float)) {
                         cve.addBadTypeField(field);
-                        Logger.warn(this, "Value of field [" + field.getVelocityVarName() + "] must be of type Float");
+                        Logger.warn(this, "Value of field [" + field.getVelocityVarName()
+                                + "] must be of type Float");
                         hasError = true;
                         continue;
                     }
-                }else if(isFieldTypeLong(field)){
-                    if(!(fieldValue instanceof Long || fieldValue instanceof Integer)){
+                } else if (isFieldTypeLong(field)) {
+                    if (!(fieldValue instanceof Long || fieldValue instanceof Integer)) {
                         cve.addBadTypeField(field);
-                        Logger.warn(this, "Value of field [" + field.getVelocityVarName() + "] must be of type Long or Integer");
-                        hasError = true;
-                        continue;
-                    }
-                    //  binary field validation
-                }else if(isFieldTypeBinary(field)){
-                    if(!(fieldValue instanceof java.io.File)){
-                        cve.addBadTypeField(field);
-                        Logger.warn(this, "Value of field [" + field.getVelocityVarName() + "] must be of type File");
-                        hasError = true;
-                        continue;
-                    }
-                }else if(newField instanceof JSONField) {
-                    if(!(fieldValue instanceof String) || !(JsonUtil.isValidJSON(fieldValue.toString()))){
-                        cve.addBadTypeField(field);
-                        Logger.warn(this, "Value of field [" + field.getVelocityVarName() + "] must be of type JSON");
+                        Logger.warn(this, "Value of field [" + field.getVelocityVarName()
+                                + "] must be of type Long or Integer");
                         hasError = true;
                         continue;
                     }
                     //  binary field validation
-                }else if(isFieldTypeSystem(field) || isFieldTypeConstant(field)){
+                } else if (isFieldTypeBinary(field)) {
+                    if (!(fieldValue instanceof java.io.File)) {
+                        cve.addBadTypeField(field);
+                        Logger.warn(this, "Value of field [" + field.getVelocityVarName()
+                                + "] must be of type File");
+                        hasError = true;
+                        continue;
+                    }
+                } else if (newField instanceof JSONField) {
+                    if (!(fieldValue instanceof String) || !(JsonUtil.isValidJSON(
+                            fieldValue.toString()))) {
+                        cve.addBadTypeField(field);
+                        Logger.warn(this, "Value of field [" + field.getVelocityVarName()
+                                + "] must be of type JSON");
+                        hasError = true;
+                        continue;
+                    }
+                    //  binary field validation
+                } else if (isFieldTypeSystem(field) || isFieldTypeConstant(field)) {
                     // Do not validate system or constant field values
-                }else{
-                    Logger.warn(this,"Found an unknown field type : This should never happen!!!");
-                    throw new DotContentletStateException("Field [" + field.getVelocityVarName() + "] has an unknown type");
+                } else {
+                    Logger.warn(this, "Found an unknown field type : This should never happen!!!");
+                    throw new DotContentletStateException(
+                            "Field [" + field.getVelocityVarName() + "] has an unknown type");
                 }
             }
             // validate required
             if (field.isRequired()) {
 
-                if(fieldValue instanceof Map){
-                    final Map map = (Map)fieldValue;
-                    if(field.getFieldType().equals(Field.FieldType.KEY_VALUE.toString()) && map.isEmpty()) {
+                if (fieldValue instanceof Map) {
+                    final Map map = (Map) fieldValue;
+                    if (field.getFieldType().equals(Field.FieldType.KEY_VALUE.toString())
+                            && map.isEmpty()) {
                         cve.addRequiredField(field);
                         hasError = true;
-                        Logger.warn(this, "String Field [" + field.getVelocityVarName() + "] is required");
+                        Logger.warn(this,
+                                "String Field [" + field.getVelocityVarName() + "] is required");
                         continue;
                     }
-                }
-                else if(fieldValue instanceof String){
-                    String s1 = (String)fieldValue;
-                    if(!UtilMethods.isSet(s1.trim()) || (field.getFieldType().equals(Field.FieldType.KEY_VALUE.toString())) && s1.equals("{}")) {
+                } else if (fieldValue instanceof String) {
+                    String s1 = (String) fieldValue;
+                    if (!UtilMethods.isSet(s1.trim())
+                            || (field.getFieldType().equals(Field.FieldType.KEY_VALUE.toString()))
+                            && s1.equals("{}")) {
                         cve.addRequiredField(field);
                         hasError = true;
-                        Logger.warn(this, "String Field [" + field.getVelocityVarName() + "] is required");
+                        Logger.warn(this,
+                                "String Field [" + field.getVelocityVarName() + "] is required");
                         continue;
                     }
-                }
-                else if(fieldValue instanceof java.io.File){
+                } else if (fieldValue instanceof java.io.File) {
                     String s1 = ((java.io.File) fieldValue).getPath();
-                    if(!UtilMethods.isSet(s1.trim())||s1.trim().contains("-removed-")) {
+                    if (!UtilMethods.isSet(s1.trim()) || s1.trim().contains("-removed-")) {
                         cve.addRequiredField(field);
                         hasError = true;
-                        Logger.warn(this, "File Field [" + field.getVelocityVarName() + "] is required");
+                        Logger.warn(this,
+                                "File Field [" + field.getVelocityVarName() + "] is required");
                         continue;
                     }
-                }
-                else if(field.getFieldType().equals(Field.FieldType.DATE_TIME.toString())){
-                    if(!UtilMethods.isSet(fieldValue)){
+                } else if (field.getFieldType().equals(Field.FieldType.DATE_TIME.toString())) {
+                    if (!UtilMethods.isSet(fieldValue)) {
                         if (null != contentType.expireDateVar()) {
-                            if(field.getVelocityVarName().equals(contentType.expireDateVar())){
-                                if(NEVER_EXPIRE.equals(contentletMap.get(NEVER_EXPIRE))){
+                            if (field.getVelocityVarName().equals(contentType.expireDateVar())) {
+                                if (NEVER_EXPIRE.equals(contentletMap.get(NEVER_EXPIRE))) {
                                     continue;
-                                }else{
+                                } else {
                                     cve.addRequiredField(field);
                                     hasError = true;
-                                    Logger.warn(this, "Date/Time in CT Field [" + field.getVelocityVarName() + "] is" +
-                                            " required");
+                                    Logger.warn(this,
+                                            "Date/Time in CT Field [" + field.getVelocityVarName()
+                                                    + "] is" +
+                                                    " required");
                                     continue;
                                 }
-                            }else{
+                            } else {
                                 cve.addRequiredField(field);
                                 hasError = true;
-                                Logger.warn(this, "Date/Time expire Field [" + field.getVelocityVarName() + "] is required");
+                                Logger.warn(this,
+                                        "Date/Time expire Field [" + field.getVelocityVarName()
+                                                + "] is required");
                                 continue;
                             }
-                        }else{
+                        } else {
                             cve.addRequiredField(field);
                             hasError = true;
-                            Logger.warn(this, "Date/Time Field [" + field.getVelocityVarName() + "] is required");
+                            Logger.warn(this, "Date/Time Field [" + field.getVelocityVarName()
+                                    + "] is required");
                             continue;
                         }
                     }
-                } else if(field.getFieldType().equals(FieldType.RELATIONSHIP.toString()) ) {
+                } else if (field.getFieldType().equals(FieldType.RELATIONSHIP.toString())) {
                     continue;
-                } else if( field.getFieldType().equals(Field.FieldType.CATEGORY.toString()) ) {
-                    if( cats == null || cats.size() == 0 ) {
+                } else if (field.getFieldType().equals(Field.FieldType.CATEGORY.toString())) {
+                    if (cats == null || cats.size() == 0) {
                         cve.addRequiredField(field);
                         hasError = true;
-                        Logger.warn(this, "Category Field [" + field.getVelocityVarName() + "] is required (empty)");
+                        Logger.warn(this, "Category Field [" + field.getVelocityVarName()
+                                + "] is required (empty)");
                         continue;
                     }
                     try {
@@ -6838,66 +7554,82 @@ public class ESContentletAPIImpl implements ContentletAPI {
                         if (field.getFieldType().equals(Field.FieldType.CATEGORY.toString())) {
                             CategoryAPI catAPI = APILocator.getCategoryAPI();
                             Category baseCat = catAPI.find(field.getValues(), systemUser, false);
-                            List<Category> childrenCats = catAPI.getAllChildren(baseCat, systemUser, false);
+                            List<Category> childrenCats = catAPI.getAllChildren(baseCat, systemUser,
+                                    false);
                             boolean found = false;
-                            for(Category cat : childrenCats) {
-                                for(Category passedCat : cats) {
+                            for (Category cat : childrenCats) {
+                                for (Category passedCat : cats) {
                                     try {
-                                        if(passedCat.getInode().equalsIgnoreCase(cat.getInode()))
+                                        if (passedCat.getInode().equalsIgnoreCase(cat.getInode())) {
                                             found = true;
-                                    } catch (NumberFormatException e) { }
+                                        }
+                                    } catch (NumberFormatException e) {
+                                    }
                                 }
                             }
-                            if(!found) {
+                            if (!found) {
                                 cve.addRequiredField(field);
                                 hasError = true;
-                                Logger.warn(this, "Category Field [" + field.getVelocityVarName() + "] is required (values not found)");
+                                Logger.warn(this, "Category Field [" + field.getVelocityVarName()
+                                        + "] is required (values not found)");
                                 continue;
                             }
                         }
                     } catch (DotDataException | DotSecurityException e) {
-                        Logger.warn(this, "Unable to validate a category field [" + field.getVelocityVarName() + "]", e);
-                        throw new DotContentletValidationException("Unable to validate a category field: " + field.getVelocityVarName(), e);
+                        Logger.warn(this,
+                                "Unable to validate a category field [" + field.getVelocityVarName()
+                                        + "]", e);
+                        throw new DotContentletValidationException(
+                                "Unable to validate a category field: "
+                                        + field.getVelocityVarName(), e);
                     }
                 } else if (field.getFieldType().equals(Field.FieldType.HOST_OR_FOLDER.toString())) {
-                    if (!UtilMethods.isSet(contentlet.getHost()) && !UtilMethods.isSet(contentlet.getFolder())) {
+                    if (!UtilMethods.isSet(contentlet.getHost()) && !UtilMethods.isSet(
+                            contentlet.getFolder())) {
                         cve.addRequiredField(field);
                         hasError = true;
-                        Logger.warn(this, "Site or Folder Field [" + field.getVelocityVarName() + "] is required");
+                        Logger.warn(this, "Site or Folder Field [" + field.getVelocityVarName()
+                                + "] is required");
                         continue;
                     }
-                } else if(!UtilMethods.isSet(fieldValue)) {
+                } else if (!UtilMethods.isSet(fieldValue)) {
                     cve.addRequiredField(field);
                     hasError = true;
                     Logger.warn(this, "Field [" + field.getVelocityVarName() + "] is required");
                     continue;
                 }
-                if(field.getFieldType().equals(Field.FieldType.IMAGE.toString()) || field.getFieldType().equals(Field.FieldType.FILE.toString())){
-                    if(fieldValue instanceof Number){
-                        Number n = (Number)fieldValue;
-                        if(n.longValue() == 0){
+                if (field.getFieldType().equals(Field.FieldType.IMAGE.toString())
+                        || field.getFieldType().equals(Field.FieldType.FILE.toString())) {
+                    if (fieldValue instanceof Number) {
+                        Number n = (Number) fieldValue;
+                        if (n.longValue() == 0) {
                             cve.addRequiredField(field);
                             hasError = true;
-                            Logger.warn(this, "Image Field (as number) [" + field.getVelocityVarName() + "] is required");
+                            Logger.warn(this,
+                                    "Image Field (as number) [" + field.getVelocityVarName()
+                                            + "] is required");
                             continue;
                         }
-                    }else if(fieldValue instanceof String){
-                        String s = (String)fieldValue;
-                        if(s.trim().equals("0")){
+                    } else if (fieldValue instanceof String) {
+                        String s = (String) fieldValue;
+                        if (s.trim().equals("0")) {
                             cve.addRequiredField(field);
                             hasError = true;
-                            Logger.warn(this, "Image Field (as String) [" + field.getVelocityVarName() + "] is required");
+                            Logger.warn(this,
+                                    "Image Field (as String) [" + field.getVelocityVarName()
+                                            + "] is required");
                             continue;
                         }
                     }
                     //WYSIWYG patch for blank content
-                }else if(field.getFieldType().equals(Field.FieldType.WYSIWYG.toString())){
-                    if(fieldValue instanceof String){
-                        String s = (String)fieldValue;
-                        if (s.trim().toLowerCase().equals("<br>")){
+                } else if (field.getFieldType().equals(Field.FieldType.WYSIWYG.toString())) {
+                    if (fieldValue instanceof String) {
+                        String s = (String) fieldValue;
+                        if (s.trim().toLowerCase().equals("<br>")) {
                             cve.addRequiredField(field);
                             hasError = true;
-                            Logger.warn(this, "WYSIWYG Field [" + field.getVelocityVarName() + "] is required");
+                            Logger.warn(this, "WYSIWYG Field [" + field.getVelocityVarName()
+                                    + "] is required");
                             continue;
                         }
                     }
@@ -6905,13 +7637,14 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             // validate unique
-            if(field.isUnique()){
-                final boolean isDataTypeNumber = field.getDataType().contains(DataTypes.INTEGER.toString())
-                        || field.getDataType().contains(DataTypes.FLOAT.toString());
-                try{
+            if (field.isUnique()) {
+                final boolean isDataTypeNumber =
+                        field.getDataType().contains(DataTypes.INTEGER.toString())
+                                || field.getDataType().contains(DataTypes.FLOAT.toString());
+                try {
                     final StringBuilder buffy = new StringBuilder(UUIDGenerator.generateUuid());
                     buffy.append(" +structureInode:" + contentlet.getStructureInode());
-                    if(UtilMethods.isSet(contentlet.getIdentifier())){
+                    if (UtilMethods.isSet(contentlet.getIdentifier())) {
                         buffy.append(" -(identifier:" + contentlet.getIdentifier() + ")");
                     }
 
@@ -6925,7 +7658,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                         buffy.append(" +conHost:" + contentlet.getHost());
                     }
 
-                    buffy.append(" +").append(contentlet.getContentType().variable()).append(StringPool.PERIOD)
+                    buffy.append(" +").append(contentlet.getContentType().variable())
+                            .append(StringPool.PERIOD)
                             .append(field.getVelocityVarName()).append(ESUtils.SHA_256)
                             .append(StringPool.COLON)
                             .append(ESUtils.sha256(contentlet.getContentType().variable()
@@ -6934,21 +7668,28 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                     final List<ContentletSearch> contentlets = new ArrayList<>();
                     try {
-                        contentlets.addAll(searchIndex(buffy.toString() + " +working:true", -1, 0, "inode", APILocator.getUserAPI().getSystemUser(), false));
-                        contentlets.addAll(searchIndex(buffy.toString() + " +live:true", -1, 0, "inode", APILocator.getUserAPI().getSystemUser(), false));
+                        contentlets.addAll(
+                                searchIndex(buffy.toString() + " +working:true", -1, 0, "inode",
+                                        APILocator.getUserAPI().getSystemUser(), false));
+                        contentlets.addAll(
+                                searchIndex(buffy.toString() + " +live:true", -1, 0, "inode",
+                                        APILocator.getUserAPI().getSystemUser(), false));
                     } catch (final Exception e) {
-                        final String errorMsg = "Unique field [" + field.getVelocityVarName() + "] with value '" +
-                                fieldValue + "' could not be validated: " + e.getMessage();
+                        final String errorMsg =
+                                "Unique field [" + field.getVelocityVarName() + "] with value '" +
+                                        fieldValue + "' could not be validated: " + e.getMessage();
                         Logger.warn(this, errorMsg, e);
                         throw new DotContentletValidationException(errorMsg, e);
                     }
                     int size = contentlets.size();
-                    if(size > 0 && !hasError){
+                    if (size > 0 && !hasError) {
                         Boolean unique = true;
                         for (final ContentletSearch contentletSearch : contentlets) {
-                            final Contentlet uniqueContent = contentFactory.find(contentletSearch.getInode());
+                            final Contentlet uniqueContent = contentFactory.find(
+                                    contentletSearch.getInode());
                             if (null == uniqueContent) {
-                                final String errorMsg = String.format("Unique field [%s] could not be validated, as " +
+                                final String errorMsg = String.format(
+                                        "Unique field [%s] could not be validated, as " +
                                                 "unique content Inode '%s' was not found. ES Index might need to be reindexed.",
                                         field.getVelocityVarName(), contentletSearch.getInode());
                                 Logger.warn(this, errorMsg);
@@ -6956,54 +7697,62 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             }
                             final Map<String, Object> uniqueContentMap = uniqueContent.getMap();
                             final Object obj = uniqueContentMap.get(field.getVelocityVarName());
-                            if ( ( isDataTypeNumber && fieldValue.equals(obj) ) ||
-                                    ( !isDataTypeNumber && ((String) obj).equalsIgnoreCase(((String) fieldValue)) ) )  {
+                            if ((isDataTypeNumber && fieldValue.equals(obj)) ||
+                                    (!isDataTypeNumber && ((String) obj).equalsIgnoreCase(
+                                            ((String) fieldValue)))) {
                                 unique = false;
                                 break;
                             }
 
                         }
-                        if(!unique) {
-                            if(UtilMethods.isSet(contentlet.getIdentifier())){
+                        if (!unique) {
+                            if (UtilMethods.isSet(contentlet.getIdentifier())) {
                                 Iterator<ContentletSearch> contentletsIter = contentlets.iterator();
                                 while (contentletsIter.hasNext()) {
                                     ContentletSearch cont = (ContentletSearch) contentletsIter.next();
-                                    if(!contentlet.getIdentifier().equalsIgnoreCase(cont.getIdentifier()))
-                                    {
+                                    if (!contentlet.getIdentifier()
+                                            .equalsIgnoreCase(cont.getIdentifier())) {
                                         cve.addUniqueField(field);
                                         hasError = true;
-                                        Logger.warn(this, getUniqueFieldErrorMessage(field, fieldValue, cont));
+                                        Logger.warn(this,
+                                                getUniqueFieldErrorMessage(field, fieldValue,
+                                                        cont));
                                         break;
                                     }
                                 }
-                            }else{
+                            } else {
                                 cve.addUniqueField(field);
                                 hasError = true;
-                                Logger.warn(this, getUniqueFieldErrorMessage(field, fieldValue, contentlets.get(0)));
+                                Logger.warn(this, getUniqueFieldErrorMessage(field, fieldValue,
+                                        contentlets.get(0)));
                                 break;
                             }
                         }
                     }
                 } catch (DotDataException | DotSecurityException e) {
-                    Logger.warn(this,"Unable to get contentlets for Content Type: " + contentlet.getStructure().getName(), e);
+                    Logger.warn(this, "Unable to get contentlets for Content Type: "
+                            + contentlet.getStructure().getName(), e);
                 }
             }
 
             // validate text
-            String dataType = (field.getFieldContentlet() != null) ? field.getFieldContentlet().replaceAll("[0-9]*", "") : "";
+            String dataType = (field.getFieldContentlet() != null) ? field.getFieldContentlet()
+                    .replaceAll("[0-9]*", "") : "";
             if (UtilMethods.isSet(fieldValue) && dataType.equals("text")) {
                 String s = "";
-                try{
-                    s = (String)fieldValue;
-                }catch (Exception e) {
-                    Logger.warn(this, "Unable to get string value from text field [" + field.getVelocityVarName() +
+                try {
+                    s = (String) fieldValue;
+                } catch (Exception e) {
+                    Logger.warn(this, "Unable to get string value from text field ["
+                            + field.getVelocityVarName() +
                             "] in contentlet", e);
                     continue;
                 }
                 if (s.length() > 255) {
                     hasError = true;
                     cve.addMaxLengthField(field);
-                    Logger.warn(this, "Value of String field [" + field.getVelocityVarName() + "] is greater than 255" +
+                    Logger.warn(this, "Value of String field [" + field.getVelocityVarName()
+                            + "] is greater than 255" +
                             " characters");
                     continue;
                 }
@@ -7013,25 +7762,30 @@ public class ESContentletAPIImpl implements ContentletAPI {
             String regext = field.getRegexCheck();
             if (UtilMethods.isSet(regext)) {
                 if (UtilMethods.isSet(fieldValue)) {
-                    if(fieldValue instanceof Number){
-                        Number n = (Number)fieldValue;
+                    if (fieldValue instanceof Number) {
+                        Number n = (Number) fieldValue;
                         String s = n.toString();
                         boolean match = Pattern.matches(regext, s);
                         if (!match) {
                             hasError = true;
                             cve.addPatternField(field);
-                            Logger.warn(this, "Field with number regex [" + field.getVelocityVarName() + "] does not " +
-                                    "match. Regex: " + regext);
+                            Logger.warn(this,
+                                    "Field with number regex [" + field.getVelocityVarName()
+                                            + "] does not " +
+                                            "match. Regex: " + regext);
                             continue;
                         }
-                    }else if(fieldValue instanceof String && UtilMethods.isSet(((String)fieldValue).trim())){
-                        String s = ((String)fieldValue).trim();
+                    } else if (fieldValue instanceof String && UtilMethods.isSet(
+                            ((String) fieldValue).trim())) {
+                        String s = ((String) fieldValue).trim();
                         boolean match = Pattern.matches(regext, s);
                         if (!match) {
                             hasError = true;
                             cve.addPatternField(field);
-                            Logger.warn(this, "Field with string regex [" + field.getVelocityVarName() + "] does not " +
-                                    "match. Regex: " + regext);
+                            Logger.warn(this,
+                                    "Field with string regex [" + field.getVelocityVarName()
+                                            + "] does not " +
+                                            "match. Regex: " + regext);
                             continue;
                         }
                     }
@@ -7039,31 +7793,36 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             // validate binary
-            if(isFieldTypeBinary(field)) {
-                this.validateBinary (File.class.cast(fieldValue), field.getVelocityVarName(), field, contentType);
+            if (isFieldTypeBinary(field)) {
+                this.validateBinary(File.class.cast(fieldValue), field.getVelocityVarName(), field,
+                        contentType);
             }
 
         }
-        if(hasError){
+        if (hasError) {
             throw cve;
         }
     }
 
-    private String getUniqueFieldErrorMessage(final Field field, final Object fieldValue, final ContentletSearch contentletSearch) {
+    private String getUniqueFieldErrorMessage(final Field field, final Object fieldValue,
+            final ContentletSearch contentletSearch) {
 
-        return String.format("Value of Field [%s] must be unique. Contents having the same value (%s): %s",
+        return String.format(
+                "Value of Field [%s] must be unique. Contents having the same value (%s): %s",
                 field.getVelocityVarName(), fieldValue, contentletSearch.getIdentifier());
     }
 
     private boolean getUniquePerSiteConfig(final Field field) {
-     return getUniquePerSiteConfig(LegacyFieldTransformer.from(field));
+        return getUniquePerSiteConfig(LegacyFieldTransformer.from(field));
     }
 
     private boolean getUniquePerSiteConfig(final com.dotcms.contenttype.model.field.Field field) {
-        return field.fieldVariableValue(UNIQUE_PER_SITE_FIELD_VARIABLE_NAME).map(value ->  Boolean.valueOf(value)).orElse(false);
+        return field.fieldVariableValue(UNIQUE_PER_SITE_FIELD_VARIABLE_NAME)
+                .map(value -> Boolean.valueOf(value)).orElse(false);
     }
 
-    private void validateBinary(final File binary, final String fieldName, final Field legacyField, final ContentType contentType) {
+    private void validateBinary(final File binary, final String fieldName, final Field legacyField,
+            final ContentType contentType) {
 
         final Map<String, com.dotcms.contenttype.model.field.Field> fieldMap = contentType.fieldMap();
 
@@ -7079,25 +7838,33 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                     if (BinaryField.ALLOWED_FILE_TYPES.equalsIgnoreCase(keyField)) {
 
-                        final String binaryMimeType   = APILocator.getFileAssetAPI().getMimeType(binary);
+                        final String binaryMimeType = APILocator.getFileAssetAPI()
+                                .getMimeType(binary);
                         final String allowedFileTypes = fieldVariable.value();
-                        if (UtilMethods.isSet(allowedFileTypes) && UtilMethods.isSet(binaryMimeType) &&
+                        if (UtilMethods.isSet(allowedFileTypes) && UtilMethods.isSet(binaryMimeType)
+                                &&
                                 !FileAsset.UNKNOWN_MIME_TYPE.equals(binaryMimeType)) {
 
                             boolean allowed = false;
-                            final MimeType fileMimeType = Sneaky.sneak(() -> new MimeType(binaryMimeType));
-                            final String[] allowedFileTypeArray = StringUtil.split(allowedFileTypes);
+                            final MimeType fileMimeType = Sneaky.sneak(
+                                    () -> new MimeType(binaryMimeType));
+                            final String[] allowedFileTypeArray = StringUtil.split(
+                                    allowedFileTypes);
                             for (final String allowFileType : allowedFileTypeArray) {
 
-                                final MimeType mimeType = Sneaky.sneak(() -> new MimeType(allowFileType));
+                                final MimeType mimeType = Sneaky.sneak(
+                                        () -> new MimeType(allowFileType));
                                 allowed |= mimeType.match(fileMimeType);
                             }
 
                             // if the extension of the file is not supported
                             if (!allowed) {
 
-                                final DotContentletValidationException cve = new DotContentletValidationException(Sneaky.sneak(()->LanguageUtil.get("message.contentlet.binary.type.notallowed")));
-                                Logger.warn(this, "Name of Binary field [" + fieldName + "] has an not allowed type: " + binaryMimeType);
+                                final DotContentletValidationException cve = new DotContentletValidationException(
+                                        Sneaky.sneak(() -> LanguageUtil.get(
+                                                "message.contentlet.binary.type.notallowed")));
+                                Logger.warn(this, "Name of Binary field [" + fieldName
+                                        + "] has an not allowed type: " + binaryMimeType);
                                 cve.addBadTypeField(legacyField);
                                 throw cve;
                             }
@@ -7106,18 +7873,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                     if (BinaryField.MAX_FILE_LENGTH.equalsIgnoreCase(keyField)) {
 
-                        final long fileLength        = binary.length();
+                        final long fileLength = binary.length();
                         final String maxLengthString = fieldVariable.value();
-                        final long maxLength         = ConversionUtils.toLongFromByteCountHumanDisplaySize(maxLengthString, -1l);
+                        final long maxLength = ConversionUtils.toLongFromByteCountHumanDisplaySize(
+                                maxLengthString, -1l);
 
                         if (-1 != maxLength && // if the user sets a valid value
                                 fileLength > maxLength) {
 
                             final DotContentletValidationException cve =
                                     new DotContentletValidationException(
-                                            Sneaky.sneak(()->LanguageUtil.get("message.contentlet.binary.file.exceeds.size", binary.getName(), UtilMethods.prettyByteify(maxLength))));
-                            Logger.warn(this, "Name of Binary field [" + fieldName + "] has a length: " + fileLength
-                                    + " but the max length is: " + maxLength);
+                                            Sneaky.sneak(() -> LanguageUtil.get(
+                                                    "message.contentlet.binary.file.exceeds.size",
+                                                    binary.getName(),
+                                                    UtilMethods.prettyByteify(maxLength))));
+                            Logger.warn(this,
+                                    "Name of Binary field [" + fieldName + "] has a length: "
+                                            + fileLength
+                                            + " but the max length is: " + maxLength);
                             cve.addBadTypeField(legacyField);
                             throw cve;
                         }
@@ -7127,72 +7900,96 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
     } // validateBinary.
 
-    private void validateHtmlPage(Contentlet contentlet, String contentIdentifier, ContentType contentType) {
-        if(contentlet.getHost()!=null && contentlet.getHost().equals(Host.SYSTEM_HOST) && (!UtilMethods.isSet(contentlet.getFolder()) || contentlet.getFolder().equals(FolderAPI.SYSTEM_FOLDER))){
-            final DotContentletValidationException cve = new FileAssetValidationException(Sneaky.sneak(()->LanguageUtil.get("message.contentlet.fileasset.invalid.hostfolder")));
-            Logger.warn(this, "HTML Page [" + contentIdentifier + "] cannot be created directly under System " +
-                    "Host");
+    private void validateHtmlPage(Contentlet contentlet, String contentIdentifier,
+            ContentType contentType) {
+        if (contentlet.getHost() != null && contentlet.getHost().equals(Host.SYSTEM_HOST) && (
+                !UtilMethods.isSet(contentlet.getFolder()) || contentlet.getFolder()
+                        .equals(FolderAPI.SYSTEM_FOLDER))) {
+            final DotContentletValidationException cve = new FileAssetValidationException(
+                    Sneaky.sneak(() -> LanguageUtil.get(
+                            "message.contentlet.fileasset.invalid.hostfolder")));
+            Logger.warn(this,
+                    "HTML Page [" + contentIdentifier + "] cannot be created directly under System "
+                            +
+                            "Host");
             cve.addBadTypeField(new LegacyFieldTransformer(contentType.fieldMap().get(FileAssetAPI
                     .HOST_FOLDER_FIELD)).asOldField());
             throw cve;
         }
-        try{
-            final Host site = APILocator.getHostAPI().find(contentlet.getHost(), APILocator.getUserAPI().getSystemUser(), false);
+        try {
+            final Host site = APILocator.getHostAPI()
+                    .find(contentlet.getHost(), APILocator.getUserAPI().getSystemUser(), false);
             Folder folder = null;
-            if(UtilMethods.isSet(contentlet.getFolder())){
-                folder=APILocator.getFolderAPI().find(contentlet.getFolder(), APILocator.getUserAPI().getSystemUser(), false);
-            }
-            else{
-                folder=APILocator.getFolderAPI().findSystemFolder();
+            if (UtilMethods.isSet(contentlet.getFolder())) {
+                folder = APILocator.getFolderAPI()
+                        .find(contentlet.getFolder(), APILocator.getUserAPI().getSystemUser(),
+                                false);
+            } else {
+                folder = APILocator.getFolderAPI().findSystemFolder();
             }
 
             //Get the URL from Identifier if it is not in Contentlet
             String url = contentlet.getStringProperty(HTMLPageAssetAPI.URL_FIELD);
 
-            if(!UtilMethods.isSet(url)){
+            if (!UtilMethods.isSet(url)) {
 
-                if (InodeUtils.isSet(contentlet.getVersionId()) || InodeUtils.isSet(contentlet.getInode())) {
+                if (InodeUtils.isSet(contentlet.getVersionId()) || InodeUtils.isSet(
+                        contentlet.getInode())) {
                     Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
-                    if (UtilMethods.isSet(identifier) && UtilMethods.isSet(identifier.getAssetName())) {
+                    if (UtilMethods.isSet(identifier) && UtilMethods.isSet(
+                            identifier.getAssetName())) {
 
                         url = identifier.getAssetName();
                     }
                 }
             }
 
-            if(UtilMethods.isSet(url)){
+            if (UtilMethods.isSet(url)) {
                 contentlet.setProperty(HTMLPageAssetAPI.URL_FIELD, url);
                 Identifier folderId = APILocator.getIdentifierAPI().find(folder.getIdentifier());
-                String path = folder.getInode().equals(FolderAPI.SYSTEM_FOLDER)?"/"+url:folderId.getPath()+url;
+                String path = folder.getInode().equals(FolderAPI.SYSTEM_FOLDER) ? "/" + url
+                        : folderId.getPath() + url;
                 Identifier htmlpage = APILocator.getIdentifierAPI().find(site, path);
-                if(htmlpage!=null && InodeUtils.isSet(htmlpage.getId()) && !htmlpage.getId().equals(contentlet.getIdentifier()) ){
-                    final String errorMsg = "Page URL [" + path + "] already exists with content ID [" + htmlpage
-                            .getId() + "]";
-                    final DotContentletValidationException cve = new FileAssetValidationException(errorMsg);
+                if (htmlpage != null && InodeUtils.isSet(htmlpage.getId()) && !htmlpage.getId()
+                        .equals(contentlet.getIdentifier())) {
+                    final String errorMsg =
+                            "Page URL [" + path + "] already exists with content ID [" + htmlpage
+                                    .getId() + "]";
+                    final DotContentletValidationException cve = new FileAssetValidationException(
+                            errorMsg);
                     Logger.warn(this, errorMsg);
-                    cve.addBadTypeField(new LegacyFieldTransformer(contentType.fieldMap().get(HTMLPageAssetAPI
-                            .URL_FIELD)).asOldField());
+                    cve.addBadTypeField(
+                            new LegacyFieldTransformer(contentType.fieldMap().get(HTMLPageAssetAPI
+                                    .URL_FIELD)).asOldField());
                     throw cve;
                 }
                 UtilMethods.validateFileName(url);
             }
 
         } catch (final DotDataException | DotSecurityException | IllegalArgumentException e) {
-            final String errorMsg = "Contentlet [" + contentIdentifier + "] has an invalid URL: " + contentlet
-                    .getStringProperty(HTMLPageAssetAPI.URL_FIELD);
+            final String errorMsg =
+                    "Contentlet [" + contentIdentifier + "] has an invalid URL: " + contentlet
+                            .getStringProperty(HTMLPageAssetAPI.URL_FIELD);
             final DotContentletValidationException cve = new FileAssetValidationException(errorMsg);
             Logger.warn(this, errorMsg);
-            cve.addBadTypeField(new LegacyFieldTransformer(contentType.fieldMap().get(HTMLPageAssetAPI
-                    .URL_FIELD)).asOldField());
+            cve.addBadTypeField(
+                    new LegacyFieldTransformer(contentType.fieldMap().get(HTMLPageAssetAPI
+                            .URL_FIELD)).asOldField());
             throw cve;
         }
     }
 
-    private void validateFileAsset(final Contentlet contentlet, final String contentIdentifier, final ContentType contentType) {
+    private void validateFileAsset(final Contentlet contentlet, final String contentIdentifier,
+            final ContentType contentType) {
 
-        if(contentlet.getHost()!=null && contentlet.getHost().equals(Host.SYSTEM_HOST) && (!UtilMethods.isSet(contentlet.getFolder()) || contentlet.getFolder().equals(FolderAPI.SYSTEM_FOLDER))){
-            final DotContentletValidationException cve = new FileAssetValidationException(Sneaky.sneak(()->LanguageUtil.get("message.contentlet.fileasset.invalid.hostfolder")));
-            Logger.warn(this, "File Asset [" + contentIdentifier + "] cannot be created directly under System " +
+        if (contentlet.getHost() != null && contentlet.getHost().equals(Host.SYSTEM_HOST) && (
+                !UtilMethods.isSet(contentlet.getFolder()) || contentlet.getFolder()
+                        .equals(FolderAPI.SYSTEM_FOLDER))) {
+            final DotContentletValidationException cve = new FileAssetValidationException(
+                    Sneaky.sneak(() -> LanguageUtil.get(
+                            "message.contentlet.fileasset.invalid.hostfolder")));
+            Logger.warn(this, "File Asset [" + contentIdentifier
+                    + "] cannot be created directly under System " +
                     "Host");
             cve.addBadTypeField(new LegacyFieldTransformer(contentType.fieldMap().get(FileAssetAPI
                     .HOST_FOLDER_FIELD)).asOldField());
@@ -7200,44 +7997,57 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
 
         //Enforce validation only if the file name isn't the same we've already got
-        if(hasNewIncomingFile(contentlet)){
+        if (hasNewIncomingFile(contentlet)) {
             boolean fileNameExists = false;
             try {
-                final Host site = APILocator.getHostAPI ().find(contentlet.getHost(), APILocator.getUserAPI().getSystemUser(), false);
-                final Folder folder = UtilMethods.isSet(contentlet.getFolder())?
-                        APILocator.getFolderAPI().find(contentlet.getFolder(), APILocator.getUserAPI().getSystemUser(), false):
+                final Host site = APILocator.getHostAPI()
+                        .find(contentlet.getHost(), APILocator.getUserAPI().getSystemUser(), false);
+                final Folder folder = UtilMethods.isSet(contentlet.getFolder()) ?
+                        APILocator.getFolderAPI().find(contentlet.getFolder(),
+                                APILocator.getUserAPI().getSystemUser(), false) :
                         APILocator.getFolderAPI().findSystemFolder();
 
-                String fileName = contentlet.getBinary(FileAssetAPI.BINARY_FIELD) != null ? contentlet.getBinary(FileAssetAPI.BINARY_FIELD).getName() : StringPool.BLANK;
-                if(UtilMethods.isSet(contentlet.getStringProperty("fileName"))){
+                String fileName = contentlet.getBinary(FileAssetAPI.BINARY_FIELD) != null
+                        ? contentlet.getBinary(FileAssetAPI.BINARY_FIELD).getName()
+                        : StringPool.BLANK;
+                if (UtilMethods.isSet(contentlet.getStringProperty("fileName"))) {
                     fileName = contentlet.getStringProperty("fileName");
                 }
-                if(UtilMethods.isSet(fileName)){
-                    fileNameExists = APILocator.getFileAssetAPI().fileNameExists(site, folder, fileName, contentlet.getIdentifier());
-                    if(!APILocator.getFolderAPI().matchFilter(folder, fileName)) {
-                        final DotContentletValidationException cve = new FileAssetValidationException(Sneaky.sneak(()->LanguageUtil.get("message.file_asset.error.filename.filters")));
-                        Logger.warn(this, "File Asset [" + contentIdentifier + "] does not match specified folder" +
+                if (UtilMethods.isSet(fileName)) {
+                    fileNameExists = APILocator.getFileAssetAPI()
+                            .fileNameExists(site, folder, fileName, contentlet.getIdentifier());
+                    if (!APILocator.getFolderAPI().matchFilter(folder, fileName)) {
+                        final DotContentletValidationException cve = new FileAssetValidationException(
+                                Sneaky.sneak(() -> LanguageUtil.get(
+                                        "message.file_asset.error.filename.filters")));
+                        Logger.warn(this, "File Asset [" + contentIdentifier
+                                + "] does not match specified folder" +
                                 " file filters");
-                        cve.addBadTypeField(new LegacyFieldTransformer(contentType.fieldMap().get(FileAssetAPI
-                                .HOST_FOLDER_FIELD)).asOldField());
+                        cve.addBadTypeField(
+                                new LegacyFieldTransformer(contentType.fieldMap().get(FileAssetAPI
+                                        .HOST_FOLDER_FIELD)).asOldField());
                         throw cve;
                     }
                 }
 
             } catch (final Exception e) {
-                if(e instanceof FileAssetValidationException) {
+                if (e instanceof FileAssetValidationException) {
                     throw (FileAssetValidationException) e;
                 }
-                final String errorMsg = "Unable to validate field: " + FileAssetAPI.BINARY_FIELD + " in " +
-                        "contentlet [" + contentIdentifier + "]";
+                final String errorMsg =
+                        "Unable to validate field: " + FileAssetAPI.BINARY_FIELD + " in " +
+                                "contentlet [" + contentIdentifier + "]";
                 Logger.warn(this, errorMsg);
                 throw new FileAssetValidationException(errorMsg, e);
             }
-            if(fileNameExists){
-                final DotContentletValidationException cve = new FileAssetValidationException(Sneaky.sneak(()->LanguageUtil.get("message.contentlet.fileasset.filename.already.exists")));
+            if (fileNameExists) {
+                final DotContentletValidationException cve = new FileAssetValidationException(
+                        Sneaky.sneak(() -> LanguageUtil.get(
+                                "message.contentlet.fileasset.filename.already.exists")));
                 Logger.warn(this, "Name of File Asset [" + contentIdentifier + "] already exists");
-                cve.addBadTypeField(new LegacyFieldTransformer(contentType.fieldMap().get(FileAssetAPI
-                        .HOST_FOLDER_FIELD)).asOldField());
+                cve.addBadTypeField(
+                        new LegacyFieldTransformer(contentType.fieldMap().get(FileAssetAPI
+                                .HOST_FOLDER_FIELD)).asOldField());
                 throw cve;
             }
         }
@@ -7247,6 +8057,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * Host validation method shared by HostResource and ContentletWebAPI
+     *
      * @param contentlet
      */
     private void validateSite(Contentlet contentlet) {
@@ -7261,15 +8072,19 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public void validateContentlet(Contentlet contentlet,Map<Relationship, List<Contentlet>> contentRelationships,List<Category> cats)throws DotContentletValidationException {
-        Structure st = CacheLocator.getContentTypeCache().getStructureByInode(contentlet.getStructureInode());
+    public void validateContentlet(Contentlet contentlet,
+            Map<Relationship, List<Contentlet>> contentRelationships, List<Category> cats)
+            throws DotContentletValidationException {
+        Structure st = CacheLocator.getContentTypeCache()
+                .getStructureByInode(contentlet.getStructureInode());
         ContentletRelationships relationshipsData = new ContentletRelationships(contentlet);
-        List<ContentletRelationshipRecords> relationshipsRecords = new ArrayList<ContentletRelationshipRecords> ();
+        List<ContentletRelationshipRecords> relationshipsRecords = new ArrayList<ContentletRelationshipRecords>();
         relationshipsData.setRelationshipsRecords(relationshipsRecords);
-        for(Entry<Relationship, List<Contentlet>> relEntry : contentRelationships.entrySet()) {
+        for (Entry<Relationship, List<Contentlet>> relEntry : contentRelationships.entrySet()) {
             Relationship relationship = relEntry.getKey();
             boolean hasParent = APILocator.getRelationshipAPI().isParent(relationship, st);
-            ContentletRelationshipRecords records = relationshipsData.new ContentletRelationshipRecords(relationship, hasParent);
+            ContentletRelationshipRecords records = relationshipsData.new ContentletRelationshipRecords(
+                    relationship, hasParent);
             records.setRecords(relEntry.getValue());
         }
         validateContentlet(contentlet, relationshipsData, cats);
@@ -7284,13 +8099,15 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
         final String contentTypeId = contentlet.getContentTypeId();
         if (!InodeUtils.isSet(contentTypeId)) {
-            final String errorMsg = "Contentlet [" + contentlet.getIdentifier() + "] has an empty Content Type ID";
+            final String errorMsg =
+                    "Contentlet [" + contentlet.getIdentifier() + "] has an empty Content Type ID";
             Logger.error(this, errorMsg);
             throw new DotContentletValidationException(errorMsg);
         }
         try {
             validateContentlet(contentlet, cats);
-            if (BaseContentType.PERSONA.getType() == contentlet.getContentType().baseType().getType()) {
+            if (BaseContentType.PERSONA.getType() == contentlet.getContentType().baseType()
+                    .getType()) {
                 APILocator.getPersonaAPI().validatePersona(contentlet);
             }
             if (contentlet.isVanityUrl()) {
@@ -7303,20 +8120,23 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public void validateContentlet(final Contentlet contentlet, final ContentletRelationships contentRelationships,
+    public void validateContentlet(final Contentlet contentlet,
+            final ContentletRelationships contentRelationships,
             final List<Category> cats) throws DotContentletValidationException {
         if (null != contentlet.getMap().get(Contentlet.DONT_VALIDATE_ME)) {
             return;
         }
         final String contentTypeId = contentlet.getContentTypeId();
         if (!InodeUtils.isSet(contentTypeId)) {
-            final String errorMsg = "Contentlet [" + contentlet.getIdentifier() + "] has an empty Content Type ID";
+            final String errorMsg =
+                    "Contentlet [" + contentlet.getIdentifier() + "] has an empty Content Type ID";
             Logger.error(this, errorMsg);
             throw new DotContentletValidationException(errorMsg);
         }
         try {
             validateContentlet(contentlet, cats);
-            if (BaseContentType.PERSONA.getType() == contentlet.getContentType().baseType().getType()) {
+            if (BaseContentType.PERSONA.getType() == contentlet.getContentType().baseType()
+                    .getType()) {
                 APILocator.getPersonaAPI().validatePersona(contentlet);
             }
             if (contentlet.isVanityUrl()) {
@@ -7326,31 +8146,36 @@ public class ESContentletAPIImpl implements ContentletAPI {
             throw ve;
         }
 
-        if(Try.of(()->!contentlet.getBoolProperty(Contentlet.SKIP_RELATIONSHIPS_VALIDATION)).getOrElse(true)) {
+        if (Try.of(() -> !contentlet.getBoolProperty(Contentlet.SKIP_RELATIONSHIPS_VALIDATION))
+                .getOrElse(true)) {
             validateRelationships(contentlet, contentRelationships);
         }
     }
 
     /**
-     * Validates that the relationships where the specified {@code contentlet} is involved are correct in terms of
-     * cardinality and Content Type match.
+     * Validates that the relationships where the specified {@code contentlet} is involved are
+     * correct in terms of cardinality and Content Type match.
      *
-     * @param contentlet           The {@link Contentlet} object whose relationships will be validated, if any.
-     * @param contentRelationships The {@link ContentletRelationships} containing the information of the Contentlet's
-     *                             relationships and associated Contentlets.
-     *
-     * @throws DotContentletValidationException An error occurred during the validation. This usually means a problem
-     *                                          with the data being sent by the user.
+     * @param contentlet           The {@link Contentlet} object whose relationships will be
+     *                             validated, if any.
+     * @param contentRelationships The {@link ContentletRelationships} containing the information of
+     *                             the Contentlet's relationships and associated Contentlets.
+     * @throws DotContentletValidationException An error occurred during the validation. This
+     *                                          usually means a problem with the data being sent by
+     *                                          the user.
      */
     private void validateRelationships(final Contentlet contentlet,
-            final ContentletRelationships contentRelationships) throws DotContentletValidationException {
+            final ContentletRelationships contentRelationships)
+            throws DotContentletValidationException {
 
         boolean hasError = false;
-        final String contentletId = (UtilMethods.isSet(contentlet.getIdentifier()) ? contentlet.getIdentifier() :
+        final String contentletId = (UtilMethods.isSet(contentlet.getIdentifier())
+                ? contentlet.getIdentifier() :
                 "Unknown/New");
         final ContentType contentType = contentlet.getContentType();
-        final DotContentletValidationException cve = new DotContentletValidationException("Contentlet [" +
-                contentletId + "] has invalid/missing relationships");
+        final DotContentletValidationException cve = new DotContentletValidationException(
+                "Contentlet [" +
+                        contentletId + "] has invalid/missing relationships");
 
         if (null != contentRelationships) {
             final List<ContentletRelationshipRecords> records = contentRelationships.getRelationshipsRecords();
@@ -7363,32 +8188,39 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 }
 
                 if (relationship.getCardinality() == RELATIONSHIP_CARDINALITY.ONE_TO_ONE
-                        .ordinal() && contentsInRelationship.size() > 0){
-                    hasError |= !isValidOneToOneRelationship(contentlet, cve, relationship, contentsInRelationship);
+                        .ordinal() && contentsInRelationship.size() > 0) {
+                    hasError |= !isValidOneToOneRelationship(contentlet, cve, relationship,
+                            contentsInRelationship);
 
-                    if (hasError)
+                    if (hasError) {
                         continue;
+                    }
                 }
                 //There is a case when the Relationship is between same structures
                 //We need to validate that case
                 boolean isRelationshipParent = true;
-                if(APILocator.getRelationshipAPI().sameParentAndChild(relationship)){
-                    if (contentsInRelationship.stream().anyMatch(con -> contentlet.getIdentifier().equals(con.getIdentifier()))) {
-                        Logger.error(this, "Cannot relate content [" + contentletId + "] to itself");
+                if (APILocator.getRelationshipAPI().sameParentAndChild(relationship)) {
+                    if (contentsInRelationship.stream().anyMatch(
+                            con -> contentlet.getIdentifier().equals(con.getIdentifier()))) {
+                        Logger.error(this,
+                                "Cannot relate content [" + contentletId + "] to itself");
                         hasError = true;
                         cve.addInvalidContentRelationship(relationship, contentsInRelationship);
                     }
-                    if(!cr.isHasParent()){
+                    if (!cr.isHasParent()) {
                         isRelationshipParent = false;
                     }
                 }
 
                 // if i am the parent
-                if (APILocator.getRelationshipAPI().isParent(relationship,contentType) && isRelationshipParent) {
+                if (APILocator.getRelationshipAPI().isParent(relationship, contentType)
+                        && isRelationshipParent) {
                     if (relationship.isChildRequired() && contentsInRelationship.isEmpty()) {
                         hasError = true;
-                        Logger.error(this, "Error in Contentlet [" + contentletId + "]: Child relationship [" + relationship
-                                .getRelationTypeValue() + "] is required.");
+                        Logger.error(this,
+                                "Error in Contentlet [" + contentletId + "]: Child relationship ["
+                                        + relationship
+                                        .getRelationTypeValue() + "] is required.");
                         cve.addRequiredRelationship(relationship, contentsInRelationship);
                     }
                     for (final Contentlet contentInRelationship : contentsInRelationship) {
@@ -7397,47 +8229,62 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             // that has -boolean pullByParent- as parameter so we can pass -false-
                             // to get related content where we are parents.
                             final List<Contentlet> relatedContents = getRelatedContentFromIndex(
-                                    contentInRelationship, relationship, false, APILocator.getUserAPI()
+                                    contentInRelationship, relationship, false,
+                                    APILocator.getUserAPI()
                                             .getSystemUser(), true);
                             // If there's a 1-N relationship and the parent
                             // content is relating to a child that already has
                             // a parent...
-                            if (relationship.getCardinality() == RELATIONSHIP_CARDINALITY.ONE_TO_MANY.ordinal()
+                            if (relationship.getCardinality()
+                                    == RELATIONSHIP_CARDINALITY.ONE_TO_MANY.ordinal()
                                     && relatedContents.size() > 0
                                     && !relatedContents.get(0).getIdentifier()
                                     .equals(contentlet.getIdentifier())) {
                                 final StringBuilder error = new StringBuilder();
                                 error.append("ERROR! Parent content [").append(contentletId)
-                                        .append("] cannot be related to child content [").append(contentInRelationship.getIdentifier())
+                                        .append("] cannot be related to child content [")
+                                        .append(contentInRelationship.getIdentifier())
                                         .append("] because it is already related to parent content [")
                                         .append(relatedContents.get(0).getIdentifier()).append("]");
                                 Logger.error(this, error.toString());
                                 hasError = true;
-                                cve.addBadCardinalityRelationship(relationship, contentsInRelationship);
+                                cve.addBadCardinalityRelationship(relationship,
+                                        contentsInRelationship);
                             }
 
-                            if (!contentInRelationship.getContentTypeId().equalsIgnoreCase(relationship.getChildStructureInode())) {
+                            if (!contentInRelationship.getContentTypeId()
+                                    .equalsIgnoreCase(relationship.getChildStructureInode())) {
                                 hasError = true;
-                                Logger.error(this, "Content Type of Contentlet [" + contentInRelationship
-                                        .getIdentifier() + "] does not match the Content Type in child relationship [" +
-                                        relationship.getRelationTypeValue() + "]");
-                                cve.addInvalidContentRelationship(relationship, contentsInRelationship);
+                                Logger.error(this,
+                                        "Content Type of Contentlet [" + contentInRelationship
+                                                .getIdentifier()
+                                                + "] does not match the Content Type in child relationship ["
+                                                +
+                                                relationship.getRelationTypeValue() + "]");
+                                cve.addInvalidContentRelationship(relationship,
+                                        contentsInRelationship);
                             }
                         } catch (final DotSecurityException | DotDataException e) {
-                            Logger.error(this, "An error occurred when retrieving information from related Contentlet" +
-                                    " [" + contentInRelationship.getIdentifier() + "]", e);
+                            Logger.error(this,
+                                    "An error occurred when retrieving information from related Contentlet"
+                                            +
+                                            " [" + contentInRelationship.getIdentifier() + "]", e);
                         }
                     }
                 } else if (APILocator.getRelationshipAPI().isChild(relationship, contentType)) {
                     if (relationship.isParentRequired() && contentsInRelationship.isEmpty()) {
                         hasError = true;
-                        Logger.error(this, "Error in Contentlet [" + contentletId + "]: Parent relationship [" + relationship
-                                .getRelationTypeValue() + "] is required.");
+                        Logger.error(this,
+                                "Error in Contentlet [" + contentletId + "]: Parent relationship ["
+                                        + relationship
+                                        .getRelationTypeValue() + "] is required.");
                         cve.addRequiredRelationship(relationship, contentsInRelationship);
                     }
                     // If there's a 1-N relationship and the child content is
                     // trying to relate to one more parent...
-                    if (relationship.getCardinality() == RELATIONSHIP_CARDINALITY.ONE_TO_MANY.ordinal() && contentsInRelationship.size() > 1) {
+                    if (relationship.getCardinality()
+                            == RELATIONSHIP_CARDINALITY.ONE_TO_MANY.ordinal()
+                            && contentsInRelationship.size() > 1) {
                         final StringBuilder error = new StringBuilder();
                         error.append("ERROR! Child content [").append(contentletId)
                                 .append("] is already related to another parent content [");
@@ -7453,34 +8300,38 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     for (final Contentlet contentInRelationship : contentsInRelationship) {
                         if (!UtilMethods.isSet(contentInRelationship.getContentTypeId())) {
                             hasError = true;
-                            Logger.error(this, "Contentlet with Identifier [" + contentletId + "] has an empty " +
+                            Logger.error(this, "Contentlet with Identifier [" + contentletId
+                                    + "] has an empty " +
                                     "Content Type Inode");
                             cve.addInvalidContentRelationship(relationship, contentsInRelationship);
                             continue;
                         }
-                        if (null != relationship.getParentStructureInode() && !contentInRelationship.getContentTypeId().equalsIgnoreCase(
+                        if (null != relationship.getParentStructureInode()
+                                && !contentInRelationship.getContentTypeId().equalsIgnoreCase(
                                 relationship.getParentStructureInode())) {
                             hasError = true;
-                            Logger.error(this, "Content Type of Contentlet [" + contentletId + "] does not match the " +
-                                    "Content Type in relationship [" + relationship.getRelationTypeValue() + "]");
+                            Logger.error(this, "Content Type of Contentlet [" + contentletId
+                                    + "] does not match the " +
+                                    "Content Type in relationship ["
+                                    + relationship.getRelationTypeValue() + "]");
                             cve.addInvalidContentRelationship(relationship, contentsInRelationship);
                         }
                     }
                 } else {
                     hasError = true;
-                    Logger.error(this, "Relationship [" + relationship.getRelationTypeValue() + "] is neither parent nor child" +
+                    Logger.error(this, "Relationship [" + relationship.getRelationTypeValue()
+                            + "] is neither parent nor child" +
                             " of Contentlet [" + contentletId + "]");
                     cve.addBadRelationship(relationship, contentsInRelationship);
                 }
             }
         }
-        if (hasError){
+        if (hasError) {
             throw cve;
         }
     }
 
     /**
-     *
      * @param contentlet
      * @param cve
      * @param relationship
@@ -7520,8 +8371,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 return false;
             }
         } catch (final DotSecurityException | DotDataException e) {
-            Logger.error(this, "An error occurred when retrieving information from related Contentlet" +
-                    " [" + contentsInRelationship.get(0).getIdentifier() + "]", e);
+            Logger.error(this,
+                    "An error occurred when retrieving information from related Contentlet" +
+                            " [" + contentsInRelationship.get(0).getIdentifier() + "]", e);
             cve.addInvalidContentRelationship(relationship, contentsInRelationship);
             return false;
         }
@@ -7530,7 +8382,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @Override
     public boolean isFieldTypeBoolean(Field field) {
-        if(field.getFieldContentlet().startsWith("bool")){
+        if (field.getFieldContentlet().startsWith("bool")) {
             return true;
         }
         return false;
@@ -7538,7 +8390,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @Override
     public boolean isFieldTypeDate(Field field) {
-        if(field.getFieldContentlet().startsWith("date")){
+        if (field.getFieldContentlet().startsWith("date")) {
             return true;
         }
         return false;
@@ -7546,7 +8398,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @Override
     public boolean isFieldTypeFloat(Field field) {
-        if(field.getFieldContentlet().startsWith("float")){
+        if (field.getFieldContentlet().startsWith("float")) {
             return true;
         }
         return false;
@@ -7554,7 +8406,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @Override
     public boolean isFieldTypeLong(Field field) {
-        if(field.getFieldContentlet().startsWith("integer")){
+        if (field.getFieldContentlet().startsWith("integer")) {
             return true;
         }
         return false;
@@ -7562,71 +8414,73 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @Override
     public boolean isFieldTypeString(Field field) {
-        if(field.getFieldContentlet().startsWith("text")){
+        if (field.getFieldContentlet().startsWith("text")) {
             return true;
         }
         return false;
     }
 
     /**
-     *
      * @param field
      * @return
      */
     public boolean isFieldTypeBinary(Field field) {
-        if(Field.FieldType.BINARY.toString().equals(field.getFieldType())){
+        if (Field.FieldType.BINARY.toString().equals(field.getFieldType())) {
             return true;
         }
         return false;
     }
 
     /**
-     *
      * @param field
      * @return
      */
     public boolean isFieldTypeSystem(Field field) {
-        if(field.getFieldContentlet().startsWith("system")){
+        if (field.getFieldContentlet().startsWith("system")) {
             return true;
         }
         return false;
     }
 
     /**
-     *
      * @param field
      * @return
      */
     public boolean isFieldTypeConstant(Field field) {
-        if(field.getFieldContentlet().startsWith("constant")){
+        if (field.getFieldContentlet().startsWith("constant")) {
             return true;
         }
         return false;
     }
 
     /**
-     *
      * @param content
      * @return
      * @throws DotSecurityException
      * @throws DotDataException
      * @throws DotContentletStateException
      */
-    private Contentlet findWorkingContentlet(Contentlet content)throws DotSecurityException, DotDataException, DotContentletStateException{
+    private Contentlet findWorkingContentlet(Contentlet content)
+            throws DotSecurityException, DotDataException, DotContentletStateException {
         Contentlet con = null;
         List<Contentlet> workingCons = new ArrayList<Contentlet>();
-        if(InodeUtils.isSet(content.getIdentifier())){
-            workingCons = contentFactory.findContentletsByIdentifier(content.getIdentifier(), false, content.getLanguageId());
+        if (InodeUtils.isSet(content.getIdentifier())) {
+            workingCons = contentFactory.findContentletsByIdentifier(content.getIdentifier(), false,
+                    content.getLanguageId());
         }
-        if(workingCons.size() > 0)
+        if (workingCons.size() > 0) {
             con = workingCons.get(0);
-        if(workingCons.size()>1)
-            Logger.warn(this, "Multiple working contentlets found for identifier:" + content.getIdentifier() + " with languageid:" + content.getLanguageId() + " returning the lastest modified.");
+        }
+        if (workingCons.size() > 1) {
+            Logger.warn(this,
+                    "Multiple working contentlets found for identifier:" + content.getIdentifier()
+                            + " with languageid:" + content.getLanguageId()
+                            + " returning the lastest modified.");
+        }
         return con;
     }
 
     /**
-     *
      * @param contentlet
      * @return
      * @throws DotDataException
@@ -7635,11 +8489,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
     private Map<Relationship, List<Contentlet>> findContentRelationships(Contentlet contentlet)
             throws DotDataException {
         Map<Relationship, List<Contentlet>> contentRelationships = new HashMap<>();
-        if(contentlet == null)
+        if (contentlet == null) {
             return contentRelationships;
-        List<Relationship> rels = APILocator.getRelationshipAPI().byContentType(contentlet.getStructure());
+        }
+        List<Relationship> rels = APILocator.getRelationshipAPI()
+                .byContentType(contentlet.getStructure());
         for (Relationship r : rels) {
-            if(!contentRelationships.containsKey(r)){
+            if (!contentRelationships.containsKey(r)) {
                 contentRelationships.put(r, new ArrayList<>());
             }
             List<Contentlet> cons = relationshipAPI.dbRelatedContent(r, contentlet);
@@ -7656,7 +8512,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
     @Override
     public int deleteOldContent(Date deleteFrom) throws DotDataException {
         int results = 0;
-        if(deleteFrom == null){
+        if (deleteFrom == null) {
             throw new DotDataException("Date to delete from must not be null");
         }
         results = contentFactory.deleteOldContent(deleteFrom);
@@ -7665,7 +8521,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<String> findFieldValues(String structureInode, Field field, User user, boolean respectFrontEndRoles) throws DotDataException {
+    public List<String> findFieldValues(String structureInode, Field field, User user,
+            boolean respectFrontEndRoles) throws DotDataException {
         List<String> result = new ArrayList<String>();
 
         List<Contentlet> contentlets;
@@ -7674,17 +8531,23 @@ public class ESContentletAPIImpl implements ContentletAPI {
             List<Contentlet> tempContentlets = new ArrayList<Contentlet>();
             int limit = 500;
 
-            StringBuilder query = new StringBuilder("+deleted:false +live:true +structureInode:" + structureInode);
+            StringBuilder query = new StringBuilder(
+                    "+deleted:false +live:true +structureInode:" + structureInode);
 
             try {
-                tempContentlets = search(query.toString(), limit, 0, field.getFieldContentlet(), user, respectFrontEndRoles, PermissionAPI.PERMISSION_READ);
-                if (0 < tempContentlets.size())
+                tempContentlets = search(query.toString(), limit, 0, field.getFieldContentlet(),
+                        user, respectFrontEndRoles, PermissionAPI.PERMISSION_READ);
+                if (0 < tempContentlets.size()) {
                     contentlets.addAll(tempContentlets);
+                }
 
-                for (int offset = limit; 0 < tempContentlets.size(); offset+=limit) {
-                    tempContentlets = search(query.toString(), limit, offset, field.getFieldContentlet(), user, respectFrontEndRoles, PermissionAPI.PERMISSION_READ);
-                    if (0 < tempContentlets.size())
+                for (int offset = limit; 0 < tempContentlets.size(); offset += limit) {
+                    tempContentlets = search(query.toString(), limit, offset,
+                            field.getFieldContentlet(), user, respectFrontEndRoles,
+                            PermissionAPI.PERMISSION_READ);
+                    if (0 < tempContentlets.size()) {
                         contentlets.addAll(tempContentlets);
+                    }
                 }
             } catch (Exception e) {
                 Logger.debug(this, e.toString());
@@ -7692,31 +8555,34 @@ public class ESContentletAPIImpl implements ContentletAPI {
         } else {
             contentlets = contentFactory.findContentletsWithFieldValue(structureInode, field);
             try {
-                contentlets = permissionAPI.filterCollection(contentlets, PermissionAPI.PERMISSION_READ, respectFrontEndRoles, user);
+                contentlets = permissionAPI.filterCollection(contentlets,
+                        PermissionAPI.PERMISSION_READ, respectFrontEndRoles, user);
             } catch (Exception e) {
                 Logger.debug(this, e.toString());
             }
         }
 
         String value;
-        for (Contentlet contentlet: contentlets) {
+        for (Contentlet contentlet : contentlets) {
             try {
                 value = null;
-                if (field.getFieldType().equals(Field.DataType.BOOL))
+                if (field.getFieldType().equals(Field.DataType.BOOL)) {
                     value = "" + contentlet.getBoolProperty(field.getVelocityVarName());
-                else if (field.getFieldType().equals(Field.DataType.DATE))
+                } else if (field.getFieldType().equals(Field.DataType.DATE)) {
                     value = "" + contentlet.getDateProperty(field.getVelocityVarName());
-                else if (field.getFieldType().equals(Field.DataType.FLOAT))
+                } else if (field.getFieldType().equals(Field.DataType.FLOAT)) {
                     value = "" + contentlet.getFloatProperty(field.getVelocityVarName());
-                else if (field.getFieldType().equals(Field.DataType.INTEGER))
+                } else if (field.getFieldType().equals(Field.DataType.INTEGER)) {
                     value = "" + contentlet.getLongProperty(field.getVelocityVarName());
-                else if (field.getFieldType().equals(Field.DataType.LONG_TEXT))
+                } else if (field.getFieldType().equals(Field.DataType.LONG_TEXT)) {
                     value = contentlet.getStringProperty(field.getVelocityVarName());
-                else
+                } else {
                     value = contentlet.getStringProperty(field.getVelocityVarName());
+                }
 
-                if (UtilMethods.isSet(value))
+                if (UtilMethods.isSet(value)) {
                     result.add(value);
+                }
             } catch (Exception e) {
                 Logger.debug(this, e.toString());
             }
@@ -7726,11 +8592,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     *
      * @param contentlets
      * @param field
      */
-    private void deleteBinaryFiles(List<Contentlet> contentlets,Field field) {
+    private void deleteBinaryFiles(List<Contentlet> contentlets, Field field) {
         contentlets.stream().forEach(con -> {
 
             String contentletAssetPath = getContentletAssetPath(con, field);
@@ -7745,11 +8610,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     *
      * @param contentlets
      * @param field
      */
-    private void moveBinaryFilesToTrash(List<Contentlet> contentlets,Field field) {
+    private void moveBinaryFilesToTrash(List<Contentlet> contentlets, Field field) {
         contentlets.stream().forEach(con -> {
 
             String contentletAssetPath = getContentletAssetPath(con, field);
@@ -7757,19 +8621,21 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
             try {
                 // To delete binary files
-                new TrashUtils().moveFileToTrash(new File(contentletAssetPath), "binaries/asset/"+con.getInode());
+                new TrashUtils().moveFileToTrash(new File(contentletAssetPath),
+                        "binaries/asset/" + con.getInode());
 
                 // To delete resized images
-                new TrashUtils().moveFileToTrash(new File(contentletAssetCachePath), "binaries/cache/"+con.getInode());
+                new TrashUtils().moveFileToTrash(new File(contentletAssetCachePath),
+                        "binaries/cache/" + con.getInode());
 
             } catch (IOException e) {
-                Logger.error(this, "Error moving files to trash: '"+contentletAssetPath+"', '"+ contentletAssetCachePath +"'" );
+                Logger.error(this, "Error moving files to trash: '" + contentletAssetPath + "', '"
+                        + contentletAssetCachePath + "'");
             }
         });
     }
 
     /**
-     *
      * @param con
      * @param field
      * @return
@@ -7785,7 +8651,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 + File.separator
                 + inode;
 
-        if(field != null){
+        if (field != null) {
             result += File.separator + field.getVelocityVarName();
         }
 
@@ -7793,7 +8659,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     *
      * @param con
      * @param field
      * @return
@@ -7811,7 +8676,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 + File.separator
                 + inode;
 
-        if(field != null){
+        if (field != null) {
             result += File.separator + field.getVelocityVarName();
         }
 
@@ -7821,9 +8686,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
     @CloseDBIfOpened
     @Override
     public File getBinaryFile(final String contentletInode, final String velocityVariableName,
-            final User user) throws DotDataException,DotSecurityException {
+            final User user) throws DotDataException, DotSecurityException {
 
-        Logger.debug(this,"Retrieving binary file name : getBinaryFileName()." );
+        Logger.debug(this, "Retrieving binary file name : getBinaryFileName().");
 
         Contentlet con = contentFactory.find(contentletInode);
 
@@ -7854,17 +8719,19 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     + velocityVariableName;
             File binaryFilefolder = new File(binaryFilePath);
 
-            if ( binaryFilefolder.exists() ) {
+            if (binaryFilefolder.exists()) {
                 java.io.File[] files = binaryFilefolder.listFiles(new BinaryFileFilter());
 
-                if ( files.length > 0 ) {
+                if (files.length > 0) {
                     binaryFile = files[0];
                 }
             }
         } catch (Exception e) {
-            Logger.error(this, "Error occured while retrieving binary file name : getBinaryFileName(). ContentletInode : " + contentletInode
-                    + "  velocityVaribleName : " + velocityVariableName
-                    + "  path : " + binaryFilePath);
+            Logger.error(this,
+                    "Error occured while retrieving binary file name : getBinaryFileName(). ContentletInode : "
+                            + contentletInode
+                            + "  velocityVaribleName : " + velocityVariableName
+                            + "  path : " + binaryFilePath);
             throw new DotDataException("File System error.", e);
         }
         return binaryFile;
@@ -7884,15 +8751,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public List<Map<String, Serializable>> DBSearch(Query query, User user,boolean respectFrontendRoles) throws ValidationException,DotDataException {
+    public List<Map<String, Serializable>> DBSearch(Query query, User user,
+            boolean respectFrontendRoles) throws ValidationException, DotDataException {
 
         List<com.dotcms.contenttype.model.field.Field> fields;
         try {
-            fields = APILocator.getContentTypeAPI(APILocator.systemUser()).find(query.getFromClause()).fields();
+            fields = APILocator.getContentTypeAPI(APILocator.systemUser())
+                    .find(query.getFromClause()).fields();
         } catch (DotSecurityException e) {
             throw new DotStateException(e);
         }
-        if(fields == null || fields.size() < 1){
+        if (fields == null || fields.size() < 1) {
             throw new ValidationException("No Fields found for Content");
         }
         Map<String, String> dbColToObjectAttribute = new HashMap<String, String>();
@@ -7902,67 +8771,64 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         String title = "inode";
         for (com.dotcms.contenttype.model.field.Field f : fields) {
-            if(f.listed()){
+            if (f.listed()) {
                 title = f.dbColumn();
                 break;
             }
         }
-        if(UtilMethods.isSet(query.getSelectAttributes())){
+        if (UtilMethods.isSet(query.getSelectAttributes())) {
 
-            if(!query.getSelectAttributes().contains(title)){
+            if (!query.getSelectAttributes().contains(title)) {
                 query.getSelectAttributes().add(title);
             }
-        }else{
+        } else {
             List<String> atts = new ArrayList<String>();
             atts.add("*");
             atts.add(title);
             query.setSelectAttributes(atts);
         }
 
-        return QueryUtil.DBSearch(query, dbColToObjectAttribute, "structure_inode = '" + fields.get(0).contentTypeId() + "'", user, true,respectFrontendRoles);
+        return QueryUtil.DBSearch(query, dbColToObjectAttribute,
+                "structure_inode = '" + fields.get(0).contentTypeId() + "'", user, true,
+                respectFrontendRoles);
     }
 
     /**
-     * Copies a contentlet, including all its fields including binary files,
-     * image and file fields are pointers and the are preserved as the are so if
-     * source contentlet points to image A and resulting new contentlet will
-     * point to same image A as well, also copies source permissions.
+     * Copies a contentlet, including all its fields including binary files, image and file fields
+     * are pointers and the are preserved as the are so if source contentlet points to image A and
+     * resulting new contentlet will point to same image A as well, also copies source permissions.
      *
-     * @param sourceContentlet
-     *            - The contentlet that will be copied to the new destination.
-     * @param host
-     *            - The destination host.
-     * @param folder
-     *            - The destination folder.
-     * @param user
-     *            - The user performing this action.
-     * @param copySuffix
-     *            - A name suffix when there is a contentlet that already has
-     *            the same URL.
-     * @param respectFrontendRoles
-     *            -
-     * @return The {@link Contentlet} object that was created. Its inode
-     *         represents the latest version of such a contentlet.
-     * @throws DotDataException
-     *             An error occurred when accessing the database.
-     * @throws DotSecurityException
-     *             The {@code user} object does not have the permissions to
-     *             perform this action.
-     * @throws DotContentletStateException
-     *             The contentlet object could not be saved.
+     * @param sourceContentlet     - The contentlet that will be copied to the new destination.
+     * @param host                 - The destination host.
+     * @param folder               - The destination folder.
+     * @param user                 - The user performing this action.
+     * @param copySuffix           - A name suffix when there is a contentlet that already has the
+     *                             same URL.
+     * @param respectFrontendRoles -
+     * @return The {@link Contentlet} object that was created. Its inode represents the latest
+     * version of such a contentlet.
+     * @throws DotDataException            An error occurred when accessing the database.
+     * @throws DotSecurityException        The {@code user} object does not have the permissions to
+     *                                     perform this action.
+     * @throws DotContentletStateException The contentlet object could not be saved.
      */
     @WrapInTransaction
     @Override
-    public Contentlet copyContentlet(final Contentlet sourceContentlet, final Host host, final Folder folder, final User user, final String copySuffix, final boolean respectFrontendRoles) throws DotDataException, DotSecurityException, DotContentletStateException {
+    public Contentlet copyContentlet(final Contentlet sourceContentlet, final Host host,
+            final Folder folder, final User user, final String copySuffix,
+            final boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
         if (user == null || UtilMethods.isNotSet(user.getUserId())) {
             throw new DotSecurityException("A user must be specified.");
         }
-        final Map<String, HTMLPageAssetAPI.TemplateContainersReMap> templateMappings = (Map<String, TemplateContainersReMap>) sourceContentlet.get(Contentlet.TEMPLATE_MAPPINGS);
+        final Map<String, HTMLPageAssetAPI.TemplateContainersReMap> templateMappings = (Map<String, TemplateContainersReMap>) sourceContentlet.get(
+                Contentlet.TEMPLATE_MAPPINGS);
         Contentlet copyContentlet = new Contentlet();
         String newIdentifier = StringPool.BLANK;
         final List<Contentlet> versionsToMarkWorking = new ArrayList<>();
         final Map<String, Map<String, Contentlet>> contentletsToCopyRules = Maps.newHashMap();
-        final Identifier sourceContentletIdentifier = APILocator.getIdentifierAPI().find(sourceContentlet.getIdentifier());
+        final Identifier sourceContentletIdentifier = APILocator.getIdentifierAPI()
+                .find(sourceContentlet.getIdentifier());
         final List<Contentlet> versionsToCopy = new ArrayList<>(
                 findAllVersions(sourceContentletIdentifier, false, user, respectFrontendRoles));
 
@@ -7975,28 +8841,33 @@ public class ESContentletAPIImpl implements ContentletAPI {
             final boolean isContentletWorking = contentlet.isWorking();
             final boolean isContentletDeleted = contentlet.isArchived();
 
-            if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_READ, user, respectFrontendRoles)) {
-                throw new DotSecurityException(String.format("User '%s' does not have READ permissions on Contentlet " +
-                                                                     "Inode '%s'", user.getUserId(), contentlet.getInode()));
+            if (!permissionAPI.doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_READ,
+                    user, respectFrontendRoles)) {
+                throw new DotSecurityException(
+                        String.format("User '%s' does not have READ permissions on Contentlet " +
+                                "Inode '%s'", user.getUserId(), contentlet.getInode()));
             }
 
             // gets the new information for the template from the request object
             Contentlet newContentlet = new Contentlet();
             newContentlet.setStructureInode(contentlet.getStructureInode());
-            copyProperties(newContentlet, contentlet.getMap(),true);
+            copyProperties(newContentlet, contentlet.getMap(), true);
 
             newContentlet.setInode(StringPool.BLANK);
             newContentlet.setIdentifier(StringPool.BLANK);
-            newContentlet.setHost(host != null?host.getIdentifier(): (folder!=null? folder.getHostId() : contentlet.getHost()));
-            newContentlet.setFolder(folder != null?folder.getInode(): null);
+            newContentlet.setHost(host != null ? host.getIdentifier()
+                    : (folder != null ? folder.getHostId() : contentlet.getHost()));
+            newContentlet.setFolder(folder != null ? folder.getInode() : null);
             newContentlet.setLowIndexPriority(contentlet.isLowIndexPriority());
-            final boolean copyingSite = (!newContentlet.getHost().equals(sourceContentlet.getHost()));
-            if(contentlet.isFileAsset()){
-                final String newName = generateCopyName(newContentlet.getStringProperty(FileAssetAPI.FILE_NAME_FIELD), copySuffix);
+            final boolean copyingSite = (!newContentlet.getHost()
+                    .equals(sourceContentlet.getHost()));
+            if (contentlet.isFileAsset()) {
+                final String newName = generateCopyName(
+                        newContentlet.getStringProperty(FileAssetAPI.FILE_NAME_FIELD), copySuffix);
                 newContentlet.setStringProperty(FileAssetAPI.FILE_NAME_FIELD, newName);
 
                 final String newIdentifierName;
-                if(copyingSite){
+                if (copyingSite) {
                     //if we're copying a site.. re-using the asset-name is a safe strategy (it's supposed to be unique).
                     newIdentifierName = sourceContentletIdentifier.getAssetName();
                 } else {
@@ -8004,30 +8875,34 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     final Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
                     newIdentifierName = generateCopyName(identifier.getAssetName(), copySuffix);
                 }
-                newContentlet.setStringProperty(Contentlet.CONTENTLET_ASSET_NAME_COPY, newIdentifierName);
+                newContentlet.setStringProperty(Contentlet.CONTENTLET_ASSET_NAME_COPY,
+                        newIdentifierName);
             }
 
             final String temporalFolder =
                     APILocator.getFileAssetAPI().getRealAssetPathTmpBinary() + File.separator
                             + UUIDGenerator.generateUuid();
 
-            final List <Field> fields = FieldsCache.getFieldsByStructureInode(contentlet.getStructureInode());
+            final List<Field> fields = FieldsCache.getFieldsByStructureInode(
+                    contentlet.getStructureInode());
             File srcFile;
             File destFile = new File(temporalFolder);
             if (!destFile.exists()) {
                 destFile.mkdirs();
             }
             String fieldValue;
-            for (final Field tempField: fields) {
+            for (final Field tempField : fields) {
                 if (tempField.getFieldType().equals(Field.FieldType.BINARY.toString())) {
                     fieldValue = "";
                     try {
-                        srcFile = getBinaryFile(contentlet.getInode(), tempField.getVelocityVarName(), user);
-                        if(srcFile != null) {
-                            if(BaseContentType.FILEASSET.equals(contentlet.getContentType().baseType())){
+                        srcFile = getBinaryFile(contentlet.getInode(),
+                                tempField.getVelocityVarName(), user);
+                        if (srcFile != null) {
+                            if (BaseContentType.FILEASSET.equals(
+                                    contentlet.getContentType().baseType())) {
                                 fieldValue = generateCopyName(srcFile.getName(), copySuffix);
-                            }else{
-                                fieldValue=srcFile.getName();
+                            } else {
+                                fieldValue = srcFile.getName();
                             }
                             destFile = new File(temporalFolder + File.separator + fieldValue);
                             if (!destFile.exists()) {
@@ -8037,34 +8912,40 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             newContentlet.setBinary(tempField.getVelocityVarName(), destFile);
                         }
                     } catch (final Exception e) {
-                        throw new DotDataException("Error copying binary file: '" + fieldValue + "': " + e.getMessage(), e);
+                        throw new DotDataException(
+                                "Error copying binary file: '" + fieldValue + "': "
+                                        + e.getMessage(), e);
                     }
                 }
 
                 if (tempField.getFieldType().equals(Field.FieldType.HOST_OR_FOLDER.toString())) {
-                    if (folder != null || host != null){
-                        newContentlet.setStringProperty(tempField.getVelocityVarName(), folder != null?folder.getInode():host.getIdentifier());
-                    }else{
-                        if(contentlet.getFolder().equals(FolderAPI.SYSTEM_FOLDER)){
-                            newContentlet.setStringProperty(tempField.getVelocityVarName(), contentlet.getFolder());
-                        }else{
-                            newContentlet.setStringProperty(tempField.getVelocityVarName(), contentlet.getHost());
+                    if (folder != null || host != null) {
+                        newContentlet.setStringProperty(tempField.getVelocityVarName(),
+                                folder != null ? folder.getInode() : host.getIdentifier());
+                    } else {
+                        if (contentlet.getFolder().equals(FolderAPI.SYSTEM_FOLDER)) {
+                            newContentlet.setStringProperty(tempField.getVelocityVarName(),
+                                    contentlet.getFolder());
+                        } else {
+                            newContentlet.setStringProperty(tempField.getVelocityVarName(),
+                                    contentlet.getHost());
                         }
                     }
                 }
             }
 
-            final List<Category> parentCats = categoryAPI.getParents(contentlet, false, user, respectFrontendRoles);
+            final List<Category> parentCats = categoryAPI.getParents(contentlet, false, user,
+                    respectFrontendRoles);
             final Map<Relationship, List<Contentlet>> rels = new HashMap<>();
             String destinationHostId;
-            if(host != null && UtilMethods.isSet(host.getIdentifier())){
+            if (host != null && UtilMethods.isSet(host.getIdentifier())) {
                 destinationHostId = host.getIdentifier();
-            } else if(folder!=null){
+            } else if (folder != null) {
                 destinationHostId = folder.getHostId();
-            } else{
+            } else {
                 destinationHostId = contentlet.getHost();
             }
-            if(sourceContentlet.getHost().equals(destinationHostId)){
+            if (sourceContentlet.getHost().equals(destinationHostId)) {
                 final ContentletRelationships cr = getAllRelationships(contentlet);
                 final List<ContentletRelationshipRecords> rr = cr.getRelationshipsRecords();
                 for (final ContentletRelationshipRecords crr : rr) {
@@ -8073,22 +8954,29 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
 
             //Set URL in the new contentlet because is needed to create Identifier in EscontentletAPI.
-            if(contentlet.isHTMLPage()){
-                final String sourceTemplateId = contentlet.getStringProperty(HTMLPageAssetAPI.TEMPLATE_FIELD);
+            if (contentlet.isHTMLPage()) {
+                final String sourceTemplateId = contentlet.getStringProperty(
+                        HTMLPageAssetAPI.TEMPLATE_FIELD);
                 if (null != templateMappings && templateMappings.containsKey(sourceTemplateId)) {
-                    final Template destinationTemplate = templateMappings.get(sourceTemplateId).getDestinationTemplate();
-                    newContentlet.setStringProperty(HTMLPageAssetAPI.TEMPLATE_FIELD, destinationTemplate.getIdentifier());
+                    final Template destinationTemplate = templateMappings.get(sourceTemplateId)
+                            .getDestinationTemplate();
+                    newContentlet.setStringProperty(HTMLPageAssetAPI.TEMPLATE_FIELD,
+                            destinationTemplate.getIdentifier());
                 } else {
-                    final Template template = APILocator.getTemplateAPI().findWorkingTemplate(sourceTemplateId, user, false);
+                    final Template template = APILocator.getTemplateAPI()
+                            .findWorkingTemplate(sourceTemplateId, user, false);
                     if (template.isAnonymous()) {//If the Template has a custom layout we need to create a copy of it, so when is modified it does not modify the other pages.
-                        final Template copiedTemplate = APILocator.getTemplateAPI().copy(template, user);
-                        newContentlet.setStringProperty(HTMLPageAssetAPI.TEMPLATE_FIELD, copiedTemplate.getIdentifier());
+                        final Template copiedTemplate = APILocator.getTemplateAPI()
+                                .copy(template, user);
+                        newContentlet.setStringProperty(HTMLPageAssetAPI.TEMPLATE_FIELD,
+                                copiedTemplate.getIdentifier());
                     }
                 }
 
                 final Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
-                if(UtilMethods.isSet(identifier) && UtilMethods.isSet(identifier.getAssetName())){
-                    final String newAssetName = generateCopyName(identifier.getAssetName(), copySuffix);
+                if (UtilMethods.isSet(identifier) && UtilMethods.isSet(identifier.getAssetName())) {
+                    final String newAssetName = generateCopyName(identifier.getAssetName(),
+                            copySuffix);
                     newContentlet.setProperty(HTMLPageAssetAPI.URL_FIELD, newAssetName);
                 } else {
                     Logger.warn(this, "Unable to get URL from Contentlet: " + contentlet);
@@ -8105,54 +8993,56 @@ public class ESContentletAPIImpl implements ContentletAPI {
             if (UtilMethods.isSet(newIdentifier)) {
                 newContentlet.setIdentifier(newIdentifier);
             }
-            newContentlet = checkin(newContentlet, rels, parentCats, permissionAPI.getPermissions(contentlet), user, respectFrontendRoles);
-            if(!UtilMethods.isSet(newIdentifier)){
+            newContentlet = checkin(newContentlet, rels, parentCats,
+                    permissionAPI.getPermissions(contentlet), user, respectFrontendRoles);
+            if (!UtilMethods.isSet(newIdentifier)) {
                 newIdentifier = newContentlet.getIdentifier();
             }
 
             permissionAPI.copyPermissions(contentlet, newContentlet);
 
-
             //Using a map to make sure one identifier per page.
             //Avoiding multi languages pages.
-            if (!contentletsToCopyRules.containsKey(contentlet.getIdentifier())){
+            if (!contentletsToCopyRules.containsKey(contentlet.getIdentifier())) {
                 final Map<String, Contentlet> contentletMap = Maps.newHashMap();
                 contentletMap.put("contentlet", contentlet);
                 contentletMap.put("newContentlet", newContentlet);
                 contentletsToCopyRules.put(contentlet.getIdentifier(), contentletMap);
             }
 
-            if(isContentletLive){
+            if (isContentletLive) {
                 APILocator.getVersionableAPI().setLive(newContentlet);
             }
 
-            if(isContentletWorking) {
+            if (isContentletWorking) {
                 versionsToMarkWorking.add(newContentlet);
             }
             if (isContentletDeleted) {
                 APILocator.getVersionableAPI().setDeleted(newContentlet, true);
             }
-            if(contentlet.getInode().equals(sourceContentlet.getInode())){
+            if (contentlet.getInode().equals(sourceContentlet.getInode())) {
                 copyContentlet = newContentlet;
             }
         }
 
         for (final Map<String, Contentlet> stringContentletMap : contentletsToCopyRules.values()) {
-            try{
+            try {
                 final Contentlet contentlet = stringContentletMap.get("contentlet");
                 final Contentlet newContentlet = stringContentletMap.get("newContentlet");
-                APILocator.getRulesAPI().copyRulesByParent(contentlet, newContentlet, user, respectFrontendRoles);
-            } catch (final InvalidLicenseException ilexp){
-                Logger.warn(this, "License is required to copy rules under pages") ;
+                APILocator.getRulesAPI()
+                        .copyRulesByParent(contentlet, newContentlet, user, respectFrontendRoles);
+            } catch (final InvalidLicenseException ilexp) {
+                Logger.warn(this, "License is required to copy rules under pages");
             }
         }
 
-        for(final Contentlet con : versionsToMarkWorking){
+        for (final Contentlet con : versionsToMarkWorking) {
             APILocator.getVersionableAPI().setWorking(con);
         }
 
         if (sourceContentlet.isHTMLPage()) {
-            final boolean copyingSite = (!copyContentlet.getHost().equals(sourceContentlet.getHost()));
+            final boolean copyingSite = (!copyContentlet.getHost()
+                    .equals(sourceContentlet.getHost()));
             if (!copyingSite) { // We only want to execute this logic if we're not copying a whole site.
                 // If the content is an HTML Page then copy page associated contentlets
                 final List<MultiTree> pageContents = APILocator.getMultiTreeAPI()
@@ -8177,23 +9067,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * Copies the Workflow Task information from the "source" Contentlet to the "destination" Contentlet. This is very
-     * important in order to keep the copied Contentlet and its respective language versions in the same Workflow Step
-     * as the source Contentlet.
+     * Copies the Workflow Task information from the "source" Contentlet to the "destination"
+     * Contentlet. This is very important in order to keep the copied Contentlet and its respective
+     * language versions in the same Workflow Step as the source Contentlet.
      *
      * @param sourceContentlet The {@link Contentlet} instance that will be copied.
      * @param copyContentlet   The resulting copy of the original Contentlet.
      * @param user             The {@link User} executing this action.
-     *
      * @throws DotDataException An error occurred when interacting with the data source.
      */
-    private void copyWorkflowState(final Contentlet sourceContentlet, final Contentlet copyContentlet, final User user) throws DotDataException {
+    private void copyWorkflowState(final Contentlet sourceContentlet,
+            final Contentlet copyContentlet, final User user) throws DotDataException {
         final long sourceLangId = sourceContentlet.getLanguageId();
         final List<Language> availableLanguages = APILocator.getLanguageAPI().getLanguages();
         try {
             for (final Language language : availableLanguages) {
                 sourceContentlet.setLanguageId(language.getId());
-                final WorkflowTask task = APILocator.getWorkflowAPI().findTaskByContentlet(sourceContentlet);
+                final WorkflowTask task = APILocator.getWorkflowAPI()
+                        .findTaskByContentlet(sourceContentlet);
                 if (null != task) {
                     final WorkflowTask newTask = new WorkflowTask();
                     Try.run(() -> BeanUtils.copyProperties(newTask, task));
@@ -8204,7 +9095,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                     final WorkflowComment newComment = new WorkflowComment();
                     newComment.setPostedBy(user.getUserId());
-                    newComment.setComment("Content copied from content id: " + sourceContentlet.getIdentifier());
+                    newComment.setComment(
+                            "Content copied from content id: " + sourceContentlet.getIdentifier());
                     newComment.setCreationDate(new Date());
                     newComment.setWorkflowtaskId(newTask.getId());
                     APILocator.getWorkflowAPI().saveComment(newComment);
@@ -8228,18 +9120,20 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 copyName = originalName + copySuffix;
             }
         }
-        Logger.debug(this,"new copy file will be named: "+copyName);
+        Logger.debug(this, "new copy file will be named: " + copyName);
         return copyName;
     }
 
-    private void sendCopyEvent (final Contentlet contentlet) throws DotHibernateException {
+    private void sendCopyEvent(final Contentlet contentlet) throws DotHibernateException {
 
-        HibernateUtil.addCommitListener(() -> this.contentletSystemEventUtil.pushCopyEvent(contentlet), 1000);
+        HibernateUtil.addCommitListener(
+                () -> this.contentletSystemEventUtil.pushCopyEvent(contentlet), 1000);
     }
 
     @WrapInTransaction
     @Override
-    public Contentlet copyContentlet(Contentlet contentlet, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException, DotContentletStateException {
+    public Contentlet copyContentlet(Contentlet contentlet, User user, boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
         HostAPI hostAPI = APILocator.getHostAPI();
         FolderAPI folderAPI = APILocator.getFolderAPI();
 
@@ -8247,28 +9141,39 @@ public class ESContentletAPIImpl implements ContentletAPI {
         Identifier contIdentifier = APILocator.getIdentifierAPI().find(contentlet);
 
         Host host = hostAPI.find(hostIdentfier, user, respectFrontendRoles);
-        if(host == null)
+        if (host == null) {
             host = new Host();
-        Folder folder = folderAPI.findFolderByPath(contIdentifier.getParentPath(), host, user, false);
+        }
+        Folder folder = folderAPI.findFolderByPath(contIdentifier.getParentPath(), host, user,
+                false);
 
-        return copyContentlet(contentlet, host, folder, user, generateCopySuffix(contentlet, host, folder), respectFrontendRoles);
+        return copyContentlet(contentlet, host, folder, user,
+                generateCopySuffix(contentlet, host, folder), respectFrontendRoles);
     }
 
     @WrapInTransaction
     @Override
-    public Contentlet copyContentlet(Contentlet contentlet, Host host, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException, DotContentletStateException {
-        return copyContentlet(contentlet, host, null, user, generateCopySuffix(contentlet, host, null), respectFrontendRoles);
+    public Contentlet copyContentlet(Contentlet contentlet, Host host, User user,
+            boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
+        return copyContentlet(contentlet, host, null, user,
+                generateCopySuffix(contentlet, host, null), respectFrontendRoles);
     }
 
     @WrapInTransaction
     @Override
-    public Contentlet copyContentlet(Contentlet contentlet, Folder folder, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException, DotContentletStateException {
-        return copyContentlet(contentlet, null, folder, user, generateCopySuffix(contentlet, null, folder), respectFrontendRoles);
+    public Contentlet copyContentlet(Contentlet contentlet, Folder folder, User user,
+            boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
+        return copyContentlet(contentlet, null, folder, user,
+                generateCopySuffix(contentlet, null, folder), respectFrontendRoles);
     }
 
     @WrapInTransaction
     @Override
-    public Contentlet copyContentlet(Contentlet contentlet, Folder folder, User user, boolean appendCopyToFileName, boolean respectFrontendRoles) throws DotDataException, DotSecurityException, DotContentletStateException {
+    public Contentlet copyContentlet(Contentlet contentlet, Folder folder, User user,
+            boolean appendCopyToFileName, boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException, DotContentletStateException {
         // Suffix that we need to apply to append in content name
         final String copySuffix = appendCopyToFileName ? "_copy" : StringPool.BLANK;
 
@@ -8276,8 +9181,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * This method generates the copy suffix when there is a contentlet that
-     * already has the same URL.
+     * This method generates the copy suffix when there is a contentlet that already has the same
+     * URL.
      * <ul>
      * <li>if the new contentlet URL is NOT used then returns an empty suffix.</li>
      * <li>if the new contentlet URL without "_copy" is used then returns a
@@ -8287,44 +9192,46 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * suffix.</li>
      * </ul>
      *
-     * @param contentlet
-     *            the contentlet that we are going to copy or move
+     * @param contentlet the contentlet that we are going to copy or move
      * @param host
-     * @param folder
-     *            the destination folder
+     * @param folder     the destination folder
      * @return the generated contentlet asset name suffix
      * @throws DotDataException
      * @throws DotStateException
      * @throws DotSecurityException
      */
-    private String generateCopySuffix(Contentlet contentlet, Host host, Folder folder) throws DotDataException, DotStateException, DotSecurityException {
+    private String generateCopySuffix(Contentlet contentlet, Host host, Folder folder)
+            throws DotDataException, DotStateException, DotSecurityException {
         String assetNameSuffix = StringPool.BLANK;
 
-        final boolean diffHost = ((host != null && contentlet.getHost() != null) && !contentlet.getHost()
+        final boolean diffHost = ((host != null && contentlet.getHost() != null)
+                && !contentlet.getHost()
                 .equalsIgnoreCase(host.getIdentifier()));
 
         // if different host we really don't need to
         if ((!contentlet.isFileAsset() && !contentlet.isHTMLPage()) && (
                 diffHost || (folder != null && contentlet.getHost() != null) && !folder.getHostId()
-                        .equalsIgnoreCase(contentlet.getHost()))){
+                        .equalsIgnoreCase(contentlet.getHost()))) {
             return assetNameSuffix;
         }
 
-        final String sourcef = (UtilMethods.isSet(contentlet.getFolder())) ? contentlet.getFolder() : APILocator.getFolderAPI().findSystemFolder().getInode();
-        final String destf = (UtilMethods.isSet(folder)) ? folder.getInode() : APILocator.getFolderAPI().findSystemFolder().getInode();
+        final String sourcef = (UtilMethods.isSet(contentlet.getFolder())) ? contentlet.getFolder()
+                : APILocator.getFolderAPI().findSystemFolder().getInode();
+        final String destf = (UtilMethods.isSet(folder)) ? folder.getInode()
+                : APILocator.getFolderAPI().findSystemFolder().getInode();
 
-
-        if(!diffHost && sourcef.equals(destf)) { // is copying in the same folder and samehost?
+        if (!diffHost && sourcef.equals(destf)) { // is copying in the same folder and samehost?
             assetNameSuffix = "_copy";
 
             // We need to verify if already exist a content with suffix "_copy",
             // if already exists we need to append a timestamp
-            if(isContentletUrlAlreadyUsed(contentlet, host, folder, assetNameSuffix)) {
+            if (isContentletUrlAlreadyUsed(contentlet, host, folder, assetNameSuffix)) {
                 assetNameSuffix += "_" + System.currentTimeMillis();
             }
         } else {
-            if(isContentletUrlAlreadyUsed(contentlet, host, folder, assetNameSuffix)) {
-                throw new DotDataException(Sneaky.sneak(()->LanguageUtil.get("error.copy.url.conflict")));
+            if (isContentletUrlAlreadyUsed(contentlet, host, folder, assetNameSuffix)) {
+                throw new DotDataException(
+                        Sneaky.sneak(() -> LanguageUtil.get("error.copy.url.conflict")));
             }
         }
 
@@ -8332,46 +9239,45 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * This method verifies if the contentlet that we are going to copy or cut
-     * into a folder doesn't have conflict with other contentlet that has the
-     * same URL.
+     * This method verifies if the contentlet that we are going to copy or cut into a folder doesn't
+     * have conflict with other contentlet that has the same URL.
      *
-     * @param contentlet
-     *            the contentlet that we are going to copy or move
-     * @param destinationHost
-     *            the destination host
-     * @param destinationFolder
-     *            the destination folder
-     * @param assetNameSuffix
-     *            the suffix string that we will append in the asset name.
-     *            Sometimes you need to know if a asset name with a suffix is
-     *            used or not
-     * @return true if the contentlet URL is already used otherwise returns
-     *         false
+     * @param contentlet        the contentlet that we are going to copy or move
+     * @param destinationHost   the destination host
+     * @param destinationFolder the destination folder
+     * @param assetNameSuffix   the suffix string that we will append in the asset name. Sometimes
+     *                          you need to know if a asset name with a suffix is used or not
+     * @return true if the contentlet URL is already used otherwise returns false
      * @throws DotStateException
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    private boolean isContentletUrlAlreadyUsed(Contentlet contentlet, Host destinationHost, Folder destinationFolder, final String assetNameSuffix) throws DotStateException, DotDataException, DotSecurityException {
+    private boolean isContentletUrlAlreadyUsed(Contentlet contentlet, Host destinationHost,
+            Folder destinationFolder, final String assetNameSuffix)
+            throws DotStateException, DotDataException, DotSecurityException {
         Identifier contentletId = APILocator.getIdentifierAPI().find(contentlet);
 
         // Create new asset name
         final String contentletIdAssetName = contentletId.getAssetName();
         String fileExtension = StringPool.BLANK;
-        if(contentlet.hasAssetNameExtension()){
+        if (contentlet.hasAssetNameExtension()) {
             final String ext = UtilMethods.getFileExtension(contentletIdAssetName);
-            if(UtilMethods.isSet(ext)){
+            if (UtilMethods.isSet(ext)) {
                 fileExtension = '.' + ext;
             }
         }
-        final String futureAssetNameWithSuffix = UtilMethods.getFileName(contentletIdAssetName) + assetNameSuffix + fileExtension;
+        final String futureAssetNameWithSuffix =
+                UtilMethods.getFileName(contentletIdAssetName) + assetNameSuffix + fileExtension;
 
         // Check if page url already exist
         Identifier identifierWithSameUrl = null;
-        if(UtilMethods.isSet(destinationFolder) && InodeUtils.isSet(destinationFolder.getInode())) { // Folders
+        if (UtilMethods.isSet(destinationFolder) && InodeUtils.isSet(
+                destinationFolder.getInode())) { // Folders
             // Create new path
-            Identifier folderId = APILocator.getIdentifierAPI().find(destinationFolder.getIdentifier());
-            final String path = (destinationFolder.getInode().equals(FolderAPI.SYSTEM_FOLDER) ? "/" : folderId.getPath()) + futureAssetNameWithSuffix;
+            Identifier folderId = APILocator.getIdentifierAPI()
+                    .find(destinationFolder.getIdentifier());
+            final String path = (destinationFolder.getInode().equals(FolderAPI.SYSTEM_FOLDER) ? "/"
+                    : folderId.getPath()) + futureAssetNameWithSuffix;
 
             final Host host =
                     destinationFolder.getInode().equals(FolderAPI.SYSTEM_FOLDER) ? destinationHost
@@ -8379,40 +9285,43 @@ public class ESContentletAPIImpl implements ContentletAPI {
                                     .find(destinationFolder.getHostId(),
                                             APILocator.getUserAPI().getSystemUser(), false);
             identifierWithSameUrl = APILocator.getIdentifierAPI().find(host, path);
-        } else if(UtilMethods.isSet(destinationHost) && InodeUtils.isSet(destinationHost.getInode())) { // Hosts
+        } else if (UtilMethods.isSet(destinationHost) && InodeUtils.isSet(
+                destinationHost.getInode())) { // Hosts
             identifierWithSameUrl = APILocator.getIdentifierAPI()
                     .find(destinationHost, "/" + futureAssetNameWithSuffix);
         } else {
             // Host or folder object MUST be define
-            Logger.error(this, "Host or folder destination are invalid, please check that one of those values are set propertly.");
-            throw new DotDataException("Host or folder destination are invalid, please check that one of those values are set propertly.");
+            Logger.error(this,
+                    "Host or folder destination are invalid, please check that one of those values are set propertly.");
+            throw new DotDataException(
+                    "Host or folder destination are invalid, please check that one of those values are set propertly.");
         }
 
         return InodeUtils.isSet(identifierWithSameUrl.getId());
     }
 
     /**
-     *
      * @param structureInode
      * @return
      */
     private boolean hasAHostField(String structureInode) {
         List<Field> fields = FieldsCache.getFieldsByStructureInode(structureInode);
-        for(Field f : fields) {
-            if(f.getFieldType().equals("host or folder"))
+        for (Field f : fields) {
+            if (f.getFieldType().equals("host or folder")) {
                 return true;
+            }
         }
         return false;
     }
 
     @Override
     public boolean isInodeIndexed(String inode) {
-        return isInodeIndexed(inode,false);
+        return isInodeIndexed(inode, false);
     }
 
     @Override
-    public boolean isInodeIndexed(String inode,boolean live) {
-        if(!UtilMethods.isSet(inode)){
+    public boolean isInodeIndexed(String inode, boolean live) {
+        if (!UtilMethods.isSet(inode)) {
             Logger.warn(this, "Requested Inode is not indexed because Inode is not set");
         }
 
@@ -8450,7 +9359,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     @Override
-    public boolean isInodeIndexedArchived(String inode){
+    public boolean isInodeIndexedArchived(String inode) {
 
         return isInodeIndexedArchived(inode, -1);
     }
@@ -8462,35 +9371,40 @@ public class ESContentletAPIImpl implements ContentletAPI {
             Logger.warn(this, "Requested Inode is not indexed because Inode is not set");
         }
 
-        return isInodeIndexedWithQuery("+inode:" + inode + String.format(" +deleted:%s",true), secondsToWait);
+        return isInodeIndexedWithQuery("+inode:" + inode + String.format(" +deleted:%s", true),
+                secondsToWait);
     }
 
     private boolean isInodeIndexedWithQuery(String luceneQuery) {
         return isInodeIndexedWithQuery(luceneQuery + " " + UUIDGenerator.shorty(), -1);
     }
 
-    private final List<Integer> fibonacciMapping = Arrays.asList(1, 2, 3, 5, 8, 13, 21, 34, 55); // it is around 14 + 9 (by the timeout delay) seconds, enough to wait
+    private final List<Integer> fibonacciMapping = Arrays.asList(1, 2, 3, 5, 8, 13, 21, 34,
+            55); // it is around 14 + 9 (by the timeout delay) seconds, enough to wait
 
     private boolean isInodeIndexedWithQuery(final String luceneQuery,
             final int milliSecondsToWait) {
 
-        final long millistoWait    = Config.getLongProperty("IS_NODE_INDEXED_INDEX_MILLIS_WAIT", 100);
-        final int limit            = - 1 != milliSecondsToWait?milliSecondsToWait: 300;
-        boolean   found            = false;
-        int       counter          = 0;
-        int       fibonacciIndex   = 0;
+        final long millistoWait = Config.getLongProperty("IS_NODE_INDEXED_INDEX_MILLIS_WAIT", 100);
+        final int limit = -1 != milliSecondsToWait ? milliSecondsToWait : 300;
+        boolean found = false;
+        int counter = 0;
+        int fibonacciIndex = 0;
 
         if (this.contentFactory.indexCount(luceneQuery) > 0) {
 
             if (ConfigUtils.isDevMode()) {
-                Logger.info(this, ()-> "******>>>>>> Index count found in the fist hit for the query: " + luceneQuery);
+                Logger.info(this,
+                        () -> "******>>>>>> Index count found in the fist hit for the query: "
+                                + luceneQuery);
             }
             found = true;
         } else {
 
             while (counter < limit && fibonacciIndex < this.fibonacciMapping.size()) {
 
-                counter += millistoWait * this.fibonacciMapping.get(fibonacciIndex++); // 100, 200, 300, 500, 800, 1300, 2100, 3400 ...
+                counter += millistoWait * this.fibonacciMapping.get(
+                        fibonacciIndex++); // 100, 200, 300, 500, 800, 1300, 2100, 3400 ...
                 DateUtil.sleep(counter);
 
                 try {
@@ -8512,42 +9426,47 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public void UpdateContentWithSystemHost(String hostIdentifier)throws DotDataException, DotSecurityException {
+    public void UpdateContentWithSystemHost(String hostIdentifier)
+            throws DotDataException, DotSecurityException {
         contentFactory.UpdateContentWithSystemHost(hostIdentifier);
     }
 
     @CloseDBIfOpened
     @Override
-    public void removeUserReferences(String userId)throws DotDataException, DotSecurityException {
+    public void removeUserReferences(String userId) throws DotDataException, DotSecurityException {
         contentFactory.removeUserReferences(userId);
     }
 
     @WrapInTransaction
     @Override
-    public void updateUserReferences(User userToReplace, String replacementUserId, User user) throws DotDataException, DotSecurityException{
+    public void updateUserReferences(User userToReplace, String replacementUserId, User user)
+            throws DotDataException, DotSecurityException {
         contentFactory.updateUserReferences(userToReplace, replacementUserId, user);
     }
 
     @CloseDBIfOpened
     @Override
-    public String getUrlMapForContentlet(Contentlet contentlet, User user, boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
+    public String getUrlMapForContentlet(Contentlet contentlet, User user,
+            boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
         // no structure, no inode, no workee
-        if (!InodeUtils.isSet(contentlet.getInode()) || !InodeUtils.isSet(contentlet.getStructureInode())) {
+        if (!InodeUtils.isSet(contentlet.getInode()) || !InodeUtils.isSet(
+                contentlet.getStructureInode())) {
             return null;
         }
 
         final String CONTENTLET_URL_MAP_FOR_CONTENT_404 = "URL_MAP_FOR_CONTENT_404";
         String result = (String) contentlet.getMap().get(URL_MAP_FOR_CONTENT_KEY);
-        if(result != null){
-            if(CONTENTLET_URL_MAP_FOR_CONTENT_404.equals(result) ){
+        if (result != null) {
+            if (CONTENTLET_URL_MAP_FOR_CONTENT_404.equals(result)) {
                 return null;
             }
             return result;
         }
 
         // if there is no detail page, return
-        Structure structure = CacheLocator.getContentTypeCache().getStructureByInode(contentlet.getStructureInode());
-        if(!UtilMethods.isSet(structure.getDetailPage())) {
+        Structure structure = CacheLocator.getContentTypeCache()
+                .getStructureByInode(contentlet.getStructureInode());
+        if (!UtilMethods.isSet(structure.getDetailPage())) {
             return null;
         }
 
@@ -8560,42 +9479,42 @@ public class ESContentletAPIImpl implements ContentletAPI {
             String urlMapField;
             String urlMapFieldValue;
             result = structure.getUrlMapPattern();
-            for (RegExMatch match: matches) {
+            for (RegExMatch match : matches) {
                 urlMapField = match.getMatch();
-                urlMapFieldValue = contentlet.getStringProperty(urlMapField.substring(1, (urlMapField.length() - 1)));
+                urlMapFieldValue = contentlet.getStringProperty(
+                        urlMapField.substring(1, (urlMapField.length() - 1)));
 
                 //Clean up the contents before to replace the values
                 urlMapFieldValue = sanitizeForURLMap(urlMapFieldValue);
                 urlMapField = sanitizeForURLMap(urlMapField);
 
-                if (UtilMethods.isSet(urlMapFieldValue)){
+                if (UtilMethods.isSet(urlMapFieldValue)) {
                     result = result.replaceAll(urlMapField, urlMapFieldValue);
-                }
-                else{
+                } else {
                     result = result.replaceAll(urlMapField, "");
                 }
             }
         }
 
         // or Detail page with id=uuid
-        else{
-            IHTMLPage p = loadPageByIdentifier(structure.getDetailPage(), false, user, respectFrontendRoles);
-            if(p != null && UtilMethods.isSet(p.getIdentifier())){
+        else {
+            IHTMLPage p = loadPageByIdentifier(structure.getDetailPage(), false, user,
+                    respectFrontendRoles);
+            if (p != null && UtilMethods.isSet(p.getIdentifier())) {
                 result = p.getURI() + "?id=" + contentlet.getInode();
             }
         }
 
         // we send the host of the content, not the detail page (is this right?)
-        if ((host != null) && !host.isSystemHost() && ! respectFrontendRoles && result !=null) {
-            if(result.indexOf("?") <0){
+        if ((host != null) && !host.isSystemHost() && !respectFrontendRoles && result != null) {
+            if (result.indexOf("?") < 0) {
                 result = result + "?host_id=" + host.getIdentifier();
-            }
-            else{
+            } else {
                 result = result + "&host_id=" + host.getIdentifier();
             }
         }
 
-        if(result == null){
+        if (result == null) {
             result = CONTENTLET_URL_MAP_FOR_CONTENT_404;
         }
         contentlet.setStringProperty(URL_MAP_FOR_CONTENT_KEY, result);
@@ -8608,9 +9527,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
      * @param value
      * @return
      */
-    private String sanitizeForURLMap ( String value ) {
+    private String sanitizeForURLMap(String value) {
 
-        if ( UtilMethods.isSet(value) ) {
+        if (UtilMethods.isSet(value)) {
             value = value.replaceFirst("\\{", "\\\\{");
             value = value.replaceFirst("\\}", "\\\\}");
             value = value.replaceFirst("\\$", "\\\\\\$");
@@ -8625,11 +9544,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
             final ContentletRelationships contentletRelationships,
             final List<Category> cats,
             final List<Permission> permissions,
-            final User user,boolean respectFrontendRoles)
-            throws IllegalArgumentException,DotDataException,DotSecurityException, DotContentletStateException, DotContentletValidationException {
+            final User user, boolean respectFrontendRoles)
+            throws IllegalArgumentException, DotDataException, DotSecurityException, DotContentletStateException, DotContentletValidationException {
 
         if (!InodeUtils.isSet(contentlet.getInode())) {
-            return checkin(contentlet, contentletRelationships, cats, permissions, user, respectFrontendRoles);
+            return checkin(contentlet, contentletRelationships, cats, permissions, user,
+                    respectFrontendRoles);
         } else {
             canLock(contentlet, user);
             //get the latest and greatest from db
@@ -8647,7 +9567,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 // if we are the latest and greatest and are a draft
                 if (working.getInode().equals(contentlet.getInode())) {
 
-                    return checkin(contentlet, contentletRelationships, cats ,
+                    return checkin(contentlet, contentletRelationships, cats,
                             user, respectFrontendRoles, false, false);
 
                 } else {
@@ -8655,7 +9575,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     copyProperties(working, contentlet.getMap());
                     working.setInode(workingInode);
                     working.setModUser(user.getUserId());
-                    return checkin(contentlet, contentletRelationships, cats ,
+                    return checkin(contentlet, contentletRelationships, cats,
                             user, respectFrontendRoles, false, false);
                 }
             }
@@ -8716,7 +9636,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public void removeFolderReferences(Folder folder)throws DotDataException, DotSecurityException {
+    public void removeFolderReferences(Folder folder)
+            throws DotDataException, DotSecurityException {
         contentFactory.removeFolderReferences(folder);
     }
 
@@ -8728,43 +9649,47 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @CloseDBIfOpened
     @Override
-    public boolean canLock(final Contentlet contentlet, final User user, final boolean respectFrontendRoles) throws DotLockException {
+    public boolean canLock(final Contentlet contentlet, final User user,
+            final boolean respectFrontendRoles) throws DotLockException {
 
-        if(contentlet ==null || !UtilMethods.isSet(contentlet.getIdentifier())) {
+        if (contentlet == null || !UtilMethods.isSet(contentlet.getIdentifier())) {
 
             return true;
         }
 
-        if(user ==null) {
+        if (user == null) {
 
             throw new DotLockException("null User cannot lock content");
         }
 
         try {
 
-            if(APILocator.getRoleAPI().doesUserHaveRole(user, APILocator.getRoleAPI().loadCMSAdminRole())) {
+            if (APILocator.getRoleAPI()
+                    .doesUserHaveRole(user, APILocator.getRoleAPI().loadCMSAdminRole())) {
 
                 return true;
-            } else if(!APILocator.getPermissionAPI().doesUserHavePermission(
+            } else if (!APILocator.getPermissionAPI().doesUserHavePermission(
                     contentlet, PermissionAPI.PERMISSION_EDIT, user, respectFrontendRoles)) {
 
-                throw new DotLockException("User: "+ (user != null ? user.getUserId() : "Unknown")
-                        +" does not have Edit Permissions to lock content: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"));
+                throw new DotLockException("User: " + (user != null ? user.getUserId() : "Unknown")
+                        + " does not have Edit Permissions to lock content: " + (contentlet != null
+                        ? contentlet.getIdentifier() : "Unknown"));
             }
-        }catch(DotDataException dde) {
+        } catch (DotDataException dde) {
 
-            throw new DotLockException("User: "+ (user != null ? user.getUserId() : "Unknown")
-                    +" does not have Edit Permissions to lock content: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"));
+            throw new DotLockException("User: " + (user != null ? user.getUserId() : "Unknown")
+                    + " does not have Edit Permissions to lock content: " + (contentlet != null
+                    ? contentlet.getIdentifier() : "Unknown"));
         }
 
         Optional<String> lockedBy = Optional.empty();
         try {
             lockedBy = APILocator.getVersionableAPI().getLockedBy(contentlet);
-        } catch(Exception e) {
+        } catch (Exception e) {
 
         }
 
-        if(lockedBy.isPresent() && !user.getUserId().equals(lockedBy.get())){
+        if (lockedBy.isPresent() && !user.getUserId().equals(lockedBy.get())) {
             throw new DotLockException(CANT_GET_LOCK_ON_CONTENT);
         }
 
@@ -8777,62 +9702,73 @@ public class ESContentletAPIImpl implements ContentletAPI {
             Contentlet contentlet, User user) throws DotDataException,
             DotSecurityException {
 
-        if(!APILocator.getPermissionAPI().doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT, user)){
+        if (!APILocator.getPermissionAPI()
+                .doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_EDIT, user)) {
             throw new DotLockException("User: " + (user != null ? user.getUserId() : "Unknown")
-                    + " does not have Edit Permissions on the content: " + (contentlet != null ? contentlet.getIdentifier() : "Unknown"));
+                    + " does not have Edit Permissions on the content: " + (contentlet != null
+                    ? contentlet.getIdentifier() : "Unknown"));
         }
 
         return findContentRelationships(contentlet);
     }
 
     @Override
-    public long indexCount(String luceneQuery, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+    public long indexCount(String luceneQuery, User user, boolean respectFrontendRoles)
+            throws DotDataException, DotSecurityException {
         boolean isAdmin = false;
         List<Role> roles = new ArrayList<Role>();
-        if(user == null && !respectFrontendRoles){
-            throw new DotSecurityException("You must specify a user if you are not respecting frontend roles");
+        if (user == null && !respectFrontendRoles) {
+            throw new DotSecurityException(
+                    "You must specify a user if you are not respecting frontend roles");
         }
-        if(user != null){
-            if (!APILocator.getRoleAPI().doesUserHaveRole(user, APILocator.getRoleAPI().loadCMSAdminRole())) {
+        if (user != null) {
+            if (!APILocator.getRoleAPI()
+                    .doesUserHaveRole(user, APILocator.getRoleAPI().loadCMSAdminRole())) {
                 roles = APILocator.getRoleAPI().loadRolesForUser(user.getUserId());
-            }else{
+            } else {
                 isAdmin = true;
             }
         }
         StringBuffer buffy = new StringBuffer(luceneQuery);
 
         // Permissions in the query
-        if (!isAdmin)
+        if (!isAdmin) {
             addPermissionsToQuery(buffy, user, roles, respectFrontendRoles);
+        }
 
         return contentFactory.indexCount(buffy.toString());
     }
 
     @CloseDBIfOpened
     @Override
-    public List<Map<String, String>> getMostViewedContent(String structureVariableName, String startDateStr, String endDateStr, User user) {
+    public List<Map<String, String>> getMostViewedContent(String structureVariableName,
+            String startDateStr, String endDateStr, User user) {
 
-        String[] dateFormats = new String[] { "yyyy-MM-dd HH:mm", "d-MMM-yy", "MMM-yy", "MMMM-yy", "d-MMM", "dd-MMM-yyyy", "MM/dd/yyyy hh:mm aa", "MM/dd/yy HH:mm",
-                "MM/dd/yyyy HH:mm", "MMMM dd, yyyy", "M/d/y", "M/d", "EEEE, MMMM dd, yyyy", "MM/dd/yyyy",
+        String[] dateFormats = new String[]{"yyyy-MM-dd HH:mm", "d-MMM-yy", "MMM-yy", "MMMM-yy",
+                "d-MMM", "dd-MMM-yyyy", "MM/dd/yyyy hh:mm aa", "MM/dd/yy HH:mm",
+                "MM/dd/yyyy HH:mm", "MMMM dd, yyyy", "M/d/y", "M/d", "EEEE, MMMM dd, yyyy",
+                "MM/dd/yyyy",
                 "hh:mm:ss aa", "HH:mm:ss", "yyyy-MM-dd"};
 
         List<Map<String, String>> result = new ArrayList<Map<String, String>>();
 
-        String structureInode = CacheLocator.getContentTypeCache().getStructureByVelocityVarName(structureVariableName).getInode();
-        if(!UtilMethods.isSet(structureInode))
+        String structureInode = CacheLocator.getContentTypeCache()
+                .getStructureByVelocityVarName(structureVariableName).getInode();
+        if (!UtilMethods.isSet(structureInode)) {
             return result;
+        }
 
         GregorianCalendar gCal = new GregorianCalendar();
         Date endDate = gCal.getTime();
         gCal.add(2, -3);
         Date startDate = gCal.getTime();// Default interval
 
-        if(!UtilMethods.isSet(startDateStr) && !UtilMethods.isSet(endDateStr)){
+        if (!UtilMethods.isSet(startDateStr) && !UtilMethods.isSet(endDateStr)) {
             GregorianCalendar gc = new GregorianCalendar();
             endDate = gc.getTime();
             gc.add(2, -3);
             startDate = gc.getTime();
-        }else if(!UtilMethods.isSet(startDateStr)){
+        } else if (!UtilMethods.isSet(startDateStr)) {
             try {
                 endDate = DateUtil.convertDate(endDateStr, dateFormats);
                 Calendar gc = new GregorianCalendar();
@@ -8845,7 +9781,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 gc.add(2, -3);
                 startDate = gc.getTime();
             }
-        }else if(!UtilMethods.isSet(endDateStr)){
+        } else if (!UtilMethods.isSet(endDateStr)) {
             try {
                 startDate = DateUtil.convertDate(endDateStr, dateFormats);
                 Calendar gc = new GregorianCalendar();
@@ -8858,32 +9794,29 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 gc.add(2, -3);
                 startDate = gc.getTime();
             }
-        }else{
+        } else {
             try {
                 startDate = DateUtil.convertDate(startDateStr, dateFormats);
                 endDate = DateUtil.convertDate(endDateStr, dateFormats);
-            } catch (java.text.ParseException e) {}
+            } catch (java.text.ParseException e) {
+            }
         }
 
         try {
-            result = contentFactory.getMostViewedContent(structureInode, startDate, endDate , user);
-        } catch (Exception e) {}
+            result = contentFactory.getMostViewedContent(structureInode, startDate, endDate, user);
+        } catch (Exception e) {
+        }
         return result;
     }
 
     /**
-     * Utility method used to log the different operations performed on a list
-     * of {@link Contentlet} objects. The information of the operation will be
-     * logged in the Activity Logger file.
+     * Utility method used to log the different operations performed on a list of {@link Contentlet}
+     * objects. The information of the operation will be logged in the Activity Logger file.
      *
-     * @param contentlets
-     *            - List of {@link Contentlet} objects whose information will be
-     *            logged.
-     * @param description
-     *            - A small description of the operation being performed. E.g.,
-     *            "Deleting Content", "Error Publishing Content", etc.
-     * @param user
-     *            - The currently logged in user.
+     * @param contentlets - List of {@link Contentlet} objects whose information will be logged.
+     * @param description - A small description of the operation being performed. E.g., "Deleting
+     *                    Content", "Error Publishing Content", etc.
+     * @param user        - The currently logged in user.
      */
     private void logContentletActivity(List<Contentlet> contentlets,
             String description, User user) {
@@ -8893,17 +9826,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * Utility method used to log the different operations performed on
-     * {@link Contentlet} objects. The information of the operation will be
-     * logged in the Activity Logger file.
+     * Utility method used to log the different operations performed on {@link Contentlet} objects.
+     * The information of the operation will be logged in the Activity Logger file.
      *
-     * @param contentlet
-     *            - The {@link Contentlet} whose information will be logged.
-     * @param description
-     *            - A small description of the operation being performed. E.g.,
-     *            "Deleting Content", "Error Publishing Content", etc.
-     * @param user
-     *            - The currently logged in user.
+     * @param contentlet  - The {@link Contentlet} whose information will be logged.
+     * @param description - A small description of the operation being performed. E.g., "Deleting
+     *                    Content", "Error Publishing Content", etc.
+     * @param user        - The currently logged in user.
      */
     private void logContentletActivity(final Contentlet contentlet,
             final String description, final User user) {
@@ -8938,71 +9867,84 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * Utility method that removes from a given contentlet the URL field as it should never be saved on the DB.
-     * The URL of a HTMLPage should always been retrieved from the Identifier.
+     * Utility method that removes from a given contentlet the URL field as it should never be saved
+     * on the DB. The URL of a HTMLPage should always been retrieved from the Identifier.
      *
      * @param contentlet
      */
-    private void removeURLFromContentlet ( Contentlet contentlet ) {
+    private void removeURLFromContentlet(Contentlet contentlet) {
 
-        if ( contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_HTMLPAGE ) {
-            contentlet.setProperty( HTMLPageAssetAPI.URL_FIELD, null );
+        if (contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_HTMLPAGE) {
+            contentlet.setProperty(HTMLPageAssetAPI.URL_FIELD, null);
         }
     }
 
     /**
-     * Utility method that adds to a given contentlet a given URL, remember that we just use the URL field to move aroung the value
-     * but we never save it into the DB for HTMLPages, the URL of a HTMLPage should always been retrieved from the Identifier.
+     * Utility method that adds to a given contentlet a given URL, remember that we just use the URL
+     * field to move aroung the value but we never save it into the DB for HTMLPages, the URL of a
+     * HTMLPage should always been retrieved from the Identifier.
      *
      * @param contentlet
      * @param url
      */
-    private void addURLToContentlet ( Contentlet contentlet, String url ) {
+    private void addURLToContentlet(Contentlet contentlet, String url) {
 
-        if ( contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_HTMLPAGE ) {
-            contentlet.setProperty( HTMLPageAssetAPI.URL_FIELD, url );
+        if (contentlet.getStructure().getStructureType() == Structure.STRUCTURE_TYPE_HTMLPAGE) {
+            contentlet.setProperty(HTMLPageAssetAPI.URL_FIELD, url);
         }
     }
 
     @Override
     public Contentlet checkin(Contentlet contentlet, ContentletRelationships contentRelationships,
             List<Category> cats, List<Permission> selectedPermissions, User user,
-            boolean respectFrontendRoles, boolean generateSystemEvent) throws IllegalArgumentException,
+            boolean respectFrontendRoles, boolean generateSystemEvent)
+            throws IllegalArgumentException,
             DotDataException, DotSecurityException, DotContentletStateException, DotContentletValidationException {
 
-        final Contentlet contentletReturned = checkin(contentlet, contentRelationships, cats, user, respectFrontendRoles, true, generateSystemEvent);
+        final Contentlet contentletReturned = checkin(contentlet, contentRelationships, cats, user,
+                respectFrontendRoles, true, generateSystemEvent);
 
-        if (InodeUtils.isSet(contentletReturned.getInode()) && UtilMethods.isSet(selectedPermissions)) {
+        if (InodeUtils.isSet(contentletReturned.getInode()) && UtilMethods.isSet(
+                selectedPermissions)) {
 
             final Runnable savePermissions = () -> {
 
                 try {
 
-                    Logger.debug(this, ()-> "Removing the permissions for: "  + contentlet.getTitle() +
-                            ", id: " + contentlet.getIdentifier());
+                    Logger.debug(this,
+                            () -> "Removing the permissions for: " + contentlet.getTitle() +
+                                    ", id: " + contentlet.getIdentifier());
                     this.permissionAPI.removePermissions(contentletReturned);
-                    Logger.debug(this, ()-> "Saving the permissions for: "  + contentlet.getTitle() +
-                            ", id: " + contentlet.getIdentifier());
+                    Logger.debug(this,
+                            () -> "Saving the permissions for: " + contentlet.getTitle() +
+                                    ", id: " + contentlet.getIdentifier());
                     this.permissionAPI.save(selectedPermissions.stream()
-                        .map(permission -> new Permission(contentletReturned.getPermissionId(), permission.getRoleId(), permission.getPermission()))
-                        .collect(Collectors.toList()), contentletReturned, user, respectFrontendRoles);
+                                    .map(permission -> new Permission(contentletReturned.getPermissionId(),
+                                            permission.getRoleId(), permission.getPermission()))
+                                    .collect(Collectors.toList()), contentletReturned, user,
+                            respectFrontendRoles);
                 } catch (Exception e) {
 
-                    Logger.error(this, "Could not save the permissions for: " + contentlet.getTitle() +
-                            ", id: " + contentlet.getIdentifier() + ", msg: " + e.getMessage(), e);
+                    Logger.error(this,
+                            "Could not save the permissions for: " + contentlet.getTitle() +
+                                    ", id: " + contentlet.getIdentifier() + ", msg: "
+                                    + e.getMessage(), e);
                 }
             };
 
             FunctionUtils.ifOrElse(DbConnectionFactory.inTransaction(),
-                    ()-> HibernateUtil.addCommitListener(contentletReturned.getInode(), savePermissions),
-                    ()-> savePermissions.run());
+                    () -> HibernateUtil.addCommitListener(contentletReturned.getInode(),
+                            savePermissions),
+                    () -> savePermissions.run());
         }
 
         return contentletReturned;
     }
 
     @Override
-    public Contentlet checkin(final Contentlet contentlet, final ContentletDependencies contentletDependencies) throws DotSecurityException, DotDataException {
+    public Contentlet checkin(final Contentlet contentlet,
+            final ContentletDependencies contentletDependencies)
+            throws DotSecurityException, DotDataException {
 
         if (null != contentletDependencies.getIndexPolicy()) {
 
@@ -9011,23 +9953,28 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         if (null != contentletDependencies.getIndexPolicyDependencies()) {
 
-            contentlet.setIndexPolicyDependencies(contentletDependencies.getIndexPolicyDependencies());
+            contentlet.setIndexPolicyDependencies(
+                    contentletDependencies.getIndexPolicyDependencies());
         }
 
-        return checkin(contentlet, contentletDependencies.getRelationships(), contentletDependencies.getCategories(), contentletDependencies.getPermissions(), contentletDependencies.getModUser(),
-                contentletDependencies.isRespectAnonymousPermissions(), contentletDependencies.isGenerateSystemEvent());
+        return checkin(contentlet, contentletDependencies.getRelationships(),
+                contentletDependencies.getCategories(), contentletDependencies.getPermissions(),
+                contentletDependencies.getModUser(),
+                contentletDependencies.isRespectAnonymousPermissions(),
+                contentletDependencies.isGenerateSystemEvent());
     }
 
     /**
-     * Triggers a local system event when this contentlet commit listener is executed,
-     * anyone who need it can subscribed to this commit listener event, on this case will be
-     * mostly use it in order to invalidate this contentlet cache.
+     * Triggers a local system event when this contentlet commit listener is executed, anyone who
+     * need it can subscribed to this commit listener event, on this case will be mostly use it in
+     * order to invalidate this contentlet cache.
      *
      * @param contentlet Contentlet to be processed by the Commit listener event
      * @param user       User that triggered the event
      * @param publish    true if it is publish, false unpublish
      */
-    private void triggerCommitListenerEvent(final Contentlet contentlet, final User user, final boolean publish) {
+    private void triggerCommitListenerEvent(final Contentlet contentlet, final User user,
+            final boolean publish) {
 
         try {
             if (!contentlet.getBoolProperty(Contentlet.IS_TEST_MODE)) {
@@ -9050,7 +9997,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 });
             }
 
-            HibernateUtil.addCommitListener(()-> {
+            HibernateUtil.addCommitListener(() -> {
                 //Triggering event listener when this commit listener is executed
                 localSystemEventsAPI
                         .notify(new ContentletPublishEvent(contentlet, user, publish));
@@ -9062,6 +10009,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     /**
      * Basically this method updates the mod_date on a piece of content
+     *
      * @param inodes
      * @param user
      * @return
@@ -9074,12 +10022,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * This method takes the properties that were once set as null an nullify the real properties
-     * By doing this right before save. We Will null the field values on the desired entries.
+     * This method takes the properties that were once set as null an nullify the real properties By
+     * doing this right before save. We Will null the field values on the desired entries.
+     *
      * @param contentlet
      * @return
      */
-    private Contentlet applyNullProperties(final Contentlet contentlet){
+    private Contentlet applyNullProperties(final Contentlet contentlet) {
         contentlet.getNullProperties().forEach(s -> {
             contentlet.getMap().put(s, null);
         });
@@ -9087,22 +10036,26 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     /**
-     * sets the host / folder if it is not set
-     * to either a sibling's host/folder or
-     * the content type's host folder
+     * sets the host / folder if it is not set to either a sibling's host/folder or the content
+     * type's host folder
+     *
      * @param contentlet
      * @return
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    protected Contentlet populateHost(final Contentlet contentlet) throws DotDataException, DotSecurityException {
+    protected Contentlet populateHost(final Contentlet contentlet)
+            throws DotDataException, DotSecurityException {
         // check contentlet Host
         // If host and folder are not set yet
-        if (!UtilMethods.isSet(contentlet.getHost()) && !UtilMethods.isSet(contentlet.getFolder())) {
+        if (!UtilMethods.isSet(contentlet.getHost()) && !UtilMethods.isSet(
+                contentlet.getFolder())) {
             // Try to get host from sibling
-            final Contentlet crownPrince = findContentletByIdentifierAnyLanguage(contentlet.getIdentifier());
+            final Contentlet crownPrince = findContentletByIdentifierAnyLanguage(
+                    contentlet.getIdentifier());
             // if has a viable sibling, take siblings host/folder
-            if (UtilMethods.isSet(crownPrince) && UtilMethods.isSet(crownPrince.getHost()) && UtilMethods.isSet(crownPrince.getFolder())) {
+            if (UtilMethods.isSet(crownPrince) && UtilMethods.isSet(crownPrince.getHost())
+                    && UtilMethods.isSet(crownPrince.getFolder())) {
                 contentlet.setHost(crownPrince.getHost());
                 contentlet.setFolder(crownPrince.getFolder());
             } else { // Try to get host from Content Type

--- a/dotCMS/src/main/java/com/dotcms/rest/LicenseResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/LicenseResource.java
@@ -51,13 +51,14 @@ import org.glassfish.jersey.media.multipart.FormDataParam;
 public class LicenseResource {
 
     private final WebResource webResource = new WebResource();
-    private static final String SERVER_ID  = "serverid";
+    private static final String SERVER_ID = "serverid";
 
     @NoCache
     @GET
     @Path("/all/{params:.*}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getAll(@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam("params") String params) {
+    public Response getAll(@Context HttpServletRequest request,
+            @Context final HttpServletResponse response, @PathParam("params") String params) {
 
         final InitDataObject initData = new WebResource.InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -69,64 +70,60 @@ public class LicenseResource {
                 .init();
 
         try {
-            JSONArray array=new JSONArray();
+            JSONArray array = new JSONArray();
 
-            Calendar cal=Calendar.getInstance();
+            Calendar cal = Calendar.getInstance();
             cal.add(Calendar.YEAR, -1);
 
-            
-            for ( DotLicenseRepoEntry lic : LicenseUtil.getLicenseRepoList() ) {
+            for (DotLicenseRepoEntry lic : LicenseUtil.getLicenseRepoList()) {
                 JSONObject obj = new JSONObject();
                 obj.put("serverId", lic.serverId);
                 obj.put("perpetual", lic.dotLicense.perpetual);
                 obj.put("validUntil", lic.dotLicense.validUntil);
                 obj.put("expired", lic.dotLicense.expired);
-                
-                
+
                 obj.put("serial", lic.dotLicense.serial);
-                obj.put("level",  LicenseManager.getInstance().getLevelName(lic.dotLicense.level));
+                obj.put("level", LicenseManager.getInstance().getLevelName(lic.dotLicense.level));
                 obj.put("id", lic.dotLicense.serial);
                 obj.put("licenseType", lic.dotLicense.licenseType);
-                obj.put("startupTime", (lic.startupTime==0) ? "n/a" : new Date(lic.startupTime));
-                if(lic.lastPing.after(cal.getTime())){
+                obj.put("startupTime", (lic.startupTime == 0) ? "n/a" : new Date(lic.startupTime));
+                if (lic.lastPing.after(cal.getTime())) {
                     obj.put("lastPingStr", DateUtil.prettyDateSince(lic.lastPing));
-                }
-                else{
+                } else {
                     obj.put("lastPingStr", "");
                 }
-                
-                
+
                 Calendar outThere = Calendar.getInstance();
                 outThere.add(Calendar.YEAR, 25);
-                if(lic.dotLicense.validUntil.after(outThere.getTime())){
+                if (lic.dotLicense.validUntil.after(outThere.getTime())) {
                     obj.put("validUntilStr", "-");
                     obj.put("perpetual", true);
-                }
-                else{
-                    obj.put("validUntilStr", new SimpleDateFormat("MMMM d, yyyy").format(lic.dotLicense.validUntil));
+                } else {
+                    obj.put("validUntilStr",
+                            new SimpleDateFormat("MMMM d, yyyy").format(lic.dotLicense.validUntil));
                     obj.put("perpetual", lic.dotLicense.perpetual);
-                
+
                 }
 
-
-                array.put( obj );
+                array.put(obj);
             }
-            
+
             return Response.ok(array.toString(), MediaType.APPLICATION_JSON_TYPE).build();
-        }
-        catch(Exception ex) {
+        } catch (Exception ex) {
             Logger.error(this, "can't get all license on repo", ex);
             return Response.serverError().build();
         }
-        
+
     }
 
     @NoCache
     @POST
     @Path("/upload/{params:.*}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Response putZipFile(@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam("params") String params,
-            @FormDataParam("file") InputStream inputFile, @FormDataParam("file") FormDataContentDisposition inputFileDetail,
+    public Response putZipFile(@Context HttpServletRequest request,
+            @Context final HttpServletResponse response, @PathParam("params") String params,
+            @FormDataParam("file") InputStream inputFile,
+            @FormDataParam("file") FormDataContentDisposition inputFileDetail,
             @FormDataParam("return") String ret) {
 
         final InitDataObject initData = new WebResource.InitBuilder(webResource)
@@ -139,31 +136,32 @@ public class LicenseResource {
                 .init();
 
         try {
-           
-            if(inputFile!=null) {
+
+            if (inputFile != null) {
                 LicenseUtil.uploadLicenseRepoFile(inputFile);
-                
-                AdminLogger.log(this.getClass(), "putZipFile", "uploaded zip to license repo", initData.getUser());
-                
+
+                AdminLogger.log(this.getClass(), "putZipFile", "uploaded zip to license repo",
+                        initData.getUser());
+
                 return Response.ok().build();
             }
-            
+
             return Response.status(Response.Status.BAD_REQUEST)
-                           .entity("where is the zip file?")
-                           .type(MediaType.TEXT_PLAIN).build();
-        }
-        catch(Exception ex) {
+                    .entity("where is the zip file?")
+                    .type(MediaType.TEXT_PLAIN).build();
+        } catch (Exception ex) {
             Logger.error(this, "can't upload license to repo", ex);
             return Response.serverError().build();
         }
-        
+
     }
 
 
     @NoCache
     @DELETE
     @Path("/delete/{params:.*}")
-    public Response delete(@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam("params") String params) {
+    public Response delete(@Context HttpServletRequest request,
+            @Context final HttpServletResponse response, @PathParam("params") String params) {
 
         final InitDataObject initData = new WebResource.InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -174,27 +172,26 @@ public class LicenseResource {
                 .requiredPortlet(PortletID.CONFIGURATION.toString())
                 .init();
 
-        String id=initData.getParamsMap().get("id");
+        String id = initData.getParamsMap().get("id");
         try {
-            if(UtilMethods.isSet(id)) {
+            if (UtilMethods.isSet(id)) {
                 LicenseUtil.deleteLicense(id);
-                
-        			//waiting 10seconds just in case the user is only changing the server license
-                	// if not the try to remove it
-        		//TODO
-            }
-            else {
+
+                //waiting 10seconds just in case the user is only changing the server license
+                // if not the try to remove it
+                //TODO
+            } else {
                 return Response.status(Response.Status.BAD_REQUEST)
                         .entity("no id provided")
                         .type(MediaType.TEXT_PLAIN).build();
             }
-            
-            AdminLogger.log(this.getClass(), "delete", "Deleted license from repo with id "+id, initData.getUser());
-            
+
+            AdminLogger.log(this.getClass(), "delete", "Deleted license from repo with id " + id,
+                    initData.getUser());
+
             return Response.ok().build();
-        }
-        catch(Exception ex) {
-            Logger.error(this, "can't delete license "+id, ex);
+        } catch (Exception ex) {
+            Logger.error(this, "can't delete license " + id, ex);
             return Response.serverError().build();
         }
     }
@@ -202,7 +199,8 @@ public class LicenseResource {
     @NoCache
     @POST
     @Path("/pick/{params:.*}")
-    public Response pickLicense(@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam("params") String params) {
+    public Response pickLicense(@Context HttpServletRequest request,
+            @Context final HttpServletResponse response, @PathParam("params") String params) {
 
         final InitDataObject initData = new WebResource.InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -214,23 +212,24 @@ public class LicenseResource {
                 .init();
 
         String serial = initData.getParamsMap().get("serial");
-        
+
         final long currentLevel = LicenseUtil.getLevel();
-        final String currentSerial = currentLevel > LicenseLevel.COMMUNITY.level ? LicenseUtil.getSerial() : "";
-        
-        if(currentLevel < LicenseLevel.STANDARD.level || !currentSerial.equals(serial)) {
-            
+        final String currentSerial =
+                currentLevel > LicenseLevel.COMMUNITY.level ? LicenseUtil.getSerial() : "";
+
+        if (currentLevel < LicenseLevel.STANDARD.level || !currentSerial.equals(serial)) {
+
             try {
                 HibernateUtil.startTransaction();
-                
+
                 LicenseUtil.pickLicense(serial);
 
                 HibernateUtil.closeAndCommitTransaction();
-                
-                AdminLogger.log(LicenseResource.class, "pickLicense", "Picked license from repo. Serial: "+serial, initData.getUser());
-            }
-            catch(Exception ex) {
-                Logger.error(this, "can't pick license "+serial,ex);
+
+                AdminLogger.log(LicenseResource.class, "pickLicense",
+                        "Picked license from repo. Serial: " + serial, initData.getUser());
+            } catch (Exception ex) {
+                Logger.error(this, "can't pick license " + serial, ex);
                 try {
                     HibernateUtil.rollbackTransaction();
                 } catch (DotHibernateException e) {
@@ -241,11 +240,11 @@ public class LicenseResource {
                 HibernateUtil.closeSessionSilently();
             }
         }
-        
-        if(currentLevel==LicenseLevel.COMMUNITY.level || currentSerial.equals(LicenseUtil.getSerial())) {
+
+        if (currentLevel == LicenseLevel.COMMUNITY.level || currentSerial.equals(
+                LicenseUtil.getSerial())) {
             return Response.notModified().build();
-        }
-        else {
+        } else {
             return Response.ok().build();
         }
     }
@@ -253,7 +252,8 @@ public class LicenseResource {
     @NoCache
     @POST
     @Path("/free/{params:.*}")
-    public Response freeLicense(@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam("params") String params) {
+    public Response freeLicense(@Context HttpServletRequest request,
+            @Context final HttpServletResponse response, @PathParam("params") String params) {
 
         final InitDataObject initData = new WebResource.InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -263,97 +263,107 @@ public class LicenseResource {
                 .rejectWhenNoUser(true)
                 .requiredPortlet(PortletID.CONFIGURATION.toString())
                 .init();
-        
+
         String localServerId = APILocator.getServerAPI().readServerId();
         String remoteServerId = initData.getParamsMap().get(SERVER_ID);
         String serial = initData.getParamsMap().get("serial");
 
-        
         try {
             //If we are removing a remote Server we need to create a ServerAction.
-            if(UtilMethods.isSet(remoteServerId) && !remoteServerId.equals("undefined")){
-            	ResetLicenseServerAction resetLicenseServerAction = new ResetLicenseServerAction();
-            	Long timeoutSeconds = new Long(1);
-            	
-            	ServerActionBean resetLicenseServerActionBean = 
-            			resetLicenseServerAction.getNewServerAction(localServerId, remoteServerId, timeoutSeconds);
-            	
-            	resetLicenseServerActionBean = APILocator.getServerActionAPI()
-            			.saveServerActionBean(resetLicenseServerActionBean);
-            	
-            	//Waits for 3 seconds in order all the servers respond.
-    			int maxWaitTime = 
-    					timeoutSeconds.intValue() * 1000 + Config.getIntProperty("CLUSTER_SERVER_THREAD_SLEEP", 2000) ;
-    			int passedWaitTime = 0;
-    			
-    			//Trying to NOT wait whole 3 secons for returning the info.
-    			while (passedWaitTime <= maxWaitTime){
-    				try {
-    				    Thread.sleep(10);
-    				    passedWaitTime += 10;
-    				    
-    				    resetLicenseServerActionBean = 
-    				    		APILocator.getServerActionAPI().findServerActionBean(resetLicenseServerActionBean.getId());
-    				    
-    				    //No need to wait if we have all Action results. 
-    				    if(resetLicenseServerActionBean != null && resetLicenseServerActionBean.isCompleted()){
-    				    	passedWaitTime = maxWaitTime + 1;
-    				    }
-    				    
-    				} catch(InterruptedException ex) {
-    				    Thread.currentThread().interrupt();
-    				    passedWaitTime = maxWaitTime + 1;
-    				}
-    			}
-    			
-    			//If we reach the timeout and the server didn't respond.
-    			//We assume the server is down and remove the license from the table.
-    			if(!resetLicenseServerActionBean.isCompleted()){
-    				
-    				resetLicenseServerActionBean.setCompleted(true);
-    				resetLicenseServerActionBean.setFailed(true);
-    				resetLicenseServerActionBean
-    					.setResponse(new com.dotmarketing.util.json.JSONObject()
-							.put(ServerAction.ERROR_STATE, "Server did NOT respond on time"));
-    				APILocator.getServerActionAPI().saveServerActionBean(resetLicenseServerActionBean);
-				LicenseUtil.freeLicenseOnRepo(serial, remoteServerId);
-    			
-    			//If it was completed but we got some error, we need to alert it.
-    			} else if(resetLicenseServerActionBean.isCompleted() 
-    					&& resetLicenseServerActionBean.isFailed()){
-    				
-    				throw new Exception(resetLicenseServerActionBean.getResponse().getString(ServerAction.ERROR_STATE));
-    			}
-            	
-            //If the server we are removing license is local.
+            if (UtilMethods.isSet(remoteServerId) && !remoteServerId.equals("undefined")) {
+                ResetLicenseServerAction resetLicenseServerAction = new ResetLicenseServerAction();
+                Long timeoutSeconds = new Long(1);
+
+                ServerActionBean resetLicenseServerActionBean =
+                        resetLicenseServerAction.getNewServerAction(localServerId, remoteServerId,
+                                timeoutSeconds);
+
+                resetLicenseServerActionBean = APILocator.getServerActionAPI()
+                        .saveServerActionBean(resetLicenseServerActionBean);
+
+                //Waits for 3 seconds in order all the servers respond.
+                int maxWaitTime =
+                        timeoutSeconds.intValue() * 1000 + Config.getIntProperty(
+                                "CLUSTER_SERVER_THREAD_SLEEP", 2000);
+                int passedWaitTime = 0;
+
+                //Trying to NOT wait whole 3 secons for returning the info.
+                while (passedWaitTime <= maxWaitTime) {
+                    try {
+                        Thread.sleep(10);
+                        passedWaitTime += 10;
+
+                        resetLicenseServerActionBean =
+                                APILocator.getServerActionAPI()
+                                        .findServerActionBean(resetLicenseServerActionBean.getId());
+
+                        //No need to wait if we have all Action results.
+                        if (resetLicenseServerActionBean != null
+                                && resetLicenseServerActionBean.isCompleted()) {
+                            passedWaitTime = maxWaitTime + 1;
+                        }
+
+                    } catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                        passedWaitTime = maxWaitTime + 1;
+                    }
+                }
+
+                //If we reach the timeout and the server didn't respond.
+                //We assume the server is down and remove the license from the table.
+                if (!resetLicenseServerActionBean.isCompleted()) {
+
+                    resetLicenseServerActionBean.setCompleted(true);
+                    resetLicenseServerActionBean.setFailed(true);
+                    resetLicenseServerActionBean
+                            .setResponse(new com.dotmarketing.util.json.JSONObject()
+                                    .put(ServerAction.ERROR_STATE,
+                                            "Server did NOT respond on time"));
+                    APILocator.getServerActionAPI()
+                            .saveServerActionBean(resetLicenseServerActionBean);
+                    LicenseUtil.freeLicenseOnRepo(serial, remoteServerId);
+
+                    //If it was completed but we got some error, we need to alert it.
+                } else if (resetLicenseServerActionBean.isCompleted()
+                        && resetLicenseServerActionBean.isFailed()) {
+
+                    throw new Exception(resetLicenseServerActionBean.getResponse()
+                            .getString(ServerAction.ERROR_STATE));
+                }
+
+                //If the server we are removing license is local.
             } else {
-            	HibernateUtil.startTransaction();
-            	LicenseUtil.freeLicenseOnRepo();
-            	HibernateUtil.closeAndCommitTransaction();
+                HibernateUtil.startTransaction();
+                LicenseUtil.freeLicenseOnRepo();
+                HibernateUtil.closeAndCommitTransaction();
             }
-            
-            AdminLogger.log(LicenseResource.class, "freeLicense", "License From Repo Freed", initData.getUser());
-            
-        } catch(Exception exception) {
-            Logger.error(this, "can't free license ",exception);
-            try {
-            	if(HibernateUtil.getSession().isOpen()){
-            		HibernateUtil.rollbackTransaction();
-            	}
-            } catch (DotHibernateException dotHibernateException) {
-                Logger.warn(this, "can't rollback", dotHibernateException);
-            }
+
+            AdminLogger.log(LicenseResource.class, "freeLicense", "License From Repo Freed",
+                    initData.getUser());
+
+        } catch (Exception exception) {
+            Logger.error(this, "can't free license ", exception);
+
+            HibernateUtil.getSessionIfOpened().ifPresent(session -> {
+                try {
+                    HibernateUtil.rollbackTransaction();
+                } catch (DotHibernateException dotHibernateException) {
+                    Logger.warn(this, "can't rollback", dotHibernateException);
+                }
+            });
+
             return Response.serverError().build();
         }
-        
+
         return Response.ok().build();
     }
-    
+
     @POST
     @Path("/requestCode/{params:.*}")
-    @Consumes (MediaType.APPLICATION_FORM_URLENCODED)
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     public Response requestLicense(
-    	@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam ("params") String params
+            @Context HttpServletRequest request, @Context final HttpServletResponse response,
+            @PathParam("params") String params
     ) {
 
         final InitDataObject initData = new WebResource.InitBuilder(webResource)
@@ -368,63 +378,64 @@ public class LicenseResource {
         Map<String, String> paramsMap = initData.getParamsMap();
 
         //Validate the parameters
-        String licenseType = paramsMap.get( "licensetype" );
-        String licenseLevel = paramsMap.get( "licenselevel" );
+        String licenseType = paramsMap.get("licensetype");
+        String licenseLevel = paramsMap.get("licenselevel");
 
         StringBuilder responseMessage = new StringBuilder();
 
-        if ( !UtilMethods.isSet( licenseType ) ) {
-        	return Response.status( HttpStatus.SC_BAD_REQUEST ).entity(
-        		responseMessage.append( "Error: " ).append( "'licenseType'" ).append( " is a required param." )
-        	).build();
+        if (!UtilMethods.isSet(licenseType)) {
+            return Response.status(HttpStatus.SC_BAD_REQUEST).entity(
+                    responseMessage.append("Error: ").append("'licenseType'")
+                            .append(" is a required param.")
+            ).build();
         }
 
-        if ( !UtilMethods.isSet( licenseLevel ) ) {
-        	return Response.status( HttpStatus.SC_BAD_REQUEST ).entity(
-        		responseMessage.append( "Error: " ).append( "'licenseLevel'" ).append( " is a required param." )
-        	).build();
+        if (!UtilMethods.isSet(licenseLevel)) {
+            return Response.status(HttpStatus.SC_BAD_REQUEST).entity(
+                    responseMessage.append("Error: ").append("'licenseLevel'")
+                            .append(" is a required param.")
+            ).build();
         }
-
 
         try {
-	        HttpSession session = request.getSession();
-            session.setAttribute( "iwantTo", "request_code" );
-            session.setAttribute( "license_type", licenseType );
-            session.setAttribute( "license_level", licenseLevel );
-            if(!"trial".equals(licenseType) && !   
-            		"dev".equals(licenseType) && !   
-            		"prod".equals(licenseType) 
-            		
-            		){
-            	throw new DotStateException("invalid License Type");
+            HttpSession session = request.getSession();
+            session.setAttribute("iwantTo", "request_code");
+            session.setAttribute("license_type", licenseType);
+            session.setAttribute("license_level", licenseLevel);
+            if (!"trial".equals(licenseType) && !
+                    "dev".equals(licenseType) && !
+                    "prod".equals(licenseType)
+
+            ) {
+                throw new DotStateException("invalid License Type");
             }
 
-            LicenseUtil.processForm( request );
+            LicenseUtil.processForm(request);
 
             JSONObject jsonResponse = new JSONObject();
-            if(UtilMethods.isSet(request.getAttribute("requestCode"))){
-            	jsonResponse.put("success", true );
-            	jsonResponse.put("requestCode", request.getAttribute("requestCode"));
+            if (UtilMethods.isSet(request.getAttribute("requestCode"))) {
+                jsonResponse.put("success", true);
+                jsonResponse.put("requestCode", request.getAttribute("requestCode"));
             } else {
-            	jsonResponse.put("success", false );
+                jsonResponse.put("success", false);
             }
             return Response.ok(jsonResponse.toString(), MediaType.APPLICATION_JSON_TYPE).build();
-        }
-        catch(Exception ex) {
-            Logger.error(this, "can't request license ",ex);
+        } catch (Exception ex) {
+            Logger.error(this, "can't request license ", ex);
 
             return Response.serverError().build();
         }
-        
+
     }
 
     @NoCache
     @POST
     @Path("/applyLicense")
-    @Consumes (MediaType.APPLICATION_FORM_URLENCODED)
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     public Response applyLicense(
-    	@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam("params") String params,
-    	@QueryParam("licenseText") String licenseText
+            @Context HttpServletRequest request, @Context final HttpServletResponse response,
+            @PathParam("params") String params,
+            @QueryParam("licenseText") String licenseText
     ) {
         final InitDataObject initData = new WebResource.InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -438,42 +449,42 @@ public class LicenseResource {
         //Validate the parameters
         StringBuilder responseMessage = new StringBuilder();
 
-        if ( !UtilMethods.isSet( licenseText ) ) {
-        	return Response.status( HttpStatus.SC_BAD_REQUEST ).entity(
-        		responseMessage.append( "Error: " ).append( "'licenseText'" ).append( " is a required param." )
-        	).build();
+        if (!UtilMethods.isSet(licenseText)) {
+            return Response.status(HttpStatus.SC_BAD_REQUEST).entity(
+                    responseMessage.append("Error: ").append("'licenseText'")
+                            .append(" is a required param.")
+            ).build();
         }
-
 
         try {
-	        HttpSession session = request.getSession();
+            HttpSession session = request.getSession();
 
+            session.setAttribute("applyForm", Boolean.TRUE);
+            session.setAttribute("iwantTo", "paste_license");
+            session.setAttribute("paste_license", "paste_license");
+            session.setAttribute("license_text", licenseText);
 
-            session.setAttribute( "applyForm", Boolean.TRUE );
-            session.setAttribute( "iwantTo", "paste_license" );
-            session.setAttribute( "paste_license", "paste_license" );
-            session.setAttribute( "license_text", licenseText );
-
-            String error = LicenseUtil.processForm( request );
+            String error = LicenseUtil.processForm(request);
             User u = WebAPILocator.getUserWebAPI().getLoggedInUser(request);
-            if(error !=null){
-            	return Response.ok( LanguageUtil.get(u, "license-bad-id-explanation"), MediaType.APPLICATION_JSON_TYPE).build();
+            if (error != null) {
+                return Response.ok(LanguageUtil.get(u, "license-bad-id-explanation"),
+                        MediaType.APPLICATION_JSON_TYPE).build();
             }
-        	return Response.ok( error, MediaType.APPLICATION_JSON_TYPE).build();
-        }
-        catch(Exception ex) {
-            Logger.error(this, "can't request license ",ex);
+            return Response.ok(error, MediaType.APPLICATION_JSON_TYPE).build();
+        } catch (Exception ex) {
+            Logger.error(this, "can't request license ", ex);
 
             return Response.serverError().build();
         }
-        
+
     }
 
     @NoCache
     @POST
     @Path("/resetLicense/{params:.*}")
-    @Consumes (MediaType.APPLICATION_FORM_URLENCODED)
-    public Response resetLicense(@Context HttpServletRequest request, @Context final HttpServletResponse response, @PathParam("params") String params) {
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response resetLicense(@Context HttpServletRequest request,
+            @Context final HttpServletResponse response, @PathParam("params") String params) {
 
         final InitDataObject initData = new WebResource.InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -485,31 +496,24 @@ public class LicenseResource {
                 .init();
 
         try {
-        	freeLicense(request, response, params);
+            freeLicense(request, response, params);
 
-        	
-	        HttpSession session = request.getSession();
+            HttpSession session = request.getSession();
 
-            session.setAttribute( "applyForm", Boolean.TRUE );
-            session.setAttribute( "iwantTo", "paste_license" );
-            session.setAttribute( "paste_license", "paste_license" );
-            session.setAttribute( "license_text", "blah" );
+            session.setAttribute("applyForm", Boolean.TRUE);
+            session.setAttribute("iwantTo", "paste_license");
+            session.setAttribute("paste_license", "paste_license");
+            session.setAttribute("license_text", "blah");
 
-
-            String error = LicenseUtil.processForm( request );
-        	return Response.ok("", MediaType.APPLICATION_JSON_TYPE).build();
-        }
-        catch(Exception ex) {
-            Logger.error(this, "can't request license ",ex);
+            String error = LicenseUtil.processForm(request);
+            return Response.ok("", MediaType.APPLICATION_JSON_TYPE).build();
+        } catch (Exception ex) {
+            Logger.error(this, "can't request license ", ex);
 
             return Response.serverError().build();
         }
-        
+
     }
-    
-    
-    
-    
-    
-    
+
+
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/cache/provider/caffine/CaffineCache.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/cache/provider/caffine/CaffineCache.java
@@ -28,17 +28,16 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * In-Memory Cache implementation using https://github.com/ben-manes/caffeine
- *
- * Supports key-specific time invalidations by providing an {@link Expirable} object
- * in the {@link #put(String, String, Object)} method with the desired TTL.
- *
+ * <p>
+ * Supports key-specific time invalidations by providing an {@link Expirable} object in the
+ * {@link #put(String, String, Object)} method with the desired TTL.
+ * <p>
  * A group-wide invalidation time can also be set by config properties.
- *
+ * <p>
  * i.e., for the "graphqlquerycache" group
- *
+ * <p>
  * cache.graphqlquerycache.chain=com.dotmarketing.business.cache.provider.caffine.CaffineCache
  * cache.graphqlquerycache.seconds=15
- *
  */
 public class CaffineCache extends CacheProvider {
 
@@ -87,7 +86,7 @@ public class CaffineCache extends CacheProvider {
                 if (key.endsWith(".size")) {
                     int inMemory = Config.getIntProperty(key, 0);
                     _availableCaches.add(cacheName.toLowerCase());
-                    Logger.info(this.getClass(),
+                    Logger.debug(this.getClass(),
                             "***\t Cache Config Memory : " + cacheName + ": " + inMemory);
                 }
 
@@ -178,7 +177,7 @@ public class CaffineCache extends CacheProvider {
     public CacheProviderStats getStats() {
 
         CacheStats providerStats = new CacheStats();
-        CacheProviderStats ret = new CacheProviderStats(providerStats,getName());
+        CacheProviderStats ret = new CacheProviderStats(providerStats, getName());
 
         Set<String> currentGroups = new HashSet<>();
         currentGroups.addAll(getGroups());
@@ -187,43 +186,49 @@ public class CaffineCache extends CacheProvider {
 
         CacheSizingUtil sizer = new CacheSizingUtil();
 
-
-
         for (String group : currentGroups) {
             final CacheStats stats = new CacheStats();
 
             final Cache<String, Object> foundCache = getCache(group);
 
-
             final boolean isDefault = (Config.getIntProperty("cache." + group + ".size", -1) == -1);
-
 
             final int size = isDefault ? Config.getIntProperty("cache." + DEFAULT_CACHE + ".size")
                     : (Config.getIntProperty("cache." + group + ".size", -1) != -1)
                             ? Config.getIntProperty("cache." + group + ".size")
                             : Config.getIntProperty("cache." + DEFAULT_CACHE + ".size");
 
-            final int seconds = isDefault ? Config.getIntProperty("cache." + DEFAULT_CACHE + ".seconds", 100)
-                    : (Config.getIntProperty("cache." + group + ".seconds", -1) != -1)
-                            ? Config.getIntProperty("cache." + group + ".seconds")
-                            : Config.getIntProperty("cache." + DEFAULT_CACHE + ".seconds", 100);
+            final int seconds =
+                    isDefault ? Config.getIntProperty("cache." + DEFAULT_CACHE + ".seconds", 100)
+                            : (Config.getIntProperty("cache." + group + ".seconds", -1) != -1)
+                                    ? Config.getIntProperty("cache." + group + ".seconds")
+                                    : Config.getIntProperty("cache." + DEFAULT_CACHE + ".seconds",
+                                            100);
 
             com.github.benmanes.caffeine.cache.stats.CacheStats cstats = foundCache.stats();
             stats.addStat(CacheStats.REGION, group);
             stats.addStat(CacheStats.REGION_DEFAULT, isDefault + "");
-            stats.addStat(CacheStats.REGION_CONFIGURED_SIZE, "size:" + nf.format(size) + " / " + seconds + "s");
+            stats.addStat(CacheStats.REGION_CONFIGURED_SIZE,
+                    "size:" + nf.format(size) + " / " + seconds + "s");
             stats.addStat(CacheStats.REGION_SIZE, nf.format(foundCache.estimatedSize()));
-            stats.addStat(CacheStats.REGION_LOAD, nf.format(cstats.missCount()+cstats.hitCount()));
+            stats.addStat(CacheStats.REGION_LOAD,
+                    nf.format(cstats.missCount() + cstats.hitCount()));
             stats.addStat(CacheStats.REGION_HITS, nf.format(cstats.hitCount()));
             stats.addStat(CacheStats.REGION_HIT_RATE, pf.format(cstats.hitRate()));
-            stats.addStat(CacheStats.REGION_AVG_LOAD_TIME, nf.format(cstats.averageLoadPenalty()/1000000) + " ms");
+            stats.addStat(CacheStats.REGION_AVG_LOAD_TIME,
+                    nf.format(cstats.averageLoadPenalty() / 1000000) + " ms");
             stats.addStat(CacheStats.REGION_EVICTIONS, nf.format(cstats.evictionCount()));
 
-            long averageObjectSize = Try.of(()-> sizer.averageSize(foundCache.asMap())).getOrElse(-1L);
+            long averageObjectSize = Try.of(() -> sizer.averageSize(foundCache.asMap()))
+                    .getOrElse(-1L);
             long totalObjectSize = averageObjectSize * foundCache.estimatedSize();
 
-            stats.addStat(CacheStats.REGION_MEM_PER_OBJECT, "<div class='hideSizer'>" + String.format("%010d", averageObjectSize) + "</div>" + UtilMethods.prettyByteify(averageObjectSize));
-            stats.addStat(CacheStats.REGION_MEM_TOTAL_PRETTY, "<div class='hideSizer'>" + String.format("%010d", totalObjectSize) + "</div>" + UtilMethods.prettyByteify(totalObjectSize));
+            stats.addStat(CacheStats.REGION_MEM_PER_OBJECT,
+                    "<div class='hideSizer'>" + String.format("%010d", averageObjectSize) + "</div>"
+                            + UtilMethods.prettyByteify(averageObjectSize));
+            stats.addStat(CacheStats.REGION_MEM_TOTAL_PRETTY,
+                    "<div class='hideSizer'>" + String.format("%010d", totalObjectSize) + "</div>"
+                            + UtilMethods.prettyByteify(totalObjectSize));
             ret.addStatRecord(stats);
         }
 
@@ -263,10 +268,10 @@ public class CaffineCache extends CacheProvider {
                             size = Config.getIntProperty("cache." + DEFAULT_CACHE + ".size", 100);
                         }
 
-                        final int defaultTTL = Config.getIntProperty("cache." + cacheName + ".seconds", -1);
+                        final int defaultTTL = Config.getIntProperty(
+                                "cache." + cacheName + ".seconds", -1);
 
-
-                        Logger.info(this.getClass(),
+                        Logger.debug(this.getClass(),
                                 "***\t Building Cache : " + cacheName + ", size:" + size
                                         + ",Concurrency:"
                                         + Config.getIntProperty("cache.concurrencylevel", 32));
@@ -275,10 +280,11 @@ public class CaffineCache extends CacheProvider {
                                 .maximumSize(size)
                                 .recordStats()
                                 .expireAfter(new Expiry<String, Object>() {
-                                    public long expireAfterCreate(String key, Object value, long currentTime) {
+                                    public long expireAfterCreate(String key, Object value,
+                                            long currentTime) {
                                         long ttlInSeconds;
 
-                                        if(value instanceof Expirable
+                                        if (value instanceof Expirable
                                                 && ((Expirable) value).getTtl() > 0) {
                                             ttlInSeconds = ((Expirable) value).getTtl();
                                         } else if (defaultTTL > 0) {
@@ -289,10 +295,12 @@ public class CaffineCache extends CacheProvider {
 
                                         return TimeUnit.SECONDS.toNanos(ttlInSeconds);
                                     }
+
                                     public long expireAfterUpdate(String key, Object value,
                                             long currentTime, long currentDuration) {
                                         return currentDuration;
                                     }
+
                                     public long expireAfterRead(String key, Object value,
                                             long currentTime, long currentDuration) {
                                         return currentDuration;
@@ -303,7 +311,7 @@ public class CaffineCache extends CacheProvider {
                         groups.put(cacheName, cache);
 
                     } else {
-                        Logger.info(this.getClass(),
+                        Logger.debug(this.getClass(),
                                 "***\t No Cache for   : " + cacheName + ", using " + DEFAULT_CACHE);
                         cache = getCache(DEFAULT_CACHE);
                         groups.put(cacheName, cache);

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -1,14 +1,5 @@
 package com.dotmarketing.common.reindex;
 
-import java.sql.SQLException;
-import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-import org.apache.felix.framework.OSGISystem;
-import org.elasticsearch.action.bulk.BulkProcessor;
 import com.dotcms.api.system.event.Visibility;
 import com.dotcms.business.SystemCache;
 import com.dotcms.concurrent.DotConcurrentFactory;
@@ -20,12 +11,9 @@ import com.dotcms.notifications.bean.NotificationLevel;
 import com.dotcms.notifications.bean.NotificationType;
 import com.dotcms.notifications.business.NotificationAPI;
 import com.dotcms.util.I18NMessage;
-import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.CacheLocator;
-import com.dotmarketing.business.Role;
-import com.dotmarketing.business.RoleAPI;
-import com.dotmarketing.business.UserAPI;
+import com.dotmarketing.business.*;
 import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.db.HibernateUtil;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
@@ -34,6 +22,16 @@ import com.google.common.annotations.VisibleForTesting;
 import com.liferay.portal.language.LanguageException;
 import com.liferay.portal.model.User;
 import io.vavr.Lazy;
+import org.apache.felix.framework.OSGISystem;
+import org.elasticsearch.action.bulk.BulkProcessor;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * This thread is in charge of re-indexing the contenlet information placed in the
@@ -41,19 +39,18 @@ import io.vavr.Lazy;
  * record in the table and will add its information to the Elastic index.
  * <p>
  * The records added to the table will have a priority level set by the
- * {@link ReindexQueueFactory.Priority} enum. During the process, all
- * the "correct" contents will be processed and re-indexed first. All the "bad" records (contents
- * that could not be re-indexed) will be set a different priority level and be
- * given more opportunities to be re-indexed after all of the correct contents have already been
- * processed.
+ * {@link ReindexQueueFactory.Priority} enum. During the process, all the "correct" contents will be
+ * processed and re-indexed first. All the "bad" records (contents that could not be re-indexed)
+ * will be set a different priority level and be given more opportunities to be re-indexed after all
+ * of the correct contents have already been processed.
  * </p>
  * <p>
  * The number of times the bad contents can re-try the re-index process is specified by the
- * {@link ReindexQueueFactory#REINDEX_MAX_FAILURE_ATTEMPTS} property, which can be customized through
- * the {@code dotmarketing-config.properties} file. If a content cannot be re-indexed after all the
- * specified attempts, a notification will be sent to the Notification Bar indicating the Identifier
- * of the bad contentlet. This way users can keep track of the failed records and check the logs to
- * get more information about the failure.
+ * {@link ReindexQueueFactory#REINDEX_MAX_FAILURE_ATTEMPTS} property, which can be customized
+ * through the {@code dotmarketing-config.properties} file. If a content cannot be re-indexed after
+ * all the specified attempts, a notification will be sent to the Notification Bar indicating the
+ * Identifier of the bad contentlet. This way users can keep track of the failed records and check
+ * the logs to get more information about the failure.
  * </p>
  * <p>
  * The reasons why a content cannot be re-indexed can be, for example:
@@ -69,7 +66,6 @@ import io.vavr.Lazy;
  * @author root
  * @version 3.3
  * @since Mar 22, 2012
- *
  */
 public class ReindexThread {
 
@@ -83,89 +79,90 @@ public class ReindexThread {
     private final RoleAPI roleAPI;
     private final UserAPI userAPI;
 
-    private static ReindexThread instance ;
+    private static ReindexThread instance;
 
     private final long SLEEP = Config.getLongProperty("REINDEX_THREAD_SLEEP", 250);
     private final int SLEEP_ON_ERROR = Config.getIntProperty("REINDEX_THREAD_SLEEP_ON_ERROR", 500);
     private long contentletsIndexed = 0;
     // bulk up to this many requests
     public static final int ELASTICSEARCH_BULK_ACTIONS =
-                    Config.getIntProperty("REINDEX_THREAD_ELASTICSEARCH_BULK_ACTIONS", 10);
+            Config.getIntProperty("REINDEX_THREAD_ELASTICSEARCH_BULK_ACTIONS", 10);
 
     // How often should the bulk request processor should flush its request - default 3 seconds
     public static final int ELASTICSEARCH_BULK_FLUSH_INTERVAL =
-                    Config.getIntProperty("REINDEX_THREAD_ELASTICSEARCH_BULK_FLUSH_INTERVAL_MS", 3000);
+            Config.getIntProperty("REINDEX_THREAD_ELASTICSEARCH_BULK_FLUSH_INTERVAL_MS", 3000);
 
     // Setting this to number > 0 makes each bulk request asynchronous,
     // If set to 0 the bulk requests will be performed synchronously
     public static final int ELASTICSEARCH_CONCURRENT_REQUESTS =
-                    Config.getIntProperty("REINDEX_THREAD_CONCURRENT_REQUESTS", 1);
+            Config.getIntProperty("REINDEX_THREAD_CONCURRENT_REQUESTS", 1);
 
     // Max Bulk size in MB. -1 means disabled
     public static final int ELASTICSEARCH_BULK_SIZE =
-                    Config.getIntProperty("REINDEX_THREAD_ELASTICSEARCH_BULK_SIZE", 1);
+            Config.getIntProperty("REINDEX_THREAD_ELASTICSEARCH_BULK_SIZE", 1);
 
     // Time (in seconds) to wait before closing bulk processor in a full reindex
-    private static final int BULK_PROCESSOR_AWAIT_TIMEOUT = Config.getIntProperty("BULK_PROCESSOR_AWAIT_TIMEOUT", 20);
+    private static final int BULK_PROCESSOR_AWAIT_TIMEOUT = Config.getIntProperty(
+            "BULK_PROCESSOR_AWAIT_TIMEOUT", 20);
 
-    public static final int BACKOFF_POLICY_TIME_IN_SECONDS = Config.getIntProperty("BACKOFF_POLICY_TIME_IN_SECONDS", 20);
-    
-    public static final int BACKOFF_POLICY_MAX_RETRYS = Config.getIntProperty("BACKOFF_POLICY_MAX_RETRYS", 10);
-    
-    
-    private AtomicReference<ThreadState> STATE = new AtomicReference<>(ThreadState.RUNNING);
-    
+    public static final int BACKOFF_POLICY_TIME_IN_SECONDS = Config.getIntProperty(
+            "BACKOFF_POLICY_TIME_IN_SECONDS", 20);
+
+    public static final int BACKOFF_POLICY_MAX_RETRYS = Config.getIntProperty(
+            "BACKOFF_POLICY_MAX_RETRYS", 10);
 
 
-    
-    
-    
-    
+    public static final int WAIT_BEFORE_PAUSE_SECONDS = Config.getIntProperty(
+            "WAIT_BEFORE_PAUSE_SECONDS", 0);
+
+
+    private AtomicReference<ThreadState> state = new AtomicReference<>(ThreadState.STOPPED);
+
+
     private final static String REINDEX_THREAD_PAUSED = "REINDEX_THREAD_PAUSED";
     private final static Lazy<SystemCache> cache = Lazy.of(() -> CacheLocator.getSystemCache());
-    
-    private final static AtomicBoolean rebuildBulkIndexer=new AtomicBoolean(false);
+
+    private final static AtomicBoolean rebuildBulkIndexer = new AtomicBoolean(false);
 
     public static void rebuildBulkIndexer() {
-      Logger.warn(ReindexThread.class, "--- ReindexThread BulkProcessor needs to be Rebuilt");
-      ReindexThread.rebuildBulkIndexer.set(true);
+        Logger.warn(ReindexThread.class, "--- ReindexThread BulkProcessor needs to be Rebuilt");
+        ReindexThread.rebuildBulkIndexer.set(true);
     }
 
     private ReindexThread() {
 
-        this(APILocator.getReindexQueueAPI(), APILocator.getNotificationAPI(), APILocator.getUserAPI(), APILocator.getRoleAPI(),
+        this(APILocator.getReindexQueueAPI(), APILocator.getNotificationAPI(),
+                APILocator.getUserAPI(), APILocator.getRoleAPI(),
                 APILocator.getContentletIndexAPI());
     }
 
     @VisibleForTesting
-     ReindexThread(final ReindexQueueAPI queueApi, final NotificationAPI notificationAPI, final UserAPI userAPI,
+    ReindexThread(final ReindexQueueAPI queueApi, final NotificationAPI notificationAPI,
+            final UserAPI userAPI,
             final RoleAPI roleAPI, final ContentletIndexAPI indexAPI) {
         this.queueApi = queueApi;
         this.notificationAPI = notificationAPI;
         this.userAPI = userAPI;
         this.roleAPI = roleAPI;
         this.indexAPI = indexAPI;
-        instance=this;
+        instance = this;
 
     }
-    
-
-    
-    
 
 
     private final Runnable ReindexThreadRunnable = () -> {
-        Logger.info(this.getClass(), "---  ReindexThread is starting, background indexing will begin");
+        Logger.info(this.getClass(),
+                "---  ReindexThread is starting, background indexing will begin");
 
-
-        while (STATE.get() != ThreadState.STOPPED) {
+        while (state.get() != ThreadState.STOPPED) {
             try {
                 runReindexLoop();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 Logger.error(this.getClass(), e.getMessage(), e);
             }
         }
-        Logger.warn(this.getClass(), "---  ReindexThread is stopping, background indexing will not take place");
+        Logger.warn(this.getClass(),
+                "---  ReindexThread is stopping, background indexing will not take place");
 
     };
 
@@ -175,82 +172,85 @@ public class ReindexThread {
     }
 
 
-    private BulkProcessor closeBulkProcessor(final BulkProcessor bulkProcessor) throws InterruptedException {
-      if(bulkProcessor!=null) {
-        bulkProcessor.awaitClose(BULK_PROCESSOR_AWAIT_TIMEOUT, TimeUnit.SECONDS);
-      }
-      rebuildBulkIndexer.set(false);
-      return null;
+    private BulkProcessor closeBulkProcessor(final BulkProcessor bulkProcessor)
+            throws InterruptedException {
+        if (bulkProcessor != null) {
+            bulkProcessor.awaitClose(BULK_PROCESSOR_AWAIT_TIMEOUT, TimeUnit.SECONDS);
+        }
+        rebuildBulkIndexer.set(false);
+        return null;
     }
 
 
-    private BulkProcessor finalizeReIndex(BulkProcessor bulkProcessor) throws InterruptedException, LanguageException, DotDataException, SQLException {
+    private BulkProcessor finalizeReIndex(BulkProcessor bulkProcessor)
+            throws InterruptedException, LanguageException, DotDataException, SQLException {
         bulkProcessor = closeBulkProcessor(bulkProcessor);
         switchOverIfNeeded();
         if (!indexAPI.isInFullReindex()) {
             ReindexThread.pause();
         }
         return bulkProcessor;
-        
+
     }
-    
-    
-    
-    
 
-  /**
-   * This method is constantly verifying the existence of records in the {@code dist_reindex_journal}
-   * table. If a record is found, then it must be added to the Elastic index. If that's not possible,
-   * a notification containing the content identifier will be sent to the user via the Notifications
-   * API to take care of the problem as soon as possible.
-   */
-  private void runReindexLoop() {
-    BulkProcessor bulkProcessor = null;
-    BulkProcessorListener bulkProcessorListener = null;
-    while (STATE.get() != ThreadState.STOPPED) {
-      try {
 
-        final Map<String, ReindexEntry> workingRecords = queueApi.findContentToReindex();
+    /**
+     * This method is constantly verifying the existence of records in the
+     * {@code dist_reindex_journal} table. If a record is found, then it must be added to the
+     * Elastic index. If that's not possible, a notification containing the content identifier will
+     * be sent to the user via the Notifications API to take care of the problem as soon as
+     * possible.
+     */
+    private void runReindexLoop() {
+        BulkProcessor bulkProcessor = null;
+        BulkProcessorListener bulkProcessorListener = null;
+        while (state.get() != ThreadState.STOPPED) {
+            try {
 
-        if (workingRecords.isEmpty()) {
-            bulkProcessor = finalizeReIndex(bulkProcessor);
+                final Map<String, ReindexEntry> workingRecords = queueApi.findContentToReindex();
+
+                if (workingRecords.isEmpty()) {
+                    bulkProcessor = finalizeReIndex(bulkProcessor);
+                }
+
+                if (!workingRecords.isEmpty() && !ElasticReadOnlyCommand.getInstance()
+                        .isIndexOrClusterReadOnly()) {
+                    Logger.info(this,
+                            "Found  " + workingRecords + " index items to process");
+
+                    if (bulkProcessor == null || rebuildBulkIndexer.get()) {
+                        closeBulkProcessor(bulkProcessor);
+                        bulkProcessorListener = new BulkProcessorListener();
+                        bulkProcessor = indexAPI.createBulkProcessor(bulkProcessorListener);
+                    }
+                    bulkProcessorListener.workingRecords.putAll(workingRecords);
+                    indexAPI.appendToBulkProcessor(bulkProcessor, workingRecords.values());
+                    contentletsIndexed += bulkProcessorListener.getContentletsIndexed();
+                    // otherwise, reindex normally
+
+                }
+            } catch (Throwable ex) {
+                Logger.error(this, "ReindexThread Exception", ex);
+                ThreadUtils.sleep(SLEEP_ON_ERROR);
+            } finally {
+                DbConnectionFactory.closeSilently();
+            }
+            while (state.get() == ThreadState.PAUSED) {
+                ThreadUtils.sleep(SLEEP);
+                //Logs every 60 minutes
+                Logger.infoEvery(ReindexThread.class, "--- ReindexThread Paused",
+                        Config.getIntProperty("REINDEX_THREAD_PAUSE_IN_MINUTES", 60) * 60000);
+                Long restartTime = (Long) cache.get().get(REINDEX_THREAD_PAUSED);
+                if (restartTime == null || restartTime < System.currentTimeMillis()) {
+                    state.set(ThreadState.RUNNING);
+                }
+            }
         }
-        
-        
-        if (!workingRecords.isEmpty() && !ElasticReadOnlyCommand.getInstance().isIndexOrClusterReadOnly()) {
-              if (bulkProcessor == null || rebuildBulkIndexer.get()) {
-                  closeBulkProcessor(bulkProcessor);
-                  bulkProcessorListener = new BulkProcessorListener();
-                  bulkProcessor = indexAPI.createBulkProcessor(bulkProcessorListener);
-              }
-              bulkProcessorListener.workingRecords.putAll(workingRecords);
-              indexAPI.appendToBulkProcessor(bulkProcessor, workingRecords.values());
-              contentletsIndexed += bulkProcessorListener.getContentletsIndexed();
-              // otherwise, reindex normally
-          
-        } 
-      } catch (Throwable ex) {
-        Logger.error(this, "ReindexThread Exception", ex);
-        ThreadUtils.sleep(SLEEP_ON_ERROR);
-      } finally {
-        DbConnectionFactory.closeSilently();
-      }
-      while (STATE.get() == ThreadState.PAUSED) {
-        ThreadUtils.sleep(SLEEP);
-        //Logs every 60 minutes
-          Logger.infoEvery(ReindexThread.class, "--- ReindexThread Paused",
-                  Config.getIntProperty("REINDEX_THREAD_PAUSE_IN_MINUTES", 60) * 60000);
-        Long restartTime = (Long) cache.get().get(REINDEX_THREAD_PAUSED);
-        if(restartTime ==null || restartTime < System.currentTimeMillis()) {
-            STATE.set(ThreadState.RUNNING);
-        }
-      }
     }
-  }
 
 
-
-    private boolean switchOverIfNeeded() throws LanguageException, DotDataException, SQLException, InterruptedException {
+    private boolean switchOverIfNeeded()
+            throws LanguageException, DotDataException, SQLException, InterruptedException {
         if (ESReindexationProcessStatus.inFullReindexation() && queueApi.recordsInQueue() == 0) {
             // The re-indexation process has finished successfully
             if (indexAPI.reindexSwitchover(false)) {
@@ -266,12 +266,13 @@ public class ReindexThread {
      * Tells the thread to start processing. Starts the thread
      */
     public static void startThread() {
-        unpause();        
+        unpause();
     }
 
     private void state(ThreadState state) {
-        getInstance().STATE.set(state);
+        getInstance().state.set(state);
     }
+
     /**
      * Tells the thread to stop processing. Doesn't shut down the thread.
      */
@@ -281,16 +282,14 @@ public class ReindexThread {
     }
 
 
-
-
     /**
-     * This instance is intended to already be started. It will try to restart the thread if instance is
-     * null.
+     * This instance is intended to already be started. It will try to restart the thread if
+     * instance is null.
      */
     public static ReindexThread getInstance() {
-        if(instance==null) {
+        if (instance == null) {
             synchronized (ReindexThread.class) {
-                if(instance==null) {
+                if (instance == null) {
                     return new ReindexThread().instance;
                 }
             }
@@ -307,59 +306,81 @@ public class ReindexThread {
         getInstance().state(ThreadState.PAUSED);
     }
 
-
-
     public static void unpause() {
-        OSGISystem.getInstance().initializeFramework();
-        Logger.infoEvery(ReindexThread.class, "--- ReindexThread Running", 60000);
-        cache.get().remove(REINDEX_THREAD_PAUSED);
-        final Thread thread = new Thread(getInstance().ReindexThreadRunnable, "ReindexThreadRunnable");
-        
-        final DotSubmitter submitter = DotConcurrentFactory.getInstance().getSubmitter("ReindexThreadSubmitter",
-                        new DotConcurrentFactory.SubmitterConfigBuilder()
-                                .poolSize(1)
-                                .maxPoolSize(1)
-                                .queueCapacity(2)
-                                .rejectedExecutionHandler(new ThreadPoolExecutor.DiscardOldestPolicy())
-                                .build()
-                );
-        
-        
-       submitter.submit(thread);
-        getInstance().state(ThreadState.RUNNING);
+        if (!Config.getBooleanProperty("ALLOW_MANUAL_REINDEX_UNPAUSE", false)) {
+            Logger.debug(ReindexThread.class, "--- Adding unpause commit listener");
+            HibernateUtil.addCommitListener("unpauseIndex", ReindexThread::unpauseImpl);
+        } else {
+            unpauseImpl();
+        }
+    }
+
+    private static void unpauseImpl() {
+
+        ThreadState state = getInstance().state.get();
+        if (state == ThreadState.PAUSED) {
+            Logger.info(ReindexThread.class, "--- Unpausing reindex thread ");
+            cache.get().remove(REINDEX_THREAD_PAUSED);
+            getInstance().state(ThreadState.RUNNING);
+        } else if (state == ThreadState.STOPPED) {
+            Logger.info(ReindexThread.class, "--- Recreating ReindexThread from stopped");
+            OSGISystem.getInstance().initializeFramework();
+            Logger.infoEvery(ReindexThread.class, "--- ReindexThread Running", 60000);
+            cache.get().remove(REINDEX_THREAD_PAUSED);
+            final Thread thread = new Thread(getInstance().ReindexThreadRunnable,
+                    "ReindexThreadRunnable");
+
+            final DotSubmitter submitter = DotConcurrentFactory.getInstance()
+                    .getSubmitter("ReindexThreadSubmitter",
+                            new DotConcurrentFactory.SubmitterConfigBuilder()
+                                    .poolSize(1)
+                                    .maxPoolSize(1)
+                                    .queueCapacity(2)
+                                    .rejectedExecutionHandler(
+                                            new ThreadPoolExecutor.DiscardOldestPolicy())
+                                    .build()
+                    );
+            submitter.submit(thread);
+            getInstance().state(ThreadState.RUNNING);
+        }
+
     }
 
     public static boolean isWorking() {
-        return getInstance().STATE.get() == ThreadState.RUNNING;
+        return getInstance().state.get() == ThreadState.RUNNING;
     }
 
 
     /**
-     * Generates a new notification displayed at the top left side of the back-end page in dotCMS. This
-     * utility method allows you to send reports to the user regarding the operations performed during
-     * the re-index, whether they succeeded or failed.
+     * Generates a new notification displayed at the top left side of the back-end page in dotCMS.
+     * This utility method allows you to send reports to the user regarding the operations performed
+     * during the re-index, whether they succeeded or failed.
      *
-     * @param key - The message key that should be present in the language properties files.
-     * @param msgParams - The parameters, if any, that will replace potential placeholders in the
-     *        message. E.g.: "This is {0} test."
-     * @param defaultMsg - If set, the default message in case the key does not exist in the properties
-     *        file. Otherwise, the message key will be returned.
-     * @param error - true if we want to send an error notification
-     * @throws DotDataException The notification could not be posted to the system.
+     * @param key        - The message key that should be present in the language properties files.
+     * @param msgParams  - The parameters, if any, that will replace potential placeholders in the
+     *                   message. E.g.: "This is {0} test."
+     * @param defaultMsg - If set, the default message in case the key does not exist in the
+     *                   properties file. Otherwise, the message key will be returned.
+     * @param error      - true if we want to send an error notification
+     * @throws DotDataException  The notification could not be posted to the system.
      * @throws LanguageException The language properties could not be retrieved.
      */
-    protected void sendNotification(final String key, final Object[] msgParams, final String defaultMsg, boolean error)
+    protected void sendNotification(final String key, final Object[] msgParams,
+            final String defaultMsg, boolean error)
             throws DotDataException, LanguageException {
 
-        NotificationLevel notificationLevel = error ? NotificationLevel.ERROR : NotificationLevel.INFO;
+        NotificationLevel notificationLevel =
+                error ? NotificationLevel.ERROR : NotificationLevel.INFO;
 
         // Search for the CMS Admin role and System User
         final Role cmsAdminRole = this.roleAPI.loadCMSAdminRole();
         final User systemUser = this.userAPI.getSystemUser();
 
-        this.notificationAPI.generateNotification(new I18NMessage("notification.reindex.error.title"), // title = Reindex Notification
+        this.notificationAPI.generateNotification(
+                new I18NMessage("notification.reindex.error.title"), // title = Reindex Notification
                 new I18NMessage(key, defaultMsg, msgParams), null, // no actions
-                notificationLevel, NotificationType.GENERIC, Visibility.ROLE, cmsAdminRole.getId(), systemUser.getUserId(),
-        systemUser.getLocale());
-  }
+                notificationLevel, NotificationType.GENERIC, Visibility.ROLE, cmsAdminRole.getId(),
+                systemUser.getUserId(),
+                systemUser.getLocale());
+    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/db/HibernateUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/HibernateUtil.java
@@ -28,10 +28,10 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 /**
- * This class provides a great number of utility methods that allow developers to interact with
- * the underlying data source in dotCMS. Without regards to using the legacy Hibernate queries or
- * the new {@link com.dotmarketing.common.db.DotConnect} class, developers can manage
- * database transactions, connections, commit listeners, and many other configuration settings.
+ * This class provides a great number of utility methods that allow developers to interact with the
+ * underlying data source in dotCMS. Without regards to using the legacy Hibernate queries or the
+ * new {@link com.dotmarketing.common.db.DotConnect} class, developers can manage database
+ * transactions, connections, commit listeners, and many other configuration settings.
  *
  * @author will & david (2005)
  */
@@ -40,582 +40,619 @@ public class HibernateUtil {
     private static final String LISTENER_SUBMITTER = "dotListenerSubmitter";
     private static final String NETWORK_CACHE_FLUSH_DELAY = "NETWORK_CACHE_FLUSH_DELAY";
 
-	private static Dialect dialect;
-	private static SessionFactory sessionFactory;
+    private static Dialect dialect;
+    private static SessionFactory sessionFactory;
 
-	private static ThreadLocal <Session> sessionHolder = new ThreadLocal<>();
+    private static ThreadLocal<Session> sessionHolder = new ThreadLocal<>();
 
-	private Class thisClass;
+    private Class thisClass;
 
-	private Query query;
+    private Query query;
 
-	private int maxResults;
+    private int maxResults;
 
-	private int firstResult;
+    private int firstResult;
 
-	private int t;
+    private int t;
 
-	private static Mappings mappings;
+    private static Mappings mappings;
 
-	private static final boolean useCache = true;
-	
-	public HibernateUtil(SessionFactory sessionFac){
-		this.sessionFactory = sessionFac;
-	}
+    private static final boolean useCache = true;
 
-	public enum TransactionListenerStatus {
-		ENABLED, DISABLED;
-	}
+    public HibernateUtil(SessionFactory sessionFac) {
+        this.sessionFactory = sessionFac;
+    }
 
-	public static final String addToIndex="-add-to-index";
-	public static final String removeFromIndex="-remove-from-index";
+    public enum TransactionListenerStatus {
+        ENABLED, DISABLED;
+    }
 
-	/**
-	 * Status for listeners of thread-local -based transactions. This allows to control whether listeners are appended or not (ENABLED by default)
-	 */
-	private static final ThreadLocal< TransactionListenerStatus > listenersStatus = new ThreadLocal< TransactionListenerStatus >(){
+    public static final String addToIndex = "-add-to-index";
+    public static final String removeFromIndex = "-remove-from-index";
+
+    /**
+     * Status for listeners of thread-local -based transactions. This allows to control whether
+     * listeners are appended or not (ENABLED by default)
+     */
+    private static final ThreadLocal<TransactionListenerStatus> listenersStatus = new ThreadLocal<TransactionListenerStatus>() {
         protected TransactionListenerStatus initialValue() {
             return TransactionListenerStatus.ENABLED;
         }
     };
 
-	private static final ThreadLocal<Boolean> asyncCommitListenersFinalization = ThreadLocal.withInitial(()->true);
+    private static final ThreadLocal<Boolean> asyncCommitListenersFinalization = ThreadLocal.withInitial(
+            () -> true);
 
-	@VisibleForTesting
-	static final ThreadLocal<Map<String, Runnable>> asyncCommitListeners = ThreadLocal
-			.withInitial(LinkedHashMap::new);
-
-	@VisibleForTesting
-	static final ThreadLocal<Map<String, Runnable>> syncCommitListeners = ThreadLocal
-			.withInitial(LinkedHashMap::new);
-
-    static final ThreadLocal<Map<String, Runnable>> rollbackListeners= ThreadLocal
+    @VisibleForTesting
+    static final ThreadLocal<Map<String, Runnable>> asyncCommitListeners = ThreadLocal
             .withInitial(LinkedHashMap::new);
 
-	public HibernateUtil(Class c) {
-		setClass(c);
-	}
+    @VisibleForTesting
+    static final ThreadLocal<Map<String, Runnable>> syncCommitListeners = ThreadLocal
+            .withInitial(LinkedHashMap::new);
 
-	public HibernateUtil() {
-	}
+    static final ThreadLocal<Map<String, Runnable>> rollbackListeners = ThreadLocal
+            .withInitial(LinkedHashMap::new);
 
-	public void setClass(Class c) {
-		thisClass = c;
-	}
+    public HibernateUtil(Class c) {
+        setClass(c);
+    }
 
-	public static String getTableName(Class c) {
+    public HibernateUtil() {
+    }
 
-		return mappings.getClass(c).getTable().getName();
-	}
+    public void setClass(Class c) {
+        thisClass = c;
+    }
 
-	public static Dialect getDialect() {
-		if (sessionFactory == null) {
-			buildSessionFactory();
-		}
-		return dialect;
-	}
-	public int getCount() throws DotHibernateException {
-		try{
-			getSession();
-			int i = 0;
-			if (maxResults > 0) {
-				query.setMaxResults(maxResults);
-			}
-			if (firstResult > 0) {
-				query.setFirstResult(firstResult);
-			}
-			i = ((Integer) query.list().iterator().next()).intValue();
-			return i;
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to get count ", e);
-		}
-	}
+    public static String getTableName(Class c) {
 
-	public void setFirstResult(int firstResult) {
-		this.firstResult = firstResult;
-	}
+        return mappings.getClass(c).getTable().getName();
+    }
 
-	public void setMaxResults(int g) {
-		this.maxResults = g;
-	}
+    public static Dialect getDialect() {
+        if (sessionFactory == null) {
+            buildSessionFactory();
+        }
+        return dialect;
+    }
 
-	public void setParam(long g) {
-		query.setLong(t, g);
-		t++;
-	}
+    public int getCount() throws DotHibernateException {
+        try {
+            getSession();
+            int i = 0;
+            if (maxResults > 0) {
+                query.setMaxResults(maxResults);
+            }
+            if (firstResult > 0) {
+                query.setFirstResult(firstResult);
+            }
+            i = ((Integer) query.list().iterator().next()).intValue();
+            return i;
+        } catch (Exception e) {
+            throw new DotHibernateException("Unable to get count ", e);
+        }
+    }
 
-	public void setParam(Long g) {
-		query.setLong(t, g);
-		t++;
-	}
+    public void setFirstResult(int firstResult) {
+        this.firstResult = firstResult;
+    }
 
-	public void setParam(String g) {
-		query.setString(t, g);
-		t++;
-	}
+    public void setMaxResults(int g) {
+        this.maxResults = g;
+    }
 
-	public void setParam(int g) {
-		query.setInteger(t, g);
-		t++;
-	}
+    public void setParam(long g) {
+        query.setLong(t, g);
+        t++;
+    }
 
-	public void setParam(Integer g) {
-		query.setInteger(t, g);
-		t++;
-	}
+    public void setParam(Long g) {
+        query.setLong(t, g);
+        t++;
+    }
 
-	public void setParam(java.util.Date g) {
-		query.setTimestamp(t, g);
-		t++;
-	}
+    public void setParam(String g) {
+        query.setString(t, g);
+        t++;
+    }
 
-	public void setParam(boolean g) {
-		query.setBoolean(t, g);
-		t++;
-	}
+    public void setParam(int g) {
+        query.setInteger(t, g);
+        t++;
+    }
 
-	public void setParam(Boolean g) {
-		query.setBoolean(t, g);
-		t++;
-	}
+    public void setParam(Integer g) {
+        query.setInteger(t, g);
+        t++;
+    }
 
-	public void setParam(double g) {
-		query.setDouble(t, g);
-		t++;
-	}
+    public void setParam(java.util.Date g) {
+        query.setTimestamp(t, g);
+        t++;
+    }
 
-	public void setParam(Double g) {
-		query.setDouble(t, g);
-		t++;
-	}
+    public void setParam(boolean g) {
+        query.setBoolean(t, g);
+        t++;
+    }
 
-	public void setParam(float g) {
-		query.setFloat(t, g);
-		t++;
-	}
+    public void setParam(Boolean g) {
+        query.setBoolean(t, g);
+        t++;
+    }
 
-	public void setParam(Float g) {
-		query.setFloat(t, g);
-		t++;
-	}
+    public void setParam(double g) {
+        query.setDouble(t, g);
+        t++;
+    }
 
-	public void setParam(Object g) {
-		query.setEntity(t, g);
-		t++;
-	}
+    public void setParam(Double g) {
+        query.setDouble(t, g);
+        t++;
+    }
 
-	public void setQuery(String x) throws DotHibernateException{
-		try{
-			Session session = getSession();
-			query = session.createQuery(x);
-			query.setCacheable(useCache);
-		}catch(Exception ex){
-			throw new DotHibernateException("Error setting Query",ex);
-		}
-	}
+    public void setParam(float g) {
+        query.setFloat(t, g);
+        t++;
+    }
 
-	public void setSQLQuery(String x) throws DotHibernateException{
-		try{
-		Session session = getSession();
-			query = session.createSQLQuery(x, getTableName(thisClass), thisClass);
-			query.setCacheable(useCache);
-		}catch (Exception e) {
-			throw new DotHibernateException("Error setting SQLQuery ", e);
-		}
-	}
+    public void setParam(Float g) {
+        query.setFloat(t, g);
+        t++;
+    }
 
-	/*
-	 * hibernate delete object
-	 */
-	public static void delete(Object obj) throws DotHibernateException {
-		try{
-			Session session = getSession();
-			session.delete(obj);
-			session.flush();
-		}catch (Exception e) {
-			throw new DotHibernateException("Error deleting object " + e.getMessage(), e);
-		}
-	}
+    public void setParam(Object g) {
+        query.setEntity(t, g);
+        t++;
+    }
 
-	/**
-	 * Do a query, settings the parameters (if exists) and return a unique result
-	 * @param clazz
-	 * @param query
-	 * @param parameters
-	 * @param <T>
-	 * @return
-	 * @throws DotHibernateException
-	 * @throws HibernateException
-	 */
-	public static <T> T load(final Class<T> clazz, final String query,
-							 final Object ...parameters) throws DotHibernateException {
+    public void setQuery(String x) throws DotHibernateException {
+        try {
+            Session session = getSession();
+            query = session.createQuery(x);
+            query.setCacheable(useCache);
+        } catch (Exception ex) {
+            throw new DotHibernateException("Error setting Query", ex);
+        }
+    }
 
-		T result = null;
-		int index = 0;
-		Query hibernateQuery = null;
+    public void setSQLQuery(String x) throws DotHibernateException {
+        try {
+            Session session = getSession();
+            query = session.createSQLQuery(x, getTableName(thisClass), thisClass);
+            query.setCacheable(useCache);
+        } catch (Exception e) {
+            throw new DotHibernateException("Error setting SQLQuery ", e);
+        }
+    }
 
-		try {
+    /*
+     * hibernate delete object
+     */
+    public static void delete(Object obj) throws DotHibernateException {
+        try {
+            Session session = getSession();
+            session.delete(obj);
+            session.flush();
+        } catch (Exception e) {
+            throw new DotHibernateException("Error deleting object " + e.getMessage(), e);
+        }
+    }
 
-			hibernateQuery = getSession().createQuery(query).setCacheable(useCache);
+    /**
+     * Do a query, settings the parameters (if exists) and return a unique result
+     *
+     * @param clazz
+     * @param query
+     * @param parameters
+     * @param <T>
+     * @return
+     * @throws DotHibernateException
+     * @throws HibernateException
+     */
+    public static <T> T load(final Class<T> clazz, final String query,
+            final Object... parameters) throws DotHibernateException {
 
-			for (Object parameter : parameters) {
-				hibernateQuery.setParameter(index++, parameter);
-			}
+        T result = null;
+        int index = 0;
+        Query hibernateQuery = null;
 
-			result         = (T)hibernateQuery.list().get(0);
-			hibernateQuery = null;
-		} catch (java.lang.IndexOutOfBoundsException iob) {
-			// if no object is found in db, return an new Object
-			try {
-				result = clazz.newInstance();
-			} catch (Exception ex) {
-				Logger.error(HibernateUtil.class, hibernateQuery.getQueryString(), ex);
-				throw new DotRuntimeException(ex.toString());
-			}
-		} catch ( ObjectNotFoundException e ) {
-			Logger.warn(HibernateUtil.class, "---------- DotHibernate: can't load- no results from query---------------", e);
-			try {
-				result = clazz.newInstance();
-			} catch (Exception ee) {
-				Logger.error(HibernateUtil.class, "---------- DotHibernate: can't load- thisClass.newInstance()---------------", e);
-				throw new DotRuntimeException(e.toString());
-			}
-		} catch ( Exception e ) {
-			throw new DotRuntimeException( e.getMessage(), e );
-		}
+        try {
 
-		return result;
-	}
+            hibernateQuery = getSession().createQuery(query).setCacheable(useCache);
 
-	/*
-	 * hibernate delete object
-	 */
-	public static void delete(String sql) throws DotHibernateException {
-		try{
-			Session session = getSession();
-			session.delete(sql);
-		}catch (Exception e) {
-			throw new DotHibernateException("Error deleteing SQL " + e.getMessage(), e);
-		}
-	}
+            for (Object parameter : parameters) {
+                hibernateQuery.setParameter(index++, parameter);
+            }
 
-	public static java.util.List find(String x)  throws DotHibernateException{
-		try{
-			Session session = getSession();
-			return session.find(x);
-		}catch (Exception e) {
-			throw new DotHibernateException("Error executing a find on Hibernate Session " + e.getMessage(), e);
-		}
-	}
+            result = (T) hibernateQuery.list().get(0);
+            hibernateQuery = null;
+        } catch (java.lang.IndexOutOfBoundsException iob) {
+            // if no object is found in db, return an new Object
+            try {
+                result = clazz.newInstance();
+            } catch (Exception ex) {
+                Logger.error(HibernateUtil.class, hibernateQuery.getQueryString(), ex);
+                throw new DotRuntimeException(ex.toString());
+            }
+        } catch (ObjectNotFoundException e) {
+            Logger.warn(HibernateUtil.class,
+                    "---------- DotHibernate: can't load- no results from query---------------", e);
+            try {
+                result = clazz.newInstance();
+            } catch (Exception ee) {
+                Logger.error(HibernateUtil.class,
+                        "---------- DotHibernate: can't load- thisClass.newInstance()---------------",
+                        e);
+                throw new DotRuntimeException(e.toString());
+            }
+        } catch (Exception e) {
+            throw new DotRuntimeException(e.getMessage(), e);
+        }
 
-    public static Object load(Class c, Serializable key)  throws DotHibernateException{
-    	Session session = getSession();
-    	
-    	try{
+        return result;
+    }
+
+    /*
+     * hibernate delete object
+     */
+    public static void delete(String sql) throws DotHibernateException {
+        try {
+            Session session = getSession();
+            session.delete(sql);
+        } catch (Exception e) {
+            throw new DotHibernateException("Error deleteing SQL " + e.getMessage(), e);
+        }
+    }
+
+    public static java.util.List find(String x) throws DotHibernateException {
+        try {
+            Session session = getSession();
+            return session.find(x);
+        } catch (Exception e) {
+            throw new DotHibernateException(
+                    "Error executing a find on Hibernate Session " + e.getMessage(), e);
+        }
+    }
+
+    public static Object load(Class c, Serializable key) throws DotHibernateException {
+        Session session = getSession();
+
+        try {
             return (Object) session.load(c, key);
-		}catch (Exception e) {
-			try
-			{
-				/*
-				 * DOTCMS-1398
-				 * when we try to find an object that doesn't exist the session become "dirty" cause:
-				 *
-				 * "Like all Hibernate exceptions, this exception is considered unrecoverable."
-				 *  http://hibernate.bluemars.net/hib_docs/v3/api/org/hibernate/ObjectNotFoundException.html
-				 *
-				 *  and we have to close the session, cause it can't be used anymore.
-				 */
-				session.close();
-			}
-			catch(Exception ex)
-			{
-				Logger.debug(HibernateUtil.class,ex.toString());
-			}
-			throw new DotHibernateException("Error loading object from Hibernate Session ", e);
-		}
+        } catch (Exception e) {
+            try {
+                /*
+                 * DOTCMS-1398
+                 * when we try to find an object that doesn't exist the session become "dirty" cause:
+                 *
+                 * "Like all Hibernate exceptions, this exception is considered unrecoverable."
+                 *  http://hibernate.bluemars.net/hib_docs/v3/api/org/hibernate/ObjectNotFoundException.html
+                 *
+                 *  and we have to close the session, cause it can't be used anymore.
+                 */
+                session.close();
+            } catch (Exception ex) {
+                Logger.debug(HibernateUtil.class, ex.toString());
+            }
+            throw new DotHibernateException("Error loading object from Hibernate Session ", e);
+        }
     }
 
-	/*
-	 * hibernate RecipientList object
-	 */
-	public List list() throws DotHibernateException{
-		try{
-			getSession();
-			if (maxResults > 0) {
-				query.setMaxResults(maxResults);
-			}
-			if (firstResult > 0) {
-				query.setFirstResult(firstResult);
-			}
-			long before = System.currentTimeMillis();
-			java.util.List l = query.list();
-			long after = System.currentTimeMillis();
-			if(((after - before) / 1000) > 20) {
-				String[] paramsA = query.getNamedParameters();
-				String params = "";
-				for(String s : paramsA)
+    /*
+     * hibernate RecipientList object
+     */
+    public List list() throws DotHibernateException {
+        try {
+            getSession();
+            if (maxResults > 0) {
+                query.setMaxResults(maxResults);
+            }
+            if (firstResult > 0) {
+                query.setFirstResult(firstResult);
+            }
+            long before = System.currentTimeMillis();
+            java.util.List l = query.list();
+            long after = System.currentTimeMillis();
+            if (((after - before) / 1000) > 20) {
+                String[] paramsA = query.getNamedParameters();
+                String params = "";
+				for (String s : paramsA) {
 					params = s + ", ";
-				Logger.warn(this, "Too slow query sql: " + query.getQueryString() + " " + params);
-			}
-			return l;
-        } catch ( ObjectNotFoundException e ) {
+				}
+                Logger.warn(this, "Too slow query sql: " + query.getQueryString() + " " + params);
+            }
+            return l;
+        } catch (ObjectNotFoundException e) {
             Logger.warn(this, "---------- DotHibernate: error on list ---------------", e);
-			/*Ozzy i comment this because see DOTCMS-206. it have nonsence to make a rollback
-			 * when we are doing a search and the object is not found. this make some other operation
-			 * to rollback when this is not required
-			 **/
-			//handleSessionException();
-			// throw new DotRuntimeException(e.toString());
-			return new java.util.ArrayList();
-        } catch ( Exception e ) {
-            throw new DotRuntimeException( e.getMessage(), e );
+            /*Ozzy i comment this because see DOTCMS-206. it have nonsence to make a rollback
+             * when we are doing a search and the object is not found. this make some other operation
+             * to rollback when this is not required
+             **/
+            //handleSessionException();
+            // throw new DotRuntimeException(e.toString());
+            return new java.util.ArrayList();
+        } catch (Exception e) {
+            throw new DotRuntimeException(e.getMessage(), e);
         }
     }
 
-	public Object load(long id)throws DotHibernateException {
-		Session session = getSession();
+    public Object load(long id) throws DotHibernateException {
+        Session session = getSession();
 
-		if (id == 0) {
-			try {
-				return thisClass.newInstance();
-			} catch (Exception e) {
-				throw new DotRuntimeException(e.toString());
-			}
-		}
+        if (id == 0) {
+            try {
+                return thisClass.newInstance();
+            } catch (Exception e) {
+                throw new DotRuntimeException(e.toString());
+            }
+        }
 
-		try {
-			return session.load(thisClass, new Long(id));
-        } catch ( ObjectNotFoundException e ) {
+        try {
+            return session.load(thisClass, new Long(id));
+        } catch (ObjectNotFoundException e) {
             Logger.debug(this, "---------- DotHibernate: error on load ---------------", e);
-			/*Ozzy i comment this because see DOTCMS-206. it have nonsence to make a rollback
-			 * when we are doing a search and the object is not found. this make some other operation
-			 * to rollback when this is not required
-			 **/
-			//handleSessionException();
+            /*Ozzy i comment this because see DOTCMS-206. it have nonsence to make a rollback
+             * when we are doing a search and the object is not found. this make some other operation
+             * to rollback when this is not required
+             **/
+            //handleSessionException();
 
-			// if no object is found in db, return an new Object
-			try {
-				return thisClass.newInstance();
-			} catch (Exception ex) {
-				throw new DotRuntimeException(e.toString());
-			}
-		} catch ( Exception e ) {
-            throw new DotRuntimeException( e.getMessage(), e );
+            // if no object is found in db, return an new Object
+            try {
+                return thisClass.newInstance();
+            } catch (Exception ex) {
+                throw new DotRuntimeException(e.toString());
+            }
+        } catch (Exception e) {
+            throw new DotRuntimeException(e.getMessage(), e);
         }
-	}
-
-	/**
-	 * Will return null if object not found
-	 * @param id
-	 * @return
-	 * @throws DotHibernateException
-	 */
-	public Object load(String id) throws DotHibernateException{
-		Session session = getSession();
-
-		if (id == null) {
-			try {
-				return thisClass.newInstance();
-			} catch (Exception e) {
-				throw new DotRuntimeException(e.toString());
-			}
-		}
-
-		try {
-			return session.load(thisClass, id);
-        } catch ( ObjectNotFoundException e ) {
-            Logger.debug(this, "---------- DotHibernate: error on load ---------------", e);
-
-			/*Ozzy i comment this because see DOTCMS-206. it have nonsence to make a rollback
-			 * when we are doing a search and the object is not found. this make some other operation
-			 * to rollback when this is not required
-			 **/
-			//handleSessionException();
-
-			// if no object is found in db, return an new Object
-			try {
-				return thisClass.newInstance();
-			} catch (Exception ex) {
-				throw new DotRuntimeException(e.toString());
-			}
-		} catch ( Exception e ) {
-            throw new DotRuntimeException( e.getMessage(), e );
-        }
-	}
-
-	public Object get(long id)throws DotHibernateException {
-		try{
-			Session session = getSession();
-			if (id == 0) {
-				return thisClass.newInstance();
-			}
-				return session.get(thisClass, id);
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to get Object with id " + id + " from Hibernate Session ", e);
-		}
-	}
-
-	public Object get(String id) throws DotHibernateException{
-		try{
-			Session session = getSession();
-			if (id == null)
-				return thisClass.newInstance();
-			return session.get(thisClass, id);
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to get Object with id " + id + " from Hibernate Session ", e);
-		}
-	}
-
-	/**
-	 *
-	 * @return The object loaded from the query or null if no object matches the query
-	 * @throws DotHibernateException
-	 */
-	public Object load() throws DotHibernateException{
-		getSession();
-		Object obj;
-
-		try {
-			if (maxResults > 0) {
-				query.setMaxResults(maxResults);
-			}
-
-			List l = (java.util.List) query.list();
-			obj = l.get(0);
-			query = null;
-		} catch (java.lang.IndexOutOfBoundsException iob) {
-			// if no object is found in db, return an new Object
-			try {
-				obj = thisClass.newInstance();
-			} catch (Exception ex) {
-				Logger.error(this, query.getQueryString(), ex);
-				throw new DotRuntimeException(ex.toString());
-			}
-        } catch ( ObjectNotFoundException e ) {
-            Logger.warn(this, "---------- DotHibernate: can't load- no results from query---------------", e);
-			/*Ozzy i comment this because see DOTCMS-206. it have nonsence to make a rollback
-			 * when we are doing a search and the object is not found. this make some other operation
-			 * to rollback when this is not required
-			 **/
-			//handleSessionException();
-
-			try {
-				obj = thisClass.newInstance();
-			} catch (Exception ee) {
-				Logger.error(this, "---------- DotHibernate: can't load- thisClass.newInstance()---------------", e);
-				throw new DotRuntimeException(e.toString());
-			}
-		} catch ( Exception e ) {
-            throw new DotRuntimeException( e.getMessage(), e );
-        }
-
-		return obj;
-	}
-
-	public String getQuery() throws DotHibernateException {
-		try{
-		final StringBuilder sb = new StringBuilder(this.query.getQueryString() + "\n");
-			for (int i = 0; i < this.query.getNamedParameters().length; i++) {
-				sb.append("param " + i + " = " + query.getNamedParameters()[i]);
-			}
-
-		return sb.toString();
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to set Query ", e);
-		}
-	}
-
-	public static void save(Object obj)  throws DotHibernateException{
-		try{
-		    forceDirtyObject.set(obj);
-			Session session = getSession();
-			session.save(obj);
-			session.flush();
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to save Object to Hibernate Session ", e);
-		}
-		finally {
-            forceDirtyObject.remove();
-        }
-	}
-
-	public static void saveOrUpdate(Object obj)  throws DotHibernateException{
-		try{
-		    forceDirtyObject.set(obj);
-			Session session = getSession();
-			session.saveOrUpdate(obj);
-			session.flush();
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to save/update Object to Hibernate Session ", e);
-		}
-		finally {
-		    forceDirtyObject.remove();
-		}
-	}
-
-	/**
-	 * Merge is pretty similar to saveOrUpdate method, but specially util for add/update detached objects (objects that are not longer in the current session or
-	 * objects that were loaded from JDBC)
-	 * @param obj Object
-	 * @throws DotHibernateException
-	 */
-	public static void merge(final Object obj)  throws DotHibernateException{
-		try{
-			forceDirtyObject.set(obj);
-			Session session = getSession();
-			session.saveOrUpdateCopy(obj);
-			session.flush();
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to merge Object to Hibernate Session ", e);
-		}
-		finally {
-			forceDirtyObject.remove();
-		}
-	}
-
-	public static void update(Object obj)  throws DotHibernateException{
-		try{
-		    forceDirtyObject.set(obj);
-			Session session = getSession();
-			session.update(obj);
-			session.flush();
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to update Object to Hibernate Session ", e);
-		}
-		finally {
-            forceDirtyObject.remove();
-        }
-	}
-
-	// Session management methods
-
-	private static ThreadLocal <Object>forceDirtyObject = new ThreadLocal<>();
-
-	protected static class NoDirtyFlushInterceptor implements Interceptor {
-
-        protected final static int[] EMPTY=new int[0];
-
-        public int[] findDirty(Object entity, Serializable id, Object[] currentState, Object[] previousState, String[] propertyNames,Type[] types) {
-            if(forceDirtyObject.get() == entity)
-                return null;
-            else
-                return EMPTY;
-        }
-
-        public Object instantiate(Class entityClass, Serializable id) throws CallbackException { return null; }
-        public Boolean isUnsaved(Object arg0) { return null; }
-        public void onDelete(Object arg0, Serializable arg1, Object[] arg2, String[] arg3, Type[] arg4) throws CallbackException { }
-        public boolean onFlushDirty(Object arg0, Serializable arg1,Object[] arg2, Object[] arg3, String[] arg4, Type[] arg5) throws CallbackException { return false; }
-        public boolean onLoad(Object arg0, Serializable arg1, Object[] arg2,String[] arg3, Type[] arg4) throws CallbackException { return false; }
-        public boolean onSave(Object arg0, Serializable arg1, Object[] arg2, String[] arg3, Type[] arg4) throws CallbackException { return false; }
-        public void postFlush(Iterator arg0) throws CallbackException { }
-        public void preFlush(Iterator arg0) throws CallbackException { }
     }
 
-	private static synchronized void buildSessionFactory() {
-		long start = System.currentTimeMillis();
-		try {
-			// Initialize the Hibernate environment
+    /**
+     * Will return null if object not found
+     *
+     * @param id
+     * @return
+     * @throws DotHibernateException
+     */
+    public Object load(String id) throws DotHibernateException {
+        Session session = getSession();
+
+        if (id == null) {
+            try {
+                return thisClass.newInstance();
+            } catch (Exception e) {
+                throw new DotRuntimeException(e.toString());
+            }
+        }
+
+        try {
+            return session.load(thisClass, id);
+        } catch (ObjectNotFoundException e) {
+            Logger.debug(this, "---------- DotHibernate: error on load ---------------", e);
+
+            /*Ozzy i comment this because see DOTCMS-206. it have nonsence to make a rollback
+             * when we are doing a search and the object is not found. this make some other operation
+             * to rollback when this is not required
+             **/
+            //handleSessionException();
+
+            // if no object is found in db, return an new Object
+            try {
+                return thisClass.newInstance();
+            } catch (Exception ex) {
+                throw new DotRuntimeException(e.toString());
+            }
+        } catch (Exception e) {
+            throw new DotRuntimeException(e.getMessage(), e);
+        }
+    }
+
+    public Object get(long id) throws DotHibernateException {
+        try {
+            Session session = getSession();
+            if (id == 0) {
+                return thisClass.newInstance();
+            }
+            return session.get(thisClass, id);
+        } catch (Exception e) {
+            throw new DotHibernateException(
+                    "Unable to get Object with id " + id + " from Hibernate Session ", e);
+        }
+    }
+
+    public Object get(String id) throws DotHibernateException {
+        try {
+            Session session = getSession();
+			if (id == null) {
+				return thisClass.newInstance();
+			}
+            return session.get(thisClass, id);
+        } catch (Exception e) {
+            throw new DotHibernateException(
+                    "Unable to get Object with id " + id + " from Hibernate Session ", e);
+        }
+    }
+
+    /**
+     * @return The object loaded from the query or null if no object matches the query
+     * @throws DotHibernateException
+     */
+    public Object load() throws DotHibernateException {
+        getSession();
+        Object obj;
+
+        try {
+            if (maxResults > 0) {
+                query.setMaxResults(maxResults);
+            }
+
+            List l = (java.util.List) query.list();
+            obj = l.get(0);
+            query = null;
+        } catch (java.lang.IndexOutOfBoundsException iob) {
+            // if no object is found in db, return an new Object
+            try {
+                obj = thisClass.newInstance();
+            } catch (Exception ex) {
+                Logger.error(this, query.getQueryString(), ex);
+                throw new DotRuntimeException(ex.toString());
+            }
+        } catch (ObjectNotFoundException e) {
+            Logger.warn(this,
+                    "---------- DotHibernate: can't load- no results from query---------------", e);
+            /*Ozzy i comment this because see DOTCMS-206. it have nonsence to make a rollback
+             * when we are doing a search and the object is not found. this make some other operation
+             * to rollback when this is not required
+             **/
+            //handleSessionException();
+
+            try {
+                obj = thisClass.newInstance();
+            } catch (Exception ee) {
+                Logger.error(this,
+                        "---------- DotHibernate: can't load- thisClass.newInstance()---------------",
+                        e);
+                throw new DotRuntimeException(e.toString());
+            }
+        } catch (Exception e) {
+            throw new DotRuntimeException(e.getMessage(), e);
+        }
+
+        return obj;
+    }
+
+    public String getQuery() throws DotHibernateException {
+        try {
+            final StringBuilder sb = new StringBuilder(this.query.getQueryString() + "\n");
+            for (int i = 0; i < this.query.getNamedParameters().length; i++) {
+                sb.append("param " + i + " = " + query.getNamedParameters()[i]);
+            }
+
+            return sb.toString();
+        } catch (Exception e) {
+            throw new DotHibernateException("Unable to set Query ", e);
+        }
+    }
+
+    public static void save(Object obj) throws DotHibernateException {
+        try {
+            forceDirtyObject.set(obj);
+            Session session = getSession();
+            session.save(obj);
+            session.flush();
+        } catch (Exception e) {
+            throw new DotHibernateException("Unable to save Object to Hibernate Session ", e);
+        } finally {
+            forceDirtyObject.remove();
+        }
+    }
+
+    public static void saveOrUpdate(Object obj) throws DotHibernateException {
+        try {
+            forceDirtyObject.set(obj);
+            Session session = getSession();
+            session.saveOrUpdate(obj);
+            session.flush();
+        } catch (Exception e) {
+            throw new DotHibernateException("Unable to save/update Object to Hibernate Session ",
+                    e);
+        } finally {
+            forceDirtyObject.remove();
+        }
+    }
+
+    /**
+     * Merge is pretty similar to saveOrUpdate method, but specially util for add/update detached
+     * objects (objects that are not longer in the current session or objects that were loaded from
+     * JDBC)
+     *
+     * @param obj Object
+     * @throws DotHibernateException
+     */
+    public static void merge(final Object obj) throws DotHibernateException {
+        try {
+            forceDirtyObject.set(obj);
+            Session session = getSession();
+            session.saveOrUpdateCopy(obj);
+            session.flush();
+        } catch (Exception e) {
+            throw new DotHibernateException("Unable to merge Object to Hibernate Session ", e);
+        } finally {
+            forceDirtyObject.remove();
+        }
+    }
+
+    public static void update(Object obj) throws DotHibernateException {
+        try {
+            forceDirtyObject.set(obj);
+            Session session = getSession();
+            session.update(obj);
+            session.flush();
+        } catch (Exception e) {
+            throw new DotHibernateException("Unable to update Object to Hibernate Session ", e);
+        } finally {
+            forceDirtyObject.remove();
+        }
+    }
+
+    // Session management methods
+
+    private static ThreadLocal<Object> forceDirtyObject = new ThreadLocal<>();
+
+    protected static class NoDirtyFlushInterceptor implements Interceptor {
+
+        protected final static int[] EMPTY = new int[0];
+
+        public int[] findDirty(Object entity, Serializable id, Object[] currentState,
+                Object[] previousState, String[] propertyNames, Type[] types) {
+			if (forceDirtyObject.get() == entity) {
+				return null;
+			} else {
+				return EMPTY;
+			}
+        }
+
+        public Object instantiate(Class entityClass, Serializable id) throws CallbackException {
+            return null;
+        }
+
+        public Boolean isUnsaved(Object arg0) {
+            return null;
+        }
+
+        public void onDelete(Object arg0, Serializable arg1, Object[] arg2, String[] arg3,
+                Type[] arg4) throws CallbackException {
+        }
+
+        public boolean onFlushDirty(Object arg0, Serializable arg1, Object[] arg2, Object[] arg3,
+                String[] arg4, Type[] arg5) throws CallbackException {
+            return false;
+        }
+
+        public boolean onLoad(Object arg0, Serializable arg1, Object[] arg2, String[] arg3,
+                Type[] arg4) throws CallbackException {
+            return false;
+        }
+
+        public boolean onSave(Object arg0, Serializable arg1, Object[] arg2, String[] arg3,
+                Type[] arg4) throws CallbackException {
+            return false;
+        }
+
+        public void postFlush(Iterator arg0) throws CallbackException {
+        }
+
+        public void preFlush(Iterator arg0) throws CallbackException {
+        }
+    }
+
+    private static synchronized void buildSessionFactory() {
+        long start = System.currentTimeMillis();
+        try {
+            // Initialize the Hibernate environment
 			/*
 			################################
 			##
@@ -623,258 +660,249 @@ public class HibernateUtil {
 			##
 			#################################
 			*/
-			Configuration cfg = new Configuration().configure();
-			cfg.setProperty("hibernate.cache.provider_class", "com.dotmarketing.db.NoCacheProvider");
-			cfg.setProperty("hibernate.jdbc.use_scrollable_resultset","true");
-			cfg.addResource("META-INF/portal-hbm.xml");
-			final String[] additionalConfigs = Config.getStringArrayProperty("additional.hibernate.configs",new String[] {});
-		    for(String config:additionalConfigs) {
-		        cfg.addResource(config);
-		    }
+            Configuration cfg = new Configuration().configure();
+            cfg.setProperty("hibernate.cache.provider_class",
+                    "com.dotmarketing.db.NoCacheProvider");
+            cfg.setProperty("hibernate.jdbc.use_scrollable_resultset", "true");
+            cfg.addResource("META-INF/portal-hbm.xml");
+            final String[] additionalConfigs = Config.getStringArrayProperty(
+                    "additional.hibernate.configs", new String[]{});
+            for (String config : additionalConfigs) {
+                cfg.addResource(config);
+            }
 
-			if (DbConnectionFactory.isMySql()) {
-				//http://jira.dotmarketing.net/browse/DOTCMS-4937
-				cfg.setNamingStrategy(new LowercaseNamingStrategy());
-				cfg.addResource("com/dotmarketing/beans/DotCMSId.hbm.xml");
-				cfg.addResource("com/dotmarketing/beans/DotCMSId_NOSQLGEN.hbm.xml");
-				getPluginsHBM("Id",cfg);
-				cfg.setProperty("hibernate.dialect", "com.dotcms.repackage.net.sf.hibernate.dialect.MySQLDialect");
-			} else if (DbConnectionFactory.isPostgres()) {
-				cfg.addResource("com/dotmarketing/beans/DotCMSSeq.hbm.xml");
-				cfg.addResource("com/dotmarketing/beans/DotCMSSeq_NOSQLGEN.hbm.xml");
-				getPluginsHBM("Seq",cfg);
-				cfg.setProperty("hibernate.dialect", "com.dotcms.repackage.net.sf.hibernate.dialect.PostgreSQLDialect");
-			} else if (DbConnectionFactory.isMsSql()) {
-				cfg.addResource("com/dotmarketing/beans/DotCMSId.hbm.xml");
-				cfg.addResource("com/dotmarketing/beans/DotCMSId_NOSQLGEN.hbm.xml");
-				getPluginsHBM("Id",cfg);
-				cfg.setProperty("hibernate.dialect", "com.dotcms.repackage.net.sf.hibernate.dialect.SQLServerDialect");
-			} else if (DbConnectionFactory.isOracle()) {
-				cfg.addResource("com/dotmarketing/beans/DotCMSSeq.hbm.xml");
-				cfg.addResource("com/dotmarketing/beans/DotCMSSeq_NOSQLGEN.hbm.xml");
-				getPluginsHBM("Seq",cfg);
-				cfg.setProperty("hibernate.dialect", "com.dotcms.repackage.net.sf.hibernate.dialect.OracleDialect");
-			}
+            if (DbConnectionFactory.isMySql()) {
+                //http://jira.dotmarketing.net/browse/DOTCMS-4937
+                cfg.setNamingStrategy(new LowercaseNamingStrategy());
+                cfg.addResource("com/dotmarketing/beans/DotCMSId.hbm.xml");
+                cfg.addResource("com/dotmarketing/beans/DotCMSId_NOSQLGEN.hbm.xml");
+                getPluginsHBM("Id", cfg);
+                cfg.setProperty("hibernate.dialect",
+                        "com.dotcms.repackage.net.sf.hibernate.dialect.MySQLDialect");
+            } else if (DbConnectionFactory.isPostgres()) {
+                cfg.addResource("com/dotmarketing/beans/DotCMSSeq.hbm.xml");
+                cfg.addResource("com/dotmarketing/beans/DotCMSSeq_NOSQLGEN.hbm.xml");
+                getPluginsHBM("Seq", cfg);
+                cfg.setProperty("hibernate.dialect",
+                        "com.dotcms.repackage.net.sf.hibernate.dialect.PostgreSQLDialect");
+            } else if (DbConnectionFactory.isMsSql()) {
+                cfg.addResource("com/dotmarketing/beans/DotCMSId.hbm.xml");
+                cfg.addResource("com/dotmarketing/beans/DotCMSId_NOSQLGEN.hbm.xml");
+                getPluginsHBM("Id", cfg);
+                cfg.setProperty("hibernate.dialect",
+                        "com.dotcms.repackage.net.sf.hibernate.dialect.SQLServerDialect");
+            } else if (DbConnectionFactory.isOracle()) {
+                cfg.addResource("com/dotmarketing/beans/DotCMSSeq.hbm.xml");
+                cfg.addResource("com/dotmarketing/beans/DotCMSSeq_NOSQLGEN.hbm.xml");
+                getPluginsHBM("Seq", cfg);
+                cfg.setProperty("hibernate.dialect",
+                        "com.dotcms.repackage.net.sf.hibernate.dialect.OracleDialect");
+            }
 
-			cfg.setInterceptor(new NoDirtyFlushInterceptor());
+            cfg.setInterceptor(new NoDirtyFlushInterceptor());
 
-			mappings = cfg.createMappings();
-			
-			sessionFactory = cfg.buildSessionFactory();
-			dialect = ((SessionFactoryImpl)sessionFactory).getDialect();
-			System.setProperty(WebKeys.DOTCMS_STARTUP_TIME_DB, String.valueOf(System.currentTimeMillis() - start));
-			
-		}catch (Exception e) {
-			throw new DotStateException("Unable to build Session Factory ", e);
-		}
-	}
+            mappings = cfg.createMappings();
 
+            sessionFactory = cfg.buildSessionFactory();
+            dialect = ((SessionFactoryImpl) sessionFactory).getDialect();
+            System.setProperty(WebKeys.DOTCMS_STARTUP_TIME_DB,
+                    String.valueOf(System.currentTimeMillis() - start));
 
-
-	private static void getPluginsHBM(String type,Configuration cfg) {
-		Logger.debug(HibernateUtil.class, "Loading Hibernate Mappings from plugins ");
-		PluginAPI pAPI=APILocator.getPluginAPI();
-
-		File pluginDir=pAPI.getPluginJarDir();
-		if (pluginDir==null) {
-		return;
-		}
-		File[] plugins=pluginDir.listFiles(new FilenameFilter(){
-
-			public boolean accept(File dir, String name) {
-				if (name.startsWith("plugin-") && name.endsWith(".jar")) {
-					return true;
-				}
-				return false;
-			}
-
-		});
-		for (File plugin:plugins) {
-			try {
-				JarFile jar = new JarFile(plugin);
-				JarEntry entry=jar.getJarEntry("conf/DotCMS"+type+".hbm.xml");
-				if (entry!=null) {
-					InputStream in = new BufferedInputStream(jar.getInputStream(entry));
-					StringBuffer out = new StringBuffer();
-					byte[] b = new byte[4096];
-					for (int n; (n = in.read(b)) != -1;) {
-				        out.append(new String(b, 0, n));
-				    }
-					Logger.debug(HibernateUtil.class, "Loading Hibernate Mapping from: " + plugin.getName());
-					cfg.addXML(out.toString());
-				}
-			} catch (IOException e) {
-				Logger.debug(HibernateUtil.class,"IOException: " + e.getMessage(),e);
-			} catch (MappingException e) {
-				Logger.debug(HibernateUtil.class,"MappingException: " + e.getMessage(),e);
-			}
-		}
-		Logger.debug(HibernateUtil.class, "Done loading Hibernate Mappings from plugins ");
-	}
+        } catch (Exception e) {
+            throw new DotStateException("Unable to build Session Factory ", e);
+        }
+    }
 
 
-	public static Optional<Session> getSessionIfOpened() {
-		if (sessionFactory == null) {
-			buildSessionFactory();
-		}
-		return Optional.ofNullable(sessionHolder.get());
-	}
+    private static void getPluginsHBM(String type, Configuration cfg) {
+        Logger.debug(HibernateUtil.class, "Loading Hibernate Mappings from plugins ");
+        PluginAPI pAPI = APILocator.getPluginAPI();
 
-	/**
-	 * Creates a new Hibernate Session based on the conn on the parameter
-	 * Also
-	 * @param newTransactionConnection  {@link Connection}
-	 * @return Session
-	 */
-	public static Session createNewSession(final Connection newTransactionConnection) {
+        File pluginDir = pAPI.getPluginJarDir();
+        if (pluginDir == null) {
+            return;
+        }
+        File[] plugins = pluginDir.listFiles(new FilenameFilter() {
 
-		try{
+            public boolean accept(File dir, String name) {
+                if (name.startsWith("plugin-") && name.endsWith(".jar")) {
+                    return true;
+                }
+                return false;
+            }
 
-			// just to create the initial if are not set
-			getSessionIfOpened();
-			final Session session = sessionFactory.openSession(newTransactionConnection);
-			if(null != session){
-				session.setFlushMode(FlushMode.NEVER);
-			}
-			return session;
-		}catch (Exception e) {
-			throw new DotStateException("Unable to get Hibernate Session ", e);
-		}
-	}
+        });
+        for (File plugin : plugins) {
+            try {
+                JarFile jar = new JarFile(plugin);
+                JarEntry entry = jar.getJarEntry("conf/DotCMS" + type + ".hbm.xml");
+                if (entry != null) {
+                    InputStream in = new BufferedInputStream(jar.getInputStream(entry));
+                    StringBuffer out = new StringBuffer();
+                    byte[] b = new byte[4096];
+                    for (int n; (n = in.read(b)) != -1; ) {
+                        out.append(new String(b, 0, n));
+                    }
+                    Logger.debug(HibernateUtil.class,
+                            "Loading Hibernate Mapping from: " + plugin.getName());
+                    cfg.addXML(out.toString());
+                }
+            } catch (IOException e) {
+                Logger.debug(HibernateUtil.class, "IOException: " + e.getMessage(), e);
+            } catch (MappingException e) {
+                Logger.debug(HibernateUtil.class, "MappingException: " + e.getMessage(), e);
+            }
+        }
+        Logger.debug(HibernateUtil.class, "Done loading Hibernate Mappings from plugins ");
+    }
 
-	/**
-	 * Set a session on the parameter as the new session to use on all next hibernate calls
-	 * @param newSession
-	 */
-	public static void setSession(final Session newSession) {
 
-		try {
-			if (null != newSession && null != newSession.connection()
-					&& !newSession.connection().isClosed()) {
-				sessionHolder.set(newSession);
-			}
-		} catch (Exception e) {
-			Logger.error(HibernateUtil.class, "---------- HibernateUtil: error : " + e);
-			Logger.debug(HibernateUtil.class, "---------- HibernateUtil: error ", e);
-			throw new DotRuntimeException(e.getMessage(), e);
-		}
-	}
+    public static Optional<Session> getSessionIfOpened() {
+        if (sessionFactory == null) {
+            buildSessionFactory();
+        }
+        return Optional.ofNullable(sessionHolder.get());
+    }
 
-	/**
-	 * Attempts to find a session associated with the Thread. If there isn't a
-	 * session, it will create one.
-	 */
-	public static Session getSession() {
-		try{
-			final Optional<Session> sessionOptional = getSessionIfOpened();
-			Session session = sessionOptional.isPresent() ? sessionOptional.get() : null;
+    /**
+     * Creates a new Hibernate Session based on the conn on the parameter Also
+     *
+     * @param newTransactionConnection {@link Connection}
+     * @return Session
+     */
+    public static Session createNewSession(final Connection newTransactionConnection) {
 
-			if (session == null) {
-					session = sessionFactory.openSession(DbConnectionFactory.getConnection());
-			} else {
-				try {
-					if (session.connection().isClosed()) {
+        try {
+
+            // just to create the initial if are not set
+            getSessionIfOpened();
+            final Session session = sessionFactory.openSession(newTransactionConnection);
+            if (null != session) {
+                session.setFlushMode(FlushMode.NEVER);
+            }
+            return session;
+        } catch (Exception e) {
+            throw new DotStateException("Unable to get Hibernate Session ", e);
+        }
+    }
+
+    /**
+     * Set a session on the parameter as the new session to use on all next hibernate calls
+     *
+     * @param newSession
+     */
+    public static void setSession(final Session newSession) {
+
+        try {
+            if (null != newSession && null != newSession.connection()
+                    && !newSession.connection().isClosed()) {
+                sessionHolder.set(newSession);
+            }
+        } catch (Exception e) {
+            Logger.error(HibernateUtil.class, "---------- HibernateUtil: error : " + e);
+            Logger.debug(HibernateUtil.class, "---------- HibernateUtil: error ", e);
+            throw new DotRuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Attempts to find a session associated with the Thread. If there isn't a session, it will
+     * create one.
+     */
+    public static Session getSession() {
+        try {
+            final Optional<Session> sessionOptional = getSessionIfOpened();
+            Session session = sessionOptional.isPresent() ? sessionOptional.get() : null;
+
+            if (session == null) {
+                session = sessionFactory.openSession(DbConnectionFactory.getConnection());
+            } else {
+                try {
+                    if (session.connection().isClosed()) {
                         try {
                             session.close();
                         } catch (HibernateException e1) {
-                            Logger.error(HibernateUtil.class,e1.getMessage(),e1);
+                            Logger.error(HibernateUtil.class, e1.getMessage(), e1);
                         }
                         session = null;
-						session = sessionFactory.openSession(DbConnectionFactory.getConnection());
-					}
-    			} catch (Exception e) {
-    	        	try {
-    	        	   if(null != session) {
-						  session.close();
-					   }
-    				} catch (Exception ex) {
-    					Logger.error(HibernateUtil.class,e.getMessage() );
-    		        	Logger.debug(HibernateUtil.class,e.getMessage(),e);
-    				}
-    				session = null;
-    				try{
-    					session = sessionFactory.openSession(DbConnectionFactory.getConnection());
-    				} catch (Exception ex) {
-    					Logger.error(HibernateUtil.class,ex.getMessage() );
-    		        	Logger.debug(HibernateUtil.class,ex.getMessage(),ex);
-    				}
-            	}
-			}
-			sessionHolder.set(session);
-			if(null != session){
-			   session.setFlushMode(FlushMode.NEVER);
-			 }
-			return session;
-		}catch (Exception e) {
-			throw new DotStateException("Unable to get Hibernate Session ", e);
-		}
-	}
+                        session = sessionFactory.openSession(DbConnectionFactory.getConnection());
+                    }
+                } catch (Exception e) {
+                    try {
+                        if (null != session) {
+                            session.close();
+                        }
+                    } catch (Exception ex) {
+                        Logger.error(HibernateUtil.class, e.getMessage());
+                        Logger.debug(HibernateUtil.class, e.getMessage(), e);
+                    }
+                    session = null;
+                    try {
+                        session = sessionFactory.openSession(DbConnectionFactory.getConnection());
+                    } catch (Exception ex) {
+                        Logger.error(HibernateUtil.class, ex.getMessage());
+                        Logger.debug(HibernateUtil.class, ex.getMessage(), ex);
+                    }
+                }
+            }
+            sessionHolder.set(session);
+            if (null != session) {
+                session.setFlushMode(FlushMode.NEVER);
+            }
+            return session;
+        } catch (Exception e) {
+            throw new DotStateException("Unable to get Hibernate Session ", e);
+        }
+    }
 
-	/**
-	 * Returns the listeners status currently associated to the thread-local -based transaction (ENABLED by default)
-	 */
-	public static TransactionListenerStatus getTransactionListenersStatus() {
-		return listenersStatus.get();
-	}
-	/**
-	 * Allows to override the status of the listeners associated to the current thread-local -based transaction (DISABLED if overriden)
-	 * When using TransactionListenerStatus.DISABLED, client code should be aware of controlling the operations that are suppossed to be done by listeners
-	 * @param status TransactionListenerStatus
-	 */
-	public static void setTransactionListenersStatus(TransactionListenerStatus status) {
-		listenersStatus.set(status);
-	}
-
-	public static boolean getAsyncCommitListenersFinalization() {
-		return asyncCommitListenersFinalization.get();
-	}
-
-	public static void setAsyncCommitListenersFinalization(boolean finalizeAsync) {
-		asyncCommitListenersFinalization.set(finalizeAsync);
-	}
-
-	/**
-	 * Allows you to add an asynchronous commit listener to the current database
-	 * session/transaction. This means that the current flow of the application will continue its
-	 * way and the specified commit listener will be spawned subsequently after the transaction has
-	 * been committed or the session has been closed. <p>By default, asynchronous commit listeners
-	 * will be spawned by a new thread. This means that they will not share the same database
-	 * connection information with the main thread of the dotCMS application.</p>
-	 *
-	 * @param runnable The commit listener wrapped as a {@link Runnable} object.
-	 * @param order    in case you want to add an order
-	 *
-	 * @throws DotHibernateException An error occurred when registering the commit listener.
-	 */
-	public static void addCommitListener(final Runnable runnable, final int order) throws
-			DotHibernateException {
-		addCommitListener(new DotOrderedRunnable(runnable, order));
-	}
-
-	/**
-	 * Adds a commit listener to the current database transaction/session. There are several
-	 * types of commit listeners, namely:
-	 * <ul>
-	 * <li>{@link DotSyncRunnable}</li>
-	 * <li>{@link DotOrderedRunnable}</li>
-	 * <li>{@link FlushCacheRunnable}</li>
-	 * <li>{@link ReindexRunnable}</li>
-	 * <li>Among others.</li>
-	 * </ul>
-	 * Commit listeners allow developers to execute code after a transaction has been committed
-	 * or the session has ended.
-	 *
-	 * @param listener The commit listener wrapped as a {@link Runnable} object.
-	 *
-	 * @throws DotHibernateException An error occurred when registering the commit listener.
-	 */
-	public static void addCommitListener(final Runnable listener) throws DotHibernateException {
-	    addCommitListener(UUIDGenerator.generateUuid(),listener);
-	}
-	
     /**
-     * Adds a commit listener to the current database transaction/session. There are several
-     * types of commit listeners, namely:
+     * Returns the listeners status currently associated to the thread-local -based transaction
+     * (ENABLED by default)
+     */
+    public static TransactionListenerStatus getTransactionListenersStatus() {
+        return listenersStatus.get();
+    }
+
+    /**
+     * Allows to override the status of the listeners associated to the current thread-local -based
+     * transaction (DISABLED if overriden) When using TransactionListenerStatus.DISABLED, client
+     * code should be aware of controlling the operations that are suppossed to be done by
+     * listeners
+     *
+     * @param status TransactionListenerStatus
+     */
+    public static void setTransactionListenersStatus(TransactionListenerStatus status) {
+        listenersStatus.set(status);
+    }
+
+    public static boolean getAsyncCommitListenersFinalization() {
+        return asyncCommitListenersFinalization.get();
+    }
+
+    public static void setAsyncCommitListenersFinalization(boolean finalizeAsync) {
+        asyncCommitListenersFinalization.set(finalizeAsync);
+    }
+
+    /**
+     * Allows you to add an asynchronous commit listener to the current database
+     * session/transaction. This means that the current flow of the application will continue its
+     * way and the specified commit listener will be spawned subsequently after the transaction has
+     * been committed or the session has been closed. <p>By default, asynchronous commit listeners
+     * will be spawned by a new thread. This means that they will not share the same database
+     * connection information with the main thread of the dotCMS application.</p>
+     *
+     * @param runnable The commit listener wrapped as a {@link Runnable} object.
+     * @param order    in case you want to add an order
+     * @throws DotHibernateException An error occurred when registering the commit listener.
+     */
+    public static void addCommitListener(final Runnable runnable, final int order) throws
+            DotHibernateException {
+        addCommitListener(new DotOrderedRunnable(runnable, order));
+    }
+
+    /**
+     * Adds a commit listener to the current database transaction/session. There are several types
+     * of commit listeners, namely:
      * <ul>
      * <li>{@link DotSyncRunnable}</li>
      * <li>{@link DotOrderedRunnable}</li>
@@ -886,103 +914,121 @@ public class HibernateUtil {
      * or the session has ended.
      *
      * @param listener The commit listener wrapped as a {@link Runnable} object.
-     *
      * @throws DotHibernateException An error occurred when registering the commit listener.
      */
-    public static void addCommitListenerNoThrow(final Runnable listener)  {
-		addCommitListener(UUIDGenerator.generateUuid(),listener);
+    public static void addCommitListener(final Runnable listener) throws DotHibernateException {
+        addCommitListener(UUIDGenerator.generateUuid(), listener);
     }
 
-	/**
-	 * Allows you to add an asynchronous commit listener to the current database
-	 * session/transaction. This means that the current flow of the application will take care of
-	 * running the specified commit listener. This is particularly useful when you need to keep
-	 * database objects that were created during the database transaction.
-	 * <p>For example, if you created a temporary table that your commit listener needs to access,
-	 * you will definitely need to create a synchronous listener for it to be able to access the
-	 * such a table as temporary tables are only available for the duration of the transaction or
-	 * the session. With synchronous commit listeners, dotCMS will use the its main execution thread
-	 * to call the listener; therefore, it can access the same database connection and see the
-	 * temporary table.</p>
-	 *
-	 * @param runnable The commit listener wrapped as a {@link Runnable} object.
-	 *
-	 * @throws DotHibernateException An error occurred when registering the commit listener.
-	 */
-	public static void addSyncCommitListener(final Runnable runnable) throws
-			DotHibernateException {
-		addCommitListener(new DotSyncRunnable(runnable));
-	}
+    /**
+     * Adds a commit listener to the current database transaction/session. There are several types
+     * of commit listeners, namely:
+     * <ul>
+     * <li>{@link DotSyncRunnable}</li>
+     * <li>{@link DotOrderedRunnable}</li>
+     * <li>{@link FlushCacheRunnable}</li>
+     * <li>{@link ReindexRunnable}</li>
+     * <li>Among others.</li>
+     * </ul>
+     * Commit listeners allow developers to execute code after a transaction has been committed
+     * or the session has ended.
+     *
+     * @param listener The commit listener wrapped as a {@link Runnable} object.
+     * @throws DotHibernateException An error occurred when registering the commit listener.
+     */
+    public static void addCommitListenerNoThrow(final Runnable listener) {
+        addCommitListener(UUIDGenerator.generateUuid(), listener);
+    }
 
-	/**
-	 * In case you need to execute the Runnable in an specific order, you can use this class.
-	 */
-	public static class DotOrderedRunnable implements Runnable {
+    /**
+     * Allows you to add an asynchronous commit listener to the current database
+     * session/transaction. This means that the current flow of the application will take care of
+     * running the specified commit listener. This is particularly useful when you need to keep
+     * database objects that were created during the database transaction.
+     * <p>For example, if you created a temporary table that your commit listener needs to access,
+     * you will definitely need to create a synchronous listener for it to be able to access the
+     * such a table as temporary tables are only available for the duration of the transaction or
+     * the session. With synchronous commit listeners, dotCMS will use the its main execution thread
+     * to call the listener; therefore, it can access the same database connection and see the
+     * temporary table.</p>
+     *
+     * @param runnable The commit listener wrapped as a {@link Runnable} object.
+     * @throws DotHibernateException An error occurred when registering the commit listener.
+     */
+    public static void addSyncCommitListener(final Runnable runnable) throws
+            DotHibernateException {
+        addCommitListener(new DotSyncRunnable(runnable));
+    }
 
-		private final Runnable runnable;
-		private final int      order;
+    /**
+     * In case you need to execute the Runnable in an specific order, you can use this class.
+     */
+    public static class DotOrderedRunnable implements Runnable {
 
-		public DotOrderedRunnable(final Runnable runnable) {
-			this(runnable, 0);
-		}
+        private final Runnable runnable;
+        private final int order;
 
-		public DotOrderedRunnable(final Runnable runnable, final int order) {
-			this.runnable = runnable;
-			this.order    = order;
-		}
+        public DotOrderedRunnable(final Runnable runnable) {
+            this(runnable, 0);
+        }
 
-		@Override
-		public void run() {
-			runnable.run();
-		}
+        public DotOrderedRunnable(final Runnable runnable, final int order) {
+            this.runnable = runnable;
+            this.order = order;
+        }
 
-		public Runnable getRunnable() {
-			return runnable;
-		}
+        @Override
+        public void run() {
+            runnable.run();
+        }
 
-		public int getOrder() {
-			return order;
-		}
-	}
+        public Runnable getRunnable() {
+            return runnable;
+        }
 
-	/**
-	 * Allows you to create a synchronous commit listener, which represents code that will be
-	 * called after a database transaction has been committed or the session has been closed.
-	 * Synchronous listeners will NOT RUN ON A NEW THREAD, they will use the main dotCMS thread.
-	 */
-	public static class DotSyncRunnable implements Runnable {
+        public int getOrder() {
+            return order;
+        }
+    }
 
-		private final Runnable runnable;
-		private final int      order;
+    /**
+     * Allows you to create a synchronous commit listener, which represents code that will be called
+     * after a database transaction has been committed or the session has been closed. Synchronous
+     * listeners will NOT RUN ON A NEW THREAD, they will use the main dotCMS thread.
+     */
+    public static class DotSyncRunnable implements Runnable {
 
-		public DotSyncRunnable(final Runnable runnable) {
-			this(runnable, 0);
-		}
-		public DotSyncRunnable(final Runnable runnable, final int order) {
+        private final Runnable runnable;
+        private final int order;
 
-			this.runnable = runnable;
-			this.order    = order;
-		}
+        public DotSyncRunnable(final Runnable runnable) {
+            this(runnable, 0);
+        }
 
-		@Override
-		public void run() {
-			runnable.run();
-		}
+        public DotSyncRunnable(final Runnable runnable, final int order) {
 
-		public Runnable getRunnable() {
-			return runnable;
-		}
+            this.runnable = runnable;
+            this.order = order;
+        }
 
-		public int getOrder() {
-			return order;
-		}
-	}
+        @Override
+        public void run() {
+            runnable.run();
+        }
 
+        public Runnable getRunnable() {
+            return runnable;
+        }
+
+        public int getOrder() {
+            return order;
+        }
+    }
 
 
     /**
-     * Adds a commit listener to the current database transaction/session. There are several types of
-     * commit listeners, namely:
+     * Adds a commit listener to the current database transaction/session. There are several types
+     * of commit listeners, namely:
      * <ul>
      * <li>{@link DotSyncRunnable}</li>
      * <li>{@link DotOrderedRunnable}</li>
@@ -996,13 +1042,13 @@ public class HibernateUtil {
      * REINDEX_ON_SAVE_IN_SEPARATE_THREAD} determines whether listeners are executed in a separate
      * thread, or in the same dotCMS thread. By default, they run in a brand new thread.
      *
-     * @param tag A unique ID for the specified listener.
+     * @param tag      A unique ID for the specified listener.
      * @param listener The commit listener wrapped as a {@link Runnable} object.
-     *
      * @throws DotHibernateException An error occurred when registering the commit listener.
      */
     public static void addCommitListener(final String tag, final Runnable listener) {
-        if (DbConnectionFactory.inTransaction() && getTransactionListenersStatus() != TransactionListenerStatus.DISABLED) {
+        if (DbConnectionFactory.inTransaction()
+                && getTransactionListenersStatus() != TransactionListenerStatus.DISABLED) {
             if (listener instanceof DotSyncRunnable) {
                 syncCommitListeners.get().put(tag, listener);
             } else if (listener instanceof ReindexRunnable && asyncReindexCommitListeners()) {
@@ -1019,330 +1065,358 @@ public class HibernateUtil {
         }
     }
 
-	public static void addRollbackListener(Runnable listener) {
-	    addRollbackListener(UUIDGenerator.generateUuid(), listener);
+    public static void addRollbackListener(Runnable listener) {
+        addRollbackListener(UUIDGenerator.generateUuid(), listener);
     }
-	
-	
+
+
     public static void addRollbackListener(final String key, Runnable listener) {
-        if (getTransactionListenersStatus() != TransactionListenerStatus.DISABLED && DbConnectionFactory.inTransaction()) {
+        if (getTransactionListenersStatus() != TransactionListenerStatus.DISABLED
+                && DbConnectionFactory.inTransaction()) {
             rollbackListeners.get().put(key, listener);
         }
     }
-    
-	public static void closeSessionSilently() {
 
-		try {
-			closeSession();
-		} catch (DotHibernateException e) {
+    public static void closeSessionSilently() {
 
-		}
-	}
+        try {
+            closeSession();
+        } catch (DotHibernateException e) {
 
-	public static void closeSession()  throws DotHibernateException{
-		try{
-			// if there is nothing to close
-			if (null == sessionHolder.get()){
-				return;
-			}
-			Session session = getSession();
+        }
+    }
 
-			if (null != session) {
-				session.flush();
-				if (!session.connection().getAutoCommit()) {
-					Logger.debug(HibernateUtil.class, "Closing session. Commiting changes!");
-					session.connection().commit();
-					session.connection().setAutoCommit(true);
-					if (!syncCommitListeners.get().isEmpty() || !asyncCommitListeners.get().isEmpty()) {
-						finalizeCommitListeners();
-					}
-				}
-				DbConnectionFactory.closeConnection();
-				session.close();
-				session = null;
-				sessionHolder.set(null);
-			}
-		}catch (Exception e) {
-			Logger.error(HibernateUtil.class, e.getMessage(), e);
-			throw new DotHibernateException("Unable to close Hibernate Session ", e);
-		} finally {
-		    syncCommitListeners.get().clear();
-			asyncCommitListeners.get().clear();
-		    rollbackListeners.get().clear();
-		}
-	}
+    public static void closeSession() throws DotHibernateException {
+        try {
+            // if there is nothing to close
+            if (null == sessionHolder.get()) {
+                return;
+            }
+            Optional<Session> sessionOptional = getSessionIfOpened();
 
-	/**
-	 * Traverses the lists of both synchronous and asynchronous commit listeners and starts them
-	 * up. The asynchronous listeners are executed as separate threads, whereas synchronous
-	 * listeners use the main dotCMS thread to run.
-	 */
-	private static void finalizeCommitListeners() {
-		final List<Runnable> asyncListeners = new ArrayList<>(asyncCommitListeners.get().values());
-		final List<Runnable> syncListeners = new ArrayList<>(syncCommitListeners.get().values());
-		asyncCommitListeners.get().clear();
-		syncCommitListeners.get().clear();
+            if (sessionOptional.isPresent()) {
+                Session session = sessionOptional.get();
+                if (session.isOpen()) {
+                    session.flush();
+                    Connection connection = session.connection();
+                    if (connection != null && !connection.isClosed()) {
+                        if (!connection.getAutoCommit()) {
+                            connection.commit();
+                            connection.setAutoCommit(true);
+                        }
+                        if (!syncCommitListeners.get().isEmpty() || !asyncCommitListeners.get()
+                                .isEmpty()) {
+                            finalizeCommitListeners();
+                        }
+                    }
+                }
 
-		if (!asyncListeners.isEmpty()) {
+                DbConnectionFactory.closeConnection();
+                if (session.isOpen()) {
+                    session.close();
+                }
+                sessionHolder.set(session);
+            }
+        } catch (Exception e) {
+            Logger.error(HibernateUtil.class, e.getMessage(), e);
+            throw new DotHibernateException("Unable to close Hibernate Session ", e);
+        } finally {
+            syncCommitListeners.get().clear();
+            asyncCommitListeners.get().clear();
+            rollbackListeners.get().clear();
+        }
+    }
 
-			final List<Runnable> listeners = getListeners(asyncListeners);
-			final List<Runnable> flushers  = getFlushers(asyncListeners);
-            final DotSubmitter submitter   = DotConcurrentFactory.getInstance().getSubmitter(LISTENER_SUBMITTER);
+    /**
+     * Traverses the lists of both synchronous and asynchronous commit listeners and starts them up.
+     * The asynchronous listeners are executed as separate threads, whereas synchronous listeners
+     * use the main dotCMS thread to run.
+     */
+    private static void finalizeCommitListeners() {
+        final List<Runnable> asyncListeners = new ArrayList<>(asyncCommitListeners.get().values());
+        final List<Runnable> syncListeners = new ArrayList<>(syncCommitListeners.get().values());
+        asyncCommitListeners.get().clear();
+        syncCommitListeners.get().clear();
+
+        if (!asyncListeners.isEmpty()) {
+
+            final List<Runnable> listeners = getListeners(asyncListeners);
+            final List<Runnable> flushers = getFlushers(asyncListeners);
+            final DotSubmitter submitter = DotConcurrentFactory.getInstance()
+                    .getSubmitter(LISTENER_SUBMITTER);
 
             if (!listeners.isEmpty()) {
-				submitter.submit(new DotRunnableThread(listeners, true));
-			}
+                submitter.submit(new DotRunnableThread(listeners, true));
+            }
 
-			if (!flushers.isEmpty()) {
-			    submitter.submit(new DotRunnableFlusherThread(flushers, true));
-				submitter.delay(new DotRunnableFlusherThread(flushers, true),
-						Config.getLongProperty(NETWORK_CACHE_FLUSH_DELAY, 3000), TimeUnit.MILLISECONDS);
-			}
-		}
-
-		if (!syncListeners.isEmpty()) {
-
-			final List<Runnable> listeners = getListeners(syncListeners);
-			final List<Runnable> flushers  = getFlushers(syncListeners);
-			if (!listeners.isEmpty()) {
-				new DotRunnableThread(listeners).run();
-			}
-
-			if (!flushers.isEmpty()) {
-			    new DotRunnableFlusherThread(flushers).run();
-				DateUtil.sleep(Config.getLongProperty(NETWORK_CACHE_FLUSH_DELAY, 3000));
-				new DotRunnableFlusherThread(flushers, false).run(); // todo: double check this if we still want a thread for the flushers
-			}
-		}
-	}
-
-	private static List<Runnable> getListeners(final List<Runnable> allListeners) {
-		return allListeners.stream().filter(HibernateUtil::isNotFlushCacheRunnable).sorted(HibernateUtil::compare).collect(Collectors.toList());
-	}
-
-	private static int compare(final Runnable runnable, final Runnable runnable1) {
-		return getOrder(runnable).compareTo(getOrder(runnable1));
-	}
-
-	private static Integer getOrder(final Runnable runnable) {
-
-		final int order = (runnable instanceof HibernateUtil.DotSyncRunnable) ?
-				HibernateUtil.DotSyncRunnable.class.cast(runnable).getOrder() : 0;
-
-		return (runnable instanceof HibernateUtil.DotOrderedRunnable) ?
-				HibernateUtil.DotOrderedRunnable.class.cast(runnable).getOrder() : order;
-	}
-
-	private static boolean isNotFlushCacheRunnable(final Runnable listener) {
-
-		return !isFlushCacheRunnable(listener);
-	}
-
-	private static List<Runnable> getFlushers(final List<Runnable> allListeners) {
-		return allListeners.stream().filter(HibernateUtil::isFlushCacheRunnable).collect(Collectors.toList());
-	}
-
-	private static boolean isFlushCacheRunnable(final Runnable listener) {
-
-		return (
-				listener instanceof FlushCacheRunnable ||
-						(listener instanceof HibernateUtil.DotOrderedRunnable
-								&& HibernateUtil.DotOrderedRunnable.class.cast(listener).getRunnable() instanceof FlushCacheRunnable) ||
-						(listener instanceof HibernateUtil.DotSyncRunnable
-								&& HibernateUtil.DotSyncRunnable.class.cast(listener).getRunnable() instanceof FlushCacheRunnable)
-		);
-	}
-
-	public static void startTransaction()  throws DotHibernateException{
-		try{
-		/*
-		 * Transactions are now used by default
-		 *
-		 */
-			getSession().connection().setAutoCommit(false);
-			rollbackListeners.get().clear();
-			syncCommitListeners.get().clear();
-			asyncCommitListeners.get().clear();
-			Logger.debug(HibernateUtil.class, "Starting Transaction!");
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to set AutoCommit to false on Hibernate Session ", e);
-		}
-	}
-
-	/**
-	 * This just commit the transaction and process the listeners.
-	 * @throws DotHibernateException
-	 */
-	public static void commitTransaction()  throws DotHibernateException{
-
-		try{
-			// if there is nothing to close
-			if (null == sessionHolder.get()) {
-				return;
-			}
-			Session session = getSession();
-
-			if (null != session) {
-				session.flush();
-				if (!session.connection().getAutoCommit()) {
-					Logger.debug(HibernateUtil.class, "Closing session. Commiting changes!");
-					session.connection().commit();
-					session.connection().setAutoCommit(true);
-					if (!asyncCommitListeners.get().isEmpty() || !syncCommitListeners.get().isEmpty()) {
-						finalizeCommitListeners();
-					}
-				}
-			}
-		}catch (Exception e) {
-			Logger.error(HibernateUtil.class, e.getMessage(), e);
-			throw new DotHibernateException("Unable to close Hibernate Session ", e);
-		} finally {
-			syncCommitListeners.get().clear();
-			asyncCommitListeners.get().clear();
-			rollbackListeners.get().clear();
-		}
-	}
-
-	/**
-	 * This commit and close the current session, connection
-	 * @return
-	 * @throws DotHibernateException
-	 */
-	public static boolean closeAndCommitTransaction()  throws DotHibernateException{
-		closeSession();
-		return true;
-	}
-
-	public static void rollbackTransaction() throws DotHibernateException {
-
-		sessionCleanupAndRollback();
-
-	}
-
-	public static boolean startLocalTransactionIfNeeded() throws DotDataException{
-    	boolean startTransaction = false;
-
-    	try {
-    		startTransaction = DbConnectionFactory.getConnection().getAutoCommit();
-			if(startTransaction){
-				HibernateUtil.startTransaction();
-			}
-		} catch (SQLException e) {
-			Logger.error(HibernateUtil.class,e.getMessage(),e);
-			throw new DotDataException(e.getMessage(),e);
-		}
-		return startTransaction;
-    }
-
-	public static void flush()  throws DotHibernateException{
-		try{
-			Session session = getSession();
-			session.flush();
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to flush Hibernate Session ", e);
-		}
-	}
-
-	public static void sessionCleanupAndRollback()  throws DotHibernateException{
-		syncCommitListeners.get().clear();
-		asyncCommitListeners.get().clear();
-		Logger.debug(HibernateUtil.class, "sessionCleanupAndRollback");
-		Session session = getSession();
-		session.clear();
-
-		try {
-			session.connection().rollback();
-			session.connection().setAutoCommit(true);
-		} catch (Exception ex) {
-			Logger.debug(HibernateUtil.class, "---------- DotHibernate: error on rollbackTransaction ---------------",
-					ex);
-			Logger.error(HibernateUtil.class, "---------- DotHibernate: error on rollbackTransaction ---------------\n"+ ex);
-			// throw new DotRuntimeException(ex.toString());
-		}
-
-		try {
-			DbConnectionFactory.closeConnection();
-			session.close();
-			session = null;
-			sessionHolder.set(null);
-		} catch (Exception ex) {
-			Logger.debug(HibernateUtil.class, "---------- DotHibernate: error on rollbackTransaction ---------------",
-					ex);
-			Logger.error(HibernateUtil.class, "---------- DotHibernate: error on rollbackTransaction ---------------\n"+ ex);
-			// throw new DotRuntimeException(ex.toString());
-		}
-
-		if(rollbackListeners.get().size()>0) {
-            List<Runnable> r = new ArrayList<>(rollbackListeners.get().values());
-            rollbackListeners.get().clear();
-            for(Runnable runnable :r){
-            	runnable.run();
+            if (!flushers.isEmpty()) {
+                submitter.submit(new DotRunnableFlusherThread(flushers, true));
+                submitter.delay(new DotRunnableFlusherThread(flushers, true),
+                        Config.getLongProperty(NETWORK_CACHE_FLUSH_DELAY, 3000),
+                        TimeUnit.MILLISECONDS);
             }
         }
-	}
 
-    public static Savepoint setSavepoint() throws DotHibernateException {
-    	Connection conn;
-		try {
-			conn = getSession().connection();
-			if(!conn.getAutoCommit())
-				return conn.setSavepoint();
-			return null;
-		} catch (HibernateException e) {
-			throw new DotHibernateException(e.getMessage(), e);
-		} catch (SQLException e) {
-			throw new DotHibernateException(e.getMessage(), e);
-		}
+        if (!syncListeners.isEmpty()) {
+
+            final List<Runnable> listeners = getListeners(syncListeners);
+            final List<Runnable> flushers = getFlushers(syncListeners);
+            if (!listeners.isEmpty()) {
+                new DotRunnableThread(listeners).run();
+            }
+
+            if (!flushers.isEmpty()) {
+                new DotRunnableFlusherThread(flushers).run();
+                DateUtil.sleep(Config.getLongProperty(NETWORK_CACHE_FLUSH_DELAY, 3000));
+                new DotRunnableFlusherThread(flushers,
+                        false).run(); // todo: double check this if we still want a thread for the flushers
+            }
+        }
     }
 
-	public static void rollbackSavepoint(Savepoint savepoint) throws DotHibernateException {
+    private static List<Runnable> getListeners(final List<Runnable> allListeners) {
+        return allListeners.stream().filter(HibernateUtil::isNotFlushCacheRunnable)
+                .sorted(HibernateUtil::compare).collect(Collectors.toList());
+    }
 
-		try {
-			getSession().connection().rollback(savepoint);
-		} catch (HibernateException e) {
-			throw new DotHibernateException(e.getMessage(), e);
-		} catch (SQLException e) {
-			throw new DotHibernateException(e.getMessage(), e);
-		}
+    private static int compare(final Runnable runnable, final Runnable runnable1) {
+        return getOrder(runnable).compareTo(getOrder(runnable1));
+    }
 
-	}
+    private static Integer getOrder(final Runnable runnable) {
 
-	public static void saveWithPrimaryKey(Object obj, Serializable id)  throws DotHibernateException{
-		try{
-			Session session = getSession();
-			session.save(obj, id);
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to save Object with primary key " + id + " to Hibernate Session ", e);
-		}try{
-			Session session = getSession();
-			session.flush();
-		}catch (Exception e) {
-			throw new DotHibernateException("Unable to flush Hibernate Session ", e);
-		}
-	}
+        final int order = (runnable instanceof HibernateUtil.DotSyncRunnable) ?
+                HibernateUtil.DotSyncRunnable.class.cast(runnable).getOrder() : 0;
+
+        return (runnable instanceof HibernateUtil.DotOrderedRunnable) ?
+                HibernateUtil.DotOrderedRunnable.class.cast(runnable).getOrder() : order;
+    }
+
+    private static boolean isNotFlushCacheRunnable(final Runnable listener) {
+
+        return !isFlushCacheRunnable(listener);
+    }
+
+    private static List<Runnable> getFlushers(final List<Runnable> allListeners) {
+        return allListeners.stream().filter(HibernateUtil::isFlushCacheRunnable)
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isFlushCacheRunnable(final Runnable listener) {
+
+        return (
+                listener instanceof FlushCacheRunnable ||
+                        (listener instanceof HibernateUtil.DotOrderedRunnable
+                                && HibernateUtil.DotOrderedRunnable.class.cast(listener)
+                                .getRunnable() instanceof FlushCacheRunnable) ||
+                        (listener instanceof HibernateUtil.DotSyncRunnable
+                                && HibernateUtil.DotSyncRunnable.class.cast(listener)
+                                .getRunnable() instanceof FlushCacheRunnable)
+        );
+    }
+
+    public static void startTransaction() throws DotHibernateException {
+        try {
+            /*
+             * Transactions are now used by default
+             *
+             */
+            getSession().connection().setAutoCommit(false);
+            rollbackListeners.get().clear();
+            syncCommitListeners.get().clear();
+            asyncCommitListeners.get().clear();
+            Logger.debug(HibernateUtil.class, "Starting Transaction!");
+        } catch (Exception e) {
+            throw new DotHibernateException(
+                    "Unable to set AutoCommit to false on Hibernate Session ", e);
+        }
+    }
+
+    /**
+     * This just commit the transaction and process the listeners.
+     *
+     * @throws DotHibernateException
+     */
+    public static void commitTransaction() throws DotHibernateException {
+
+        try {
+            // if there is nothing to close
+            if (null == sessionHolder.get()) {
+                return;
+            }
+            Session session = getSession();
+
+            if (null != session) {
+                session.flush();
+                if (!session.connection().getAutoCommit()) {
+                    Logger.debug(HibernateUtil.class, "Closing session. Commiting changes!");
+                    session.connection().commit();
+                    session.connection().setAutoCommit(true);
+                    if (!asyncCommitListeners.get().isEmpty() || !syncCommitListeners.get()
+                            .isEmpty()) {
+                        finalizeCommitListeners();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Logger.error(HibernateUtil.class, e.getMessage(), e);
+            throw new DotHibernateException("Unable to close Hibernate Session ", e);
+        } finally {
+            syncCommitListeners.get().clear();
+            asyncCommitListeners.get().clear();
+            rollbackListeners.get().clear();
+        }
+    }
+
+    /**
+     * This commit and close the current session, connection
+     *
+     * @return
+     * @throws DotHibernateException
+     */
+    public static boolean closeAndCommitTransaction() throws DotHibernateException {
+        closeSession();
+        return true;
+    }
+
+    public static void rollbackTransaction() throws DotHibernateException {
+
+        sessionCleanupAndRollback();
+
+    }
+
+    public static boolean startLocalTransactionIfNeeded() throws DotDataException {
+        boolean startTransaction = false;
+
+        try {
+            startTransaction = DbConnectionFactory.getConnection().getAutoCommit();
+            if (startTransaction) {
+                HibernateUtil.startTransaction();
+            }
+        } catch (SQLException e) {
+            Logger.error(HibernateUtil.class, e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+        return startTransaction;
+    }
+
+    public static void flush() throws DotHibernateException {
+        try {
+            Session session = getSession();
+            session.flush();
+        } catch (Exception e) {
+            throw new DotHibernateException("Unable to flush Hibernate Session ", e);
+        }
+    }
+
+    public static void sessionCleanupAndRollback() throws DotHibernateException {
+        syncCommitListeners.get().clear();
+        asyncCommitListeners.get().clear();
+        Logger.debug(HibernateUtil.class, "sessionCleanupAndRollback");
+        Session session = getSession();
+        session.clear();
+
+        try {
+            session.connection().rollback();
+            session.connection().setAutoCommit(true);
+        } catch (Exception ex) {
+            Logger.debug(HibernateUtil.class,
+                    "---------- DotHibernate: error on rollbackTransaction ---------------",
+                    ex);
+            Logger.error(HibernateUtil.class,
+                    "---------- DotHibernate: error on rollbackTransaction ---------------\n" + ex);
+            // throw new DotRuntimeException(ex.toString());
+        }
+
+        try {
+            DbConnectionFactory.closeConnection();
+            session.close();
+            session = null;
+            sessionHolder.set(null);
+        } catch (Exception ex) {
+            Logger.debug(HibernateUtil.class,
+                    "---------- DotHibernate: error on rollbackTransaction ---------------",
+                    ex);
+            Logger.error(HibernateUtil.class,
+                    "---------- DotHibernate: error on rollbackTransaction ---------------\n" + ex);
+            // throw new DotRuntimeException(ex.toString());
+        }
+
+        if (rollbackListeners.get().size() > 0) {
+            List<Runnable> r = new ArrayList<>(rollbackListeners.get().values());
+            rollbackListeners.get().clear();
+            for (Runnable runnable : r) {
+                runnable.run();
+            }
+        }
+    }
+
+    public static Savepoint setSavepoint() throws DotHibernateException {
+        Connection conn;
+        try {
+            conn = getSession().connection();
+			if (!conn.getAutoCommit()) {
+				return conn.setSavepoint();
+			}
+            return null;
+        } catch (HibernateException e) {
+            throw new DotHibernateException(e.getMessage(), e);
+        } catch (SQLException e) {
+            throw new DotHibernateException(e.getMessage(), e);
+        }
+    }
+
+    public static void rollbackSavepoint(Savepoint savepoint) throws DotHibernateException {
+
+        try {
+            getSession().connection().rollback(savepoint);
+        } catch (HibernateException e) {
+            throw new DotHibernateException(e.getMessage(), e);
+        } catch (SQLException e) {
+            throw new DotHibernateException(e.getMessage(), e);
+        }
+
+    }
+
+    public static void saveWithPrimaryKey(Object obj, Serializable id)
+            throws DotHibernateException {
+        try {
+            Session session = getSession();
+            session.save(obj, id);
+        } catch (Exception e) {
+            throw new DotHibernateException(
+                    "Unable to save Object with primary key " + id + " to Hibernate Session ", e);
+        }
+        try {
+            Session session = getSession();
+            session.flush();
+        } catch (Exception e) {
+            throw new DotHibernateException("Unable to flush Hibernate Session ", e);
+        }
+    }
 
     public void setDate(java.util.Date g) {
         query.setDate(t, g);
         t++;
     }
 
-    public static void evict(Object obj) throws DotHibernateException{
-		final Optional<Session> sessionOptional = getSessionIfOpened();
-		try {
-        	if (sessionOptional.isPresent()) {
-				sessionOptional.get().evict(obj);
-			}
+    public static void evict(Object obj) throws DotHibernateException {
+        final Optional<Session> sessionOptional = getSessionIfOpened();
+        try {
+            if (sessionOptional.isPresent()) {
+                sessionOptional.get().evict(obj);
+            }
         } catch (HibernateException e) {
-        	throw new DotHibernateException("Unable to evict from Hibernate Session ", e);
+            throw new DotHibernateException("Unable to evict from Hibernate Session ", e);
         }
     }
 
     private static boolean asyncReindexCommitListeners() {
-		return Config.getBooleanProperty("ASYNC_REINDEX_COMMIT_LISTENERS", true);
-	}
+        return Config.getBooleanProperty("ASYNC_REINDEX_COMMIT_LISTENERS", true);
+    }
 
-	private static boolean asyncCommitListeners() {
-		return Config.getBooleanProperty("ASYNC_COMMIT_LISTENERS", true);
-	}
+    private static boolean asyncCommitListeners() {
+        return Config.getBooleanProperty("ASYNC_COMMIT_LISTENERS", true);
+    }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/db/LocalTransaction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/LocalTransaction.java
@@ -1,60 +1,61 @@
 package com.dotmarketing.db;
 
 
-import java.sql.Connection;
-
 import com.dotcms.repackage.net.sf.hibernate.Session;
 import com.dotcms.util.ReturnableDelegate;
 import com.dotcms.util.VoidDelegate;
 import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
-
 import com.microsoft.sqlserver.jdbc.ISQLServerConnection;
 import io.vavr.control.Try;
 
+import java.sql.Connection;
+import java.util.function.Function;
+
 public class LocalTransaction {
 
-  private static enum TransactionErrorEnum {
-    NOTHING,
-    LOG,
-    THROW;
-  }
-
-
+    private enum TransactionErrorEnum {
+        NOTHING,
+        LOG,
+        THROW
+    }
 
 
     private final static String WARN_MESSAGE = "Transaction broken - Connection that started the transaction is not the same as the one who is commiting";
 
     /**
-     *
      * @param delegate {@link ReturnableDelegate}
      * @return T result of the {@link ReturnableDelegate}
-     * @throws DotDataException
-     *
-     * This class can be used to wrap methods in a "externalized transaction" pattern including the listeners (commit and rollback listeners)
-     * this pattern will use a new connection (if the parent caller is already in a transaction, that transaction will be restored after this method gets done)
-     * If the SQL call fails, it will rollback the work, close  the db connection
-     * and throw the error up the stack.
-     *
-     * Since it uses a new connection, that one will be closed at the end of the transaction.
-     *
-     *  How to use:
-     *
-     *	return new LocalTransaction().externalizeTransaction(() ->{
-     *		return myDBMethod(args);
-     *  });
+     * @throws DotDataException This class can be used to wrap methods in a "externalized
+     *                          transaction" pattern including the listeners (commit and rollback
+     *                          listeners) this pattern will use a new connection (if the parent
+     *                          caller is already in a transaction, that transaction will be
+     *                          restored after this method gets done) If the SQL call fails, it will
+     *                          rollback the work, close  the db connection and throw the error up
+     *                          the stack.
+     *                          <p>
+     *                          Since it uses a new connection, that one will be closed at the end
+     *                          of the transaction.
+     *                          <p>
+     *                          How to use:
+     *                          <p>
+     *                          return new LocalTransaction().externalizeTransaction(() ->{ return
+     *                          myDBMethod(args); });
      */
-    static public <T> T externalizeTransaction(final ReturnableDelegate<T> delegate) throws Exception {
-
+    static public <T> T externalizeTransaction(final ReturnableDelegate<T> delegate)
+            throws Exception {
+        T result = null;
         // gets the current conn
-        final Connection currentConnection        = DbConnectionFactory.getConnection();
-        final Session    currentSession           = HibernateUtil.getSession();
+        final Connection currentConnection = DbConnectionFactory.getConnection();
+        final Session currentSession = HibernateUtil.getSession();
         // creates a new one
-        final Connection newTransactionConnection = DbConnectionFactory.getDataSource().getConnection();
+        final Connection newTransactionConnection = DbConnectionFactory.getDataSource()
+                .getConnection();
         if (DbConnectionFactory.MSSQL.equals(DbConnectionFactory.getDBType())) {
-            newTransactionConnection.setTransactionIsolation(ISQLServerConnection.TRANSACTION_SNAPSHOT);
+            newTransactionConnection.setTransactionIsolation(
+                    ISQLServerConnection.TRANSACTION_SNAPSHOT);
         }
         // overrides the current thread
         DbConnectionFactory.setConnection(newTransactionConnection);
@@ -62,8 +63,6 @@ public class LocalTransaction {
         HibernateUtil.setSession(newSession);
 
         HibernateUtil.startTransaction();
-
-        T result = null;
 
         try {
             final StackTraceElement[] threadStack = Thread.currentThread().getStackTrace();
@@ -81,34 +80,43 @@ public class LocalTransaction {
             HibernateUtil.setSession(currentSession);
             DbConnectionFactory.setConnection(currentConnection);
         }
-
         return result;
     } // transaction.
 
     /**
-     *
      * @param delegate {@link ReturnableDelegate}
      * @return T result of the {@link ReturnableDelegate}
      * @throws DotDataException
-     *
-     * This class can be used to wrap methods in a "local transaction" pattern including the listeners (commit and rollback listeners)
-     * this pattern will check to see if the method is being called in an existing transaction.
-     * if it is being called in a transaction, it will do nothing.  If it is not being called in a transaction
-     * it will checkout a db connection,start a transaction, do the work, commit the transaction, return the result
-     * and  finally close the db connection.  If the SQL call fails, it will rollback the work, close  the db connection
-     * and throw the error up the stack.
-     *
-     * In addition the connection will be closed, only if the current transaction is opening it.
-     *
-     *  How to use:
-     *
-     *	return new LocalTransaction().wrapReturnWithListeners(() ->{
-     *		return myDBMethod(args);
-     *  });
+     * @deprecated use wrapReturn All commits need to handle listeners or there will be unknown or
+     * unintended side effects
      */
-    static public <T> T wrapReturnWithListeners(final ReturnableDelegate<T> delegate) throws Exception {
+    @Deprecated
+    public static <T> T wrapReturnWithListeners(final ReturnableDelegate<T> delegate)
+            throws Exception {
+        return wrapReturn(delegate);
+    } // wrapReturn.
 
-        final boolean isNewConnection    = !DbConnectionFactory.connectionExists();
+
+    /**
+     * @param delegate {@link ReturnableDelegate}
+     * @return T result of the {@link ReturnableDelegate}
+     * @throws DotDataException This class can be used to wrap methods in a "local transaction"
+     *                          pattern this pattern will check to see if the method is being called
+     *                          in an existing transaction. if it is being called in a transaction,
+     *                          it will do nothing.  If it is not being called in a transaction it
+     *                          will checkout a db connection,start a transaction, do the work,
+     *                          commit the transaction, return the result and  finally close the db
+     *                          connection.  If the SQL call fails, it will rollback the work, close
+     *                          the db connection and throw the error up the stack.
+     *                          <p>
+     *                          How to use:
+     *                          <p>
+     *                          return new LocalTransaction().wrapReturn(() ->{ return
+     *                          myDBMethod(args); });
+     */
+    public static <T> T wrapReturn(final ReturnableDelegate<T> delegate) throws Exception {
+
+        final boolean isNewConnection = !DbConnectionFactory.connectionExists();
         final boolean isLocalTransaction = HibernateUtil.startLocalTransactionIfNeeded();
 
         T result = null;
@@ -116,67 +124,12 @@ public class LocalTransaction {
         try {
             final StackTraceElement[] threadStack = Thread.currentThread().getStackTrace();
             final Connection conn = DbConnectionFactory.getConnection();
-            result= delegate.execute();
+            result = delegate.execute();
             if (isLocalTransaction) {
-               handleTransactionInteruption(conn, threadStack);
-               HibernateUtil.commitTransaction();
-
+                handleTransactionInteruption(conn, threadStack);
+                HibernateUtil.commitTransaction();
             }
         } catch (Throwable e) {
-
-            if (isLocalTransaction) {
-                HibernateUtil.rollbackTransaction();
-            }
-
-            throwException(e);
-        } finally {
-
-            if (isLocalTransaction && isNewConnection) {
-                HibernateUtil.closeSessionSilently();
-            }
-
-        }
-
-        return result;
-    } // wrapReturn.
-
-
-    /**
-     *
-     * @param delegate {@link ReturnableDelegate}
-     * @return T result of the {@link ReturnableDelegate}
-     * @throws DotDataException
-     *
-     * This class can be used to wrap methods in a "local transaction" pattern
-     * this pattern will check to see if the method is being called in an existing transaction.
-     * if it is being called in a transaction, it will do nothing.  If it is not being called in a transaction
-     * it will checkout a db connection,start a transaction, do the work, commit the transaction, return the result
-     * and  finally close the db connection.  If the SQL call fails, it will rollback the work, close  the db connection
-     * and throw the error up the stack.
-     *
-     *  How to use:
-     *
-     *	return new LocalTransaction().wrapReturn(() ->{
-     *		return myDBMethod(args);
-     *  });
-     */
-    static public <T> T wrapReturn(final ReturnableDelegate<T> delegate) throws Exception {
-
-        final boolean isNewConnection    = !DbConnectionFactory.connectionExists();
-        final boolean isLocalTransaction = DbConnectionFactory.startTransactionIfNeeded();
-
-        T result = null;
-
-        try {
-            final StackTraceElement[] threadStack = Thread.currentThread().getStackTrace();
-            final Connection conn = DbConnectionFactory.getConnection();
-            result= delegate.execute();
-            if (isLocalTransaction) {
-              handleTransactionInteruption(conn,threadStack);
-              DbConnectionFactory.commit();
-            }
-        } catch (Throwable e) {
-
             handleException(isLocalTransaction, e);
         } finally {
 
@@ -192,37 +145,33 @@ public class LocalTransaction {
     } // wrapReturn.
 
     /**
-     *
      * @param delegate {@link VoidDelegate}
-     * @throws DotDataException
-     *
-     * this will accept a method that does not need to return anything and wrap it in a transaction
-     * if it is not in one already.  At the end of the call, it will
-     * return the db connection to the connection pool
-     *
-     * 	 *  How to use:
-     *
-     *	 new LocalTransaction().wrap(() ->{
-     *		 myDBMethod(args);
-     *      return null;
-     *  });
+     * @throws DotDataException this will accept a method that does not need to return anything and
+     *                          wrap it in a transaction if it is not in one already.  At the end of
+     *                          the call, it will return the db connection to the connection pool
+     *                          <p>
+     *                          *  How to use:
+     *                          <p>
+     *                          new LocalTransaction().wrap(() ->{ myDBMethod(args); return null;
+     *                          });
      */
-    static public void wrap(final VoidDelegate delegate) throws Exception {
+    public static void wrap(final VoidDelegate delegate)
+            throws DotDataException, DotSecurityException {
 
-        final boolean isNewConnection    = !DbConnectionFactory.connectionExists();
-        final boolean isLocalTransaction = DbConnectionFactory.startTransactionIfNeeded();
+        final boolean isNewConnection = !DbConnectionFactory.connectionExists();
+        final boolean isLocalTransaction = HibernateUtil.startLocalTransactionIfNeeded();
 
         try {
+
             final StackTraceElement[] threadStack = Thread.currentThread().getStackTrace();
             final Connection conn = DbConnectionFactory.getConnection();
             delegate.execute();
 
             if (isLocalTransaction) {
-              handleTransactionInteruption(conn,threadStack);
-              DbConnectionFactory.commit();
+                handleTransactionInteruption(conn, threadStack);
+                HibernateUtil.commitTransaction();
             }
         } catch (Exception e) {
-
             handleException(isLocalTransaction, e);
         } finally {
 
@@ -236,74 +185,97 @@ public class LocalTransaction {
         }
     } // wrap.
 
-    static public void wrapNoException(final VoidDelegate delegate)  {
-        try {
-            wrap(delegate);
-        }
-        catch(Exception e) {
-            throw new DotRuntimeException(e);
-        }
-    } // wrapNoException.
+    @SuppressWarnings("unchecked")
+    static <T extends Throwable, R> R sneakyThrow(Throwable t) throws T {
+        throw (T) t;
+    }
 
-    private static void handleException(final boolean isLocalTransaction,
-                                        final Throwable  e) throws Exception {
-        if(isLocalTransaction){
-            DbConnectionFactory.rollbackTransaction();
-        }
+    public interface ThrowingFunction<T, R> {
 
-        throwException(e);
+        @SuppressWarnings("java:S112")
+        R apply(T t) throws Exception;
+    }
+
+
+    public static <T> Function<T, T> unchecked(ReturnableDelegate<T> f) {
+        return t -> {
+            try {
+                return f.execute();
+            } catch (Throwable ex) {
+                return sneakyThrow(ex);
+            }
+        };
+    }
+
+
+    public static VoidDelegate unchecked(VoidDelegate t) {
+        return () -> {
+            try {
+                t.execute();
+            } catch (Exception ex) {
+                sneakyThrow(ex);
+            }
+        };
+    }
+
+
+    private static <T extends Throwable> void handleException(final boolean isLocalTransaction,
+            final Throwable t) throws T, DotDataException {
+        if (isLocalTransaction) {
+            HibernateUtil.rollbackTransaction();
+        }
+        throw (T) t;
     } // handleException.
 
 
-    private static void handleTransactionInteruption(final Connection conn, final StackTraceElement[] threadStack) throws DotDataException {
-      if (DbConnectionFactory.getConnection() != conn) {
-        final String action = Config.getStringProperty("LOCAL_TRANSACTION_INTERUPTED_ACTION", TransactionErrorEnum.LOG.name());
-        if (TransactionErrorEnum.LOG.name().equalsIgnoreCase(action)) {
+    private static void handleTransactionInteruption(final Connection conn,
+            final StackTraceElement[] threadStack) throws DotDataException {
+        if (DbConnectionFactory.getConnection() != conn) {
+            final String action = Config.getStringProperty("LOCAL_TRANSACTION_INTERUPTED_ACTION",
+                    TransactionErrorEnum.LOG.name());
+            if (TransactionErrorEnum.LOG.name().equalsIgnoreCase(action)) {
 
-          Logger.warn(LocalTransaction.class, WARN_MESSAGE);
-          for(StackTraceElement ste :  threadStack) {
-            Logger.warn(LocalTransaction.class, "    " + ste.toString());
-          }
-        } else if (TransactionErrorEnum.THROW.name().equalsIgnoreCase(action)) {
-          throw new DotDataException(WARN_MESSAGE);
+                Logger.warn(LocalTransaction.class, WARN_MESSAGE);
+                for (StackTraceElement ste : threadStack) {
+                    Logger.warn(LocalTransaction.class, "    " + ste.toString());
+                }
+            } else if (TransactionErrorEnum.THROW.name().equalsIgnoreCase(action)) {
+                throw new DotDataException(WARN_MESSAGE);
+            }
         }
-      }
     }
-    
-    
-    private static void throwException ( final Throwable  e) throws Exception {
+
+
+    private static void throwException(final Throwable e) throws Exception {
 
         if (e instanceof Exception) {
 
-            throw Exception.class.cast(e);
+            throw (Exception) e;
         }
 
         Throwable t = e;
-        while(t.getCause()!=null){
-            t=t.getCause();
+        while (t.getCause() != null) {
+            t = t.getCause();
         }
-        if(t instanceof DotDataException){
+        if (t instanceof DotDataException) {
             throw (DotDataException) t;
         }
-        throw new DotDataException(t.getMessage(),t);
+        throw new DotDataException(t.getMessage(), t);
     }
 
-    
-    
-    private final static String LocalTransationName= LocalTransaction.class.getCanonicalName();
+
+    private static final String LOCAL_TRANSACTION_NAME = LocalTransaction.class.getCanonicalName();
+
     static public boolean inLocalTransaction() {
-      final StackTraceElement[] stes =  Thread.currentThread().getStackTrace();
-      for(int i=2;i<stes.length;i++) {
-        final int stackNumber=i;
-        String steName = Try.of(()->stes[stackNumber].getClassName()).getOrNull();
-        if(LocalTransationName.equals(steName)) {
-          return true;
+        final StackTraceElement[] stes = Thread.currentThread().getStackTrace();
+        for (int i = 2; i < stes.length; i++) {
+            final int stackNumber = i;
+            String steName = Try.of(() -> stes[stackNumber].getClassName()).getOrNull();
+            if (LOCAL_TRANSACTION_NAME.equals(steName)) {
+                return true;
+            }
         }
-      }
-      return false;
+        return false;
     }
-    
-    
-    
-    
+
 } // E:O:F:LocalTransaction.

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowFactoryImpl.java
@@ -70,2539 +70,2631 @@ import org.apache.commons.beanutils.BeanUtils;
 
 public class WorkflowFactoryImpl implements WorkFlowFactory {
 
-	public static final int PARTITION_IN_SIZE = 100;
-	private final WorkflowCache cache;
-	private final WorkflowSQL   sql;
-
-
-	/**
-	 * Creates an instance of the {@link WorkFlowFactory}.
-	 */
-	public WorkflowFactoryImpl() {
-		this.sql   = WorkflowSQL.getInstance();
-		this.cache = CacheLocator.getWorkFlowCache();
-	}
-
-	@Override
-	public void attachFileToTask(WorkflowTask task, String fileInode) throws DotDataException {
-		final WorkFlowTaskFiles taskFile = new WorkFlowTaskFiles();
-		taskFile.setWorkflowtaskId(task.getId());
-		taskFile.setFileInode(fileInode);
-		HibernateUtil.save(taskFile);
-	}
-
-	/**
-	 *
-	 * @param obj
-	 * @param map
-	 * @return
-	 * @throws IllegalAccessException
-	 * @throws InvocationTargetException
-	 */
-	private Object convert(Object obj, Map<String, Object> map) throws IllegalAccessException, InvocationTargetException {
-		BeanUtils.copyProperties(obj, map);
-		return obj;
-	}
-
-	/**
-	 *
-	 * @param row
-	 * @return
-	 * @throws IllegalAccessException
-	 * @throws InvocationTargetException
-	 */
-	private WorkflowAction convertAction(Map<String, Object> row) throws IllegalAccessException, InvocationTargetException {
-		final WorkflowAction action = new WorkflowAction();
-		row.put("schemeId", row.get("scheme_id"));
-		row.put("condition", row.get("condition_to_progress"));
-		row.put("nextStep", row.get("next_step_id"));
-		row.put("nextAssign", row.get("next_assign"));
-		row.put("order", row.get("my_order"));
-		row.put("requiresCheckout", row.get("requires_checkout"));
-		row.put("showOn", WorkflowState.toSet(row.get("show_on")));
-		row.put("roleHierarchyForAssign", row.get("use_role_hierarchy_assign"));
-		BeanUtils.copyProperties(action, row);
-		action.setPushPublishActionlet(ActionletUtil.hasPushPublishActionlet(action));
-		return action;
-	}
-
-	/**
-	 *
-	 * @param row
-	 * @return
-	 * @throws IllegalAccessException
-	 * @throws InvocationTargetException
-	 */
-	private WorkflowActionClass convertActionClass(Map<String, Object> row) throws IllegalAccessException, InvocationTargetException {
-		final WorkflowActionClass actionClass = new WorkflowActionClass();
-
-		row.put("clazz", row.get("clazz"));
-
-		row.put("order", row.get("my_order"));
-		row.put("actionId", row.get("action_id"));
-		BeanUtils.copyProperties(actionClass, row);
-		return actionClass;
-	}
-
-	/**
-	 *
-	 * @param row
-	 * @return
-	 * @throws IllegalAccessException
-	 * @throws InvocationTargetException
-	 */
-	private WorkflowActionClassParameter convertActionClassParameter(Map<String, Object> row) throws IllegalAccessException, InvocationTargetException {
-		final WorkflowActionClassParameter param = new WorkflowActionClassParameter();
-		row.put("actionClassId", row.get("workflow_action_class_id"));
-		BeanUtils.copyProperties(param, row);
-		return param;
-	}
-
-	/**
-	 *
-	 * @param rs
-	 * @param clazz
-	 * @return
-	 * @throws DotDataException
-	 */
-	private <T> List<T> convertListToObjects(List<Map<String, Object>> rs, Class<T> clazz) throws DotDataException {
-		final List ret = new ArrayList();
-		try {
-			for (final Map<String, Object> map : rs) {
-				ret.add(this.convertMaptoObject(map, clazz));
-			}
-		} catch (final Exception e) {
-			Logger.error(this, "cannot convert object to " + clazz + " " + e.getMessage(), e);
-			throw new DotDataException("cannot convert object to " + clazz + " " + e.getMessage(),
-					e);
-		}
-
-		return ret;
-	}
-
-	/**
-	 *
-	 * @param map
-	 * @param clazz
-	 * @return
-	 * @throws InstantiationException
-	 * @throws IllegalAccessException
-	 * @throws InvocationTargetException
-	 */
-	private Object convertMaptoObject(Map<String, Object> map, Class clazz) throws InstantiationException, IllegalAccessException, InvocationTargetException {
-
-		if(ContentType.class.equals(clazz)){
-			//Content type is an abstract class therefore it can not be instantiated directly
-			return new DbContentTypeTransformer(map).from();
-		}
-
-		final Object obj = clazz.newInstance();
-
-		if (obj instanceof WorkflowAction) {
-			return this.convertAction(map);
-		} else if (obj instanceof WorkflowStep) {
-			return this.convertStep(map);
-		} else if (obj instanceof WorkflowActionClass) {
-			return this.convertActionClass(map);
-		} else if (obj instanceof WorkflowActionClassParameter) {
-			return this.convertActionClassParameter(map);
-		} else if (obj instanceof WorkflowScheme) {
-			return WorkflowSchemeTransformer.transform(map);
-		} else if (obj instanceof WorkflowHistory) {
-			return this.convertHistory(map);
-		} else if (obj instanceof WorkflowTask) {
-			return WorkflowTaskTransformer.transform(map);
-		} else {
-			return this.convert(obj, map);
-		}
-	}
-
-	/**
-	 *
-	 * @param row
-	 * @return
-	 * @throws IllegalAccessException
-	 * @throws InvocationTargetException
-	 */
-	private WorkflowScheme convertScheme(Map<String, Object> row) throws IllegalAccessException, InvocationTargetException {
-		final WorkflowScheme scheme = new WorkflowScheme();
-		row.put("entryActionId", row.get("entry_action_id"));
-		row.put("defaultScheme", row.get("default_scheme"));
-		row.put("modDate", row.get("mod_date"));
-
-		BeanUtils.copyProperties(scheme, row);
-
-		return scheme;
-	}
-
-	/**
-	 *
-	 * @param row
-	 * @return
-	 * @throws IllegalAccessException
-	 * @throws InvocationTargetException
-	 */
-	private WorkflowStep convertStep(Map<String, Object> row) throws IllegalAccessException, InvocationTargetException {
-		final WorkflowStep step = new WorkflowStep();
-		row.put("myOrder", row.get("my_order"));
-		row.put("schemeId", row.get("scheme_id"));
-		row.put("enableEscalation", row.get("escalation_enable"));
-		row.put("escalationAction", row.get("escalation_action"));
-		row.put("escalationTime", row.get("escalation_time"));
-		BeanUtils.copyProperties(step, row);
-
-		return step;
-	}
-
-	private WorkflowTask convertTask(Map<String, Object> row)
-			throws IllegalAccessException, InvocationTargetException {
-
-		final WorkflowTask task = new WorkflowTask();
-		row.put("languageId", row.get("language_id"));
-		row.put("creationDate", row.get("creation_date"));
-		row.put("modDate", row.get("mod_date"));
-		row.put("dueDate", row.get("due_date"));
-		row.put("createdBy", row.get("created_by"));
-		row.put("assignedTo", row.get("assigned_to"));
-		row.put("belongsTo", row.get("belongs_to"));
-		BeanUtils.copyProperties(task, row);
-
-		return task;
-	}
-
-	/**
-	 *
-	 * @param row
-	 * @return
-	 * @throws IllegalAccessException
-	 * @throws InvocationTargetException
-	 */
-	private WorkflowHistory convertHistory(Map<String, Object> row) throws IllegalAccessException, InvocationTargetException {
-		final WorkflowHistory scheme = new WorkflowHistory();
-		row.put("actionId", row.get("workflow_action_id"));
-
-		BeanUtils.copyProperties(scheme, row);
-
-		return scheme;
-	}
-
-	@Override
-	public void copyWorkflowAction(WorkflowAction from, WorkflowStep step) throws DotDataException {
-		throw new DotWorkflowException("Not implemented");
-	}
-
-	@Override
-	public void copyWorkflowActionClass(WorkflowActionClass from, WorkflowAction action) throws DotDataException {
-		throw new DotWorkflowException("Not implemented");
-	}
-
-	@Override
-	public void copyWorkflowActionClassParameter(WorkflowActionClassParameter from, WorkflowActionClass actionClass) throws DotDataException {
-		throw new DotWorkflowException("Not implemented");
-	}
-
-	@Override
-	public void copyWorkflowStep(WorkflowStep from, WorkflowScheme scheme) throws DotDataException {
-		throw new DotWorkflowException("Not implemented");
-	}
-
-	@Override
-	public int countTasks(WorkflowSearcher searcher) throws DotDataException {
-		DotConnect dc = getWorkflowSqlQuery(searcher, true);
-		return dc.getInt("mycount");
-	}
-
-	@Override
-	public void deleteAction(final WorkflowAction action) throws DotDataException, AlreadyExistException {
-
-		Logger.debug(this,
-				"Removing action steps dependencies, for the action: " + action.getId());
-
-		final List<Map<String, Object>> stepIdList =
-				new DotConnect().setSQL(sql.SELECT_STEPS_ID_BY_ACTION)
-				.addParam(action.getId()).loadObjectResults();
-
-		if (null != stepIdList && stepIdList.size() > 0) {
-			new DotConnect().setSQL(sql.DELETE_ACTIONS_BY_STEP)
-					.addParam(action.getId()).loadResult();
-
-			for (Map<String, Object> stepIdRow : stepIdList) {
-				Logger.debug(this,
-						"Removing action steps cache " + stepIdRow.get("stepid"));
-				final WorkflowStep proxyStep = new WorkflowStep();
-				proxyStep.setId((String)stepIdRow.get("stepid"));
-				cache.removeActions(proxyStep);
-			}
-		}
-
-		Logger.debug(this,
-				"Removing the action: " + action.getId());
-
-		new DotConnect().setSQL(sql.DELETE_ACTION)
-				.addParam(action.getId()).loadResult();
-
-		final WorkflowScheme proxyScheme = new WorkflowScheme();
-		proxyScheme.setId(action.getSchemeId());
-		cache.removeActions(proxyScheme);
-		cache.remove(action);
-
-		// update scheme mod date
-		final WorkflowScheme scheme = findScheme(action.getSchemeId());
-		saveScheme(scheme);
-	}
-
-	@Override
-	public void deleteAction(final WorkflowAction action, final WorkflowStep step) throws DotDataException, AlreadyExistException {
-
-		Logger.debug(this, "Deleting the action: " + action.getId() +
-						", from the step: " + step.getId());
-
-		new DotConnect().setSQL(sql.DELETE_ACTION_STEP)
-				.addParam(action.getId()).addParam(step.getId()).loadResult();
-
-		Logger.debug(this, "Cleaning the actions from the step CACHE: " + step.getId());
-		cache.removeActions(step);
-
-		Logger.debug(this, "Updating the scheme: " + step.getSchemeId());
-		// update scheme mod date
-		final WorkflowScheme scheme = findScheme(step.getSchemeId());
-		saveScheme(scheme);
-	} // deleteAction
-
-	@Override
-	public void deleteActions(final WorkflowStep step) throws DotDataException, AlreadyExistException {
-
-		Logger.debug(this, "Removing the actions associated to the step: " + step.getId());
-		new DotConnect().setSQL(sql.DELETE_ACTIONS_STEP)
-				.addParam(step.getId()).loadResult();
-
-		Logger.debug(this, "Removing the actions cache associated to the step: " + step.getId());
-		final List<WorkflowAction> actions =
-				this.cache.getActions(step);
-		if (null != actions) {
-			actions.stream().forEach(action -> this.cache.remove(action));
-		}
-		cache.removeActions(step);
-
-
-		Logger.debug(this, "Updating schema associated to the step: " + step.getId());
-		// update scheme mod date
-		final WorkflowScheme scheme = findScheme(step.getSchemeId());
-		saveScheme(scheme);
-	} // deleteActions.
-
-	@Override
-	public void deleteActionClass(WorkflowActionClass actionClass) throws DotDataException, AlreadyExistException {
-		String actionId = actionClass.getActionId();
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.DELETE_ACTION_CLASS_PARAM_BY_ACTION_CLASS);
-		db.addParam(actionClass.getId());
-		db.loadResult();
-
-		db.setSQL(sql.DELETE_ACTION_CLASS);
-		db.addParam(actionClass.getId());
-		db.loadResult();
-
-		// update scheme mod date
-		final WorkflowAction action = findAction(actionId);
-		final WorkflowScheme scheme = findScheme(action.getSchemeId());
-		saveScheme(scheme);
-		this.cache.remove(action);
-	}
-
-	/**
-	 *
-	 * @param action
-	 * @throws DotDataException
-	 * @throws DotSecurityException
-	 * @throws AlreadyExistException
-	 */
-	public void deleteActionClassByAction(WorkflowAction action) throws DotDataException, DotSecurityException, AlreadyExistException {
-
-		new DotConnect().setSQL(sql.DELETE_ACTION_CLASS_BY_ACTION).addParam(action.getId()).loadResult();
-
-		// update scheme mod date
-		final WorkflowScheme scheme = findScheme(action.getSchemeId());
-		saveScheme(scheme);
-		this.cache.remove(action);
-	}
-
-	@Override
-	public void deleteComment(WorkflowComment comment) throws DotDataException {
-		final DotConnect db = new DotConnect();
-		db.setSQL("delete from workflow_comment where id = ?");
-		db.addParam(comment.getId());
-		db.loadResult();
-	}
-
-	@Override
-	public void deleteStep(final WorkflowStep step,
-						   final Consumer<WorkflowTask> workflowTaskConsumer) throws DotDataException, AlreadyExistException {
-		final String schemeId = step.getSchemeId();
-		final DotConnect db   = new DotConnect();
-
-		// delete tasks referencing it
-		db.setSQL("select id from workflow_task where status=?");
-		db.addParam(step.getId());
-		for(final Map<String,Object> resultMap : db.loadObjectResults()) {
-
-			final String taskId		= (String) resultMap.get("id");
-			final WorkflowTask task = findWorkFlowTaskById(taskId);
-			deleteWorkflowTask(task);
-			if (null != workflowTaskConsumer) {
-				workflowTaskConsumer.accept(task);
-			}
-		}
-
-		db.setSQL(sql.DELETE_STEP);
-		db.addParam(step.getId());
-		db.loadResult();
-		cache.remove(step);
-
-		// update scheme mod date
-		WorkflowScheme scheme = findScheme(schemeId);
-		saveScheme(scheme);
-	}
-
-	@Override
-	public int getCountContentletsReferencingStep(WorkflowStep step) throws DotDataException{
-
-		final DotConnect db = new DotConnect();
-
-		// get step related assets
-		db.setSQL(sql.SELECT_COUNT_CONTENTLES_BY_STEP);
-		db.addParam(step.getId());
-		Map<String,Object> res = db.loadObjectResults().get(0);
-		return ConversionUtils.toInt(res.get("count"), 0);
-	}
-
-	@Override
-	public void deleteWorkflowActionClassParameters(WorkflowActionClass actionClass) throws DotDataException, AlreadyExistException {
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.DELETE_ACTION_CLASS_PARAM_BY_ACTION_CLASS);
-		db.addParam(actionClass.getId());
-		db.loadResult();
-
-		// update scheme mod date
-		WorkflowAction action = findAction(actionClass.getActionId());
-		WorkflowScheme scheme = findScheme(action.getSchemeId());
-		saveScheme(scheme);
-
-	}
-
-	@Override
-	public void deleteWorkflowHistory(WorkflowHistory history) throws DotDataException {
-		final DotConnect db = new DotConnect();
-		db.setSQL("delete from workflow_history where id = ?");
-		db.addParam(history.getId());
-		db.loadResult();
-	}
-
-	@Override
-	public int deleteWorkflowHistoryOldVersions(final Date olderThan) throws DotDataException {
-
-		DotConnect dotConnect = new DotConnect();
-
-		//Get the count of the workflow history records before deleting.
-		String countSQL = "select count(*) as count from workflow_history";
-		dotConnect.setSQL(countSQL);
-		List<Map<String, String>> result = dotConnect.loadResults();
-		final int before = Integer.parseInt(result.get(0).get("count"));
-
-		// Delete the records using a given date
-		dotConnect.setSQL("delete from workflow_history where creation_date < ?");
-		dotConnect.addParam(olderThan);
-		dotConnect.loadResult();
-
-		//Get the count of the workflow history records after deleting.
-		dotConnect.setSQL(countSQL);
-		result = dotConnect.loadResults();
-		final int after = Integer.parseInt(result.get(0).get("count"));
-
-		return before - after;
-	}
-
-	@Override
-	public void deleteWorkflowTaskByContentletIdAnyLanguage(final String webAsset) throws DotDataException {
-
-		final DotConnect db = new DotConnect();
-		db.setSQL("SELECT * FROM workflow_task WHERE webasset = ?");
-		db.addParam(webAsset);
-
-		final List<WorkflowTask> tasksToClearFromCache = this
-				.convertListToObjects(db.loadObjectResults(), WorkflowTask.class);
-
-		new DotConnect().setSQL("delete from workflow_comment where workflowtask_id   in (select id from workflow_task where webasset = ?)")
-				.addParam(webAsset).loadResult();
-
-		new DotConnect().setSQL("delete from workflow_history where workflowtask_id   in (select id from workflow_task where webasset = ?)")
-				.addParam(webAsset).loadResult();
-
-		new DotConnect().setSQL("delete from workflowtask_files where workflowtask_id in (select id from workflow_task where webasset = ?)")
-				.addParam(webAsset).loadResult();
-
-		new DotConnect().setSQL("delete from workflow_task where webasset = ?")
-				.addParam(webAsset).loadResult();
-
-		tasksToClearFromCache.forEach(cache::remove);
-
-	}
-
-	@Override
-	public void deleteWorkflowTaskByContentletIdAndLanguage(final String webAsset, final long languageId) throws DotDataException {
-
-		final List<WorkflowTask> tasksToClearFromCache = this
-				.convertListToObjects(new DotConnect()
-						.setSQL("SELECT * FROM workflow_task WHERE webasset = ? and language_id=?")
-						.addParam(webAsset)
-						.addParam(languageId).loadObjectResults(), WorkflowTask.class);
-
-		new DotConnect().setSQL("delete from workflow_comment where workflowtask_id   in (select id from workflow_task where webasset = ? and language_id=?)")
-				.addParam(webAsset).addParam(languageId).loadResult();
-
-		new DotConnect().setSQL("delete from workflow_history where workflowtask_id   in (select id from workflow_task where webasset = ? and language_id=?)")
-				.addParam(webAsset).addParam(languageId).loadResult();
-
-		new DotConnect().setSQL("delete from workflowtask_files where workflowtask_id in (select id from workflow_task where webasset = ? and language_id=?)")
-				.addParam(webAsset).addParam(languageId).loadResult();
-
-		new DotConnect().setSQL("delete from workflow_task where webasset = ? and language_id=?")
-				.addParam(webAsset).addParam(languageId).loadResult();
-
-		tasksToClearFromCache.forEach(cache::remove);
-
-	}
-
-	@Override
-	public void deleteWorkflowTaskByLanguage(final Language language) throws DotDataException {
-
-		final List<WorkflowTask> tasksToClearFromCache = this
-				.convertListToObjects(new DotConnect()
-						.setSQL("SELECT * FROM workflow_task WHERE language_id=?")
-						.addParam(language.getId()).loadObjectResults(), WorkflowTask.class);
-
-		new DotConnect().setSQL("delete from workflow_comment where workflowtask_id   in (select id from workflow_task where language_id=?)")
-				.addParam(language.getId()).loadResult();
-
-		new DotConnect().setSQL("delete from workflow_history where workflowtask_id   in (select id from workflow_task where language_id=?)")
-				.addParam(language.getId()).loadResult();
-
-		new DotConnect().setSQL("delete from workflowtask_files where workflowtask_id in (select id from workflow_task where language_id=?)")
-				.addParam(language.getId()).loadResult();
-
-		new DotConnect().setSQL("delete from workflow_task where language_id=?")
-				.addParam(language.getId()).loadResult();
-
-		tasksToClearFromCache.forEach(cache::remove);
-	}
-
-	@Override
-	public void deleteWorkflowTask(WorkflowTask task) throws DotDataException {
-		final DotConnect db = new DotConnect();
-
-		HibernateUtil.evict(task);
-
-		Contentlet c = new Contentlet();
-		c.setIdentifier(task.getWebasset());
-		c.setLanguageId(task.getLanguageId());
-
-		boolean localTransaction = false;
-		try {
-			localTransaction = HibernateUtil.startLocalTransactionIfNeeded();
-
-			/* Clean the comments */
-			db.setSQL("delete from workflow_comment where workflowtask_id = ?");
-			db.addParam(task.getId());
-			db.loadResult();
-
-			/* Clean the history */
-			db.setSQL("delete from workflow_history where workflowtask_id = ?");
-			db.addParam(task.getId());
-			db.loadResult();
-
-			/* Clean the files of task */
-			db.setSQL("delete from workflowtask_files where workflowtask_id = ?");
-			db.addParam(task.getId());
-			db.loadResult();
-
-			/* delete the task */
-			db.setSQL("delete from workflow_task where id = ?");
-			db.addParam(task.getId());
-			db.loadResult();
-
-			if(localTransaction){
-				HibernateUtil.closeAndCommitTransaction();
-			}
-
-		} catch (final Exception e) {
-			if(localTransaction){
-				HibernateUtil.rollbackTransaction();
-			}
-			Logger.error(this, "deleteWorkflowTask failed:" + e, e);
-			throw new DotDataException(e);
-		}
-		finally {
-			cache.remove(task);
-		}
-	}
-
-	@Override
-	public WorkflowAction findAction(String id) throws DotDataException {
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.SELECT_ACTION);
-		db.addParam(id);
-		try {
-			return (WorkflowAction) this.convertListToObjects(db.loadObjectResults(), WorkflowAction.class).get(0);
-		} catch (IndexOutOfBoundsException ioob) {
-			return null;
-		}
-	}
-
-	@Override
-	public WorkflowAction findAction(final String actionId,
-									 final String stepId) throws DotDataException {
-
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.SELECT_ACTION_BY_STEP);
-		db.addParam(actionId).addParam(stepId);
-
-		try {
-			return (WorkflowAction) this.convertListToObjects(db.loadObjectResults(), WorkflowAction.class).get(0);
-		} catch (IndexOutOfBoundsException ioob) {
-			return null;
-		}
-	}
-
-	@Override
-	public WorkflowActionClass findActionClass(String id) throws DotDataException {
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.SELECT_ACTION_CLASS);
-		db.addParam(id);
-
-		try {
-			return (WorkflowActionClass) this.convertListToObjects(db.loadObjectResults(), WorkflowActionClass.class).get(0);
-		} catch (IndexOutOfBoundsException ioob) {
-			return null;
-		}
-	}
-
-	@Override
-	public List<WorkflowActionClass> findActionClasses(final WorkflowAction action) throws DotDataException {
-
-		List<WorkflowActionClass> classes = cache.getActionClasses(action);
-
-		if (null == classes) {
-
-			classes = this.convertListToObjects(new DotConnect().setSQL(sql.SELECT_ACTION_CLASSES_BY_ACTION)
-					.addParam(action.getId()).loadObjectResults(), WorkflowActionClass.class);
-
-			classes = (classes == null)?Collections.emptyList():classes;
-
-			cache.addActionClasses(action, classes);
-		}
-
-		return classes;
-	}
-
-	@Override
-	public List<WorkflowActionClass> findActionClassesByClassName(final String actionClassName) throws DotDataException {
-
-		final List<WorkflowActionClass> classes = this.convertListToObjects(new DotConnect().setSQL(sql.SELECT_ACTION_CLASSES_BY_CLASS)
-				.addParam(actionClassName).loadObjectResults(), WorkflowActionClass.class);
-
-		return classes;
-	}
-
-
-	public WorkflowActionClassParameter findActionClassParameter(String id) throws DotDataException {
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.SELECT_ACTION_CLASS_PARAM);
-		db.addParam(id);
-		return (WorkflowActionClassParameter) this.convertListToObjects(db.loadObjectResults(), WorkflowActionClassParameter.class).get(0);
-	}
-
-	@Override
-	public List<WorkflowAction> findActions(final WorkflowStep step) throws DotDataException {
-
-		List<WorkflowAction> actions = cache.getActions(step);
-
-		if(null == actions) {
-
-			actions = this.convertListToObjects(
-					new DotConnect().setSQL(sql.SELECT_ACTIONS_BY_STEP)
-							.addParam(step.getId()).loadObjectResults(), WorkflowAction.class);
-
-			if (null == actions) {
-
-				actions = Collections.emptyList();
-				cache.addActions(step, actions);
-				return actions;
-			}
-
-			cache.addActions(step, actions);
-		}
-
-		// we need always a copy to avoid futher modification to the WorkflowAction since they are not immutable.
-		return ImmutableList.copyOf(actions);
-	}
-
-	@Override
-	public List<WorkflowAction> findActions(final WorkflowScheme scheme) throws DotDataException {
-
-		List<WorkflowAction> actions = cache.getActions(scheme);
-		if(null == actions) {
-
-			final DotConnect db = new DotConnect();
-			db.setSQL(sql.SELECT_ACTIONS_BY_SCHEME);
-			db.addParam(scheme.getId());
-			actions =  this.convertListToObjects(db.loadObjectResults(), WorkflowAction.class);
-
-			if(actions == null) {
-				actions = new ArrayList<>();
-			}
-
-			cache.addActions(scheme, actions);
-		}
-
-		return actions;
-	} // findActions.
-
-
-	@Override
-	public Map<String, WorkflowActionClassParameter> findParamsForActionClass(WorkflowActionClass actionClass) throws DotDataException {
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.SELECT_ACTION_CLASS_PARAMS_BY_ACTIONCLASS);
-		db.addParam(actionClass.getId());
-		final List<WorkflowActionClassParameter> list = (List<WorkflowActionClassParameter>) this.convertListToObjects(db.loadObjectResults(), WorkflowActionClassParameter.class);
-		final Map<String, WorkflowActionClassParameter> map = loadDefaultActionClassParams(actionClass);
-		for (final WorkflowActionClassParameter param : list) {
-			map.put(param.getKey(), param);
-		}
-
-
-		return map;
-
-	}
-  /**
-   * When an actionlet is added, we do not add the default values to the db.
-   * 
-   * you need to make sure that the default values of the actionlet are
-   * persisted, otherwise if you try to use it, it will throw an NPE
-   */
-	private Map<String, WorkflowActionClassParameter> loadDefaultActionClassParams(final WorkflowActionClass actionClass){
-	  
-	  final Map<String, WorkflowActionClassParameter> map = new LinkedHashMap<String, WorkflowActionClassParameter>();
-
-	  if(actionClass!=null && actionClass.getActionlet()!=null && actionClass.getActionlet().getParameters()!=null) {
-      for(WorkflowActionletParameter param :actionClass.getActionlet().getParameters()) {
-        WorkflowActionClassParameter instanceParam  =  new WorkflowActionClassParameter();
-        instanceParam.setActionClassId(actionClass.getId());
-        instanceParam.setKey(param.getKey());
-        instanceParam.setValue(param.getDefaultValue());
-        map.put(param.getKey(), instanceParam);
-      }
-	  }
-    return map;
-    
-	  
-	  
-	}
-
-	@Override
-	public WorkflowScheme findScheme(String id) throws DotDataException {
-		WorkflowScheme scheme = cache.getScheme(id);
-		if (scheme == null) {
-			try {
-				final DotConnect db = new DotConnect();
-				db.setSQL(sql.SELECT_SCHEME);
-				db.addParam(id);
-				scheme = (WorkflowScheme) this.convertListToObjects(db.loadObjectResults(), WorkflowScheme.class).get(0);
-				cache.add(scheme);
-			} catch (final IndexOutOfBoundsException e) {
-				throw new DoesNotExistException("Workflow-does-not-exists-scheme");
-			} catch (final Exception e) {
-				throw new DotDataException(e.getMessage(), e);
-			}
-		}
-		return scheme;
-	}
-
-
-	@Override
-	public List<WorkflowScheme> findSchemesForStruct(final String structId) throws DotDataException {
-
-		List<WorkflowScheme> schemes = cache.getSchemesByStruct(structId);
-
-		if (schemes != null) {
-
-			// checks if any of the schemes has been invalidated (save recently and needs to refresh the schemes for the content type).
-			if (!schemes.stream().filter(scheme -> null == cache.getScheme(scheme.getId())).findFirst().isPresent()) {
-				return schemes;
-			}
-		}
-
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.SELECT_SCHEME_BY_STRUCT);
-		db.addParam(structId);
-		try {
-			schemes = this.convertListToObjects(db.loadObjectResults(), WorkflowScheme.class);
-		} catch (final Exception er) {
-			schemes = new ArrayList();
-		}
-
-		cache.addForStructure(structId, schemes);
-		schemes.stream().forEach(scheme -> cache.add(scheme));
-		return schemes;
-
-	}
-
-	@Override
-	public WorkflowScheme findSystemWorkflow() throws DotDataException {
-		return this.findScheme(WorkFlowFactory.SYSTEM_WORKFLOW_ID);
-	}
-
-	@Override
-	public List<WorkflowScheme> findSchemes(boolean showArchived) throws DotDataException {
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.SELECT_SCHEMES);
-		db.addParam(false);
-		db.addParam(showArchived);
-		return this.convertListToObjects(db.loadObjectResults(), WorkflowScheme.class);
-	}
-
-	@Override
-	public List<WorkflowScheme> findArchivedSchemes() throws DotDataException {
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.SELECT_SCHEMES);
-		db.addParam(true);
-		db.addParam(true);
-		return this.convertListToObjects(db.loadObjectResults(), WorkflowScheme.class);
-	}
-
-	@Override
-	public WorkflowStep findStep(String id) throws DotDataException {
-		WorkflowStep step = cache.getStep(id);
-		if (step == null) {
-			final DotConnect db = new DotConnect();
-			db.setSQL(sql.SELECT_STEP);
-			db.addParam(id);
-			try{
-			  step = (WorkflowStep) this.convertListToObjects(db.loadObjectResults(), WorkflowStep.class).get(0);
-			  cache.add(step);
-			}catch (IndexOutOfBoundsException e){
-				throw new DoesNotExistException("Workflow-does-not-exists-step");
-			}
-		}
-		return step;
-	}
-
-	@Override
-	public Optional<WorkflowStep> findFirstStep(final String actionId, final String actionSchemeId) throws DotDataException {
-
-		WorkflowStep workflowStep = null;
-		final List<Map<String, Object>> workflowStepRows =
-				new DotConnect().setMaxRows(1).setSQL(sql.SELECT_STEPS_BY_ACTION)
-					.addParam(actionId).loadObjectResults();
-
-		try {
-
-			workflowStep = UtilMethods.isSet(workflowStepRows) && workflowStepRows.size() > 0?
-					this.convertStep(workflowStepRows.get(0)):
-					this.findFirstStep(actionSchemeId).orElse(null);
-		} catch (IllegalAccessException | InvocationTargetException e) {
-
-			throw new DotDataException(e);
-		}
-
-		return Optional.ofNullable(workflowStep);
-	}
-
-	@Override
-	public Optional<WorkflowStep> findFirstStep(final String schemeId) throws DotDataException {
-
-		return this.findSteps(this.findScheme(schemeId))
-				.stream().findFirst();
-	}
-
-	@Override
-	public List<WorkflowStep> findStepsByContentlet(final Contentlet contentlet, final List<WorkflowScheme> schemes) throws DotDataException {
-		List<WorkflowStep> steps            = new ArrayList<>();
-        List<WorkflowStep> currentSteps     = cache.getSteps(contentlet);
-		String workflowTaskId        		= null;
-		List<Map<String, Object>> dbResults = null;
-
-		if (currentSteps == null) {
+    public static final int PARTITION_IN_SIZE = 100;
+    private final WorkflowCache cache;
+    private final WorkflowSQL sql;
+
+
+    /**
+     * Creates an instance of the {@link WorkFlowFactory}.
+     */
+    public WorkflowFactoryImpl() {
+        this.sql = WorkflowSQL.getInstance();
+        this.cache = CacheLocator.getWorkFlowCache();
+    }
+
+    @Override
+    public void attachFileToTask(WorkflowTask task, String fileInode) throws DotDataException {
+        final WorkFlowTaskFiles taskFile = new WorkFlowTaskFiles();
+        taskFile.setWorkflowtaskId(task.getId());
+        taskFile.setFileInode(fileInode);
+        HibernateUtil.save(taskFile);
+    }
+
+    /**
+     * @param obj
+     * @param map
+     * @return
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    private Object convert(Object obj, Map<String, Object> map)
+            throws IllegalAccessException, InvocationTargetException {
+        BeanUtils.copyProperties(obj, map);
+        return obj;
+    }
+
+    /**
+     * @param row
+     * @return
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    private WorkflowAction convertAction(Map<String, Object> row)
+            throws IllegalAccessException, InvocationTargetException {
+        final WorkflowAction action = new WorkflowAction();
+        row.put("schemeId", row.get("scheme_id"));
+        row.put("condition", row.get("condition_to_progress"));
+        row.put("nextStep", row.get("next_step_id"));
+        row.put("nextAssign", row.get("next_assign"));
+        row.put("order", row.get("my_order"));
+        row.put("requiresCheckout", row.get("requires_checkout"));
+        row.put("showOn", WorkflowState.toSet(row.get("show_on")));
+        row.put("roleHierarchyForAssign", row.get("use_role_hierarchy_assign"));
+        BeanUtils.copyProperties(action, row);
+        action.setPushPublishActionlet(ActionletUtil.hasPushPublishActionlet(action));
+        return action;
+    }
+
+    /**
+     * @param row
+     * @return
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    private WorkflowActionClass convertActionClass(Map<String, Object> row)
+            throws IllegalAccessException, InvocationTargetException {
+        final WorkflowActionClass actionClass = new WorkflowActionClass();
+
+        row.put("clazz", row.get("clazz"));
+
+        row.put("order", row.get("my_order"));
+        row.put("actionId", row.get("action_id"));
+        BeanUtils.copyProperties(actionClass, row);
+        return actionClass;
+    }
+
+    /**
+     * @param row
+     * @return
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    private WorkflowActionClassParameter convertActionClassParameter(Map<String, Object> row)
+            throws IllegalAccessException, InvocationTargetException {
+        final WorkflowActionClassParameter param = new WorkflowActionClassParameter();
+        row.put("actionClassId", row.get("workflow_action_class_id"));
+        BeanUtils.copyProperties(param, row);
+        return param;
+    }
+
+    /**
+     * @param rs
+     * @param clazz
+     * @return
+     * @throws DotDataException
+     */
+    private <T> List<T> convertListToObjects(List<Map<String, Object>> rs, Class<T> clazz)
+            throws DotDataException {
+        final List ret = new ArrayList();
+        try {
+            for (final Map<String, Object> map : rs) {
+                ret.add(this.convertMaptoObject(map, clazz));
+            }
+        } catch (final Exception e) {
+            Logger.error(this, "cannot convert object to " + clazz + " " + e.getMessage(), e);
+            throw new DotDataException("cannot convert object to " + clazz + " " + e.getMessage(),
+                    e);
+        }
+
+        return ret;
+    }
+
+    /**
+     * @param map
+     * @param clazz
+     * @return
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    private Object convertMaptoObject(Map<String, Object> map, Class clazz)
+            throws InstantiationException, IllegalAccessException, InvocationTargetException {
+
+        if (ContentType.class.equals(clazz)) {
+            //Content type is an abstract class therefore it can not be instantiated directly
+            return new DbContentTypeTransformer(map).from();
+        }
+
+        final Object obj = clazz.newInstance();
+
+        if (obj instanceof WorkflowAction) {
+            return this.convertAction(map);
+        } else if (obj instanceof WorkflowStep) {
+            return this.convertStep(map);
+        } else if (obj instanceof WorkflowActionClass) {
+            return this.convertActionClass(map);
+        } else if (obj instanceof WorkflowActionClassParameter) {
+            return this.convertActionClassParameter(map);
+        } else if (obj instanceof WorkflowScheme) {
+            return WorkflowSchemeTransformer.transform(map);
+        } else if (obj instanceof WorkflowHistory) {
+            return this.convertHistory(map);
+        } else if (obj instanceof WorkflowTask) {
+            return WorkflowTaskTransformer.transform(map);
+        } else {
+            return this.convert(obj, map);
+        }
+    }
+
+    /**
+     * @param row
+     * @return
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    private WorkflowScheme convertScheme(Map<String, Object> row)
+            throws IllegalAccessException, InvocationTargetException {
+        final WorkflowScheme scheme = new WorkflowScheme();
+        row.put("entryActionId", row.get("entry_action_id"));
+        row.put("defaultScheme", row.get("default_scheme"));
+        row.put("modDate", row.get("mod_date"));
+
+        BeanUtils.copyProperties(scheme, row);
+
+        return scheme;
+    }
+
+    /**
+     * @param row
+     * @return
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    private WorkflowStep convertStep(Map<String, Object> row)
+            throws IllegalAccessException, InvocationTargetException {
+        final WorkflowStep step = new WorkflowStep();
+        row.put("myOrder", row.get("my_order"));
+        row.put("schemeId", row.get("scheme_id"));
+        row.put("enableEscalation", row.get("escalation_enable"));
+        row.put("escalationAction", row.get("escalation_action"));
+        row.put("escalationTime", row.get("escalation_time"));
+        BeanUtils.copyProperties(step, row);
+
+        return step;
+    }
+
+    private WorkflowTask convertTask(Map<String, Object> row)
+            throws IllegalAccessException, InvocationTargetException {
+
+        final WorkflowTask task = new WorkflowTask();
+        row.put("languageId", row.get("language_id"));
+        row.put("creationDate", row.get("creation_date"));
+        row.put("modDate", row.get("mod_date"));
+        row.put("dueDate", row.get("due_date"));
+        row.put("createdBy", row.get("created_by"));
+        row.put("assignedTo", row.get("assigned_to"));
+        row.put("belongsTo", row.get("belongs_to"));
+        BeanUtils.copyProperties(task, row);
+
+        return task;
+    }
+
+    /**
+     * @param row
+     * @return
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    private WorkflowHistory convertHistory(Map<String, Object> row)
+            throws IllegalAccessException, InvocationTargetException {
+        final WorkflowHistory scheme = new WorkflowHistory();
+        row.put("actionId", row.get("workflow_action_id"));
+
+        BeanUtils.copyProperties(scheme, row);
+
+        return scheme;
+    }
+
+    @Override
+    public void copyWorkflowAction(WorkflowAction from, WorkflowStep step) throws DotDataException {
+        throw new DotWorkflowException("Not implemented");
+    }
+
+    @Override
+    public void copyWorkflowActionClass(WorkflowActionClass from, WorkflowAction action)
+            throws DotDataException {
+        throw new DotWorkflowException("Not implemented");
+    }
+
+    @Override
+    public void copyWorkflowActionClassParameter(WorkflowActionClassParameter from,
+            WorkflowActionClass actionClass) throws DotDataException {
+        throw new DotWorkflowException("Not implemented");
+    }
+
+    @Override
+    public void copyWorkflowStep(WorkflowStep from, WorkflowScheme scheme) throws DotDataException {
+        throw new DotWorkflowException("Not implemented");
+    }
+
+    @Override
+    public int countTasks(WorkflowSearcher searcher) throws DotDataException {
+        DotConnect dc = getWorkflowSqlQuery(searcher, true);
+        return dc.getInt("mycount");
+    }
+
+    @Override
+    public void deleteAction(final WorkflowAction action)
+            throws DotDataException, AlreadyExistException {
+
+        Logger.debug(this,
+                "Removing action steps dependencies, for the action: " + action.getId());
+
+        final List<Map<String, Object>> stepIdList =
+                new DotConnect().setSQL(sql.SELECT_STEPS_ID_BY_ACTION)
+                        .addParam(action.getId()).loadObjectResults();
+
+        if (null != stepIdList && stepIdList.size() > 0) {
+            new DotConnect().setSQL(sql.DELETE_ACTIONS_BY_STEP)
+                    .addParam(action.getId()).loadResult();
+
+            for (Map<String, Object> stepIdRow : stepIdList) {
+                Logger.debug(this,
+                        "Removing action steps cache " + stepIdRow.get("stepid"));
+                final WorkflowStep proxyStep = new WorkflowStep();
+                proxyStep.setId((String) stepIdRow.get("stepid"));
+                cache.removeActions(proxyStep);
+            }
+        }
+
+        Logger.debug(this,
+                "Removing the action: " + action.getId());
+
+        new DotConnect().setSQL(sql.DELETE_ACTION)
+                .addParam(action.getId()).loadResult();
+
+        final WorkflowScheme proxyScheme = new WorkflowScheme();
+        proxyScheme.setId(action.getSchemeId());
+        cache.removeActions(proxyScheme);
+        cache.remove(action);
+
+        // update scheme mod date
+        final WorkflowScheme scheme = findScheme(action.getSchemeId());
+        saveScheme(scheme);
+    }
+
+    @Override
+    public void deleteAction(final WorkflowAction action, final WorkflowStep step)
+            throws DotDataException, AlreadyExistException {
+
+        Logger.debug(this, "Deleting the action: " + action.getId() +
+                ", from the step: " + step.getId());
+
+        new DotConnect().setSQL(sql.DELETE_ACTION_STEP)
+                .addParam(action.getId()).addParam(step.getId()).loadResult();
+
+        Logger.debug(this, "Cleaning the actions from the step CACHE: " + step.getId());
+        cache.removeActions(step);
+
+        Logger.debug(this, "Updating the scheme: " + step.getSchemeId());
+        // update scheme mod date
+        final WorkflowScheme scheme = findScheme(step.getSchemeId());
+        saveScheme(scheme);
+    } // deleteAction
+
+    @Override
+    public void deleteActions(final WorkflowStep step)
+            throws DotDataException, AlreadyExistException {
+
+        Logger.debug(this, "Removing the actions associated to the step: " + step.getId());
+        new DotConnect().setSQL(sql.DELETE_ACTIONS_STEP)
+                .addParam(step.getId()).loadResult();
+
+        Logger.debug(this, "Removing the actions cache associated to the step: " + step.getId());
+        final List<WorkflowAction> actions =
+                this.cache.getActions(step);
+        if (null != actions) {
+            actions.stream().forEach(action -> this.cache.remove(action));
+        }
+        cache.removeActions(step);
+
+        Logger.debug(this, "Updating schema associated to the step: " + step.getId());
+        // update scheme mod date
+        final WorkflowScheme scheme = findScheme(step.getSchemeId());
+        saveScheme(scheme);
+    } // deleteActions.
+
+    @Override
+    public void deleteActionClass(WorkflowActionClass actionClass)
+            throws DotDataException, AlreadyExistException {
+        String actionId = actionClass.getActionId();
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.DELETE_ACTION_CLASS_PARAM_BY_ACTION_CLASS);
+        db.addParam(actionClass.getId());
+        db.loadResult();
+
+        db.setSQL(sql.DELETE_ACTION_CLASS);
+        db.addParam(actionClass.getId());
+        db.loadResult();
+
+        // update scheme mod date
+        final WorkflowAction action = findAction(actionId);
+        final WorkflowScheme scheme = findScheme(action.getSchemeId());
+        saveScheme(scheme);
+        this.cache.remove(action);
+    }
+
+    /**
+     * @param action
+     * @throws DotDataException
+     * @throws DotSecurityException
+     * @throws AlreadyExistException
+     */
+    public void deleteActionClassByAction(WorkflowAction action)
+            throws DotDataException, DotSecurityException, AlreadyExistException {
+
+        new DotConnect().setSQL(sql.DELETE_ACTION_CLASS_BY_ACTION).addParam(action.getId())
+                .loadResult();
+
+        // update scheme mod date
+        final WorkflowScheme scheme = findScheme(action.getSchemeId());
+        saveScheme(scheme);
+        this.cache.remove(action);
+    }
+
+    @Override
+    public void deleteComment(WorkflowComment comment) throws DotDataException {
+        final DotConnect db = new DotConnect();
+        db.setSQL("delete from workflow_comment where id = ?");
+        db.addParam(comment.getId());
+        db.loadResult();
+    }
+
+    @Override
+    public void deleteStep(final WorkflowStep step,
+            final Consumer<WorkflowTask> workflowTaskConsumer)
+            throws DotDataException, AlreadyExistException {
+        final String schemeId = step.getSchemeId();
+        final DotConnect db = new DotConnect();
+
+        // delete tasks referencing it
+        db.setSQL("select id from workflow_task where status=?");
+        db.addParam(step.getId());
+        for (final Map<String, Object> resultMap : db.loadObjectResults()) {
+
+            final String taskId = (String) resultMap.get("id");
+            final WorkflowTask task = findWorkFlowTaskById(taskId);
+            deleteWorkflowTask(task);
+            if (null != workflowTaskConsumer) {
+                workflowTaskConsumer.accept(task);
+            }
+        }
+
+        db.setSQL(sql.DELETE_STEP);
+        db.addParam(step.getId());
+        db.loadResult();
+        cache.remove(step);
+
+        // update scheme mod date
+        WorkflowScheme scheme = findScheme(schemeId);
+        saveScheme(scheme);
+    }
+
+    @Override
+    public int getCountContentletsReferencingStep(WorkflowStep step) throws DotDataException {
+
+        final DotConnect db = new DotConnect();
+
+        // get step related assets
+        db.setSQL(sql.SELECT_COUNT_CONTENTLES_BY_STEP);
+        db.addParam(step.getId());
+        Map<String, Object> res = db.loadObjectResults().get(0);
+        return ConversionUtils.toInt(res.get("count"), 0);
+    }
+
+    @Override
+    public void deleteWorkflowActionClassParameters(WorkflowActionClass actionClass)
+            throws DotDataException, AlreadyExistException {
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.DELETE_ACTION_CLASS_PARAM_BY_ACTION_CLASS);
+        db.addParam(actionClass.getId());
+        db.loadResult();
+
+        // update scheme mod date
+        WorkflowAction action = findAction(actionClass.getActionId());
+        WorkflowScheme scheme = findScheme(action.getSchemeId());
+        saveScheme(scheme);
+
+    }
+
+    @Override
+    public void deleteWorkflowHistory(WorkflowHistory history) throws DotDataException {
+        final DotConnect db = new DotConnect();
+        db.setSQL("delete from workflow_history where id = ?");
+        db.addParam(history.getId());
+        db.loadResult();
+    }
+
+    @Override
+    public int deleteWorkflowHistoryOldVersions(final Date olderThan) throws DotDataException {
+
+        DotConnect dotConnect = new DotConnect();
+
+        //Get the count of the workflow history records before deleting.
+        String countSQL = "select count(*) as count from workflow_history";
+        dotConnect.setSQL(countSQL);
+        List<Map<String, String>> result = dotConnect.loadResults();
+        final int before = Integer.parseInt(result.get(0).get("count"));
+
+        // Delete the records using a given date
+        dotConnect.setSQL("delete from workflow_history where creation_date < ?");
+        dotConnect.addParam(olderThan);
+        dotConnect.loadResult();
+
+        //Get the count of the workflow history records after deleting.
+        dotConnect.setSQL(countSQL);
+        result = dotConnect.loadResults();
+        final int after = Integer.parseInt(result.get(0).get("count"));
+
+        return before - after;
+    }
+
+    @Override
+    public void deleteWorkflowTaskByContentletIdAnyLanguage(final String webAsset)
+            throws DotDataException {
+
+        final DotConnect db = new DotConnect();
+        db.setSQL("SELECT * FROM workflow_task WHERE webasset = ?");
+        db.addParam(webAsset);
+
+        final List<WorkflowTask> tasksToClearFromCache = this
+                .convertListToObjects(db.loadObjectResults(), WorkflowTask.class);
+
+        new DotConnect().setSQL(
+                        "delete from workflow_comment where workflowtask_id   in (select id from workflow_task where webasset = ?)")
+                .addParam(webAsset).loadResult();
+
+        new DotConnect().setSQL(
+                        "delete from workflow_history where workflowtask_id   in (select id from workflow_task where webasset = ?)")
+                .addParam(webAsset).loadResult();
+
+        new DotConnect().setSQL(
+                        "delete from workflowtask_files where workflowtask_id in (select id from workflow_task where webasset = ?)")
+                .addParam(webAsset).loadResult();
+
+        new DotConnect().setSQL("delete from workflow_task where webasset = ?")
+                .addParam(webAsset).loadResult();
+
+        tasksToClearFromCache.forEach(cache::remove);
+
+    }
+
+    @Override
+    public void deleteWorkflowTaskByContentletIdAndLanguage(final String webAsset,
+            final long languageId) throws DotDataException {
+
+        final List<WorkflowTask> tasksToClearFromCache = this
+                .convertListToObjects(new DotConnect()
+                        .setSQL("SELECT * FROM workflow_task WHERE webasset = ? and language_id=?")
+                        .addParam(webAsset)
+                        .addParam(languageId).loadObjectResults(), WorkflowTask.class);
+
+        new DotConnect().setSQL(
+                        "delete from workflow_comment where workflowtask_id   in (select id from workflow_task where webasset = ? and language_id=?)")
+                .addParam(webAsset).addParam(languageId).loadResult();
+
+        new DotConnect().setSQL(
+                        "delete from workflow_history where workflowtask_id   in (select id from workflow_task where webasset = ? and language_id=?)")
+                .addParam(webAsset).addParam(languageId).loadResult();
+
+        new DotConnect().setSQL(
+                        "delete from workflowtask_files where workflowtask_id in (select id from workflow_task where webasset = ? and language_id=?)")
+                .addParam(webAsset).addParam(languageId).loadResult();
+
+        new DotConnect().setSQL("delete from workflow_task where webasset = ? and language_id=?")
+                .addParam(webAsset).addParam(languageId).loadResult();
+
+        tasksToClearFromCache.forEach(cache::remove);
+
+    }
+
+    @Override
+    public void deleteWorkflowTaskByLanguage(final Language language) throws DotDataException {
+
+        final List<WorkflowTask> tasksToClearFromCache = this
+                .convertListToObjects(new DotConnect()
+                        .setSQL("SELECT * FROM workflow_task WHERE language_id=?")
+                        .addParam(language.getId()).loadObjectResults(), WorkflowTask.class);
+
+        new DotConnect().setSQL(
+                        "delete from workflow_comment where workflowtask_id   in (select id from workflow_task where language_id=?)")
+                .addParam(language.getId()).loadResult();
+
+        new DotConnect().setSQL(
+                        "delete from workflow_history where workflowtask_id   in (select id from workflow_task where language_id=?)")
+                .addParam(language.getId()).loadResult();
+
+        new DotConnect().setSQL(
+                        "delete from workflowtask_files where workflowtask_id in (select id from workflow_task where language_id=?)")
+                .addParam(language.getId()).loadResult();
+
+        new DotConnect().setSQL("delete from workflow_task where language_id=?")
+                .addParam(language.getId()).loadResult();
+
+        tasksToClearFromCache.forEach(cache::remove);
+    }
+
+    @Override
+    public void deleteWorkflowTask(WorkflowTask task) throws DotDataException {
+        final DotConnect db = new DotConnect();
+
+        HibernateUtil.evict(task);
+
+        Contentlet c = new Contentlet();
+        c.setIdentifier(task.getWebasset());
+        c.setLanguageId(task.getLanguageId());
+
+        boolean localTransaction = false;
+        try {
+            localTransaction = HibernateUtil.startLocalTransactionIfNeeded();
+
+            /* Clean the comments */
+            db.setSQL("delete from workflow_comment where workflowtask_id = ?");
+            db.addParam(task.getId());
+            db.loadResult();
+
+            /* Clean the history */
+            db.setSQL("delete from workflow_history where workflowtask_id = ?");
+            db.addParam(task.getId());
+            db.loadResult();
+
+            /* Clean the files of task */
+            db.setSQL("delete from workflowtask_files where workflowtask_id = ?");
+            db.addParam(task.getId());
+            db.loadResult();
+
+            /* delete the task */
+            db.setSQL("delete from workflow_task where id = ?");
+            db.addParam(task.getId());
+            db.loadResult();
+
+            if (localTransaction) {
+                HibernateUtil.closeAndCommitTransaction();
+            }
+
+        } catch (final Exception e) {
+            if (localTransaction) {
+                HibernateUtil.rollbackTransaction();
+            }
+            Logger.error(this, "deleteWorkflowTask failed:" + e, e);
+            throw new DotDataException(e);
+        } finally {
+            cache.remove(task);
+        }
+    }
+
+    @Override
+    public WorkflowAction findAction(String id) throws DotDataException {
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.SELECT_ACTION);
+        db.addParam(id);
+        try {
+            return (WorkflowAction) this.convertListToObjects(db.loadObjectResults(),
+                    WorkflowAction.class).get(0);
+        } catch (IndexOutOfBoundsException ioob) {
+            return null;
+        }
+    }
+
+    @Override
+    public WorkflowAction findAction(final String actionId,
+            final String stepId) throws DotDataException {
+
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.SELECT_ACTION_BY_STEP);
+        db.addParam(actionId).addParam(stepId);
+
+        try {
+            return (WorkflowAction) this.convertListToObjects(db.loadObjectResults(),
+                    WorkflowAction.class).get(0);
+        } catch (IndexOutOfBoundsException ioob) {
+            return null;
+        }
+    }
+
+    @Override
+    public WorkflowActionClass findActionClass(String id) throws DotDataException {
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.SELECT_ACTION_CLASS);
+        db.addParam(id);
+
+        try {
+            return (WorkflowActionClass) this.convertListToObjects(db.loadObjectResults(),
+                    WorkflowActionClass.class).get(0);
+        } catch (IndexOutOfBoundsException ioob) {
+            return null;
+        }
+    }
+
+    @Override
+    public List<WorkflowActionClass> findActionClasses(final WorkflowAction action)
+            throws DotDataException {
+
+        List<WorkflowActionClass> classes = cache.getActionClasses(action);
+
+        if (null == classes) {
+
+            classes = this.convertListToObjects(
+                    new DotConnect().setSQL(sql.SELECT_ACTION_CLASSES_BY_ACTION)
+                            .addParam(action.getId()).loadObjectResults(),
+                    WorkflowActionClass.class);
+
+            cache.addActionClasses(action, classes);
+        }
+
+        return classes;
+    }
+
+    @Override
+    public List<WorkflowActionClass> findActionClassesByClassName(final String actionClassName)
+            throws DotDataException {
+
+        final List<WorkflowActionClass> classes = this.convertListToObjects(
+                new DotConnect().setSQL(sql.SELECT_ACTION_CLASSES_BY_CLASS)
+                        .addParam(actionClassName).loadObjectResults(), WorkflowActionClass.class);
+
+        return classes;
+    }
+
+
+    public WorkflowActionClassParameter findActionClassParameter(String id)
+            throws DotDataException {
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.SELECT_ACTION_CLASS_PARAM);
+        db.addParam(id);
+        return (WorkflowActionClassParameter) this.convertListToObjects(db.loadObjectResults(),
+                WorkflowActionClassParameter.class).get(0);
+    }
+
+    @Override
+    public List<WorkflowAction> findActions(final WorkflowStep step) throws DotDataException {
+
+        List<WorkflowAction> actions = cache.getActions(step);
+
+        if (null == actions) {
+
+            actions = this.convertListToObjects(
+                    new DotConnect().setSQL(sql.SELECT_ACTIONS_BY_STEP)
+                            .addParam(step.getId()).loadObjectResults(), WorkflowAction.class);
+
+            cache.addActions(step, actions);
+        }
+
+        // we need always a copy to avoid futher modification to the WorkflowAction since they are not immutable.
+        return ImmutableList.copyOf(actions);
+    }
+
+    @Override
+    public List<WorkflowAction> findActions(final WorkflowScheme scheme) throws DotDataException {
+
+        List<WorkflowAction> actions = cache.getActions(scheme);
+        if (null == actions) {
+
+            final DotConnect db = new DotConnect();
+            db.setSQL(sql.SELECT_ACTIONS_BY_SCHEME);
+            db.addParam(scheme.getId());
+            actions = this.convertListToObjects(db.loadObjectResults(), WorkflowAction.class);
+
+            cache.addActions(scheme, actions);
+        }
+
+        return actions;
+    } // findActions.
+
+
+    @Override
+    public Map<String, WorkflowActionClassParameter> findParamsForActionClass(
+            WorkflowActionClass actionClass) throws DotDataException {
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.SELECT_ACTION_CLASS_PARAMS_BY_ACTIONCLASS);
+        db.addParam(actionClass.getId());
+        final List<WorkflowActionClassParameter> list = (List<WorkflowActionClassParameter>) this.convertListToObjects(
+                db.loadObjectResults(), WorkflowActionClassParameter.class);
+        final Map<String, WorkflowActionClassParameter> map = loadDefaultActionClassParams(
+                actionClass);
+        for (final WorkflowActionClassParameter param : list) {
+            map.put(param.getKey(), param);
+        }
+
+        return map;
+
+    }
+
+    /**
+     * When an actionlet is added, we do not add the default values to the db.
+     * <p>
+     * you need to make sure that the default values of the actionlet are persisted, otherwise if
+     * you try to use it, it will throw an NPE
+     */
+    private Map<String, WorkflowActionClassParameter> loadDefaultActionClassParams(
+            final WorkflowActionClass actionClass) {
+
+        final Map<String, WorkflowActionClassParameter> map = new LinkedHashMap<String, WorkflowActionClassParameter>();
+
+        if (actionClass != null && actionClass.getActionlet() != null
+                && actionClass.getActionlet().getParameters() != null) {
+            for (WorkflowActionletParameter param : actionClass.getActionlet().getParameters()) {
+                WorkflowActionClassParameter instanceParam = new WorkflowActionClassParameter();
+                instanceParam.setActionClassId(actionClass.getId());
+                instanceParam.setKey(param.getKey());
+                instanceParam.setValue(param.getDefaultValue());
+                map.put(param.getKey(), instanceParam);
+            }
+        }
+        return map;
+
+
+    }
+
+    @Override
+    public WorkflowScheme findScheme(String id) throws DotDataException {
+        WorkflowScheme scheme = cache.getScheme(id);
+        if (scheme == null) {
+            try {
+                final DotConnect db = new DotConnect();
+                db.setSQL(sql.SELECT_SCHEME);
+                db.addParam(id);
+                scheme = (WorkflowScheme) this.convertListToObjects(db.loadObjectResults(),
+                        WorkflowScheme.class).get(0);
+                cache.add(scheme);
+            } catch (final IndexOutOfBoundsException e) {
+                throw new DoesNotExistException("Workflow-does-not-exists-scheme");
+            } catch (final Exception e) {
+                throw new DotDataException(e.getMessage(), e);
+            }
+        }
+        return scheme;
+    }
+
+
+    @Override
+    public List<WorkflowScheme> findSchemesForStruct(final String structId)
+            throws DotDataException {
+
+        List<WorkflowScheme> schemes = cache.getSchemesByStruct(structId);
+
+        if (schemes != null) {
+
+            // checks if any of the schemes has been invalidated (save recently and needs to refresh the schemes for the content type).
+            if (!schemes.stream().filter(scheme -> null == cache.getScheme(scheme.getId()))
+                    .findFirst().isPresent()) {
+                return schemes;
+            }
+        }
+
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.SELECT_SCHEME_BY_STRUCT);
+        db.addParam(structId);
+        try {
+            schemes = this.convertListToObjects(db.loadObjectResults(), WorkflowScheme.class);
+        } catch (final Exception er) {
+            schemes = new ArrayList();
+        }
+
+        cache.addForStructure(structId, schemes);
+        schemes.stream().forEach(scheme -> cache.add(scheme));
+        return schemes;
+
+    }
+
+    @Override
+    public WorkflowScheme findSystemWorkflow() throws DotDataException {
+        return this.findScheme(WorkFlowFactory.SYSTEM_WORKFLOW_ID);
+    }
+
+    @Override
+    public List<WorkflowScheme> findSchemes(boolean showArchived) throws DotDataException {
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.SELECT_SCHEMES);
+        db.addParam(false);
+        db.addParam(showArchived);
+        return this.convertListToObjects(db.loadObjectResults(), WorkflowScheme.class);
+    }
+
+    @Override
+    public List<WorkflowScheme> findArchivedSchemes() throws DotDataException {
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.SELECT_SCHEMES);
+        db.addParam(true);
+        db.addParam(true);
+        return this.convertListToObjects(db.loadObjectResults(), WorkflowScheme.class);
+    }
+
+    @Override
+    public WorkflowStep findStep(String id) throws DotDataException {
+        WorkflowStep step = cache.getStep(id);
+        if (step == null) {
+            final DotConnect db = new DotConnect();
+            db.setSQL(sql.SELECT_STEP);
+            db.addParam(id);
+            try {
+                step = (WorkflowStep) this.convertListToObjects(db.loadObjectResults(),
+                        WorkflowStep.class).get(0);
+                cache.add(step);
+            } catch (IndexOutOfBoundsException e) {
+                throw new DoesNotExistException("Workflow-does-not-exists-step");
+            }
+        }
+        return step;
+    }
+
+    @Override
+    public Optional<WorkflowStep> findFirstStep(final String actionId, final String actionSchemeId)
+            throws DotDataException {
+
+        WorkflowStep workflowStep = null;
+        final List<Map<String, Object>> workflowStepRows =
+                new DotConnect().setMaxRows(1).setSQL(sql.SELECT_STEPS_BY_ACTION)
+                        .addParam(actionId).loadObjectResults();
+
+        try {
+
+            workflowStep = UtilMethods.isSet(workflowStepRows) && workflowStepRows.size() > 0 ?
+                    this.convertStep(workflowStepRows.get(0)) :
+                    this.findFirstStep(actionSchemeId).orElse(null);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+
+            throw new DotDataException(e);
+        }
+
+        return Optional.ofNullable(workflowStep);
+    }
+
+    @Override
+    public Optional<WorkflowStep> findFirstStep(final String schemeId) throws DotDataException {
+
+        return this.findSteps(this.findScheme(schemeId))
+                .stream().findFirst();
+    }
+
+    @Override
+    public List<WorkflowStep> findStepsByContentlet(final Contentlet contentlet,
+            final List<WorkflowScheme> schemes) throws DotDataException {
+        List<WorkflowStep> steps = new ArrayList<>();
+        List<WorkflowStep> currentSteps = cache.getSteps(contentlet);
+        String workflowTaskId = null;
+        List<Map<String, Object>> dbResults = null;
+
+        if (currentSteps == null) {
             WorkflowStep step = null;
-			try {
-				final DotConnect db = new DotConnect();
-				db.setSQL(sql.SELECT_STEP_BY_CONTENTLET);
-				db.addParam(contentlet.getIdentifier());
-				db.addParam(contentlet.getLanguageId());
+            try {
+                final DotConnect db = new DotConnect();
+                db.setSQL(sql.SELECT_STEP_BY_CONTENTLET);
+                db.addParam(contentlet.getIdentifier());
+                db.addParam(contentlet.getLanguageId());
 
-				dbResults = db.loadObjectResults();
-                step      = (WorkflowStep) this.convertListToObjects
-						(dbResults, WorkflowStep.class).get(0);
+                dbResults = db.loadObjectResults();
+                step = (WorkflowStep) this.convertListToObjects
+                        (dbResults, WorkflowStep.class).get(0);
                 steps.add(step);
 
-				workflowTaskId =  (String)dbResults.get(0).get("workflowid");
-			} catch (final Exception e) {
-				Logger.debug(this.getClass(), e.getMessage());
-			}
+                workflowTaskId = (String) dbResults.get(0).get("workflowid");
+            } catch (final Exception e) {
+                Logger.debug(this.getClass(), e.getMessage());
+            }
 
-			if (step == null) {
-				try {
-					for(WorkflowScheme scheme : schemes) {
-						final List<WorkflowStep> schemeSteps = this.findSteps(scheme);
-						if(UtilMethods.isSet(schemeSteps)){
-						   step = schemeSteps.get(0);
-						   steps.add(step);
-						}
-					}
-					//Add to cache list of steps
-				} catch (final Exception e) {
-					throw new DotDataException("Unable to find workflow step for content id:" + contentlet.getIdentifier());
-				}
-			}
-		} else {
-			steps.addAll(currentSteps);
-		}
+            if (step == null) {
+                try {
+                    for (WorkflowScheme scheme : schemes) {
+                        final List<WorkflowStep> schemeSteps = this.findSteps(scheme);
+                        if (UtilMethods.isSet(schemeSteps)) {
+                            step = schemeSteps.get(0);
+                            steps.add(step);
+                        }
+                    }
+                    //Add to cache list of steps
+                } catch (final Exception e) {
+                    throw new DotDataException("Unable to find workflow step for content id:"
+                            + contentlet.getIdentifier());
+                }
+            }
+        } else {
+            steps.addAll(currentSteps);
+        }
         // if the existing task belongs to another workflow schema, then remove it
-		if (steps.size() == 1 && !existSchemeIdOnSchemesList(steps.get(0).getSchemeId(),schemes)) {
+        if (steps.size() == 1 && !existSchemeIdOnSchemesList(steps.get(0).getSchemeId(), schemes)) {
 
-			if (null != workflowTaskId && !(LicenseUtil.getLevel() < LicenseLevel.STANDARD.level) ) {
-				this.deleteWorkflowTask(this.findWorkFlowTaskById(workflowTaskId));
-			}
+            if (null != workflowTaskId && !(LicenseUtil.getLevel() < LicenseLevel.STANDARD.level)) {
+                this.deleteWorkflowTask(this.findWorkFlowTaskById(workflowTaskId));
+            }
 
-			// if it is the community license, has a diff workflow of the system workflow instead of removing the steps, use the first steps of the system workflow
-			if ((LicenseUtil.getLevel() < LicenseLevel.STANDARD.level) && null != workflowTaskId && !WorkflowAPI.SYSTEM_WORKFLOW_ID.equals(workflowTaskId)) {
+            // if it is the community license, has a diff workflow of the system workflow instead of removing the steps, use the first steps of the system workflow
+            if ((LicenseUtil.getLevel() < LicenseLevel.STANDARD.level) && null != workflowTaskId
+                    && !WorkflowAPI.SYSTEM_WORKFLOW_ID.equals(workflowTaskId)) {
 
-				steps.clear();
-				final List<WorkflowStep> schemeSteps = this.findSteps(this.findSystemWorkflow());
-				if(UtilMethods.isSet(schemeSteps)){
-					final WorkflowStep step = schemeSteps.get(0);
-					steps.add(step);
-				}
-			} else {
-				steps = Collections.emptyList();
-			}
-		}
+                steps.clear();
+                final List<WorkflowStep> schemeSteps = this.findSteps(this.findSystemWorkflow());
+                if (UtilMethods.isSet(schemeSteps)) {
+                    final WorkflowStep step = schemeSteps.get(0);
+                    steps.add(step);
+                }
+            } else {
+                steps = Collections.emptyList();
+            }
+        }
 
         cache.addSteps(contentlet, steps);
 
-		return steps;
-	}
+        return steps;
+    }
 
-	@Override
-	public boolean existSchemeIdOnSchemesList(String schemeId, List<WorkflowScheme> schemes){
-	    boolean exist = false;
-	    for(WorkflowScheme scheme : schemes){
-	        if(schemeId.equals(scheme.getId())){
-	            exist = true;
-	            break;
+    @Override
+    public boolean existSchemeIdOnSchemesList(String schemeId, List<WorkflowScheme> schemes) {
+        boolean exist = false;
+        for (WorkflowScheme scheme : schemes) {
+            if (schemeId.equals(scheme.getId())) {
+                exist = true;
+                break;
             }
         }
         return exist;
     }
 
-	@Override
-	public List<WorkflowStep> findSteps(WorkflowScheme scheme) throws DotDataException {
-		final DotConnect db = new DotConnect();
-		db.setSQL(sql.SELECT_STEPS_BY_SCHEME);
-		db.addParam(scheme.getId());
-		return this.convertListToObjects(db.loadObjectResults(), WorkflowStep.class);
+    @Override
+    public List<WorkflowStep> findSteps(WorkflowScheme scheme) throws DotDataException {
+        final DotConnect db = new DotConnect();
+        db.setSQL(sql.SELECT_STEPS_BY_SCHEME);
+        db.addParam(scheme.getId());
+        return this.convertListToObjects(db.loadObjectResults(), WorkflowStep.class);
 
-	}
+    }
 
-	@Override
-	public WorkflowTask findTaskByContentlet(final Contentlet contentlet) throws DotDataException {
+    @Override
+    public WorkflowTask findTaskByContentlet(final Contentlet contentlet) throws DotDataException {
 
-		WorkflowTask task = null;
+        WorkflowTask task = null;
 
-		if (!UtilMethods.isSet(contentlet.getIdentifier()) || cache.is404(contentlet)) {
-			return task;
-		}
+        if (!UtilMethods.isSet(contentlet.getIdentifier()) || cache.is404(contentlet)) {
+            return task;
+        }
 
-		task = cache.getTask(contentlet);
+        task = cache.getTask(contentlet);
 
-		if (task == null) {
+        if (task == null) {
 
-			final DotConnect db = new DotConnect();
-			db.setSQL(WorkflowSQL.SELECT_TASK);
-			db.addParam(contentlet.getIdentifier());
-			db.addParam(contentlet.getLanguageId());
+            final DotConnect db = new DotConnect();
+            db.setSQL(WorkflowSQL.SELECT_TASK);
+            db.addParam(contentlet.getIdentifier());
+            db.addParam(contentlet.getLanguageId());
 
-			List<WorkflowTask> foundTasks = this
-					.convertListToObjects(db.loadObjectResults(), WorkflowTask.class);
-			if (null != foundTasks && !foundTasks.isEmpty()) {
-				task = foundTasks.get(0);
-			}
+            List<WorkflowTask> foundTasks = this
+                    .convertListToObjects(db.loadObjectResults(), WorkflowTask.class);
+            if (null != foundTasks && !foundTasks.isEmpty()) {
+                task = foundTasks.get(0);
+            }
 
-			if (null != task && null != task.getId()) {
-				cache.addTask(contentlet, task);
-			} else {
-				cache.add404Task(contentlet);
-			}
-		}
+            if (null != task && null != task.getId()) {
+                cache.addTask(contentlet, task);
+            } else {
+                cache.add404Task(contentlet);
+            }
+        }
 
-		return task;
-	}
+        return task;
+    }
 
-	@Override
-	public WorkflowComment findWorkFlowCommentById(String id) throws DotDataException {
-		final HibernateUtil hu = new HibernateUtil(WorkflowComment.class);
-		hu.setQuery("from workflow_comment in class com.dotmarketing.portlets.workflows.model.WorkflowComment where id = ?");
-		hu.setParam(id);
-		return (WorkflowComment) hu.load();
-	}
+    @Override
+    public WorkflowComment findWorkFlowCommentById(String id) throws DotDataException {
+        final HibernateUtil hu = new HibernateUtil(WorkflowComment.class);
+        hu.setQuery(
+                "from workflow_comment in class com.dotmarketing.portlets.workflows.model.WorkflowComment where id = ?");
+        hu.setParam(id);
+        return (WorkflowComment) hu.load();
+    }
 
-	@Override
-	@SuppressWarnings("unchecked")
-	public List<WorkflowComment> findWorkFlowComments(WorkflowTask task) throws DotDataException {
-		final DotConnect dotConnect = new DotConnect();
-		dotConnect.setSQL("SELECT * FROM workflow_comment WHERE workflowtask_id = ? ORDER BY creation_date DESC");
-		dotConnect.addParam(task.getId());
-		final List<Map<String, Object>> results = dotConnect.loadObjectResults();
-		return TransformerLocator.createWorkflowCommentTransformer(results).asList();
-	}
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<WorkflowComment> findWorkFlowComments(WorkflowTask task) throws DotDataException {
+        final DotConnect dotConnect = new DotConnect();
+        dotConnect.setSQL(
+                "SELECT * FROM workflow_comment WHERE workflowtask_id = ? ORDER BY creation_date DESC");
+        dotConnect.addParam(task.getId());
+        final List<Map<String, Object>> results = dotConnect.loadObjectResults();
+        return TransformerLocator.createWorkflowCommentTransformer(results).asList();
+    }
 
-	@Override
-	@SuppressWarnings("unchecked")
-	public List<WorkflowHistory> findWorkflowHistory(WorkflowTask task) throws DotDataException {
-		final HibernateUtil hu = new HibernateUtil(WorkflowHistory.class);
-		hu.setQuery("from workflow_history in class com.dotmarketing.portlets.workflows.model.WorkflowHistory " + "where workflowtask_id = ? order by creation_date");
-		hu.setParam(task.getId());
-		return (List<WorkflowHistory>) hu.list();
-	}
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<WorkflowHistory> findWorkflowHistory(WorkflowTask task) throws DotDataException {
+        final HibernateUtil hu = new HibernateUtil(WorkflowHistory.class);
+        hu.setQuery(
+                "from workflow_history in class com.dotmarketing.portlets.workflows.model.WorkflowHistory "
+                        + "where workflowtask_id = ? order by creation_date");
+        hu.setParam(task.getId());
+        return (List<WorkflowHistory>) hu.list();
+    }
 
-	@Override
-	public WorkflowHistory findWorkFlowHistoryById(String id) throws DotDataException {
-		final HibernateUtil hu = new HibernateUtil(WorkflowHistory.class);
-		hu.setQuery("from workflow_history in class com.dotmarketing.portlets.workflows.model.WorkflowHistory where id = ?");
-		hu.setParam(id);
-		return (WorkflowHistory) hu.load();
-	}
+    @Override
+    public WorkflowHistory findWorkFlowHistoryById(String id) throws DotDataException {
+        final HibernateUtil hu = new HibernateUtil(WorkflowHistory.class);
+        hu.setQuery(
+                "from workflow_history in class com.dotmarketing.portlets.workflows.model.WorkflowHistory where id = ?");
+        hu.setParam(id);
+        return (WorkflowHistory) hu.load();
+    }
 
-	@Override
-	public WorkflowTask findWorkFlowTaskById(String id) throws DotDataException {
-		final HibernateUtil hu = new HibernateUtil(WorkflowTask.class);
-		hu.setQuery("from workflow_task in class com.dotmarketing.portlets.workflows.model.WorkflowTask where id = ?");
-		hu.setParam(id);
-		return (WorkflowTask) hu.load();
-	}
+    @Override
+    public WorkflowTask findWorkFlowTaskById(String id) throws DotDataException {
+        final HibernateUtil hu = new HibernateUtil(WorkflowTask.class);
+        hu.setQuery(
+                "from workflow_task in class com.dotmarketing.portlets.workflows.model.WorkflowTask where id = ?");
+        hu.setParam(id);
+        return (WorkflowTask) hu.load();
+    }
 
-	@SuppressWarnings("unchecked")
-	public List<Contentlet> findWorkflowTaskFilesAsContent(WorkflowTask task, User user) throws DotDataException {
-		final HibernateUtil hu = new HibernateUtil(WorkFlowTaskFiles.class);
-		hu.setQuery("from workflow_task_files in class com.dotmarketing.portlets.workflows.model.WorkFlowTaskFiles where workflowtask_id = ?");
-		hu.setParam(task.getId());
-		List<Contentlet> contents = new ArrayList<Contentlet>();
-		List<WorkFlowTaskFiles> l =  hu.list();
+    @SuppressWarnings("unchecked")
+    public List<Contentlet> findWorkflowTaskFilesAsContent(WorkflowTask task, User user)
+            throws DotDataException {
+        final HibernateUtil hu = new HibernateUtil(WorkFlowTaskFiles.class);
+        hu.setQuery(
+                "from workflow_task_files in class com.dotmarketing.portlets.workflows.model.WorkFlowTaskFiles where workflowtask_id = ?");
+        hu.setParam(task.getId());
+        List<Contentlet> contents = new ArrayList<Contentlet>();
+        List<WorkFlowTaskFiles> l = hu.list();
 
-		for (WorkFlowTaskFiles f : l) {
-			try {
-				contents.add(APILocator.getContentletAPI().find(f.getFileInode(), user, false));
-			} catch (DotSecurityException e) {
-				throw new DotDataException(e.getMessage(),e);
-			} catch(ClassCastException c) {
-				// not file as contentlet
-			}
+        for (WorkFlowTaskFiles f : l) {
+            try {
+                contents.add(APILocator.getContentletAPI().find(f.getFileInode(), user, false));
+            } catch (DotSecurityException e) {
+                throw new DotDataException(e.getMessage(), e);
+            } catch (ClassCastException c) {
+                // not file as contentlet
+            }
 
-		}
+        }
 
+        return contents;
+    }
 
-		return contents;
-	}
+    /**
+     * @param searcher
+     * @param counting
+     * @return
+     * @throws DotDataException
+     */
+    private DotConnect getWorkflowSqlQuery(WorkflowSearcher searcher, boolean counting)
+            throws DotDataException {
 
-	/**
-	 *
-	 * @param searcher
-	 * @param counting
-	 * @return
-	 * @throws DotDataException
-	 */
-	private DotConnect getWorkflowSqlQuery(WorkflowSearcher searcher, boolean counting) throws DotDataException {
+        DotConnect dc = new DotConnect();
+        final StringBuilder query = new StringBuilder();
 
-		DotConnect dc = new DotConnect();
-		final StringBuilder query = new StringBuilder();
-
-		if(counting)
+		if (counting) {
 			query.append("select count(*) as mycount from workflow_task ");
-		else
+		} else {
 			query.append("select workflow_task.*  from workflow_task ");
+		}
 
-
-		query.append(", workflow_scheme, workflow_step ");
-		query.append(" where  ");
-		if (UtilMethods.isSet(searcher.getKeywords())) {
-			query.append(" (lower(workflow_task.title) like ? or ");
-			if(DbConnectionFactory.isMsSql())
-				query.append(" lower(cast(workflow_task.description as varchar(max))) like ? )  and ");
-			else
+        query.append(", workflow_scheme, workflow_step ");
+        query.append(" where  ");
+        if (UtilMethods.isSet(searcher.getKeywords())) {
+            query.append(" (lower(workflow_task.title) like ? or ");
+			if (DbConnectionFactory.isMsSql()) {
+				query.append(
+						" lower(cast(workflow_task.description as varchar(max))) like ? )  and ");
+			} else {
 				query.append(" lower(workflow_task.description) like ? )  and ");
-		}
-
-		if(!searcher.getShow4All() || !(APILocator.getRoleAPI().doesUserHaveRole(searcher.getUser(), APILocator.getRoleAPI().loadCMSAdminRole())
-				|| APILocator.getRoleAPI().doesUserHaveRole(searcher.getUser(),RoleAPI.WORKFLOW_ADMIN_ROLE_KEY))) {
-			final List<Role> userRoles = new ArrayList<Role>();
-			if (UtilMethods.isSet(searcher.getAssignedTo())) {
-
-
-				final Role r = APILocator.getRoleAPI().loadRoleById(searcher.getAssignedTo());
-				if(r!=null)userRoles.add(r);
-			} else {
-				userRoles.addAll(APILocator.getRoleAPI().loadRolesForUser(searcher.getUser().getUserId(), false));
-				userRoles.add(APILocator.getRoleAPI().getUserRole(searcher.getUser()));
-
 			}
+        }
 
-			String rolesString = "";
+        if (!searcher.getShow4All() || !(APILocator.getRoleAPI()
+                .doesUserHaveRole(searcher.getUser(), APILocator.getRoleAPI().loadCMSAdminRole())
+                || APILocator.getRoleAPI()
+                .doesUserHaveRole(searcher.getUser(), RoleAPI.WORKFLOW_ADMIN_ROLE_KEY))) {
+            final List<Role> userRoles = new ArrayList<Role>();
+            if (UtilMethods.isSet(searcher.getAssignedTo())) {
 
-			for (final Role role : userRoles) {
-				if (!rolesString.equals("")) {
-					rolesString += ",";
+                final Role r = APILocator.getRoleAPI().loadRoleById(searcher.getAssignedTo());
+				if (r != null) {
+					userRoles.add(r);
 				}
-				rolesString += "'" + role.getId() + "'";
-			}
+            } else {
+                userRoles.addAll(APILocator.getRoleAPI()
+                        .loadRolesForUser(searcher.getUser().getUserId(), false));
+                userRoles.add(APILocator.getRoleAPI().getUserRole(searcher.getUser()));
 
-			if(rolesString.length()>0){
-				query.append(" ( workflow_task.assigned_to in (" + rolesString + ")  ) and ");
-			}
-		}
-		query.append(" workflow_step.id = workflow_task.status and workflow_step.scheme_id = workflow_scheme.id and ");
+            }
 
-		if(searcher.getDaysOld()!=-1) {
-			if(DbConnectionFactory.isMySql())
+            String rolesString = "";
+
+            for (final Role role : userRoles) {
+                if (!rolesString.equals("")) {
+                    rolesString += ",";
+                }
+                rolesString += "'" + role.getId() + "'";
+            }
+
+            if (rolesString.length() > 0) {
+                query.append(" ( workflow_task.assigned_to in (" + rolesString + ")  ) and ");
+            }
+        }
+        query.append(
+                " workflow_step.id = workflow_task.status and workflow_step.scheme_id = workflow_scheme.id and ");
+
+        if (searcher.getDaysOld() != -1) {
+			if (DbConnectionFactory.isMySql()) {
 				query.append(" datediff(now(),workflow_task.creation_date)>=?");
-			else if(DbConnectionFactory.isPostgres())
+			} else if (DbConnectionFactory.isPostgres()) {
 				query.append(" extract(day from (now()-workflow_task.creation_date))>=?");
-			else if(DbConnectionFactory.isMsSql())
+			} else if (DbConnectionFactory.isMsSql()) {
 				query.append(" datediff(d,workflow_task.creation_date,GETDATE())>=?");
-			else if(DbConnectionFactory.isOracle())
+			} else if (DbConnectionFactory.isOracle()) {
 				query.append(" floor(sysdate-workflow_task.creation_date)>=?");
-
-			query.append(" and ");
-		}
-
-		if (!searcher.isClosed() && searcher.isOpen()) {
-			query.append("  workflow_step.resolved = " + DbConnectionFactory.getDBFalse() + " and ");
-		} else if (searcher.isClosed() && !searcher.isOpen()) {
-			query.append(" workflow_step.resolved = " + DbConnectionFactory.getDBTrue() + " and ");
-		}
-
-		if (UtilMethods.isSet(searcher.getSchemeId())) {
-			query.append(" workflow_scheme.id = ? and ");
-		}
-
-		if (UtilMethods.isSet(searcher.getStepId())) {
-			query.append(" workflow_step.id = ? and ");
-		}
-
-		query.append(" 1=1  ");
-		if (!counting) {
-			query.append(" order by ");
-			String orderby="";
-			if (!UtilMethods.isSet(searcher.getStepId())) {
-				// condition.append(" status , ");
-			}
-			if (UtilMethods.isSet(searcher.getOrderBy())) {
-				orderby=searcher.getOrderBy().replaceAll("[^\\w_\\. ]", "");
-			} else {
-
-				orderby="mod_date desc";
-			}
-			query.append(orderby.replace("mod_date", "workflow_task.mod_date"));
-		}
-
-		dc.setSQL(query.toString());
-
-		// now we need to add the params
-
-		if (UtilMethods.isSet(searcher.getKeywords())) {
-			dc.addParam("%" + searcher.getKeywords().trim().toLowerCase() + "%");
-			dc.addParam("%" + searcher.getKeywords().trim().toLowerCase() + "%");
-		}
-
-		if(searcher.getDaysOld()!=-1) {
-			dc.addParam(searcher.getDaysOld());
-		}
-
-		if (UtilMethods.isSet(searcher.getSchemeId())) {
-			dc.addParam(searcher.getSchemeId());
-		}
-
-		if (UtilMethods.isSet(searcher.getStepId())) {
-			dc.addParam(searcher.getStepId());
-		}
-
-		return dc;
-
-	}
-
-	@Override
-	public void removeAttachedFile(WorkflowTask task, String fileInode) throws DotDataException {
-		final String query = "delete from workflowtask_files where workflowtask_id = ? and file_inode = ?";
-		final DotConnect dc = new DotConnect();
-		dc.setSQL(query);
-		dc.addParam(task.getId());
-		dc.addParam(fileInode);
-		dc.loadResult();
-
-	}
-
-	/**
-	 *
-	 * @param actionId
-	 * @return
-	 */
-	public boolean existsAction (final String actionId) {
-
-		boolean exists = false;
-
-		try {
-
-			exists = null != this.findAction(actionId);
-		} catch (final Exception e) {
-			Logger.debug(this.getClass(), e.getMessage(), e);
-		}
-
-		return exists;
-	} // existsAction.
-
-	@Override
-	public void saveAction(final WorkflowAction workflowAction,
-						   final WorkflowStep workflowStep)  throws DotDataException,AlreadyExistException {
-
-		this.saveAction(workflowAction, workflowStep, 0);
-	} // saveAction
-
-	/////////
-	@Override
-	public List<Map<String, Object>> findSystemActionsByContentType(final ContentType contentType) throws DotDataException {
-
-		List<Map<String, Object>> results = this.cache.findSystemActionsByContentType(contentType.variable());
-		if (null == results) {
-
-			results = new DotConnect().setSQL(sql.SELECT_SYSTEM_ACTION_BY_SCHEME_OR_CONTENT_TYPE_MAPPING)
-						.addParam(contentType.variable())
-						.loadObjectResults();
-
-			this.cache.addSystemActionsByContentType(contentType.variable(),
-					UtilMethods.isSet(results)?results:Collections.emptyList());
-		}
-
-		return results;
-	}
-
-	@Override
-	public Map<String, List<Map<String, Object>>> findSystemActionsMapByContentType(final List<ContentType> contentTypes)  throws DotDataException {
-
-		final ImmutableMap.Builder<String ,List<Map<String, Object>>> mappingMapBuilder = new ImmutableMap.Builder<>();
-		final String selectQueryTemplate = sql.SELECT_SYSTEM_ACTION_BY_CONTENT_TYPES;
-		final Set<String> notFoundContentTypes = new HashSet<>();
-
-		for (final ContentType contentType: contentTypes) {
-
-			final String variable = contentType.variable();
-			final List<Map<String, Object>> results = this.cache.findSystemActionsByContentType(contentType.variable());
-			if (null != results) {
-
-				mappingMapBuilder.put(variable, results);
-			} else {
-
-				notFoundContentTypes.add(variable);
-			}
-		}
-
-		if (!notFoundContentTypes.isEmpty()) {
-
-			findSystemActionsMapByContentType(mappingMapBuilder, selectQueryTemplate, notFoundContentTypes);
-		}
-
-		return mappingMapBuilder.build();
-	}
-
-	private void findSystemActionsMapByContentType(final ImmutableMap.Builder<String, List<Map<String, Object>>> mappingMapBuilder,
-												   final String selectQueryTemplate,
-												   final Set<String> notFoundContentTypesSet) throws DotDataException {
-
-		final List<List<String>> notFoundContentTypesListOfList = Lists.partition
-				(new ArrayList<>(notFoundContentTypesSet), 100); // select in does not support more than 100
-
-		for (final List<String> notFoundContentTypes: notFoundContentTypesListOfList) {
-
-			final DotConnect dotConnect = new DotConnect()
-					.setSQL(String.format(selectQueryTemplate, this.createQueryIn(notFoundContentTypes)));
-
-			notFoundContentTypes.stream().forEach(dotConnect::addObject);
-
-			final List<Map<String, Object>> mappingRows = dotConnect.loadObjectResults();
-
-			if (!mappingRows.isEmpty()) {
-
-				final Map<String, List<Map<String, Object>>> dbMappingMap = new HashMap<>();
-
-				for (final Map<String, Object> rowMap : mappingRows) {
-
-					final String variable = (String) rowMap.get("scheme_or_content_type");
-					dbMappingMap.computeIfAbsent(variable, key -> new ArrayList<>()).add(rowMap);
-				}
-
-				for (final Map.Entry<String, List<Map<String, Object>>> contentTypeResultsEntry : dbMappingMap.entrySet()) {
-
-					final String variable = contentTypeResultsEntry.getKey();
-					final List<Map<String, Object>> results = contentTypeResultsEntry.getValue();
-					this.cache.addSystemActionsByContentType(variable,
-							UtilMethods.isSet(results)?results:Collections.emptyList());
-				}
-
-				mappingMapBuilder.putAll(dbMappingMap);
-			}
-		}
-	}
-
-	/**
-	 * Finds the {@link com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction}'s by {@link WorkflowScheme}
-	 * @param workflowScheme {@link WorkflowScheme}
-	 * @return List of Rows
-	 */
-	@Override
-	public List<Map<String, Object>> findSystemActionsByScheme(final WorkflowScheme workflowScheme) throws DotDataException {
-
-		List<Map<String, Object>> results = this.cache.findSystemActionsByScheme(workflowScheme.getId());
-		if (null == results) {
-
-			results = new DotConnect()
-					.setSQL(sql.SELECT_SYSTEM_ACTION_BY_SCHEME_OR_CONTENT_TYPE_MAPPING)
-					.addParam(workflowScheme.getId())
-					.loadObjectResults();
-
-			this.cache.addSystemActionsByScheme(workflowScheme.getId(),
-					UtilMethods.isSet(results)?results:Collections.emptyList());
-		}
-
-		return results;
-	}
-
-	@Override
-	public List<Map<String, Object>> findSystemActionsByWorkflowAction(final WorkflowAction workflowAction) throws DotDataException {
-
-		List<Map<String, Object>> results = this.cache.findSystemActionsByWorkflowAction(workflowAction.getId());
-		if (null == results) {
-
-			results = new DotConnect()
-					.setSQL(sql.SELECT_SYSTEM_ACTION_BY_WORKFLOW_ACTION)
-					.addParam(workflowAction.getId())
-					.loadObjectResults();
-
-			this.cache.addSystemActionsByWorkflowAction(workflowAction.getId(),
-					UtilMethods.isSet(results)?results:Collections.emptyList());
-		}
-
-		return results;
-	}
-
-	/**
-	 * Finds the {@link SystemActionWorkflowActionMapping}  associated to the {@link com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction}
-	 * and {@link ContentType}
-	 * @param systemAction  {@link com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction}
-	 * @param contentType   {@link ContentType}
-	 * @return Map<String, Object>
-	 */
-	@Override
-	public Map<String, Object> findSystemActionByContentType(final WorkflowAPI.SystemAction systemAction, final ContentType contentType) throws DotDataException {
-
-		Map<String, Object> mappingRow = this.cache.findSystemActionByContentType(systemAction.name(), contentType.variable());
-		if (!UtilMethods.isSet(mappingRow)) {
-
-			final List<Map<String, Object>> rows = new DotConnect()
-					.setSQL(sql.SELECT_SYSTEM_ACTION_BY_SYSTEM_ACTION_AND_SCHEME_OR_CONTENT_TYPE_MAPPING)
-					.addParam(systemAction.name())
-					.addParam(contentType.variable())
-					.loadObjectResults();
-
-			if (UtilMethods.isSet(rows)) {
-
-				mappingRow = rows.get(0);
 			}
 
-			this.cache.addSystemActionBySystemActionNameAndContentTypeVariable(
-					systemAction.name(), contentType.variable(),
-					UtilMethods.isSet(mappingRow)?mappingRow:Collections.emptyMap());
-		}
+            query.append(" and ");
+        }
+
+        if (!searcher.isClosed() && searcher.isOpen()) {
+            query.append(
+                    "  workflow_step.resolved = " + DbConnectionFactory.getDBFalse() + " and ");
+        } else if (searcher.isClosed() && !searcher.isOpen()) {
+            query.append(" workflow_step.resolved = " + DbConnectionFactory.getDBTrue() + " and ");
+        }
+
+        if (UtilMethods.isSet(searcher.getSchemeId())) {
+            query.append(" workflow_scheme.id = ? and ");
+        }
+
+        if (UtilMethods.isSet(searcher.getStepId())) {
+            query.append(" workflow_step.id = ? and ");
+        }
+
+        query.append(" 1=1  ");
+        if (!counting) {
+            query.append(" order by ");
+            String orderby = "";
+            if (!UtilMethods.isSet(searcher.getStepId())) {
+                // condition.append(" status , ");
+            }
+            if (UtilMethods.isSet(searcher.getOrderBy())) {
+                orderby = searcher.getOrderBy().replaceAll("[^\\w_\\. ]", "");
+            } else {
+
+                orderby = "mod_date desc";
+            }
+            query.append(orderby.replace("mod_date", "workflow_task.mod_date"));
+        }
+
+        dc.setSQL(query.toString());
+
+        // now we need to add the params
+
+        if (UtilMethods.isSet(searcher.getKeywords())) {
+            dc.addParam("%" + searcher.getKeywords().trim().toLowerCase() + "%");
+            dc.addParam("%" + searcher.getKeywords().trim().toLowerCase() + "%");
+        }
+
+        if (searcher.getDaysOld() != -1) {
+            dc.addParam(searcher.getDaysOld());
+        }
+
+        if (UtilMethods.isSet(searcher.getSchemeId())) {
+            dc.addParam(searcher.getSchemeId());
+        }
+
+        if (UtilMethods.isSet(searcher.getStepId())) {
+            dc.addParam(searcher.getStepId());
+        }
+
+        return dc;
 
-		return mappingRow;
-	}
+    }
 
-	/**
-	 * Finds the list of {@link SystemActionWorkflowActionMapping}  associated to the {@link com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction}
-	 * and {@link List} of {@link WorkflowScheme}'s
-	 * @param systemAction {@link com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction}
-	 * @param schemesList  {@link List} of {@link WorkflowScheme}'s
-	 * @return List<Map<String, Object>>
-	 */
-	@Override
-	public List<Map<String, Object>> findSystemActionsBySchemes(final WorkflowAPI.SystemAction systemAction, final List<WorkflowScheme> schemesList) throws DotDataException {
+    @Override
+    public void removeAttachedFile(WorkflowTask task, String fileInode) throws DotDataException {
+        final String query = "delete from workflowtask_files where workflowtask_id = ? and file_inode = ?";
+        final DotConnect dc = new DotConnect();
+        dc.setSQL(query);
+        dc.addParam(task.getId());
+        dc.addParam(fileInode);
+        dc.loadResult();
 
-		final List<String> schemeIdList   = schemesList.stream().map(WorkflowScheme::getId).collect(Collectors.toList());
-		List<Map<String, Object>> results = this.cache.findSystemActionsBySchemes(systemAction.name(), schemeIdList);
+    }
 
-		if (null == results) {
+    /**
+     * @param actionId
+     * @return
+     */
+    public boolean existsAction(final String actionId) {
 
-			if (UtilMethods.isSet(schemesList)) {
+        boolean exists = false;
 
-				final List<List<WorkflowScheme>> schemeListOfList =
-						Lists.partition(schemesList, PARTITION_IN_SIZE); // select in does not support more than 100.
-				results = new ArrayList<>();
+        try {
 
-				for (final List<WorkflowScheme> schemes : schemeListOfList) {
+            exists = null != this.findAction(actionId);
+        } catch (final Exception e) {
+            Logger.debug(this.getClass(), e.getMessage(), e);
+        }
 
-					final DotConnect dotConnect = new DotConnect()
-							.setSQL(String.format(sql.SELECT_SYSTEM_ACTION_BY_SYSTEM_ACTION_AND_SCHEMES, this.createQueryIn(schemes)))
-							.addParam(systemAction.name());
+        return exists;
+    } // existsAction.
 
-					for (final WorkflowScheme scheme : schemes) {
+    @Override
+    public void saveAction(final WorkflowAction workflowAction,
+            final WorkflowStep workflowStep) throws DotDataException, AlreadyExistException {
 
-						dotConnect.addParam(scheme.getId());
-					}
+        this.saveAction(workflowAction, workflowStep, 0);
+    } // saveAction
 
-					results.addAll(dotConnect.loadObjectResults());
-				}
+    /////////
+    @Override
+    public List<Map<String, Object>> findSystemActionsByContentType(final ContentType contentType)
+            throws DotDataException {
 
-				if (UtilMethods.isSet(results)) {
+        List<Map<String, Object>> results = this.cache.findSystemActionsByContentType(
+                contentType.variable());
+        if (null == results) {
 
-					this.cache.addSystemActionsBySystemActionNameAndSchemeIds(
-							systemAction.name(), schemeIdList, results);
-				}
-			}
-		}
+            results = new DotConnect().setSQL(
+                            sql.SELECT_SYSTEM_ACTION_BY_SCHEME_OR_CONTENT_TYPE_MAPPING)
+                    .addParam(contentType.variable())
+                    .loadObjectResults();
 
-		return results;
-	}
+            this.cache.addSystemActionsByContentType(contentType.variable(),
+                    UtilMethods.isSet(results) ? results : Collections.emptyList());
+        }
 
-	@Override
-	public Map<String, Object> findSystemActionByIdentifier(final String identifier) throws DotDataException {
+        return results;
+    }
 
-		final List<Map<String, Object>> rows = new DotConnect().setSQL(sql.SELECT_SYSTEM_ACTION_BY_IDENTIFIER)
-				.addParam(identifier)
-				.loadObjectResults();
-		return UtilMethods.isSet(rows) ? rows.get(0) : Collections.emptyMap();
-	}
+    @Override
+    public Map<String, List<Map<String, Object>>> findSystemActionsMapByContentType(
+            final List<ContentType> contentTypes) throws DotDataException {
 
-	@Override
-	public boolean deleteSystemAction(final SystemActionWorkflowActionMapping mapping) throws DotDataException {
+        final ImmutableMap.Builder<String, List<Map<String, Object>>> mappingMapBuilder = new ImmutableMap.Builder<>();
+        final String selectQueryTemplate = sql.SELECT_SYSTEM_ACTION_BY_CONTENT_TYPES;
+        final Set<String> notFoundContentTypes = new HashSet<>();
 
-		new DotConnect().setSQL(sql.DELETE_SYSTEM_ACTION_BY_IDENTIFIER)
-				.addParam(mapping.getIdentifier())
-				.loadResult();
+        for (final ContentType contentType : contentTypes) {
 
-		this.cache.removeSystemActionWorkflowActionMapping(mapping);
+            final String variable = contentType.variable();
+            final List<Map<String, Object>> results = this.cache.findSystemActionsByContentType(
+                    contentType.variable());
+            if (null != results) {
 
-		return true; //  todo: if rows affected 0 -> false
-	}
+                mappingMapBuilder.put(variable, results);
+            } else {
 
-	@Override
-	public void deleteSystemActionsByWorkflowAction(final WorkflowAction action) throws DotDataException {
+                notFoundContentTypes.add(variable);
+            }
+        }
 
-		Logger.debug(this, ()->"Removing system action mappings associated to the action: " + action.getId());
+        if (!notFoundContentTypes.isEmpty()) {
 
-		final List<Map<String, Object>> mappingsToClean = new DotConnect().setSQL(sql.SELECT_SYSTEM_ACTION_BY_WORKFLOW_ACTION).
-				addParam(action.getId())
-				.loadObjectResults();
+            findSystemActionsMapByContentType(mappingMapBuilder, selectQueryTemplate,
+                    notFoundContentTypes);
+        }
 
-		new DotConnect().setSQL(sql.DELETE_SYSTEM_ACTION_BY_WORKFLOW_ACTION_ID)
-				.addParam(action.getId())
-				.loadResult();
+        return mappingMapBuilder.build();
+    }
+
+    private void findSystemActionsMapByContentType(
+            final ImmutableMap.Builder<String, List<Map<String, Object>>> mappingMapBuilder,
+            final String selectQueryTemplate,
+            final Set<String> notFoundContentTypesSet) throws DotDataException {
+
+        final List<List<String>> notFoundContentTypesListOfList = Lists.partition
+                (new ArrayList<>(notFoundContentTypesSet),
+                        100); // select in does not support more than 100
+
+        for (final List<String> notFoundContentTypes : notFoundContentTypesListOfList) {
+
+            final DotConnect dotConnect = new DotConnect()
+                    .setSQL(String.format(selectQueryTemplate,
+                            this.createQueryIn(notFoundContentTypes)));
+
+            notFoundContentTypes.stream().forEach(dotConnect::addObject);
+
+            final List<Map<String, Object>> mappingRows = dotConnect.loadObjectResults();
+
+            if (!mappingRows.isEmpty()) {
+
+                final Map<String, List<Map<String, Object>>> dbMappingMap = new HashMap<>();
+
+                for (final Map<String, Object> rowMap : mappingRows) {
+
+                    final String variable = (String) rowMap.get("scheme_or_content_type");
+                    dbMappingMap.computeIfAbsent(variable, key -> new ArrayList<>()).add(rowMap);
+                }
+
+                for (final Map.Entry<String, List<Map<String, Object>>> contentTypeResultsEntry : dbMappingMap.entrySet()) {
+
+                    final String variable = contentTypeResultsEntry.getKey();
+                    final List<Map<String, Object>> results = contentTypeResultsEntry.getValue();
+                    this.cache.addSystemActionsByContentType(variable,
+                            UtilMethods.isSet(results) ? results : Collections.emptyList());
+                }
+
+                mappingMapBuilder.putAll(dbMappingMap);
+            }
+        }
+    }
+
+    /**
+     * Finds the {@link com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction}'s by
+     * {@link WorkflowScheme}
+     *
+     * @param workflowScheme {@link WorkflowScheme}
+     * @return List of Rows
+     */
+    @Override
+    public List<Map<String, Object>> findSystemActionsByScheme(final WorkflowScheme workflowScheme)
+            throws DotDataException {
+
+        List<Map<String, Object>> results = this.cache.findSystemActionsByScheme(
+                workflowScheme.getId());
+        if (null == results) {
+
+            results = new DotConnect()
+                    .setSQL(sql.SELECT_SYSTEM_ACTION_BY_SCHEME_OR_CONTENT_TYPE_MAPPING)
+                    .addParam(workflowScheme.getId())
+                    .loadObjectResults();
+
+            this.cache.addSystemActionsByScheme(workflowScheme.getId(),
+                    UtilMethods.isSet(results) ? results : Collections.emptyList());
+        }
+
+        return results;
+    }
+
+    @Override
+    public List<Map<String, Object>> findSystemActionsByWorkflowAction(
+            final WorkflowAction workflowAction) throws DotDataException {
+
+        List<Map<String, Object>> results = this.cache.findSystemActionsByWorkflowAction(
+                workflowAction.getId());
+        if (null == results) {
+
+            results = new DotConnect()
+                    .setSQL(sql.SELECT_SYSTEM_ACTION_BY_WORKFLOW_ACTION)
+                    .addParam(workflowAction.getId())
+                    .loadObjectResults();
+
+            this.cache.addSystemActionsByWorkflowAction(workflowAction.getId(),
+                    UtilMethods.isSet(results) ? results : Collections.emptyList());
+        }
+
+        return results;
+    }
+
+    /**
+     * Finds the {@link SystemActionWorkflowActionMapping}  associated to the
+     * {@link com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction} and
+     * {@link ContentType}
+     *
+     * @param systemAction {@link
+     *                     com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction}
+     * @param contentType  {@link ContentType}
+     * @return Map<String, Object>
+     */
+    @Override
+    public Map<String, Object> findSystemActionByContentType(
+            final WorkflowAPI.SystemAction systemAction, final ContentType contentType)
+            throws DotDataException {
+
+        Map<String, Object> mappingRow = this.cache.findSystemActionByContentType(
+                systemAction.name(), contentType.variable());
+        if (!UtilMethods.isSet(mappingRow)) {
+
+            final List<Map<String, Object>> rows = new DotConnect()
+                    .setSQL(sql.SELECT_SYSTEM_ACTION_BY_SYSTEM_ACTION_AND_SCHEME_OR_CONTENT_TYPE_MAPPING)
+                    .addParam(systemAction.name())
+                    .addParam(contentType.variable())
+                    .loadObjectResults();
+
+            if (UtilMethods.isSet(rows)) {
+
+                mappingRow = rows.get(0);
+            }
+
+            this.cache.addSystemActionBySystemActionNameAndContentTypeVariable(
+                    systemAction.name(), contentType.variable(),
+                    UtilMethods.isSet(mappingRow) ? mappingRow : Collections.emptyMap());
+        }
+
+        return mappingRow;
+    }
+
+    /**
+     * Finds the list of {@link SystemActionWorkflowActionMapping}  associated to the
+     * {@link com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction} and
+     * {@link List} of {@link WorkflowScheme}'s
+     *
+     * @param systemAction {@link
+     *                     com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction}
+     * @param schemesList  {@link List} of {@link WorkflowScheme}'s
+     * @return List<Map < String, Object>>
+     */
+    @Override
+    public List<Map<String, Object>> findSystemActionsBySchemes(
+            final WorkflowAPI.SystemAction systemAction, final List<WorkflowScheme> schemesList)
+            throws DotDataException {
 
-		this.cache.removeSystemActionsByWorkflowAction(action.getId());
+        final List<String> schemeIdList = schemesList.stream().map(WorkflowScheme::getId)
+                .collect(Collectors.toList());
+        List<Map<String, Object>> results = this.cache.findSystemActionsBySchemes(
+                systemAction.name(), schemeIdList);
 
-		if (UtilMethods.isSet(mappingsToClean)) {
+        if (null == results && UtilMethods.isSet(schemesList)) {
 
-			for (final Map<String, Object> mappingRow : mappingsToClean) {
+            final List<List<WorkflowScheme>> schemeListOfList =
+                    Lists.partition(schemesList,
+                            PARTITION_IN_SIZE); // select in does not support more than 100.
+            results = new ArrayList<>();
 
-				final String owner = (String)mappingRow.get("scheme_or_content_type");
-				this.cache.removeSystemActionsByContentType(owner);
-				this.cache.removeSystemActionsByScheme(owner);
-			}
-		}
-	}
+            for (final List<WorkflowScheme> schemes : schemeListOfList) {
 
-	private String createQueryIn (final Collection list) {
-
-		final StringBuilder builder = new StringBuilder();
-
-		for (int i = 0; i < list.size(); ++i) {
-
-			builder.append("?");
-			if (i < list.size() -1) {
-
-				builder.append(",");
-			}
-		}
-
-		return builder.toString();
-	}
-
-
-	@Override
-	public SystemActionWorkflowActionMapping saveSystemActionWorkflowActionMapping(final SystemActionWorkflowActionMapping mapping) throws DotDataException  {
-
-		final String ownerKey = this.getOwnerKey (mapping, mapping.getOwner());
-		SystemActionWorkflowActionMapping toReturn = mapping;
-
-		final List<Map<String, Object>> existsRow =
-				new DotConnect().setSQL(sql.SELECT_SYSTEM_ACTION_BY_SYSTEM_ACTION_AND_SCHEME_OR_CONTENT_TYPE_MAPPING)
-				.addParam(mapping.getSystemAction().name())
-				.addParam(ownerKey)
-				.loadObjectResults();
-
-		if (!UtilMethods.isSet(existsRow)) {
-
-			new DotConnect().setSQL(sql.INSERT_SYSTEM_ACTION_WORKFLOW_ACTION_MAPPING)
-					.addParam(mapping.getIdentifier())
-					.addParam(mapping.getSystemAction().name())
-					.addParam(mapping.getWorkflowAction().getId())
-					.addParam(ownerKey)
-					.loadResult();
-		} else {
-
-			// if exists, we override the id and update.
-			final String existingId = (String)existsRow.get(0).get("id");
-			toReturn = new SystemActionWorkflowActionMapping(existingId,
-					mapping.getSystemAction(),
-					mapping.getWorkflowAction(),
-					mapping.getOwner());
-
-			new DotConnect().setSQL(sql.UPDATE_SYSTEM_ACTION_WORKFLOW_ACTION_MAPPING)
-					.addParam(mapping.getSystemAction().name())
-					.addParam(mapping.getWorkflowAction().getId())
-					.addParam(ownerKey)
-					.addParam(existingId)
-					.loadResult();
-		}
-
-		this.cache.removeSystemActionWorkflowActionMapping(mapping);
-
-		return toReturn;
-	}
-
-	/*
-	* The owner could be a ContentType (variable) or WorkflowScheme (identifier)
-	*/
-	private String getOwnerKey (final SystemActionWorkflowActionMapping mapping, final Object ownerContentTypeOrScheme) {
-
-		return mapping.isOwnerContentType()?
-			ContentType.class.cast(ownerContentTypeOrScheme).variable():
-			WorkflowScheme.class.cast(ownerContentTypeOrScheme).getId();
-	}
-
-	///////
-
-	@Override
-	public void saveAction(final WorkflowAction workflowAction,
-						   final WorkflowStep workflowStep,
-						   final int order)  throws DotDataException,AlreadyExistException {
-
-		boolean isNew = true;
-		if (UtilMethods.isSet(workflowAction.getId()) && UtilMethods.isSet(workflowStep.getId())) {
-			isNew = (null == findAction(workflowAction.getId(), workflowStep.getId()));
-		}
-		if (isNew) {
-			new DotConnect().setSQL(sql.INSERT_ACTION_FOR_STEP)
-					.addParam(workflowAction.getId())
-					.addParam(workflowStep.getId())
-					.addParam(order)
-					.loadResult();
-		} else {
-			new DotConnect().setSQL(sql.UPDATE_ACTION_FOR_STEP_ORDER)
-					.addParam(order)
-					.addParam(workflowAction.getId())
-					.addParam(workflowStep.getId())
-					.loadResult();
-		}
-
-		final WorkflowStep proxyStep = new WorkflowStep();
-		proxyStep.setId(workflowStep.getId());
-		cache.removeActions(proxyStep);
-
-		final WorkflowScheme proxyScheme = new WorkflowScheme();
-		proxyScheme.setId(workflowAction.getSchemeId());
-		cache.removeActions(proxyScheme);
-
-		// update workflowScheme mod date
-		final WorkflowScheme scheme = findScheme(workflowAction.getSchemeId());
-		saveScheme(scheme);
-	} // saveAction.
-
-	@Override
-	public void updateOrder(final WorkflowAction workflowAction,
-							final WorkflowStep workflowStep,
-							final int order)  throws DotDataException,AlreadyExistException {
-
-		new DotConnect().setSQL(sql.UPDATE_ACTION_FOR_STEP_ORDER)
-				.addParam(order)
-				.addParam(workflowAction.getId())
-				.addParam(workflowStep.getId())
-				.loadResult();
-
-		final WorkflowStep proxyStep = new WorkflowStep();
-		proxyStep.setId(workflowStep.getId());
-		cache.removeActions(proxyStep);
-
-		final WorkflowScheme proxyScheme = new WorkflowScheme();
-		proxyScheme.setId(workflowAction.getSchemeId());
-		cache.removeActions(proxyScheme);
-
-		// update workflowScheme mod date
-		final WorkflowScheme scheme = findScheme(workflowAction.getSchemeId());
-		saveScheme(scheme);
-	} // updateOrder.
-
-	/**
-	 *
-	 * @param workflowAction
-	 * @return
-	 */
-	private String getNextStep (final WorkflowAction workflowAction) {
-
-		return (!UtilMethods.isSet(workflowAction.getNextStep()))?
-				WorkflowAction.CURRENT_STEP: workflowAction.getNextStep();
-	}
-
-	@Override
-	public void saveAction(final WorkflowAction action) throws DotDataException,AlreadyExistException {
-
-		boolean isNew = true;
-		if (UtilMethods.isSet(action.getId())) {
-
-			isNew = !this.existsAction(action.getId());
-		} else {
-			action.setId(UUIDGenerator.generateUuid());
-		}
-
-		final String     nextStep = this.getNextStep(action);
-		final DotConnect db       = new DotConnect();
-		if (isNew) {
-			db.setSQL(sql.INSERT_ACTION);
-			db.addParam(action.getId());
-			db.addParam(action.getSchemeId());
-			db.addParam(action.getName());
-			db.addParam(action.getCondition());
-			db.addParam(nextStep);
-			db.addParam(action.getNextAssign());
-			db.addParam(action.getOrder());
-			db.addParam(action.isAssignable());
-			db.addParam(action.isCommentable());
-			db.addParam(action.getIcon());
-			db.addParam(action.isRoleHierarchyForAssign());
-			db.addParam(action.isRequiresCheckout());
-			db.addParam(WorkflowState.toCommaSeparatedString(action.getShowOn()));
-			db.loadResult();
-		} else {
-			db.setSQL(sql.UPDATE_ACTION);
-			db.addParam(action.getSchemeId());
-			db.addParam(action.getName());
-			db.addParam(action.getCondition());
-			db.addParam(nextStep);
-			db.addParam(action.getNextAssign());
-			db.addParam(action.getOrder());
-			db.addParam(action.isAssignable());
-			db.addParam(action.isCommentable());
-			db.addParam(action.getIcon());
-			db.addParam(action.isRoleHierarchyForAssign());
-			db.addParam(action.isRequiresCheckout());
-			db.addParam(WorkflowState.toCommaSeparatedString(action.getShowOn()));
-			db.addParam(action.getId());
-			db.loadResult();
-		}
-
-		final List<WorkflowStep> relatedProxiesSteps =
-				this.findProxiesSteps(action);
-		relatedProxiesSteps.forEach( cache::removeActions );
-
-		final WorkflowScheme proxyScheme = new WorkflowScheme();
-		proxyScheme.setId(action.getSchemeId());
-		cache.removeActions(proxyScheme);
-
-		// update workflowScheme mod date
-		final WorkflowScheme scheme = findScheme(action.getSchemeId());
-		saveScheme(scheme);
-
-	}
-
-	/**
-	 *
-	 * @param action
-	 * @return
-	 * @throws DotDataException
-	 */
-	public List<WorkflowStep> findProxiesSteps(final WorkflowAction action) throws DotDataException {
-
-		final ImmutableList.Builder<WorkflowStep> stepsBuilder =
-				new ImmutableList.Builder<>();
-
-		final List<Map<String, Object>> stepIdList =
-				new DotConnect().setSQL(sql.SELECT_STEPS_ID_BY_ACTION)
-						.addParam(action.getId()).loadObjectResults();
-
-		if (null != stepIdList) {
-
-			stepIdList.forEach( mapRow ->  stepsBuilder.add
-					(this.buildProxyWorkflowStep((String)mapRow.get("stepid"))) );
-		}
-
-		return stepsBuilder.build();
-	}
-
-	/**
-	 *
-	 * @param stepId
-	 * @return
-	 */
-	private WorkflowStep buildProxyWorkflowStep (final String stepId) {
-
-		final WorkflowStep proxyWorkflowStep =
-				new WorkflowStep();
-
-		proxyWorkflowStep.setId(stepId);
-
-		return proxyWorkflowStep;
-	}
-
-	@Override
-	public void saveActionClass(final WorkflowActionClass actionClass) throws DotDataException,AlreadyExistException {
-
-		boolean isNew = true;
-		if (UtilMethods.isSet(actionClass.getId())) {
-			try {
-				final WorkflowActionClass test = this.findActionClass(actionClass.getId());
-				if (test != null) {
-					isNew = false;
-				}
-			} catch (final Exception e) {
-				Logger.debug(this.getClass(), e.getMessage(), e);
-			}
-		} else {
-			actionClass.setId(UUIDGenerator.generateUuid());
-		}
-
-		final DotConnect db = new DotConnect();
-		if (isNew) {
-			db.setSQL(sql.INSERT_ACTION_CLASS);
-			db.addParam(actionClass.getId());
-			db.addParam(actionClass.getActionId());
-			db.addParam(actionClass.getName());
-			db.addParam(actionClass.getOrder());
-			db.addParam(actionClass.getClazz());
-			db.loadResult();
-			
-
-			
-		} else {
-			db.setSQL(sql.UPDATE_ACTION_CLASS);
-			db.addParam(actionClass.getActionId());
-			db.addParam(actionClass.getName());
-			db.addParam(actionClass.getOrder());
-			db.addParam(actionClass.getClazz());
-			db.addParam(actionClass.getId());
-
-			db.loadResult();
-		}
-		// cache.remove(step);
-
-		// update workflowScheme mod date
-		final WorkflowAction action = findAction(actionClass.getActionId());
-		final WorkflowScheme scheme = findScheme(action.getSchemeId());
-
-		saveScheme(scheme);
-		cache.remove(action);
-	}
-
-	@Override
-	public void saveComment(WorkflowComment comment) throws DotDataException {
-		boolean isNew = true;
-		if (UtilMethods.isSet(comment.getId())) {
-			try {
-				final WorkflowComment test = this.findWorkFlowCommentById(comment.getId());
-				if (test != null) {
-					isNew = false;
-				}
-			} catch (final Exception e) {
-				Logger.debug(this.getClass(), e.getMessage(), e);
-			}
-		} else {
-			comment.setId(UUIDGenerator.generateUuid());
-		}
-
-		final DotConnect db = new DotConnect();
-
-		if (isNew) {
-			db.setSQL(WorkflowSQL.INSERT_WORKFLOW_COMMENT);
-			db.addParam(comment.getId());
-			setCommentDBParams(comment, db);
-			db.loadResult();
-		} else {
-			db.setSQL(WorkflowSQL.UPDATE_WORKFLOW_COMMENT);
-			setCommentDBParams(comment, db);
-			db.addParam(comment.getId());
-			db.loadResult();
-		}
-
-	}
-
-	private void setCommentDBParams(WorkflowComment comment, DotConnect db) {
-		db.addParam(comment.getCreationDate());
-		db.addParam(comment.getPostedBy());
-		db.addParam(comment.getComment());
-		db.addParam(comment.getWorkflowtaskId());
-	}
-
-	@Override
-	public void saveScheme(WorkflowScheme scheme) throws DotDataException, AlreadyExistException {
-
-		boolean isNew = true;
-		if (UtilMethods.isSet(scheme.getId())) {
-			try {
-				final WorkflowScheme test = this.findScheme(scheme.getId());
-				if (test != null) {
-					isNew = false;
-				}
-			} catch (final Exception e) {
-				Logger.debug(this.getClass(), e.getMessage(), e);
-			}
-		} else {
-			scheme.setId(UUIDGenerator.generateUuid());
-		}
-
-		scheme.setModDate(new Date());
-
-		final DotConnect db = new DotConnect();
-		try {
-
-			if (isNew) {
-
-				db.setSQL(sql.INSERT_SCHEME);
-				db.addParam(scheme.getId());
-				db.addParam(scheme.getName());
-				db.addParam(scheme.getDescription());
-				db.addParam(scheme.isArchived());
-				db.addParam(false);
-				db.addParam(scheme.isDefaultScheme());
-				db.addParam(scheme.getModDate());
-				db.loadResult();
-			} else {
-				db.setSQL(sql.UPDATE_SCHEME);
-				db.addParam(scheme.getName());
-				db.addParam(scheme.getDescription());
-				db.addParam(scheme.isArchived());
-				db.addParam(false);
-				db.addParam(scheme.getModDate());
-				db.addParam(scheme.getId());
-				db.loadResult();
-
-			}
-			cache.remove(scheme);
-		} catch (final Exception e) {
-			throw new DotDataException(e.getMessage(),e);
-		}
-	}
-
-	public void forceDeleteSchemeForContentType(final String contentTypeId) throws DotDataException {
-
-		try {
-
-			Logger.info(this, "Deleting the schemes associated to the content type: " + contentTypeId);
-
-			new DotConnect().setSQL(sql.DELETE_SCHEME_FOR_STRUCT)
-				.addParam(contentTypeId).loadResult();
-
-			cache.removeStructure(contentTypeId);
-		} catch (final Exception e) {
-			Logger.error(this.getClass(), e.getMessage(), e);
-			throw new DotDataException(e.getMessage(),e);
-		}
-	}
-
-	@Override
-	public void deleteSchemeForStruct(final String struc) throws DotDataException {
-		if (LicenseUtil.getLevel() < LicenseLevel.STANDARD.level) {
-			return;
-		}
-
-		this.forceDeleteSchemeForContentType(struc);
-	}
-
-	@Override
-	public void saveSchemeIdsForContentType(final String contentTypeInode,
-											final Set<String> schemesIds,
-											final Consumer<WorkflowTask> workflowTaskConsumer) throws DotDataException {
-
-		if (LicenseUtil.getLevel() < LicenseLevel.STANDARD.level) {
-
-			return;
-		}
-
-		try {
-
-			final DotConnect db = new DotConnect();
-			db.setSQL(sql.DELETE_SCHEME_FOR_STRUCT);
-			db.addParam(contentTypeInode);
-			db.loadResult();
-
-			final ImmutableList.Builder<WorkflowStep> stepBuilder = new ImmutableList.Builder<>();
-			for(final String id : schemesIds) {
-				db.setSQL(sql.INSERT_SCHEME_FOR_STRUCT);
-				db.addParam(UUIDGenerator.generateUuid());
-				db.addParam(id);
-				db.addParam(contentTypeInode);
-				db.loadResult();
-
-				stepBuilder.addAll(this.findSteps(this.findScheme(id)));
-			}
-			// update all tasks for the content type and reset their step to
-			// null
-			this.cleanWorkflowTaskStatus(contentTypeInode, stepBuilder.build(), workflowTaskConsumer);
-			this.checkContentTypeWorkflowTaskNullStatus(contentTypeInode, workflowTaskConsumer);
-
-			// we have to clear the saved steps/tasks for all contentlets using
-			// this workflow
-
-			cache.removeStructure(contentTypeInode);
-			cache.clearStepsCache();
-		} catch (final Exception e) {
-
-			Logger.error(this.getClass(), e.getMessage(), e);
-			throw new DotDataException(e.getMessage(),e);
-		}
-	}
-
-	private void checkContentTypeWorkflowTaskNullStatus(final String contentTypeInode,
-														final Consumer<WorkflowTask> workflowTaskConsumer) throws DotDataException {
-
-		try {
-
-			final List<WorkflowTask> tasks = this
-					.convertListToObjects(new DotConnect()
-							.setSQL(sql.SELECT_TASK_NULL_BY_STRUCT)
-							.addParam(contentTypeInode).loadObjectResults(), WorkflowTask.class);
-
-			//clean cache
-			tasks.stream().forEach(task -> {
-
-				if (null != workflowTaskConsumer) {
-
-					workflowTaskConsumer.accept(task);
-				}
-			});
-		} catch (final Exception e) {
-			Logger.error(this.getClass(), e.getMessage(), e);
-			throw new DotDataException(e.getMessage(), e);
-		}
-	}
-
-	/**
-	 * Set workflow tasks with status null, for all the existing workflow task with the specified
-	 * contentTypeInode and not in the list of steps availables fot the content type schemes
-	 *
-	 * @param contentTypeInode Content Type Inode {@link String}
-	 * @param steps List of valid Steps {@link List}
-	 * @param workflowTaskConsumer {@link Consumer}
-	 */
-	private void cleanWorkflowTaskStatus(final String contentTypeInode,
-										 final List<WorkflowStep> steps,
-										 final Consumer<WorkflowTask> workflowTaskConsumer)
-			throws DotDataException {
-		try {
-
-			String condition = "";
-			if (steps.size() > 0) {
-				condition = " and status not in (";
-				StringBuilder parameters = new StringBuilder();
-				for (WorkflowStep step : steps) {
-					parameters.append(", ?");
-				}
-				condition += parameters.toString().substring(1) + " )";
-			}
-
-			final DotConnect db = new DotConnect();
-			db.setSQL(sql.SELECT_TASK_STEPS_TO_CLEAN_BY_STRUCT + condition);
-			db.addParam(contentTypeInode);
-			if (steps.size() > 0) {
-				for (WorkflowStep step : steps) {
-					db.addParam(step.getId());
-				}
-			}
-			final List<WorkflowTask> tasks = this
-					.convertListToObjects(db.loadObjectResults(), WorkflowTask.class);
-
-			//clean cache
-			tasks.stream().forEach(task -> {
-
-				cache.remove(task);
-				if (null != workflowTaskConsumer) {
-
-					workflowTaskConsumer.accept(task);
-				}
-			});
-
-			db.setSQL(sql.UPDATE_STEPS_BY_STRUCT + condition);
-			db.addParam((Object) null);
-			db.addParam(contentTypeInode);
-			if (steps.size() > 0) {
-				for (WorkflowStep step : steps) {
-					db.addParam(step.getId());
-				}
-			}
-			db.loadResult();
-
-		} catch (final Exception e) {
-			Logger.error(this.getClass(), e.getMessage(), e);
-			throw new DotDataException(e.getMessage(), e);
-		}
-	}
-
-	@Override
-	public void saveSchemesForStruct(final String contentTypeInode,
-									 final List<WorkflowScheme> schemes,
-									 final Consumer<WorkflowTask> workflowTaskConsumer) throws DotDataException {
-
-		final Set<String> ids = schemes.stream()
-				.map(WorkflowScheme::getId)
-				.collect(Collectors.toSet());
-
-		this.saveSchemeIdsForContentType(contentTypeInode, ids, workflowTaskConsumer);
-	}
-
-	@Override
-	public void saveStep(WorkflowStep step) throws DotDataException, AlreadyExistException {
-
-		boolean isNew = true;
-		if (UtilMethods.isSet(step.getId())) {
-			try {
-				final WorkflowStep test = this.findStep(step.getId());
-				if (test != null) {
-					isNew = false;
-				}
-			} catch (final Exception e) {
-				Logger.debug(this.getClass(), e.getMessage(), e);
-			}
-		} else {
-			step.setId(UUIDGenerator.generateUuid());
-		}
-
-		final DotConnect db = new DotConnect();
-		if (isNew) {
-
-			db.setSQL(sql.INSERT_STEP);
-			db.addParam(step.getId());
-			db.addParam(step.getName());
-			db.addParam(step.getSchemeId());
-			db.addParam(step.getMyOrder());
-			db.addParam(step.isResolved());
-			db.addParam(step.isEnableEscalation());
-			if(step.isEnableEscalation()) {
-				db.addParam(step.getEscalationAction());
-				db.addParam(step.getEscalationTime());
-			}
-			else {
-				db.addParam((Object)null);
-				db.addParam(0);
-			}
-			db.loadResult();
-		} else {
-			db.setSQL(sql.UPDATE_STEP);
-			db.addParam(step.getName());
-			db.addParam(step.getSchemeId());
-			db.addParam(step.getMyOrder());
-			db.addParam(step.isResolved());
-			db.addParam(step.isEnableEscalation());
-			if(step.isEnableEscalation()) {
-				db.addParam(step.getEscalationAction());
-				db.addParam(step.getEscalationTime());
-			}
-			else {
-				db.addParam((Object)null);
-				db.addParam(0);
-			}
-			db.addParam(step.getId());
-			db.loadResult();
-		}
-		cache.remove(step);
-
-		// update workflowScheme mod date
-		WorkflowScheme scheme = findScheme(step.getSchemeId());
-		saveScheme(scheme);
-
-	}
-
-	@Override
-	public void saveWorkflowActionClassParameter(WorkflowActionClassParameter param) throws DotDataException, AlreadyExistException {
-
-		boolean isNew = true;
-		if (UtilMethods.isSet(param.getId())) {
-			try {
-				final WorkflowActionClassParameter test = this.findActionClassParameter(param.getId());
-				if (test != null) {
-					isNew = false;
-				}
-			} catch (final Exception e) {
-				Logger.debug(this.getClass(), e.getMessage(), e);
-			}
-		} else {
-			param.setId(UUIDGenerator.generateUuid());
-		}
-
-		final DotConnect db = new DotConnect();
-		if (isNew) {
-			db.setSQL(sql.INSERT_ACTION_CLASS_PARAM);
-			db.addParam(param.getId());
-			db.addParam(param.getActionClassId());
-			db.addParam(param.getKey());
-			db.addParam(param.getValue());
-			db.loadResult();
-		} else {
-			db.setSQL(sql.UPDATE_ACTION_CLASS_PARAM);
-
-			db.addParam(param.getActionClassId());
-			db.addParam(param.getKey());
-			db.addParam(param.getValue());
-			db.addParam(param.getId());
-
-			db.loadResult();
-		}
-
-		// update workflowScheme mod date
-		final WorkflowActionClass actionClass = findActionClass(param.getActionClassId());
-		final WorkflowAction action = findAction(actionClass.getActionId());
-		final WorkflowScheme scheme = findScheme(action.getSchemeId());
-		saveScheme(scheme);
-	}
-
-	@Override
-	public void saveWorkflowHistory(WorkflowHistory history) throws DotDataException {
-		boolean isNew = true;
-		if (UtilMethods.isSet(history.getId())) {
-			try {
-				final WorkflowHistory test = this.findWorkFlowHistoryById(history.getId());
-				if (test != null) {
-					isNew = false;
-				}
-			} catch (final Exception e) {
-				Logger.debug(this.getClass(), e.getMessage(), e);
-			}
-		} else {
-			history.setId(UUIDGenerator.generateUuid());
-		}
-
-		final DotConnect db = new DotConnect();
-
-		if (isNew) {
-			db.setSQL(WorkflowSQL.INSERT_WORKFLOW_HISTORY);
-			db.addParam(history.getId());
-			setHistoryDBParams(history, db);
-			db.loadResult();
-		} else {
-			db.setSQL(WorkflowSQL.UPDATE_WORKFLOW_HISTORY);
-			setHistoryDBParams(history, db);
-			db.addParam(history.getId());
-			db.loadResult();
-		}
-	}
-
-	private void setHistoryDBParams(WorkflowHistory history, DotConnect db) {
-		db.addParam(history.getCreationDate());
-		db.addParam(history.getMadeBy());
-		db.addParam(history.getRawChangeDescription());
-		db.addParam(history.getWorkflowtaskId());
-		db.addParam(history.getActionId());
-		db.addParam(history.getStepId());
-	}
-
-	@Override
-	public void saveWorkflowTask ( WorkflowTask task ) throws DotDataException {
-
-		final DotConnect db = new DotConnect()
-				.setSQL(WorkflowSQL.SELECT_TASK)
-				.addParam(task.getWebasset())
-				.addParam(task.getLanguageId());
-
-		final WorkflowTask dbTask =  Try
-				.of(() -> this.convertListToObjects(db.loadObjectResults(), WorkflowTask.class).get(0))
-				.getOrNull();
-
-		final boolean isNew = !UtilMethods.isSet(dbTask) || UtilMethods.isEmpty(dbTask.getId()) ;
-
-		if (isNew) {
-			task.setId(UUIDGenerator.generateUuid());
-			db.setSQL(WorkflowSQL.INSERT_WORKFLOW_TASK);
-			db.addParam(task.getId());
-			setTaskDBParams(task, db);
-		} else {
-			task.setId(dbTask.getId());
-			db.setSQL(WorkflowSQL.UPDATE_WORKFLOW_TASK);
-			setTaskDBParams(task, db);
-			db.addParam(task.getId());
-		}
-		db.loadResult();
-
-		cache.remove(task);
-	}
-
-	private void setTaskDBParams(WorkflowTask task, DotConnect db) {
-		db.addParam(task.getCreationDate());
-		db.addParam(task.getModDate());
-		db.addParam(task.getDueDate());
-		db.addParam(task.getCreatedBy());
-		db.addParam(task.getAssignedTo());
-		db.addParam(task.getBelongsTo());
-		db.addParam(task.getTitle());
-		db.addParam(task.getDescription());
-		db.addParam(task.getStatus());
-		db.addParam(task.getWebasset());
-		db.addParam(task.getLanguageId());
-	}
-
-	@Override
-	public List<WorkflowTask> searchTasks(WorkflowSearcher searcher) throws DotDataException {
-		DotConnect dc = getWorkflowSqlQuery(searcher, false);
-		dc.setStartRow(searcher.getCount() * searcher.getPage());
-		dc.setMaxRows(searcher.getCount());
-		List<Map<String,Object>> results = dc.loadObjectResults();
-		List<WorkflowTask> wfTasks = new ArrayList<WorkflowTask>();
-
-		for (Map<String, Object> row : results) {
-			WorkflowTask wt = new WorkflowTask();
-			wt.setId(getStringValue(row, "id"));
-			wt.setCreationDate((Date)row.get("creation_date"));
-			wt.setModDate((Date)row.get("mod_date"));
-			wt.setDueDate((Date)row.get("due_date"));
-			wt.setCreatedBy(getStringValue(row, "created_by"));
-			wt.setAssignedTo(getStringValue(row, "assigned_to"));
-			wt.setBelongsTo(getStringValue(row, "belongs_to"));
-			wt.setTitle(getStringValue(row, "title"));
-			wt.setDescription(getStringValue(row, "description"));
-			wt.setStatus(getStringValue(row, "status"));
-			wt.setWebasset(getStringValue(row, "webasset"));
-			wt.setLanguageId(getLongValue(row, "language_id"));
-			wfTasks.add(wt);
-		}
-
-		return wfTasks;
-	}
-
-	/**
-	 *
-	 * @param row
-	 * @param key
-	 * @return
-	 */
-	private String getStringValue(Map<String, Object> row, String key) {
-		Object value = row.get(key);
-		return (value == null) ? "" : value.toString();
-	}
-
-	/**
-	 *
-	 * @param row
-	 * @param key
-	 * @return
-	 */
-	private Long getLongValue(final Map<String, Object> row, final String key) {
-		return ConversionUtils.toLong(row.get(key), 0L);
-	}
-
-	@Override
-	public List<WorkflowTask> searchAllTasks(WorkflowSearcher searcher) throws DotDataException {
-
-		final HibernateUtil hu = new HibernateUtil(WorkflowTask.class);
-		final StringWriter sw = new StringWriter();
-		sw.append("select {workflow_task.*}  from workflow_task   ");
-		hu.setSQLQuery(sw.toString());
-		if (searcher != null) {
-			hu.setMaxResults(searcher.getCount());
-			hu.setFirstResult(searcher.getCount() * searcher.getPage());
-		}
-
-		return (List<WorkflowTask>) hu.list();
-
-	}
-
-	@Override
-	public WorkflowHistory retrieveLastStepAction(String taskId) throws DotDataException {
-
-		final DotConnect db = new DotConnect();
-		try {
-
-			db.setSQL(sql.RETRIEVE_LAST_STEP_ACTIONID);
-			db.addParam(taskId);
-			db.loadResult();
-		} catch (final Exception e) {
-			Logger.debug(this.getClass(), e.getMessage(), e);
-		}
-
-		return (WorkflowHistory) this.convertListToObjects(db.loadObjectResults(), WorkflowHistory.class).get(0);
-
-	}
-
-	@Override
-	public List<WorkflowTask> findExpiredTasks() throws DotDataException, DotSecurityException {
-		final DotConnect db = new DotConnect();
-		List<WorkflowTask> list=new ArrayList<WorkflowTask>();
-		try {
-			db.setSQL(sql.SELECT_EXPIRED_TASKS);
-			List<Map<String,Object>> results=db.loadResults();
-			for (Map<String, Object> map : results) {
-				String taskId=(String)map.get("id");
-				WorkflowTask task=findWorkFlowTaskById(taskId);
-				list.add(task);
-			}
-		} catch (final Exception e) {
-			Logger.error(this, e.getMessage(), e);
-		}
-		finally {
-			HibernateUtil.getSession().clear();
-		}
-		return list;
-	}
-
-	@Override
-	public WorkflowScheme findSchemeByName(String schemaName) throws DotDataException {
-		WorkflowScheme scheme = null;
-		try {
-			final DotConnect db = new DotConnect();
-			db.setSQL(sql.SELECT_SCHEME_NAME);
-			db.addParam((schemaName != null ? schemaName.trim() : ""));
-			List<WorkflowScheme> list = this.convertListToObjects(db.loadObjectResults(), WorkflowScheme.class);
-			scheme = list.size()>0 ? (WorkflowScheme)list.get(0) : null;
-		} catch (final Exception e) {
-			throw new DotDataException(e.getMessage(),e);
-		}
-		return scheme;
-	}
-
-	@Override
-	public void deleteWorkflowActionClassParameter(WorkflowActionClassParameter param) throws DotDataException, AlreadyExistException {
-		DotConnect db=new DotConnect();
-		db.setSQL(sql.DELETE_ACTION_CLASS_PARAM_BY_ID);
-		db.addParam(param.getId());
-		db.loadResult();
-
-		// update scheme mod date
-		WorkflowActionClass clazz = findActionClass(param.getActionClassId());
-		WorkflowAction action = findAction(clazz.getActionId());
-		WorkflowScheme scheme = findScheme(action.getSchemeId());
-		saveScheme(scheme);
-	}
-
-	@Override
-	public void updateUserReferences(String userId, String userRoleId, String replacementUserId, String replacementUserRoleId)throws DotDataException, DotSecurityException{
-		DotConnect dc = new DotConnect();
-
-		try {
-			dc.setSQL("select id from workflow_task where (assigned_to = ? or assigned_to=? or created_by=? or created_by=?)");
-			dc.addParam(userId);
-			dc.addParam(userRoleId);
-			dc.addParam(userId);
-			dc.addParam(userRoleId);
-			List<HashMap<String, String>> tasks = dc.loadResults();
-
-			dc.setSQL("update workflow_comment set posted_by=? where posted_by  = ?");
-			dc.addParam(replacementUserId);
-			dc.addParam(userId);
-			dc.loadResults();
-
-			dc.setSQL("update workflow_comment set posted_by=? where posted_by  = ?");
-			dc.addParam(replacementUserRoleId);
-			dc.addParam(userRoleId);
-			dc.loadResults();
-
-			dc.setSQL("update workflow_task set assigned_to=? where assigned_to  = ?");
-			dc.addParam(replacementUserRoleId);
-			dc.addParam(userRoleId);
-			dc.loadResult();
-
-			dc.setSQL("update workflow_task set created_by=? where created_by  = ?");
-			dc.addParam(replacementUserId);
-			dc.addParam(userId);
-			dc.loadResult();
-
-			dc.setSQL("update workflow_task set created_by=? where created_by  = ?");
-			dc.addParam(replacementUserRoleId);
-			dc.addParam(userRoleId);
-			dc.loadResult();
-
-			dc.setSQL("update workflow_action set next_assign=? where next_assign = ?");
-			dc.addParam(replacementUserRoleId);
-			dc.addParam(userRoleId);
-			dc.loadResult();
-
-			for(HashMap<String, String> val : tasks){
-				String id = val.get("id");
-				WorkflowTask task = findWorkFlowTaskById(id);
-				cache.remove(task);
-				
-				dc.setSQL("select workflow_step.id from workflow_step join workflow_task on workflow_task.status = workflow_step.id where workflow_task.webasset= ?");
-				dc.addParam(task.getWebasset());
-				List<HashMap<String, String>> steps = dc.loadResults();
-				for(HashMap<String, String> v : steps){
-					String stepId = v.get("id");
-					WorkflowStep step = findStep(stepId);
-					cache.remove(step);					
-				}
-			}
-		} catch (DotDataException e) {
-			Logger.error(WorkFlowFactory.class,e.getMessage(),e);
-			throw new DotDataException(e.getMessage(), e);
-		}
-	}
-
-	@Override
-	public void updateStepReferences(String stepId, String replacementStepId) throws DotDataException, DotSecurityException {
-		DotConnect dc = new DotConnect();
-
-		try {
-			// Replace references and clear cache for workflow actions
-			dc.setSQL("select step_id from workflow_action where next_step_id = ?");
-			dc.addParam(stepId);
-			List<HashMap<String, String>> actionStepIds = dc.loadResults();
-
-			if (replacementStepId != null){
-				dc.setSQL("update workflow_action set next_step_id = ? where next_step_id = ?");
-				dc.addParam(replacementStepId);
-				dc.addParam(stepId);
-				dc.loadResult();
-
-			} else {
-				dc.setSQL("update workflow_action set next_step_id = step_id where next_step_id = ?");
-				dc.addParam(stepId);
-				dc.loadResult();
-			}
-
-			for(HashMap<String, String> v : actionStepIds){
-				String id = v.get("step_id");
-				WorkflowStep step = findStep(id);
-				cache.remove(step);					
-			}
-
-			
-			// Replace references and clear cache for workflow tasks
-			dc.setSQL("select id from workflow_task where status = ?");
-			dc.addParam(stepId);
-			List<HashMap<String, String>> taskIds = dc.loadResults();
-
-			dc.setSQL("update workflow_task set status = ? where status = ?");
-			dc.addParam(replacementStepId);
-			dc.addParam(stepId);
-			dc.loadResults();
-
-			for(HashMap<String, String> val : taskIds){
-				String id = val.get("id");
-				WorkflowTask task = findWorkFlowTaskById(id);
-				cache.remove(task);
-			}
-
-		} catch (DotDataException e) {
-			Logger.error(WorkFlowFactory.class,e.getMessage(),e);
-			throw new DotDataException(e.getMessage(), e);
-		}
-	}
-
-	@Override
-	public List<WorkflowTask> findTasksByStep(final String stepId) throws DotDataException, DotSecurityException {
-		List<WorkflowTask> tasks;
-		DotConnect dc = new DotConnect();
-
-		try {
-			dc.setSQL(sql.SELECT_TASKS_BY_STEP);
-			dc.addParam(stepId);
-			tasks =  this.convertListToObjects(dc.loadObjectResults(), WorkflowTask.class);
-		} catch (DotDataException e) {
-			Logger.error(WorkFlowFactory.class,e.getMessage(),e);
-			throw new DotDataException(e.getMessage(), e);
-		}
-		return tasks;
-	}
-
-	@Override
-	public List<ContentType> findContentTypesByScheme(final WorkflowScheme scheme) throws DotDataException, DotSecurityException{
-		List<ContentType> contentTypes;
-		DotConnect dc = new DotConnect();
-		try {
-			dc.setSQL(sql.SELECT_STRUCTS_FOR_SCHEME);
-			dc.addParam(scheme.getId());
-			contentTypes =  this.convertListToObjects(dc.loadObjectResults(), ContentType.class);
-
-		} catch (DotDataException e) {
-			Logger.error(WorkFlowFactory.class,e.getMessage(),e);
-			throw new DotDataException(e.getMessage(), e);
-		}
-		return contentTypes;
-	}
-
-	@Override
-	public void deleteScheme(final WorkflowScheme scheme) throws DotDataException, DotSecurityException{
-		DotConnect dc = new DotConnect();
-		try {
-			//delete association of content types with the scheme
-			dc.setSQL(sql.DELETE_STRUCTS_FOR_SCHEME);
-			dc.addParam(scheme.getId());
-			dc.loadResult();
-
-			//delete the scheme
-			dc.setSQL(sql.DELETE_SCHEME);
-			dc.addParam(scheme.getId());
-			dc.loadResult();
-
-			final List<WorkflowAction> actions =
-					this.cache.getActions(scheme);
-			if (null != actions) {
-				actions.stream().forEach(action -> this.cache.remove(action));
-			}
-
-			this.deleteSystemActionsByScheme(scheme);
-			this.cache.remove(scheme);
-		} catch (DotDataException e) {
-			Logger.error(WorkFlowFactory.class,e.getMessage(),e);
-			throw new DotDataException(e.getMessage(), e);
-		}
-	}
-
-	@Override
-	public void deleteSystemActionsByScheme(final WorkflowScheme scheme) throws DotDataException {
-
-		Logger.debug(this,
-				()-> "Deleting the system action mappings associated to the scheme: " + scheme.getId());
-
-		new DotConnect()
-				.setSQL(sql.DELETE_SYSTEM_ACTION_BY_SCHEME_OR_CONTENT_TYPE)
-				.addParam(scheme.getId())
-				.loadResult();
-		this.cache.removeSystemActionsByScheme(scheme.getId());
-	}
-
-	@Override
-	public void deleteSystemActionsByContentType(final String contentTypeVariable) throws DotDataException {
-
-		Logger.debug(this,
-				()-> "Deleting the system action mappings associated to the content type: " + contentTypeVariable);
-
-		new DotConnect()
-				.setSQL(sql.DELETE_SYSTEM_ACTION_BY_SCHEME_OR_CONTENT_TYPE)
-				.addParam(contentTypeVariable)
-				.loadResult();
-		this.cache.removeSystemActionsByContentType(contentTypeVariable);
-	}
-
-	@Override
-	public Set<String> findNullTaskContentletIdentifiersForScheme(final String workflowSchemeId) throws DotDataException {
-		final DotConnect dc = new DotConnect();
-		try {
-			dc.setSQL(sql.SELECT_NULL_TASK_CONTENTLET_FOR_WORKFLOW);
-			dc.addParam(workflowSchemeId);
-			final List<Map<String, String>> result = dc.loadResults();
+                final DotConnect dotConnect = new DotConnect()
+                        .setSQL(String.format(sql.SELECT_SYSTEM_ACTION_BY_SYSTEM_ACTION_AND_SCHEMES,
+                                this.createQueryIn(schemes)))
+                        .addParam(systemAction.name());
+
+                for (final WorkflowScheme scheme : schemes) {
+
+                    dotConnect.addParam(scheme.getId());
+                }
+
+                results.addAll(dotConnect.loadObjectResults());
+            }
+
+            if (UtilMethods.isSet(results)) {
+
+                this.cache.addSystemActionsBySystemActionNameAndSchemeIds(
+                        systemAction.name(), schemeIdList, results);
+            }
+        }
+
+        return results;
+    }
+
+    @Override
+    public Map<String, Object> findSystemActionByIdentifier(final String identifier)
+            throws DotDataException {
+
+        final List<Map<String, Object>> rows = new DotConnect().setSQL(
+                        sql.SELECT_SYSTEM_ACTION_BY_IDENTIFIER)
+                .addParam(identifier)
+                .loadObjectResults();
+        return UtilMethods.isSet(rows) ? rows.get(0) : Collections.emptyMap();
+    }
+
+    @Override
+    public boolean deleteSystemAction(final SystemActionWorkflowActionMapping mapping)
+            throws DotDataException {
+
+        new DotConnect().setSQL(sql.DELETE_SYSTEM_ACTION_BY_IDENTIFIER)
+                .addParam(mapping.getIdentifier())
+                .loadResult();
+
+        this.cache.removeSystemActionWorkflowActionMapping(mapping);
+
+        return true; //  todo: if rows affected 0 -> false
+    }
+
+    @Override
+    public void deleteSystemActionsByWorkflowAction(final WorkflowAction action)
+            throws DotDataException {
+
+        Logger.debug(this, () -> "Removing system action mappings associated to the action: "
+                + action.getId());
+
+        final List<Map<String, Object>> mappingsToClean = new DotConnect().setSQL(
+                        sql.SELECT_SYSTEM_ACTION_BY_WORKFLOW_ACTION).
+                addParam(action.getId())
+                .loadObjectResults();
+
+        new DotConnect().setSQL(sql.DELETE_SYSTEM_ACTION_BY_WORKFLOW_ACTION_ID)
+                .addParam(action.getId())
+                .loadResult();
+
+        this.cache.removeSystemActionsByWorkflowAction(action.getId());
+
+        if (UtilMethods.isSet(mappingsToClean)) {
+
+            for (final Map<String, Object> mappingRow : mappingsToClean) {
+
+                final String owner = (String) mappingRow.get("scheme_or_content_type");
+                this.cache.removeSystemActionsByContentType(owner);
+                this.cache.removeSystemActionsByScheme(owner);
+            }
+        }
+    }
+
+    private String createQueryIn(final Collection list) {
+
+        final StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < list.size(); ++i) {
+
+            builder.append("?");
+            if (i < list.size() - 1) {
+
+                builder.append(",");
+            }
+        }
+
+        return builder.toString();
+    }
+
+
+    @Override
+    public SystemActionWorkflowActionMapping saveSystemActionWorkflowActionMapping(
+            final SystemActionWorkflowActionMapping mapping) throws DotDataException {
+
+        final String ownerKey = this.getOwnerKey(mapping, mapping.getOwner());
+        SystemActionWorkflowActionMapping toReturn = mapping;
+
+        final List<Map<String, Object>> existsRow =
+                new DotConnect().setSQL(
+                                sql.SELECT_SYSTEM_ACTION_BY_SYSTEM_ACTION_AND_SCHEME_OR_CONTENT_TYPE_MAPPING)
+                        .addParam(mapping.getSystemAction().name())
+                        .addParam(ownerKey)
+                        .loadObjectResults();
+
+        if (!UtilMethods.isSet(existsRow)) {
+
+            new DotConnect().setSQL(sql.INSERT_SYSTEM_ACTION_WORKFLOW_ACTION_MAPPING)
+                    .addParam(mapping.getIdentifier())
+                    .addParam(mapping.getSystemAction().name())
+                    .addParam(mapping.getWorkflowAction().getId())
+                    .addParam(ownerKey)
+                    .loadResult();
+        } else {
+
+            // if exists, we override the id and update.
+            final String existingId = (String) existsRow.get(0).get("id");
+            toReturn = new SystemActionWorkflowActionMapping(existingId,
+                    mapping.getSystemAction(),
+                    mapping.getWorkflowAction(),
+                    mapping.getOwner());
+
+            new DotConnect().setSQL(sql.UPDATE_SYSTEM_ACTION_WORKFLOW_ACTION_MAPPING)
+                    .addParam(mapping.getSystemAction().name())
+                    .addParam(mapping.getWorkflowAction().getId())
+                    .addParam(ownerKey)
+                    .addParam(existingId)
+                    .loadResult();
+        }
+
+        this.cache.removeSystemActionWorkflowActionMapping(mapping);
+
+        return toReturn;
+    }
+
+    /*
+     * The owner could be a ContentType (variable) or WorkflowScheme (identifier)
+     */
+    private String getOwnerKey(final SystemActionWorkflowActionMapping mapping,
+            final Object ownerContentTypeOrScheme) {
+
+        return mapping.isOwnerContentType() ?
+                ContentType.class.cast(ownerContentTypeOrScheme).variable() :
+                WorkflowScheme.class.cast(ownerContentTypeOrScheme).getId();
+    }
+
+    ///////
+
+    @Override
+    public void saveAction(final WorkflowAction workflowAction,
+            final WorkflowStep workflowStep,
+            final int order) throws DotDataException, AlreadyExistException {
+
+        boolean isNew = true;
+        if (UtilMethods.isSet(workflowAction.getId()) && UtilMethods.isSet(workflowStep.getId())) {
+            isNew = (null == findAction(workflowAction.getId(), workflowStep.getId()));
+        }
+        if (isNew) {
+            new DotConnect().setSQL(sql.INSERT_ACTION_FOR_STEP)
+                    .addParam(workflowAction.getId())
+                    .addParam(workflowStep.getId())
+                    .addParam(order)
+                    .loadResult();
+        } else {
+            new DotConnect().setSQL(sql.UPDATE_ACTION_FOR_STEP_ORDER)
+                    .addParam(order)
+                    .addParam(workflowAction.getId())
+                    .addParam(workflowStep.getId())
+                    .loadResult();
+        }
+
+        final WorkflowStep proxyStep = new WorkflowStep();
+        proxyStep.setId(workflowStep.getId());
+        cache.removeActions(proxyStep);
+
+        final WorkflowScheme proxyScheme = new WorkflowScheme();
+        proxyScheme.setId(workflowAction.getSchemeId());
+        cache.removeActions(proxyScheme);
+
+        // update workflowScheme mod date
+        final WorkflowScheme scheme = findScheme(workflowAction.getSchemeId());
+        saveScheme(scheme);
+    } // saveAction.
+
+    @Override
+    public void updateOrder(final WorkflowAction workflowAction,
+            final WorkflowStep workflowStep,
+            final int order) throws DotDataException, AlreadyExistException {
+
+        new DotConnect().setSQL(sql.UPDATE_ACTION_FOR_STEP_ORDER)
+                .addParam(order)
+                .addParam(workflowAction.getId())
+                .addParam(workflowStep.getId())
+                .loadResult();
+
+        final WorkflowStep proxyStep = new WorkflowStep();
+        proxyStep.setId(workflowStep.getId());
+        cache.removeActions(proxyStep);
+
+        final WorkflowScheme proxyScheme = new WorkflowScheme();
+        proxyScheme.setId(workflowAction.getSchemeId());
+        cache.removeActions(proxyScheme);
+
+        // update workflowScheme mod date
+        final WorkflowScheme scheme = findScheme(workflowAction.getSchemeId());
+        saveScheme(scheme);
+    } // updateOrder.
+
+    /**
+     * @param workflowAction
+     * @return
+     */
+    private String getNextStep(final WorkflowAction workflowAction) {
+
+        return (!UtilMethods.isSet(workflowAction.getNextStep())) ?
+                WorkflowAction.CURRENT_STEP : workflowAction.getNextStep();
+    }
+
+    @Override
+    public void saveAction(final WorkflowAction action)
+            throws DotDataException, AlreadyExistException {
+
+        boolean isNew = true;
+        if (UtilMethods.isSet(action.getId())) {
+
+            isNew = !this.existsAction(action.getId());
+        } else {
+            action.setId(UUIDGenerator.generateUuid());
+        }
+
+        final String nextStep = this.getNextStep(action);
+        final DotConnect db = new DotConnect();
+        if (isNew) {
+            db.setSQL(sql.INSERT_ACTION);
+            db.addParam(action.getId());
+            db.addParam(action.getSchemeId());
+            db.addParam(action.getName());
+            db.addParam(action.getCondition());
+            db.addParam(nextStep);
+            db.addParam(action.getNextAssign());
+            db.addParam(action.getOrder());
+            db.addParam(action.isAssignable());
+            db.addParam(action.isCommentable());
+            db.addParam(action.getIcon());
+            db.addParam(action.isRoleHierarchyForAssign());
+            db.addParam(action.isRequiresCheckout());
+            db.addParam(WorkflowState.toCommaSeparatedString(action.getShowOn()));
+            db.loadResult();
+        } else {
+            db.setSQL(sql.UPDATE_ACTION);
+            db.addParam(action.getSchemeId());
+            db.addParam(action.getName());
+            db.addParam(action.getCondition());
+            db.addParam(nextStep);
+            db.addParam(action.getNextAssign());
+            db.addParam(action.getOrder());
+            db.addParam(action.isAssignable());
+            db.addParam(action.isCommentable());
+            db.addParam(action.getIcon());
+            db.addParam(action.isRoleHierarchyForAssign());
+            db.addParam(action.isRequiresCheckout());
+            db.addParam(WorkflowState.toCommaSeparatedString(action.getShowOn()));
+            db.addParam(action.getId());
+            db.loadResult();
+        }
+
+        final List<WorkflowStep> relatedProxiesSteps =
+                this.findProxiesSteps(action);
+        relatedProxiesSteps.forEach(cache::removeActions);
+
+        final WorkflowScheme proxyScheme = new WorkflowScheme();
+        proxyScheme.setId(action.getSchemeId());
+        cache.removeActions(proxyScheme);
+
+        // update workflowScheme mod date
+        final WorkflowScheme scheme = findScheme(action.getSchemeId());
+        saveScheme(scheme);
+
+    }
+
+    /**
+     * @param action
+     * @return
+     * @throws DotDataException
+     */
+    public List<WorkflowStep> findProxiesSteps(final WorkflowAction action)
+            throws DotDataException {
+
+        final ImmutableList.Builder<WorkflowStep> stepsBuilder =
+                new ImmutableList.Builder<>();
+
+        final List<Map<String, Object>> stepIdList =
+                new DotConnect().setSQL(sql.SELECT_STEPS_ID_BY_ACTION)
+                        .addParam(action.getId()).loadObjectResults();
+
+        if (null != stepIdList) {
+
+            stepIdList.forEach(mapRow -> stepsBuilder.add
+                    (this.buildProxyWorkflowStep((String) mapRow.get("stepid"))));
+        }
+
+        return stepsBuilder.build();
+    }
+
+    /**
+     * @param stepId
+     * @return
+     */
+    private WorkflowStep buildProxyWorkflowStep(final String stepId) {
+
+        final WorkflowStep proxyWorkflowStep =
+                new WorkflowStep();
+
+        proxyWorkflowStep.setId(stepId);
+
+        return proxyWorkflowStep;
+    }
+
+    @Override
+    public void saveActionClass(final WorkflowActionClass actionClass)
+            throws DotDataException, AlreadyExistException {
+
+        boolean isNew = true;
+        if (UtilMethods.isSet(actionClass.getId())) {
+            try {
+                final WorkflowActionClass test = this.findActionClass(actionClass.getId());
+                if (test != null) {
+                    isNew = false;
+                }
+            } catch (final Exception e) {
+                Logger.debug(this.getClass(), e.getMessage(), e);
+            }
+        } else {
+            actionClass.setId(UUIDGenerator.generateUuid());
+        }
+
+        final DotConnect db = new DotConnect();
+        if (isNew) {
+            db.setSQL(sql.INSERT_ACTION_CLASS);
+            db.addParam(actionClass.getId());
+            db.addParam(actionClass.getActionId());
+            db.addParam(actionClass.getName());
+            db.addParam(actionClass.getOrder());
+            db.addParam(actionClass.getClazz());
+            db.loadResult();
+
+
+        } else {
+            db.setSQL(sql.UPDATE_ACTION_CLASS);
+            db.addParam(actionClass.getActionId());
+            db.addParam(actionClass.getName());
+            db.addParam(actionClass.getOrder());
+            db.addParam(actionClass.getClazz());
+            db.addParam(actionClass.getId());
+
+            db.loadResult();
+        }
+
+        // update workflowScheme mod date
+        final WorkflowAction action = findAction(actionClass.getActionId());
+        final WorkflowScheme scheme = findScheme(action.getSchemeId());
+
+        saveScheme(scheme);
+        cache.remove(action);
+    }
+
+    @Override
+    public void saveComment(WorkflowComment comment) throws DotDataException {
+        boolean isNew = true;
+        if (UtilMethods.isSet(comment.getId())) {
+            try {
+                final WorkflowComment test = this.findWorkFlowCommentById(comment.getId());
+                if (test != null) {
+                    isNew = false;
+                }
+            } catch (final Exception e) {
+                Logger.debug(this.getClass(), e.getMessage(), e);
+            }
+        } else {
+            comment.setId(UUIDGenerator.generateUuid());
+        }
+
+        final DotConnect db = new DotConnect();
+
+        if (isNew) {
+            db.setSQL(WorkflowSQL.INSERT_WORKFLOW_COMMENT);
+            db.addParam(comment.getId());
+            setCommentDBParams(comment, db);
+            db.loadResult();
+        } else {
+            db.setSQL(WorkflowSQL.UPDATE_WORKFLOW_COMMENT);
+            setCommentDBParams(comment, db);
+            db.addParam(comment.getId());
+            db.loadResult();
+        }
+
+    }
+
+    private void setCommentDBParams(WorkflowComment comment, DotConnect db) {
+        db.addParam(comment.getCreationDate());
+        db.addParam(comment.getPostedBy());
+        db.addParam(comment.getComment());
+        db.addParam(comment.getWorkflowtaskId());
+    }
+
+    @Override
+    public void saveScheme(WorkflowScheme scheme) throws DotDataException, AlreadyExistException {
+
+        boolean isNew = true;
+        if (UtilMethods.isSet(scheme.getId())) {
+            try {
+                final WorkflowScheme test = this.findScheme(scheme.getId());
+                if (test != null) {
+                    isNew = false;
+                }
+            } catch (final Exception e) {
+                Logger.debug(this.getClass(), e.getMessage(), e);
+            }
+        } else {
+            scheme.setId(UUIDGenerator.generateUuid());
+        }
+
+        scheme.setModDate(new Date());
+
+        final DotConnect db = new DotConnect();
+        try {
+
+            if (isNew) {
+
+                db.setSQL(sql.INSERT_SCHEME);
+                db.addParam(scheme.getId());
+                db.addParam(scheme.getName());
+                db.addParam(scheme.getDescription());
+                db.addParam(scheme.isArchived());
+                db.addParam(false);
+                db.addParam(scheme.isDefaultScheme());
+                db.addParam(scheme.getModDate());
+                db.loadResult();
+            } else {
+                db.setSQL(sql.UPDATE_SCHEME);
+                db.addParam(scheme.getName());
+                db.addParam(scheme.getDescription());
+                db.addParam(scheme.isArchived());
+                db.addParam(false);
+                db.addParam(scheme.getModDate());
+                db.addParam(scheme.getId());
+                db.loadResult();
+
+            }
+            cache.remove(scheme);
+        } catch (final Exception e) {
+            throw new DotDataException(e.getMessage(), e);
+        }
+    }
+
+    public void forceDeleteSchemeForContentType(final String contentTypeId)
+            throws DotDataException {
+
+        try {
+
+            Logger.info(this,
+                    "Deleting the schemes associated to the content type: " + contentTypeId);
+
+            new DotConnect().setSQL(sql.DELETE_SCHEME_FOR_STRUCT)
+                    .addParam(contentTypeId).loadResult();
+
+            cache.removeStructure(contentTypeId);
+        } catch (final Exception e) {
+            Logger.error(this.getClass(), e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void deleteSchemeForStruct(final String struc) throws DotDataException {
+        if (LicenseUtil.getLevel() < LicenseLevel.STANDARD.level) {
+            return;
+        }
+
+        this.forceDeleteSchemeForContentType(struc);
+    }
+
+    @Override
+    public void saveSchemeIdsForContentType(final String contentTypeInode,
+            final Set<String> schemesIds,
+            final Consumer<WorkflowTask> workflowTaskConsumer) throws DotDataException {
+
+        if (LicenseUtil.getLevel() < LicenseLevel.STANDARD.level) {
+
+            return;
+        }
+
+        try {
+
+            final DotConnect db = new DotConnect();
+            db.setSQL(sql.DELETE_SCHEME_FOR_STRUCT);
+            db.addParam(contentTypeInode);
+            db.loadResult();
+
+            final ImmutableList.Builder<WorkflowStep> stepBuilder = new ImmutableList.Builder<>();
+            for (final String id : schemesIds) {
+                db.setSQL(sql.INSERT_SCHEME_FOR_STRUCT);
+                db.addParam(UUIDGenerator.generateUuid());
+                db.addParam(id);
+                db.addParam(contentTypeInode);
+                db.loadResult();
+
+                stepBuilder.addAll(this.findSteps(this.findScheme(id)));
+            }
+            // update all tasks for the content type and reset their step to
+            // null
+            this.cleanWorkflowTaskStatus(contentTypeInode, stepBuilder.build(),
+                    workflowTaskConsumer);
+            this.checkContentTypeWorkflowTaskNullStatus(contentTypeInode, workflowTaskConsumer);
+
+            // we have to clear the saved steps/tasks for all contentlets using
+            // this workflow
+
+            cache.removeStructure(contentTypeInode);
+            cache.clearStepsCache();
+        } catch (final Exception e) {
+
+            Logger.error(this.getClass(), e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+    }
+
+    private void checkContentTypeWorkflowTaskNullStatus(final String contentTypeInode,
+            final Consumer<WorkflowTask> workflowTaskConsumer) throws DotDataException {
+
+        try {
+
+            final List<WorkflowTask> tasks = this
+                    .convertListToObjects(new DotConnect()
+                            .setSQL(sql.SELECT_TASK_NULL_BY_STRUCT)
+                            .addParam(contentTypeInode).loadObjectResults(), WorkflowTask.class);
+
+            //clean cache
+            tasks.stream().forEach(task -> {
+
+                if (null != workflowTaskConsumer) {
+
+                    workflowTaskConsumer.accept(task);
+                }
+            });
+        } catch (final Exception e) {
+            Logger.error(this.getClass(), e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Set workflow tasks with status null, for all the existing workflow task with the specified
+     * contentTypeInode and not in the list of steps availables fot the content type schemes
+     *
+     * @param contentTypeInode     Content Type Inode {@link String}
+     * @param steps                List of valid Steps {@link List}
+     * @param workflowTaskConsumer {@link Consumer}
+     */
+    private void cleanWorkflowTaskStatus(final String contentTypeInode,
+            final List<WorkflowStep> steps,
+            final Consumer<WorkflowTask> workflowTaskConsumer)
+            throws DotDataException {
+        try {
+
+            String condition = "";
+            if (steps.size() > 0) {
+                condition = " and status not in (";
+                StringBuilder parameters = new StringBuilder();
+                for (int i = 0; i < steps.size(); i++) {
+                    parameters.append(", ?");
+                }
+                condition += parameters.toString().substring(1) + " )";
+            }
+
+            final DotConnect db = new DotConnect();
+            db.setSQL(sql.SELECT_TASK_STEPS_TO_CLEAN_BY_STRUCT + condition);
+            db.addParam(contentTypeInode);
+            if (steps.size() > 0) {
+                for (WorkflowStep step : steps) {
+                    db.addParam(step.getId());
+                }
+            }
+            final List<WorkflowTask> tasks = this
+                    .convertListToObjects(db.loadObjectResults(), WorkflowTask.class);
+
+            //clean cache
+            tasks.stream().forEach(task -> {
+
+                cache.remove(task);
+                if (null != workflowTaskConsumer) {
+
+                    workflowTaskConsumer.accept(task);
+                }
+            });
+
+            db.setSQL(sql.UPDATE_STEPS_BY_STRUCT + condition);
+            db.addParam((Object) null);
+            db.addParam(contentTypeInode);
+            if (steps.size() > 0) {
+                for (WorkflowStep step : steps) {
+                    db.addParam(step.getId());
+                }
+            }
+            db.loadResult();
+
+        } catch (final Exception e) {
+            Logger.error(this.getClass(), e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void saveSchemesForStruct(final String contentTypeInode,
+            final List<WorkflowScheme> schemes,
+            final Consumer<WorkflowTask> workflowTaskConsumer) throws DotDataException {
+
+        final Set<String> ids = schemes.stream()
+                .map(WorkflowScheme::getId)
+                .collect(Collectors.toSet());
+
+        this.saveSchemeIdsForContentType(contentTypeInode, ids, workflowTaskConsumer);
+    }
+
+    @Override
+    public void saveStep(WorkflowStep step) throws DotDataException, AlreadyExistException {
+
+        boolean isNew = true;
+        if (UtilMethods.isSet(step.getId())) {
+            try {
+                final WorkflowStep test = this.findStep(step.getId());
+                if (test != null) {
+                    isNew = false;
+                }
+            } catch (final Exception e) {
+                Logger.debug(this.getClass(), e.getMessage(), e);
+            }
+        } else {
+            step.setId(UUIDGenerator.generateUuid());
+        }
+
+        final DotConnect db = new DotConnect();
+        if (isNew) {
+
+            db.setSQL(sql.INSERT_STEP);
+            db.addParam(step.getId());
+            db.addParam(step.getName());
+            db.addParam(step.getSchemeId());
+            db.addParam(step.getMyOrder());
+            db.addParam(step.isResolved());
+            db.addParam(step.isEnableEscalation());
+            if (step.isEnableEscalation()) {
+                db.addParam(step.getEscalationAction());
+                db.addParam(step.getEscalationTime());
+            } else {
+                db.addParam((Object) null);
+                db.addParam(0);
+            }
+            db.loadResult();
+        } else {
+            db.setSQL(sql.UPDATE_STEP);
+            db.addParam(step.getName());
+            db.addParam(step.getSchemeId());
+            db.addParam(step.getMyOrder());
+            db.addParam(step.isResolved());
+            db.addParam(step.isEnableEscalation());
+            if (step.isEnableEscalation()) {
+                db.addParam(step.getEscalationAction());
+                db.addParam(step.getEscalationTime());
+            } else {
+                db.addParam((Object) null);
+                db.addParam(0);
+            }
+            db.addParam(step.getId());
+            db.loadResult();
+        }
+        cache.remove(step);
+
+        // update workflowScheme mod date
+        WorkflowScheme scheme = findScheme(step.getSchemeId());
+        saveScheme(scheme);
+
+    }
+
+    @Override
+    public void saveWorkflowActionClassParameter(WorkflowActionClassParameter param)
+            throws DotDataException, AlreadyExistException {
+
+        boolean isNew = true;
+        if (UtilMethods.isSet(param.getId())) {
+            try {
+                final WorkflowActionClassParameter test = this.findActionClassParameter(
+                        param.getId());
+                if (test != null) {
+                    isNew = false;
+                }
+            } catch (final Exception e) {
+                Logger.debug(this.getClass(), e.getMessage(), e);
+            }
+        } else {
+            param.setId(UUIDGenerator.generateUuid());
+        }
+
+        final DotConnect db = new DotConnect();
+        if (isNew) {
+            db.setSQL(sql.INSERT_ACTION_CLASS_PARAM);
+            db.addParam(param.getId());
+            db.addParam(param.getActionClassId());
+            db.addParam(param.getKey());
+            db.addParam(param.getValue());
+            db.loadResult();
+        } else {
+            db.setSQL(sql.UPDATE_ACTION_CLASS_PARAM);
+
+            db.addParam(param.getActionClassId());
+            db.addParam(param.getKey());
+            db.addParam(param.getValue());
+            db.addParam(param.getId());
+
+            db.loadResult();
+        }
+
+        // update workflowScheme mod date
+        final WorkflowActionClass actionClass = findActionClass(param.getActionClassId());
+        final WorkflowAction action = findAction(actionClass.getActionId());
+        final WorkflowScheme scheme = findScheme(action.getSchemeId());
+        saveScheme(scheme);
+    }
+
+    @Override
+    public void saveWorkflowHistory(WorkflowHistory history) throws DotDataException {
+        boolean isNew = true;
+        if (UtilMethods.isSet(history.getId())) {
+            try {
+                final WorkflowHistory test = this.findWorkFlowHistoryById(history.getId());
+                if (test != null) {
+                    isNew = false;
+                }
+            } catch (final Exception e) {
+                Logger.debug(this.getClass(), e.getMessage(), e);
+            }
+        } else {
+            history.setId(UUIDGenerator.generateUuid());
+        }
+
+        final DotConnect db = new DotConnect();
+
+        if (isNew) {
+            db.setSQL(WorkflowSQL.INSERT_WORKFLOW_HISTORY);
+            db.addParam(history.getId());
+            setHistoryDBParams(history, db);
+            db.loadResult();
+        } else {
+            db.setSQL(WorkflowSQL.UPDATE_WORKFLOW_HISTORY);
+            setHistoryDBParams(history, db);
+            db.addParam(history.getId());
+            db.loadResult();
+        }
+    }
+
+    private void setHistoryDBParams(WorkflowHistory history, DotConnect db) {
+        db.addParam(history.getCreationDate());
+        db.addParam(history.getMadeBy());
+        db.addParam(history.getRawChangeDescription());
+        db.addParam(history.getWorkflowtaskId());
+        db.addParam(history.getActionId());
+        db.addParam(history.getStepId());
+    }
+
+    @Override
+    public void saveWorkflowTask(WorkflowTask task) throws DotDataException {
+
+        final DotConnect db = new DotConnect()
+                .setSQL(WorkflowSQL.SELECT_TASK)
+                .addParam(task.getWebasset())
+                .addParam(task.getLanguageId());
+
+        final WorkflowTask dbTask = Try
+                .of(() -> this.convertListToObjects(db.loadObjectResults(), WorkflowTask.class)
+                        .get(0))
+                .getOrNull();
+
+        final boolean isNew = !UtilMethods.isSet(dbTask) || UtilMethods.isEmpty(dbTask.getId());
+
+        if (isNew) {
+            task.setId(UUIDGenerator.generateUuid());
+            db.setSQL(WorkflowSQL.INSERT_WORKFLOW_TASK);
+            db.addParam(task.getId());
+            setTaskDBParams(task, db);
+        } else {
+            task.setId(dbTask.getId());
+            db.setSQL(WorkflowSQL.UPDATE_WORKFLOW_TASK);
+            setTaskDBParams(task, db);
+            db.addParam(task.getId());
+        }
+        db.loadResult();
+
+        cache.remove(task);
+    }
+
+    private void setTaskDBParams(WorkflowTask task, DotConnect db) {
+        db.addParam(task.getCreationDate());
+        db.addParam(task.getModDate());
+        db.addParam(task.getDueDate());
+        db.addParam(task.getCreatedBy());
+        db.addParam(task.getAssignedTo());
+        db.addParam(task.getBelongsTo());
+        db.addParam(task.getTitle());
+        db.addParam(task.getDescription());
+        db.addParam(task.getStatus());
+        db.addParam(task.getWebasset());
+        db.addParam(task.getLanguageId());
+    }
+
+    @Override
+    public List<WorkflowTask> searchTasks(WorkflowSearcher searcher) throws DotDataException {
+        DotConnect dc = getWorkflowSqlQuery(searcher, false);
+        dc.setStartRow(searcher.getCount() * searcher.getPage());
+        dc.setMaxRows(searcher.getCount());
+        List<Map<String, Object>> results = dc.loadObjectResults();
+        List<WorkflowTask> wfTasks = new ArrayList<>();
+
+        for (Map<String, Object> row : results) {
+            WorkflowTask wt = new WorkflowTask();
+            wt.setId(getStringValue(row, "id"));
+            wt.setCreationDate((Date) row.get("creation_date"));
+            wt.setModDate((Date) row.get("mod_date"));
+            wt.setDueDate((Date) row.get("due_date"));
+            wt.setCreatedBy(getStringValue(row, "created_by"));
+            wt.setAssignedTo(getStringValue(row, "assigned_to"));
+            wt.setBelongsTo(getStringValue(row, "belongs_to"));
+            wt.setTitle(getStringValue(row, "title"));
+            wt.setDescription(getStringValue(row, "description"));
+            wt.setStatus(getStringValue(row, "status"));
+            wt.setWebasset(getStringValue(row, "webasset"));
+            wt.setLanguageId(getLongValue(row, "language_id"));
+            wfTasks.add(wt);
+        }
+
+        return wfTasks;
+    }
+
+    /**
+     * @param row
+     * @param key
+     * @return
+     */
+    private String getStringValue(Map<String, Object> row, String key) {
+        Object value = row.get(key);
+        return (value == null) ? "" : value.toString();
+    }
+
+    /**
+     * @param row
+     * @param key
+     * @return
+     */
+    private Long getLongValue(final Map<String, Object> row, final String key) {
+        return ConversionUtils.toLong(row.get(key), 0L);
+    }
+
+    @Override
+    public List<WorkflowTask> searchAllTasks(WorkflowSearcher searcher) throws DotDataException {
+
+        final HibernateUtil hu = new HibernateUtil(WorkflowTask.class);
+        final StringWriter sw = new StringWriter();
+        sw.append("select {workflow_task.*}  from workflow_task   ");
+        hu.setSQLQuery(sw.toString());
+        if (searcher != null) {
+            hu.setMaxResults(searcher.getCount());
+            hu.setFirstResult(searcher.getCount() * searcher.getPage());
+        }
+
+        return (List<WorkflowTask>) hu.list();
+
+    }
+
+    @Override
+    public WorkflowHistory retrieveLastStepAction(String taskId) throws DotDataException {
+
+        final DotConnect db = new DotConnect();
+        try {
+
+            db.setSQL(sql.RETRIEVE_LAST_STEP_ACTIONID);
+            db.addParam(taskId);
+            db.loadResult();
+        } catch (final Exception e) {
+            Logger.debug(this.getClass(), e.getMessage(), e);
+        }
+
+        return (WorkflowHistory) this.convertListToObjects(db.loadObjectResults(),
+                WorkflowHistory.class).get(0);
+
+    }
+
+    @Override
+    public List<WorkflowTask> findExpiredTasks() throws DotDataException, DotSecurityException {
+        final DotConnect db = new DotConnect();
+        List<WorkflowTask> list = new ArrayList<>();
+        try {
+            db.setSQL(sql.SELECT_EXPIRED_TASKS);
+            List<Map<String, Object>> results = db.loadResults();
+            for (Map<String, Object> map : results) {
+                String taskId = (String) map.get("id");
+                WorkflowTask task = findWorkFlowTaskById(taskId);
+                list.add(task);
+            }
+        } catch (final Exception e) {
+            Logger.error(this, e.getMessage(), e);
+        } finally {
+            //Why do we need to clear the session here?
+            HibernateUtil.getSessionIfOpened().ifPresent(session -> session.clear());
+        }
+        return list;
+    }
+
+    @Override
+    public WorkflowScheme findSchemeByName(String schemaName) throws DotDataException {
+        WorkflowScheme scheme = null;
+        try {
+            final DotConnect db = new DotConnect();
+            db.setSQL(sql.SELECT_SCHEME_NAME);
+            db.addParam((schemaName != null ? schemaName.trim() : ""));
+            List<WorkflowScheme> list = this.convertListToObjects(db.loadObjectResults(),
+                    WorkflowScheme.class);
+            scheme = list.size() > 0 ? (WorkflowScheme) list.get(0) : null;
+        } catch (final Exception e) {
+            throw new DotDataException(e.getMessage(), e);
+        }
+        return scheme;
+    }
+
+    @Override
+    public void deleteWorkflowActionClassParameter(WorkflowActionClassParameter param)
+            throws DotDataException, AlreadyExistException {
+        DotConnect db = new DotConnect();
+        db.setSQL(sql.DELETE_ACTION_CLASS_PARAM_BY_ID);
+        db.addParam(param.getId());
+        db.loadResult();
+
+        // update scheme mod date
+        WorkflowActionClass clazz = findActionClass(param.getActionClassId());
+        WorkflowAction action = findAction(clazz.getActionId());
+        WorkflowScheme scheme = findScheme(action.getSchemeId());
+        saveScheme(scheme);
+    }
+
+    @Override
+    public void updateUserReferences(String userId, String userRoleId, String replacementUserId,
+            String replacementUserRoleId) throws DotDataException, DotSecurityException {
+        DotConnect dc = new DotConnect();
+
+        try {
+            dc.setSQL(
+                    "select id from workflow_task where (assigned_to = ? or assigned_to=? or created_by=? or created_by=?)");
+            dc.addParam(userId);
+            dc.addParam(userRoleId);
+            dc.addParam(userId);
+            dc.addParam(userRoleId);
+            List<HashMap<String, String>> tasks = dc.loadResults();
+
+            dc.setSQL("update workflow_comment set posted_by=? where posted_by  = ?");
+            dc.addParam(replacementUserId);
+            dc.addParam(userId);
+            dc.loadResults();
+
+            dc.setSQL("update workflow_comment set posted_by=? where posted_by  = ?");
+            dc.addParam(replacementUserRoleId);
+            dc.addParam(userRoleId);
+            dc.loadResults();
+
+            dc.setSQL("update workflow_task set assigned_to=? where assigned_to  = ?");
+            dc.addParam(replacementUserRoleId);
+            dc.addParam(userRoleId);
+            dc.loadResult();
+
+            dc.setSQL("update workflow_task set created_by=? where created_by  = ?");
+            dc.addParam(replacementUserId);
+            dc.addParam(userId);
+            dc.loadResult();
+
+            dc.setSQL("update workflow_task set created_by=? where created_by  = ?");
+            dc.addParam(replacementUserRoleId);
+            dc.addParam(userRoleId);
+            dc.loadResult();
+
+            dc.setSQL("update workflow_action set next_assign=? where next_assign = ?");
+            dc.addParam(replacementUserRoleId);
+            dc.addParam(userRoleId);
+            dc.loadResult();
+
+            for (HashMap<String, String> val : tasks) {
+                String id = val.get("id");
+                WorkflowTask task = findWorkFlowTaskById(id);
+                cache.remove(task);
+
+                dc.setSQL(
+                        "select workflow_step.id from workflow_step join workflow_task on workflow_task.status = workflow_step.id where workflow_task.webasset= ?");
+                dc.addParam(task.getWebasset());
+                List<HashMap<String, String>> steps = dc.loadResults();
+                for (HashMap<String, String> v : steps) {
+                    String stepId = v.get("id");
+                    WorkflowStep step = findStep(stepId);
+                    cache.remove(step);
+                }
+            }
+        } catch (DotDataException e) {
+            Logger.error(WorkFlowFactory.class, e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void updateStepReferences(String stepId, String replacementStepId)
+            throws DotDataException, DotSecurityException {
+        DotConnect dc = new DotConnect();
+
+        try {
+            // Replace references and clear cache for workflow actions
+            dc.setSQL("select step_id from workflow_action where next_step_id = ?");
+            dc.addParam(stepId);
+            List<HashMap<String, String>> actionStepIds = dc.loadResults();
+
+            if (replacementStepId != null) {
+                dc.setSQL("update workflow_action set next_step_id = ? where next_step_id = ?");
+                dc.addParam(replacementStepId);
+                dc.addParam(stepId);
+                dc.loadResult();
+
+            } else {
+                dc.setSQL(
+                        "update workflow_action set next_step_id = step_id where next_step_id = ?");
+                dc.addParam(stepId);
+                dc.loadResult();
+            }
+
+            for (HashMap<String, String> v : actionStepIds) {
+                String id = v.get("step_id");
+                WorkflowStep step = findStep(id);
+                cache.remove(step);
+            }
+
+            // Replace references and clear cache for workflow tasks
+            dc.setSQL("select id from workflow_task where status = ?");
+            dc.addParam(stepId);
+            List<HashMap<String, String>> taskIds = dc.loadResults();
+
+            dc.setSQL("update workflow_task set status = ? where status = ?");
+            dc.addParam(replacementStepId);
+            dc.addParam(stepId);
+            dc.loadResults();
+
+            for (HashMap<String, String> val : taskIds) {
+                String id = val.get("id");
+                WorkflowTask task = findWorkFlowTaskById(id);
+                cache.remove(task);
+            }
+
+        } catch (DotDataException e) {
+            Logger.error(WorkFlowFactory.class, e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<WorkflowTask> findTasksByStep(final String stepId)
+            throws DotDataException, DotSecurityException {
+        List<WorkflowTask> tasks;
+        DotConnect dc = new DotConnect();
+
+        try {
+            dc.setSQL(sql.SELECT_TASKS_BY_STEP);
+            dc.addParam(stepId);
+            tasks = this.convertListToObjects(dc.loadObjectResults(), WorkflowTask.class);
+        } catch (DotDataException e) {
+            Logger.error(WorkFlowFactory.class, e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+        return tasks;
+    }
+
+    @Override
+    public List<ContentType> findContentTypesByScheme(final WorkflowScheme scheme)
+            throws DotDataException, DotSecurityException {
+        List<ContentType> contentTypes;
+        DotConnect dc = new DotConnect();
+        try {
+            dc.setSQL(sql.SELECT_STRUCTS_FOR_SCHEME);
+            dc.addParam(scheme.getId());
+            contentTypes = this.convertListToObjects(dc.loadObjectResults(), ContentType.class);
+
+        } catch (DotDataException e) {
+            Logger.error(WorkFlowFactory.class, e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+        return contentTypes;
+    }
+
+    @Override
+    public void deleteScheme(final WorkflowScheme scheme)
+            throws DotDataException, DotSecurityException {
+        DotConnect dc = new DotConnect();
+        try {
+            //delete association of content types with the scheme
+            dc.setSQL(sql.DELETE_STRUCTS_FOR_SCHEME);
+            dc.addParam(scheme.getId());
+            dc.loadResult();
+
+            //delete the scheme
+            dc.setSQL(sql.DELETE_SCHEME);
+            dc.addParam(scheme.getId());
+            dc.loadResult();
+
+            final List<WorkflowAction> actions =
+                    this.cache.getActions(scheme);
+            if (null != actions) {
+                actions.stream().forEach(action -> this.cache.remove(action));
+            }
+
+            this.deleteSystemActionsByScheme(scheme);
+            this.cache.remove(scheme);
+        } catch (DotDataException e) {
+            Logger.error(WorkFlowFactory.class, e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void deleteSystemActionsByScheme(final WorkflowScheme scheme) throws DotDataException {
+
+        Logger.debug(this,
+                () -> "Deleting the system action mappings associated to the scheme: "
+                        + scheme.getId());
+
+        new DotConnect()
+                .setSQL(sql.DELETE_SYSTEM_ACTION_BY_SCHEME_OR_CONTENT_TYPE)
+                .addParam(scheme.getId())
+                .loadResult();
+        this.cache.removeSystemActionsByScheme(scheme.getId());
+    }
+
+    @Override
+    public void deleteSystemActionsByContentType(final String contentTypeVariable)
+            throws DotDataException {
+
+        Logger.debug(this,
+                () -> "Deleting the system action mappings associated to the content type: "
+                        + contentTypeVariable);
+
+        new DotConnect()
+                .setSQL(sql.DELETE_SYSTEM_ACTION_BY_SCHEME_OR_CONTENT_TYPE)
+                .addParam(contentTypeVariable)
+                .loadResult();
+        this.cache.removeSystemActionsByContentType(contentTypeVariable);
+    }
+
+    @Override
+    public Set<String> findNullTaskContentletIdentifiersForScheme(final String workflowSchemeId)
+            throws DotDataException {
+        final DotConnect dc = new DotConnect();
+        try {
+            dc.setSQL(sql.SELECT_NULL_TASK_CONTENTLET_FOR_WORKFLOW);
+            dc.addParam(workflowSchemeId);
+            final List<Map<String, String>> result = dc.loadResults();
             return result.stream().map(row -> row.get("identifier")).collect(Collectors.toSet());
-		} catch (DotDataException e) {
-			Logger.error(WorkFlowFactory.class,e.getMessage(),e);
-			throw new DotDataException(e.getMessage(), e);
-		}
-	}
+        } catch (DotDataException e) {
+            Logger.error(WorkFlowFactory.class, e.getMessage(), e);
+            throw new DotDataException(e.getMessage(), e);
+        }
+    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/startup/AbstractJDBCStartupTask.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/AbstractJDBCStartupTask.java
@@ -3,6 +3,7 @@ package com.dotmarketing.startup;
 import static com.dotcms.util.CollectionsUtils.getMapValue;
 import static com.dotcms.util.CollectionsUtils.map;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.util.SQLUtil;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -704,6 +705,7 @@ public abstract class AbstractJDBCStartupTask implements StartupTask {
 	}
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException{
 		DotConnect dc = new DotConnect();
 		Connection conn = null;

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00001LoadSchema.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00001LoadSchema.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runalways;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.enterprise.license.LicenseManager;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.util.SQLUtil;
@@ -9,14 +10,10 @@ import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.startup.StartupTask;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.MaintenanceUtil;
-
 import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -35,6 +32,7 @@ import java.util.List;
 public class Task00001LoadSchema implements StartupTask {
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		Logger.info(this.getClass(), "Loading schema");
 		String schemaFile = null;

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00002LoadClusterLicenses.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00002LoadClusterLicenses.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runalways;
 
+import com.dotcms.business.WrapInTransaction;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -45,6 +46,7 @@ public class Task00002LoadClusterLicenses implements StartupTask {
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         
         for(File pack : licensePackFiles()){

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00003CreateSystemRoles.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00003CreateSystemRoles.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runalways;
 
+import com.dotcms.business.WrapInTransaction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -30,6 +31,8 @@ public class Task00003CreateSystemRoles implements StartupTask {
 	
 	private final String[] rolesWithUsersLocked = { "LDAP User", "CMS Owner", "CMS Anonymous" };
 
+	@WrapInTransaction
+	@Override
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		
 		DotConnect dc = new DotConnect();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00004LoadStarter.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00004LoadStarter.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runalways;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DotCMSInitDb;
 import com.dotmarketing.exception.DotDataException;
@@ -8,7 +9,8 @@ import com.dotmarketing.startup.StartupTask;
 
 public class Task00004LoadStarter implements StartupTask {
 
-	
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 
 		DotCMSInitDb.InitializeDb();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00005LoadFixassets.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00005LoadFixassets.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.startup.runalways;
 
 
+import com.dotcms.business.WrapInTransaction;
 import org.quartz.JobExecutionContext;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -13,14 +14,12 @@ import com.dotmarketing.util.Logger;
 
 public class Task00005LoadFixassets implements StartupTask {
 
-	
-		public void executeUpgrade() throws DotDataException, DotRuntimeException {
-			
-
-	    	FixTasksExecutor fixtask=FixTasksExecutor.getInstance();
-	        JobExecutionContext arg0=null;
-	        fixtask.execute(arg0);
-			
+	@Override
+	@WrapInTransaction
+	public void executeUpgrade() throws DotDataException, DotRuntimeException {
+		FixTasksExecutor fixtask=FixTasksExecutor.getInstance();
+		JobExecutionContext arg0=null;
+		fixtask.execute(arg0);
 	}
 
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00006CreateSystemLayout.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00006CreateSystemLayout.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runalways;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.startup.runonce.Task04355SystemEventAddServerIdColumn;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +15,9 @@ import com.dotmarketing.util.Logger;
 
 public class Task00006CreateSystemLayout implements StartupTask {
 	List<String> missingPortlets=new ArrayList<String>();
+
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		try {
 			Layout layout=getAdminLayout();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00007RemoveSitesearchQuartzJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00007RemoveSitesearchQuartzJob.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runalways;
 
+import com.dotcms.business.WrapInTransaction;
 import org.quartz.SchedulerException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -19,7 +20,8 @@ public class Task00007RemoveSitesearchQuartzJob implements StartupTask {
 	
 	private final String deleteJobDetails = "DELETE FROM qrtz_excl_job_details WHERE job_name = 'site-search-execute-once'";
 	
-
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		
 		try {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00030ClusterInitialize.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00030ClusterInitialize.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runalways;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.enterprise.cluster.ClusterFactory;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -47,6 +48,7 @@ public class Task00030ClusterInitialize implements StartupTask {
     }
 
     @Override
+	@WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
             ClusterFactory.initialize();
     }

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00040CheckAnonymousUser.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00040CheckAnonymousUser.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runalways;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Map;
@@ -35,6 +36,7 @@ public class Task00040CheckAnonymousUser implements StartupTask{
 	}
 
 	@Override
+    @WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecrets.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecrets.java
@@ -11,6 +11,7 @@ import static com.dotcms.security.apps.AppsUtil.validateForSave;
 import static com.dotmarketing.util.UtilMethods.isSet;
 import static com.liferay.util.StringPool.BLANK;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.security.apps.AppDescriptor;
 import com.dotcms.security.apps.AppDescriptorHelper;
 import com.dotcms.security.apps.AppSecrets;
@@ -87,6 +88,7 @@ public class Task00050LoadAppsSecrets implements StartupTask {
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         final DotConnect dotConnect = new DotConnect();
         final Map<String, AppDescriptor> descriptorsMap = getAppDescriptors();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00768CreateTagStorageFieldOnHostStructure.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00768CreateTagStorageFieldOnHostStructure.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.cache.FieldsCache;
@@ -38,6 +39,8 @@ public class Task00768CreateTagStorageFieldOnHostStructure implements StartupTas
         }
     }
 
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		
 	    upgradeStructureFields();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00782CleanDataInconsistencies.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00782CleanDataInconsistencies.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.beans.Inode;
@@ -21,7 +22,9 @@ public class Task00782CleanDataInconsistencies implements StartupTask {
     public boolean forceRun() {
         return true;
     }
-    
+
+    @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         DotConnect dc=new DotConnect();
         

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00785DataModelChanges.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00785DataModelChanges.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -1259,6 +1260,8 @@ public class Task00785DataModelChanges implements StartupTask  {
 	  return true;
 	}
 
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		DotConnect dc = new DotConnect();
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00790DataModelChangesForWebAssets.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00790DataModelChangesForWebAssets.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -415,6 +416,8 @@ public class Task00790DataModelChangesForWebAssets implements StartupTask {
 		}
 	}
 
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotHibernateException {
 		DotConnect dc = new DotConnect();
 		HibernateUtil.startTransaction();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00795LiveWorkingToIdentifier.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00795LiveWorkingToIdentifier.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.PreparedStatement;
@@ -644,6 +645,8 @@ public class Task00795LiveWorkingToIdentifier implements StartupTask {
         } while(notDone);
     }
 
+    @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00800CreateTemplateContainers.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00800CreateTemplateContainers.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.util.List;
 import java.util.Map;
 
@@ -14,6 +15,8 @@ import com.dotmarketing.util.UUIDGenerator;
 
 public class Task00800CreateTemplateContainers implements StartupTask{
 
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		
 		DotConnect dc = new DotConnect();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00810FilesAsContentChanges.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00810FilesAsContentChanges.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.startup.runonce;
 
 
+import com.dotcms.business.WrapInTransaction;
 import java.util.Date;
 
 import com.dotmarketing.beans.Host;
@@ -29,6 +30,8 @@ public class Task00810FilesAsContentChanges implements StartupTask {
 		return true;
 	}
 
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		
 		try{

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00815WorkFlowTablesChanges.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00815WorkFlowTablesChanges.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -243,6 +244,8 @@ public class Task00815WorkFlowTablesChanges implements StartupTask{
     	}
     }
 
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		Connection conn = null;
 		DotConnect dc = new DotConnect();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00820CreateNewWorkFlowTables.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00820CreateNewWorkFlowTables.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -378,6 +379,8 @@ public class Task00820CreateNewWorkFlowTables implements StartupTask {
 
     }
 
+	@Override
+	@WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00840FixContentletVersionInfo.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00840FixContentletVersionInfo.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.Date;
@@ -244,7 +245,8 @@ public class Task00840FixContentletVersionInfo implements StartupTask {
            "alter table contentlet_version_info add constraint FK_con_ver_lockedby    " +
            "  foreign key (locked_by) references user_(userid)");
     }
-    
+    @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00845ChangeLockedOnToTimeStamp.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00845ChangeLockedOnToTimeStamp.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -35,7 +36,8 @@ public class Task00845ChangeLockedOnToTimeStamp implements StartupTask {
 
     }
 
-
+    @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00850DropOldFilesConstraintInWorkflow.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00850DropOldFilesConstraintInWorkflow.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -31,7 +32,8 @@ public class Task00850DropOldFilesConstraintInWorkflow implements StartupTask {
 
     }
 
-
+    @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00860ExtendServerIdsMSSQL.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00860ExtendServerIdsMSSQL.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -39,7 +40,8 @@ public class Task00860ExtendServerIdsMSSQL implements StartupTask {
         }
     }
 
-
+    @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00865AddTimestampToVersionTables.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00865AddTimestampToVersionTables.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -77,7 +78,8 @@ public class Task00865AddTimestampToVersionTables implements StartupTask {
         }
     }
 
-
+    @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00900CreateLogConsoleTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00900CreateLogConsoleTable.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -15,7 +16,8 @@ public class Task00900CreateLogConsoleTable implements StartupTask {
 	public boolean forceRun() {
 		return true;
 	}
-
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		try {
 			DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00920AddContentletVersionSystemHost.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00920AddContentletVersionSystemHost.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -25,6 +26,7 @@ public class Task00920AddContentletVersionSystemHost implements StartupTask {
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade () throws DotDataException, DotRuntimeException {
 
         //Update identifier table for the SYSTEM_HOST

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00935LogConsoleTableData.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00935LogConsoleTableData.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
@@ -16,7 +17,8 @@ public class Task00935LogConsoleTableData implements StartupTask {
     public boolean forceRun () {
         return true;
     }
-
+    @Override
+    @WrapInTransaction
     public void executeUpgrade () throws DotDataException, DotRuntimeException {
 
         try {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00940AlterTemplateTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00940AlterTemplateTable.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.beans.Inode;
@@ -57,7 +58,8 @@ public class Task00940AlterTemplateTable implements StartupTask {
         }
     }
 
-
+    @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00945AddTableContentPublishing.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00945AddTableContentPublishing.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.math.BigDecimal;
 import java.sql.SQLException;
 
@@ -194,6 +195,7 @@ public class Task00945AddTableContentPublishing implements StartupTask {
 	}	
 	
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00950AddTablePublishingEndpoint.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task00950AddTablePublishingEndpoint.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.math.BigDecimal;
 import java.sql.SQLException;
 
@@ -117,6 +118,7 @@ public class Task00950AddTablePublishingEndpoint implements StartupTask {
 	}
 	
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01020CreateDefaultWorkflow.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01020CreateDefaultWorkflow.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -266,6 +267,7 @@ public class Task01020CreateDefaultWorkflow implements StartupTask {
 	}
 	
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		try {
 			DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01055CreatePushPublishEnvironmentTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01055CreatePushPublishEnvironmentTable.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -112,6 +113,7 @@ public class Task01055CreatePushPublishEnvironmentTable implements StartupTask {
 	}
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		try {
 			DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01060CreatePushPublishPushedAssets.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01060CreatePushPublishPushedAssets.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -35,6 +36,7 @@ public class Task01060CreatePushPublishPushedAssets implements StartupTask {
 	}
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		try {
 			DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01080CreateModDateForMissingObjects.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01080CreateModDateForMissingObjects.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -87,6 +88,7 @@ public class Task01080CreateModDateForMissingObjects implements StartupTask {
 	}
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		try {
 			DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01090AddWorkflowSchemeUniqueNameContraint.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01090AddWorkflowSchemeUniqueNameContraint.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -12,6 +13,8 @@ import com.dotmarketing.util.Logger;
 public class Task01090AddWorkflowSchemeUniqueNameContraint implements StartupTask{
 
 	final private String WORKFLOW_SCHEME_CONSTRAINT = "alter table workflow_scheme add constraint unique_workflow_scheme_name unique (name)";
+	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		DotConnect dc = new DotConnect();
 		  try {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01096CreateContainerStructuresTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task01096CreateContainerStructuresTable.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -18,6 +19,7 @@ public class Task01096CreateContainerStructuresTable implements StartupTask {
 
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 
 		try {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03000CreateContainertStructures.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03000CreateContainertStructures.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,7 @@ public class Task03000CreateContainertStructures implements StartupTask {
 	}
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 
 		String createIndex = "create index idx_container_id on container_structures(container_id)";

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03015CreateClusterConfigModel.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03015CreateClusterConfigModel.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotcms.enterprise.cluster.ClusterFactory;
@@ -41,6 +42,7 @@ public class Task03015CreateClusterConfigModel implements StartupTask {
 	}
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		try {
 			DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03045TagnameTypeChangeMSSQL.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03045TagnameTypeChangeMSSQL.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -29,7 +30,8 @@ public class Task03045TagnameTypeChangeMSSQL implements StartupTask {
         }
     }
 
-
+    @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03100HTMLPageAsContentChanges.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03100HTMLPageAsContentChanges.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.util.List;
 import java.util.Map;
 
@@ -104,7 +105,8 @@ public class Task03100HTMLPageAsContentChanges implements StartupTask {
         return results==null || results.size()<1;
     }
 
-    @Override
+	@Override
+	@WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
     	
     	try{

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03120AddInodeToContainerStructure.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03120AddInodeToContainerStructure.java
@@ -1,6 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
-import com.dotmarketing.beans.Inode;
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
@@ -72,6 +72,7 @@ public class Task03120AddInodeToContainerStructure implements StartupTask {
      * @throws com.dotmarketing.exception.DotRuntimeException
      */
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
 
         try {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03510CreateDefaultPersona.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03510CreateDefaultPersona.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -58,6 +59,7 @@ public class Task03510CreateDefaultPersona extends AbstractJDBCStartupTask {
      * But I did not want to "CALL an API in a startup task"
      */
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
 
         DotConnect dc = new DotConnect();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03525LowerTagsTagname.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03525LowerTagsTagname.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
@@ -21,6 +22,7 @@ import java.util.UUID;
 public class Task03525LowerTagsTagname extends AbstractJDBCStartupTask {
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03540UpdateTagInodesReferences.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03540UpdateTagInodesReferences.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -39,6 +40,7 @@ public class Task03540UpdateTagInodesReferences extends AbstractJDBCStartupTask 
 	 * Update/fix the contentlets tags references in the tag_inode table 
 	 */
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException  {
 		if (DbConnectionFactory.isPostgres()){
 			executeUpgradeForPostgres();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03565FixContainerVersionsCheck.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03565FixContainerVersionsCheck.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.beans.Inode;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.util.SQLUtil;
@@ -20,7 +21,8 @@ public class Task03565FixContainerVersionsCheck implements StartupTask {
     public boolean forceRun() {
         return true;
     }
-
+    @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         DotConnect dc = new DotConnect();
         List<String> statements = new ArrayList<>();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03710AddFKForIntegrityCheckerTables.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03710AddFKForIntegrityCheckerTables.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -75,6 +76,7 @@ public class Task03710AddFKForIntegrityCheckerTables implements StartupTask {
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03715AddFKForPublishingBundleTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03715AddFKForPublishingBundleTable.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -39,6 +40,7 @@ public class Task03715AddFKForPublishingBundleTable implements StartupTask {
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03720AddRolesIntegrityCheckerTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03720AddRolesIntegrityCheckerTable.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 
 import com.dotmarketing.common.db.DotConnect;
@@ -35,6 +36,7 @@ public class Task03720AddRolesIntegrityCheckerTable implements StartupTask {
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03735UpdatePortletsIds.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03735UpdatePortletsIds.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +30,7 @@ public class Task03735UpdatePortletsIds implements StartupTask {
 	}
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		try {
 			DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03740UpdateLayoutIcons.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03740UpdateLayoutIcons.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
@@ -25,6 +26,7 @@ public class Task03740UpdateLayoutIcons implements StartupTask {
 	}
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		try {
 			DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03745DropLegacyHTMLPageAndFileTables.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task03745DropLegacyHTMLPageAndFileTables.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import java.sql.SQLException;
 import java.util.*;
 
@@ -19,6 +20,7 @@ public class Task03745DropLegacyHTMLPageAndFileTables implements StartupTask {
 	}
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
 		try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04115LowercaseIdentifierUrls.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04115LowercaseIdentifierUrls.java
@@ -2,6 +2,7 @@ package com.dotmarketing.startup.runonce;
 
 import static com.dotmarketing.portlets.folders.business.FolderAPI.SYSTEM_FOLDER_PARENT_PATH;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.util.SQLUtil;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -52,7 +53,8 @@ public class Task04115LowercaseIdentifierUrls implements StartupTask {
 		return true;
 	}
 
-	@Override
+    @Override
+    @WrapInTransaction
 	public void executeUpgrade() throws DotDataException, DotRuntimeException {
         try {
             DbConnectionFactory.getConnection().setAutoCommit(true);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04200CreateDefaultVanityURL.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04200CreateDefaultVanityURL.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.startup.AbstractJDBCStartupTask;
@@ -59,6 +60,7 @@ public class Task04200CreateDefaultVanityURL extends AbstractJDBCStartupTask {
 	private static final String SELECT_FIELD = "com.dotcms.contenttype.model.field.SelectField";
 
 	@Override
+	@WrapInTransaction
 	public void executeUpgrade() throws DotDataException {
 		DotConnect dc = new DotConnect();
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04205MigrateVanityURLToContent.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04205MigrateVanityURLToContent.java
@@ -2,6 +2,7 @@ package com.dotmarketing.startup.runonce;
 
 import static com.dotcms.util.CollectionsUtils.map;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.UserAPI;
 import com.dotmarketing.common.db.DotConnect;
@@ -85,6 +86,7 @@ public class Task04205MigrateVanityURLToContent extends AbstractJDBCStartupTask 
     private Map<String, String> siteIds = new HashMap<>();
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
 
         Connection conn =null;

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04210CreateDefaultLanguageVariable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04210CreateDefaultLanguageVariable.java
@@ -3,6 +3,7 @@ package com.dotmarketing.startup.runonce;
 import static com.dotcms.util.CollectionsUtils.list;
 import static com.dotcms.util.CollectionsUtils.map;
 
+import com.dotcms.business.WrapInTransaction;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +52,7 @@ public class Task04210CreateDefaultLanguageVariable implements StartupTask {
     };
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         DotConnect dc = new DotConnect();
         // Inserts into Inode table the reference to the Language Variable Content Type

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04230FixVanityURLInconsistencies.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04230FixVanityURLInconsistencies.java
@@ -32,7 +32,7 @@ public class Task04230FixVanityURLInconsistencies extends AbstractJDBCStartupTas
     }
 
     @Override
-    @CloseDBIfOpened
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
 
         final DotConnect dc = new DotConnect();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04235RemoveFKFromWorkflowTaskTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04235RemoveFKFromWorkflowTaskTable.java
@@ -3,6 +3,7 @@
 package com.dotmarketing.startup.runonce;
 
 import com.dotcms.business.CloseDBIfOpened;
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
@@ -36,7 +37,7 @@ public class Task04235RemoveFKFromWorkflowTaskTable extends AbstractJDBCStartupT
     }
 
     @Override
-    @CloseDBIfOpened
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
         DotConnect dc = new DotConnect();
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04300UpdateSystemFolderIdentifier.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04300UpdateSystemFolderIdentifier.java
@@ -35,7 +35,7 @@ public class Task04300UpdateSystemFolderIdentifier extends AbstractJDBCStartupTa
     }
 
     @Override
-    @CloseDBIfOpened
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
         DotConnect dc = new DotConnect();
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04310CreateWorkflowRoles.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04310CreateWorkflowRoles.java
@@ -46,6 +46,7 @@ public class Task04310CreateWorkflowRoles extends AbstractJDBCStartupTask {
     private String systemRootRoleId;
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
 
         dc = new DotConnect();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04315UpdateMultiTreePK.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04315UpdateMultiTreePK.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.google.common.collect.ImmutableList;
 
 import com.dotmarketing.beans.MultiTree;
@@ -54,6 +55,7 @@ public class Task04315UpdateMultiTreePK extends AbstractJDBCStartupTask{
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
         
         try {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04330WorkflowTaskAddLanguageIdColumn.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04330WorkflowTaskAddLanguageIdColumn.java
@@ -3,6 +3,7 @@
 package com.dotmarketing.startup.runonce;
 
 import com.dotcms.business.CloseDBIfOpened;
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.concurrent.DotConcurrentFactory;
 import com.dotcms.concurrent.DotSubmitter;
 import com.dotcms.util.CloseUtils;
@@ -109,6 +110,7 @@ public class Task04330WorkflowTaskAddLanguageIdColumn extends AbstractJDBCStartu
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
 
         final boolean created = this.addLanguageIdColumn();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04355SystemEventAddServerIdColumn.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04355SystemEventAddServerIdColumn.java
@@ -2,6 +2,7 @@
 
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.db.DotDatabaseMetaData;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -53,6 +54,7 @@ public class Task04355SystemEventAddServerIdColumn extends AbstractJDBCStartupTa
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
 
         this.addServerIdColumn();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04365RelationshipUniqueConstraint.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04365RelationshipUniqueConstraint.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
@@ -99,6 +100,7 @@ public class Task04365RelationshipUniqueConstraint extends AbstractJDBCStartupTa
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         //Run upgrade as usual
         super.executeUpgrade();

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task05160MultiTreeAddPersonalizationColumnAndChangingPK.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task05160MultiTreeAddPersonalizationColumnAndChangingPK.java
@@ -3,6 +3,7 @@
 package com.dotmarketing.startup.runonce;
 
 import com.dotcms.business.CloseDBIfOpened;
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.util.CollectionsUtils;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.db.DotDatabaseMetaData;
@@ -55,6 +56,7 @@ public class Task05160MultiTreeAddPersonalizationColumnAndChangingPK extends Abs
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
 
         if (DbConnectionFactory.isMsSql() && !DbConnectionFactory.getAutoCommit()) {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task05165CreateContentTypeWorkflowActionMappingTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task05165CreateContentTypeWorkflowActionMappingTable.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.startup.runonce;
 
 import com.dotcms.business.CloseDBIfOpened;
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.db.DotDatabaseMetaData;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -79,6 +80,7 @@ public class Task05165CreateContentTypeWorkflowActionMappingTable extends Abstra
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
 
         if (DbConnectionFactory.isMsSql() && !DbConnectionFactory.getAutoCommit()) {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task201102UpdateColumnSitelicTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task201102UpdateColumnSitelicTable.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.db.DotDatabaseMetaData;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -33,6 +34,7 @@ public class Task201102UpdateColumnSitelicTable implements StartupTask {
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         final Optional<String> type = getColumnType();
         if (!type.isPresent()) {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210218MigrateUserProxyTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210218MigrateUserProxyTable.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.rest.api.v1.DotObjectMapperProvider;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.db.DotDatabaseMetaData;
@@ -32,6 +33,7 @@ public class Task210218MigrateUserProxyTable implements StartupTask {
     private static final String MSSQL_SCRIPT = "alter table user_ add additional_info NVARCHAR(MAX) NULL;";
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
 
         try{

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210901UpdateDateTimezones.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task210901UpdateDateTimezones.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.util.DataSourceAttributes;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.db.DotDatabaseMetaData;
@@ -124,6 +125,7 @@ public class Task210901UpdateDateTimezones extends AbstractJDBCStartupTask {
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         tablesCount = 0;
         try {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task211101AddContentletAsJsonColumn.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task211101AddContentletAsJsonColumn.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.db.DotDatabaseMetaData;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -28,6 +29,7 @@ public class Task211101AddContentletAsJsonColumn implements StartupTask {
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         final Optional<String> type = getColumnType();
         if (!type.isPresent()) {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220402UpdateDateTimezones.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220402UpdateDateTimezones.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotDatabaseMetaData;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
@@ -67,6 +68,7 @@ public class Task220402UpdateDateTimezones extends Task210901UpdateDateTimezones
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
         tablesCount = 0;
         String tableName = null;

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220825MakeSomeSystemFieldsRemovable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task220825MakeSomeSystemFieldsRemovable.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.startup.AbstractJDBCStartupTask;
@@ -112,6 +113,7 @@ public class Task220825MakeSomeSystemFieldsRemovable extends AbstractJDBCStartup
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
         if (isPostgres() || isMsSql()) {
             for (final String baseType : newBaseTypes.keySet()) {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230110MakeSomeSystemFieldsRemovableByBaseType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230110MakeSomeSystemFieldsRemovableByBaseType.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.startup.runonce;
 
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
@@ -83,6 +84,7 @@ public class Task230110MakeSomeSystemFieldsRemovableByBaseType extends AbstractJ
     }
 
     @Override
+    @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
         if (isPostgres() || isMsSql()) {
             for (final Map.Entry<Object, List<String>> entry : BASE_TYPES_AND_FIELDS.entrySet()) {

--- a/dotCMS/src/main/java/com/dotmarketing/util/Config.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Config.java
@@ -1,22 +1,6 @@
 package com.dotmarketing.util;
 
-import com.google.common.collect.ImmutableList;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.lang.reflect.Array;
-import java.net.URL;
-import java.nio.file.Files;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import com.dotcms.repackage.com.google.common.base.Supplier;
-import org.apache.commons.io.IOUtils;
 import com.dotcms.util.ConfigurationInterpolator;
 import com.dotcms.util.FileWatcherAPI;
 import com.dotcms.util.ReflectionUtils;
@@ -26,208 +10,229 @@ import com.dotmarketing.business.APILocator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import io.vavr.control.Try;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Array;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.io.IOUtils;
 
 /**
- * This class provides access to the system configuration parameters that are
- * set through the {@code dotmarketing-config.properties}, and the
- * {@code dotcms-config-cluster.properties} files.
- * 
+ * This class provides access to the system configuration parameters that are set through the
+ * {@code dotmarketing-config.properties}, and the {@code dotcms-config-cluster.properties} files.
+ *
  * @author root
  * @version 1.0
  * @since Mar 22, 2012
- *
  */
 
 public class Config {
 
-	//Generated File Indicator
-	public static final String GENERATED_FILE ="dotGenerated_";
-	public static final String RENDITION_FILE ="dotRendition_";
-	public static final AtomicBoolean useWatcherMode = new AtomicBoolean(true);
-	public static final AtomicBoolean isWatching     = new AtomicBoolean(false);
+    //Generated File Indicator
+    public static final String GENERATED_FILE = "dotGenerated_";
+    public static final String RENDITION_FILE = "dotRendition_";
+    public static final AtomicBoolean useWatcherMode = new AtomicBoolean(true);
+    public static final AtomicBoolean isWatching = new AtomicBoolean(false);
+
+    public static final Map<String, String> testOverrideTracker = new ConcurrentHashMap<>();
 
 
-	/**
-	 * If this property is set in the dotmarketing-config, will try to use the interpolator for the properties
-	 * Otherwise will use {@link SystemEnvironmentConfigurationInterpolator}
-	 */
-	public static final String DOTCMS_CUSTOM_INTERPOLATOR = "dotcms.custom.interpolator";
+    /**
+     * If this property is set in the dotmarketing-config, will try to use the interpolator for the
+     * properties Otherwise will use {@link SystemEnvironmentConfigurationInterpolator}
+     */
+    public static final String DOTCMS_CUSTOM_INTERPOLATOR = "dotcms.custom.interpolator";
 
-	/**
-	 * If this property is set, defines the way you want to use to monitoring the changes over the dotmarketing-config.properties file.
-	 * By default is true and means that the {@link FileWatcherAPI} will be used to monitoring any change over the file and refresh the property based on it.
-	 * If you set it to false, will use the legacy mode previously used on dotCMS.
-	 */
-	public static final String DOTCMS_USEWATCHERMODE = "dotcms.usewatchermode";
-	public static int DB_VERSION=0;
+    /**
+     * If this property is set, defines the way you want to use to monitoring the changes over the
+     * dotmarketing-config.properties file. By default is true and means that the
+     * {@link FileWatcherAPI} will be used to monitoring any change over the file and refresh the
+     * property based on it. If you set it to false, will use the legacy mode previously used on
+     * dotCMS.
+     */
+    public static final String DOTCMS_USEWATCHERMODE = "dotcms.usewatchermode";
+    public static final String USE_CONFIG_TEST_OVERRIDE_TRACKER = "USE_CONFIG_TEST_OVERRIDE_TRACKER";
+    public static int DB_VERSION = 0;
 
     //Object Config properties      n
-	public static javax.servlet.ServletContext CONTEXT = null;
-	public static String CONTEXT_PATH = null;
+    public static javax.servlet.ServletContext CONTEXT = null;
+    public static String CONTEXT_PATH = null;
 
 
-
-	//Config internal properties
-	private static int refreshInterval = 5; //In minutes, Default 5 can be overridden in the config file as config.refreshinterval int property
-	private static Date lastRefreshTime = new Date ();
-	protected static PropertiesConfiguration props = null;
-	private static ClassLoader classLoader = null;
+    //Config internal properties
+    private static int refreshInterval = 5; //In minutes, Default 5 can be overridden in the config file as config.refreshinterval int property
+    private static Date lastRefreshTime = new Date();
+    protected static PropertiesConfiguration props = null;
+    private static ClassLoader classLoader = null;
     protected static URL dotmarketingPropertiesUrl = null;
     protected static URL clusterPropertiesUrl = null;
     private static int prevInterval = Integer.MIN_VALUE;
     private static FileWatcherAPI fileWatcherAPI = null;
 
 
-	/**
-	 * Config internal methods
-	 */
-	public static void initializeConfig () {
-	    classLoader = Thread.currentThread().getContextClassLoader();
-	    _loadProperties();
-	}
+    /**
+     * Config internal methods
+     */
+    public static void initializeConfig() {
+        classLoader = Thread.currentThread().getContextClassLoader();
+        _loadProperties();
+    }
 
-	private static void registerWatcher(final File fileToRead) {
+    private static void registerWatcher(final File fileToRead) {
 
-		initWatcherAPI();
-		if (null != fileWatcherAPI) {
+        initWatcherAPI();
+        if (null != fileWatcherAPI) {
 
-			// if we are not already watching, so register the waticher
-			if (!isWatching.get()) {
-				try {
+            // if we are not already watching, so register the waticher
+            if (!isWatching.get()) {
+                try {
 
-					Logger.debug(APILocator.class, "Start watching: " + fileToRead);
-					fileWatcherAPI.watchFile(fileToRead, () -> _loadProperties());
-					isWatching.set(true);
-				} catch (IOException e) {
-					Logger.error(Config.class, e.getMessage(), e);
-				}
-			}
-		} else {
-			// if not fileWatcherAPI could not monitoring, so use the fallback
-			useWatcherMode.set(false); isWatching.set(false);
-		}
-	} // registerWatcher.
+                    Logger.debug(APILocator.class, "Start watching: " + fileToRead);
+                    fileWatcherAPI.watchFile(fileToRead, () -> _loadProperties());
+                    isWatching.set(true);
+                } catch (IOException e) {
+                    Logger.error(Config.class, e.getMessage(), e);
+                }
+            }
+        } else {
+            // if not fileWatcherAPI could not monitoring, so use the fallback
+            useWatcherMode.set(false);
+            isWatching.set(false);
+        }
+    } // registerWatcher.
 
-	private static void initWatcherAPI() {
+    private static void initWatcherAPI() {
 
-		// checki if the watcher is already instantiated.
-		if (null == fileWatcherAPI) {
-			synchronized (Config.class) {
+        // checki if the watcher is already instantiated.
+        if (null == fileWatcherAPI) {
+            synchronized (Config.class) {
 
-				if (null == fileWatcherAPI) {
+                if (null == fileWatcherAPI) {
 
-					fileWatcherAPI = APILocator.getFileWatcherAPI();
-				}
-			}
-		}
-	}
+                    fileWatcherAPI = APILocator.getFileWatcherAPI();
+                }
+            }
+        }
+    }
 
-	private static void unregisterWatcher(final File fileToRead) {
+    private static void unregisterWatcher(final File fileToRead) {
 
-		initWatcherAPI();
-		if (null != fileWatcherAPI) {
+        initWatcherAPI();
+        if (null != fileWatcherAPI) {
 
-			Logger.debug(APILocator.class, "Stop watching: " + fileToRead);
-			fileWatcherAPI.stopWatchingFile(fileToRead);
-		}
-	}
-	/**
-	 * 
-	 */
-    private static void _loadProperties () {
+            Logger.debug(APILocator.class, "Stop watching: " + fileToRead);
+            fileWatcherAPI.stopWatchingFile(fileToRead);
+        }
+    }
 
-         if ( classLoader == null ) {
+    /**
+     *
+     */
+    private static void _loadProperties() {
+
+        if (classLoader == null) {
             classLoader = Thread.currentThread().getContextClassLoader();
             Logger.info(Config.class, "Initializing properties reader.");
         }
 
         //dotmarketing config file
         String propertyFile = "dotmarketing-config.properties";
-        if ( dotmarketingPropertiesUrl == null ) {
-            dotmarketingPropertiesUrl = classLoader.getResource( propertyFile );
+        if (dotmarketingPropertiesUrl == null) {
+            dotmarketingPropertiesUrl = classLoader.getResource(propertyFile);
         }
 
         //cluster config file
         propertyFile = "dotcms-config-cluster.properties";
-        if ( clusterPropertiesUrl == null ) {
-            clusterPropertiesUrl = classLoader.getResource( propertyFile );
+        if (clusterPropertiesUrl == null) {
+            clusterPropertiesUrl = classLoader.getResource(propertyFile);
         }
 
         //Reading both property files
-        readProperties( dotmarketingPropertiesUrl, clusterPropertiesUrl );
-        
+        readProperties(dotmarketingPropertiesUrl, clusterPropertiesUrl);
+
         // Include ENV variables that start with DOT_
 
         readEnvironmentVariables();
     }
 
-	/**
-	 * Reads the properties on the dotmarketing-config.properties and the
-	 * dotcms-config-cluster.properties properties files.
-	 *
-	 * @param dotmarketingURL
-	 * @param clusterURL
-	 */
-	private static void readProperties(URL dotmarketingURL, URL clusterURL) {
-		File dotmarketingFile = new File(dotmarketingURL.getPath());
-		Date lastDotmarketingModified = new Date(
-				dotmarketingFile.lastModified());
-		File clusterFile = new File(clusterURL.getPath());
-		Date lastClusterModified = new Date(clusterFile.lastModified());
+    /**
+     * Reads the properties on the dotmarketing-config.properties and the
+     * dotcms-config-cluster.properties properties files.
+     *
+     * @param dotmarketingURL
+     * @param clusterURL
+     */
+    private static void readProperties(URL dotmarketingURL, URL clusterURL) {
+        File dotmarketingFile = new File(dotmarketingURL.getPath());
+        Date lastDotmarketingModified = new Date(
+                dotmarketingFile.lastModified());
+        File clusterFile = new File(clusterURL.getPath());
+        Date lastClusterModified = new Date(clusterFile.lastModified());
 
-		if (props == null) {
-			synchronized (Config.class) {
-				if (props == null) {
-					readProperties(dotmarketingFile,
-							"dotmarketing-config.properties");
-					readProperties(clusterFile,
-							"dotcms-config-cluster.properties");
-				}
-			}
-		} else {
-			// Refresh the properties if changes detected in any of these
-			// properties files
-			if (lastDotmarketingModified.after(lastRefreshTime)
-					|| lastClusterModified.after(lastRefreshTime)) {
-				synchronized (Config.class) {
-					if (lastDotmarketingModified.after(lastRefreshTime)
-							|| lastClusterModified.after(lastRefreshTime)) {
-						try {
-							props = new PropertiesConfiguration();
-							// Cleanup and read the properties for both files
-							readProperties(dotmarketingFile,
-									"dotmarketing-config.properties");
-							readProperties(clusterFile,
-									"dotcms-config-cluster.properties");
-						} catch (Exception e) {
-							Logger.fatal(
-									Config.class,
-									"Exception loading property files [dotmarketing-config.properties, dotcms-config-cluster.properties]",
-									e);
-							props = null;
-						}
-					}
-				}
-			}
-		}
-		String type = "";
-		try {
-			refreshInterval = props.getInt("config.refreshinterval");
-			type = "custom";
-		} catch (NoSuchElementException e) {
-			// Property not present, use default interval value
-			type = "default";
-		} finally {
-			// Display log message the first time, and then only if interval changes
-			if (prevInterval != refreshInterval) {
-				Logger.info(Config.class, "Assigned " + type + " refresh: "
-						+ refreshInterval + " minutes.");
-				prevInterval = refreshInterval;
-			}
-		}
-		// Set the last time we refresh/read the properties files
-		Config.lastRefreshTime = new Date();
-	}
+        if (props == null) {
+            synchronized (Config.class) {
+                if (props == null) {
+                    readProperties(dotmarketingFile,
+                            "dotmarketing-config.properties");
+                    readProperties(clusterFile,
+                            "dotcms-config-cluster.properties");
+                }
+            }
+        } else {
+            // Refresh the properties if changes detected in any of these
+            // properties files
+            if (lastDotmarketingModified.after(lastRefreshTime)
+                    || lastClusterModified.after(lastRefreshTime)) {
+                synchronized (Config.class) {
+                    if (lastDotmarketingModified.after(lastRefreshTime)
+                            || lastClusterModified.after(lastRefreshTime)) {
+                        try {
+                            props = new PropertiesConfiguration();
+                            // Cleanup and read the properties for both files
+                            readProperties(dotmarketingFile,
+                                    "dotmarketing-config.properties");
+                            readProperties(clusterFile,
+                                    "dotcms-config-cluster.properties");
+                        } catch (Exception e) {
+                            Logger.fatal(
+                                    Config.class,
+                                    "Exception loading property files [dotmarketing-config.properties, dotcms-config-cluster.properties]",
+                                    e);
+                            props = null;
+                        }
+                    }
+                }
+            }
+        }
+        String type = "";
+        try {
+            refreshInterval = props.getInt("config.refreshinterval");
+            type = "custom";
+        } catch (NoSuchElementException e) {
+            // Property not present, use default interval value
+            type = "default";
+        } finally {
+            // Display log message the first time, and then only if interval changes
+            if (prevInterval != refreshInterval) {
+                Logger.info(Config.class, "Assigned " + type + " refresh: "
+                        + refreshInterval + " minutes.");
+                prevInterval = refreshInterval;
+            }
+        }
+        // Set the last time we refresh/read the properties files
+        Config.lastRefreshTime = new Date();
+    }
 
     /**
      * Reads a given property file and appends its content to the current read properties
@@ -235,83 +240,89 @@ public class Config {
      * @param fileToRead
      * @param fileName
      */
-    private static void readProperties ( File fileToRead, String fileName ) {
+    private static void readProperties(File fileToRead, String fileName) {
 
-		InputStream propsInputStream = null;
+        InputStream propsInputStream = null;
 
         try {
 
-            Logger.info( Config.class, "Loading dotCMS [" + fileName + "] Properties..." );
+            Logger.info(Config.class, "Loading dotCMS [" + fileName + "] Properties...");
 
-            if ( props == null ) {
+            if (props == null) {
                 props = new PropertiesConfiguration();
             }
 
             propsInputStream = Files.newInputStream(fileToRead.toPath());
-            props.load( new InputStreamReader( propsInputStream ) );
-            Logger.info( Config.class, "dotCMS Properties [" + fileName + "] Loaded" );
+            props.load(new InputStreamReader(propsInputStream));
+            Logger.info(Config.class, "dotCMS Properties [" + fileName + "] Loaded");
             postProperties();
             // check if the configuration for the watcher has changed.
-			useWatcherMode.set(getBooleanProperty(DOTCMS_USEWATCHERMODE, true));
-			if (useWatcherMode.get()) {
+            useWatcherMode.set(getBooleanProperty(DOTCMS_USEWATCHERMODE, true));
+            if (useWatcherMode.get()) {
 
-				registerWatcher (fileToRead);
-			} else if (isWatching.get()) {
-				unregisterWatcher (fileToRead);
-				isWatching.set(false);
-			}
-        } catch ( Exception e ) {
-            Logger.fatal( Config.class, "Exception loading properties for file [" + fileName + "]", e );
+                registerWatcher(fileToRead);
+            } else if (isWatching.get()) {
+                unregisterWatcher(fileToRead);
+                isWatching.set(false);
+            }
+        } catch (Exception e) {
+            Logger.fatal(Config.class, "Exception loading properties for file [" + fileName + "]",
+                    e);
             props = null;
         } finally {
 
-			IOUtils.closeQuietly(propsInputStream);
-		}
-	}
+            IOUtils.closeQuietly(propsInputStream);
+        }
+    }
 
-
-
-	/**
-	 * Does the post process properties based on the interpolator
-	 */
-    protected static void postProperties () {
-
-    	final String customConfigurationInterpolator       = getStringProperty(DOTCMS_CUSTOM_INTERPOLATOR, null);
-    	final ConfigurationInterpolator customInterpolator = UtilMethods.isSet(customConfigurationInterpolator)?
-				(ConfigurationInterpolator) ReflectionUtils.newInstance(customConfigurationInterpolator) :null;
-		final ConfigurationInterpolator interpolator       = (null != customInterpolator)?
-				customInterpolator:SystemEnvironmentConfigurationInterpolator.INSTANCE;
-		final Configuration configuration = interpolator.interpolate(props);
-
-		props = (configuration instanceof PropertiesConfiguration)?(PropertiesConfiguration)configuration: props;
-	}
 
     /**
-     * 
+     * Does the post process properties based on the interpolator
      */
-	private static void _refreshProperties () {
+    protected static void postProperties() {
 
-		if ((props == null) || // if props is null go ahead.
-				(
-						(!useWatcherMode.get()) && // if we are using watcher mode, do not need to check this
-						(System.currentTimeMillis() > lastRefreshTime.getTime() + (refreshInterval * 60 * 1000))
-				)) {
-			_loadProperties();
-		}
-	}
+        final String customConfigurationInterpolator = getStringProperty(DOTCMS_CUSTOM_INTERPOLATOR,
+                null);
+        final ConfigurationInterpolator customInterpolator =
+                UtilMethods.isSet(customConfigurationInterpolator) ?
+                        (ConfigurationInterpolator) ReflectionUtils.newInstance(
+                                customConfigurationInterpolator) : null;
+        final ConfigurationInterpolator interpolator = (null != customInterpolator) ?
+                customInterpolator : SystemEnvironmentConfigurationInterpolator.INSTANCE;
+        final Configuration configuration = interpolator.interpolate(props);
+
+        props = (configuration instanceof PropertiesConfiguration)
+                ? (PropertiesConfiguration) configuration : props;
+    }
+
+    /**
+     *
+     */
+    private static void _refreshProperties() {
+
+        if ((props == null) || // if props is null go ahead.
+                (
+                        (!useWatcherMode.get()) &&
+                                // if we are using watcher mode, do not need to check this
+                                (System.currentTimeMillis() > lastRefreshTime.getTime() + (
+                                        refreshInterval * 60 * 1000))
+                )) {
+            _loadProperties();
+        }
+    }
 
 
-	private final static String ENV_PREFIX="DOT_";
+    private final static String ENV_PREFIX = "DOT_";
 
-	private static void readEnvironmentVariables() {
-		synchronized (Config.class) {
-			System.getenv().entrySet().stream().filter(e -> e.getKey().startsWith(ENV_PREFIX))
-					.forEach(e -> props.setProperty(e.getKey(), e.getValue()));
-		}
-	}
-	
-	
-	private static String envKey(final String theKey) {
+    private static void readEnvironmentVariables() {
+        synchronized (Config.class) {
+            System.getenv().entrySet().stream().filter(e -> e.getKey().startsWith(ENV_PREFIX))
+                    .forEach(e -> props.setProperty(e.getKey(), e.getValue()));
+        }
+    }
+
+
+    private static String envKey(final String theKey) {
 
         String envKey = ENV_PREFIX + theKey.toUpperCase().replace(".", "_");
         while (envKey.contains("__")) {
@@ -319,119 +330,120 @@ public class Config {
         }
         return envKey.endsWith("_") ? envKey.substring(0, envKey.length() - 1) : envKey;
 
-	}
-
-	/**
-	 * Given a property name, evaluates if it belongs to the environment variables.
-	 *
-	 * @param key property name
-	 * @return true if key is found when looked by its environment variable name equivalent and if it has properties
-	 * associated to, otherwise false.
-	 */
-	public static boolean isKeyEnvBased(final String key) {
-		final String envKey = envKey(key);
-
-		if (!props.containsKey(envKey)) {
-			return false;
-		}
-
-		final String[] properties = props.getStringArray(envKey);
-		return properties != null && properties.length > 0;
-	}
-	
-	/**
-	 * Returns a string property
-	 *
-	 * @param name     The name of the property to locate.
-	 * @param defValue Value to return if property is not found.
-	 * @return The value of the property.  If property is found more than once, all the occurrences will be concatenated (with a comma separating each
-	 * element).
-	 */
-	public static String getStringProperty(final String name, final String defValue) {
-
-	    final String[] propsArr = getStringArrayProperty(name,  defValue==null ? null : new String[] {defValue});
-
-		if (propsArr == null || propsArr.length == 0) {
-		    return defValue;
-		} 
-		
-		return String.join(",", propsArr);
-		
-	}
-
-	/**
-	 * this is only here so the old tests pass
-	 * 
-	 * @param name
-	 * @param defValue
-	 * @param thing
-	 * @return
-	 */
-	@VisibleForTesting
-	@Deprecated
-    public static String getStringProperty(final String name, final String defValue, boolean thing) {
-
-        return getStringProperty(name, defValue);
-        
     }
 
-	
-	
-	
+    /**
+     * Given a property name, evaluates if it belongs to the environment variables.
+     *
+     * @param key property name
+     * @return true if key is found when looked by its environment variable name equivalent and if
+     * it has properties associated to, otherwise false.
+     */
+    public static boolean isKeyEnvBased(final String key) {
+        final String envKey = envKey(key);
 
-	/**
-	 * @deprecated  Use getStringProperty(String name, String default) and
-	 * set an intelligent default
-	 */
-	@Deprecated
-    public static String getStringProperty (String name) {
+        if (!props.containsKey(envKey)) {
+            return false;
+        }
+
+        final String[] properties = props.getStringArray(envKey);
+        return properties != null && properties.length > 0;
+    }
+
+    /**
+     * Returns a string property
+     *
+     * @param name     The name of the property to locate.
+     * @param defValue Value to return if property is not found.
+     * @return The value of the property.  If property is found more than once, all the occurrences
+     * will be concatenated (with a comma separating each element).
+     */
+    public static String getStringProperty(final String name, final String defValue) {
+
+        final String[] propsArr = getStringArrayProperty(name,
+                defValue == null ? null : new String[]{defValue});
+
+        if (propsArr == null || propsArr.length == 0) {
+            return defValue;
+        }
+
+        return String.join(",", propsArr);
+
+    }
+
+    /**
+     * this is only here so the old tests pass
+     *
+     * @param name
+     * @param defValue
+     * @param thing
+     * @return
+     */
+    @VisibleForTesting
+    @Deprecated
+    public static String getStringProperty(final String name, final String defValue,
+            boolean thing) {
+
+        return getStringProperty(name, defValue);
+
+    }
+
+
+    /**
+     * @deprecated Use getStringProperty(String name, String default) and set an intelligent default
+     */
+    @Deprecated
+    public static String getStringProperty(String name) {
         return getStringProperty(name, null);
     }
 
-	/**
-	 * 
-	 * @param name
-	 * @return
-	 */
-	public static String[] getStringArrayProperty (String name) {
-	    return getStringArrayProperty(name, null);
-	}
+    /**
+     * @param name
+     * @return
+     */
+    public static String[] getStringArrayProperty(String name) {
+        return getStringArrayProperty(name, null);
+    }
 
-	/**
-	 * Transform an array into an array of entity, needs a transformer to convert the string from the config to object
-	 * and the class.
-	 * In addition if the name does not exists, the supplier will be invoke
-	 * @param name {@link String} name of the array property
-	 * @param stringToEntityTransformer {@link StringToEntityTransformer} transformer to string to T
-	 * @param clazz {@link Class}
-	 * @param defaultSupplier {@link Supplier}
-	 * @param <T>
-	 * @return Array of T
-	 */
-	public static <T>  T[] getCustomArrayProperty(final String name,
-												  final StringToEntityTransformer<T> stringToEntityTransformer,
-												  final Class<T> clazz,
-												  final Supplier<T[]> defaultSupplier) {
+    /**
+     * Transform an array into an array of entity, needs a transformer to convert the string from
+     * the config to object and the class. In addition if the name does not exists, the supplier
+     * will be invoke
+     *
+     * @param name                      {@link String} name of the array property
+     * @param stringToEntityTransformer {@link StringToEntityTransformer} transformer to string to
+     *                                  T
+     * @param clazz                     {@link Class}
+     * @param defaultSupplier           {@link Supplier}
+     * @param <T>
+     * @return Array of T
+     */
+    public static <T> T[] getCustomArrayProperty(final String name,
+            final StringToEntityTransformer<T> stringToEntityTransformer,
+            final Class<T> clazz,
+            final Supplier<T[]> defaultSupplier) {
 
-		final String [] values = getStringArrayProperty(name);
-		return props.containsKey(name)?convert(values, clazz, stringToEntityTransformer): defaultSupplier.get();
-	}
+        final String[] values = getStringArrayProperty(name);
+        return props.containsKey(name) ? convert(values, clazz, stringToEntityTransformer)
+                : defaultSupplier.get();
+    }
 
-	private static <T> T[] convert(final String[] values, final Class<T> clazz, final StringToEntityTransformer<T> stringToEntityTransformer) {
+    private static <T> T[] convert(final String[] values, final Class<T> clazz,
+            final StringToEntityTransformer<T> stringToEntityTransformer) {
 
-		final T[] entities = (T[]) Array.newInstance(clazz, values.length);
+        final T[] entities = (T[]) Array.newInstance(clazz, values.length);
 
-		for (int i = 0; i < values.length; ++i) {
+        for (int i = 0; i < values.length; ++i) {
 
-			entities[i] = stringToEntityTransformer.from(values[i]);
-		}
+            entities[i] = stringToEntityTransformer.from(values[i]);
+        }
 
-		return entities;
-	}
+        return entities;
+    }
 
     /**
      * If config value == null, returns the default
-     * 
+     *
      * @param name
      * @param defaultValue
      * @return
@@ -439,164 +451,184 @@ public class Config {
     public static String[] getStringArrayProperty(final String name, final String[] defaultValue) {
         _refreshProperties();
 
-        return props.containsKey(envKey(name)) 
+        return props.containsKey(envKey(name))
                 ? props.getStringArray(envKey(name))
-                : props.containsKey(name) 
-                    ? props.getStringArray(name) 
-                    : defaultValue;
+                : props.containsKey(name)
+                        ? props.getStringArray(name)
+                        : defaultValue;
     }
-	/**
-	 * @deprecated  Use getIntProperty(String name, int default) and
-	 * set an intelligent default
-	 */
-	@Deprecated
-	public static int getIntProperty (final String name) {
-	    _refreshProperties ();
-	    
-        Integer value = Try.of(()->props.getInt(envKey(name))).getOrNull();
-        if(value!=null) {
+
+    /**
+     * @deprecated Use getIntProperty(String name, int default) and set an intelligent default
+     */
+    @Deprecated
+    public static int getIntProperty(final String name) {
+        _refreshProperties();
+
+        Integer value = Try.of(() -> props.getInt(envKey(name))).getOrNull();
+        if (value != null) {
             return value;
         }
-	    
-	    
-	    return props.getInt(name);
-	}
 
-	public static long getLongProperty (final String name, final long defaultVal) {
-		_refreshProperties ();
-		Long value = Try.of(()->props.getLong(envKey(name))).getOrNull();
-		if ( value != null ) {
-			return value;
-		}
-		return props.getLong(name, defaultVal);
-	}
+        return props.getInt(name);
+    }
 
-	/**
-	 * 
-	 * @param name
-	 * @param defaultVal
-	 * @return
-	 */
-	public static int getIntProperty (final String name, final int defaultVal) {
-	    _refreshProperties ();
-        Integer value = Try.of(()->props.getInt(envKey(name))).getOrNull();
-        if(value!=null) {
+    public static long getLongProperty(final String name, final long defaultVal) {
+        _refreshProperties();
+        Long value = Try.of(() -> props.getLong(envKey(name))).getOrNull();
+        if (value != null) {
             return value;
         }
-        
+        return props.getLong(name, defaultVal);
+    }
+
+    /**
+     * @param name
+     * @param defaultVal
+     * @return
+     */
+    public static int getIntProperty(final String name, final int defaultVal) {
+        _refreshProperties();
+        Integer value = Try.of(() -> props.getInt(envKey(name))).getOrNull();
+        if (value != null) {
+            return value;
+        }
+
         return props.getInt(name, defaultVal);
-	}
+    }
 
-	/**
-	 * @deprecated  Use getFloatProperty(String name, float default) and
-	 * set an intelligent default
-	 */
-	@Deprecated
-	public static float getFloatProperty (final String name) {
-	    _refreshProperties ();
-	    
-        Float value = Try.of(()->props.getFloat(envKey(name))).getOrNull();
-        if(value!=null) {
+    /**
+     * @deprecated Use getFloatProperty(String name, float default) and set an intelligent default
+     */
+    @Deprecated
+    public static float getFloatProperty(final String name) {
+        _refreshProperties();
+
+        Float value = Try.of(() -> props.getFloat(envKey(name))).getOrNull();
+        if (value != null) {
             return value;
         }
-        
-	    
-	    return props.getFloat( name );
-	}
 
-	/**
-	 * 
-	 * @param name
-	 * @param defaultVal
-	 * @return
-	 */
-	public static float getFloatProperty (final String name, final float defaultVal) {
-	    _refreshProperties ();
-        Float value = Try.of(()->props.getFloat(envKey(name))).getOrNull();
-        if(value!=null) {
+        return props.getFloat(name);
+    }
+
+    /**
+     * @param name
+     * @param defaultVal
+     * @return
+     */
+    public static float getFloatProperty(final String name, final float defaultVal) {
+        _refreshProperties();
+        Float value = Try.of(() -> props.getFloat(envKey(name))).getOrNull();
+        if (value != null) {
             return value;
         }
         return props.getFloat(name, defaultVal);
-	}
+    }
 
-	/**
-	 * @deprecated  Use getBooleanProperty(String name, boolean default) and
-	 * set an intelligent default
-	 */
-	@Deprecated
-	public static boolean getBooleanProperty (String name) {
-	    _refreshProperties ();
-        Boolean value = Try.of(()->props.getBoolean(envKey(name))).getOrNull();
-        if(value!=null) {
+    /**
+     * @deprecated Use getBooleanProperty(String name, boolean default) and set an intelligent
+     * default
+     */
+    @Deprecated
+    public static boolean getBooleanProperty(String name) {
+        _refreshProperties();
+        Boolean value = Try.of(() -> props.getBoolean(envKey(name))).getOrNull();
+        if (value != null) {
             return value;
         }
         return props.getBoolean(name);
-	}
+    }
 
-	/**
-	 * 
-	 * @param name
-	 * @param defaultVal
-	 * @return
-	 */
-	public static boolean getBooleanProperty (String name, boolean defaultVal) {
-        final Boolean value = props.containsKey(envKey(name))  ? Try.of(()->props.getBoolean(envKey(name))).getOrNull() : null;
-        if(null != value) {
+    /**
+     * @param name
+     * @param defaultVal
+     * @return
+     */
+    public static boolean getBooleanProperty(String name, boolean defaultVal) {
+        final Boolean value =
+                props.containsKey(envKey(name)) ? Try.of(() -> props.getBoolean(envKey(name)))
+                        .getOrNull() : null;
+        if (null != value) {
             return value;
         }
         return props.getBoolean(name, defaultVal);
-	}
+    }
 
-	/**
-	 * 
-	 * @param key
-	 * @param value
-	 */
-	public static void setProperty(String key, Object value) {
-		if(props!=null) {
-			props.setProperty(key, value);
-		}
-	}
+    /**
+     * @param key
+     * @param value
+     */
+    public static void setProperty(String key, Object value) {
+        if (props != null) {
+            trackOverrides(key, value);
+            Logger.info(Config.class, "Setting property: " + key + " to " + value);
+            props.setProperty(key, value);
+        }
+    }
 
-	/**
-	 * 
-	 * @return
-	 */
-	@SuppressWarnings("unchecked")
-	public static Iterator<String> getKeys () {
-	    _refreshProperties ();
-	    return ImmutableSet.copyOf(props.getKeys()).iterator();
-	}
+    private static void trackOverrides(String key, Object value) {
+        if (props.getBoolean(USE_CONFIG_TEST_OVERRIDE_TRACKER, false)) {
+            if (value == null) {
+                testOverrideTracker.remove(key);
+            } else {
+                testOverrideTracker.put(key, value.toString());
+            }
+        }
+    }
 
-	/**
-	 * 
-	 * @param prefix
-	 * @return
-	 */
-	@SuppressWarnings ( "unchecked" )
-	public static Iterator<String> subset ( String prefix ) {
-		_refreshProperties();
-		return ImmutableSet.copyOf(props.subset(prefix).getKeys()).iterator();
-	}
+    public static Map<String, String> getOverrides() {
+        return Map.copyOf(testOverrideTracker);
+    }
 
-
-	/**
-	 * Spindle Config
-	 * 
-	 * @param myApp
-	 */
-	public static void setMyApp(javax.servlet.ServletContext myApp) {
-		CONTEXT = myApp;
-		CONTEXT_PATH = myApp.getRealPath("/");
-	}
+    public static Map<String, String> compareOverrides(Map<String, String> before) {
+        Map<String, String> after = getOverrides();
+        Map<String, String> diff = new HashMap<String, String>();
+        for (String key : after.keySet()) {
+            if (!before.containsKey(key) || !before.get(key).equals(after.get(key))) {
+                diff.put(key, after.get(key));
+            }
+        }
+        return diff;
+    }
 
 
+    /**
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public static Iterator<String> getKeys() {
+        _refreshProperties();
+        return ImmutableSet.copyOf(props.getKeys()).iterator();
+    }
 
-	/**
-	 * 
-	 */
-	public static void forceRefresh(){
-		lastRefreshTime = new Date(0);
-	}
+    /**
+     * @param prefix
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public static Iterator<String> subset(String prefix) {
+        _refreshProperties();
+        return ImmutableSet.copyOf(props.subset(prefix).getKeys()).iterator();
+    }
+
+
+    /**
+     * Spindle Config
+     *
+     * @param myApp
+     */
+    public static void setMyApp(javax.servlet.ServletContext myApp) {
+        CONTEXT = myApp;
+        CONTEXT_PATH = myApp.getRealPath("/");
+    }
+
+
+    /**
+     *
+     */
+    public static void forceRefresh() {
+        lastRefreshTime = new Date(0);
+    }
 
 }


### PR DESCRIPTION
Add Awaitability to replace Thread.sleep for test polling fixing testRemoveContentFromIndexMultilingualContent Fix test_content_type_reindex test handle duplicate entries make LocalTransaction consistent with commit listeners use commit listener for index unpause
fix indexer pausing early
fix session connection closing
fix reset of DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE
handle exception and close transaction
ensure startup tasks always run in transaction
Add temp config override tracking
fix testBundlerHandler_UnpublishHost_Success
Turn off AUTO_ASSIGN_WORKFLOW for integration tests as it breaks after transaction fixes Test_Get_Bulk_Actions_For_Contentlet_Ids await index queue empty
Initialize Integration Tests in Runner
fix CaffineCache over logging
create single log file for cicd
update log file size to see all log
fix SAVE_CONTENTLET_AS_JSON not being reset
ServerAPIImplTest leaves extra enabled index servers after Fix leftover index entries
Missing DELETE_SITE SystemEventType called from ESContentletAPIImpi.deleteContetlet duplicate key due to time resolution in test_save_and_delete_pushed_assets_on_two_env Fix test_that_live_and_working_content_makes_it_into_the_index
