### PR TITLE
#22477 Promote a variant to be the DEFAULT one

### DIFF
--- a/dotCMS/src/curl-test/Promote Variant.postman_collection.json
+++ b/dotCMS/src/curl-test/Promote Variant.postman_collection.json
@@ -14,8 +14,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test(\"Status code should be ok 400\", function () {",
-							"    pm.response.to.have.status(400);",
+							"pm.test(\"Status code should be ok 404\", function () {",
+							"    pm.response.to.have.status(404);",
 							"});",
 							""
 						],

--- a/dotCMS/src/curl-test/Promote Variant.postman_collection.json
+++ b/dotCMS/src/curl-test/Promote Variant.postman_collection.json
@@ -1,0 +1,132 @@
+{
+	"info": {
+		"_postman_id": "7dd20c64-c95d-4957-b702-365ce73eca87",
+		"name": "Promote Variant",
+		"description": "Promote a Variant, Step:\n\n- Create an Experiment, beacuse this is for now the only way to Create a Variant.\n- Create a Variant into the Experiment.\n- Create two Contentlet into the Variant.\n- Promote the Variant",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "1549189"
+	},
+	"item": [
+		{
+			"name": "Promote a Not exists Variant",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code should be ok 400\", function () {",
+							"    pm.response.to.have.status(400);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin@dotcms.com",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PUT",
+				"header": [],
+				"url": {
+					"raw": "{{serverURL}}/api/v1/variants/not_exists/_promote",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"variants",
+						"not_exists",
+						"_promote"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Logout",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{serverURL}}/dotAdmin/logout",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"dotAdmin",
+						"logout"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Try to promote a Variant with no user",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code should be ok 401\", function () {",
+							"    pm.response.to.have.status(401);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [],
+				"url": {
+					"raw": "{{serverURL}}/api/v1/variants/not_exists/_promote",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"variants",
+						"not_exists",
+						"_promote"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"variable": [
+		{
+			"key": "promoteTestPageId",
+			"value": ""
+		},
+		{
+			"key": "promoteTestExperimentId",
+			"value": ""
+		},
+		{
+			"key": "parentId1",
+			"value": ""
+		},
+		{
+			"key": "parentInode1",
+			"value": ""
+		}
+	]
+}

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -75,7 +75,6 @@ import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import com.liferay.util.StringPool;
 
-import graphql.AssertException;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -1991,7 +1990,7 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link ESContentletAPIImpl#saveContentOnVariant(Contentlet, String, User)}
+     * Method to test: {@link ESContentletAPIImpl#copyContentToVariant(Contentlet, String, User)}
      * When:
      * - Create a {@link Contentlet} in the DEFAULT Variant.
      * - Create a new {@link Variant}.
@@ -2019,7 +2018,7 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
 
         ContentletDataGen.createNewVersion(contentlet, variant, map("title", "Variant Version"));
 
-        APILocator.getContentletAPI().saveContentOnVariant(contentlet, variant.name(),
+        APILocator.getContentletAPI().copyContentToVariant(contentlet, variant.name(),
                 APILocator.systemUser());
 
         final Contentlet contentletByIdentifierSpecificVariant = APILocator.getContentletAPI()
@@ -2047,7 +2046,7 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link ESContentletAPIImpl#saveContentOnVariant(Contentlet, String, User)}
+     * Method to test: {@link ESContentletAPIImpl#copyContentToVariant(Contentlet, String, User)}
      * When:
      * - Creata a {@link Variant} let call it variant_1
      * - Create a {@link Contentlet} with a version in variant_1, but not any version in DEFAULT Variant.
@@ -2074,7 +2073,7 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
                 .setProperty("title", "Variant 1 Version")
                 .variant(variant_1)
                 .nextPersisted();
-        APILocator.getContentletAPI().saveContentOnVariant(contentlet, variant_2.name(),
+        APILocator.getContentletAPI().copyContentToVariant(contentlet, variant_2.name(),
                 APILocator.systemUser());
 
         final Contentlet contentletByIdentifierVariant1 = APILocator.getContentletAPI()

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -22,6 +22,7 @@ import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.FieldAPI;
 import com.dotcms.contenttype.model.field.BinaryField;
+import com.dotcms.contenttype.model.field.DataTypes;
 import com.dotcms.contenttype.model.field.DateTimeField;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.FieldBuilder;
@@ -74,6 +75,7 @@ import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import com.liferay.util.StringPool;
 
+import graphql.AssertException;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -1987,4 +1989,122 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
 
         return APILocator.getHTMLPageAssetAPI().fromContentlet(contentlet);
     }
+
+    /**
+     * Method to test: {@link ESContentletAPIImpl#saveContentOnVariant(Contentlet, String, User)}
+     * When:
+     * - Create a {@link Contentlet} in the DEFAULT Variant.
+     * - Create a new {@link Variant}.
+     * - Create a new Version of the newly created {@link Contentlet} into the newly {@link Variant}
+     * - Save a new version os the {@link Contentlet} in the specific {@link Variant} version.
+     * Should: Create  a copy from the specific {@link Variant} {@link Contentlet} Version to the DEFAULT {@link Variant}
+     */
+    @Test
+    public void saveContentToSpecificVariant() throws DotDataException, DotSecurityException {
+        final Language language = new LanguageDataGen().nextPersisted();
+        final Variant variant = new VariantDataGen().nextPersisted();
+
+        final Field titleField = new FieldDataGen()
+                .name("title")
+                .velocityVarName("title")
+                .dataType(DataTypes.TEXT)
+                .indexed(true)
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen().field(titleField).nextPersisted();
+        final Contentlet contentlet = new ContentletDataGen(contentType)
+                .languageId(language.getId())
+                .setProperty("title", "Default Version")
+                .nextPersisted();
+
+        ContentletDataGen.createNewVersion(contentlet, variant, map("title", "Variant Version"));
+
+        APILocator.getContentletAPI().saveContentOnVariant(contentlet, variant.name(),
+                APILocator.systemUser());
+
+        final Contentlet contentletByIdentifierSpecificVariant = APILocator.getContentletAPI()
+                .findContentletByIdentifier(contentlet.getIdentifier(), false,
+                        language.getId(), variant.name(), APILocator.systemUser(), false);
+
+        assertNotNull(contentletByIdentifierSpecificVariant);
+
+        assertEquals(contentlet.getIdentifier(), contentletByIdentifierSpecificVariant.getIdentifier());
+        assertEquals(contentlet.getLanguageId(), contentletByIdentifierSpecificVariant.getLanguageId());
+        assertEquals(variant.name(), contentletByIdentifierSpecificVariant.getVariantId());
+        assertEquals("Default Version", contentletByIdentifierSpecificVariant.getStringProperty("title"));
+
+        final Contentlet contentletByIdentifierDefaultVariant = APILocator.getContentletAPI()
+                .findContentletByIdentifier(contentlet.getIdentifier(), false,
+                        language.getId(), VariantAPI.DEFAULT_VARIANT.name(),
+                        APILocator.systemUser(), false);
+
+        assertNotNull(contentletByIdentifierDefaultVariant);
+
+        assertEquals(contentlet.getIdentifier(), contentletByIdentifierDefaultVariant.getIdentifier());
+        assertEquals(contentlet.getLanguageId(), contentletByIdentifierDefaultVariant.getLanguageId());
+        assertEquals(contentlet.getVariantId(), contentletByIdentifierDefaultVariant.getVariantId());
+        assertEquals("Default Version", contentletByIdentifierSpecificVariant.getStringProperty("title"));
+    }
+
+    /**
+     * Method to test: {@link ESContentletAPIImpl#saveContentOnVariant(Contentlet, String, User)}
+     * When:
+     * - Creata a {@link Variant} let call it variant_1
+     * - Create a {@link Contentlet} with a version in variant_1, but not any version in DEFAULT Variant.
+     * - Create another {@link Variant}, let call it variant_2.
+     * - Save a new version os the {@link Contentlet} in variant_2.
+     * Should: Create  a copy from the variant_1 {@link Contentlet} Version to the DEFAULT {@link Variant}
+     */
+    @Test
+    public void saveContentToAnotherVariant() throws DotDataException, DotSecurityException {
+        final Language language = new LanguageDataGen().nextPersisted();
+        final Variant variant_1 = new VariantDataGen().nextPersisted();
+        final Variant variant_2 = new VariantDataGen().nextPersisted();
+
+        final Field titleField = new FieldDataGen()
+                .name("title")
+                .velocityVarName("title")
+                .dataType(DataTypes.TEXT)
+                .indexed(true)
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen().field(titleField).nextPersisted();
+        final Contentlet contentlet = new ContentletDataGen(contentType)
+                .languageId(language.getId())
+                .setProperty("title", "Variant 1 Version")
+                .variant(variant_1)
+                .nextPersisted();
+        APILocator.getContentletAPI().saveContentOnVariant(contentlet, variant_2.name(),
+                APILocator.systemUser());
+
+        final Contentlet contentletByIdentifierVariant1 = APILocator.getContentletAPI()
+                .findContentletByIdentifier(contentlet.getIdentifier(), false,
+                        language.getId(), variant_1.name(), APILocator.systemUser(), false);
+
+        assertNotNull(contentletByIdentifierVariant1);
+
+        assertEquals(contentlet.getIdentifier(), contentletByIdentifierVariant1.getIdentifier());
+        assertEquals(contentlet.getLanguageId(), contentletByIdentifierVariant1.getLanguageId());
+        assertEquals(variant_1.name(), contentletByIdentifierVariant1.getVariantId());
+        assertEquals("Variant 1 Version", contentletByIdentifierVariant1.getStringProperty("title"));
+
+        final Contentlet contentletByIdentifierDefaultVariant = APILocator.getContentletAPI()
+                .findContentletByIdentifier(contentlet.getIdentifier(), false,
+                        language.getId(), VariantAPI.DEFAULT_VARIANT.name(),
+                        APILocator.systemUser(), false);
+
+        assertNull(contentletByIdentifierDefaultVariant);
+
+        final Contentlet contentletByIdentifierVariant2 = APILocator.getContentletAPI()
+                .findContentletByIdentifier(contentlet.getIdentifier(), false,
+                        language.getId(), variant_2.name(), APILocator.systemUser(), false);
+
+        assertNotNull(contentletByIdentifierVariant2);
+
+        assertEquals(contentlet.getIdentifier(), contentletByIdentifierVariant2.getIdentifier());
+        assertEquals(contentlet.getLanguageId(), contentletByIdentifierVariant2.getLanguageId());
+        assertEquals(variant_2.name(), contentletByIdentifierVariant2.getVariantId());
+        assertEquals("Variant 1 Version", contentletByIdentifierVariant2.getStringProperty("title"));
+    }
+
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/ContentletDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/ContentletDataGen.java
@@ -19,8 +19,11 @@ import com.dotmarketing.portlets.contentlet.business.DotContentletStateException
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
+import com.liferay.portal.model.User;
 import io.vavr.control.Try;
 import java.io.File;
 import java.net.URL;
@@ -430,5 +433,58 @@ public class ContentletDataGen extends AbstractDataGen<Contentlet> {
         final Contentlet contentlet = nextPersisted();
         publish(contentlet);
         return contentlet;
+    }
+
+    /**
+     * Creates a new version of a {@link Contentlet} based on the given inode and variantId
+     *
+     * @param user to check permission
+     * @param oldContentletVersion old {@link Contentlet} version
+     * @param variantId Target {@link Variant}
+     * @return
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    public static Contentlet createNewVersion(final Contentlet oldContentletVersion,
+            final Variant variant, final Map<String, Object> properties) throws DotDataException, DotSecurityException {
+        final Language defaultLanguage = APILocator.getLanguageAPI().getDefaultLanguage();
+        return createNewVersion(oldContentletVersion, variant, defaultLanguage, properties);
+    }
+
+    public static Contentlet createNewVersion(final Contentlet oldContentletVersion,
+        final Variant variant, final Language language, final Map<String, Object> properties)
+            throws DotDataException, DotSecurityException {
+
+        final User user = APILocator.systemUser();
+        final Contentlet checkout = APILocator.getContentletAPI()
+                .checkout(oldContentletVersion.getInode(), user, false);
+
+        checkout.setVariantId(variant.name());
+        checkout.setLanguageId(language.getId());
+
+        if (properties != null) {
+            properties.forEach((key, value) -> checkout.getMap().put(key, value));
+        }
+
+        return APILocator.getContentletAPI().checkin(checkout, user, false);
+    }
+
+    /**
+     * Update a Contentlet using the given properties
+     *
+     * @param contentlet
+     * @param updatedProperties
+     */
+    public static void update(final Contentlet contentlet, final Map<String, Object> updatedProperties) {
+        try {
+            final Contentlet contentletToUpdate = APILocator.getContentletAPI().find(contentlet.getInode(), APILocator.systemUser(), false);
+            final Contentlet checkout = APILocator.getContentletAPI()
+                    .checkout(contentletToUpdate.getInode(), APILocator.systemUser(), false);
+            updatedProperties.forEach((key, value) -> checkout.getMap().put(key, value));
+            APILocator.getContentletAPI().checkin(checkout, APILocator.systemUser(), false);
+        } catch (DotDataException | DotSecurityException e) {
+            throw new RuntimeException(e);
+        }
+
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/variant/VariantAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/variant/VariantAPITest.java
@@ -1,25 +1,51 @@
 package com.dotcms.variant;
 
+import static com.dotcms.util.CollectionsUtils.map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import com.dotcms.contenttype.model.field.Field;
+import com.dotcms.contenttype.model.field.TextField;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.datagen.ContainerDataGen;
+import com.dotcms.datagen.ContentTypeDataGen;
+import com.dotcms.datagen.ContentletDataGen;
+import com.dotcms.datagen.FieldDataGen;
+import com.dotcms.datagen.HTMLPageDataGen;
+import com.dotcms.datagen.LanguageDataGen;
+import com.dotcms.datagen.MultiTreeDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.TemplateDataGen;
 import com.dotcms.datagen.VariantDataGen;
 import com.dotcms.experiments.business.ExperimentsAPI;
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.util.ConversionUtils;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.variant.model.Variant;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.beans.MultiTree;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.containers.model.Container;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.dotmarketing.portlets.templates.model.Template;
 import com.liferay.portal.model.User;
+import graphql.AssertException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -364,4 +390,773 @@ public class VariantAPITest {
     public void testDeleteDefaultVariant_shouldFail() throws DotDataException {
         APILocator.getVariantAPI().delete(VariantAPI.DEFAULT_VARIANT.name());
     }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}}
+     * When:
+     * - You create a {@link Variant}
+     * - Create two {@link Contentlet} and create a version in the newly {@link Variant} also create
+     * version to the DEFAULT Variant, not publish any of this versions.
+     * - Promote the {@link Variant}
+     *
+     * Should:
+     * - Copy the specific version of the {@link Contentlet} and turn it into the WORKING DEFAULT Variant
+     */
+    @Test
+    public void promoteWorkingVersion() throws DotDataException, DotSecurityException {
+
+        final Field titleField = new FieldDataGen()
+                .type(TextField.class)
+                .name("title")
+                .velocityVarName("title")
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .field(titleField)
+                .nextPersisted();
+
+        final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "contentlet1")
+                .nextPersisted();
+
+        final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "contentlet2")
+                .nextPersisted();
+
+        final Variant variant = new VariantDataGen().nextPersisted();
+
+        ContentletDataGen.createNewVersion(contentlet1, variant, map(
+                titleField.variable(), "contentlet1_variant"
+        ));
+        ContentletDataGen.createNewVersion(contentlet2, variant, map(
+                titleField.variable(), "contentlet2_variant"
+        ));
+
+        APILocator.getVariantAPI().promote(variant, APILocator.systemUser());
+
+        checkVersion(contentlet1, false, VariantAPI.DEFAULT_VARIANT, "contentlet1_variant",
+                titleField);
+
+        checkVersion(contentlet2, false, VariantAPI.DEFAULT_VARIANT, "contentlet2_variant",
+                titleField);
+
+        final Variant variantFromDataBase = APILocator.getVariantAPI().get(variant.name())
+                .orElseThrow(() -> new DotStateException("Unable to find Variant"));
+
+        assertTrue(variantFromDataBase.archived());
+    }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}
+     * When:
+     * - You create a {@link Variant}
+     * - Create two {@link Contentlet} and create a version into the newly {@link Variant} also
+     * create version to the DEFAULT Variant, Save and publish them.
+     * - Make any change to the {@link Contentlet} and just save.
+     * - Promote the {@link Variant}
+     *
+     * Should:
+     * - Copy both version of the specific Variant  and turn it into the WORKING/LIVE DEFAULT Variant
+     */
+    @Test
+    public void promoteWorkingLiveVersion() throws DotDataException, DotSecurityException {
+        final Field titleField = new FieldDataGen()
+                .type(TextField.class)
+                .name("title")
+                .velocityVarName("title")
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .field(titleField)
+                .nextPersisted();
+
+        final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "LIVE contentlet1")
+                .nextPersisted();
+
+        final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "LIVE contentlet2")
+                .nextPersisted();
+
+        final Variant variant = new VariantDataGen().nextPersisted();
+
+        final Contentlet contentlet1Variant = ContentletDataGen.createNewVersion(contentlet1,
+                variant, map(
+                        titleField.variable(), "LIVE contentlet1_variant"
+                ));
+        final Contentlet contentlet2Variant = ContentletDataGen.createNewVersion(contentlet2,
+                variant, map(
+                        titleField.variable(), "LIVE contentlet2_variant"
+                ));
+
+        APILocator.getContentletAPI().publish(contentlet1, APILocator.systemUser(), false);
+        APILocator.getContentletAPI().publish(contentlet2, APILocator.systemUser(), false);
+
+        APILocator.getContentletAPI().publish(contentlet1Variant, APILocator.systemUser(), false);
+        APILocator.getContentletAPI().publish(contentlet2Variant, APILocator.systemUser(), false);
+
+        ContentletDataGen.update(contentlet1, map("title", "WORKING contentlet1"));
+        ContentletDataGen.update(contentlet2, map("title", "WORKING contentlet2"));
+        ContentletDataGen.update(contentlet1Variant, map("title", "WORKING contentlet1_variant"));
+        ContentletDataGen.update(contentlet2Variant, map("title", "WORKING contentlet2_variant"));
+
+        APILocator.getVariantAPI().promote(variant, APILocator.systemUser());
+
+        checkVersion(contentlet1, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet1_variant",
+                titleField);
+
+        checkVersion(contentlet1, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet1_variant",
+                titleField);
+
+        checkVersion(contentlet1, false, variant, "WORKING contentlet1_variant", titleField);
+        checkVersion(contentlet1, true, variant, "LIVE contentlet1_variant", titleField);
+
+
+        checkVersion(contentlet2, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet2_variant",
+                titleField);
+        checkVersion(contentlet2, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet2_variant",
+                titleField);
+
+        checkVersion(contentlet2, true, variant, "LIVE contentlet2_variant", titleField);
+        checkVersion(contentlet2, false, variant, "WORKING contentlet2_variant", titleField);
+    }
+
+    private static void checkVersion(final Contentlet contentlet, final boolean live,
+            final Variant defaultVariant, final String value, final Field titleField)
+            throws DotDataException, DotSecurityException {
+
+        checkVersion(contentlet, live, defaultVariant, APILocator.getLanguageAPI().getDefaultLanguage(),
+                value, titleField);
+    }
+    private static void checkVersion(Contentlet contentlet, boolean live, Variant defaultVariant,
+            final Language language, final String  value, Field titleField)
+            throws DotDataException, DotSecurityException {
+
+        final Contentlet contentlet1DefaultVariantFromDataBase = APILocator.getContentletAPI()
+                .findContentletByIdentifier(contentlet.getIdentifier(),
+                        live, language.getId(),
+                        defaultVariant.name(), APILocator.systemUser(),
+                        false);
+
+        assertEquals(value, contentlet1DefaultVariantFromDataBase
+                .getStringProperty(titleField.variable()));
+    }
+
+    private static void checkNull(final Contentlet contentlet, final boolean live, final Variant defaultVariant)
+            throws DotDataException, DotSecurityException {
+        checkNull(contentlet, live, defaultVariant, APILocator.getLanguageAPI().getDefaultLanguage());
+    }
+
+    private static void checkNull(final Contentlet contentlet, final boolean live,
+            final Variant defaultVariant, final Language language) throws DotDataException, DotSecurityException {
+        final Contentlet contentlet1DefaultVariantFromDataBase = APILocator.getContentletAPI()
+                .findContentletByIdentifier(contentlet.getIdentifier(),
+                        live, language.getId(),
+                        defaultVariant.name(), APILocator.systemUser(),
+                        false);
+
+        assertNull(contentlet1DefaultVariantFromDataBase);
+    }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}
+     * When:
+     * - You create a {@link Variant}
+     * - Create two {@link Contentlet} and create versions of them into the newly {@link Variant}
+     * also create version to the DEFAULT Variant.
+     * - Publish the version for the newly created {@link Variant}.
+     * - Promote the {@link Variant}
+     *
+     * Should:
+     * - Copy both version of the specific Variant  and turn it into the WORKING/LIVE DEFAULT Variant
+     */
+    @Test
+    public void promoteWithOutLiveDefaultVersion() throws DotDataException, DotSecurityException {
+        final Field titleField = new FieldDataGen()
+                .type(TextField.class)
+                .name("title")
+                .velocityVarName("title")
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .field(titleField)
+                .nextPersisted();
+
+        final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "WORKING contentlet1")
+                .nextPersisted();
+
+        final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "WORKING contentlet2")
+                .nextPersisted();
+
+        final Variant variant = new VariantDataGen().nextPersisted();
+
+        final Contentlet contentlet1Variant = ContentletDataGen.createNewVersion(contentlet1,
+                variant, map(
+                        titleField.variable(), "LIVE contentlet1_variant"
+                ));
+        final Contentlet contentlet2Variant = ContentletDataGen.createNewVersion(contentlet2,
+                variant, map(
+                        titleField.variable(), "LIVE contentlet2_variant"
+                ));
+
+        APILocator.getContentletAPI().publish(contentlet1Variant, APILocator.systemUser(), false);
+        APILocator.getContentletAPI().publish(contentlet2Variant, APILocator.systemUser(), false);
+
+        ContentletDataGen.update(contentlet1Variant, map("title", "WORKING contentlet1_variant"));
+        ContentletDataGen.update(contentlet2Variant, map("title", "WORKING contentlet2_variant"));
+
+        APILocator.getVariantAPI().promote(variant, APILocator.systemUser());
+
+        checkVersion(contentlet1, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet1_variant",
+                titleField);
+
+        checkVersion(contentlet1, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet1_variant",
+                titleField);
+
+        checkVersion(contentlet1, false, variant, "WORKING contentlet1_variant", titleField);
+        checkVersion(contentlet1, true, variant, "LIVE contentlet1_variant", titleField);
+
+
+        checkVersion(contentlet2, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet2_variant",
+                titleField);
+        checkVersion(contentlet2, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet2_variant",
+                titleField);
+
+        checkVersion(contentlet2, true, variant, "LIVE contentlet2_variant", titleField);
+        checkVersion(contentlet2, false, variant, "WORKING contentlet2_variant", titleField);
+    }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}
+     * When:
+     * - You create two {@link Variant}s
+     * - Create two {@link Contentlet} and create version in both {@link Variant}s also create version to the DEFAULT Variant.
+     * - Publish all of them.
+     * - Promote one of the {@link Variant}'s
+     *
+     * Should:
+     * - Copy both version of the specific Variant that was promoted and turn it into the WORKING/LIVE DEFAULT Variant
+     */
+    @Test
+    public void promoteWithTwoVersion() throws DotDataException, DotSecurityException {
+        final Field titleField = new FieldDataGen()
+                .type(TextField.class)
+                .name("title")
+                .velocityVarName("title")
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .field(titleField)
+                .nextPersisted();
+
+        final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "LIVE contentlet1")
+                .nextPersisted();
+
+        final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "LIVE contentlet2")
+                .nextPersisted();
+
+        final Variant variant_1 = new VariantDataGen().nextPersisted();
+        final Variant variant_2 = new VariantDataGen().nextPersisted();
+
+        final Contentlet contentlet1Variant1 = ContentletDataGen.createNewVersion(contentlet1,
+                variant_1, map(
+                        titleField.variable(), "LIVE contentlet1_variant_1"
+                ));
+        final Contentlet contentlet2Variant1 = ContentletDataGen.createNewVersion(contentlet2,
+                variant_1, map(
+                        titleField.variable(), "LIVE contentlet2_variant_1"
+                ));
+
+
+        final Contentlet contentlet1Variant2 = ContentletDataGen.createNewVersion(contentlet1,
+                variant_2, map(
+                        titleField.variable(), "LIVE contentlet1_variant_2"
+                ));
+        final Contentlet contentlet2Variant2 = ContentletDataGen.createNewVersion(contentlet2,
+                variant_2, map(
+                        titleField.variable(), "LIVE contentlet2_variant_2"
+                ));
+
+        APILocator.getContentletAPI().publish(contentlet1, APILocator.systemUser(), false);
+        APILocator.getContentletAPI().publish(contentlet2, APILocator.systemUser(), false);
+
+        APILocator.getContentletAPI().publish(contentlet1Variant1, APILocator.systemUser(), false);
+        APILocator.getContentletAPI().publish(contentlet2Variant1, APILocator.systemUser(), false);
+
+        APILocator.getContentletAPI().publish(contentlet1Variant2, APILocator.systemUser(), false);
+        APILocator.getContentletAPI().publish(contentlet2Variant2, APILocator.systemUser(), false);
+
+        ContentletDataGen.update(contentlet1, map("title", "WORKING contentlet1"));
+        ContentletDataGen.update(contentlet2, map("title", "WORKING contentlet2"));
+        ContentletDataGen.update(contentlet1Variant1, map("title", "WORKING contentlet1_variant_1"));
+        ContentletDataGen.update(contentlet2Variant1, map("title", "WORKING contentlet2_variant_1"));
+        ContentletDataGen.update(contentlet1Variant2, map("title", "WORKING contentlet1_variant_2"));
+        ContentletDataGen.update(contentlet2Variant2, map("title", "WORKING contentlet2_variant_2"));
+
+        APILocator.getVariantAPI().promote(variant_1, APILocator.systemUser());
+
+        checkVersion(contentlet1, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet1_variant_1",
+                titleField);
+
+        checkVersion(contentlet1, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet1_variant_1",
+                titleField);
+
+        checkVersion(contentlet1, false, variant_1, "WORKING contentlet1_variant_1", titleField);
+        checkVersion(contentlet1, true, variant_1, "LIVE contentlet1_variant_1", titleField);
+
+        checkVersion(contentlet1, false, variant_2, "WORKING contentlet1_variant_2", titleField);
+        checkVersion(contentlet1, true, variant_2, "LIVE contentlet1_variant_2", titleField);
+
+        checkVersion(contentlet2, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet2_variant_1",
+                titleField);
+        checkVersion(contentlet2, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet2_variant_1",
+                titleField);
+
+        checkVersion(contentlet2, true, variant_1, "LIVE contentlet2_variant_1", titleField);
+        checkVersion(contentlet2, false, variant_1, "WORKING contentlet2_variant_1", titleField);
+
+
+        checkVersion(contentlet2, true, variant_2, "LIVE contentlet2_variant_2", titleField);
+        checkVersion(contentlet2, false, variant_2, "WORKING contentlet2_variant_2", titleField);
+    }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}
+     * When:
+     * - You create one {@link Variant}s
+     * - Create two {@link Contentlet} and create a new version into the  {@link Variant}, no create any version to the DEFAULT Variant.
+     * - Publish.
+     * - Promote the {@link Variant}'s
+     *
+     * Should:
+     * - Copy both version (WORKING and LIVE) of the specific Variant that was promoted and turn it into the WORKING/LIVE DEFAULT Variant
+     */
+    @Test
+    public void promoteWithoutDefaultVersion() throws DotDataException, DotSecurityException {
+        final Field titleField = new FieldDataGen()
+                .type(TextField.class)
+                .name("title")
+                .velocityVarName("title")
+                .next();
+
+        final Variant variant = new VariantDataGen().nextPersisted();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .field(titleField)
+                .nextPersisted();
+
+        final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "LIVE contentlet1_variant")
+                .variant(variant)
+                .nextPersisted();
+
+        final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "LIVE contentlet2_variant")
+                .variant(variant)
+                .nextPersisted();
+
+        APILocator.getContentletAPI().publish(contentlet1, APILocator.systemUser(), false);
+        APILocator.getContentletAPI().publish(contentlet2, APILocator.systemUser(), false);
+
+        ContentletDataGen.update(contentlet1, map("title", "WORKING contentlet1_variant"));
+        ContentletDataGen.update(contentlet2, map("title", "WORKING contentlet2_variant"));
+
+        APILocator.getVariantAPI().promote(variant, APILocator.systemUser());
+
+        checkVersion(contentlet1, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet1_variant",
+                titleField);
+
+        checkVersion(contentlet1, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet1_variant",
+                titleField);
+
+        checkVersion(contentlet1, false, variant, "WORKING contentlet1_variant", titleField);
+        checkVersion(contentlet1, true, variant, "LIVE contentlet1_variant", titleField);
+
+
+        checkVersion(contentlet2, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet2_variant",
+                titleField);
+        checkVersion(contentlet2, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet2_variant",
+                titleField);
+
+        checkVersion(contentlet2, true, variant, "LIVE contentlet2_variant", titleField);
+        checkVersion(contentlet2, false, variant, "WORKING contentlet2_variant", titleField);
+    }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}
+     * When:
+     * - You create one {@link Variant}s
+     * - Create two {@link Contentlet} just for DEFAULT Variant.
+     * - Publish.
+     * - Promote the {@link Variant}'s
+     *
+     * Should: do nothing
+     */
+    @Test
+    public void promoteWithoutVariantVersion() throws DotDataException, DotSecurityException {
+        final Field titleField = new FieldDataGen()
+                .type(TextField.class)
+                .name("title")
+                .velocityVarName("title")
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .field(titleField)
+                .nextPersisted();
+
+        final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "LIVE contentlet1")
+                .nextPersisted();
+
+        final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "LIVE contentlet2")
+                .nextPersisted();
+
+        final Variant variant = new VariantDataGen().nextPersisted();
+
+        APILocator.getContentletAPI().publish(contentlet1, APILocator.systemUser(), false);
+        APILocator.getContentletAPI().publish(contentlet2, APILocator.systemUser(), false);
+
+        ContentletDataGen.update(contentlet1, map("title", "WORKING contentlet1"));
+        ContentletDataGen.update(contentlet2, map("title", "WORKING contentlet2"));
+
+        APILocator.getVariantAPI().promote(variant, APILocator.systemUser());
+
+        checkVersion(contentlet1, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet1",
+                titleField);
+
+        checkVersion(contentlet1, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet1",
+                titleField);
+
+        checkNull(contentlet1, false, variant);
+        checkNull(contentlet1, true, variant);
+
+
+        checkVersion(contentlet2, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet2",
+                titleField);
+        checkVersion(contentlet2, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet2",
+                titleField);
+
+        checkNull(contentlet2, true, variant);
+        checkNull(contentlet2, false, variant);
+    }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}
+     * When:
+     * - You create one {@link Variant}s.
+     * - Create one {@link Contentlet} with a version on this newly variant.
+     * - Archived the Variant.
+     * - Promote the {@link Variant}'s
+     *
+     * Should: thorw a Exception
+     */
+    @Test
+    public void promoteArchivedVariant() throws DotDataException, DotSecurityException {
+        final Field titleField = new FieldDataGen()
+                .type(TextField.class)
+                .name("title")
+                .velocityVarName("title")
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .field(titleField)
+                .nextPersisted();
+
+        final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "DEFAULT contentlet1")
+                .nextPersisted();
+
+        final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "DEFAULT contentlet2")
+                .nextPersisted();
+
+        final Variant variant = new VariantDataGen().nextPersisted();
+
+
+        ContentletDataGen.createNewVersion(contentlet1,
+                variant, map(
+                        titleField.variable(), "LIVE contentlet1_variant_2"
+                ));
+        ContentletDataGen.createNewVersion(contentlet2,
+                variant, map(
+                        titleField.variable(), "LIVE contentlet2_variant_2"
+                ));
+
+        APILocator.getVariantAPI().archive(variant.name());
+
+        try {
+            APILocator.getVariantAPI().promote(variant, APILocator.systemUser());
+            fail("Should throw a Exception");
+        } catch (IllegalArgumentException e) {
+            //Expected
+        }
+    }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}
+     * When: You try to promote a Variant that does not exist
+     * Should: throw a Exception
+     */
+    public void promoteNonExistingVariant() throws DotDataException {
+
+        final Variant doesNotExistsVariant = new VariantDataGen().next();
+        try {
+            APILocator.getVariantAPI().promote(doesNotExistsVariant, APILocator.systemUser());
+            fail("Should throw a Exception");
+        } catch (IllegalArgumentException e) {
+            //Expected
+        }
+    }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}
+     * When: You try to promote the DEFAULT Variant.
+     * Should: throw a Exception
+     */
+    public void promoteDefaultVariant() throws DotDataException {
+        try {
+            APILocator.getVariantAPI().promote(VariantAPI.DEFAULT_VARIANT, APILocator.systemUser());
+            fail("Should throw a Exception");
+        } catch (IllegalArgumentException e) {
+            //Expected
+        }
+    }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}}
+     * When:
+     * - Create a {@link Variant}
+     * - Create 3 {@link com.dotmarketing.portlets.languagesmanager.model.Language}s: language_1, language_2 and language_3
+     * - Create two {@link Contentlet} and create for each of them versions in:
+     *   - DEFAULT Variant and language_1.
+     *   - DEFAULT Variant and language_2.
+     *   - Newly created Variant and language_1.
+     *   - Newly created Variant and language_3.
+     *
+     * - Promote the newly created {@link Variant}
+     *
+     * Should:
+     * - Copy the version of the language_1 to the language_3 to the DEFAULT Variant and keep the
+     * DEFAULT Variant and language_2 as it is.
+     */
+    @Test
+    public void promoteContentletWithSeveralLanguages() throws DotDataException, DotSecurityException {
+
+        final Variant variant = new VariantDataGen().nextPersisted();
+
+        final Language language_1 = new LanguageDataGen().nextPersisted();
+        final Language language_2 = new LanguageDataGen().nextPersisted();
+        final Language language_3 = new LanguageDataGen().nextPersisted();
+
+        final Field titleField = new FieldDataGen()
+                .type(TextField.class)
+                .name("title")
+                .velocityVarName("title")
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .field(titleField)
+                .nextPersisted();
+
+        final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "contentlet1 Language_1")
+                .languageId(language_1.getId())
+                .nextPersisted();
+
+        final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "contentlet2 Language_1")
+                .languageId(language_1.getId())
+                .nextPersisted();
+
+        ContentletDataGen.createNewVersion(contentlet1, VariantAPI.DEFAULT_VARIANT, language_2,
+                map(titleField.variable(), "contentlet1 Language_2"));
+
+        ContentletDataGen.createNewVersion(contentlet1, variant, language_1,
+                map(titleField.variable(), "contentlet1_variant Language_1"));
+
+        ContentletDataGen.createNewVersion(contentlet1, variant, language_3,
+                map(titleField.variable(), "contentlet1_variant Language_3"));
+
+
+        ContentletDataGen.createNewVersion(contentlet2, VariantAPI.DEFAULT_VARIANT, language_2,
+                map(titleField.variable(), "contentlet2 Language_2"));
+
+        ContentletDataGen.createNewVersion(contentlet2, variant, language_1,
+                map(titleField.variable(), "contentlet2_variant Language_1"
+                ));
+
+        ContentletDataGen.createNewVersion(contentlet2, variant, language_3,
+                map(titleField.variable(), "contentlet2_variant Language_3"
+        ));
+
+        APILocator.getVariantAPI().promote(variant, APILocator.systemUser());
+
+        checkVersion(contentlet1, false, VariantAPI.DEFAULT_VARIANT, language_1, "contentlet1_variant Language_1",
+                titleField);
+
+        checkVersion(contentlet1, false, VariantAPI.DEFAULT_VARIANT, language_2, "contentlet1 Language_2",
+                titleField);
+
+        checkVersion(contentlet1, false, VariantAPI.DEFAULT_VARIANT, language_3, "contentlet1_variant Language_3",
+                titleField);
+
+
+        checkVersion(contentlet2, false, VariantAPI.DEFAULT_VARIANT, language_1, "contentlet2_variant Language_1",
+                titleField);
+
+        checkVersion(contentlet2, false, VariantAPI.DEFAULT_VARIANT, language_2, "contentlet2 Language_2",
+                titleField);
+
+        checkVersion(contentlet2, false, VariantAPI.DEFAULT_VARIANT, language_3, "contentlet2_variant Language_3",
+                titleField);
+
+        checkVersion(contentlet1, false, variant, language_1, "contentlet1_variant Language_1",
+                titleField);
+
+        checkNull(contentlet1, false, variant, language_2);
+
+        checkVersion(contentlet1, false, variant, language_3, "contentlet1_variant Language_3",
+                titleField);
+
+
+        checkVersion(contentlet2, false, variant, language_1, "contentlet2_variant Language_1",
+                titleField);
+
+        checkNull(contentlet2, false, variant, language_2);
+
+        checkVersion(contentlet2, false, variant, language_3, "contentlet2_variant Language_3",
+                titleField);
+    }
+
+    /**
+     * Method to test: {@link VariantAPIImpl#promote(Variant, User)}
+     * When:
+     * - Create a {@link Variant}.
+     * - Create two {@link Contentlet} and create version for DEFAULT and the newly created Variant.
+     * - Publish them.
+     * - Create a Page and Create a version of the page for the newly created Variant.
+     * - Add the two {@link Contentlet} to the page.
+     * - Promote the newly created {@link Variant}
+     * Should: Copy the two Contetlet and the page to the DEFAULT Variant, Also should copy the {@link com.dotmarketing.beans.MultiTree}.
+     */
+    public void promotePage() throws DotDataException, DotSecurityException {
+        final Variant variant = new VariantDataGen().nextPersisted();
+
+        final Field titleField = new FieldDataGen()
+                .type(TextField.class)
+                .name("title")
+                .velocityVarName("title")
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .field(titleField)
+                .nextPersisted();
+
+        final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "LIVE contentlet1")
+                .nextPersisted();
+
+        final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                .setProperty(titleField.variable(), "LIVE contentlet2")
+                .nextPersisted();
+
+        final Contentlet contentlet1Variant = ContentletDataGen.createNewVersion(contentlet1,
+                variant, map(
+                        titleField.variable(), "LIVE contentlet1_variant"
+                ));
+        final Contentlet contentlet2Variant = ContentletDataGen.createNewVersion(contentlet2,
+                variant, map(
+                        titleField.variable(), "LIVE contentlet2_variant"
+                ));
+
+        APILocator.getContentletAPI().publish(contentlet1, APILocator.systemUser(), false);
+        APILocator.getContentletAPI().publish(contentlet2, APILocator.systemUser(), false);
+
+        APILocator.getContentletAPI().publish(contentlet1Variant, APILocator.systemUser(), false);
+        APILocator.getContentletAPI().publish(contentlet2Variant, APILocator.systemUser(), false);
+
+        ContentletDataGen.update(contentlet1, map("title", "WORKING contentlet1"));
+        ContentletDataGen.update(contentlet2, map("title", "WORKING contentlet2"));
+        ContentletDataGen.update(contentlet1Variant, map("title", "WORKING contentlet1_variant"));
+        ContentletDataGen.update(contentlet2Variant, map("title", "WORKING contentlet2_variant"));
+
+        final Host host = new SiteDataGen().nextPersisted();
+        final Container container = new ContainerDataGen().nextPersisted();
+        final Template template = new TemplateDataGen().withContainer(container.getIdentifier()).nextPersisted();
+
+        final HTMLPageAsset htmlPageAsset = new HTMLPageDataGen(host, template).nextPersisted();
+
+        new MultiTreeDataGen()
+                .setContainer(container)
+                .setPage(htmlPageAsset)
+                .setContentlet(contentlet1)
+                .nextPersisted();
+
+        new MultiTreeDataGen()
+                .setContainer(container)
+                .setPage(htmlPageAsset)
+                .setContentlet(contentlet2)
+                .nextPersisted();
+
+        APILocator.getVariantAPI().promote(variant, APILocator.systemUser());
+
+        checkVersion(contentlet1, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet1_variant Language_1",
+                titleField);
+
+        checkVersion(contentlet1, false, variant, "WORKING contentlet1_variant Language_1",
+                titleField);
+
+        checkVersion(contentlet1, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet1_variant Language_1",
+                titleField);
+
+        checkVersion(contentlet1, true, variant, "LIVE contentlet1_variant Language_1",
+                titleField);
+
+        checkVersion(contentlet2, false, VariantAPI.DEFAULT_VARIANT, "WORKING contentlet2_variant Language_1",
+                titleField);
+
+        checkVersion(contentlet2, false, variant, "WORKING contentlet2_variant Language_1",
+                titleField);
+
+        checkVersion(contentlet2, true, VariantAPI.DEFAULT_VARIANT, "LIVE contentlet2_variant Language_1",
+                titleField);
+
+        checkVersion(contentlet2, true, variant, "LIVE contentlet2_variant Language_1",
+                titleField);
+
+        checkNull(htmlPageAsset, false, variant);
+
+        final List<MultiTree> multiTrees = APILocator.getMultiTreeAPI()
+                .getMultiTrees(htmlPageAsset.getIdentifier());
+
+        assertEquals(4, multiTrees.size());
+
+        final List<MultiTree> defaultMultiTrees = multiTrees.stream()
+                .filter(multiTree -> multiTree.getVariantId().equals(VariantAPI.DEFAULT_VARIANT))
+                .collect(Collectors.toList());
+
+        assertEquals(2, defaultMultiTrees.size());
+        defaultMultiTrees.stream().map(multiTree -> multiTree.getContentlet())
+                .forEach(contentletIdentifier ->
+                    assertTrue(contentletIdentifier.equals(contentlet1.getIdentifier()) ||
+                            contentletIdentifier.equals(contentlet2.getIdentifier()))
+                );
+
+        final List<MultiTree> variantMultiTrees = multiTrees.stream()
+                .filter(multiTree -> multiTree.getVariantId().equals(variant.name()))
+                .collect(Collectors.toList());
+
+        assertEquals(2, variantMultiTrees.size());
+        variantMultiTrees.stream().map(multiTree -> multiTree.getContentlet())
+                .forEach(contentletIdentifier ->
+                    assertTrue(contentletIdentifier.equals(contentlet1.getIdentifier()) ||
+                            contentletIdentifier.equals(contentlet2.getIdentifier()))
+                );
+    }
 }
