### PR TITLE
#24344 Don't auto publish content without a publish date

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -80,6 +80,9 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -404,24 +407,28 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 
 			final String publishDateVar = contentType.publishDateVar();
 			if(UtilMethods.isSet(publishDateVar) && UtilMethods.isSet(contentlet.getDateProperty(publishDateVar))) {
-						contentletMap.put(ESMappingConstants.PUBLISH_DATE, publishExpireESDateTimeFormat.get().format(contentlet.getDateProperty(publishDateVar)));
+				contentletMap.put(ESMappingConstants.PUBLISH_DATE,
+						publishExpireESDateTimeFormat.get().format(contentlet.getDateProperty(publishDateVar)));
 				contentletMap.put(ESMappingConstants.PUBLISH_DATE + TEXT,
 						datetimeFormat.format(contentlet.getDateProperty(publishDateVar)));
 			}else {
 				contentletMap.put(ESMappingConstants.PUBLISH_DATE,
-						publishExpireESDateTimeFormat.get().format(versionInfo.get().getVersionTs()));
+						publishExpireESDateTimeFormat.get().format(dateOufOfRange));
 				contentletMap.put(ESMappingConstants.PUBLISH_DATE + TEXT,
-						datetimeFormat.format(versionInfo.get().getVersionTs()));
+						datetimeFormat.format(dateOufOfRange));
 			}
 
 			final String expireDateVar = contentType.expireDateVar();
 			if(UtilMethods.isSet(expireDateVar) &&  UtilMethods.isSet(contentlet.getDateProperty(expireDateVar))) {
-				contentletMap.put(ESMappingConstants.EXPIRE_DATE, publishExpireESDateTimeFormat.get().format(contentlet.getDateProperty(expireDateVar)));
+				contentletMap.put(ESMappingConstants.EXPIRE_DATE,
+						publishExpireESDateTimeFormat.get().format(contentlet.getDateProperty(expireDateVar)));
 				contentletMap.put(ESMappingConstants.EXPIRE_DATE + TEXT,
 						datetimeFormat.format(contentlet.getDateProperty(expireDateVar)));
 			}else {
-				contentletMap.put(ESMappingConstants.EXPIRE_DATE, publishExpireESDateTimeFormat.get().format(29990101000000L));
-				contentletMap.put(ESMappingConstants.EXPIRE_DATE + TEXT, "29990101000000");
+				contentletMap.put(ESMappingConstants.EXPIRE_DATE,
+						publishExpireESDateTimeFormat.get().format(dateOufOfRange));
+				contentletMap.put(ESMappingConstants.EXPIRE_DATE + TEXT,
+						datetimeFormat.format(dateOufOfRange));
 			}
 
 			contentletMap.put(ESMappingConstants.VERSION_TS, elasticSearchDateTimeFormat.format(versionInfo.get().getVersionTs()));
@@ -763,6 +770,9 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 
 	public static final FastDateFormat timeFormat = FastDateFormat.getInstance("HH:mm:ss");
 
+	public static final Date dateOufOfRange = Date.from(
+			LocalDate.of(2999, Month.JANUARY, 1)
+					.atStartOfDay(ZoneId.systemDefault()).toInstant());
 
 	protected void loadFields(final Contentlet contentlet, final Map<String, Object> contentletMap) throws DotDataException {
 


### PR DESCRIPTION
### Proposed Changes
* For content types including Publish Date field, when (re)index a contentlet with an empty publish date, we can set the `pubdate` field to a date out of range. Currently, the method `updatePublishExpireDates()` from the `PublishDateUpdater ` class publishes automatically all the contentlets returned by a query that searches all the contentlets with the `pubdate` value between 1970-01-01 and the current date. With this change, the query results won't include the contentlets saved with an empty publish date in the results.
