### PR TITLE
#24281 Implementing language pull command

### DIFF
--- a/tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/api/LanguageAPI.java
+++ b/tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/api/LanguageAPI.java
@@ -4,6 +4,7 @@ import com.dotcms.api.provider.DefaultResponseExceptionMapper;
 import com.dotcms.api.provider.DotCMSClientHeaders;
 import com.dotcms.model.ResponseEntityView;
 import com.dotcms.model.language.Language;
+import java.util.List;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -24,6 +25,10 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 )
 @RegisterClientHeaders(DotCMSClientHeaders.class)
 @RegisterProvider(DefaultResponseExceptionMapper.class)
+/**
+ * Interface that defines all the operations that can be performed over Languages
+ * @author nollymar
+ */
 public interface LanguageAPI {
 
     @GET
@@ -40,4 +45,10 @@ public interface LanguageAPI {
             summary = " Returns the Language that matches the specified tag"
     )
     ResponseEntityView<Language> getFromLanguageTag(@PathParam("languageTag") String languageTag);
+
+    @GET
+    @Operation(
+            summary = " Returns all the languages in the system"
+    )
+    ResponseEntityView<List<Language>> list();
 }

--- a/tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/api/LanguageAPI.java
+++ b/tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/api/LanguageAPI.java
@@ -1,0 +1,43 @@
+package com.dotcms.api;
+
+import com.dotcms.api.provider.DefaultResponseExceptionMapper;
+import com.dotcms.api.provider.DotCMSClientHeaders;
+import com.dotcms.model.ResponseEntityView;
+import com.dotcms.model.language.Language;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.eclipse.microprofile.openapi.annotations.tags.Tags;
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+
+@Path("/v2/languages")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tags(
+        value = { @Tag(name = "Language")}
+)
+@RegisterClientHeaders(DotCMSClientHeaders.class)
+@RegisterProvider(DefaultResponseExceptionMapper.class)
+public interface LanguageAPI {
+
+    @GET
+    @Path("/id/{languageid}")
+    @Operation(
+            summary = " Returns the Language that matches the specified id"
+    )
+    ResponseEntityView<Language> findById(@PathParam("languageid") String languageId);
+
+
+    @GET
+    @Path("/{languageTag}")
+    @Operation(
+            summary = " Returns the Language that matches the specified tag"
+    )
+    ResponseEntityView<Language> getFromLanguageTag(@PathParam("languageTag") String languageTag);
+}

