### PR TITLE
#24197 move input name outside of component dot-experiments-experiment-goal-reach-page-config

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.html
@@ -18,25 +18,51 @@
                 data-testId="select-goal-form"
                 novalidate
             >
-                <div class="field" formGroupName="primary">
-                    <dot-experiment-options formControlName="type">
-                        <dot-experiment-options-item
-                            [value]="goalsTypes.BOUNCE_RATE"
-                            detail="{{ goals.BOUNCE_RATE.description | dm }}"
-                            title="{{ goals.BOUNCE_RATE.label | dm }}"
-                        >
-                        </dot-experiment-options-item>
+                <div formGroupName="primary">
+                    <div class="field flex-auto flex flex-column">
+                        <label class="p-label-input-required">{{
+                            'experiments.goal.reach_page.form.name.label' | dm
+                        }}</label>
+                        <div>
+                            <input
+                                id="name"
+                                data-testId="goal-name-input"
+                                dotAutofocus
+                                formControlName="name"
+                                name="name"
+                                pInputText
+                                placeholder="{{
+                                    'experiments.goal.reach_page.form.name.placeholder' | dm
+                                }}"
+                                required
+                                type="text"
+                            />
 
-                        <dot-experiment-options-item
-                            [value]="goalsTypes.REACH_PAGE"
-                            detail="{{ goals.REACH_PAGE.description | dm }}"
-                            title="{{ goals.REACH_PAGE.label | dm }}"
-                        >
-                            <ng-template dotOptionContent>
-                                <dot-experiments-experiment-goal-reach-page-config></dot-experiments-experiment-goal-reach-page-config>
-                            </ng-template>
-                        </dot-experiment-options-item>
-                    </dot-experiment-options>
+                            <dot-field-validation-message
+                                [field]="goalNameControl"
+                            ></dot-field-validation-message>
+                        </div>
+                    </div>
+                    <div class="field">
+                        <dot-experiment-options formControlName="type">
+                            <dot-experiment-options-item
+                                [value]="goalsTypes.BOUNCE_RATE"
+                                detail="{{ goals.BOUNCE_RATE.description | dm }}"
+                                title="{{ goals.BOUNCE_RATE.label | dm }}"
+                            >
+                            </dot-experiment-options-item>
+
+                            <dot-experiment-options-item
+                                [value]="goalsTypes.REACH_PAGE"
+                                detail="{{ goals.REACH_PAGE.description | dm }}"
+                                title="{{ goals.REACH_PAGE.label | dm }}"
+                            >
+                                <ng-template dotOptionContent>
+                                    <dot-experiments-experiment-goal-reach-page-config></dot-experiments-experiment-goal-reach-page-config>
+                                </ng-template>
+                            </dot-experiment-options-item>
+                        </dot-experiment-options>
+                    </div>
                 </div>
             </form>
         </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.scss
@@ -17,6 +17,10 @@
                 margin: $spacing-0;
                 color: $color-gray-500;
             }
