### PR TITLE
dotCMS/core#24109 Make Visual Compare Tool use Equal Width Columns

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.html
@@ -1,7 +1,7 @@
 <p-table *ngIf="data" [value]="data.fields" styleClass="p-datatable-gridlines">
     <ng-template pTemplate="header">
         <tr>
-            <th style="width: 12%"></th>
+            <th></th>
             <th>
                 <span class="dot-content-compare-table__title" data-testId="table-tittle">
                     {{ data.working?.title }}
@@ -104,7 +104,7 @@
                         [fileURL]="data.compare[field.variable + 'Version']"
                         [label]="
                             data.working[field.variable + 'Version']
-                                | dotDiff: data.compare[field.variable + 'Version']:showDiff
+                                | dotDiff : data.compare[field.variable + 'Version'] : showDiff
                         "
                         data-testId="table-binary-compare"
                     >
@@ -120,7 +120,7 @@
                     [innerHTML]="
                         data.working[field.variable]
                             | json
-                            | dotDiff: (data.compare[field.variable] | json):showDiff
+                            | dotDiff : (data.compare[field.variable] | json) : showDiff
                     "
                     data-testId="table-json-compare"
                 ></td>
@@ -133,7 +133,7 @@
                 <td
                     [innerHTML]="
                         data.working[field.variable]
-                            | dotDiff: data.compare[field.variable]:showDiff
+                            | dotDiff : data.compare[field.variable] : showDiff
                     "
                     data-testId="table-field-compare"
                 ></td>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.scss
@@ -1,6 +1,6 @@
 @use "variables" as *;
 
-.dot-content-compare-table__controls{
+.dot-content-compare-table__controls {
     display: flex;
     align-items: center;
 
@@ -19,7 +19,6 @@
 }
 
 :host ::ng-deep .p-datatable {
-
     table {
         border-collapse: separate;
         border-spacing: 0;
@@ -50,6 +49,9 @@
             top: 0;
             z-index: 1;
 
+            &:not(:first-of-type) {
+                width: 45%;
+            }
         }
     }
 }


### PR DESCRIPTION
### Proposed Changes
* make equal width of visual compare column

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
![image](https://user-images.githubusercontent.com/113915849/225573774-c6741dd6-593b-4c72-b05c-5b55409b4062.png)|![Screenshot from 2023-03-16 14-26-40](https://user-images.githubusercontent.com/113915849/225573479-449a9d64-597e-4c67-a589-f69f235e3a8f.png)

