### PR TITLE
dotCMS/core#24263 Block editor field required not validating

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -246,7 +246,15 @@
                     }
 
                     blockEditor.addEventListener('valueChange', (event) => {
-                        field.value = event.detail;
+                        // https://tiptap.dev/api/commands/clear-content
+                        // https://github.com/ueberdosis/tiptap/issues/154
+                        // By default Editor Initialize with default node p even if you clear nodes
+                        // block.editor.isEmpty not working in our block editor
+                        if(block.editor.getHTML().toLowerCase() === "<p></p>"){
+                            field.value = null;
+                        } else {
+                            field.value = event.detail;
+                        }
                     });
 
                     blockEditor.showVideoThumbnail = <%=showVideoThumbnail%>;


### PR DESCRIPTION
### Proposed Changes
* prevent save empty block editor

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
[screen-capture (19).webm](https://user-images.githubusercontent.com/113915849/224354395-bddae8e5-bc87-4f74-8d51-4954724a8e38.webm)|[screen-capture (20).webm](https://user-images.githubusercontent.com/113915849/224354446-c3651cae-2312-4e67-b13f-81cb05845dd1.webm)

