### PR TITLE
dotCMS/core#24163 [Containers] : Clicking up or down arrows in Max Contents field is not working

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/dot-container-properties.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/dot-container-properties.component.spec.ts
@@ -338,6 +338,10 @@ describe('DotContainerPropertiesComponent', () => {
         it('should render content types when max-content greater then zero', fakeAsync(() => {
             spyOn(fixture.componentInstance, 'showContentTypeAndCode');
             fixture.componentInstance.form.get('maxContentlets').setValue(0);
+            fixture.componentInstance.form.get('maxContentlets').valueChanges.subscribe((value) => {
+                expect(value).toBe(5);
+            });
+            expect(fixture.componentInstance.form.get('maxContentlets').updateOn).toBe('change');
             fixture.componentInstance.form.get('maxContentlets').setValue(5);
             tick();
             fixture.detectChanges();

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/dot-container-properties.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/dot-container-properties.component.ts
@@ -54,8 +54,7 @@ export class DotContainerPropertiesComponent implements OnInit, AfterViewInit {
                     title: new FormControl(container?.title ?? '', [Validators.required]),
                     friendlyName: new FormControl(container?.friendlyName ?? ''),
                     maxContentlets: new FormControl(container?.maxContentlets ?? 0, {
-                        validators: [Validators.required],
-                        updateOn: 'blur'
+                        validators: [Validators.required]
                     }),
                     code: new FormControl(
                         container?.code ?? '',


### PR DESCRIPTION
### Proposed Changes
* show or hide content type on clicking on up or down arrow on max content field

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
