### PR TITLE
#23603 : Allow users to write code when creating a file

### DIFF
--- a/dotCMS/src/curl-test/Content Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Content Resource.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "64a156b5-40b4-46ce-8bab-6083e910e48a",
+		"_postman_id": "50e22041-5236-42d7-8d37-b9a39f0457e3",
 		"name": "Content Resource",
 		"description": "Content Resource test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -1763,6 +1763,15 @@
 								"type": "text"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/UNPUBLISH?inode={{fileInode}}&identifier={{fileId}}",
 							"host": [
@@ -1835,6 +1844,15 @@
 								"type": "text"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/ARCHIVE?inode={{fileInode}}&identifier={{fileId}}",
 							"host": [
@@ -1907,6 +1925,15 @@
 								"type": "text"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/DELETE?inode={{fileInode}}&identifier={{fileId}}",
 							"host": [

--- a/dotCMS/src/curl-test/TempAPI.postman_collection.json
+++ b/dotCMS/src/curl-test/TempAPI.postman_collection.json
@@ -1,11 +1,241 @@
 {
 	"info": {
-		"_postman_id": "1faea77b-c035-4129-a215-3608487d19b3",
+		"_postman_id": "b65639a1-cec6-4b6c-b8b6-ab483db33b5b",
 		"name": "TempAPI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "11174695"
+		"_exporter_id": "5403727"
 	},
 	"item": [
+		{
+			"name": "Temp File As Plain Text",
+			"item": [
+				{
+					"name": "Create Temp File",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"let randomNumber = Math.floor(Math.random() * 100);",
+									"pm.collectionVariables.set(\"tempFileName\", randomNumber + \"-test-temp-file.txt\");"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Test Temporary File creation HTTP Status must be successful\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.collectionVariables.set(\"tempFileId\", pm.response.json().tempFiles[0].id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "localhost",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"fileName\": \"{{tempFileName}}\",\n    \"fileContent\": \"This is the content of the Temporary File.\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/temp/id/new",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"temp",
+								"id",
+								"new"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Existing Temp File Content",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Test Temporary File update HTTP Status must be successful\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Temporary File ID must be the same\", function() {",
+									"    let tempFileId = pm.collectionVariables.get(\"tempFileId\");",
+									"    pm.expect(pm.response.json().tempFiles[0].id).to.eql(tempFileId, \"An error occurred when checking the temp file ID\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "localhost",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"fileName\": \"{{tempFileName}}\",\n    \"fileContent\": \"This is the new content of the Temporary File.\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/temp/id/{{tempFileId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"temp",
+								"id",
+								"{{tempFileId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Non-Existent Temp File",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Non-Existing Test Temporary File creation HTTP Status must be successful\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"New Temporary File ID must NOT match the previous one\", function() {",
+									"    let tempFileId = pm.collectionVariables.get(\"tempFileId\");",
+									"    pm.expect(pm.response.json().tempFiles[0].id).to.not.eql(tempFileId, \"An error occurred when checking different temp file IDs\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"let randomNumber = Math.floor(Math.random() * 100);",
+									"pm.collectionVariables.set(\"tempFileName\", \"new-\" + randomNumber + \"-test-temp-file.txt\");"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "localhost",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"fileName\": \"{{tempFileName}}\",\n    \"fileContent\": \"Here is some test content.\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/temp/id/non-existent-id",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"temp",
+								"id",
+								"non-existent-id"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "This request collection creates Temporary Files provided as plain text instead of binary files."
+		},
 		{
 			"name": "Upload Multiple with one wrong file",
 			"event": [
@@ -156,6 +386,16 @@
 				}
 			},
 			"response": []
+		}
+	],
+	"variable": [
+		{
+			"key": "tempFileName",
+			"value": ""
+		},
+		{
+			"key": "tempFileId",
+			"value": ""
 		}
 	]
 }

--- a/dotCMS/src/curl-test/TempAPI.postman_collection.json
+++ b/dotCMS/src/curl-test/TempAPI.postman_collection.json
@@ -2,6 +2,7 @@
 	"info": {
 		"_postman_id": "b65639a1-cec6-4b6c-b8b6-ab483db33b5b",
 		"name": "TempAPI",
+		"description": "Verifies that the Temp File API is working as expected. It allows users to create temporary files in the dotCMS assets folder.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "5403727"
 	},
@@ -243,14 +244,36 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"var jsonData = pm.response.json();",
+							"pm.test(\"Checking file names and operation status code\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    let found = false;",
+							"    jsonData.tempFiles.forEach((item) => {",
 							"",
-							"pm.test(\"File name check\", function () {",
-							"    pm.expect(jsonData.tempFiles[0].fileName).to.eql('Landscape_2009_romantic_country_garden.jpeg');",
-							"    pm.expect(jsonData.tempFiles[1].fileName).to.eql('16475687531_eac8a30914_b.jpeg');",
-							"    pm.expect(jsonData.tempFiles[2].errorCode).to.eql('400');",
+							"        if (item.fileName == \"Landscape_2009_romantic_country_garden.jpeg\") {",
+							"            found = true;",
+							"        }",
+							"",
+							"    });",
+							"    pm.expect(found).to.eq(true, \"Expected image 'Landscape_2009_romantic_country_garden.jpeg' was not found.\")",
+							"    found = false;",
+							"    jsonData.tempFiles.forEach((item) => {",
+							"",
+							"        if (item.fileName == \"16475687531_eac8a30914_b.jpeg\") {",
+							"            found = true;",
+							"        }",
+							"",
+							"    });",
+							"    pm.expect(found).to.eq(true, \"Expected image '16475687531_eac8a30914_b.jpeg' was not found.\")",
+							"    found = false;",
+							"    jsonData.tempFiles.forEach((item) => {",
+							"",
+							"        if (item.errorCode == \"400\") {",
+							"            found = true;",
+							"        }",
+							"",
+							"    });",
+							"    pm.expect(found).to.eq(true, \"Expected error code '400' not found.\")",
 							"});",
-							"",
 							""
 						],
 						"type": "text/javascript"
@@ -386,6 +409,26 @@
 				}
 			},
 			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
 		}
 	],
 	"variable": [

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/PlainTextFileForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/PlainTextFileForm.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
- *
+ * Provides all the required information of a File Asset that is being provided as plain text. For instance, this can
+ * be used by the Temp File Resource to create a file with the specified contents, which is what allows Users to create
+ * a text file -- i.e, TXT, VTL, JS, CSS, and so on -- directly from the dotCMS back-end.
  *
  * @author Jose Castro
- * @since
+ * @since Feb 22nd, 2023
  */
 @JsonDeserialize(builder = PlainTextFileForm.Builder.class)
 public class PlainTextFileForm {
@@ -15,7 +17,7 @@ public class PlainTextFileForm {
     private final String fileName;
     private final String fileContent;
 
-    public PlainTextFileForm(final Builder builder) {
+    private PlainTextFileForm(final Builder builder) {
         this.fileName = builder.fileName;
         this.fileContent = builder.fileContent;
     }
@@ -28,6 +30,9 @@ public class PlainTextFileForm {
         return fileName;
     }
 
+    /**
+     * Allows you to build an instance of the {@link PlainTextFileForm} class.
+     */
     public static final class Builder {
 
         @JsonProperty(required = true)
@@ -35,16 +40,35 @@ public class PlainTextFileForm {
         @JsonProperty(required = true)
         private String fileContent;
 
+        /**
+         * Sets the name of the plain text file.
+         *
+         * @param fileName The file name.
+         *
+         * @return An instance of the class' builder.
+         */
         public PlainTextFileForm.Builder fileName(final String fileName) {
             this.fileName = fileName;
             return this;
         }
 
+        /**
+         * Sets the content of the plain text file.
+         *
+         * @param fileContent The file's content.
+         *
+         * @return An instance of the class' builder.
+         */
         public PlainTextFileForm.Builder file(final String fileContent) {
             this.fileContent = fileContent;
             return this;
         }
 
+        /**
+         * Creates an instance of the {@link PlainTextFileForm} class.
+         *
+         * @return The instantiated class.
+         */
         public PlainTextFileForm build() {
             return new PlainTextFileForm(this);
         }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/PlainTextFileForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/PlainTextFileForm.java
@@ -1,0 +1,54 @@
+package com.dotcms.rest.api.v1.temp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ *
+ *
+ * @author Jose Castro
+ * @since
+ */
+@JsonDeserialize(builder = PlainTextFileForm.Builder.class)
+public class PlainTextFileForm {
+
+    private final String fileName;
+    private final String fileContent;
+
+    public PlainTextFileForm(final Builder builder) {
+        this.fileName = builder.fileName;
+        this.fileContent = builder.fileContent;
+    }
+
+    public String fileContent() {
+        return fileContent;
+    }
+
+    public String fileName() {
+        return fileName;
+    }
+
+    public static final class Builder {
+
+        @JsonProperty(required = true)
+        private String fileName;
+        @JsonProperty(required = true)
+        private String fileContent;
+
+        public PlainTextFileForm.Builder fileName(final String fileName) {
+            this.fileName = fileName;
+            return this;
+        }
+
+        public PlainTextFileForm.Builder file(final String fileContent) {
+            this.fileContent = fileContent;
+            return this;
+        }
+
+        public PlainTextFileForm build() {
+            return new PlainTextFileForm(this);
+        }
+
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileAPI.java
@@ -21,7 +21,6 @@ import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.PortalUtil;
@@ -46,6 +45,14 @@ import java.util.Optional;
 
 import static com.dotcms.storage.FileMetadataAPIImpl.META_TMP;
 
+/**
+ * This API allows you to create temporary files in dotCMS. This API is very useful for uploading resources that can be
+ * safely deleted after a given amount of time, and also used by the File Asset edit mode when a new file is being
+ * uploaded to the repository.
+ *
+ * @author Will Ezell
+ * @since Jul 8th, 2019
+ */
 public class TempFileAPI {
 
   public static final String TEMP_RESOURCE_MAX_AGE_SECONDS = "TEMP_RESOURCE_MAX_AGE_SECONDS";
@@ -53,24 +60,25 @@ public class TempFileAPI {
   public static final String TEMP_RESOURCE_ALLOW_NO_REFERER = "TEMP_RESOURCE_ALLOW_NO_REFERER";
   public static final String TEMP_RESOURCE_MAX_FILE_SIZE = "TEMP_RESOURCE_MAX_FILE_SIZE";
   public static final String TEMP_RESOURCE_MAX_FILE_SIZE_ANONYMOUS = "TEMP_RESOURCE_MAX_FILE_SIZE_ANONYMOUS";
+  public static final String MAX_FILE_LENGTH_PARAM = "maxFileLength";
   
   public static final String TEMP_RESOURCE_ENABLED = "TEMP_RESOURCE_ENABLED";
   public static final String TEMP_RESOURCE_PREFIX = "temp_";
 
   private static final String WHO_CAN_USE_TEMP_FILE = "whoCanUse.tmp";
   private static final String TEMP_RESOURCE_BY_URL_ADMIN_ONLY="TEMP_RESOURCE_BY_URL_ADMIN_ONLY";
-  
-  
 
   /**
-   * Returns an empty TempFile of a unique id and file handle that can be used to write and access a
-   * temp file. The request will be used to create a fingerprint that will be written to the "allowList" and can
-   * be used to retreive the temp resource in other requests
-   * 
-   * @param incomingFileName
-   * @param request
-   * @return
-   * @throws DotSecurityException
+   * Returns an empty TempFile of a unique id and file handle that can be used to write and access a temp file. The
+   * request will be used to create a fingerprint that will be written to the "allowList" and can be used to retrieve
+   * the temp resource in other requests.
+   *
+   * @param incomingFileName The name of the Temporary File.
+   * @param request          The current instance of the {@link HttpServletRequest}
+   *
+   * @return The empty {@link DotTempFile}.
+   *
+   * @throws DotSecurityException An error occurred when creating the Temporary File.
    */
   public DotTempFile createEmptyTempFile(final String incomingFileName,final HttpServletRequest request) throws DotSecurityException {
     final String anon = Try.of(() -> APILocator.getUserAPI().getAnonymousUser().getUserId()).getOrElse("anonymous");
@@ -119,77 +127,62 @@ public class TempFileAPI {
   }
 
   /**
-   * This method takes a request and based upon it it returns the max file size that can be
-   * uploaded, based on the user uploading.  Anonymous users can have smaller file size limitations
-   * than authenticated users.  A return of -1 means unlimited.
-   * @param request
-   * @return
+   * This method takes a request and based upon it returns the max file size that can be uploaded, based on the user
+   * uploading. Anonymous users can have smaller file size limitations than authenticated users. A return of -1 means
+   * unlimited.
+   *
+   * @param request The current instance of the {@link HttpServletRequest}
+   *
+   * @return The maximum file size allowed by dotCMS.
    */
   @VisibleForTesting
   public long maxFileSize(final HttpServletRequest request) {
-    
-
-    final long requestedMax = ConversionUtils.toLongFromByteCountHumanDisplaySize(request.getParameter("maxFileLength"), -1);
-    final long systemMax    =  Config.getLongProperty(TEMP_RESOURCE_MAX_FILE_SIZE, -1l);
-    final long anonMax      =  Config.getLongProperty(TEMP_RESOURCE_MAX_FILE_SIZE_ANONYMOUS, -1l);
+    final long requestedMax = ConversionUtils.toLongFromByteCountHumanDisplaySize(request.getParameter(MAX_FILE_LENGTH_PARAM), -1L);
+    final long systemMax    =  Config.getLongProperty(TEMP_RESOURCE_MAX_FILE_SIZE, -1L);
+    final long anonMax      =  Config.getLongProperty(TEMP_RESOURCE_MAX_FILE_SIZE_ANONYMOUS, -1L);
     final boolean isAnon    = PortalUtil.getUserId(request) == null || UserAPI.CMS_ANON_USER_ID.equals(PortalUtil.getUserId(request));
     
-    List<Long> longs = (isAnon) ? Lists.newArrayList(requestedMax,systemMax,anonMax) : Lists.newArrayList(requestedMax,systemMax);
+    final List<Long> longs = (isAnon) ? Lists.newArrayList(requestedMax,systemMax,anonMax) : Lists.newArrayList(requestedMax,systemMax);
     longs.removeIf(i-> i < 0);
     Collections.sort(longs); 
-    return longs.isEmpty() ? -1l : longs.get(0);
-
+    return longs.isEmpty() ? -1L : longs.get(0);
   }
-  
-  
-  
+
   /**
-   * Writes an InputStream to a temp file and returns the tempFile with a unique id and file handle
-   * that can be used to access the temp file. The request will be used to create a fingerprint
-   * that will be written to the "allowList" and can
-   * be used to retreive the temp resource in other requests
-   * 
-   * @param incomingFileName
-   * @param request
-   * @param inputStream
-   * @return
-   * @throws DotSecurityException
+   * Writes an InputStream to a temp file and returns the tempFile with a unique id and file handle that can be used to
+   * access the temp file. The request will be used to create a fingerprint that will be written to the "allowList" and
+   * can be used to retrieve the temp resource in other requests.
+   *
+   * @param incomingFileName The name of the Temporary File.
+   * @param request          The current instance of the {@link HttpServletRequest}
+   * @param inputStream      The content of the Temporary File.
+   *
+   * @return The new {@link DotTempFile}
+   *
+   * @throws DotSecurityException An error occurred when creating the Temporary File.
    */
   public DotTempFile createTempFile(final String incomingFileName,final HttpServletRequest request, final InputStream inputStream)
       throws DotSecurityException {
-    
     final DotTempFile dotTempFile = this.createEmptyTempFile(incomingFileName, request);
-    final File tempFile = dotTempFile.file;
-    final long maxLength = maxFileSize(request);
-        
-    try (final OutputStream out = new BoundedOutputStream(maxLength,Files.newOutputStream(tempFile.toPath()))) {
-
-
-      int read = 0;
-      final byte[] bytes = new byte[4096];
-      while ((read = inputStream.read(bytes)) != -1) {
-        out.write(bytes, 0, read);
-      }
-      return dotTempFile;
-    } catch (IOException e) {
-      final String message = APILocator.getLanguageAPI().getStringKey(WebAPILocator.getLanguageWebAPI().getLanguage(request), "temp.file.max.file.size.error").replace("{0}", UtilMethods.prettyByteify(maxLength));
-      throw new DotStateException(message, e);
-    } catch (Exception e) {
-      throw new DotRuntimeException(e.getMessage(), e);
-    } finally {
-      CloseUtils.closeQuietly(inputStream);
-    }
+    this.writeFile(request, dotTempFile, inputStream);
+    return dotTempFile;
   }
 
   /**
-   * Takes a url, downloads it and the returns the resulting file as tempFile with a unique id and
-   * file handle that can be used to access the temp file. The request will be used to create a fingerprint
-   * that will be written to the "allowList" and can be used to retreive the temp resource in other requests
-   * 
-   * @param incomingFileName
-   * @param request
-   * @return
-   * @throws DotSecurityException
+   * Takes a URL, downloads it and the returns the resulting file as tempFile with a unique id and file handle that can
+   * be used to access the temp file. The request will be used to create a fingerprint that will be written to the
+   * "allowList" and can be used to retrieve the temp resource in other requests
+   *
+   * @param incomingFileName The name of the Temporary File, if required.
+   * @param request          The current instance of the {@link HttpServletRequest}
+   * @param url              The {@link URL} pointing to the file that must be retrieved.
+   * @param timeoutSeconds   The specified timeout for reading the files via the URL.
+   * @param maxLength        The maximum allowed size of the file being retrieved.
+   *
+   * @return The {@link DotTempFile} with the file specified via the URL.
+   *
+   * @throws DotSecurityException An error occurred when creating the Temporary File.
+   * @throws IOException          An error occurred retrieving the contents of the file via URL.
    */
   public DotTempFile createTempFileFromUrl(final String incomingFileName,
           final HttpServletRequest request, final URL url, final int timeoutSeconds,
@@ -245,8 +238,21 @@ public class TempFileAPI {
 
   }
 
-  public DotTempFile updateTempFile(final String tempFileId, final String incomingFileName,
-                                    final HttpServletRequest request, final InputStream inputStream) throws DotSecurityException {
+  /**
+   * Updates the contents of an existing Temporary File. If the ID of such a file equals the word {@code "new"} or if
+   * the ID doesn't exist anymore, a new temporary file with the specified content will be returned instead.
+   *
+   * @param request          The current instance of the {@link HttpServletRequest}.
+   * @param tempFileId       The ID of the Temporary File.
+   * @param incomingFileName The actual file name of the Temporary File. This is used only when the original
+   *                         Temporary File ID doesn't exist.
+   * @param inputStream      The new content of the Temporary File.
+   *
+   * @return The {@link DotTempFile} representing the specified file, or a new one if the ID doesn't exist.
+   *
+   * @throws DotSecurityException An error occurred when creating Temporary File.
+   */
+  public DotTempFile upsertTempFile(final HttpServletRequest request, final String tempFileId, final String incomingFileName, final InputStream inputStream) throws DotSecurityException {
     if ("new".equalsIgnoreCase(tempFileId)) {
       return this.createTempFile(incomingFileName, request, inputStream);
     }
@@ -254,37 +260,23 @@ public class TempFileAPI {
     if (dotTempFile.isEmpty()) {
       return this.createTempFile(incomingFileName, request, inputStream);
     }
-    final File tempFile = dotTempFile.get().file;
-    final long maxLength = maxFileSize(request);
-    try (final OutputStream out = new BoundedOutputStream(maxLength,Files.newOutputStream(tempFile.toPath()))) {
-      int read;
-      final byte[] bytes = new byte[4096];
-      while ((read = inputStream.read(bytes)) != -1) {
-        out.write(bytes, 0, read);
-      }
-      return dotTempFile.get();
-    } catch (final IOException e) {
-      final String message = APILocator.getLanguageAPI().getStringKey(WebAPILocator.getLanguageWebAPI().getLanguage(request), "temp.file.max.file.size.error").replace("{0}", UtilMethods.prettyByteify(maxLength));
-      throw new DotStateException(message, e);
-    } catch (final Exception e) {
-      throw new DotRuntimeException(e.getMessage(), e);
-    } finally {
-      CloseUtils.closeQuietly(inputStream);
-    }
+    this.writeFile(request, dotTempFile.get(), inputStream);
+    return dotTempFile.get();
   }
 
   /**
-   * This method receives a URL and checks if starts with http or https,
-   * and also makes a request to the URL and if returns 200 the URL is valid,
-   * if returns any other response will be false
-   * @param url
+   * This method receives a URL and checks if starts with http or https, and also makes a request to the URL and if
+   * returns 200 the URL is valid, if returns any other response will be false.
+   *
+   * @param url The specified URL
+   *
    * @return boolean if the url is valid or not
    */
   public boolean validUrl(final String url) {
 
     if(!(url.toLowerCase().startsWith("http://") ||
             url.toLowerCase().startsWith("https://"))){
-      Logger.error(this, "URL does not starts with http or https");
+      Logger.error(this, String.format("URL [ %s ] does not start with http or https", url));
       return false;
     }
     try {
@@ -298,6 +290,15 @@ public class TempFileAPI {
     return true;
   }
 
+  /**
+   * Resolves the name of the Temporary File based on either the specified desired name, or by retrieving it from the
+   * URL.
+   *
+   * @param desiredName The specified desired file name.
+   * @param url         The URL that contains the file name.
+   *
+   * @return The name of the Temporary File.
+   */
   private String resolveFileName(final String desiredName, final URL url) {
     final String path=(url!=null)? url.getPath() : UUIDGenerator.shorty();
     final String tryFileName = (desiredName!=null) 
@@ -307,10 +308,21 @@ public class TempFileAPI {
               : path;
     return FileUtil.sanitizeFileName(tryFileName);
   }
-  
-  
-  
-  
+
+  /**
+   * Creates a {@code whoCanUse.tmp} file for every empty Temporary File. Such a file contains the following
+   * information:
+   * <ul>
+   *     <li>The User ID who created the Temporary File.</li>
+   *     <li>The Session ID.</li>
+   *     <li>The request's fingerprint.</li>
+   * </ul>
+   *
+   * @param parentFolder          The folder that this TMP file will be created in.
+   * @param incomingAccessingList The list of properties that will be included in the file.
+   *
+   * @return The temporary permissions file.
+   */
   private File createTempPermissionFile(final File parentFolder, final List<String> incomingAccessingList) {
     List<String> accessingList = new ArrayList<>(incomingAccessingList);
     accessingList.removeIf(Objects::isNull);
@@ -325,6 +337,15 @@ public class TempFileAPI {
 
   }
 
+  /**
+   * Returns the Temporary File based on its ID. If such a file doesn't exist or if it was created more than 30 minutes
+   * ago -- of the value specified by {@link #TEMP_RESOURCE_MAX_AGE_SECONDS} -- then an empty {@link DotTempFile} object
+   * will be returned instead.
+   *
+   * @param tempFileId The ID of the Temporary File.
+   *
+   * @return The {@link DotTempFile} matching the specified ID.
+   */
   private Optional<DotTempFile> getTempFile(final String tempFileId) {
 
     if (tempFileId == null || !tempFileId.startsWith(TEMP_RESOURCE_PREFIX)) {
@@ -343,12 +364,18 @@ public class TempFileAPI {
       return Optional.of(new DotTempFile(tempFileId, tempFile));
 
     }
-
-    Logger.error(this,"Temp File does not exists or TTL of the file already expired");
+    Logger.error(this, String.format("Temp File '%s' does not exist or its TTL already expired", tempFileId));
     return Optional.empty();
-
   }
 
+  /**
+   * Determines whether the incoming Access List has "use" permissions over a given Temporary File.
+   *
+   * @param incomingAccessingList The Access List being checked.
+   * @param dotTempFile           The {@link DotTempFile} object.
+   *
+   * @return If the incoming list matches the existing permission list, returne {@code true}.
+   */
   private boolean canUseTempFile(final List<String> incomingAccessingList, final DotTempFile dotTempFile) {
     final File tempFile = dotTempFile.file;
     final List<String> accessingList = new ArrayList<>(incomingAccessingList);
@@ -361,7 +388,7 @@ public class TempFileAPI {
         : new File(tempFile.getParentFile(), WHO_CAN_USE_TEMP_FILE);
 
     try {
-      final List<String> perms = (file.exists()) ? new ObjectMapper().readValue(file, List.class) : ImmutableList.of();
+      final List<String> perms = (file.exists()) ? new ObjectMapper().readValue(file, List.class) : List.of();
       return !Collections.disjoint(perms, accessingList);
     } catch (IOException e) {
       throw new DotStateException(e.getMessage(), e);
@@ -369,14 +396,19 @@ public class TempFileAPI {
   }
 
   /**
-   * Optionally retreives the Temp Resource. The temp resource will only be returned if 1) the
-   * accessingList contains a value that is also contained whoCanUse.tmp file that was created when
-   * the temp resource was written and 2) that the file modification time on the temp resource is
-   * newer than the value configured by TEMP_RESOURCE_MAX_AGE_SECONDS, which defaults to 30m.
-   * 
-   * @param accessingList
-   * @param tempFileId
-   * @return
+   * Optionally retrieves the Temp Resource. The temp resource will only be returned if:
+   * <ol>
+   *     <li>The {@code accessingList} contains a value that is also contained in the {@code whoCanUse.tmp} file that
+   *     was created when the temp resource was written.</li>
+   *     <li>And that the file modification time on the temp resource is newer than the value configured by
+   *     {@link #TEMP_RESOURCE_MAX_AGE_SECONDS}, which defaults to 30m.</li>
+   * </ol>
+   *
+   * @param accessingList The incoming Access List.
+   * @param tempFileId    The ID of the Temporary File.
+   *
+   * @return The optional with the {@link DotTempFile} if the Access List matched the existing one. Otherwise, an empty
+   * optional will be returned.
    */
   public Optional<DotTempFile> getTempFile(final List<String> accessingList, final String tempFileId) {
     Optional<DotTempFile> tempFile = getTempFile(tempFileId);
@@ -387,15 +419,18 @@ public class TempFileAPI {
   }
 
   /**
-   * Optionally retreives the Temp Resource using the request. The temp
-   * resource will only be returned if 1) the fingerprint or sessionId is contained in the whoCanUse.tmp
-   * file that was created when the temp resource was written and 2) that the file modification time
-   * on the temp resource is newer than the value configured by TEMP_RESOURCE_MAX_AGE_SECONDS, which
-   * defaults to 30m.
-   * 
-   * @param request
-   * @param tempFileId
-   * @return
+   * Optionally retrieves the Temp Resource using the request. The temp resource will only be returned if:
+   * <ol>
+   *     <li>The fingerprint or sessionId is contained in the {@code whoCanUse.tmp} file that was created when the temp
+   *     resource was written.</li>
+   *     <li>And that the file modification time on the temp resource is newer than the value configured by
+   *     {@link #TEMP_RESOURCE_MAX_AGE_SECONDS}, which defaults to 30m.</li>
+   * </ol>
+   *
+   * @param request    The current instance of the {@link HttpServletRequest}.
+   * @param tempFileId The ID of the Temporary File.
+   *
+   * @return The optional with the {@link DotTempFile}
    */
   public Optional<DotTempFile> getTempFile(final HttpServletRequest request, final String tempFileId) {
     final String anon = Try.of(() -> APILocator.getUserAPI().getAnonymousUser().getUserId()).getOrElse("anonymous");
@@ -418,10 +453,11 @@ public class TempFileAPI {
   }
 
   /**
-   * returns if a temp resource exits
-   * 
-   * @param tempFileId
-   * @return
+   * Checks whether the specified Temporary File ID exists or not.
+   *
+   * @param tempFileId The ID of the Temporary File.
+   *
+   * @return If the Temporary File exists, returns {@code true}.
    */
   public boolean isTempResource(final String tempFileId) {
     return getTempFile(tempFileId).isPresent();
@@ -437,10 +473,17 @@ public class TempFileAPI {
           ;
     }
   };
-  
+
+  /**
+   * Generates a String representing the fingerprint of the specified {@link HttpServletRequest}. It takes a specified
+   * set of properties from the request and generates a unique identifier for the request.
+   *
+   * @param request The current instance of the {@link HttpServletRequest}.
+   *
+   * @return The request's fingerprint.
+   */
   public String getRequestFingerprint(final HttpServletRequest request) {
-    
-    final List<String> uniqList = new ArrayList<String>();
+    final List<String> uniqList = new ArrayList<>();
     uniqList.add(request.getHeader("User-Agent"));
     uniqList.add(request.getHeader("Host"));
     uniqList.add(request.getHeader("Accept-Language"));
@@ -461,10 +504,8 @@ public class TempFileAPI {
     }
     
     final String fingerPrint = String.join(" , ", uniqList);
-    Logger.info(this.getClass(), "Unique browser fingerprint: " + fingerPrint);
+    Logger.debug(this.getClass(), "Unique browser fingerprint: " + fingerPrint);
     return Encryptor.digest(fingerPrint);
-    
-    
   }
 
   /**
@@ -483,6 +524,33 @@ public class TempFileAPI {
       Logger.warnAndDebug(TempFileAPI.class, e.getMessage(), e);
     }
     return Optional.empty();
+  }
+
+  /**
+   * Writes the specified content in the form of an Input Stream to the specified Temporary File.
+   *
+   * @param request     The current instance of the {@link HttpServletRequest}.
+   * @param dotTempFile The {@link DotTempFile} whose content will be overwritten.
+   * @param inputStream The new file content as an {@link InputStream}.
+   */
+  private void writeFile(final HttpServletRequest request, final DotTempFile dotTempFile, final InputStream inputStream) {
+    final File tempFile = dotTempFile.file;
+    final long maxLength = this.maxFileSize(request);
+    try (final OutputStream out = new BoundedOutputStream(maxLength, Files.newOutputStream(tempFile.toPath()))) {
+      int read;
+      final byte[] bytes = new byte[4096];
+      while ((read = inputStream.read(bytes)) != -1) {
+        out.write(bytes, 0, read);
+      }
+    } catch (final IOException e) {
+      final String message =
+              APILocator.getLanguageAPI().getStringKey(WebAPILocator.getLanguageWebAPI().getLanguage(request), "temp.file.max.file.size.error").replace("{0}", UtilMethods.prettyByteify(maxLength));
+      throw new DotStateException(message, e);
+    } catch (final Exception e) {
+      throw new DotRuntimeException(e.getMessage(), e);
+    } finally {
+      CloseUtils.closeQuietly(inputStream);
+    }
   }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
@@ -14,6 +14,7 @@ import com.dotcms.util.SecurityUtils;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.FileUtil;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,10 +56,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
 
+/**
+ * This REST Endpoint allows Users to interact with the Temp File API in dotCMS. Temporary Files will live in the system
+ * for a specified amount of time -- 30 minutes by default. After that they won't be accessible anymore..
+ *
+ * @author Will Ezell
+ * @since Jul 8th, 2019
+ */
 @Path("/v1/temp")
 public class TempFileResource {
 
-    public final static String MAX_FILE_LENGTH_PARAM ="maxFileLength";
+    public static final String MAX_FILE_LENGTH_PARAM ="maxFileLength";
     private final TempFileAPI tempApi;
 
     /**
@@ -74,6 +82,17 @@ public class TempFileResource {
         this.tempApi = tempApi;
     }
 
+    /**
+     * Uploads a binary file to dotCMS via the Temp File API.
+     *
+     * @param request             The current instance of the {@link HttpServletRequest}.
+     * @param response            The current instance of the {@link HttpServletResponse}.
+     * @param maxFileLengthString The maximum allowed size for the uploaded file. If not specified, the dotCMS default
+     *                            value will be used instead.
+     * @param body                The {@link FormDataMultiPart} object containing the file.
+     *
+     * @return A JSON response including important information related to the recently uploaded Temporary File.
+     */
     @POST
     @JSONP
     @NoCache
@@ -83,26 +102,14 @@ public class TempFileResource {
             @Context final HttpServletResponse response, 
             @DefaultValue("-1") @QueryParam(MAX_FILE_LENGTH_PARAM) final String maxFileLengthString, // this is being used later
             final FormDataMultiPart body) {
-
-        verifyTempResourceEnabled();
-
-        final boolean allowAnonToUseTempFiles = Config
-                .getBooleanProperty(TempFileAPI.TEMP_RESOURCE_ALLOW_ANONYMOUS, true);
-
-        new WebResource.InitBuilder(request, response)
-          .requiredAnonAccess(AnonymousAccess.WRITE)
-          .rejectWhenNoUser(!allowAnonToUseTempFiles)
-          .init();
-
-        if (!new SecurityUtils().validateReferer(request)) {
-
-            throw new BadRequestException("Invalid Origin or referer");
-        }
-
+        this.checkEndpointAccess(request, response);
         return Response.ok(new MultipleBinaryStreamingOutput(body, request))
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON).build();
     }
 
+    /**
+     * Streaming Output class used for saving one or more binary files as Temporary Files.
+     */
     protected class MultipleBinaryStreamingOutput implements StreamingOutput {
 
         private final FormDataMultiPart body;
@@ -119,16 +126,22 @@ public class TempFileResource {
         public void write(final OutputStream output) throws IOException, WebApplicationException {
 
             final ObjectMapper objectMapper = DotObjectMapperProvider.getInstance().getDefaultObjectMapper();
-            TempFileResource.this.saveMultipleBinary(body, request, output, objectMapper);
+            TempFileResource.this.saveMultipleBinaryFiles(body, request, output, objectMapper);
         }
     }
 
-    private void saveMultipleBinary(final FormDataMultiPart body, final HttpServletRequest request,
-                                    final OutputStream outputStream, final ObjectMapper objectMapper) {
-
-        final DotSubmitter dotSubmitter = DotConcurrentFactory.getInstance().getSubmitter("TEMP_API_SUBMITTER",
-                new DotConcurrentFactory.SubmitterConfigBuilder().poolSize(2).maxPoolSize(5).queueCapacity(100000).build());
-        final CompletionService<Object> completionService = new ExecutorCompletionService<>(dotSubmitter);
+    /**
+     * Saves the binary file or files that are being submitted by the user. A Completion Service is used to improve the
+     * time it takes to save every Temporary File.
+     *
+     * @param body          The {@link FormDataMultiPart} containing the file or files that will be saved.
+     * @param request       The current instance of the {@link HttpServletRequest}.
+     * @param outputStream  The streaming output of the response.
+     * @param objectMapper  The {@link ObjectMapper} that transforms the response into a JSON object.
+     */
+    private void saveMultipleBinaryFiles(final FormDataMultiPart body, final HttpServletRequest request,
+                                         final OutputStream outputStream, final ObjectMapper objectMapper) {
+        final CompletionService<Object> completionService = this.createCompletionService(2, 5, 100000);
         final List<Future<Object>> futures = new ArrayList<>();
         final HttpServletRequest statelessRequest = RequestUtil.INSTANCE.createStatelessRequest(request);
 
@@ -166,7 +179,7 @@ public class TempFileResource {
                     }
 
                     return this.tempApi.createTempFile(fileName, statelessRequest, in);
-                } catch (Exception e) {
+                } catch (final Exception e) {
 
                     Logger.error(this, e.getMessage(), e);
                     return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST),
@@ -178,17 +191,19 @@ public class TempFileResource {
             ++index;
             futures.add(future);
         }
-
-        printResponseEntityViewResult(outputStream, objectMapper, completionService, futures);
+        this.printResponseEntityViewResult(outputStream, objectMapper, completionService, futures);
     }
 
     /**
+     * Updates a specific Temporary File with the provided content as a String. If such a file doesn't exist or has
+     * expired, a brand new Temporary File with the specified content will be generated instead.
      *
-     * @param request
-     * @param response
-     * @param tempFileId
-     * @param body
-     * @return
+     * @param request       The current instance of the {@link HttpServletRequest}.
+     * @param response      The current instance of the {@link HttpServletResponse}.
+     * @param tempFileId    The ID of the Temporary File that will be updated.
+     * @param form          The {@link PlainTextFileForm} with the required file information.
+     *
+     * @return A JSON response including important information related to the recently updated Temporary File.
      */
     @PUT
     @Path("/id/{tempFileId: .*}")
@@ -196,141 +211,109 @@ public class TempFileResource {
     @NoCache
     @Produces("application/octet-stream")
     @Consumes(MediaType.APPLICATION_JSON)
-    public final Response updateTempResource(@Context final HttpServletRequest request,
+    public final Response upsertTempResource(@Context final HttpServletRequest request,
                                              @Context final HttpServletResponse response,
                                              @PathParam("tempFileId") final String tempFileId,
-                                             final PlainTextFileForm body) {
-        this.verifyTempResourceEnabled();
-        new WebResource.InitBuilder(request, response).requiredAnonAccess(AnonymousAccess.WRITE).rejectWhenNoUser(true).init();
-        if (!new SecurityUtils().validateReferer(request)) {
-            throw new BadRequestException("Invalid Origin or referer");
-        }
-
+                                             final PlainTextFileForm form) {
+        this.checkEndpointAccess(request, response);
         final StreamingOutput streamingOutput = output -> {
 
             final ObjectMapper objectMapper = DotObjectMapperProvider.getInstance().getDefaultObjectMapper();
-            TempFileResource.this.savePlainTextFile(tempFileId, body, request, output, objectMapper);
+            TempFileResource.this.savePlainTextFile(request, objectMapper, output, tempFileId, form);
 
         };
-
         return Response.ok(streamingOutput).header(HttpHeaders.CONTENT_TYPE,
                 MediaType.APPLICATION_JSON).build();
     }
 
-    protected class TempFileStreamingOutput implements StreamingOutput {
-
-        private final String tempFileId;
-        private final PlainTextFileForm body;
-        private final HttpServletRequest request;
-
-        private TempFileStreamingOutput(final String tempFileId, final PlainTextFileForm body, final HttpServletRequest request) {
-            this.tempFileId = tempFileId;
-            this.body    = body;
-            this.request = request;
-        }
-
-        @Override
-        public void write(final OutputStream output) throws IOException, WebApplicationException {
-            final ObjectMapper objectMapper = DotObjectMapperProvider.getInstance().getDefaultObjectMapper();
-            TempFileResource.this.savePlainTextFile(tempFileId, body, request, output, objectMapper);
-        }
-    }
-
-    private void savePlainTextFile(final String tempFileId, final PlainTextFileForm body, final HttpServletRequest request,
-                                    final OutputStream outputStream, final ObjectMapper objectMapper) {
-        final CompletionService<Object> completionService = this.createCompletionService(2, 5, 100000);
-        final HttpServletRequest statelessRequest = RequestUtil.INSTANCE.createStatelessRequest(request);
-        // this triggers the save
-        final InputStream in = new ByteArrayInputStream(body.fileContent().getBytes());
-        final Future<Object> future = this.updateTempFileFuture(completionService, statelessRequest, 1,
-                body.fileName(), in, tempFileId);
-        /*final Future<Object> future = completionService.submit(() -> {
-
-            try {
-                final InputStream in = new ByteArrayInputStream(body.fileContent().getBytes());
-                if (in == null) {
-                    return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST), "Invalid Binary Part, index: " + futureIndex,
-                            String.valueOf(futureIndex));
-                }
-                final String fileName = body.fileName();
-                if (fileName == null || fileName.startsWith(".") || fileName.contains("/.")) {
-
-                    return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST),
-                            "Invalid Binary Part, Name: " + fileName + ", index: " + futureIndex,
-                            String.valueOf(futureIndex));
-                }
-                return this.tempApi.updateTempFile(tempFileId, fileName, statelessRequest, in);
-            } catch (final Exception e) {
-                Logger.error(this, e.getMessage(), e);
-                return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST),
-                        "Invalid Binary Part, Message: " + e.getMessage() + ", index: " + futureIndex,
-                        String.valueOf(futureIndex));
-            }
-
-        });*/
+    /**
+     * Overwrites a specific Temporary File with new content.
+     *
+     * @param request       The current instance of the {@link HttpServletRequest}.
+     * @param objectMapper  The {@link ObjectMapper} that transforms the response into a JSON object.
+     * @param outputStream  The streaming output for the response.
+     * @param tempFileId    The ID of the Temporary File that is being overwritten.
+     * @param form          The {@link PlainTextFileForm} object with the information of the submitted file.
+     */
+    private void savePlainTextFile(final HttpServletRequest request, final ObjectMapper objectMapper, final OutputStream outputStream, final String tempFileId, final PlainTextFileForm form) {
+        final CompletionService<Object> completionService = this.createCompletionService(1, 1, 10);
+        final Future<Object> future = this.updateTempFile(completionService,
+                RequestUtil.INSTANCE.createStatelessRequest(request), tempFileId, form.fileName(),
+                new ByteArrayInputStream(form.fileContent().getBytes()));
         this.printResponseEntityViewResult(outputStream, objectMapper, completionService, List.of(future));
     }
 
-    private Future<Object> updateTempFileFuture(final CompletionService<Object> completionService,
-                                                final HttpServletRequest statelessRequest, final int futureId,
-                                                final String fileName, final InputStream in, final String tempFileId) {
+    /**
+     * Saves the content of the specified Temporary File. In order to improve the performance, a
+     * {@link CompletionService} task care of creating a Future task that calls the Temp File API that actually saves
+     * the new content of the Temporary File.
+     *
+     * @param completionService The {@link CompletionService} instance that will update the Temporary File.
+     * @param statelessRequest  A stateless {@link HttpServletRequest} taht is used to call the Temp File API.
+     * @param tempFileId        The ID of the Temporary File that is being overwritten.
+     * @param fileName          The name of the Temporary File. If the file doesn't exist or has expired, this value
+     *                          will be used to create the new Temporary File.
+     * @param in                The new content of the file as an {@link InputStream} object.
+     *
+     * @return The {@link Future} task that will save the Temporary File.
+     */
+    private Future<Object> updateTempFile(final CompletionService<Object> completionService,
+                                          final HttpServletRequest statelessRequest,
+                                          final String tempFileId, final String fileName, final InputStream in) {
         return completionService.submit(() -> {
 
             try {
-                if (fileName == null || fileName.startsWith(".") || fileName.contains("/.")) {
-                    return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST), "Invalid File Name, " +
-                                                                                                       "Name: " + fileName + ", index: " + futureId, String.valueOf(futureId));
-                }
                 if (in == null) {
-                    return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST), "Invalid Binary Stream, " +
-                                                                                                       "index: " + futureId, fileName);
+                    return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST), "Invalid Binary Stream", fileName);
                 }
-                return this.tempApi.updateTempFile(tempFileId, fileName, statelessRequest, in);
+                final String sanitizedFileName = FileUtil.sanitizeFileName(fileName);
+                return this.tempApi.upsertTempFile(statelessRequest, tempFileId, sanitizedFileName, in);
             } catch (final Exception e) {
                 Logger.error(this, e.getMessage(), e);
                 return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST), "Invalid Binary Part, " +
-                                                                                                   "Message: " + e.getMessage() + ", index: " + futureId, String.valueOf(futureId));
+                                                                                                   "Message: " + e.getMessage(), fileName);
             }
 
         });
     }
 
+    /**
+     * Returns the basic information of the created Temporary File as a JSON object. The data provided here is very
+     * useful for the service or user that called this endpoint in order to get a summary of the Temporary File that was
+     * created.
+     *
+     * @param outputStream      The streaming output for the response.
+     * @param objectMapper      The {@link ObjectMapper} that transforms the response into a JSON object.
+     * @param completionService The {@link CompletionService} instance containing the task that saved/updated the
+     *                          Temporary File.
+     * @param futures           The list of {@link Future} tasks that were created when saving one or more files.
+     */
     private void printResponseEntityViewResult(final OutputStream outputStream,
                                                final ObjectMapper objectMapper,
                                                final CompletionService<Object> completionService,
                                                final List<Future<Object>> futures) {
-
         try {
-
             outputStream.write(StringPool.OPEN_CURLY_BRACE.getBytes(StandardCharsets.UTF_8));
             ResponseUtil.beginWrapProperty(outputStream, "tempFiles", false);
             outputStream.write(StringPool.OPEN_BRACKET.getBytes(StandardCharsets.UTF_8));
             // now recover the N results
             for (int i = 0; i < futures.size(); i++) {
-
                 try {
-
-                    Logger.info(this, "Recovering the result " + (i + 1) + " of " + futures.size());
+                    Logger.debug(this, "Recovering the result " + (i + 1) + " of " + futures.size());
                     objectMapper.writeValue(outputStream, completionService.take().get());
-
                     if (i < futures.size()-1) {
                         outputStream.write(StringPool.COMMA.getBytes(StandardCharsets.UTF_8));
                     }
-                } catch (InterruptedException | ExecutionException | IOException e) {
-
+                } catch (final InterruptedException | ExecutionException | IOException e) {
                     Logger.error(this, e.getMessage(), e);
                 }
             }
-
             outputStream.write(StringPool.CLOSE_BRACKET.getBytes(StandardCharsets.UTF_8));
             ResponseUtil.endWrapProperty(outputStream);
-        } catch (IOException e) {
-
+        } catch (final IOException e) {
             Logger.error(this, e.getMessage(), e);
         }
     }
-
-
 
     @POST
     @Path("/byUrl")
@@ -340,22 +323,8 @@ public class TempFileResource {
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON})
     public final Response copyTempFromUrl(@Context final HttpServletRequest request,@Context final HttpServletResponse response,
             final RemoteUrlForm form) {
-
         try {
-
-            verifyTempResourceEnabled();
-
-            final boolean allowAnonToUseTempFiles = Config
-                .getBooleanProperty(TempFileAPI.TEMP_RESOURCE_ALLOW_ANONYMOUS, true);
-
-              new WebResource.InitBuilder(request, response)
-                .requiredAnonAccess(AnonymousAccess.WRITE)
-                .rejectWhenNoUser(!allowAnonToUseTempFiles)
-                .init();
-
-            if (!new SecurityUtils().validateReferer(request)) {
-                throw new BadRequestException("Invalid Origin or referer");
-            }
+            this.checkEndpointAccess(request, response);
             if(!UtilMethods.isSet(form.remoteUrl)){
                 throw new BadRequestException("No Url passed");
             }
@@ -363,30 +332,49 @@ public class TempFileResource {
                 throw new BadRequestException("Invalid url attempted for tempFile : " + form.remoteUrl);
             }
 
-            final List<DotTempFile> tempFiles = new ArrayList<DotTempFile>();
+            final List<DotTempFile> tempFiles = new ArrayList<>();
             tempFiles.add(tempApi
                     .createTempFileFromUrl(form.fileName, request, new URL(form.remoteUrl),
                             form.urlTimeoutSeconds, form.maxFileLength));
 
             return Response.ok(ImmutableMap.of("tempFiles", tempFiles)).build();
-
-        } catch (Exception e) {
+        } catch (final Exception e) {
             Logger.warnAndDebug(this.getClass(), e);
             return ResponseUtil.mapExceptionResponse(e);
         }
     }
 
-    private void verifyTempResourceEnabled(){
+    /**
+     * Utility method that checks that this REST Endpoint can be safely accessed under given circumstances. For
+     * instance:
+     * <ul>
+     *     <li>The Temp File Resources is enabled.</li>
+     *     <li>Whether Anonymous Users can submit Temporary Files or not.</li>
+     *     <li>The origin or referer must be valid for the current HTTP Request.</li>
+     * </ul>
+     */
+    private void checkEndpointAccess(final HttpServletRequest request, final HttpServletResponse response){
         if (!Config.getBooleanProperty(TempFileAPI.TEMP_RESOURCE_ENABLED, true)) {
             final String message = "Temp Files Resource is not enabled, please change the TEMP_RESOURCE_ENABLED to true in your properties file";
             Logger.error(this, message);
             throw new DoesNotExistException(message);
         }
+        final boolean allowAnonToUseTempFiles = Config.getBooleanProperty(TempFileAPI.TEMP_RESOURCE_ALLOW_ANONYMOUS,
+                true);
+        new WebResource.InitBuilder(request, response).requiredAnonAccess(AnonymousAccess.WRITE).rejectWhenNoUser(!allowAnonToUseTempFiles).init();
+        if (!new SecurityUtils().validateReferer(request)) {
+            throw new BadRequestException("Invalid Origin or referer");
+        }
     }
 
     /**
+     * Creates a Completion Service with the specified configuration parameters.
      *
-     * @return
+     * @param poolSize      The initial size of the thread pool.
+     * @param maxPoolSize   The maximum number of threads in the pool.
+     * @param queueCapacity The maximum capacity of the queue that will be processed.
+     *
+     * @return The {@link CompletionService} instance.
      */
     private CompletionService<Object> createCompletionService(final int poolSize, final int maxPoolSize, final int queueCapacity) {
         final DotSubmitter dotSubmitter = DotConcurrentFactory.getInstance().getSubmitter("TEMP_API_SUBMITTER",

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
@@ -2,37 +2,26 @@ package com.dotcms.rest.api.v1.temp;
 
 import com.dotcms.concurrent.DotConcurrentFactory;
 import com.dotcms.concurrent.DotSubmitter;
-import com.dotcms.mock.request.DotCMSMockRequest;
-import com.dotcms.mock.request.DotCMSMockRequestWithSession;
 import com.dotcms.rest.AnonymousAccess;
 import com.dotcms.rest.ErrorEntity;
-import com.dotcms.rest.InitDataObject;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
 import com.dotcms.rest.api.v1.DotObjectMapperProvider;
 import com.dotcms.rest.api.v1.authentication.RequestUtil;
 import com.dotcms.rest.api.v1.authentication.ResponseUtil;
-import com.dotcms.rest.api.v1.workflow.WorkflowResource;
 import com.dotcms.rest.exception.BadRequestException;
-import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.SecurityUtils;
-import com.dotcms.workflow.form.FireMultipleActionForm;
-import com.dotmarketing.beans.Request;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DoesNotExistException;
-import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.liferay.portal.util.WebKeys;
 import com.liferay.util.HttpHeaders;
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
-import org.apache.commons.lang.time.StopWatch;
 import org.glassfish.jersey.media.multipart.BodyPart;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -40,11 +29,20 @@ import org.glassfish.jersey.server.JSONP;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -52,7 +50,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
@@ -185,6 +182,119 @@ public class TempFileResource {
         printResponseEntityViewResult(outputStream, objectMapper, completionService, futures);
     }
 
+    /**
+     *
+     * @param request
+     * @param response
+     * @param tempFileId
+     * @param body
+     * @return
+     */
+    @PUT
+    @Path("/id/{tempFileId: .*}")
+    @JSONP
+    @NoCache
+    @Produces("application/octet-stream")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public final Response updateTempResource(@Context final HttpServletRequest request,
+                                             @Context final HttpServletResponse response,
+                                             @PathParam("tempFileId") final String tempFileId,
+                                             final PlainTextFileForm body) {
+        this.verifyTempResourceEnabled();
+        new WebResource.InitBuilder(request, response).requiredAnonAccess(AnonymousAccess.WRITE).rejectWhenNoUser(true).init();
+        if (!new SecurityUtils().validateReferer(request)) {
+            throw new BadRequestException("Invalid Origin or referer");
+        }
+
+        final StreamingOutput streamingOutput = output -> {
+
+            final ObjectMapper objectMapper = DotObjectMapperProvider.getInstance().getDefaultObjectMapper();
+            TempFileResource.this.savePlainTextFile(tempFileId, body, request, output, objectMapper);
+
+        };
+
+        return Response.ok(streamingOutput).header(HttpHeaders.CONTENT_TYPE,
+                MediaType.APPLICATION_JSON).build();
+    }
+
+    protected class TempFileStreamingOutput implements StreamingOutput {
+
+        private final String tempFileId;
+        private final PlainTextFileForm body;
+        private final HttpServletRequest request;
+
+        private TempFileStreamingOutput(final String tempFileId, final PlainTextFileForm body, final HttpServletRequest request) {
+            this.tempFileId = tempFileId;
+            this.body    = body;
+            this.request = request;
+        }
+
+        @Override
+        public void write(final OutputStream output) throws IOException, WebApplicationException {
+            final ObjectMapper objectMapper = DotObjectMapperProvider.getInstance().getDefaultObjectMapper();
+            TempFileResource.this.savePlainTextFile(tempFileId, body, request, output, objectMapper);
+        }
+    }
+
+    private void savePlainTextFile(final String tempFileId, final PlainTextFileForm body, final HttpServletRequest request,
+                                    final OutputStream outputStream, final ObjectMapper objectMapper) {
+        final CompletionService<Object> completionService = this.createCompletionService(2, 5, 100000);
+        final HttpServletRequest statelessRequest = RequestUtil.INSTANCE.createStatelessRequest(request);
+        // this triggers the save
+        final InputStream in = new ByteArrayInputStream(body.fileContent().getBytes());
+        final Future<Object> future = this.updateTempFileFuture(completionService, statelessRequest, 1,
+                body.fileName(), in, tempFileId);
+        /*final Future<Object> future = completionService.submit(() -> {
+
+            try {
+                final InputStream in = new ByteArrayInputStream(body.fileContent().getBytes());
+                if (in == null) {
+                    return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST), "Invalid Binary Part, index: " + futureIndex,
+                            String.valueOf(futureIndex));
+                }
+                final String fileName = body.fileName();
+                if (fileName == null || fileName.startsWith(".") || fileName.contains("/.")) {
+
+                    return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST),
+                            "Invalid Binary Part, Name: " + fileName + ", index: " + futureIndex,
+                            String.valueOf(futureIndex));
+                }
+                return this.tempApi.updateTempFile(tempFileId, fileName, statelessRequest, in);
+            } catch (final Exception e) {
+                Logger.error(this, e.getMessage(), e);
+                return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST),
+                        "Invalid Binary Part, Message: " + e.getMessage() + ", index: " + futureIndex,
+                        String.valueOf(futureIndex));
+            }
+
+        });*/
+        this.printResponseEntityViewResult(outputStream, objectMapper, completionService, List.of(future));
+    }
+
+    private Future<Object> updateTempFileFuture(final CompletionService<Object> completionService,
+                                                final HttpServletRequest statelessRequest, final int futureId,
+                                                final String fileName, final InputStream in, final String tempFileId) {
+        return completionService.submit(() -> {
+
+            try {
+                if (fileName == null || fileName.startsWith(".") || fileName.contains("/.")) {
+                    return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST), "Invalid File Name, " +
+                                                                                                       "Name: " + fileName + ", index: " + futureId, String.valueOf(futureId));
+                }
+                if (in == null) {
+                    return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST), "Invalid Binary Stream, " +
+                                                                                                       "index: " + futureId, fileName);
+                }
+                return this.tempApi.updateTempFile(tempFileId, fileName, statelessRequest, in);
+            } catch (final Exception e) {
+                Logger.error(this, e.getMessage(), e);
+                return new ErrorEntity(String.valueOf(HttpServletResponse.SC_BAD_REQUEST), "Invalid Binary Part, " +
+                                                                                                   "Message: " + e.getMessage() + ", index: " + futureId, String.valueOf(futureId));
+            }
+
+        });
+    }
+
     private void printResponseEntityViewResult(final OutputStream outputStream,
                                                final ObjectMapper objectMapper,
                                                final CompletionService<Object> completionService,
@@ -272,6 +382,16 @@ public class TempFileResource {
             Logger.error(this, message);
             throw new DoesNotExistException(message);
         }
+    }
+
+    /**
+     *
+     * @return
+     */
+    private CompletionService<Object> createCompletionService(final int poolSize, final int maxPoolSize, final int queueCapacity) {
+        final DotSubmitter dotSubmitter = DotConcurrentFactory.getInstance().getSubmitter("TEMP_API_SUBMITTER",
+                new DotConcurrentFactory.SubmitterConfigBuilder().poolSize(poolSize).maxPoolSize(maxPoolSize).queueCapacity(queueCapacity).build());
+        return new ExecutorCompletionService<>(dotSubmitter);
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
@@ -309,7 +309,7 @@ public class TempFileResource {
                         outputStream.write(StringPool.COMMA.getBytes(StandardCharsets.UTF_8));
                     }
                 } catch (final InterruptedException e) {
-                    Logger.error(this, "Thread has been interrupted" + e.getMessage(), e);
+                    Logger.error(this, "Thread has been interrupted: " + e.getMessage(), e);
                     Thread.currentThread().interrupt();
                 } catch (final ExecutionException | IOException e) {
                     Logger.error(this, e.getMessage(), e);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/ajax/FileAssetAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/ajax/FileAssetAjax.java
@@ -12,14 +12,12 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.fileassets.business.FileAsset;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
 import com.liferay.portal.model.User;
 
 import javax.servlet.http.HttpServletRequest;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -70,41 +68,39 @@ public class FileAssetAjax {
 		final Contentlet contentlet        = APILocator.getContentletAPI().find(contentletInode, user, respectFrontendRoles);
 		String incomingFileName            = null;
 		String binaryFieldName             = binField;
-		if (UtilMethods.isSet(contentletInode)) {
-			if (contentlet.isFileAsset()) {
 
-				final FileAsset fileAsset = APILocator.getFileAssetAPI().fromContentlet(contentlet);
-				incomingFileName = fileAsset.getFileAsset().getName();
-				binaryFieldName = FileAssetAPI.BINARY_FIELD;
-			} else if (contentlet.isDotAsset()) {
+		if (contentlet.isFileAsset()) {
 
-				incomingFileName = contentlet.getBinary(DotAssetContentType.ASSET_FIELD_VAR).getName();
-				binaryFieldName = DotAssetContentType.ASSET_FIELD_VAR;
-			} else {
+			final FileAsset fileAsset = APILocator.getFileAssetAPI().fromContentlet(contentlet);
+			incomingFileName = fileAsset.getFileAsset().getName();
+			binaryFieldName  = FileAssetAPI.BINARY_FIELD;
+		} else if (contentlet.isDotAsset()) {
 
-				incomingFileName = contentlet.getBinary(binField).getName();
-			}
-
-			final File tempDir = new File(APILocator.getFileAssetAPI().getRealAssetPathTmpBinary() + File.separator + contentletInode.charAt(0) + File.separator + contentletInode.charAt(1) + File.separator + contentletInode + File.separator + binaryFieldName);
-
-			if (!tempDir.exists()) {
-				tempDir.mkdirs();
-			}
-
-			final File fileData = new File(tempDir.getAbsoluteFile() + File.separator + WebKeys.TEMP_FILE_PREFIX + incomingFileName);
-
-			fileData.deleteOnExit();
-
-			try (OutputStream os = Files.newOutputStream(fileData.toPath())) {
-
-				os.write(newText.getBytes());
-			} catch (Exception e) {
-
-				Logger.error(getClass(), "Error writing to file", e);
-			}
+			incomingFileName = contentlet.getBinary(DotAssetContentType.ASSET_FIELD_VAR).getName();
+			binaryFieldName  = DotAssetContentType.ASSET_FIELD_VAR;
 		} else {
-			final InputStream inputStream = new ByteArrayInputStream(newText.getBytes());
-			APILocator.getTempFileAPI().createTempFile(incomingFileName, request, inputStream);
+
+			incomingFileName = contentlet.getBinary(binField).getName();
+		}
+
+		final File tempDir =  new File(APILocator.getFileAssetAPI().getRealAssetPathTmpBinary() + File.separator + contentletInode.charAt(0)
+				+ File.separator + contentletInode.charAt(1) + File.separator + contentletInode
+				+ File.separator + binaryFieldName);
+
+		if(!tempDir.exists()) {
+			tempDir.mkdirs();
+		}
+
+		final File fileData = new File(tempDir.getAbsoluteFile() + File.separator + WebKeys.TEMP_FILE_PREFIX + incomingFileName);
+
+		fileData.deleteOnExit();
+
+		try (OutputStream os = Files.newOutputStream(fileData.toPath())) {
+
+			os.write(newText.getBytes());
+		} catch(Exception e) {
+
+			Logger.error(getClass(), "Error writing to file", e);
 		}
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/ajax/FileAssetAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/ajax/FileAssetAjax.java
@@ -12,12 +12,14 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.fileassets.business.FileAsset;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
 import com.liferay.portal.model.User;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,39 +70,41 @@ public class FileAssetAjax {
 		final Contentlet contentlet        = APILocator.getContentletAPI().find(contentletInode, user, respectFrontendRoles);
 		String incomingFileName            = null;
 		String binaryFieldName             = binField;
+		if (UtilMethods.isSet(contentletInode)) {
+			if (contentlet.isFileAsset()) {
 
-		if (contentlet.isFileAsset()) {
+				final FileAsset fileAsset = APILocator.getFileAssetAPI().fromContentlet(contentlet);
+				incomingFileName = fileAsset.getFileAsset().getName();
+				binaryFieldName = FileAssetAPI.BINARY_FIELD;
+			} else if (contentlet.isDotAsset()) {
 
-			final FileAsset fileAsset = APILocator.getFileAssetAPI().fromContentlet(contentlet);
-			incomingFileName = fileAsset.getFileAsset().getName();
-			binaryFieldName  = FileAssetAPI.BINARY_FIELD;
-		} else if (contentlet.isDotAsset()) {
+				incomingFileName = contentlet.getBinary(DotAssetContentType.ASSET_FIELD_VAR).getName();
+				binaryFieldName = DotAssetContentType.ASSET_FIELD_VAR;
+			} else {
 
-			incomingFileName = contentlet.getBinary(DotAssetContentType.ASSET_FIELD_VAR).getName();
-			binaryFieldName  = DotAssetContentType.ASSET_FIELD_VAR;
+				incomingFileName = contentlet.getBinary(binField).getName();
+			}
+
+			final File tempDir = new File(APILocator.getFileAssetAPI().getRealAssetPathTmpBinary() + File.separator + contentletInode.charAt(0) + File.separator + contentletInode.charAt(1) + File.separator + contentletInode + File.separator + binaryFieldName);
+
+			if (!tempDir.exists()) {
+				tempDir.mkdirs();
+			}
+
+			final File fileData = new File(tempDir.getAbsoluteFile() + File.separator + WebKeys.TEMP_FILE_PREFIX + incomingFileName);
+
+			fileData.deleteOnExit();
+
+			try (OutputStream os = Files.newOutputStream(fileData.toPath())) {
+
+				os.write(newText.getBytes());
+			} catch (Exception e) {
+
+				Logger.error(getClass(), "Error writing to file", e);
+			}
 		} else {
-
-			incomingFileName = contentlet.getBinary(binField).getName();
-		}
-
-		final File tempDir =  new File(APILocator.getFileAssetAPI().getRealAssetPathTmpBinary() + File.separator + contentletInode.charAt(0)
-				+ File.separator + contentletInode.charAt(1) + File.separator + contentletInode
-				+ File.separator + binaryFieldName);
-
-		if(!tempDir.exists()) {
-			tempDir.mkdirs();
-		}
-
-		final File fileData = new File(tempDir.getAbsoluteFile() + File.separator + WebKeys.TEMP_FILE_PREFIX + incomingFileName);
-
-		fileData.deleteOnExit();
-
-		try (OutputStream os = Files.newOutputStream(fileData.toPath())) {
-
-			os.write(newText.getBytes());
-		} catch(Exception e) {
-
-			Logger.error(getClass(), "Error writing to file", e);
+			final InputStream inputStream = new ByteArrayInputStream(newText.getBytes());
+			APILocator.getTempFileAPI().createTempFile(incomingFileName, request, inputStream);
 		}
 	}
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -811,26 +811,13 @@
 
     </script>
 
-
-    <%
-
-        if(UtilMethods.isSet(value) && UtilMethods.isSet(resourceLink)){
-
-          boolean canUserWriteToContentlet = APILocator.getPermissionAPI().doesUserHavePermission(contentlet,PermissionAPI.PERMISSION_WRITE, user);
-
-    %>
-
-        <%if(canUserWriteToContentlet){%>
-            <% if (resourceLink.isEditableAsText()) { %>
-                <%
-                    if (InodeUtils.isSet(binInode) && canUserWriteToContentlet) {
-
-                %>
-                    <%@ include file="/html/portlet/ext/contentlet/field/edit_file_asset_text_inc.jsp"%>
-                <%  } %>
-            <% } %>
-
-        <% } %>
+    <% if (UtilMethods.isSet(value)) {
+            final boolean canUserWriteToContentlet = APILocator.getPermissionAPI().doesUserHavePermission(contentlet, PermissionAPI.PERMISSION_WRITE, user);
+            if (canUserWriteToContentlet && resourceLink.isEditableAsText() && InodeUtils.isSet(binInode)) { %>
+                <%@ include file="/html/portlet/ext/contentlet/field/edit_file_asset_text_inc.jsp"%>
+         <% } %>
+    <% } else { %>
+            <%@ include file="/html/portlet/ext/contentlet/field/edit_file_asset_text_inc.jsp"%>
     <% } %>
 
     <!--  END display -->

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_file_asset_text_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_file_asset_text_inc.jsp
@@ -83,37 +83,30 @@
 			aceAreaParser(parser);
      }
 
-	 let tempFileId = "new";
+	let tempFileId = "new";
 
+	/**
+	 * For text File Assets, creates a temporary file with the changes that the user made. Once the User saves/publishes
+	 * the Contentlet, these new changes will overwrite the existing file so that they can be persisted.
+	 */
 	function saveText(){
 		if(!changed) {
 			return;
 		}
-		var text = aceEditor.getValue();
+		let text = aceEditor.getValue();
 
 		if (contentletInode.value == '') {
 			let fileName = dojo.byId("fileName").value;
-			//alert(fileName);
 			if (fileName) {
-				/*const url = "/api/v1/temp?maxFileLength=-1";
-				let formData = new FormData();
-				formData.append("files", text);
-				formData.append("filename", fileName);
-
-				fetch(url, {
-					method: "PUT",
-					body: formData,
-				}).then(
-						response => console.log(response.json())// .json(), etc.
-						// same as function(response) {return response.text();}
-				).then(
-						html => console.log(html)
-				);*/
-				var data = JSON.stringify({
+				let fileExtension = fileName.split('.').pop();
+				if (fileExtension) {
+					loadAce(fileExtension);
+				}
+				let data = JSON.stringify({
 					"fileName": fileName,
 					"fileContent": text
 				});
-				var xhr = new XMLHttpRequest();
+				let xhr = new XMLHttpRequest();
 
 				xhr.addEventListener("readystatechange", function() {
 					if(this.readyState === 4) {
@@ -123,10 +116,9 @@
 
 				xhr.onload = function() {
 					let jsonData = JSON.parse(xhr.response);
-					//alert(jsonData);
 					tempFileId = jsonData.tempFiles[0].id;
-					var elements = document.getElementsByName("<%= field.getFieldContentlet() %>");
-					for (var i = 0; i < elements.length; i++) {
+					let elements = document.getElementsByName("<%= field.getFieldContentlet() %>");
+					for (let i = 0; i < elements.length; i++) {
 						if (elements[i].tagName.toLowerCase() == "input") {
 							elements[i].value = tempFileId;
 						}


### PR DESCRIPTION
### Proposed Changes
* Allow users to write code when creating a file. A new method was added to the Temp File API and the Temp File Endpoint to allow back-end users to "upsert" a temporary file.
* The Text Area field is displayed when a new File Asset is created. This way, Users can either upload a binary file, or start typing its contents in the Text Area field.
* The initial mechanism used to create the content of the File Asset is the same one used when we're editing an existing text File Asset.