### PR TITLE
Fix  #24292 Content Palette Should Not Show Archived Content

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/store/dot-palette.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/store/dot-palette.store.spec.ts
@@ -233,7 +233,7 @@ describe('DotPaletteStore', () => {
                 lang: '1',
                 filter: '',
                 offset: '0',
-                query: '+contentType: product'
+                query: '+contentType: product +deleted: false'
             });
             expect(data.contentlets).toEqual([
                 contentletProductDataMock

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/store/dot-palette.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/store/dot-palette.store.ts
@@ -195,7 +195,7 @@ export class DotPaletteStore extends ComponentStore<DotPaletteState> {
                         lang: languageId || '1',
                         filter: filter || '',
                         offset: (event && event.first.toString()) || '0',
-                        query: `+contentType: ${this.contentTypeVarName}`
+                        query: `+contentType: ${this.contentTypeVarName} +deleted: false`
                     })
                     .pipe(take(1))
                     .subscribe((response: ESContent) => {


### PR DESCRIPTION
### Proposed Changes
* Add `+deleted: false`  query to Elastic Search in order to not retrieve archived contentlets

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info

Here we can see that `services-2.jpg` is archived

![image](https://user-images.githubusercontent.com/63567962/225461469-4bf62d23-9207-4314-b0e5-21eca4144831.png)

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
<img width="352" alt="Screenshot 2022-12-05 at 12 26 28 PM" src="https://user-images.githubusercontent.com/63567962/225461725-20b3ed8b-6138-456f-b920-c8e4b1da4dcd.png"> |  <img width="352" alt="Screenshot 2022-12-05 at 12 26 28 PM" src="https://user-images.githubusercontent.com/63567962/225461863-287dffb3-d2d3-4b02-bb7b-88a9e3206732.png">
