### PR TITLE
#24492 reads from env if set

### DIFF
--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -97,8 +97,10 @@ def getCheckedOutGitCommitHash() {
 
 if (project.hasProperty('jarBaseName')) {
     archivesBaseName = "$jarBaseName"
-}else{
-    archivesBaseName = 'dotcms_'+dotcmsReleaseVersion+'_'+dotcmsReleaseBuild
+}else if(System.getenv("DOT_JAR_BASE_NAME") != ""){
+    archivesBaseName = "dotcms_" + System.getenv("DOT_JAR_BASE_NAME")
+}else {
+    archivesBaseName = 'dotcms_' + dotcmsReleaseVersion + '_' + dotcmsReleaseBuild
 }
 
 // Utils


### PR DESCRIPTION
### Proposed Changes
- This PR allows the jarBaseName to be set using an environmental variable, which can be fixed by setting the env variable  `DOT_JAR_BASE_NAME ` in any environment that needs to do so.