### PR TITLE
dotCMS/core#22964 fix favorite page star icon should not be highlighted on archived favorite pages

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -346,7 +346,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
             .get({
                 itemsPerPage: 10,
                 offset: '0',
-                query: `+contentType:DotFavoritePage +DotFavoritePage.url_dotraw:${pageUrl}`
+                query: `+contentType:DotFavoritePage +deleted:false +working:true +DotFavoritePage.url_dotraw:${pageUrl}`
             })
             .pipe(take(1))
             .subscribe((response: ESContent) => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
@@ -134,6 +134,12 @@ describe('DotPageStateService', () => {
                 },
                 {}
             ]);
+
+            expect(dotESContentService.get).toHaveBeenCalledWith({
+                itemsPerPage: 10,
+                offset: '0',
+                query: `+contentType:DotFavoritePage +deleted:false +working:true +DotFavoritePage.url_dotraw:/an/url/test?&language_id=1&device_inode=`
+            });
         });
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
@@ -215,7 +215,7 @@ export class DotPageStateService {
                         .get({
                             itemsPerPage: 10,
                             offset: '0',
-                            query: `+contentType:DotFavoritePage +DotFavoritePage.url_dotraw:${urlParam}`
+                            query: `+contentType:DotFavoritePage +deleted:false +working:true +DotFavoritePage.url_dotraw:${urlParam}`
                         })
                         .pipe(
                             take(1),


### PR DESCRIPTION
…

### Proposed Changes
Fix The STAR icon keeps highlighted for the page when the favorite page is archived


### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
![image](https://user-images.githubusercontent.com/37185433/225388539-169c9075-0f9d-426b-aec1-08823805c7c6.png)

