### PR TITLE
dev: get the correct input element for block editor

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -210,7 +210,7 @@
                 lang="<%=contentLanguage%>"
                 custom-blocks='<%=customBlocks%>'>
             </dotcms-block-editor>
-            <input type="hidden" name="<%=field.getFieldContentlet()%>" id="<%=field.getVelocityVarName()%>"/>
+            <input type="hidden" name="<%=field.getFieldContentlet()%>" id="editor-input-value-<%=field.getVelocityVarName()%>"/>
 
             <script>
 
@@ -240,7 +240,7 @@
 
                     const blockEditor = document.getElementById("block-editor-<%=field.getVelocityVarName()%>");
                     const block = blockEditor.querySelector('.ProseMirror');
-                    const field = document.querySelector('#<%=field.getVelocityVarName()%>');
+                    const field = document.querySelector('#editor-input-value-<%=field.getVelocityVarName()%>');
 
                     if (content) {
                         blockEditor.value = content;


### PR DESCRIPTION
### Proposed Changes
* Fix block editor field not allowing `saving` when the variable has the `Editor` name.

### Screenshots


https://user-images.githubusercontent.com/72418962/226719151-0e7c878e-7319-422b-8ebb-db620a9d8b55.mov