+
+            input {
+                border-color: $color-gray-300;
+            }
         }
 
         .condition {
@@ -31,5 +35,12 @@
     .option-wrapper {
         padding: $spacing-3;
         gap: $spacing-3;
+    }
+}
+
+::ng-deep {
+    dot-field-validation-message {
+        display: flex;
+        margin-top: $spacing-1;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.spec.ts
@@ -89,6 +89,9 @@ describe('DotExperimentsConfigurationGoalSelectComponent', () => {
     it('should be a form valid in case of click on a No content option item', () => {
         const bounceRateOption = spectator.query(byTestId('dot-options-item-header'));
 
+        spectator.component.form.get('primary.name').setValue('default');
+        spectator.component.form.updateValueAndValidity();
+
         spectator.click(bounceRateOption);
 
         const applyBtn = spectator.query(byTestId('add-goal-button')) as HTMLButtonElement;
@@ -145,6 +148,11 @@ describe('DotExperimentsConfigurationGoalSelectComponent', () => {
                 }
             }
         };
+
+        spectator.component.form.get('primary.name').setValue('default');
+        spectator.component.form.updateValueAndValidity();
+
+        spectator.detectComponentChanges();
 
         const bounceRateOption = spectator.query(byTestId('dot-options-item-header'));
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.ts
@@ -1,7 +1,13 @@
 import { Observable, Subject } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    OnDestroy,
+    OnInit
+} from '@angular/core';
 import { FormArray, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
@@ -16,7 +22,6 @@ import { takeUntil } from 'rxjs/operators';
 import { DotFieldValidationMessageModule } from '@components/_common/dot-field-validation-message/dot-file-validation-message.module';
 import {
     ComponentStatus,
-    DEFAULT_GOAL_NAME,
     GOAL_TYPES,
     Goals,
     GOALS_METADATA_MAP,
@@ -65,14 +70,13 @@ export class DotExperimentsConfigurationGoalSelectComponent implements OnInit, O
     goals = GOALS_METADATA_MAP;
     goalsTypes = GOAL_TYPES;
     statusList = ComponentStatus;
-
     vm$: Observable<{ experimentId: string; goals: Goals; status: StepStatus }> =
         this.dotExperimentsConfigurationStore.goalsStepVm$;
-
     private destroy$: Subject<boolean> = new Subject<boolean>();
 
     constructor(
-        private readonly dotExperimentsConfigurationStore: DotExperimentsConfigurationStore
+        private readonly dotExperimentsConfigurationStore: DotExperimentsConfigurationStore,
+        private readonly cdr: ChangeDetectorRef
     ) {}
 
     /**
@@ -85,9 +89,8 @@ export class DotExperimentsConfigurationGoalSelectComponent implements OnInit, O
         return this.form.get('primary.conditions') as FormArray;
     }
 
-    ngOnInit(): void {
-        this.initForm();
-        this.listenGoalTypeSelection();
+    get goalNameControl(): FormControl {
+        return this.form.get('primary.name') as FormControl;
     }
 
     /**
@@ -120,6 +123,11 @@ export class DotExperimentsConfigurationGoalSelectComponent implements OnInit, O
         this.destroy$.complete();
     }
 
+    ngOnInit(): void {
+        this.initForm();
+        this.listenGoalTypeSelection();
+    }
+
     private listenGoalTypeSelection(): void {
         this.form
             .get('primary.type')
@@ -136,7 +144,7 @@ export class DotExperimentsConfigurationGoalSelectComponent implements OnInit, O
     private initForm(): void {
         this.form = new FormGroup({
             primary: new FormGroup({
-                name: new FormControl(DEFAULT_GOAL_NAME, {
+                name: new FormControl('', {
                     nonNullable: true,
                     validators: [Validators.required]
                 }),
@@ -153,7 +161,6 @@ export class DotExperimentsConfigurationGoalSelectComponent implements OnInit, O
     }
 
     private addConditionsControlValidations(): void {
-        this.form.get('primary.name').reset('');
         Object.values(this.conditionsFormArray.controls).forEach((controlArray: FormArray) => {
             Object.values(controlArray.controls).forEach((control) => {
                 control.setValidators([Validators.required]);
@@ -164,7 +171,6 @@ export class DotExperimentsConfigurationGoalSelectComponent implements OnInit, O
     }
 
     private removeConditionsControlValidations(): void {
-        this.form.get('primary.name').reset(DEFAULT_GOAL_NAME);
         Object.values(this.conditionsFormArray.controls).forEach((controlArray: FormArray) => {
             Object.values(controlArray.controls).forEach((control) => {
                 control.reset('');

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-experiment-goal-reach-page-config/dot-experiments-experiment-goal-reach-page-config.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-experiment-goal-reach-page-config/dot-experiments-experiment-goal-reach-page-config.component.html
@@ -1,26 +1,5 @@
 <div class="flex flex-column wrapper" [formGroup]="primaryFormGroup">
     <div class="field flex-auto flex flex-column">
-        <label class="p-label-input-required">{{
-            'experiments.goal.reach_page.form.name.label' | dm
-        }}</label>
-        <input
-            id="name"
-            data-testId="goal-name-input"
-            dotAutofocus
-            formControlName="name"
-            name="name"
-            pInputText
-            placeholder="{{ 'experiments.goal.reach_page.form.name.placeholder' | dm }}"
-            required
-            type="text"
-        />
-
-        <dot-field-validation-message
-            [field]="primaryFormGroup.controls.name"
-        ></dot-field-validation-message>
-    </div>
-
-    <div class="field flex-auto flex flex-column">
         <h3>{{ 'experiments.goal.reach_page.form.conditions.label' | dm }}</h3>
 
         <ng-container

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-experiment-goal-reach-page-config/dot-experiments-experiment-goal-reach-page-config.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-experiment-goal-reach-page-config/dot-experiments-experiment-goal-reach-page-config.component.spec.ts
@@ -8,7 +8,6 @@ import { DotFieldValidationMessageComponent } from '@components/_common/dot-fiel
 import { DotFieldValidationMessageModule } from '@components/_common/dot-field-validation-message/dot-file-validation-message.module';
 import { DotMessageService } from '@dotcms/data-access';
 import {
-    DEFAULT_GOAL_NAME,
     DefaultGoalConfiguration,
     GOAL_OPERATORS,
     GOAL_PARAMETERS,
@@ -26,7 +25,7 @@ const messageServiceMock = new MockDotMessageService({
 
 const formMock = new FormGroup({
     primary: new FormGroup({
-        name: new FormControl(DEFAULT_GOAL_NAME, {
+        name: new FormControl('', {
             nonNullable: true,
             validators: [Validators.required]
         }),

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-field-validation-message/dot-field-validation-message.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-field-validation-message/dot-field-validation-message.html
@@ -1,6 +1,6 @@
 <small
     class="p-invalid"
-    *ngIf="_field.enabled && _field.dirty && !_field.valid"
+    *ngIf="_field &&_field.enabled && _field.dirty && !_field.valid"
     data-testId="dotErrorMsg"
 >
     {{ errorMsg | dm }}

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-field-validation-message/dot-field-validation-message.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-field-validation-message/dot-field-validation-message.ts
@@ -57,11 +57,13 @@ export class DotFieldValidationMessageComponent implements OnDestroy {
      */
     @Input()
     set field(control: UntypedFormControl | AbstractControl) {
-        this._field = control;
-        control.statusChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
-            this.errorMsg = this.getErrors(control.errors);
-            this.cd.detectChanges();
-        });
+        if (control) {
+            this._field = control;
+            control.statusChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+                this.errorMsg = this.getErrors(control.errors);
+                this.cd.detectChanges();
+            });
+        }
     }
 
     ngOnDestroy(): void {

--- a/core-web/libs/dotcms-models/src/lib/dot-experiments-constants.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-experiments-constants.ts
@@ -104,5 +104,3 @@ export const GOALS_METADATA_MAP: Record<GOAL_TYPES, { label: string; description
         description: 'experiments.goal.click_on_element.description'
     }
 };
-
-export const DEFAULT_GOAL_NAME = 'default';


### PR DESCRIPTION
### Proposed Changes
* Move input NAME outside of the conditions of REACH_PAGE and make it global.

### Checklist
- [x] Tests
- [x] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Screenshots
**Original**     
<img width="917" alt="Screenshot 2023-03-03 at 3 45 32 PM" src="https://user-images.githubusercontent.com/1909643/222825854-15a1bc93-2638-449f-92a0-58ca20a3fcaa.png">


**Updated**
<img width="922" alt="Screenshot 2023-03-03 at 3 44 38 PM" src="https://user-images.githubusercontent.com/1909643/222825665-1030ead8-cabf-4606-8449-81dda0164db4.png">
