### PR TITLE
dotCMS/core#24457 [UI] Change the mod date to be user friendly (Like Templates) 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.html
@@ -27,10 +27,10 @@
                             {{ experiment.name }}
                         </td>
                         <td data-testId="experiment-row__createdDate">
-                            {{ experiment.creationDate | date : 'longDate' }}
+                            {{ experiment.creationDate | dotRelativeDate : true }}
                         </td>
                         <td data-testId="experiment-row__modDate">
-                            {{ experiment.modDate | date : 'longDate' }}
+                            {{ experiment.modDate | dotRelativeDate : true }}
                         </td>
                         <td data-testId="experiment-row__actions">
                             <ng-container

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
@@ -13,9 +13,11 @@ import { UiDotIconButtonTooltipModule } from '@components/_common/dot-icon-butto
 import { DotMessageService } from '@dotcms/data-access';
 import { DotExperimentStatusList, GroupedExperimentByStatus } from '@dotcms/dotcms-models';
 import { DotIconModule } from '@dotcms/ui';
-import { MockDotMessageService } from '@dotcms/utils-testing';
+import { DotFormatDateServiceMock, MockDotMessageService } from '@dotcms/utils-testing';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
+import { DotRelativeDatePipe } from '@pipes/dot-relative-date/dot-relative-date.pipe';
 import { getExperimentMock } from '@portlets/dot-experiments/test/mocks';
+import { DotFormatDateService } from '@services/dot-format-date-service';
 
 import { DotExperimentsListTableComponent } from './dot-experiments-list-table.component';
 
@@ -68,7 +70,8 @@ describe('DotExperimentsListTableComponent', () => {
             ConfirmPopupModule,
             ToastModule,
             DotMessagePipeModule,
-            RouterTestingModule
+            RouterTestingModule,
+            DotRelativeDatePipe
         ],
         component: DotExperimentsListTableComponent,
         componentMocks: [ConfirmPopup],
@@ -79,7 +82,8 @@ describe('DotExperimentsListTableComponent', () => {
                 useValue: messageServiceMock
             },
             MessageService,
-            ConfirmationService
+            ConfirmationService,
+            { provide: DotFormatDateService, useClass: DotFormatDateServiceMock }
         ]
     });
 
@@ -127,11 +131,9 @@ describe('DotExperimentsListTableComponent', () => {
                 groupedExperimentByStatus.DRAFT[0].name
             );
             expect(spectator.query(byTestId('experiment-row__createdDate'))).toHaveText(
-                groupedExperimentByStatus.DRAFT[0].creationDate.toLocaleDateString()
+                '1 hour ago'
             );
-            expect(spectator.query(byTestId('experiment-row__modDate'))).toHaveText(
-                groupedExperimentByStatus.DRAFT[0].modDate.toLocaleDateString()
-            );
+            expect(spectator.query(byTestId('experiment-row__modDate'))).toHaveText('1 hour ago');
         });
 
         describe('Actions icons', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.module.ts
@@ -16,6 +16,7 @@ import { UiDotIconButtonModule } from '@components/_common/dot-icon-button/dot-i
 import { UiDotIconButtonTooltipModule } from '@components/_common/dot-icon-button-tooltip/dot-icon-button-tooltip.module';
 import { DotIconModule } from '@dotcms/ui';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
+import { DotRelativeDatePipe } from '@pipes/dot-relative-date/dot-relative-date.pipe';
 import { DotExperimentsListRoutingModule } from '@portlets/dot-experiments/dot-experiments-list/dot-experiments-list-routing.module';
 import { DotExperimentsService } from '@portlets/dot-experiments/shared/services/dot-experiments.service';
 import { DotExperimentsUiHeaderComponent } from '@portlets/dot-experiments/shared/ui/dot-experiments-header/dot-experiments-ui-header.component';
@@ -58,7 +59,8 @@ import { DotExperimentsListComponent } from './dot-experiments-list.component';
         MenuModule,
         ConfirmDialogModule,
         ConfirmPopupModule,
-        ToastModule
+        ToastModule,
+        DotRelativeDatePipe
     ],
     providers: [DotExperimentsService]
 })


### PR DESCRIPTION
### Proposed Changes
* add relative date to the dates in the experiment listing. 


### Screenshots
<img width="905" alt="image" src="https://user-images.githubusercontent.com/31667212/227575618-9de36a58-914d-4a0d-85d0-2ba1a3d0f93a.png">