--- a/tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/model/language/AbstractLanguage.java
+++ b/tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/model/language/AbstractLanguage.java
@@ -1,0 +1,22 @@
+package com.dotcms.model.language;
+
+import com.dotcms.model.annotation.ValueType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+@ValueType
+@Value.Immutable
+@JsonDeserialize(as = Language.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface AbstractLanguage {
+    long id();
+
+    String languageCode();
+
+    String countryCode();
+
+    String language();
+
+    String country();
+}

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/EntryCommand.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/EntryCommand.java
@@ -1,6 +1,7 @@
 package com.dotcms.cli.command;
 
 import com.dotcms.cli.command.contenttype.*;
+import com.dotcms.cli.command.language.LanguageCommand;
 import com.dotcms.cli.command.site.*;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import picocli.CommandLine;
@@ -21,6 +22,8 @@ import picocli.CommandLine.Command;
            ContentTypeCommand.class,
           //--- Site related stuff
            SiteCommand.class,
+          //--- Language related stuff
+           LanguageCommand.class
         }
 )
 public class EntryCommand {

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/AbstractLanguageCommand.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/AbstractLanguageCommand.java
@@ -1,0 +1,49 @@
+package com.dotcms.cli.command.language;
+
+import com.dotcms.api.LanguageAPI;
+import com.dotcms.api.client.RestClientFactory;
+import com.dotcms.model.language.Language;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ *
+ * @author nollymar
+ */
+public abstract class AbstractLanguageCommand {
+
+    @Inject
+    RestClientFactory clientFactory;
+
+    String shortFormat(final Language language) {
+        return String.format(
+                "language: [@|bold,underline,blue %s|@] id: [@|bold,underline,cyan %s|@] code: [@|bold,underline,green %s|@] country:[@|bold,yellow %s|@] countryCode: [@|bold,yellow %s|@]",
+                language.language(),
+                language.id(),
+                language.languageCode(),
+                language.country(),
+                language.countryCode()
+        );
+    }
+
+    Optional<Language> findExistingLanguage(final String languageTagOrId){
+        if (null != languageTagOrId) {
+            final Language language;
+            final LanguageAPI languageAPI = clientFactory.getClient(LanguageAPI.class);
+            try {
+                if (StringUtils.isNumeric(languageTagOrId)) {
+                    language = languageAPI.findById(languageTagOrId).entity();
+                } else {
+                    language = languageAPI.getFromLanguageTag(languageTagOrId).entity();
+                }
+                return Optional.of(language);
+            } catch (NotFoundException nfe){
+            // empty
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/AbstractLanguageCommand.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/AbstractLanguageCommand.java
@@ -28,6 +28,11 @@ public abstract class AbstractLanguageCommand {
         );
     }
 
+    /**
+     * Find a language by id or language tag
+     * @param languageTagOrId
+     * @return
+     */
     Optional<Language> findExistingLanguage(final String languageTagOrId){
         if (null != languageTagOrId) {
             final Language language;

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguageCommand.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguageCommand.java
@@ -5,16 +5,20 @@ import com.dotcms.cli.common.OutputOptionMixin;
 import java.util.List;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
-import picocli.CommandLine.ExitCode;
 
 @CommandLine.Command(
         name = com.dotcms.cli.command.language.LanguageCommand.NAME,
         aliases = { com.dotcms.cli.command.language.LanguageCommand.ALIAS },
         header = "Language CRUD operations.",
         subcommands = {
-                LanguagePull.class
+                LanguagePull.class,
+                LanguageFind.class
         }
 )
+/**
+ * Super command for language operations
+ * @author nollymar
+ */
 public class LanguageCommand implements Callable<Integer> {
 
     static final String NAME = "language";
@@ -35,7 +39,8 @@ public class LanguageCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         spec.commandLine().usage(System.out);
-        return ExitCode.USAGE;
+        output.info("Listing languages (default action)");
+        return spec.commandLine().execute(NAME, LanguageFind.NAME);
     }
 
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguageCommand.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguageCommand.java
@@ -1,0 +1,41 @@
+package com.dotcms.cli.command.language;
+
+import com.dotcms.cli.common.HelpOption;
+import com.dotcms.cli.common.OutputOptionMixin;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.ExitCode;
+
+@CommandLine.Command(
+        name = com.dotcms.cli.command.language.LanguageCommand.NAME,
+        aliases = { com.dotcms.cli.command.language.LanguageCommand.ALIAS },
+        header = "Language CRUD operations.",
+        subcommands = {
+                LanguagePull.class
+        }
+)
+public class LanguageCommand implements Callable<Integer> {
+
+    static final String NAME = "language";
+    static final String ALIAS = "lang";
+
+    @CommandLine.Mixin(name = "output")
+    protected OutputOptionMixin output;
+
+    @CommandLine.Mixin
+    protected HelpOption helpOption;
+
+    @CommandLine.Spec
+    protected CommandLine.Model.CommandSpec spec;
+
+    @CommandLine.Unmatched // avoids throwing errors for unmatched arguments
+    List<String> unmatchedArgs;
+
+    @Override
+    public Integer call() throws Exception {
+        spec.commandLine().usage(System.out);
+        return ExitCode.USAGE;
+    }
+
+}

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguageFind.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguageFind.java
@@ -1,0 +1,43 @@
+package com.dotcms.cli.command.language;
+
+import com.dotcms.api.LanguageAPI;
+import com.dotcms.api.client.RestClientFactory;
+import com.dotcms.cli.common.OutputOptionMixin;
+import com.dotcms.model.language.Language;
+import java.util.List;
+import java.util.concurrent.Callable;
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+import picocli.CommandLine;
+
+@ActivateRequestContext
+@CommandLine.Command(
+        name = LanguageFind.NAME,
+        description = "@|bold,green Get all existing languages|@"
+)
+/**
+ * Command to list all languages
+ * @author nollymar
+ */
+public class LanguageFind extends AbstractLanguageCommand implements Callable<Integer> {
+
+    static final String NAME = "find";
+
+    @CommandLine.Mixin(name = "output")
+    OutputOptionMixin output;
+
+    @Inject
+    RestClientFactory clientFactory;
+
+    @Override
+    public Integer call() throws Exception {
+        final LanguageAPI languageAPI = clientFactory.getClient(LanguageAPI.class);
+        final List<Language> result = languageAPI.list().entity();
+
+        result.forEach(language -> {
+            output.info(shortFormat(language));
+        });
+
+        return CommandLine.ExitCode.OK;
+    }
+}

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePull.java
@@ -21,6 +21,10 @@ import picocli.CommandLine.Parameters;
         name = LanguagePull.NAME,
         description = "@|bold,green Get a language given its id or tag (e.g.: en-us)|@"
 )
+/**
+ * Command to pull a language given its id or tag (e.g.: en-us)
+ * @author nollymar
+ */
 public class LanguagePull extends AbstractLanguageCommand implements Callable<Integer> {
     static final String NAME = "pull";
 

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePull.java
@@ -1,0 +1,77 @@
+package com.dotcms.cli.command.language;
+
+import static com.dotcms.cli.common.Utils.nextFileName;
+
+import com.dotcms.cli.common.OutputOptionMixin;
+import com.dotcms.model.language.Language;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.ws.rs.NotFoundException;
+import picocli.CommandLine;
+import picocli.CommandLine.Parameters;
+
+@ActivateRequestContext
+@CommandLine.Command(
+        name = LanguagePull.NAME,
+        description = "@|bold,green Get a language given its id or tag (e.g.: en-us)|@"
+)
+public class LanguagePull extends AbstractLanguageCommand implements Callable<Integer> {
+    static final String NAME = "pull";
+
+    @CommandLine.Mixin(name = "output")
+    OutputOptionMixin output;
+
+    @Parameters(index = "0", arity = "1", description = "Language Id or Tag.")
+    String languageIdOrTag;
+
+    @CommandLine.Option(names = {"-to", "--saveTo"}, order = 5, description = "Save the returned language to a file.")
+    File saveAs;
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            final Optional<Language> result = super.findExistingLanguage(languageIdOrTag);
+
+            if (result.isEmpty()){
+                output.error(String.format(
+                        "Error occurred while pulling Language Info: [%s].", languageIdOrTag));
+                return CommandLine.ExitCode.SOFTWARE;
+            }
+            final Language language = result.get();
+            final ObjectMapper objectMapper = output.objectMapper();
+
+            if(output.isShortenOutput()) {
+                final String asString = shortFormat(language);
+                output.info(asString);
+            } else {
+                final String asString = objectMapper.writeValueAsString(language);
+                output.info(asString);
+
+                //Saves the pulled language to a file. If the path is given, it will use it, otherwise it will use the language's name
+                final Path path;
+                if (null != saveAs) {
+                    path = saveAs.toPath();
+                } else {
+                    //But this behavior can be modified if we explicitly add a file name
+                    final String fileName = String.format("%s.%s",language.language(),output.getInputOutputFormat().getExtension());
+                    final Path next = Path.of(".", fileName);
+                    path = nextFileName(next);
+                }
+                Files.writeString(path, asString);
+                output.info(String.format("Output has been written to file [%s].",path));
+            }
+        } catch (IOException | NotFoundException e) {
+            output.error(String.format(
+                    "Error occurred while pulling Language: [%s] with message: [%s].",
+                    languageIdOrTag, e.getMessage()));
+            return CommandLine.ExitCode.SOFTWARE;
+        }
+        return CommandLine.ExitCode.OK;
+    }
+}

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/language/LanguageCommandTest.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/language/LanguageCommandTest.java
@@ -1,0 +1,81 @@
+package com.dotcms.cli.command.language;
+
+import com.dotcms.api.AuthenticationContext;
+import com.dotcms.cli.command.CommandTest;
+import com.dotcms.model.language.Language;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+@QuarkusTest
+public class LanguageCommandTest extends CommandTest {
+    @Inject
+    AuthenticationContext authenticationContext;
+
+    @BeforeAll
+    public static void beforeAll() {
+        disableAnsi();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        enableAnsi();
+    }
+
+    @BeforeEach
+    public void setupTest() throws IOException {
+        resetServiceProfiles();
+        final String user = "admin@dotcms.com";
+        final char[] passwd = "admin".toCharArray();
+        authenticationContext.login(user, passwd);
+    }
+
+    /**
+     * Test the language pull command by id. This test will fail if the returned language is not English
+     * @throws JsonProcessingException
+     */
+    @Test
+    void Test_Command_Language_Pull_By_Id() throws JsonProcessingException {
+        final CommandLine commandLine = getFactory().create();
+        final StringWriter writer = new StringWriter();
+        try (PrintWriter out = new PrintWriter(writer)) {
+            commandLine.setOut(out);
+            final int status = commandLine.execute(LanguageCommand.NAME, LanguagePull.NAME, "1");
+            Assertions.assertEquals(CommandLine.ExitCode.OK, status);
+            final String output = writer.toString();
+            final ObjectMapper mapper = new ObjectMapper();
+            Language result = mapper.readValue(output, Language.class);
+            Assertions.assertEquals(1, result.id());
+        }
+    }
+
+    /**
+     * Test the language pull command by tag (en-US). This test will fail if the returned language is not English
+     * @throws JsonProcessingException
+     */
+    @Test
+    void Test_Command_Language_Pull_By_Tag() throws JsonProcessingException {
+        final CommandLine commandLine = getFactory().create();
+        final StringWriter writer = new StringWriter();
+        try (PrintWriter out = new PrintWriter(writer)) {
+            commandLine.setOut(out);
+            final int status = commandLine.execute(LanguageCommand.NAME, LanguagePull.NAME, "en-US");
+            Assertions.assertEquals(CommandLine.ExitCode.OK, status);
+            final String output = writer.toString();
+            final ObjectMapper mapper = new ObjectMapper();
+            Language result = mapper.readValue(output, Language.class);
+            Assertions.assertEquals(1, result.id());
+        }
+    }
+
+}

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/language/LanguageCommandTest.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/language/LanguageCommandTest.java
@@ -78,4 +78,19 @@ public class LanguageCommandTest extends CommandTest {
         }
     }
 
+    /**
+     * Test the language find command. This test will fail if no languages are returned
+     */
+    @Test
+    void Test_Command_Language_Find() {
+        final CommandLine commandLine = getFactory().create();
+        final StringWriter writer = new StringWriter();
+        try (PrintWriter out = new PrintWriter(writer)) {
+            commandLine.setOut(out);
+            final int status = commandLine.execute(LanguageCommand.NAME, LanguageFind.NAME);
+            Assertions.assertEquals(CommandLine.ExitCode.OK, status);
+            final String output = writer.toString();
+            Assertions.assertTrue(output.contains("English"));
+        }
+    }
 }


### PR DESCRIPTION
### Proposed Changes
* New `language pull` command for the CLI. 
* A language can be pulled by id (for example: 1) or by tag (for example: en-US)
* When only `language` is executed, all the languages in the system are listed

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)
