### PR TITLE
#24070 Fixing: Ignoring Seconds and Millis when compare startDate and…

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -877,7 +877,11 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
     public void endFinalizedExperiments(final User user) throws DotDataException {
         final List<Experiment> finalizedExperiments = getRunningExperiments().stream()
                 .filter(experiment -> experiment.scheduling().orElseThrow().endDate().isPresent())
-                .filter(experiment -> isTimeReach(experiment.scheduling().orElseThrow().endDate().orElseThrow()))
+                .filter(experiment -> {
+                    final Instant endDate = experiment.scheduling().orElseThrow().endDate()
+                            .orElseThrow();
+                    return isTimeReach(endDate, ChronoUnit.MINUTES);
+                })
                 .collect(Collectors.toList());
 
         finalizedExperiments.forEach((experiment ->
@@ -889,7 +893,10 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
     public void startScheduledToStartExperiments(final User user) throws DotDataException {
         final List<Experiment> scheduledToStartExperiments = list(ExperimentFilter.builder()
                 .statuses(CollectionsUtils.set(SCHEDULED)).build(), user).stream()
-                .filter((experiment -> isTimeReach(experiment.scheduling().get().startDate().orElseThrow())))
+                .filter((experiment -> {
+                    final Instant startDate = experiment.scheduling().get().startDate().orElseThrow();
+                    return isTimeReach(startDate, ChronoUnit.MINUTES);
+                }))
                 .collect(Collectors.toList());
 
         scheduledToStartExperiments.forEach((experiment ->

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJob.java
@@ -16,6 +16,7 @@ public class StartEndScheduledExperimentsJob extends DotStatefulJob {
     @WrapInTransaction
     public void run(final JobExecutionContext jobContext)
             throws JobExecutionException {
+
         Try.run(()->APILocator.getExperimentsAPI().startScheduledToStartExperiments(APILocator.systemUser()))
                 .getOrElseThrow((e)->new JobExecutionException(e));
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/DateUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/DateUtil.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.util;
 
 import com.dotcms.content.elasticsearch.business.ESContentFactoryImpl;
+import com.dotcms.util.DotPreconditions;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.cms.factories.PublicCompanyFactory;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
@@ -8,6 +9,7 @@ import com.liferay.portal.language.LanguageUtil;
 import com.liferay.portal.model.Company;
 import com.liferay.util.StringPool;
 import io.vavr.Function0;
+import java.time.temporal.TemporalUnit;
 import org.apache.commons.lang.StringUtils;
 
 import java.text.DateFormat;
@@ -753,10 +755,18 @@ public class DateUtil {
 	 * Return true if time is equals o before to now.
 	 *
 	 * @param time
+	 * @param Unit to truncate if you want
 	 * @return
 	 */
-	public static boolean isTimeReach(final Instant time) {
+	public static boolean isTimeReach(final Instant time,final TemporalUnit truncateTo) {
+		DotPreconditions.notNull(time, "Time must be not null");
 		final Instant now = Instant.now();
-		return time != null && (time.isBefore(now) || time.equals(now));
+		final Instant innerNow = truncateTo != null ? now.truncatedTo(truncateTo) : now;
+		final Instant innerTime = truncateTo != null ? time.truncatedTo(truncateTo) : time;
+		return (innerTime.isBefore(innerNow) || innerTime.equals(innerNow));
+	}
+
+	public static boolean isTimeReach(final Instant time) {
+		return isTimeReach(time, null);
 	}
 }

--- a/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
@@ -1,5 +1,7 @@
 package com.dotmarketing.util;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -26,6 +28,7 @@ import java.time.Month;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -485,6 +488,9 @@ public class DateUtilTest extends UnitTestBase {
         assertEquals("Month should be Feb", Calendar.FEBRUARY, date1.getMonth());
     }
 
+    /**
+     * Method to test: {@link DateUtil#isTimeReach(Instant)}
+     */
     @Test
     public void timeReach(){
         //Now must be Reach
@@ -495,8 +501,48 @@ public class DateUtilTest extends UnitTestBase {
 
         //Yesterday must be reach
         assertTrue(DateUtil.isTimeReach(Instant.now().plus(-1, ChronoUnit.DAYS)));
+    }
 
+    /**
+     * Method to test: {@link DateUtil#isTimeReach(Instant)}
+     * When: the time parameter is null
+     * Should: throw {@link IllegalArgumentException}
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void timeReachNullPointerException(){
         //Null must retur false
         assertFalse(DateUtil.isTimeReach(null));
+    }
+
+
+    /**
+     * Method to test: {@link DateUtil#isTimeReach(Instant, TemporalUnit)}
+     * When: You call the method with now no matter the {@link TemporalUnit}
+     * Should: Allways return true
+     */
+    @Test
+    public void timeReachWithTemporalUnit(){
+        final ChronoUnit[] chronoUnits = new ChronoUnit[]{ChronoUnit.DAYS, ChronoUnit.MINUTES, ChronoUnit.SECONDS, ChronoUnit.MILLIS};
+
+        for (ChronoUnit chronoUnit : chronoUnits) {
+            assertTrue(DateUtil.isTimeReach(Instant.now(), chronoUnit));
+        }
+    }
+
+    /**
+     * Method to test: {@link DateUtil#isTimeReach(Instant, TemporalUnit)}
+     * When: You call the method with two future times and {@link ChronoUnit#HOURS}:
+     * - One Day plus to now it should be false because the different is in DAYS
+     * - 30 Minutes plus to now should be true because the different is in MINUTES and the Minutes are truncate
+     */
+    @Test
+    public void timeReachWithTemporalUnitAndFuture(){
+        final Instant futureByDays = Instant.now().plus(1, ChronoUnit.DAYS);
+        assertFalse(DateUtil.isTimeReach(futureByDays, ChronoUnit.HOURS));
+
+        final Calendar futureByMinutes = Calendar.getInstance();
+        futureByMinutes.roll(Calendar.MINUTE, 30);
+
+        assertTrue(DateUtil.isTimeReach(futureByMinutes.toInstant(), ChronoUnit.HOURS));
     }
 }


### PR DESCRIPTION
When the different with now and startDate or endDate was just SECONDS or MILLIS, the Experiment did not get started or ended in the right time, this is way we are ignoring the SECONS and MILLIS

https://github.com/dotCMS/core/pull/24253/files#diff-5aa71567ff53ee229d25c2386cce3169c657f37a3e04cf27b75b3fd029537a7cR883

