### PR TITLE
dotCMS/core#24237 Notification when a variant is created is wrong. 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.html
@@ -21,8 +21,8 @@
                     [tabindex]="1"
                     data-testId="add-experiment-description-input"
                     dotAutofocus
-                    formControlName="description"
-                    name="description"
+                    formControlName="name"
+                    name="name"
                     pInputText
                     placeholder="{{
                         'experiments.configure.variant.add.form.name.placeholder' | dm
@@ -31,7 +31,7 @@
                     type="text"
                 />
                 <dot-field-validation-message
-                    [field]="form.controls.description"
+                    [field]="form.controls.name"
                 ></dot-field-validation-message>
             </div>
         </form>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.spec.ts
@@ -62,7 +62,7 @@ describe('DotExperimentsConfigurationVariantsAddComponent', () => {
         let formValuesOutput;
 
         const formValues = {
-            description: 'name'
+            name: 'name'
         };
 
         spectator.component.form.setValue(formValues);
@@ -83,7 +83,7 @@ describe('DotExperimentsConfigurationVariantsAddComponent', () => {
 
     it('should disable submit button if the form is invalid', () => {
         const invalidFormValues = {
-            description: ''
+            name: ''
         };
 
         spectator.component.form.setValue(invalidFormValues);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.ts
@@ -65,8 +65,8 @@ export class DotExperimentsConfigurationVariantsAddComponent implements OnInit {
 
     saveForm(): void {
         const formValues = this.form.value as Pick<DotExperiment, 'name'>;
-
         this.formValues.emit(formValues);
+        this.closedSidebarEvent();
     }
 
     ngOnInit(): void {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.ts
@@ -80,7 +80,7 @@ export class DotExperimentsConfigurationVariantsAddComponent implements OnInit {
 
     private initForm() {
         this.form = new FormGroup({
-            description: new FormControl<string>('', {
+            name: new FormControl<string>('', {
                 nonNullable: true,
                 validators: [Validators.required, Validators.maxLength(255)]
             })

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -348,13 +348,14 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
 
         it('should emit a the form values when when save', () => {
             let output;
+            const variantForm = { name: 'Variant Name' };
             spectator.output('save').subscribe((result) => (output = result));
 
-            configurationVariantsAddComponent.form.patchValue({ description: 'value' });
+            configurationVariantsAddComponent.form.patchValue(variantForm);
             configurationVariantsAddComponent.saveForm();
             spectator.detectChanges();
 
-            expect(output).toEqual({ description: 'value' });
+            expect(output).toEqual(variantForm);
         });
 
         it('should disable tooltip if is on draft', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.ts
@@ -92,7 +92,7 @@ export class DotExperimentsConfigurationComponent implements OnInit {
      */
     saveVariant(data: Pick<DotExperiment, 'name'>, experimentId: string) {
         this.dotExperimentsConfigurationStore.addVariant({
-            data,
+            name: data.name,
             experimentId
         });
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.spec.ts
@@ -150,8 +150,8 @@ describe('DotExperimentsConfigurationStore', () => {
 
         it('should add a variant to the store', (done) => {
             dotExperimentsService.getById.and.callThrough().and.returnValue(of(ExperimentMocks[1]));
-            const newVariant: { experimentId: string; data: Pick<DotExperiment, 'name'> } = {
-                data: { name: '333' },
+            const newVariant: { experimentId: string; name: string } = {
+                name: '333',
                 experimentId: EXPERIMENT_ID
             };
 
@@ -162,7 +162,7 @@ describe('DotExperimentsConfigurationStore', () => {
                     variants: [
                         ...ExperimentMocks[1].trafficProportion.variants,
                         {
-                            ...newVariant.data,
+                            name: newVariant.name,
                             id: '222',
                             weight: 100
                         }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.ts
@@ -221,7 +221,7 @@ export class DotExperimentsConfigurationStore extends ComponentStore<DotExperime
 
     // Variants
     readonly addVariant = this.effect(
-        (variant$: Observable<{ experimentId: string; data: Pick<DotExperiment, 'name'> }>) => {
+        (variant$: Observable<{ experimentId: string; name: string }>) => {
             return variant$.pipe(
                 tap(() =>
                     this.setSidebarStatus({
@@ -230,7 +230,7 @@ export class DotExperimentsConfigurationStore extends ComponentStore<DotExperime
                     })
                 ),
                 switchMap((variant) =>
-                    this.dotExperimentsService.addVariant(variant.experimentId, variant.data).pipe(
+                    this.dotExperimentsService.addVariant(variant.experimentId, variant.name).pipe(
                         tapResponse(
                             (experiment) => {
                                 this.messageService.add({
@@ -240,7 +240,7 @@ export class DotExperimentsConfigurationStore extends ComponentStore<DotExperime
                                     ),
                                     detail: this.dotMessageService.get(
                                         'experiments.configure.variant.add.confirm-message',
-                                        experiment.name
+                                        variant.name
                                     )
                                 });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
@@ -136,13 +136,10 @@ describe('DotExperimentsListStore', () => {
     });
 
     it('should change status to archived status by experiment id of the store', () => {
-        const expected: DotExperiment[] = [...EXPERIMENT_MOCK_ALL];
-        expected[1].status = DotExperimentStatusList.ARCHIVED;
-
-        store.setExperiments([...EXPERIMENT_MOCK_ALL]);
+        store.setExperiments([{ ...getExperimentMock(1) }]);
         store.archiveExperimentById(EXPERIMENT_MOCK_1.id);
         store.getExperiments$.subscribe((exp) => {
-            expect(exp).toEqual(expected);
+            expect(exp[0].status).toEqual(DotExperimentStatusList.ARCHIVED);
         });
     });
 
@@ -220,19 +217,15 @@ describe('DotExperimentsListStore', () => {
         it('should delete experiment from the store', (done) => {
             dotExperimentsService.delete.and.returnValue(of('deleted'));
 
-            const expectedExperimentsInStore: string[] = [
-                EXPERIMENT_MOCK_1.id,
-                EXPERIMENT_MOCK_2.id
-            ];
-            const experimentToDelete = EXPERIMENT_MOCK;
+            const expectedExperimentsInStore = [EXPERIMENT_MOCK_1, EXPERIMENT_MOCK_2];
+            const experimentToDelete = { ...EXPERIMENT_MOCK };
 
             store.deleteExperiment(experimentToDelete);
 
+            expect(dotExperimentsService.delete).toHaveBeenCalled();
             expect(dotExperimentsService.delete).toHaveBeenCalledWith(EXPERIMENT_MOCK.id);
             store.getExperiments$.subscribe((experiments) => {
-                expect(experiments.map((experiment) => experiment.id)).toEqual(
-                    expectedExperimentsInStore
-                );
+                expect(experiments).toEqual(expectedExperimentsInStore);
                 done();
             });
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.service.spec.ts
@@ -220,15 +220,19 @@ describe('DotExperimentsListStore', () => {
         it('should delete experiment from the store', (done) => {
             dotExperimentsService.delete.and.returnValue(of('deleted'));
 
-            const expectedExperimentsInStore = [EXPERIMENT_MOCK_1, EXPERIMENT_MOCK_2];
-            const experimentToDelete = { ...EXPERIMENT_MOCK };
+            const expectedExperimentsInStore: string[] = [
+                EXPERIMENT_MOCK_1.id,
+                EXPERIMENT_MOCK_2.id
+            ];
+            const experimentToDelete = EXPERIMENT_MOCK;
 
             store.deleteExperiment(experimentToDelete);
 
-            expect(dotExperimentsService.delete).toHaveBeenCalled();
             expect(dotExperimentsService.delete).toHaveBeenCalledWith(EXPERIMENT_MOCK.id);
             store.getExperiments$.subscribe((experiments) => {
-                expect(experiments).toEqual(expectedExperimentsInStore);
+                expect(experiments.map((experiment) => experiment.id)).toEqual(
+                    expectedExperimentsInStore
+                );
                 done();
             });
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/services/dot-experiments.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/services/dot-experiments.service.spec.ts
@@ -5,8 +5,7 @@ import {
     DotExperiment,
     Goals,
     GoalsLevels,
-    TrafficProportionTypes,
-    Variant
+    TrafficProportionTypes
 } from '@dotcms/dotcms-models';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
 import { ExperimentMocks } from '@portlets/dot-experiments/test/mocks';
@@ -58,10 +57,7 @@ describe('DotExperimentsService', () => {
     });
 
     it('should add a variant', () => {
-        const variant: Pick<Variant, 'name'> = {
-            name: 'cool name'
-        };
-        spectator.service.addVariant(EXPERIMENT_ID, variant).subscribe();
+        spectator.service.addVariant(EXPERIMENT_ID, 'cool name').subscribe();
         spectator.expectOne(`${API_ENDPOINT}/${EXPERIMENT_ID}/variants`, HttpMethod.POST);
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/services/dot-experiments.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/services/dot-experiments.service.ts
@@ -11,8 +11,7 @@ import {
     Goals,
     GoalsLevels,
     RangeOfDateAndTime,
-    TrafficProportion,
-    Variant
+    TrafficProportion
 } from '@dotcms/dotcms-models';
 
 const API_ENDPOINT = '/api/v1/experiments';
@@ -98,16 +97,15 @@ export class DotExperimentsService {
     /**
      * Add variant to experiment
      * @param  {number} experimentId
-     * @param {Variant} variant
+     * @param {string} name
      * @returns Observable<DotExperiment>
      * @memberof DotExperimentsService
      */
-    addVariant(experimentId: string, variant: Pick<Variant, 'name'>): Observable<DotExperiment> {
+    addVariant(experimentId: string, name: string): Observable<DotExperiment> {
         return this.http
-            .post<DotCMSResponse<DotExperiment>>(
-                `${API_ENDPOINT}/${experimentId}/variants`,
-                variant
-            )
+            .post<DotCMSResponse<DotExperiment>>(`${API_ENDPOINT}/${experimentId}/variants`, {
+                description: name
+            })
             .pipe(pluck('entity'));
     }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/test/mocks.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/test/mocks.ts
@@ -29,7 +29,7 @@ export const getExperimentMock = (index: number): DotExperiment => {
 };
 
 export const getExperimentAllMocks = (): Array<DotExperiment> => {
-    return [...ExperimentMocks];
+    return [{ ...getExperimentMock(0) }, { ...getExperimentMock(1) }, { ...getExperimentMock(2) }];
 };
 
 const ExperimentMocks: Array<DotExperiment> = [


### PR DESCRIPTION
### Proposed Changes
* Display correctly the name of the variant in the notification after safe
* After a Variant is created, clear form. 
* rename field in variant form 

<img width="959" alt="image" src="https://user-images.githubusercontent.com/31667212/222502208-9899b677-2fea-48e7-af2a-5b4f41940ee3.png">