### PR TITLE
Fix: #23505 Make Site Selector Show Selected and Default Site Correctly

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.html
@@ -2,7 +2,7 @@
     <span
         class="searchable-dropdown__data-list-item"
         [class.selected]="item[labelPropertyName] === valueString"
-        [class.highlight]="item.label === selectedOptionValue"
+        [class.star]="item.default"
         (click)="handleClick(item)"
         >{{ item.label }}</span
     >

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.scss
@@ -114,8 +114,9 @@
                 background-color: $bg-hover;
             }
 
-            &.highlight {
-                background-color: $bg-highlight;
+            &.star::after {
+                content: " \2605";
+                color: $color-alert-yellow;
             }
         }
     }

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.spec.ts
@@ -339,6 +339,51 @@ describe('SearchableDropdownComponent', () => {
         hostFixture.detectChanges();
         expect(hostComp.placeholder).toEqual(comp.valueString);
     });
+
+    describe('star class', () => {
+        it('should add the star css class when item has default property set to true', () => {
+            hostComp.data = [
+                {
+                    id: 1,
+                    label: `label`,
+                    name: `label`,
+                    parentPermissionable: {
+                        hostname: 'demo.dotcms.com'
+                    },
+                    default: true
+                }
+            ];
+
+            hostFixture.detectChanges();
+
+            const item = de.query(
+                By.css('p-dataview .p-dataview-content .searchable-dropdown__data-list-item')
+            );
+
+            expect(item.classes['star']).toBeTruthy();
+        });
+        it('should not add css star class when item default property is set to false', () => {
+            hostComp.data = [
+                {
+                    id: 1,
+                    label: `label`,
+                    name: `label`,
+                    parentPermissionable: {
+                        hostname: 'demo.dotcms.com'
+                    },
+                    default: false
+                }
+            ];
+
+            hostFixture.detectChanges();
+
+            const item = de.query(
+                By.css('p-dataview .p-dataview-content .searchable-dropdown__data-list-item')
+            );
+
+            expect(item.classes['star']).toBeFalsy();
+        });
+    });
 });
 
 @Component({


### PR DESCRIPTION
### Proposed Changes
* Delete out of place grey background and add a yellow star to the default site

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
<img width="352" alt="Screenshot 2022-12-05 at 12 26 28 PM" src="https://user-images.githubusercontent.com/114953617/205713794-ca7791d3-1d05-43f1-bda0-13cfa171e1c6.png">  |  <img width="352" alt="Screenshot 2022-12-05 at 12 26 28 PM" src="https://user-images.githubusercontent.com/63567962/224406050-9d2fa82e-de27-41e3-8299-160d2a8f9e3b.png">
