### PR TITLE
#24065 Sending variantName params when edit a Contentlet

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-container-contentlet.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-container-contentlet.service.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { getTestBed, TestBed } from '@angular/core/testing';
 
+import { DotSessionStorageService } from '@dotcms/data-access';
 import { CoreWebService } from '@dotcms/dotcms-js';
 import { DotCMSContentType, DotPage, DotPageContainer } from '@dotcms/dotcms-models';
 import { CoreWebServiceMock, dotcmsContentTypeBasicMock } from '@dotcms/utils-testing';
@@ -9,7 +10,7 @@ import { DotContainerContentletService } from './dot-container-contentlet.servic
 
 import { DotPageContent } from '../../shared/models';
 
-describe('DotContainerContentletService', () => {
+fdescribe('DotContainerContentletService', () => {
     let injector: TestBed;
     let dotContainerContentletService: DotContainerContentletService;
     let httpMock: HttpTestingController;
@@ -19,7 +20,8 @@ describe('DotContainerContentletService', () => {
             imports: [HttpClientTestingModule],
             providers: [
                 { provide: CoreWebService, useClass: CoreWebServiceMock },
-                DotContainerContentletService
+                DotContainerContentletService,
+                DotSessionStorageService
             ]
         });
         injector = getTestBed();
@@ -91,7 +93,52 @@ describe('DotContainerContentletService', () => {
         httpMock.expectOne(`v1/containers/form/2?containerId=1`);
     });
 
+    it('should do a request for get the contentlet html code in a specific variant', () => {
+        window.sessionStorage.setItem('variantName', 'Testing');
+
+        const pageContainer: DotPageContainer = {
+            identifier: '1',
+            uuid: '3'
+        };
+
+        const pageContent: DotPageContent = {
+            identifier: '2',
+            inode: '4',
+            type: 'content_type'
+        };
+
+        const dotPage: DotPage = {
+            canEdit: true,
+            canRead: true,
+            canLock: true,
+            identifier: '1',
+            pageURI: '/page_test',
+            shortyLive: 'shortyLive',
+            shortyWorking: 'shortyWorking',
+            workingInode: '2',
+            contentType: undefined,
+            fileAsset: false,
+            friendlyName: '',
+            host: '',
+            inode: '2',
+            name: '',
+            systemHost: false,
+            type: '',
+            uri: '',
+            versionType: ''
+        };
+
+        dotContainerContentletService
+            .getContentletToContainer(pageContainer, pageContent, dotPage)
+            .subscribe();
+        httpMock.expectOne(`v1/containers/content/2?containerId=1&pageInode=2&variantName=Testing`);
+    });
+
     afterEach(() => {
         httpMock.verify();
+    });
+
+    afterEach(() => {
+        window.sessionStorage.removeItem('variantName');
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-container-contentlet.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-container-contentlet.service.spec.ts
@@ -10,7 +10,7 @@ import { DotContainerContentletService } from './dot-container-contentlet.servic
 
 import { DotPageContent } from '../../shared/models';
 
-fdescribe('DotContainerContentletService', () => {
+describe('DotContainerContentletService', () => {
     let injector: TestBed;
     let dotContainerContentletService: DotContainerContentletService;
     let httpMock: HttpTestingController;
@@ -136,9 +136,6 @@ fdescribe('DotContainerContentletService', () => {
 
     afterEach(() => {
         httpMock.verify();
-    });
-
-    afterEach(() => {
         window.sessionStorage.removeItem('variantName');
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-container-contentlet.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-container-contentlet.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@angular/core';
 
 import { pluck } from 'rxjs/operators';
 
+import { DotSessionStorageService } from '@dotcms/data-access';
 import { CoreWebService } from '@dotcms/dotcms-js';
 import { DotPage, DotPageContainer } from '@dotcms/dotcms-models';
 
@@ -11,7 +12,10 @@ import { DotPageContent } from '../../shared/models/dot-page-content.model';
 
 @Injectable()
 export class DotContainerContentletService {
-    constructor(private coreWebService: CoreWebService) {}
+    constructor(
+        private coreWebService: CoreWebService,
+        private dotSessionStorageService: DotSessionStorageService
+    ) {}
 
     /**
      * Get the HTML of a contentlet inside a container
@@ -27,9 +31,16 @@ export class DotContainerContentletService {
         content: DotPageContent,
         page: DotPage
     ): Observable<string> {
+        const currentVariantName = this.dotSessionStorageService.getVariationId();
+        const defaultUrl = `v1/containers/content/${content.identifier}?containerId=${container.identifier}&pageInode=${page.inode}`;
+
+        const url = !currentVariantName
+            ? defaultUrl
+            : `${defaultUrl}&variantName=${currentVariantName}`;
+
         return this.coreWebService
             .requestView({
-                url: `v1/containers/content/${content.identifier}?containerId=${container.identifier}&pageInode=${page.inode}`
+                url: url
             })
             .pipe(pluck('entity', 'render'));
     }


### PR DESCRIPTION
We need to sent the variantName when we are render a Contentlet into a Container, this happend after edit a Contentlet inside the Edit Page Portlet