+

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -219,7 +219,6 @@ import static com.dotcms.exception.ExceptionUtil.getLocalizedMessageOrDefault;
 import static com.dotmarketing.business.PermissionAPI.PERMISSION_CAN_ADD_CHILDREN;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.URL_MAP_FOR_CONTENT_KEY;
 import static com.dotmarketing.portlets.personas.business.PersonaAPI.DEFAULT_PERSONA_NAME_KEY;
-import static com.twelvemonkeys.io.FileUtil.list;
 
 /**
  * Implementation class for the {@link ContentletAPI} interface.
@@ -3718,13 +3717,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
         final String inode = contentlet.getInode();
         final Contentlet checkedoutContentlet = Try.of(() -> checkout(inode, user, false))
                 .getOrElseThrow(
-                        (e) -> new DotStateException("Unable to checkout content. Inode:" + inode, e));
+                        e -> new DotStateException("Unable to checkout content. Inode:" + inode, e));
 
         checkedoutContentlet.setVariantId(variantName);
 
         return Try.of(() -> checkin(checkedoutContentlet, user, false))
                  .getOrElseThrow(
-                        (e) -> new DotStateException("Unable to checkin content. Inode:" + inode, e));
+                        e -> new DotStateException("Unable to checkin content. Inode:" + inode, e));
     }
 
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -3711,19 +3711,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     @WrapInTransaction
     @Override
-    public Contentlet saveContentOnVariant(final Contentlet contentlet, final String variantName,
-            final User user){
+    public Contentlet copyContentToVariant(final Contentlet contentlet, final String variantName,
+            final User user) throws DotDataException, DotSecurityException {
 
-        final String inode = contentlet.getInode();
-        final Contentlet checkedoutContentlet = Try.of(() -> checkout(inode, user, false))
-                .getOrElseThrow(
-                        e -> new DotStateException("Unable to checkout content. Inode:" + inode, e));
+        final Contentlet contentletFromDataBase = find(contentlet.getInode(), user, false);
 
-        checkedoutContentlet.setVariantId(variantName);
+        final Contentlet checkout = checkout(contentletFromDataBase.getInode(), user, false);
+        checkout.setVariantId(variantName);
 
-        return Try.of(() -> checkin(checkedoutContentlet, user, false))
+        return Try.of(() -> checkin(checkout, user, false))
                  .getOrElseThrow(
-                        e -> new DotStateException("Unable to checkin content. Inode:" + inode, e));
+                        e -> new DotStateException("Unable to create a new version from Contentlet:" + contentlet.getInode(), e));
     }
 
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -39,7 +39,6 @@ import com.dotcms.rendering.velocity.services.PageLoader;
 import com.dotcms.rest.AnonymousAccess;
 import com.dotcms.rest.api.v1.temp.DotTempFile;
 import com.dotcms.rest.api.v1.temp.TempFileAPI;
-import com.dotcms.rest.exception.NotFoundException;
 import com.dotcms.storage.FileMetadataAPI;
 import com.dotcms.storage.model.Metadata;
 import com.dotcms.system.event.local.business.LocalSystemEventsAPI;
@@ -220,6 +219,7 @@ import static com.dotcms.exception.ExceptionUtil.getLocalizedMessageOrDefault;
 import static com.dotmarketing.business.PermissionAPI.PERMISSION_CAN_ADD_CHILDREN;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.URL_MAP_FOR_CONTENT_KEY;
 import static com.dotmarketing.portlets.personas.business.PersonaAPI.DEFAULT_PERSONA_NAME_KEY;
+import static com.twelvemonkeys.io.FileUtil.list;
 
 /**
  * Implementation class for the {@link ContentletAPI} interface.
@@ -3709,6 +3709,24 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
 
     }
+
+    @WrapInTransaction
+    @Override
+    public Contentlet saveContentOnVariant(final Contentlet contentlet, final String variantName,
+            final User user){
+
+        final String inode = contentlet.getInode();
+        final Contentlet checkedoutContentlet = Try.of(() -> checkout(inode, user, false))
+                .getOrElseThrow(
+                        (e) -> new DotStateException("Unable to checkout content. Inode:" + inode, e));
+
+        checkedoutContentlet.setVariantId(variantName);
+
+        return Try.of(() -> checkin(checkedoutContentlet, user, false))
+                 .getOrElseThrow(
+                        (e) -> new DotStateException("Unable to checkin content. Inode:" + inode, e));
+    }
+
 
     /**
      * @param contentlet

--- a/dotCMS/src/main/java/com/dotcms/rest/WebResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/WebResource.java
@@ -782,7 +782,6 @@ public  class WebResource {
             this.response=response;
         }
 
-        @VisibleForTesting
         public InitBuilder(final WebResource webResource) {
             this.webResource = webResource;
         }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/variants/VariantResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/variants/VariantResource.java
@@ -50,8 +50,8 @@ public class VariantResource {
         return Response.ok().build();
     }
 
-    private InitDataObject getInitData(@Context HttpServletRequest request,
-            @Context HttpServletResponse response) {
+    private InitDataObject getInitData(final HttpServletRequest request,
+            final HttpServletResponse response) {
         return new WebResource.InitBuilder(webResource)
                 .requestAndResponse(request, response)
                 .requiredBackendUser(true)

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/variants/VariantResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/variants/VariantResource.java
@@ -3,6 +3,7 @@ package com.dotcms.rest.api.v1.variants;
 import com.dotcms.rest.InitDataObject;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
+import com.dotcms.rest.exception.NotFoundException;
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
@@ -44,7 +45,7 @@ public class VariantResource {
         final User user = initData.getUser();
 
         final Variant variant = APILocator.getVariantAPI().get(variantName)
-                .orElseThrow(() -> new IllegalArgumentException("Variant not found: " + variantName));
+                .orElseThrow(() -> new NotFoundException("Variant not found: " + variantName));
 
         APILocator.getVariantAPI().promote(variant, user);
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/variants/VariantResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/variants/VariantResource.java
@@ -11,12 +11,10 @@ import com.liferay.portal.model.User;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response.ResponseBuilder;
 import  javax.ws.rs.core.Response;
 import org.glassfish.jersey.server.JSONP;
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/variants/VariantResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/variants/VariantResource.java
@@ -1,0 +1,62 @@
+package com.dotcms.rest.api.v1.variants;
+
+import com.dotcms.rest.InitDataObject;
+import com.dotcms.rest.WebResource;
+import com.dotcms.rest.annotation.NoCache;
+import com.dotcms.variant.model.Variant;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.liferay.portal.model.User;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import  javax.ws.rs.core.Response;
+import org.glassfish.jersey.server.JSONP;
+
+/**
+ * REST API for {@link com.dotcms.variant.model.Variant}
+ */
+@Path("/v1/variants")
+@Tag(name = "Variant")
+public class VariantResource {
+
+    private final WebResource webResource;
+
+    public VariantResource() {
+        webResource =  new WebResource();
+    }
+
+    @PUT
+    @Path("/{variantName}/_promote")
+    @JSONP
+    @NoCache
+    public Response promote(@Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @PathParam("variantName") final String variantName) throws DotDataException {
+
+        final InitDataObject initData = getInitData(request, response);
+        final User user = initData.getUser();
+
+        final Variant variant = APILocator.getVariantAPI().get(variantName)
+                .orElseThrow(() -> new IllegalArgumentException("Variant not found: " + variantName));
+
+        APILocator.getVariantAPI().promote(variant, user);
+
+        return Response.ok().build();
+    }
+
+    private InitDataObject getInitData(@Context HttpServletRequest request,
+            @Context HttpServletResponse response) {
+        return new WebResource.InitBuilder(webResource)
+                .requestAndResponse(request, response)
+                .requiredBackendUser(true)
+                .rejectWhenNoUser(true)
+                .init();
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/config/DotRestApplication.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/config/DotRestApplication.java
@@ -1,9 +1,22 @@
 package com.dotcms.rest.config;
 
 import com.dotcms.contenttype.model.field.FieldTypeResource;
+import com.dotcms.rest.AuditPublishingResource;
+import com.dotcms.rest.BundlePublisherResource;
+import com.dotcms.rest.BundleResource;
+import com.dotcms.rest.CMSConfigResource;
+import com.dotcms.rest.ClusterResource;
+import com.dotcms.rest.EnvironmentResource;
+import com.dotcms.rest.IntegrityResource;
+import com.dotcms.rest.JSPPortlet;
+import com.dotcms.rest.LicenseResource;
+import com.dotcms.rest.OSGIResource;
 import com.dotcms.rest.PublishQueueResource;
+import com.dotcms.rest.RestExamplePortlet;
 import com.dotcms.rest.RulesEnginePortlet;
+import com.dotcms.rest.StructureResource;
 import com.dotcms.rest.TagResource;
+import com.dotcms.rest.WidgetResource;
 import com.dotcms.rest.api.v1.apps.AppsResource;
 import com.dotcms.rest.api.v1.authentication.ApiTokenResource;
 import com.dotcms.rest.api.v1.authentication.AuthenticationResource;
@@ -28,10 +41,12 @@ import com.dotcms.rest.api.v1.experiments.ExperimentsResource;
 import com.dotcms.rest.api.v1.fileasset.FileAssetsResource;
 import com.dotcms.rest.api.v1.folder.FolderResource;
 import com.dotcms.rest.api.v1.form.FormResource;
+import com.dotcms.rest.api.v1.index.ESIndexResource;
 import com.dotcms.rest.api.v1.languages.LanguagesResource;
 import com.dotcms.rest.api.v1.maintenance.JVMInfoResource;
 import com.dotcms.rest.api.v1.maintenance.MaintenanceResource;
 import com.dotcms.rest.api.v1.menu.MenuResource;
+import com.dotcms.rest.api.v1.notification.NotificationResource;
 import com.dotcms.rest.api.v1.page.NavResource;
 import com.dotcms.rest.api.v1.page.PageResource;
 import com.dotcms.rest.api.v1.personalization.PersonalizationResource;
@@ -63,8 +78,11 @@ import com.dotcms.rest.api.v1.temp.TempFileResource;
 import com.dotcms.rest.api.v1.template.TemplateResource;
 import com.dotcms.rest.api.v1.theme.ThemeResource;
 import com.dotcms.rest.api.v1.user.UserResource;
+import com.dotcms.rest.api.v1.variants.VariantResource;
 import com.dotcms.rest.api.v1.versionable.VersionableResource;
 import com.dotcms.rest.api.v1.vtl.VTLResource;
+import com.dotcms.rest.api.v1.workflow.WorkflowResource;
+import com.dotcms.rest.elasticsearch.ESContentResourcePortlet;
 import com.dotcms.rest.personas.PersonasResourcePortlet;
 import com.dotcms.rest.servlet.ReloadableServletContainer;
 import com.google.common.collect.ImmutableSet;
@@ -124,25 +142,25 @@ public class DotRestApplication extends javax.ws.rs.core.Application {
 	 */
 	private final static Set<Class<?>> INTERNAL_CLASSES = ImmutableSet.<Class<?>>builder()
 			.add(MultiPartFeature.class)
-			.add(com.dotcms.rest.api.v1.index.ESIndexResource.class)
+			.add(ESIndexResource.class)
 			.add(com.dotcms.rest.RoleResource.class)
-			.add(com.dotcms.rest.BundleResource.class)
-			.add(com.dotcms.rest.StructureResource.class)
+			.add(BundleResource.class)
+			.add(StructureResource.class)
 			.add(com.dotcms.rest.ContentResource.class)
-			.add(com.dotcms.rest.BundlePublisherResource.class)
-			.add(com.dotcms.rest.JSPPortlet.class)
-			.add(com.dotcms.rest.AuditPublishingResource.class)
-			.add(com.dotcms.rest.WidgetResource.class)
-			.add(com.dotcms.rest.CMSConfigResource.class)
-			.add(com.dotcms.rest.OSGIResource.class)
+			.add(BundlePublisherResource.class)
+			.add(JSPPortlet.class)
+			.add(AuditPublishingResource.class)
+			.add(WidgetResource.class)
+			.add(CMSConfigResource.class)
+			.add(OSGIResource.class)
 			.add(com.dotcms.rest.UserResource.class)
-			.add(com.dotcms.rest.ClusterResource.class)
-			.add(com.dotcms.rest.EnvironmentResource.class)
-			.add(com.dotcms.rest.api.v1.notification.NotificationResource.class)
-			.add(com.dotcms.rest.IntegrityResource.class)
-			.add(com.dotcms.rest.LicenseResource.class)
-			.add(com.dotcms.rest.RestExamplePortlet.class)
-			.add(com.dotcms.rest.elasticsearch.ESContentResourcePortlet.class)
+			.add(ClusterResource.class)
+			.add(EnvironmentResource.class)
+			.add(NotificationResource.class)
+			.add(IntegrityResource.class)
+			.add(LicenseResource.class)
+			.add(RestExamplePortlet.class)
+			.add(ESContentResourcePortlet.class)
 			.add(PersonaResource.class)
 			.add(UserResource.class)
 			.add(TagResource.class)
@@ -184,7 +202,7 @@ public class DotRestApplication extends javax.ws.rs.core.Application {
 			.add(CategoriesResource.class)
 			.add(PageResource.class)
 			.add(ContentRelationshipsResource.class)
-			.add(com.dotcms.rest.api.v1.workflow.WorkflowResource.class)
+			.add(WorkflowResource.class)
 			.add(ContainerResource.class)
 			.add(ThemeResource.class)
 			.add(NavResource.class)
@@ -214,6 +232,7 @@ public class DotRestApplication extends javax.ws.rs.core.Application {
 			.add(AcceptHeaderOpenApiResource.class)
 			.add(ExperimentsResource.class)
 			.add(TailLogResource.class)
+			.add(VariantResource.class)
 			.build();
 
 

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantAPI.java
@@ -2,6 +2,7 @@ package com.dotcms.variant;
 
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.exception.DotDataException;
+import com.liferay.portal.model.User;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,8 +61,22 @@ public interface VariantAPI {
     Optional<Variant> get(final String name) throws DotDataException;
 
     /**
-     * Gets all persisted {@link Variant}
+     * Gets all persisted {@link Variant} that are not archived
      * @return the variants
      */
     List<Variant> getVariants() throws DotDataException;
+
+    /**
+     * This method will set the {@link Variant} as the DEFAULT Variant.
+     *
+     * It means that all the contentlets's version in the specific {@link Variant} are going
+     * to be copied and set as the DEFAULT version.
+     *
+     * Also this new copies are goignt o be the LIVE version into teh DEFAULT {@link Variant}.
+     *
+     * @param variant
+     * @param user to check permissions
+     * @throws DotDataException
+     */
+    void promote(final Variant variant, final User user) throws DotDataException;
 }

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
@@ -164,7 +164,7 @@ public class VariantAPIImpl implements VariantAPI {
                         .find(contentletVersionInfo.getLiveInode(), user, false);
 
                 final Contentlet contentletOnVariant = APILocator.getContentletAPI()
-                        .saveContentOnVariant(liveContentlet, VariantAPI.DEFAULT_VARIANT.name(), user);
+                        .copyContentToVariant(liveContentlet, VariantAPI.DEFAULT_VARIANT.name(), user);
 
                 APILocator.getContentletAPI().publish(contentletOnVariant, user, false);
             }
@@ -176,7 +176,7 @@ public class VariantAPIImpl implements VariantAPI {
                         .find(contentletVersionInfo.getWorkingInode(), user, false);
 
                 APILocator.getContentletAPI()
-                        .saveContentOnVariant(workingContentlet, VariantAPI.DEFAULT_VARIANT.name(), user);
+                        .copyContentToVariant(workingContentlet, VariantAPI.DEFAULT_VARIANT.name(), user);
             }
 
         } catch (DotDataException | DotSecurityException e) {

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
@@ -138,6 +138,7 @@ public class VariantAPIImpl implements VariantAPI {
         return variantFactory.getVariants();
     }
 
+    @WrapInTransaction
     @Override
     public void promote(final Variant variant, final User user) throws DotDataException {
 

--- a/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/VariantAPIImpl.java
@@ -1,6 +1,5 @@
 package com.dotcms.variant;
 
-import static com.dotcms.util.CollectionsUtils.list;
 
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
@@ -12,18 +11,17 @@ import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.FactoryLocator;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
+
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.jetbrains.annotations.NotNull;
+
 
 /**
  * API of {@link Variant}
@@ -182,7 +180,7 @@ public class VariantAPIImpl implements VariantAPI {
             }
 
         } catch (DotDataException | DotSecurityException e) {
-            throw new RuntimeException(e);
+            throw new DotRuntimeException(e);
         }
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPI.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.business;
 
+import com.dotcms.variant.model.Variant;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -436,4 +437,13 @@ public interface VersionableAPI {
 	List<ContentletVersionInfo> findContentletVersionInfos(String identifier, String variantName)
 			throws DotDataException, DotStateException;
 
+	/**
+	 * Will return a list of all {@link ContentletVersionInfo} for a given {@link com.dotcms.variant.model.Variant},
+	 * if there are multiple languages it is going to return all the languages versions.
+	 *
+	 * @param variant
+	 * @return
+	 * @throws DotDataException
+	 */
+	List<ContentletVersionInfo> findAllByVariant(final Variant variant) throws DotDataException;
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPIImpl.java
@@ -712,6 +712,7 @@ public class VersionableAPIImpl implements VersionableAPI {
     }
 	
 	@Override
+    @CloseDBIfOpened
     public List<ContentletVersionInfo> findAllByVariant(final Variant variant) throws DotDataException{
         return versionableFactory.findAllByVariant(variant);
     }

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPIImpl.java
@@ -10,6 +10,7 @@ import com.dotcms.api.system.event.message.builder.SystemMessageBuilder;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.concurrent.Debouncer;
+import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.beans.VersionInfo;
 import com.dotmarketing.exception.DotDataException;
@@ -710,7 +711,11 @@ public class VersionableAPIImpl implements VersionableAPI {
         return versionableFactory.findAllContentletVersionInfos(identifier, variantName);
     }
 	
-	
+	@Override
+    public List<ContentletVersionInfo> findAllByVariant(final Variant variant) throws DotDataException{
+        return versionableFactory.findAllByVariant(variant);
+    }
+
 	@WrapInTransaction
 	@Override
 	public void saveVersionInfo(final VersionInfo vInfo) throws DotDataException, DotStateException {

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactory.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.business;
 
+import com.dotcms.variant.model.Variant;
 import java.util.List;
 import java.util.Optional;
 
@@ -255,4 +256,14 @@ public abstract class VersionableFactory {
 
 	protected abstract List<ContentletVersionInfo> findAllContentletVersionInfos(String identifier, String variantName)
 			throws DotDataException, DotStateException ;
+
+	/**
+	 * Return all versions of the {@link com.dotmarketing.portlets.contentlet.model.Contentlet}
+	 * for the specific {@link com.dotcms.variant.model.Variant} no matter the {@Link Language}
+	 *
+	 * @param variant
+	 * @return
+	 */
+    public abstract List<ContentletVersionInfo> findAllByVariant(Variant variant)
+			throws DotDataException;
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactoryImpl.java
@@ -6,6 +6,7 @@ import static com.dotcms.variant.VariantAPI.DEFAULT_VARIANT;
 import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
 import com.dotcms.util.transform.TransformerLocator;
 import com.dotcms.variant.VariantAPI;
+import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.beans.Inode;
 import com.dotmarketing.beans.VersionInfo;
@@ -483,6 +484,21 @@ public class VersionableFactoryImpl extends VersionableFactory {
 	protected List<ContentletVersionInfo> findAllContentletVersionInfos(final String identifier, final String variantName)
 			throws DotDataException, DotStateException {
 		return findContentletVersionInfos(identifier, variantName, -1);
+	}
+
+	public List<ContentletVersionInfo> findAllByVariant(Variant variant)
+			throws DotDataException {
+
+		final DotConnect dotConnect = new DotConnect()
+				.setSQL("SELECT * FROM contentlet_version_info WHERE variant_id = ?")
+				.addParam(variant.name());
+
+		final List<ContentletVersionInfo> versionInfos = TransformerLocator
+				.createContentletVersionInfoTransformer(dotConnect.loadObjectResults()).asList();
+
+		return versionInfos == null || versionInfos.isEmpty()
+				? Collections.emptyList()
+				: versionInfos;
 	}
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -17,7 +17,6 @@ import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.categories.model.Category;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ContentletDependencies;
-import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.links.model.Link;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -2266,6 +2266,6 @@ public interface ContentletAPI {
 	 * @param user        user to check permissions
 	 * @return new contentlet version
 	 */
-	Contentlet saveContentOnVariant(final Contentlet contentlet, final String variantName,
-			final User user);
+	Contentlet copyContentToVariant(final Contentlet contentlet, final String variantName,
+			final User user) throws DotDataException, DotSecurityException;
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -17,6 +17,7 @@ import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.categories.model.Category;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ContentletDependencies;
+import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.links.model.Link;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;
@@ -2258,4 +2259,14 @@ public interface ContentletAPI {
      */
     void refresh(ContentType type) throws DotReindexStateException;
 
+	/**
+	 * This method will create a new version of the contentlet but into variantName.
+	 *
+	 * @param contentlet  to be copied
+	 * @param variantName new variant version
+	 * @param user        user to check permissions
+	 * @return new contentlet version
+	 */
+	Contentlet saveContentOnVariant(final Contentlet contentlet, final String variantName,
+			final User user);
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -22,7 +22,6 @@ import com.dotmarketing.portlets.categories.model.Category;
 import com.dotmarketing.portlets.contentlet.business.hook.HTMLPageHook;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ContentletDependencies;
-import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.links.model.Link;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -1696,8 +1696,8 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
         }
     }
 
-	public Contentlet saveContentOnVariant(final Contentlet contentlet, final String variantName,
-			final User user) {
+	public Contentlet copyContentToVariant(final Contentlet contentlet, final String variantName,
+			final User user) throws DotDataException, DotSecurityException {
 		for(ContentletAPIPreHook pre : preHooks){
 			boolean preResult = pre.saveContentOnVariant(contentlet, variantName, user);
 			if(!preResult){
@@ -1706,7 +1706,7 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 			}
 		}
 
-		final Contentlet saveContentOnVariant = conAPI.saveContentOnVariant(contentlet, variantName, user);
+		final Contentlet saveContentOnVariant = conAPI.copyContentToVariant(contentlet, variantName, user);
 
 		for(ContentletAPIPostHook post : postHooks){
 			post.saveContentOnVariant(contentlet, variantName, user);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -22,6 +22,7 @@ import com.dotmarketing.portlets.categories.model.Category;
 import com.dotmarketing.portlets.contentlet.business.hook.HTMLPageHook;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ContentletDependencies;
+import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.links.model.Link;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;
@@ -1694,6 +1695,25 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
         for(ContentletAPIPostHook post : postHooks){
             post.refresh(type);
         }
+    }
+
+	public Contentlet saveContentOnVariant(final Contentlet contentlet, final String variantName,
+			final User user) {
+		for(ContentletAPIPreHook pre : preHooks){
+			boolean preResult = pre.saveContentOnVariant(contentlet, variantName, user);
+			if(!preResult){
+				Logger.error(this, "The following prehook failed " + pre.getClass().getName());
+				throw new DotRuntimeException("The following prehook failed " + pre.getClass().getName());
+			}
+		}
+
+		final Contentlet saveContentOnVariant = conAPI.saveContentOnVariant(contentlet, variantName, user);
+
+		for(ContentletAPIPostHook post : postHooks){
+			post.saveContentOnVariant(contentlet, variantName, user);
+		}
+
+		return saveContentOnVariant;
     }
 	
 	

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
@@ -1663,4 +1663,8 @@ public interface ContentletAPIPostHook {
 	default void getAllContentByVariants(User user, boolean respectFrontendRoles, String[] variantNames) {
 
 	}
+
+    default void saveContentOnVariant(Contentlet contentlet, String variantName, User user){
+
+	}
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
@@ -1929,4 +1929,8 @@ public interface ContentletAPIPreHook {
 	default boolean getAllContentByVariants(User user, boolean respectFrontendRoles, String[] variantNames) {
     	return true;
 	}
+
+	default boolean saveContentOnVariant(Contentlet contentlet, String variantName, User user){
+		return true;
+	}
 }


### PR DESCRIPTION
### Proposed Changes

- Create new method in ContentletDataGen to create a version of a Contentlet in a different Variant or Languages

https://github.com/dotCMS/core/pull/24450/files#diff-4711bb6f31a328b793310c89d025bb809ab43228cc8d332c3cd982839914801fR448

- Create a method to copy a Contentlet but in a different Variant

https://github.com/dotCMS/core/pull/24450/files#diff-fa1ceaa19618a6b2bbc30e24c6f930b4971f417db50babb748c2e2837ba9eb82R3715

- Create. a end point to promote a Variant

https://github.com/dotCMS/core/pull/24450/files#diff-dfd9f64153f1259d35e5fd20370b26e74b328a36f3b777bfddad9b9610a7f57bR39

It is not possible do any postman test here because we don't have any end point that allow create a version of a Contentlet into a Variant.

- Create a API method to promote a Variant

https://github.com/dotCMS/core/pull/24450/files#diff-a12949e743698a4a040ef3bdb19254e41063e5c10505f5ece12b8a30fe761ef5R81

- Create a method to get all the Contentlet Version for a specific Variant

https://github.com/dotCMS/core/pull/24450/files#diff-6bf601075adc9b86a64f57ca55728b7bae35c56dcd5896c7f5c05b3cb46fcc8aR448

