### PR TITLE
fix life cycle angular error using dotRelativeDatePipe

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-custom-time.component/dot-custom-time.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-custom-time.component/dot-custom-time.component.html
@@ -1,1 +1,1 @@
-<time>{{ formattedTime }}</time>
+<time>{{ time | dotRelativeDate : true }}</time>

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-custom-time.component/dot-custom-time.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-custom-time.component/dot-custom-time.component.ts
@@ -1,10 +1,11 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 
 @Component({
     encapsulation: ViewEncapsulation.Emulated,
     selector: 'dot-custom-time',
     styleUrls: ['./dot-custom-time.component.scss'],
-    templateUrl: 'dot-custom-time.component.html'
+    templateUrl: 'dot-custom-time.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CustomTimeComponent {
     @Input() time: string;

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-custom-time.component/dot-custom-time.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-custom-time.component/dot-custom-time.component.ts
@@ -1,6 +1,4 @@
-import { AfterViewChecked, Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
-
-import { DotFormatDateService } from '@dotcms/app/api/services/dot-format-date-service';
+import { Component, Input, ViewEncapsulation } from '@angular/core';
 
 @Component({
     encapsulation: ViewEncapsulation.Emulated,
@@ -8,21 +6,6 @@ import { DotFormatDateService } from '@dotcms/app/api/services/dot-format-date-s
     styleUrls: ['./dot-custom-time.component.scss'],
     templateUrl: 'dot-custom-time.component.html'
 })
-export class CustomTimeComponent implements OnInit, AfterViewChecked {
-    @Input()
-    time;
-
-    formattedTime = '';
-
-    constructor(private dotFormatDateService: DotFormatDateService) {}
-
-    ngOnInit(): void {
-        this.formattedTime = this.dotFormatDateService.getRelative(this.time);
-    }
-
-    // TODO: this it's running every time the UI changes no matter where, need to fix it, should only run when custom-time shows
-    ngAfterViewChecked(): void {
-        // TODO: this is triggering even when open other dropdown component instance, need to check that.
-        this.formattedTime = this.dotFormatDateService.getRelative(this.time);
-    }
+export class CustomTimeComponent {
+    @Input() time: string;
 }

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-custom-time.component/dot-custom-time.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-custom-time.component/dot-custom-time.module.ts
@@ -1,10 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { DotRelativeDatePipe } from '@dotcms/app/view/pipes/dot-relative-date/dot-relative-date.pipe';
+
 import { CustomTimeComponent } from './dot-custom-time.component';
 
 @NgModule({
-    imports: [CommonModule],
+    imports: [CommonModule, DotRelativeDatePipe],
     exports: [CustomTimeComponent],
     declarations: [CustomTimeComponent]
 })


### PR DESCRIPTION
### Proposed Changes
* Use `DotRelativeDatePipe` to format the time instead of Angular Life Cycle hooks

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info

This was the error that appeared on console and appeared every time the relative time of a notification changed
![image](https://user-images.githubusercontent.com/63567962/225455074-4a47f4b1-977d-4dd2-8601-1611c55000c2.png)



### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
