### PR TITLE
#24227 : Minify CSS output by default.

### DIFF
--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -807,7 +807,7 @@ dotcms.concurrent.queuecapacity=2147483647
 # Allows devs to specify the way the Dart SASS Compiler must behave under specific circumstances that might come up
 # when SCSS files get compiled. For more information, please refer to the DartSassCompiler Javadoc and related classes.
 dartsass.compiler.verbose=false
-dartsass.compiler.expanded.css=true
+dartsass.compiler.expanded.css=false
 dartsass.compiler.error.in.css=true
 dartsass.compiler.stop.on.error=true
 dartsass.compiler.deprecation.warnings=false


### PR DESCRIPTION
### Proposed Changes
* By default, minify the result of the Dart SASS compiler when processing SCSS files.