### PR TITLE
#24358 use content selector language instead of BE lang

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
@@ -513,8 +513,7 @@ public class BrowserAjax {
 						   .sortBy(sortBy)
 						   .sortByDesc(sortByDesc)
 						   .showLinks(!excludeLinks)
-						   .withLanguageId(
-								   WebAPILocator.getLanguageWebAPI().getBackendLanguage().getId())
+						   .withLanguageId((Long) req.getSession().getAttribute(WebKeys.CONTENT_SELECTED_LANGUAGE))
 						   .showDotAssets(dotAssets)
 						   .build());
 


### PR DESCRIPTION
use content selector language instead of BE lang.

Since it's an Ajax no tests possible.