### PR TITLE
dotCMS/core#24308 Can't search for contentlets in edit page palette

### DIFF
--- a/core-web/libs/data-access/src/lib/dot-es-content/dot-es-content.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-es-content/dot-es-content.service.spec.ts
@@ -62,7 +62,35 @@ describe('DotESContentService', () => {
         const req = httpMock.expectOne('/api/content/_search');
         expect(req.request.method).toBe('POST');
         expect(req.request.body).toEqual(
-            '{"query":"+contentType: blog   +languageId : 2  ","sort":"name ASC","limit":5,"offset":"10"}'
+            '{"query":"+contentType: blog   +languageId : 2   +title : test*  ","sort":"name ASC","limit":5,"offset":"10"}'
+        );
+        req.flush({ entity: responseData });
+    });
+
+    it('should get Blogs with custom values wrap filter values into single quote if it is contain space', () => {
+        dotESContentService
+            .get({
+                itemsPerPage: 5,
+                filter: 'test one',
+                lang: '2',
+                offset: '10',
+                sortField: 'name',
+                sortOrder: ESOrderDirection.ASC,
+                query: '+contentType: blog'
+            })
+            .subscribe((res) => {
+                expect(res).toEqual(responseData);
+            });
+
+        const req = httpMock.expectOne('/api/content/_search');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(
+            JSON.stringify({
+                query: "+contentType: blog   +languageId : 2   +title : 'test one'*  ",
+                sort: 'name ASC',
+                limit: 5,
+                offset: '10'
+            })
         );
         req.flush({ entity: responseData });
     });

--- a/core-web/libs/data-access/src/lib/dot-es-content/dot-es-content.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-es-content/dot-es-content.service.spec.ts
@@ -67,15 +67,10 @@ describe('DotESContentService', () => {
         req.flush({ entity: responseData });
     });
 
-    it('should get Blogs with custom values wrap filter values into single quote if it is contain space', () => {
+    it('should get Blogs with filter values and wrap into single quote if it is contain space', () => {
         dotESContentService
             .get({
-                itemsPerPage: 5,
                 filter: 'test one',
-                lang: '2',
-                offset: '10',
-                sortField: 'name',
-                sortOrder: ESOrderDirection.ASC,
                 query: '+contentType: blog'
             })
             .subscribe((res) => {
@@ -86,10 +81,10 @@ describe('DotESContentService', () => {
         expect(req.request.method).toBe('POST');
         expect(req.request.body).toEqual(
             JSON.stringify({
-                query: "+contentType: blog   +languageId : 2   +title : 'test one'*  ",
-                sort: 'name ASC',
-                limit: 5,
-                offset: '10'
+                query: "+contentType: blog   +title : 'test one'*  ",
+                sort: 'modDate DESC',
+                limit: 40,
+                offset: '0'
             })
         );
         req.flush({ entity: responseData });

--- a/core-web/libs/data-access/src/lib/dot-es-content/dot-es-content.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-es-content/dot-es-content.service.ts
@@ -90,12 +90,12 @@ export class DotESContentService {
 
         if (params.lang) this.setExtraParams('+languageId', params.lang);
 
-        let filterValue = '';
+        let filterValue = params.filter || '';
         if (params.filter && params.filter.indexOf(' ') > 0) {
             filterValue = `'${params.filter.replace(/'/g, "\\'")}'`;
         }
 
-        if (filterValue) this.setExtraParams('+title', `${filterValue || params.filter || ''}*`);
+        if (filterValue) this.setExtraParams('+title', `${filterValue}*`);
     }
 
     private getObjectFromMap(map: Map<string, string>): { [key: string]: string | number } {

--- a/core-web/libs/data-access/src/lib/dot-es-content/dot-es-content.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-es-content/dot-es-content.service.ts
@@ -91,8 +91,8 @@ export class DotESContentService {
         if (params.lang) this.setExtraParams('+languageId', params.lang);
 
         let filterValue = params.filter || '';
-        if (params.filter && params.filter.indexOf(' ') > 0) {
-            filterValue = `'${params.filter.replace(/'/g, "\\'")}'`;
+        if (filterValue && filterValue.indexOf(' ') > 0) {
+            filterValue = `'${filterValue.replace(/'/g, "\\'")}'`;
         }
 
         if (filterValue) this.setExtraParams('+title', `${filterValue}*`);


### PR DESCRIPTION
### Proposed Changes
* fixed search contentlets

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
[screen-capture (16).webm](https://user-images.githubusercontent.com/113915849/223708877-2e012085-ba8f-4f7f-8a2d-a7268407edec.webm)|[screen-capture (17).webm](https://user-images.githubusercontent.com/113915849/223708956-2f5e0b1e-f0a9-47e3-9a38-081c6933c5f2.webm)

