### PR TITLE
dotCMS/core#24236 When Experiment is running Variant modifications should be limited. 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.html
@@ -3,6 +3,7 @@
     [(ngModel)]="mode"
     [options]="options"
     (onChange)="stateSelectorHandler($event.value)"
+    data-testId="selectButton"
 ></p-selectButton>
 
 <ng-container *ngIf="!variant">
@@ -23,4 +24,8 @@
     ></p-inputSwitch>
 </ng-container>
 
-<dot-edit-page-lock-info #pageLockInfo [pageState]="pageState"></dot-edit-page-lock-info>
+<dot-edit-page-lock-info
+    #pageLockInfo
+    [pageState]="pageState"
+    data-testId="lockInfo"
+></dot-edit-page-lock-info>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
@@ -53,7 +53,7 @@ const mockDotMessageService = new MockDotMessageService({
     'editpage.toolbar.page.locked.by.user': 'Page locked by {0}'
 });
 
-const EXPERIMENT_MOCK = getExperimentMock(0);
+const EXPERIMENT_MOCK = getExperimentMock(1);
 
 const dotVariantDataMock: DotVariantData = {
     variant: {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
@@ -144,7 +144,9 @@ describe('DotEditPageStateControllerComponent', () => {
             it('should have mode selector', async () => {
                 componentHost.variant = null;
                 fixtureHost.detectChanges();
-                const selectButton = de.query(By.css('p-selectButton')).componentInstance;
+                const selectButton = de.query(
+                    By.css('[data-testId="selectButton"]')
+                ).componentInstance;
                 await fixtureHost.whenRenderingDone();
 
                 expect(selectButton).toBeDefined();
@@ -179,7 +181,7 @@ describe('DotEditPageStateControllerComponent', () => {
 
             it('should have lock info', () => {
                 fixtureHost.detectChanges();
-                const message = de.query(By.css('dot-edit-page-lock-info')).componentInstance;
+                const message = de.query(By.css('[data-testId="lockInfo"]')).componentInstance;
                 expect(message.pageState).toEqual(pageRenderStateMock);
             });
         });
@@ -189,7 +191,9 @@ describe('DotEditPageStateControllerComponent', () => {
                 componentHost.pageState.page.canRead = false;
                 componentHost.variant = null;
                 fixtureHost.detectChanges();
-                const selectButton = de.query(By.css('p-selectButton')).componentInstance;
+                const selectButton = de.query(
+                    By.css('[data-testId="selectButton"]')
+                ).componentInstance;
 
                 fixtureHost.whenRenderingDone();
 
@@ -207,7 +211,9 @@ describe('DotEditPageStateControllerComponent', () => {
                 componentHost.pageState.page.canLock = false;
                 componentHost.variant = null;
                 fixtureHost.detectChanges();
-                const selectButton = de.query(By.css('p-selectButton')).componentInstance;
+                const selectButton = de.query(
+                    By.css('[data-testId="selectButton"]')
+                ).componentInstance;
 
                 await fixtureHost.whenRenderingDone();
 
@@ -224,7 +230,9 @@ describe('DotEditPageStateControllerComponent', () => {
                 componentHost.variant = null;
                 componentHost.pageState.page.liveInode = null;
                 fixtureHost.detectChanges();
-                const selectButton = de.query(By.css('p-selectButton')).componentInstance;
+                const selectButton = de.query(
+                    By.css('[data-testId="selectButton"]')
+                ).componentInstance;
 
                 await fixtureHost.whenRenderingDone();
 
@@ -240,7 +248,9 @@ describe('DotEditPageStateControllerComponent', () => {
             it('should enable edit and preview when variant id different than original and draft', async () => {
                 fixtureHost.detectChanges();
                 componentHost.variant = dotVariantDataMock;
-                const selectButton = de.query(By.css('p-selectButton')).componentInstance;
+                const selectButton = de.query(
+                    By.css('[data-testId="selectButton"]')
+                ).componentInstance;
 
                 await fixtureHost.whenRenderingDone();
 
@@ -262,7 +272,9 @@ describe('DotEditPageStateControllerComponent', () => {
                 };
                 fixtureHost.detectChanges();
 
-                const selectButton = de.query(By.css('p-selectButton')).componentInstance;
+                const selectButton = de.query(
+                    By.css('[data-testId="selectButton"]')
+                ).componentInstance;
 
                 await fixtureHost.whenRenderingDone();
 
@@ -283,7 +295,9 @@ describe('DotEditPageStateControllerComponent', () => {
                 };
                 fixtureHost.detectChanges();
 
-                const selectButton = de.query(By.css('p-selectButton')).componentInstance;
+                const selectButton = de.query(
+                    By.css('[data-testId="selectButton"]')
+                ).componentInstance;
 
                 await fixtureHost.whenRenderingDone();
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
@@ -34,7 +34,7 @@ import {
     mockUser
 } from '@dotcms/utils-testing';
 import { DotPipesModule } from '@pipes/dot-pipes.module';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 
 import { DotEditPageLockInfoComponent } from './components/dot-edit-page-lock-info/dot-edit-page-lock-info.component';
 import { DotEditPageStateControllerComponent } from './dot-edit-page-state-controller.component';
@@ -53,19 +53,19 @@ const mockDotMessageService = new MockDotMessageService({
     'editpage.toolbar.page.locked.by.user': 'Page locked by {0}'
 });
 
-const experiment = { ...ExperimentMocks[1] };
+const EXPERIMENT_MOCK = getExperimentMock(0);
 
 const dotVariantDataMock: DotVariantData = {
     variant: {
-        id: experiment.trafficProportion.variants[1].id,
-        url: experiment.trafficProportion.variants[1].url,
-        title: experiment.trafficProportion.variants[1].name,
-        isOriginal: experiment.trafficProportion.variants[1].name === DEFAULT_VARIANT_NAME
+        id: EXPERIMENT_MOCK.trafficProportion.variants[1].id,
+        url: EXPERIMENT_MOCK.trafficProportion.variants[1].url,
+        title: EXPERIMENT_MOCK.trafficProportion.variants[1].name,
+        isOriginal: EXPERIMENT_MOCK.trafficProportion.variants[1].name === DEFAULT_VARIANT_NAME
     },
-    pageId: experiment.pageId,
-    experimentId: experiment.id,
-    experimentStatus: experiment.status,
-    experimentName: experiment.name,
+    pageId: EXPERIMENT_MOCK.pageId,
+    experimentId: EXPERIMENT_MOCK.id,
+    experimentStatus: EXPERIMENT_MOCK.status,
+    experimentName: EXPERIMENT_MOCK.name,
     mode: 'preview'
 };
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
@@ -53,17 +53,19 @@ const mockDotMessageService = new MockDotMessageService({
     'editpage.toolbar.page.locked.by.user': 'Page locked by {0}'
 });
 
+const experiment = { ...ExperimentMocks[1] };
+
 const dotVariantDataMock: DotVariantData = {
     variant: {
-        id: ExperimentMocks[1].trafficProportion.variants[1].id,
-        url: ExperimentMocks[1].trafficProportion.variants[1].url,
-        title: ExperimentMocks[1].trafficProportion.variants[1].name,
-        isOriginal: ExperimentMocks[1].trafficProportion.variants[1].name === DEFAULT_VARIANT_NAME
+        id: experiment.trafficProportion.variants[1].id,
+        url: experiment.trafficProportion.variants[1].url,
+        title: experiment.trafficProportion.variants[1].name,
+        isOriginal: experiment.trafficProportion.variants[1].name === DEFAULT_VARIANT_NAME
     },
-    pageId: ExperimentMocks[1].pageId,
-    experimentId: ExperimentMocks[1].id,
-    experimentStatus: ExperimentMocks[1].status,
-    experimentName: ExperimentMocks[1].name,
+    pageId: experiment.pageId,
+    experimentId: experiment.id,
+    experimentStatus: experiment.status,
+    experimentName: experiment.name,
     mode: 'preview'
 };
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
@@ -166,17 +166,20 @@ we want to show the lock off so the new user can steal the lock
     }
 
     private getStateModeOptions(pageState: DotPageRenderState): SelectItem[] {
-        const items = this.variant
-            ? [
-                  ...(!this.variant.variant.isOriginal &&
-                  this.variant.experimentStatus === DotExperimentStatusList.DRAFT
-                      ? ['edit']
-                      : []),
-                  'preview'
-              ]
-            : ['edit', 'preview', 'live'];
+        const items = this.variant ? this.getModesBasedOnVariant() : ['edit', 'preview', 'live'];
 
         return items.map((mode: string) => this.getModeOption(mode, pageState));
+    }
+
+    private getModesBasedOnVariant(): string[] {
+        return [...(this.canEditVariant() ? ['edit'] : []), 'preview'];
+    }
+
+    private canEditVariant(): boolean {
+        return (
+            !this.variant.variant.isOriginal &&
+            this.variant.experimentStatus === DotExperimentStatusList.DRAFT
+        );
     }
 
     private isLocked(pageState: DotPageRenderState): boolean {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
@@ -20,6 +20,7 @@ import {
     DotPersonalizeService
 } from '@dotcms/data-access';
 import {
+    DotExperimentStatusList,
     DotPageMode,
     DotPageRenderOptions,
     DotPageRenderState,
@@ -166,7 +167,13 @@ we want to show the lock off so the new user can steal the lock
 
     private getStateModeOptions(pageState: DotPageRenderState): SelectItem[] {
         const items = this.variant
-            ? [...(!this.variant.variant.isOriginal ? ['edit'] : []), 'preview']
+            ? [
+                  ...(!this.variant.variant.isOriginal &&
+                  this.variant.experimentStatus === DotExperimentStatusList.DRAFT
+                      ? ['edit']
+                      : []),
+                  'preview'
+              ]
             : ['edit', 'preview', 'live'];
 
         return items.map((mode: string) => this.getModeOption(mode, pageState));

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -61,6 +61,7 @@ import {
     UserModel
 } from '@dotcms/dotcms-js';
 import {
+    DEFAULT_VARIANT_NAME,
     DotCMSContentlet,
     DotCMSContentType,
     DotPageContainer,
@@ -83,6 +84,7 @@ import {
     processedContainers,
     SiteServiceMock
 } from '@dotcms/utils-testing';
+import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
 
 import { DotEditPageWorkflowsActionsModule } from './components/dot-edit-page-workflows-actions/dot-edit-page-workflows-actions.module';
 import {
@@ -286,13 +288,16 @@ describe('DotEditContentComponent', () => {
                         parent: {
                             parent: {
                                 data: of({
-                                    content: mockRenderedPageState
+                                    content: mockRenderedPageState,
+                                    experiment: { ...ExperimentMocks[1] }
                                 })
                             }
                         },
                         snapshot: {
                             queryParams: {
-                                url: '/an/url/test'
+                                url: '/an/url/test',
+                                variantName: ExperimentMocks[1].trafficProportion.variants[1].id,
+                                editPageTab: 'preview'
                             }
                         },
                         data: of({})
@@ -416,6 +421,24 @@ describe('DotEditContentComponent', () => {
 
             it('should pass pageState', () => {
                 expect(toolbarElement.componentInstance.pageState).toEqual(mockRenderedPageState);
+            });
+
+            it('should pass variant information', () => {
+                const variant = ExperimentMocks[1].trafficProportion.variants[1];
+
+                expect(toolbarElement.componentInstance.variant).toEqual({
+                    variant: {
+                        id: variant.id,
+                        url: variant.url,
+                        title: variant.name,
+                        isOriginal: variant.name === DEFAULT_VARIANT_NAME
+                    },
+                    pageId: ExperimentMocks[1].pageId,
+                    experimentId: ExperimentMocks[1].id,
+                    experimentStatus: ExperimentMocks[1].status,
+                    experimentName: ExperimentMocks[1].name,
+                    mode: 'preview'
+                });
             });
 
             describe('events', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -84,7 +84,7 @@ import {
     processedContainers,
     SiteServiceMock
 } from '@dotcms/utils-testing';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 
 import { DotEditPageWorkflowsActionsModule } from './components/dot-edit-page-workflows-actions/dot-edit-page-workflows-actions.module';
 import {
@@ -101,6 +101,8 @@ import { DotEditContentToolbarHtmlService } from './services/html/dot-edit-conte
 
 import { DotEditPageInfoModule } from '../components/dot-edit-page-info/dot-edit-page-info.module';
 import { DotPageContent } from '../shared/models';
+
+const EXPERIMENT_MOCK = getExperimentMock(1);
 
 @Component({
     selector: 'dot-global-message',
@@ -289,14 +291,14 @@ describe('DotEditContentComponent', () => {
                             parent: {
                                 data: of({
                                     content: mockRenderedPageState,
-                                    experiment: { ...ExperimentMocks[1] }
+                                    experiment: EXPERIMENT_MOCK
                                 })
                             }
                         },
                         snapshot: {
                             queryParams: {
                                 url: '/an/url/test',
-                                variantName: ExperimentMocks[1].trafficProportion.variants[1].id,
+                                variantName: EXPERIMENT_MOCK.trafficProportion.variants[1].id,
                                 editPageTab: 'preview'
                             }
                         },
@@ -424,7 +426,7 @@ describe('DotEditContentComponent', () => {
             });
 
             it('should pass variant information', () => {
-                const variant = ExperimentMocks[1].trafficProportion.variants[1];
+                const variant = EXPERIMENT_MOCK.trafficProportion.variants[1];
 
                 expect(toolbarElement.componentInstance.variant).toEqual({
                     variant: {
@@ -433,10 +435,10 @@ describe('DotEditContentComponent', () => {
                         title: variant.name,
                         isOriginal: variant.name === DEFAULT_VARIANT_NAME
                     },
-                    pageId: ExperimentMocks[1].pageId,
-                    experimentId: ExperimentMocks[1].id,
-                    experimentStatus: ExperimentMocks[1].status,
-                    experimentName: ExperimentMocks[1].name,
+                    pageId: EXPERIMENT_MOCK.pageId,
+                    experimentId: EXPERIMENT_MOCK.id,
+                    experimentStatus: EXPERIMENT_MOCK.status,
+                    experimentName: EXPERIMENT_MOCK.name,
                     mode: 'preview'
                 });
             });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -675,7 +675,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
                     },
                     pageId: experiment.pageId,
                     experimentId: experiment.id,
-
+                    experimentStatus: experiment.status,
                     experimentName: experiment.name,
                     mode: editPageTab
                 } as DotVariantData;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.spec.ts
@@ -66,7 +66,7 @@ describe('DotExperimentsConfigurationGoalSelectComponent', () => {
 
         store = spectator.inject(DotExperimentsConfigurationStore);
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of(ExperimentMocks[0]));
+        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
 
         store.loadExperiment(ExperimentMocks[0].id);
         store.setSidebarStatus({

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.spec.ts
@@ -19,7 +19,7 @@ import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
 import { DotExperimentsConfigurationStore } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 import { DotDropdownDirective } from '@portlets/shared/directives/dot-dropdown.directive';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
@@ -30,7 +30,7 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.configure.goals.sidebar.header.button': 'Apply'
 });
 
-const EXPERIMENT_ID = ExperimentMocks[0].id;
+const EXPERIMENT_MOCK = getExperimentMock(0);
 
 describe('DotExperimentsConfigurationGoalSelectComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationGoalSelectComponent>;
@@ -66,9 +66,9 @@ describe('DotExperimentsConfigurationGoalSelectComponent', () => {
 
         store = spectator.inject(DotExperimentsConfigurationStore);
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
+        dotExperimentsService.getById.and.returnValue(of(EXPERIMENT_MOCK));
 
-        store.loadExperiment(ExperimentMocks[0].id);
+        store.loadExperiment(EXPERIMENT_MOCK.id);
         store.setSidebarStatus({
             experimentStep: ExperimentSteps.GOAL,
             isOpen: true
@@ -137,7 +137,7 @@ describe('DotExperimentsConfigurationGoalSelectComponent', () => {
     it('should call setSelectedGoal from the store when a item is selected and the button of apply is clicked', () => {
         spyOn(store, 'setSelectedGoal');
         const expectedGoal = {
-            experimentId: EXPERIMENT_ID,
+            experimentId: EXPERIMENT_MOCK.id,
             goals: {
                 primary: {
                     name: 'default',

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
@@ -71,7 +71,7 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
         store = spectator.inject(DotExperimentsConfigurationStore);
 
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of(ExperimentMocks[0]));
+        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
 
         store.loadExperiment(ExperimentMocks[0].id);
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
@@ -11,7 +11,7 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Card, CardModule } from 'primeng/card';
 import { ConfirmPopup, ConfirmPopupModule } from 'primeng/confirmpopup';
-import { TooltipModule } from 'primeng/tooltip';
+import { Tooltip, TooltipModule } from 'primeng/tooltip';
 
 import { DotMessagePipe } from '@dotcms/app/view/pipes';
 import { DotMessageService } from '@dotcms/data-access';
@@ -177,10 +177,7 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
     });
 
     it('should disable tooltip if is on draft', () => {
-        expect(spectator.query(byTestId('tooltip-on-disabled'))).toHaveAttribute(
-            'ng-reflect-disabled',
-            'true'
-        );
+        expect(spectator.query(Tooltip).disabled).toEqual(true);
     });
 
     it('should disable button and show tooltip when experiment is nos on draft', () => {
@@ -205,9 +202,6 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
         spectator.detectComponentChanges();
 
         expect(spectator.query(byTestId('goals-add-button'))).toHaveAttribute('disabled');
-        expect(spectator.query(byTestId('tooltip-on-disabled'))).toHaveAttribute(
-            'ng-reflect-disabled',
-            'false'
-        );
+        expect(spectator.query(Tooltip).disabled).toEqual(false);
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
@@ -21,7 +21,7 @@ import { DotExperimentsConfigurationGoalSelectComponent } from '@portlets/dot-ex
 import { DotExperimentsConfigurationGoalsComponent } from '@portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component';
 import { DotExperimentsConfigurationStore } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks, GoalsMock } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock, GoalsMock } from '@portlets/dot-experiments/test/mocks';
 import { DotDynamicDirective } from '@portlets/shared/directives/dot-dynamic.directive';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
@@ -32,7 +32,7 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.goal.reach_page.description': 'description',
     'experiments.configure.goals.no.seleted.goal.message': 'empty message'
 });
-const EXPERIMENT_ID = ExperimentMocks[0].id;
+const EXPERIMENT_MOCK = getExperimentMock(0);
 describe('DotExperimentsConfigurationGoalsComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationGoalsComponent>;
     let store: DotExperimentsConfigurationStore;
@@ -71,9 +71,9 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
         store = spectator.inject(DotExperimentsConfigurationStore);
 
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
+        dotExperimentsService.getById.and.returnValue(of(EXPERIMENT_MOCK));
 
-        store.loadExperiment(ExperimentMocks[0].id);
+        store.loadExperiment(EXPERIMENT_MOCK.id);
 
         spectator.detectChanges();
     });
@@ -101,7 +101,7 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
             status: StepStatus;
             isExperimentADraft: boolean;
         } = {
-            experimentId: EXPERIMENT_ID,
+            experimentId: EXPERIMENT_MOCK.id,
             goals: GoalsMock,
             status: {
                 status: ComponentStatus.IDLE,
@@ -151,7 +151,7 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
             status: StepStatus;
             isExperimentADraft: boolean;
         } = {
-            experimentId: EXPERIMENT_ID,
+            experimentId: EXPERIMENT_MOCK.id,
             goals: GoalsMock,
             status: {
                 status: ComponentStatus.IDLE,
@@ -187,7 +187,7 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
             status: StepStatus;
             isExperimentADraft: boolean;
         } = {
-            experimentId: EXPERIMENT_ID,
+            experimentId: EXPERIMENT_MOCK.id,
             goals: null,
             status: {
                 status: ComponentStatus.IDLE,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling-add/dot-experiments-configuration-scheduling-add.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling-add/dot-experiments-configuration-scheduling-add.component.spec.ts
@@ -18,7 +18,7 @@ import { ExperimentSteps } from '@dotcms/dotcms-models';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotExperimentsConfigurationStore } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
 import { DotExperimentsConfigurationSchedulingAddComponent } from './dot-experiments-configuration-scheduling-add.component';
@@ -30,7 +30,7 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.configure.scheduling.name': 'Scheduling'
 });
 
-const EXPERIMENT_ID = ExperimentMocks[0].id;
+const EXPERIMENT_MOCK = getExperimentMock(0);
 
 describe('DotExperimentsConfigurationSchedulingAddComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationSchedulingAddComponent>;
@@ -61,9 +61,9 @@ describe('DotExperimentsConfigurationSchedulingAddComponent', () => {
 
         store = spectator.inject(DotExperimentsConfigurationStore);
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
+        dotExperimentsService.getById.and.returnValue(of(EXPERIMENT_MOCK));
 
-        store.loadExperiment(EXPERIMENT_ID);
+        store.loadExperiment(EXPERIMENT_MOCK.id);
         store.setSidebarStatus({
             experimentStep: ExperimentSteps.SCHEDULING,
             isOpen: true
@@ -75,8 +75,8 @@ describe('DotExperimentsConfigurationSchedulingAddComponent', () => {
         const startDateCalendar: Calendar = spectator.query(Calendar);
         const endDateCalendar: Calendar = spectator.queryLast(Calendar);
 
-        expect(startDateCalendar.value.getTime()).toEqual(ExperimentMocks[0].scheduling.startDate);
-        expect(endDateCalendar.value.getTime()).toEqual(ExperimentMocks[0].scheduling.endDate);
+        expect(startDateCalendar.value.getTime()).toEqual(EXPERIMENT_MOCK.scheduling.startDate);
+        expect(endDateCalendar.value.getTime()).toEqual(EXPERIMENT_MOCK.scheduling.endDate);
     });
 
     it('should have set the props correctly', () => {
@@ -105,8 +105,8 @@ describe('DotExperimentsConfigurationSchedulingAddComponent', () => {
 
         spectator.click(submitButton);
         expect(store.setSelectedScheduling).toHaveBeenCalledWith({
-            scheduling: ExperimentMocks[0].scheduling,
-            experimentId: EXPERIMENT_ID
+            scheduling: EXPERIMENT_MOCK.scheduling,
+            experimentId: EXPERIMENT_MOCK.id
         });
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling-add/dot-experiments-configuration-scheduling-add.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling-add/dot-experiments-configuration-scheduling-add.component.spec.ts
@@ -61,7 +61,7 @@ describe('DotExperimentsConfigurationSchedulingAddComponent', () => {
 
         store = spectator.inject(DotExperimentsConfigurationStore);
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of(ExperimentMocks[0]));
+        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
 
         store.loadExperiment(EXPERIMENT_ID);
         store.setSidebarStatus({

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.spec.ts
@@ -10,6 +10,7 @@ import { of } from 'rxjs';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Card, CardModule } from 'primeng/card';
+import { TooltipModule } from 'primeng/tooltip';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { DotExperimentStatusList, ExperimentSteps } from '@dotcms/dotcms-models';
@@ -37,6 +38,7 @@ describe('DotExperimentsConfigurationSchedulingComponent', () => {
         imports: [
             ButtonModule,
             CardModule,
+            TooltipModule,
             DotExperimentsConfigurationSchedulingAddComponent,
             DotDynamicDirective
         ],

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.spec.ts
@@ -18,7 +18,7 @@ import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotExperimentsConfigurationSchedulingAddComponent } from '@portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling-add/dot-experiments-configuration-scheduling-add.component';
 import { DotExperimentsConfigurationStore } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 import { DotDynamicDirective } from '@portlets/shared/directives/dot-dynamic.directive';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
@@ -29,7 +29,9 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.configure.scheduling.start': 'When the experiment start',
     'experiments.configure.scheduling.setup': 'Setup'
 });
-fdescribe('DotExperimentsConfigurationSchedulingComponent', () => {
+
+const EXPERIMENT_MOCK = getExperimentMock(0);
+describe('DotExperimentsConfigurationSchedulingComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationSchedulingComponent>;
     let store: DotExperimentsConfigurationStore;
     let dotExperimentsService: SpyObject<DotExperimentsService>;
@@ -66,10 +68,10 @@ fdescribe('DotExperimentsConfigurationSchedulingComponent', () => {
 
         dotExperimentsService = spectator.inject(DotExperimentsService);
         dotExperimentsService.getById.and.returnValue(
-            of({ ...ExperimentMocks[0], ...{ scheduling: null } })
+            of({ ...EXPERIMENT_MOCK, ...{ scheduling: null } })
         );
 
-        store.loadExperiment(ExperimentMocks[0].id);
+        store.loadExperiment(EXPERIMENT_MOCK.id);
         spectator.detectChanges();
     });
 
@@ -96,12 +98,12 @@ fdescribe('DotExperimentsConfigurationSchedulingComponent', () => {
     it('should disable button and show tooltip when experiment is nos on draft', () => {
         dotExperimentsService.getById.and.returnValue(
             of({
-                ...ExperimentMocks[0],
+                EXPERIMENT_MOCK,
                 ...{ scheduling: null, status: DotExperimentStatusList.RUNNING }
             })
         );
 
-        store.loadExperiment(ExperimentMocks[0].id);
+        store.loadExperiment(EXPERIMENT_MOCK.id);
 
         spectator.detectChanges();
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.spec.ts
@@ -10,7 +10,7 @@ import { of } from 'rxjs';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Card, CardModule } from 'primeng/card';
-import { TooltipModule } from 'primeng/tooltip';
+import { Tooltip, TooltipModule } from 'primeng/tooltip';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { DotExperimentStatusList, ExperimentSteps } from '@dotcms/dotcms-models';
@@ -90,10 +90,7 @@ describe('DotExperimentsConfigurationSchedulingComponent', () => {
     });
 
     it('should disable tooltip if is on draft', () => {
-        expect(spectator.query(byTestId('tooltip-on-disabled'))).toHaveAttribute(
-            'ng-reflect-disabled',
-            'true'
-        );
+        expect(spectator.query(Tooltip).disabled).toEqual(true);
     });
 
     it('should disable button and show tooltip when experiment is nos on draft', () => {
@@ -109,9 +106,6 @@ describe('DotExperimentsConfigurationSchedulingComponent', () => {
         spectator.detectChanges();
 
         expect(spectator.query(byTestId('scheduling-setup-button'))).toHaveAttribute('disabled');
-        expect(spectator.query(byTestId('tooltip-on-disabled'))).toHaveAttribute(
-            'ng-reflect-disabled',
-            'false'
-        );
+        expect(spectator.query(Tooltip).disabled).toEqual(false);
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.spec.ts
@@ -29,7 +29,7 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.configure.scheduling.start': 'When the experiment start',
     'experiments.configure.scheduling.setup': 'Setup'
 });
-describe('DotExperimentsConfigurationSchedulingComponent', () => {
+fdescribe('DotExperimentsConfigurationSchedulingComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationSchedulingComponent>;
     let store: DotExperimentsConfigurationStore;
     let dotExperimentsService: SpyObject<DotExperimentsService>;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-targeting/dot-experiments-configuration-targeting.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-targeting/dot-experiments-configuration-targeting.component.spec.ts
@@ -10,6 +10,7 @@ import { of } from 'rxjs';
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Card, CardModule } from 'primeng/card';
+import { Tooltip, TooltipModule } from 'primeng/tooltip';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { DotExperimentStatusList } from '@dotcms/dotcms-models';
@@ -24,13 +25,13 @@ import { DotExperimentsConfigurationTargetingComponent } from './dot-experiments
 const messageServiceMock = new MockDotMessageService({
     'experiments.configure.targeting.name': 'Targeting'
 });
-describe('DotExperimentsConfigurationTargetingComponent', () => {
+fdescribe('DotExperimentsConfigurationTargetingComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationTargetingComponent>;
     let store: DotExperimentsConfigurationStore;
     let dotExperimentsService: SpyObject<DotExperimentsService>;
 
     const createComponent = createComponentFactory({
-        imports: [ButtonModule, CardModule],
+        imports: [ButtonModule, CardModule, TooltipModule],
         component: DotExperimentsConfigurationTargetingComponent,
         componentProviders: [],
         providers: [
@@ -59,10 +60,8 @@ describe('DotExperimentsConfigurationTargetingComponent', () => {
         expect(spectator.queryAll(Card).length).toEqual(1);
         expect(spectator.query(byTestId('targeting-card-name'))).toHaveText('Targeting');
         expect(spectator.query(byTestId('targeting-add-button'))).toExist();
-        expect(spectator.query(byTestId('tooltip-on-disabled'))).toHaveAttribute(
-            'ng-reflect-disabled',
-            'true'
-        );
+
+        expect(spectator.query(Tooltip).disabled).toEqual(true);
     });
 
     it('should disable button and show tooltip when experiment is not on draft', () => {
@@ -78,9 +77,6 @@ describe('DotExperimentsConfigurationTargetingComponent', () => {
         spectator.detectChanges();
 
         expect(spectator.query(byTestId('targeting-add-button'))).toHaveAttribute('disabled');
-        expect(spectator.query(byTestId('tooltip-on-disabled'))).toHaveAttribute(
-            'ng-reflect-disabled',
-            'false'
-        );
+        expect(spectator.query(Tooltip).disabled).toEqual(false);
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-targeting/dot-experiments-configuration-targeting.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-targeting/dot-experiments-configuration-targeting.component.spec.ts
@@ -17,7 +17,7 @@ import { DotExperimentStatusList } from '@dotcms/dotcms-models';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotExperimentsConfigurationStore } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
 import { DotExperimentsConfigurationTargetingComponent } from './dot-experiments-configuration-targeting.component';
@@ -25,7 +25,10 @@ import { DotExperimentsConfigurationTargetingComponent } from './dot-experiments
 const messageServiceMock = new MockDotMessageService({
     'experiments.configure.targeting.name': 'Targeting'
 });
-fdescribe('DotExperimentsConfigurationTargetingComponent', () => {
+
+const EXPERIMENT_MOCK = getExperimentMock(0);
+
+describe('DotExperimentsConfigurationTargetingComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationTargetingComponent>;
     let store: DotExperimentsConfigurationStore;
     let dotExperimentsService: SpyObject<DotExperimentsService>;
@@ -53,8 +56,8 @@ fdescribe('DotExperimentsConfigurationTargetingComponent', () => {
     });
 
     it('should render the card and disabled tooltip', () => {
-        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
-        store.loadExperiment(ExperimentMocks[0].id);
+        dotExperimentsService.getById.and.returnValue(of(EXPERIMENT_MOCK));
+        store.loadExperiment(EXPERIMENT_MOCK.id);
         spectator.detectChanges();
 
         expect(spectator.queryAll(Card).length).toEqual(1);
@@ -67,12 +70,12 @@ fdescribe('DotExperimentsConfigurationTargetingComponent', () => {
     it('should disable button and show tooltip when experiment is not on draft', () => {
         dotExperimentsService.getById.and.returnValue(
             of({
-                ...ExperimentMocks[0],
+                ...EXPERIMENT_MOCK,
                 ...{ status: DotExperimentStatusList.RUNNING }
             })
         );
 
-        store.loadExperiment(ExperimentMocks[0].id);
+        store.loadExperiment(EXPERIMENT_MOCK.id);
 
         spectator.detectChanges();
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic-allocation-add/dot-experiments-configuration-traffic-allocation-add.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic-allocation-add/dot-experiments-configuration-traffic-allocation-add.component.spec.ts
@@ -19,7 +19,7 @@ import { ExperimentSteps } from '@dotcms/dotcms-models';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotExperimentsConfigurationStore } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
 import { DotExperimentsConfigurationTrafficAllocationAddComponent } from './dot-experiments-configuration-traffic-allocation-add.component';
@@ -28,7 +28,8 @@ const messageServiceMock = new MockDotMessageService({
     Done: 'Done'
 });
 
-const EXPERIMENT_ID = ExperimentMocks[0].id;
+const EXPERIMENT_MOCK = getExperimentMock(0);
+
 describe('DotExperimentsConfigurationTrafficAllocationAddComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationTrafficAllocationAddComponent>;
     let store: DotExperimentsConfigurationStore;
@@ -58,9 +59,9 @@ describe('DotExperimentsConfigurationTrafficAllocationAddComponent', () => {
 
         store = spectator.inject(DotExperimentsConfigurationStore);
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of(ExperimentMocks[0]));
+        dotExperimentsService.getById.and.returnValue(of(EXPERIMENT_MOCK));
 
-        store.loadExperiment(EXPERIMENT_ID);
+        store.loadExperiment(EXPERIMENT_MOCK.id);
         store.setSidebarStatus({
             experimentStep: ExperimentSteps.TRAFFIC,
             isOpen: true
@@ -72,8 +73,8 @@ describe('DotExperimentsConfigurationTrafficAllocationAddComponent', () => {
         const slider: Slider = spectator.query(Slider);
         const input: HTMLInputElement = spectator.query(byTestId('traffic-allocation-input'));
 
-        expect(slider.value).toEqual(ExperimentMocks[0].trafficAllocation);
-        expect(parseInt(input.value)).toEqual(ExperimentMocks[0].trafficAllocation);
+        expect(slider.value).toEqual(EXPERIMENT_MOCK.trafficAllocation);
+        expect(parseInt(input.value)).toEqual(EXPERIMENT_MOCK.trafficAllocation);
     });
 
     it('should save form when is valid ', () => {
@@ -88,8 +89,8 @@ describe('DotExperimentsConfigurationTrafficAllocationAddComponent', () => {
 
         spectator.click(submitButton);
         expect(store.setSelectedAllocation).toHaveBeenCalledWith({
-            trafficAllocation: ExperimentMocks[0].trafficAllocation,
-            experimentId: EXPERIMENT_ID
+            trafficAllocation: EXPERIMENT_MOCK.trafficAllocation,
+            experimentId: EXPERIMENT_MOCK.id
         });
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.spec.ts
@@ -57,7 +57,7 @@ describe('DotExperimentsConfigurationTrafficSplitAddComponent', () => {
         });
         store = spectator.inject(DotExperimentsConfigurationStore);
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of(ExperimentMocks[1]));
+        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[1] }));
         store.loadExperiment(EXPERIMENT_ID);
         store.setSidebarStatus({
             experimentStep: ExperimentSteps.TRAFFIC,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.spec.ts
@@ -19,7 +19,7 @@ import { ExperimentSteps, TrafficProportionTypes } from '@dotcms/dotcms-models';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotExperimentsConfigurationStore } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
 import { DotExperimentsConfigurationTrafficSplitAddComponent } from './dot-experiments-configuration-traffic-split-add.component';
@@ -27,7 +27,8 @@ import { DotExperimentsConfigurationTrafficSplitAddComponent } from './dot-exper
 const messageServiceMock = new MockDotMessageService({
     Done: 'Done'
 });
-const EXPERIMENT_ID = ExperimentMocks[1].id;
+
+const EXPERIMENT_MOCK = getExperimentMock(1);
 
 describe('DotExperimentsConfigurationTrafficSplitAddComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationTrafficSplitAddComponent>;
@@ -57,8 +58,8 @@ describe('DotExperimentsConfigurationTrafficSplitAddComponent', () => {
         });
         store = spectator.inject(DotExperimentsConfigurationStore);
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[1] }));
-        store.loadExperiment(EXPERIMENT_ID);
+        dotExperimentsService.getById.and.returnValue(of({ ...EXPERIMENT_MOCK }));
+        store.loadExperiment(EXPERIMENT_MOCK.id);
         store.setSidebarStatus({
             experimentStep: ExperimentSteps.TRAFFIC,
             isOpen: true
@@ -91,8 +92,8 @@ describe('DotExperimentsConfigurationTrafficSplitAddComponent', () => {
 
         spectator.click(submitButton);
         expect(store.setSelectedTrafficProportion).toHaveBeenCalledWith({
-            trafficProportion: ExperimentMocks[1].trafficProportion,
-            experimentId: EXPERIMENT_ID
+            trafficProportion: EXPERIMENT_MOCK.trafficProportion,
+            experimentId: EXPERIMENT_MOCK.id
         });
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic/dot-experiments-configuration-traffic.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic/dot-experiments-configuration-traffic.component.spec.ts
@@ -17,7 +17,7 @@ import { DotExperimentStatusList, ExperimentSteps } from '@dotcms/dotcms-models'
 import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotExperimentsConfigurationStore } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
 import { DotExperimentsConfigurationTrafficComponent } from './dot-experiments-configuration-traffic.component';
@@ -26,6 +26,9 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.configure.traffic.name': 'Traffic',
     'experiments.configure.traffic.split.name': 'Split'
 });
+
+const EXPERIMENT_MOCK = getExperimentMock(0);
+
 describe('DotExperimentsConfigurationTrafficComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationTrafficComponent>;
     let store: DotExperimentsConfigurationStore;
@@ -56,10 +59,10 @@ describe('DotExperimentsConfigurationTrafficComponent', () => {
 
         dotExperimentsService = spectator.inject(DotExperimentsService);
         dotExperimentsService.getById.and.returnValue(
-            of({ ...ExperimentMocks[0], ...{ scheduling: null } })
+            of({ EXPERIMENT_MOCK, ...{ scheduling: null } })
         );
 
-        store.loadExperiment(ExperimentMocks[0].id);
+        store.loadExperiment(EXPERIMENT_MOCK.id);
         spectator.detectChanges();
     });
 
@@ -85,12 +88,12 @@ describe('DotExperimentsConfigurationTrafficComponent', () => {
     it('should disable button and show tooltip when experiment is nos on draft', () => {
         dotExperimentsService.getById.and.returnValue(
             of({
-                ...ExperimentMocks[0],
+                ...EXPERIMENT_MOCK,
                 ...{ status: DotExperimentStatusList.RUNNING }
             })
         );
 
-        store.loadExperiment(ExperimentMocks[0].id);
+        store.loadExperiment(EXPERIMENT_MOCK.id);
 
         spectator.detectChanges();
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic/dot-experiments-configuration-traffic.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic/dot-experiments-configuration-traffic.component.spec.ts
@@ -59,7 +59,7 @@ describe('DotExperimentsConfigurationTrafficComponent', () => {
 
         dotExperimentsService = spectator.inject(DotExperimentsService);
         dotExperimentsService.getById.and.returnValue(
-            of({ EXPERIMENT_MOCK, ...{ scheduling: null } })
+            of({ ...EXPERIMENT_MOCK, ...{ scheduling: null } })
         );
 
         store.loadExperiment(EXPERIMENT_MOCK.id);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic/dot-experiments-configuration-traffic.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-traffic/dot-experiments-configuration-traffic.component.spec.ts
@@ -10,6 +10,7 @@ import { of } from 'rxjs';
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Card, CardModule } from 'primeng/card';
+import { Tooltip } from 'primeng/tooltip';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { DotExperimentStatusList, ExperimentSteps } from '@dotcms/dotcms-models';
@@ -78,10 +79,7 @@ describe('DotExperimentsConfigurationTrafficComponent', () => {
     });
 
     it('should disable tooltip if is on draft', () => {
-        expect(spectator.query(byTestId('tooltip-on-disabled'))).toHaveAttribute(
-            'ng-reflect-disabled',
-            'true'
-        );
+        expect(spectator.query(Tooltip).disabled).toEqual(true);
     });
 
     it('should disable button and show tooltip when experiment is nos on draft', () => {
@@ -100,9 +98,6 @@ describe('DotExperimentsConfigurationTrafficComponent', () => {
         expect(spectator.query(byTestId('traffic-split-change-button'))).toHaveAttribute(
             'disabled'
         );
-        expect(spectator.queryAll(byTestId('tooltip-on-disabled'))).toHaveAttribute(
-            'ng-reflect-disabled',
-            'false'
-        );
+        expect(spectator.query(Tooltip).disabled).toEqual(false);
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -84,6 +84,10 @@
                         tooltipPosition="bottom"
                         data-testId="tooltip-on-disabled"
                     >
+                        <h1>
+                            delete:
+                            {{ vm.isExperimentADraft || variant.name === defaultVariantName }}
+                        </h1>
                         <button
                             class="p-button-sm p-button-danger p-button-text"
                             [disabled]="
@@ -152,8 +156,9 @@
 
         <ng-template pTemplate="footer">
             <div
+                class="inline-block"
                 [pTooltip]="'experiment.configure.edit.only.draft.status' | dm"
-                [tooltipDisabled]="vm.isExperimentADraft || variants?.length <= maxVariantsAllowed"
+                [tooltipDisabled]="vm.isExperimentADraft || variants?.length >= maxVariantsAllowed"
                 tooltipPosition="bottom"
                 data-testId="tooltip-on-disabled"
             >

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -84,10 +84,6 @@
                         tooltipPosition="bottom"
                         data-testId="tooltip-on-disabled"
                     >
-                        <h1>
-                            delete:
-                            {{ vm.isExperimentADraft || variant.name === defaultVariantName }}
-                        </h1>
                         <button
                             class="p-button-sm p-button-danger p-button-text"
                             [disabled]="

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -24,7 +24,10 @@
                 <div class="flex flex-row align-items-center align-content-between gap-2">
                     <div class="title flex flex-grow-1 flex-row align-items-center gap-2">
                         <ng-container
-                            *ngIf="variant.name === defaultVariantName; else editVariantNameTpl"
+                            *ngIf="
+                                variant.name === defaultVariantName || !vm.isExperimentADraft;
+                                else editVariantNameTpl
+                            "
                         >
                             <span data-testId="variant-name"> {{ variant.name }} </span>
                         </ng-container>
@@ -57,7 +60,10 @@
                     </div>
 
                     <ng-container
-                        *ngIf="variant.name === defaultVariantName; else editableButtonTpl"
+                        *ngIf="
+                            variant.name === defaultVariantName || !vm.isExperimentADraft;
+                            else editableButtonTpl
+                        "
                     >
                         <button
                             class="p-button-sm p-button-outlined no-padding"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -198,7 +198,6 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
 
             expect(addButton.disabled).not.toBe(true);
             spectator.click(addButton);
-            spectator.detectChanges();
             expect(output).toEqual(SidebarStatus.OPEN);
         });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -13,7 +13,6 @@ import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Card, CardModule } from 'primeng/card';
 import { Inplace, InplaceModule } from 'primeng/inplace';
-import { InputTextModule } from 'primeng/inputtext';
 import { Tooltip, TooltipModule } from 'primeng/tooltip';
 
 import { DotCopyButtonComponent } from '@components/dot-copy-button/dot-copy-button.component';
@@ -46,7 +45,7 @@ const messageServiceMock = new MockDotMessageService({
 });
 
 const EXPERIMENT_ID = ExperimentMocks[0].id;
-describe('DotExperimentsConfigurationVariantsComponent', () => {
+fdescribe('DotExperimentsConfigurationVariantsComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationVariantsComponent>;
     let store: DotExperimentsConfigurationStore;
     let dotExperimentsService: SpyObject<DotExperimentsService>;
@@ -61,8 +60,7 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
             InplaceModule,
             DotExperimentsConfigurationVariantsAddComponent,
             DotCopyButtonModule,
-            TooltipModule,
-            InputTextModule
+            TooltipModule
         ],
         component: DotExperimentsConfigurationVariantsComponent,
         providers: [

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -29,7 +29,7 @@ import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotExperimentsConfigurationVariantsAddComponent } from '@portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component';
 import { DotExperimentsConfigurationStore } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
 import { DotExperimentsConfigurationVariantsComponent } from './dot-experiments-configuration-variants.component';
@@ -42,8 +42,10 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.configure.variants.add': 'Add new variant'
 });
 
-const EXPERIMENT_ID = ExperimentMocks[0].id;
-fdescribe('DotExperimentsConfigurationVariantsComponent', () => {
+const EXPERIMENT_MOCK = getExperimentMock(0);
+const EXPERIMENT_MOCK_2 = getExperimentMock(2);
+
+describe('DotExperimentsConfigurationVariantsComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationVariantsComponent>;
     let store: DotExperimentsConfigurationStore;
     let dotExperimentsService: SpyObject<DotExperimentsService>;
@@ -79,9 +81,9 @@ fdescribe('DotExperimentsConfigurationVariantsComponent', () => {
 
         store = spectator.inject(DotExperimentsConfigurationStore);
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
+        dotExperimentsService.getById.and.returnValue(of(EXPERIMENT_MOCK));
 
-        store.loadExperiment(EXPERIMENT_ID);
+        store.loadExperiment(EXPERIMENT_MOCK.id);
         spectator.detectChanges();
     });
 
@@ -369,12 +371,12 @@ fdescribe('DotExperimentsConfigurationVariantsComponent', () => {
         it('should disable button and show tooltip when experiment is nos on draft', () => {
             dotExperimentsService.getById.and.returnValue(
                 of({
-                    ...ExperimentMocks[2],
+                    ...EXPERIMENT_MOCK_2,
                     ...{ status: DotExperimentStatusList.RUNNING }
                 })
             );
 
-            store.loadExperiment(ExperimentMocks[2].id);
+            store.loadExperiment(EXPERIMENT_MOCK_2.id);
             spectator.detectChanges();
 
             expect(spectator.queryAll(byTestId('variant-weight'))).toHaveAttribute('disabled');
@@ -396,12 +398,12 @@ fdescribe('DotExperimentsConfigurationVariantsComponent', () => {
         it('should view button on all variants when experiment is nos on draft', () => {
             dotExperimentsService.getById.and.returnValue(
                 of({
-                    ...ExperimentMocks[2],
+                    ...EXPERIMENT_MOCK_2,
                     ...{ status: DotExperimentStatusList.RUNNING }
                 })
             );
 
-            store.loadExperiment(ExperimentMocks[2].id);
+            store.loadExperiment(EXPERIMENT_MOCK_2.id);
 
             spectator.detectChanges();
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -80,7 +80,7 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
 
         store = spectator.inject(DotExperimentsConfigurationStore);
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of(ExperimentMocks[0]));
+        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
 
         store.loadExperiment(EXPERIMENT_ID);
         spectator.detectChanges();
@@ -385,6 +385,25 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
                 'ng-reflect-disabled',
                 'false'
             );
+        });
+
+        it('should view button on all variants when experiment is nos on draft', () => {
+            dotExperimentsService.getById.and.returnValue(
+                of({
+                    ...ExperimentMocks[2],
+                    ...{ status: DotExperimentStatusList.RUNNING }
+                })
+            );
+
+            store.loadExperiment(ExperimentMocks[2].id);
+
+            spectator.detectChanges();
+
+            const variantsViewButton = spectator.queryAll(
+                byTestId('variant-preview-button')
+            ) as HTMLButtonElement[];
+
+            expect(variantsViewButton.length).toBe(2);
         });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -7,12 +7,14 @@ import {
 } from '@ngneat/spectator';
 import { of } from 'rxjs';
 
-import { DecimalPipe } from '@angular/common';
+import { CommonModule } from '@angular/common';
 
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Card, CardModule } from 'primeng/card';
 import { Inplace, InplaceModule } from 'primeng/inplace';
+import { InputTextModule } from 'primeng/inputtext';
+import { Tooltip, TooltipModule } from 'primeng/tooltip';
 
 import { DotCopyButtonComponent } from '@components/dot-copy-button/dot-copy-button.component';
 import { DotCopyButtonModule } from '@components/dot-copy-button/dot-copy-button.module';
@@ -53,12 +55,14 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
 
     const createComponent = createComponentFactory({
         imports: [
+            CommonModule,
             ButtonModule,
             CardModule,
             InplaceModule,
-            DecimalPipe,
             DotExperimentsConfigurationVariantsAddComponent,
-            DotCopyButtonModule
+            DotCopyButtonModule,
+            TooltipModule,
+            InputTextModule
         ],
         component: DotExperimentsConfigurationVariantsComponent,
         providers: [
@@ -194,7 +198,7 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
 
             expect(addButton.disabled).not.toBe(true);
             spectator.click(addButton);
-
+            spectator.detectChanges();
             expect(output).toEqual(SidebarStatus.OPEN);
         });
 
@@ -358,10 +362,14 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
         });
 
         it('should disable tooltip if is on draft', () => {
-            expect(spectator.query(byTestId('tooltip-on-disabled'))).toHaveAttribute(
-                'ng-reflect-disabled',
-                'true'
-            );
+            spectator.detectChanges();
+
+            spectator
+                .queryAll(Tooltip)
+                .filter((tooltip) => tooltip.disabled != undefined)
+                .forEach((tooltip) => {
+                    expect(tooltip.disabled).toEqual(true);
+                });
         });
 
         it('should disable button and show tooltip when experiment is nos on draft', () => {
@@ -373,7 +381,6 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
             );
 
             store.loadExperiment(ExperimentMocks[2].id);
-
             spectator.detectChanges();
 
             expect(spectator.queryAll(byTestId('variant-weight'))).toHaveAttribute('disabled');
@@ -381,10 +388,15 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
                 'disabled'
             );
             expect(spectator.query(byTestId('variant-add-button'))).toHaveAttribute('disabled');
-            expect(spectator.queryAll(byTestId('tooltip-on-disabled'))).toHaveAttribute(
-                'ng-reflect-disabled',
-                'false'
-            );
+
+            const enableTooltips = spectator
+                .queryAll(Tooltip)
+                .filter((tooltip) => tooltip.disabled == false);
+
+            // Two: variant weight
+            // One: Delete variant
+            // One: Add New Variant.
+            expect(enableTooltips.length).toEqual(4);
         });
 
         it('should view button on all variants when experiment is nos on draft', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -7,8 +7,6 @@ import {
 } from '@ngneat/spectator';
 import { of } from 'rxjs';
 
-import { CommonModule } from '@angular/common';
-
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Card, CardModule } from 'primeng/card';
@@ -54,7 +52,6 @@ fdescribe('DotExperimentsConfigurationVariantsComponent', () => {
 
     const createComponent = createComponentFactory({
         imports: [
-            CommonModule,
             ButtonModule,
             CardModule,
             InplaceModule,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.spec.ts
@@ -12,6 +12,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { TagModule } from 'primeng/tag';
 
 import { DotMessageService, DotSessionStorageService } from '@dotcms/data-access';
 import { ComponentStatus } from '@dotcms/dotcms-models';
@@ -82,7 +84,9 @@ describe('DotExperimentsConfigurationComponent', () => {
             DotExperimentsConfigurationSchedulingComponent,
             DotExperimentsConfigurationSkeletonComponent,
             DotExperimentsExperimentSummaryComponent,
-            DotMessagePipe
+            DotMessagePipe,
+            TagModule,
+            CardModule
         ],
         component: DotExperimentsConfigurationComponent,
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.spec.ts
@@ -33,7 +33,7 @@ import { DotExperimentsExperimentSummaryComponent } from '@portlets/dot-experime
 import { DotExperimentsUiHeaderComponent } from '@portlets/dot-experiments/shared/ui/dot-experiments-header/dot-experiments-ui-header.component';
 import {
     DotExperimentsConfigurationStoreMock,
-    ExperimentMocks
+    getExperimentMock
 } from '@portlets/dot-experiments/test/mocks';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 import { DotMessagePipe } from '@tests/dot-message-mock.pipe';
@@ -54,8 +54,10 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.configure.scheduling.start': 'When the experiment start'
 });
 
+const EXPERIMENT_MOCK = getExperimentMock(0);
+
 const defaultVmMock: ConfigurationViewModel = {
-    experiment: { ...ExperimentMocks[0] },
+    experiment: EXPERIMENT_MOCK,
     stepStatusSidebar: {
         status: ComponentStatus.IDLE,
         isOpen: false,
@@ -117,7 +119,7 @@ describe('DotExperimentsConfigurationComponent', () => {
             detectChanges: false
         });
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
+        dotExperimentsService.getById.and.returnValue(of(EXPERIMENT_MOCK));
     });
 
     it('should show the skeleton component when is loading', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.spec.ts
@@ -53,7 +53,7 @@ const messageServiceMock = new MockDotMessageService({
 });
 
 const defaultVmMock: ConfigurationViewModel = {
-    experiment: ExperimentMocks[0],
+    experiment: { ...ExperimentMocks[0] },
     stepStatusSidebar: {
         status: ComponentStatus.IDLE,
         isOpen: false,
@@ -113,7 +113,7 @@ describe('DotExperimentsConfigurationComponent', () => {
             detectChanges: false
         });
         dotExperimentsService = spectator.inject(DotExperimentsService);
-        dotExperimentsService.getById.and.returnValue(of(ExperimentMocks[0]));
+        dotExperimentsService.getById.and.returnValue(of({ ...ExperimentMocks[0] }));
     });
 
     it('should show the skeleton component when is loading', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.spec.ts
@@ -77,7 +77,7 @@ describe('DotExperimentsConfigurationStore', () => {
         spectator.service.loadExperiment(EXPERIMENT_ID);
 
         const expectedInitialState: DotExperimentsConfigurationState = {
-            experiment: ExperimentMocks[0],
+            experiment: { ...ExperimentMocks[0] },
             status: ComponentStatus.IDLE,
             stepStatusSidebar: {
                 status: ComponentStatus.IDLE,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.spec.ts
@@ -28,16 +28,18 @@ import {
     DotExperimentsConfigurationStore
 } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks, GoalsMock } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock, GoalsMock } from '@portlets/dot-experiments/test/mocks';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
-const EXPERIMENT_ID = ExperimentMocks[0].id;
-const PAGE_ID = ExperimentMocks[0].pageId;
+const EXPERIMENT_MOCK = getExperimentMock(0);
+const EXPERIMENT_MOCK_1 = getExperimentMock(1);
+const EXPERIMENT_MOCK_2 = getExperimentMock(2);
+
 const ActivatedRouteMock = {
     snapshot: {
         params: {
-            experimentId: EXPERIMENT_ID,
-            pageId: PAGE_ID
+            experimentId: EXPERIMENT_MOCK.id,
+            pageId: EXPERIMENT_MOCK.pageId
         }
     }
 };
@@ -70,14 +72,14 @@ describe('DotExperimentsConfigurationStore', () => {
         store = spectator.inject(DotExperimentsConfigurationStore);
         dotExperimentsService = spectator.inject(DotExperimentsService);
         dotHttpErrorManagerService = spectator.inject(DotHttpErrorManagerService);
-        dotExperimentsService.getById.and.callThrough().and.returnValue(of(ExperimentMocks[0]));
+        dotExperimentsService.getById.and.callThrough().and.returnValue(of(EXPERIMENT_MOCK));
     });
 
     it('should set initial data', (done) => {
-        spectator.service.loadExperiment(EXPERIMENT_ID);
+        spectator.service.loadExperiment(EXPERIMENT_MOCK.id);
 
         const expectedInitialState: DotExperimentsConfigurationState = {
-            experiment: { ...ExperimentMocks[0] },
+            experiment: EXPERIMENT_MOCK,
             status: ComponentStatus.IDLE,
             stepStatusSidebar: {
                 status: ComponentStatus.IDLE,
@@ -86,7 +88,7 @@ describe('DotExperimentsConfigurationStore', () => {
             }
         };
 
-        expect(dotExperimentsService.getById).toHaveBeenCalledWith(EXPERIMENT_ID);
+        expect(dotExperimentsService.getById).toHaveBeenCalledWith(EXPERIMENT_MOCK.id);
         store.state$.subscribe((state) => {
             expect(state).toEqual(expectedInitialState);
             done();
@@ -94,7 +96,7 @@ describe('DotExperimentsConfigurationStore', () => {
     });
 
     it('should have isLoading$ from the store', (done) => {
-        spectator.service.loadExperiment(ExperimentMocks[0].id);
+        spectator.service.loadExperiment(EXPERIMENT_MOCK.id);
         store.isLoading$.subscribe((data) => {
             expect(data).toEqual(false);
             done();
@@ -138,29 +140,29 @@ describe('DotExperimentsConfigurationStore', () => {
 
     describe('Effects', () => {
         it('should load experiment to store', (done) => {
-            dotExperimentsService.getById.and.callThrough().and.returnValue(of(ExperimentMocks[1]));
+            dotExperimentsService.getById.and.callThrough().and.returnValue(of(EXPERIMENT_MOCK_1));
 
-            store.loadExperiment(EXPERIMENT_ID);
-            expect(dotExperimentsService.getById).toHaveBeenCalledWith(EXPERIMENT_ID);
+            store.loadExperiment(EXPERIMENT_MOCK_1.id);
+            expect(dotExperimentsService.getById).toHaveBeenCalledWith(EXPERIMENT_MOCK_1.id);
             store.state$.subscribe(({ experiment }) => {
-                expect(experiment).toEqual(ExperimentMocks[1]);
+                expect(experiment).toEqual(EXPERIMENT_MOCK_1);
                 done();
             });
         });
 
         it('should add a variant to the store', (done) => {
-            dotExperimentsService.getById.and.callThrough().and.returnValue(of(ExperimentMocks[1]));
+            dotExperimentsService.getById.and.callThrough().and.returnValue(of(EXPERIMENT_MOCK_1));
             const newVariant: { experimentId: string; data: Pick<DotExperiment, 'name'> } = {
                 data: { name: '333' },
-                experimentId: EXPERIMENT_ID
+                experimentId: EXPERIMENT_MOCK_1.id
             };
 
             const expectedExperiment = {
-                ...ExperimentMocks[1],
+                ...EXPERIMENT_MOCK_1,
                 trafficProportion: {
-                    ...ExperimentMocks[1].trafficProportion,
+                    ...EXPERIMENT_MOCK_1.trafficProportion,
                     variants: [
-                        ...ExperimentMocks[1].trafficProportion.variants,
+                        ...EXPERIMENT_MOCK_1.trafficProportion.variants,
                         {
                             ...newVariant.data,
                             id: '222',
@@ -174,7 +176,7 @@ describe('DotExperimentsConfigurationStore', () => {
                 .callThrough()
                 .and.returnValue(of(expectedExperiment));
 
-            store.loadExperiment(EXPERIMENT_ID);
+            store.loadExperiment(EXPERIMENT_MOCK.id);
             store.addVariant(newVariant);
 
             store.state$.subscribe(({ experiment, stepStatusSidebar }) => {
@@ -196,27 +198,27 @@ describe('DotExperimentsConfigurationStore', () => {
 
             dotExperimentsService.getById.and.callThrough().and.returnValue(
                 of({
-                    ...ExperimentMocks[0],
+                    ...EXPERIMENT_MOCK,
                     trafficProportion: {
-                        ...ExperimentMocks[0].trafficProportion,
+                        ...EXPERIMENT_MOCK.trafficProportion,
                         variants
                     }
                 })
             );
             dotExperimentsService.editVariant.and.callThrough().and.returnValue(
                 of({
-                    ...ExperimentMocks[0],
+                    ...EXPERIMENT_MOCK,
                     trafficProportion: {
-                        ...ExperimentMocks[0].trafficProportion,
+                        ...EXPERIMENT_MOCK.trafficProportion,
                         variants: variantEdited
                     }
                 })
             );
 
-            store.loadExperiment(EXPERIMENT_ID);
+            store.loadExperiment(EXPERIMENT_MOCK.id);
 
             store.editVariant({
-                experimentId: EXPERIMENT_ID,
+                experimentId: EXPERIMENT_MOCK.id,
                 data: { id: variants[1].id, name: 'new name' }
             });
 
@@ -239,16 +241,16 @@ describe('DotExperimentsConfigurationStore', () => {
             ];
 
             const experimentWithTwoVariants: DotExperiment = {
-                ...ExperimentMocks[1],
+                ...EXPERIMENT_MOCK_1,
                 trafficProportion: {
-                    ...ExperimentMocks[1].trafficProportion,
+                    ...EXPERIMENT_MOCK_1.trafficProportion,
                     variants: [...variants]
                 }
             };
             const expectedResponseRemoveVariant: DotExperiment = {
-                ...ExperimentMocks[1],
+                ...EXPERIMENT_MOCK_1,
                 trafficProportion: {
-                    ...ExperimentMocks[1].trafficProportion,
+                    ...EXPERIMENT_MOCK_1.trafficProportion,
                     variants: [{ id: 'DEFAULT', name: 'DEFAULT', weight: 50 }]
                 }
             };
@@ -260,10 +262,10 @@ describe('DotExperimentsConfigurationStore', () => {
                 .callThrough()
                 .and.returnValue(of(expectedResponseRemoveVariant));
 
-            store.loadExperiment(EXPERIMENT_ID);
-            expect(dotExperimentsService.getById).toHaveBeenCalledWith(EXPERIMENT_ID);
+            store.loadExperiment(EXPERIMENT_MOCK.id);
+            expect(dotExperimentsService.getById).toHaveBeenCalledWith(EXPERIMENT_MOCK.id);
 
-            store.deleteVariant({ experimentId: EXPERIMENT_ID, variant: variants[1] });
+            store.deleteVariant({ experimentId: EXPERIMENT_MOCK.id, variant: variants[1] });
 
             store.state$.subscribe(({ experiment }) => {
                 expect(experiment.trafficProportion.variants).toEqual(
@@ -278,18 +280,18 @@ describe('DotExperimentsConfigurationStore', () => {
 
             dotExperimentsService.getById.and
                 .callThrough()
-                .and.returnValue(of({ ...ExperimentMocks[0] }));
+                .and.returnValue(of({ ...EXPERIMENT_MOCK }));
 
             dotExperimentsService.setGoal.and.callThrough().and.returnValue(
                 of({
-                    ...ExperimentMocks[0],
+                    ...EXPERIMENT_MOCK,
                     goals: expectedGoals
                 })
             );
 
-            store.loadExperiment(EXPERIMENT_ID);
+            store.loadExperiment(EXPERIMENT_MOCK.id);
 
-            store.setSelectedGoal({ experimentId: EXPERIMENT_ID, goals: expectedGoals });
+            store.setSelectedGoal({ experimentId: EXPERIMENT_MOCK.id, goals: expectedGoals });
 
             store.state$.subscribe(({ experiment }) => {
                 expect(experiment.goals).toEqual(expectedGoals);
@@ -300,7 +302,7 @@ describe('DotExperimentsConfigurationStore', () => {
         it('should delete a Goal from an experiment', (done) => {
             const goalLevelToDelete: GoalsLevels = 'primary';
             const experimentWithGoals: DotExperiment = {
-                ...ExperimentMocks[0],
+                ...EXPERIMENT_MOCK,
                 goals: { ...GoalsMock }
             };
 
@@ -310,13 +312,13 @@ describe('DotExperimentsConfigurationStore', () => {
 
             dotExperimentsService.deleteGoal.and.callThrough().and.returnValue(
                 of({
-                    ...ExperimentMocks[0]
+                    ...EXPERIMENT_MOCK
                 })
             );
 
-            store.loadExperiment(EXPERIMENT_ID);
+            store.loadExperiment(EXPERIMENT_MOCK.id);
 
-            store.deleteGoal({ experimentId: EXPERIMENT_ID, goalLevel: goalLevelToDelete });
+            store.deleteGoal({ experimentId: EXPERIMENT_MOCK.id, goalLevel: goalLevelToDelete });
 
             store.state$.subscribe(({ experiment }) => {
                 expect(experiment.goals).toEqual(null);
@@ -332,20 +334,20 @@ describe('DotExperimentsConfigurationStore', () => {
 
             dotExperimentsService.setScheduling.and.callThrough().and.returnValue(
                 of({
-                    ...ExperimentMocks[0],
+                    ...EXPERIMENT_MOCK,
                     scheduling: expectedScheduling
                 })
             );
 
             store.setSelectedScheduling({
                 scheduling: expectedScheduling,
-                experimentId: EXPERIMENT_ID
+                experimentId: EXPERIMENT_MOCK.id
             });
 
             store.state$.pipe(take(1)).subscribe(({ experiment }) => {
                 expect(experiment.scheduling).toEqual(expectedScheduling);
                 expect(dotExperimentsService.setScheduling).toHaveBeenCalledOnceWith(
-                    EXPERIMENT_ID,
+                    EXPERIMENT_MOCK.id,
                     expectedScheduling
                 );
                 done();
@@ -357,7 +359,7 @@ describe('DotExperimentsConfigurationStore', () => {
 
             store.setSelectedScheduling({
                 scheduling: null,
-                experimentId: EXPERIMENT_ID
+                experimentId: EXPERIMENT_MOCK.id
             });
 
             expect(dotHttpErrorManagerService.handle).toHaveBeenCalledOnceWith(
@@ -370,20 +372,20 @@ describe('DotExperimentsConfigurationStore', () => {
 
             dotExperimentsService.setTrafficAllocation.and.callThrough().and.returnValue(
                 of({
-                    ...ExperimentMocks[0],
+                    ...EXPERIMENT_MOCK,
                     trafficAllocation: expectedTrafficAllocation
                 })
             );
 
             store.setSelectedAllocation({
                 trafficAllocation: expectedTrafficAllocation,
-                experimentId: EXPERIMENT_ID
+                experimentId: EXPERIMENT_MOCK.id
             });
 
             store.state$.pipe(take(1)).subscribe(({ experiment }) => {
                 expect(experiment.trafficAllocation).toEqual(expectedTrafficAllocation);
                 expect(dotExperimentsService.setTrafficAllocation).toHaveBeenCalledOnceWith(
-                    EXPERIMENT_ID,
+                    EXPERIMENT_MOCK.id,
                     expectedTrafficAllocation
                 );
                 done();
@@ -395,7 +397,7 @@ describe('DotExperimentsConfigurationStore', () => {
 
             store.setSelectedAllocation({
                 trafficAllocation: 120,
-                experimentId: EXPERIMENT_ID
+                experimentId: EXPERIMENT_MOCK.id
             });
 
             expect(dotHttpErrorManagerService.handle).toHaveBeenCalledOnceWith(
@@ -414,20 +416,20 @@ describe('DotExperimentsConfigurationStore', () => {
 
             dotExperimentsService.setTrafficProportion.and.callThrough().and.returnValue(
                 of({
-                    ...ExperimentMocks[0],
+                    ...EXPERIMENT_MOCK,
                     trafficProportion: expectedTrafficProportion
                 })
             );
 
             store.setSelectedTrafficProportion({
                 trafficProportion: expectedTrafficProportion,
-                experimentId: EXPERIMENT_ID
+                experimentId: EXPERIMENT_MOCK.id
             });
 
             store.state$.pipe(take(1)).subscribe(({ experiment }) => {
                 expect(experiment.trafficProportion).toEqual(expectedTrafficProportion);
                 expect(dotExperimentsService.setTrafficProportion).toHaveBeenCalledOnceWith(
-                    EXPERIMENT_ID,
+                    EXPERIMENT_MOCK.id,
                     expectedTrafficProportion
                 );
                 done();
@@ -439,7 +441,7 @@ describe('DotExperimentsConfigurationStore', () => {
 
             store.setSelectedTrafficProportion({
                 trafficProportion: null,
-                experimentId: EXPERIMENT_ID
+                experimentId: EXPERIMENT_MOCK.id
             });
 
             expect(dotHttpErrorManagerService.handle).toHaveBeenCalledOnceWith(
@@ -449,10 +451,10 @@ describe('DotExperimentsConfigurationStore', () => {
 
         it('should change the experiment status when Start the experiment', (done) => {
             const experimentWithGoalsAndVariant: DotExperiment = {
-                ...ExperimentMocks[3]
+                ...EXPERIMENT_MOCK_2
             };
             const expectedExperiment: DotExperiment = {
-                ...ExperimentMocks[3],
+                ...EXPERIMENT_MOCK_2,
                 status: DotExperimentStatusList.RUNNING
             };
 
@@ -466,7 +468,7 @@ describe('DotExperimentsConfigurationStore', () => {
                 })
             );
 
-            spectator.service.loadExperiment(EXPERIMENT_ID);
+            spectator.service.loadExperiment(EXPERIMENT_MOCK_2.id);
 
             store.startExperiment(experimentWithGoalsAndVariant);
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
@@ -1,6 +1,7 @@
 import { byTestId, createComponentFactory, Spectator } from '@ngneat/spectator';
 
 import { Pipe, PipeTransform } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmPopup, ConfirmPopupModule } from 'primeng/confirmpopup';
@@ -137,7 +138,8 @@ describe('DotExperimentsListTableComponent', () => {
             UiDotIconButtonTooltipModule,
             ConfirmPopupModule,
             ToastModule,
-            DotMessagePipeModule
+            DotMessagePipeModule,
+            RouterTestingModule
         ],
         component: DotExperimentsListTableComponent,
         componentMocks: [ConfirmPopup],

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.component.spec.ts
@@ -26,7 +26,7 @@ import {
 import {
     ActivatedRouteListStoreMock,
     DotExperimentsListStoreMock,
-    ExperimentMocks
+    getExperimentAllMocks
 } from '@portlets/dot-experiments/test/mocks';
 
 import { DotExperimentsListComponent } from './dot-experiments-list.component';
@@ -120,7 +120,7 @@ describe('ExperimentsListComponent', () => {
                 pageId: '1111',
                 pageTitle: 'title'
             },
-            experiments: ExperimentMocks,
+            experiments: getExperimentAllMocks(),
             filterStatus: [],
             experimentsFiltered: {},
             isLoading: false

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
@@ -126,12 +126,12 @@ describe('DotExperimentsListStore', () => {
     });
 
     it('should delete experiment by id of the store', () => {
-        const expected: DotExperiment[] = [EXPERIMENT_MOCK, EXPERIMENT_MOCK_2];
+        const expected: string[] = [EXPERIMENT_MOCK.id, EXPERIMENT_MOCK_2.id];
 
         store.setExperiments([...EXPERIMENT_MOCK_ALL]);
         store.deleteExperimentById(EXPERIMENT_MOCK_1.id);
         store.getExperiments$.subscribe((experiments) => {
-            expect(experiments).toEqual(expected);
+            expect(experiments.map((experiment) => experiment.id)).toEqual(expected);
         });
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
@@ -112,7 +112,7 @@ describe('DotExperimentsListStore', () => {
         });
     });
     it('should update experiments to the store', () => {
-        store.setExperiments(EXPERIMENT_MOCK_ALL);
+        store.setExperiments([...EXPERIMENT_MOCK_ALL]);
         store.getExperiments$.subscribe((experiments) => {
             expect(experiments).toEqual(EXPERIMENT_MOCK_ALL);
         });
@@ -126,23 +126,21 @@ describe('DotExperimentsListStore', () => {
     });
 
     it('should delete experiment by id of the store', () => {
-        const ID_TO_DELETE = '222';
         const expected: DotExperiment[] = [EXPERIMENT_MOCK, EXPERIMENT_MOCK_2];
 
-        store.setExperiments(EXPERIMENT_MOCK_ALL);
-        store.deleteExperimentById(ID_TO_DELETE);
+        store.setExperiments([...EXPERIMENT_MOCK_ALL]);
+        store.deleteExperimentById(EXPERIMENT_MOCK_1.id);
         store.getExperiments$.subscribe((experiments) => {
             expect(experiments).toEqual(expected);
         });
     });
 
     it('should change status to archived status by experiment id of the store', () => {
-        const ID_TO_ARCHIVE = '222';
-        const expected: DotExperiment[] = EXPERIMENT_MOCK_ALL;
+        const expected: DotExperiment[] = [...EXPERIMENT_MOCK_ALL];
         expected[1].status = DotExperimentStatusList.ARCHIVED;
 
-        store.setExperiments(EXPERIMENT_MOCK_ALL);
-        store.archiveExperimentById(ID_TO_ARCHIVE);
+        store.setExperiments([...EXPERIMENT_MOCK_ALL]);
+        store.archiveExperimentById(EXPERIMENT_MOCK_1.id);
         store.getExperiments$.subscribe((exp) => {
             expect(exp).toEqual(expected);
         });
@@ -242,7 +240,7 @@ describe('DotExperimentsListStore', () => {
 
             dotExperimentsService.archive.and.returnValue(of(expectedExperimentsInStore[0]));
 
-            const experimentToArchive = { ...EXPERIMENT_MOCK };
+            const experimentToArchive = EXPERIMENT_MOCK;
 
             store.archiveExperiment(experimentToArchive);
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
@@ -18,7 +18,11 @@ import {
 import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks, GoalsMock } from '@portlets/dot-experiments/test/mocks';
+import {
+    getExperimentAllMocks,
+    getExperimentMock,
+    GoalsMock
+} from '@portlets/dot-experiments/test/mocks';
 
 import { DotExperimentsListStore, DotExperimentsState } from './dot-experiments-list-store.service';
 
@@ -31,6 +35,11 @@ const ActivatedRouteMock = {
         parent: { parent: { parent: { parent: { data: { content: { page: { title: '' } } } } } } }
     }
 };
+
+const EXPERIMENT_MOCK = getExperimentMock(0);
+const EXPERIMENT_MOCK_1 = getExperimentMock(0);
+const EXPERIMENT_MOCK_2 = getExperimentMock(0);
+const EXPERIMENT_MOCK_ALL = getExperimentAllMocks();
 
 const messageServiceMock = new MockDotMessageService({
     'experimentspage.add.new.experiment': 'Add a new experiment'
@@ -103,9 +112,9 @@ describe('DotExperimentsListStore', () => {
         });
     });
     it('should update experiments to the store', () => {
-        store.setExperiments(ExperimentMocks);
+        store.setExperiments(EXPERIMENT_MOCK_ALL);
         store.getExperiments$.subscribe((experiments) => {
-            expect(experiments).toEqual(ExperimentMocks);
+            expect(experiments).toEqual(EXPERIMENT_MOCK_ALL);
         });
     });
     it('should update status filtered to the store', () => {
@@ -118,9 +127,9 @@ describe('DotExperimentsListStore', () => {
 
     it('should delete experiment by id of the store', () => {
         const ID_TO_DELETE = '222';
-        const expected: DotExperiment[] = [ExperimentMocks[0], ExperimentMocks[2]];
+        const expected: DotExperiment[] = [EXPERIMENT_MOCK, EXPERIMENT_MOCK_2];
 
-        store.setExperiments(ExperimentMocks);
+        store.setExperiments(EXPERIMENT_MOCK_ALL);
         store.deleteExperimentById(ID_TO_DELETE);
         store.getExperiments$.subscribe((experiments) => {
             expect(experiments).toEqual(expected);
@@ -129,10 +138,10 @@ describe('DotExperimentsListStore', () => {
 
     it('should change status to archived status by experiment id of the store', () => {
         const ID_TO_ARCHIVE = '222';
-        const expected: DotExperiment[] = [...ExperimentMocks];
+        const expected: DotExperiment[] = EXPERIMENT_MOCK_ALL;
         expected[1].status = DotExperimentStatusList.ARCHIVED;
 
-        store.setExperiments(ExperimentMocks);
+        store.setExperiments(EXPERIMENT_MOCK_ALL);
         store.archiveExperimentById(ID_TO_ARCHIVE);
         store.getExperiments$.subscribe((exp) => {
             expect(exp).toEqual(expected);
@@ -197,7 +206,7 @@ describe('DotExperimentsListStore', () => {
 
     describe('Effects', () => {
         beforeEach(() => {
-            dotExperimentsService.getAll.and.returnValue(of(ExperimentMocks));
+            dotExperimentsService.getAll.and.returnValue(of(EXPERIMENT_MOCK_ALL));
 
             store.initStore();
             store.loadExperiments(routerParamsPageId);
@@ -205,7 +214,7 @@ describe('DotExperimentsListStore', () => {
         it('should load experiments to store', (done) => {
             expect(dotExperimentsService.getAll).toHaveBeenCalledWith(routerParamsPageId);
             store.getExperiments$.subscribe((exp) => {
-                expect(exp).toEqual(ExperimentMocks);
+                expect(exp).toEqual(EXPERIMENT_MOCK_ALL);
                 done();
             });
         });
@@ -213,13 +222,13 @@ describe('DotExperimentsListStore', () => {
         it('should delete experiment from the store', (done) => {
             dotExperimentsService.delete.and.returnValue(of('deleted'));
 
-            const expectedExperimentsInStore = [ExperimentMocks[1], ExperimentMocks[2]];
-            const experimentToDelete = ExperimentMocks[0];
+            const expectedExperimentsInStore = [EXPERIMENT_MOCK_1, EXPERIMENT_MOCK_2];
+            const experimentToDelete = { ...EXPERIMENT_MOCK };
 
             store.deleteExperiment(experimentToDelete);
 
             expect(dotExperimentsService.delete).toHaveBeenCalled();
-            expect(dotExperimentsService.delete).toHaveBeenCalledWith(ExperimentMocks[0].id);
+            expect(dotExperimentsService.delete).toHaveBeenCalledWith(EXPERIMENT_MOCK.id);
             store.getExperiments$.subscribe((experiments) => {
                 expect(experiments).toEqual(expectedExperimentsInStore);
                 done();
@@ -227,13 +236,13 @@ describe('DotExperimentsListStore', () => {
         });
 
         it('should change experiment status to archive in the store', (done) => {
-            const expectedExperimentsInStore = [...ExperimentMocks];
+            const expectedExperimentsInStore = [...EXPERIMENT_MOCK_ALL];
 
             expectedExperimentsInStore[0].status = DotExperimentStatusList.ARCHIVED;
 
             dotExperimentsService.archive.and.returnValue(of(expectedExperimentsInStore[0]));
 
-            const experimentToArchive = ExperimentMocks[0];
+            const experimentToArchive = { ...EXPERIMENT_MOCK };
 
             store.archiveExperiment(experimentToArchive);
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
@@ -37,8 +37,8 @@ const ActivatedRouteMock = {
 };
 
 const EXPERIMENT_MOCK = getExperimentMock(0);
-const EXPERIMENT_MOCK_1 = getExperimentMock(0);
-const EXPERIMENT_MOCK_2 = getExperimentMock(0);
+const EXPERIMENT_MOCK_1 = getExperimentMock(1);
+const EXPERIMENT_MOCK_2 = getExperimentMock(2);
 const EXPERIMENT_MOCK_ALL = getExperimentAllMocks();
 
 const messageServiceMock = new MockDotMessageService({

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
@@ -204,7 +204,7 @@ describe('DotExperimentsListStore', () => {
 
     describe('Effects', () => {
         beforeEach(() => {
-            dotExperimentsService.getAll.and.returnValue(of(EXPERIMENT_MOCK_ALL));
+            dotExperimentsService.getAll.and.returnValue(of([...EXPERIMENT_MOCK_ALL]));
 
             store.initStore();
             store.loadExperiments(routerParamsPageId);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/services/dot-experiments.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/services/dot-experiments.service.spec.ts
@@ -9,12 +9,13 @@ import {
     Variant
 } from '@dotcms/dotcms-models';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
-import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
+import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
 
 const API_ENDPOINT = '/api/v1/experiments';
 const PAGE_Id = '123';
-const EXPERIMENT_ID = ExperimentMocks[0].id;
-const VARIANT_ID = ExperimentMocks[0].trafficProportion.variants[0].id;
+const EXPERIMENT_MOCK = getExperimentMock(0);
+const EXPERIMENT_ID = EXPERIMENT_MOCK.id;
+const VARIANT_ID = EXPERIMENT_MOCK.trafficProportion.variants[0].id;
 
 describe('DotExperimentsService', () => {
     let spectator: SpectatorHttp<DotExperimentsService>;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/test/mocks.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/test/mocks.ts
@@ -24,7 +24,15 @@ export const GoalsMock: Goals = {
     }
 };
 
-export const ExperimentMocks: Array<DotExperiment> = [
+export const getExperimentMock = (index: number): DotExperiment => {
+    return { ...ExperimentMocks[index] };
+};
+
+export const getExperimentAllMocks = (): Array<DotExperiment> => {
+    return [...ExperimentMocks];
+};
+
+const ExperimentMocks: Array<DotExperiment> = [
     {
         id: '111',
         identifier: '1111-1111-1111-1111',

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-cardinality-selector/dot-cardinality-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-cardinality-selector/dot-cardinality-selector.component.spec.ts
@@ -2,7 +2,10 @@ import { Observable, of } from 'rxjs';
 
 import { Component, DebugElement, EventEmitter, Injectable, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+
+import { DropdownModule } from 'primeng/dropdown';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { MockDotMessageService } from '@dotcms/utils-testing';
@@ -60,7 +63,7 @@ describe('DotCardinalitySelectorComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [DotCardinalitySelectorComponent, HostTestComponent],
-            imports: [],
+            imports: [DropdownModule, FormsModule],
             providers: [
                 { provide: DotMessageService, useValue: messageServiceMock },
                 { provide: DotRelationshipService, useClass: MockRelationshipService }
@@ -85,11 +88,7 @@ describe('DotCardinalitySelectorComponent', () => {
     });
 
     it('should load cardinalities', () => {
-        const options: Observable<DotRelationshipCardinality[]> =
-            dropdown.componentInstance.options;
-        options.subscribe((options) => {
-            expect(options).toEqual(cardinalities);
-        });
+        expect(dropdown.componentInstance.options).toEqual(cardinalities);
     });
 
     it('should trigger a change event p-dropdown', (done) => {

--- a/core-web/libs/dotcms-models/src/lib/dot-page.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-page.model.ts
@@ -1,4 +1,5 @@
 import { DotCMSContentType } from './dot-content-types.model';
+import { DotExperimentStatusList } from './dot-experiments-constants';
 import { EditPageTabs } from './dot-experiments.model';
 
 // TODO: we need to see why the endpoints are returning different "Pages" objects.
@@ -83,7 +84,7 @@ export interface DotVariantData {
     };
     pageId: string;
     experimentId: string;
-
+    experimentStatus: DotExperimentStatusList;
     experimentName: string;
     mode: EditPageTabs;
 }


### PR DESCRIPTION
### Proposed Changes
* Variants only can be viewed, change the edit button for view
* Variants Name can't be edited, remove the ability to be edited.

### Screenshots

**Before**
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/31667212/222287046-7a31f28d-618f-46c0-b4ef-092d611d38bf.png">

**After**
<img width="1116" alt="image" src="https://user-images.githubusercontent.com/31667212/222287158-5351d605-505d-4706-8965-21d40e4beb8b.png">

