### PR TITLE
 #24473: Add second variant to Bayesian calculation (ABC)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BayesianAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BayesianAPI.java
@@ -6,6 +6,7 @@ import com.dotcms.analytics.bayesian.model.BayesianPriors;
 import com.dotcms.analytics.bayesian.model.BayesianResult;
 import com.dotcms.variant.VariantAPI;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -15,14 +16,16 @@ import java.util.function.Predicate;
  */
 public interface BayesianAPI {
 
-    String VARIANT_A = "A";
-    String VARIANT_B = "B";
-    String VARIANT_C = "C";
     String TIE = "TIE";
-    String UNKNOWN = "_UNKNOWN_";
+    String NONE = "NONE";
     BayesianPriors NULL_PRIORS = BayesianPriors.builder().alpha(null).beta(null).build();
     Predicate<String> DEFAULT_VARIANT_FILTER = variant -> variant.equals(VariantAPI.DEFAULT_VARIANT.name());
     Predicate<String> OTHER_THAN_DEFAULT_VARIANT_FILTER = variant -> DEFAULT_VARIANT_FILTER.negate().test(variant);
+    BayesianResult NOOP_RESULT = BayesianResult.builder()
+        .value(0.0)
+        .probabilities(List.of())
+        .suggestedWinner(NONE)
+        .build();
 
     /**
      * Calculates probability that B (Test) beats A (Control) based on this pseudo (Julia) code:
@@ -49,5 +52,29 @@ public interface BayesianAPI {
      * @param input {@link BayesianInput} instance
      */
     BayesianResult calcProbBOverA(BayesianInput input);
+
+    /**
+     * Calculates probability that C (Test) beats A (Control) and B (Test) based on this pseudo (Julia) code:
+     *
+     * <pre>
+     *    function probability_C_beats_A_and_B(α_A, β_A, α_B, β_B, α_C, β_C)
+     *        total = 0.0
+     *        for i = 0:(α_A-1)
+     *            for j = 0:(α_B-1)
+     *                total += exp(logbeta(α_C+i+j, β_A+β_B+β_C) - log(β_A+i) - log(β_B+j)
+     *                    - logbeta(1+i, β_A) - logbeta(1+j, β_B) - logbeta(α_C, β_C))
+     *            end
+     *        end
+     *        return (1 - probability_B_beats_A(α_C, β_C, α_A, β_A)
+     *            - probability_B_beats_A(α_C, β_C, α_B, β_B) + total)
+     *    end
+     * </pre>
+     *
+     * Instead of using the provided logBeta function from Apache Commons Math we will use our own implementation:
+     * {@link com.dotcms.analytics.bayesian.BetaDistribution} which provides en density function {@see DotBetaDistribution.pdf()}.
+     *
+     * @param input {@link com.dotcms.analytics.bayesian.model.BayesianInput} instance
+     */
+    BayesianResult calcProbABC(BayesianInput input);
 
 }

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BayesianAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BayesianAPIImpl.java
@@ -1,19 +1,27 @@
 package com.dotcms.analytics.bayesian;
 
 
+import com.dotcms.analytics.bayesian.model.ABTestingType;
 import com.dotcms.analytics.bayesian.model.BayesianInput;
 import com.dotcms.analytics.bayesian.model.BayesianResult;
 import com.dotcms.analytics.bayesian.model.DifferenceData;
 import com.dotcms.analytics.bayesian.model.QuantilePair;
 import com.dotcms.analytics.bayesian.model.SampleData;
 import com.dotcms.analytics.bayesian.model.SampleGroup;
+import com.dotcms.analytics.bayesian.model.VariantInputPair;
+import com.dotcms.analytics.bayesian.model.VariantProbability;
+import com.dotcms.variant.VariantAPI;
+import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.Logger;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.numbers.gamma.LogBeta;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -22,6 +30,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 
 /**
@@ -38,6 +47,8 @@ public class BayesianAPIImpl implements BayesianAPI {
     private static final BiFunction<Double, Double, Double> LOG_BETA_FN = LogBeta::value;
     private static final double HALF = 0.5;
     private static final double TIE_COMPARE_DELTA = 0.01;
+    private static final Comparator<VariantProbability> VARIANT_PROBABILITY_COMPARATOR =
+        Comparator.comparingDouble(VariantProbability::value);
 
     /**
      * {@inheritDoc}
@@ -45,43 +56,99 @@ public class BayesianAPIImpl implements BayesianAPI {
     @Override
     public BayesianResult calcProbBOverA(final BayesianInput input) {
         // validate input
-        validateInput(input);
+        final Optional<BayesianResult> noopResult = detectNoop(input);
+        if (noopResult.isPresent()) {
+            return noopResult.get();
+        }
 
         final boolean priorPresent = isPriorPresent(input);
         final BetaDistribution controlData = priorPresent ? new BetaModel(input).distribution() : null;
         final BetaDistribution testData = priorPresent ? new BetaModel(input).distribution() : null;
         final DifferenceData differenceData = generateDifferenceData(controlData, testData);
-
+        final VariantInputPair control = input.control();
+        final VariantInputPair test = input.variantPairs().get(0);
         // call calculation
-        final double value = calcABTesting(
-            input.controlSuccesses() + 1,
-            input.controlFailures() + 1,
-            input.testSuccesses() + 1,
-            input.testFailures() + 1);
+        final double value = calcABTesting(control, test);
+
         BayesianResult.Builder builder = BayesianResult.builder()
             .value(value)
-            .suggestedWinner(suggestWinner(value, input.variants()));
+            .probabilities(List.of(
+                toProbability(input.control(), 1 - value),
+                toProbability(input.variantPairs().get(0), value)))
+            .suggestedWinner(suggestABWinner(value, control.variant(), input.variantPairs().get(0).variant()));
         if (priorPresent) {
             builder = builder
                 .distributionPdfs(calcDistributionsPdfs(controlData, testData))
                 .differenceData(differenceData)
-                .quantiles(calcQuantiles(differenceData.differences(), input.priors().alpha(), input.priors().beta()));
+                .quantiles(calcQuantiles(
+                    differenceData.differences(),
+                    input.priors().alpha(),
+                    input.priors().beta()));
         }
 
         return builder.build();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BayesianResult calcProbABC(final BayesianInput input) {
+        // validate input
+        final Optional<BayesianResult> noopResult = detectNoop(input);
+        if (noopResult.isPresent()) {
+            return noopResult.get();
+        }
+
+        final List<VariantProbability> results = calcABCTesting(
+            input.control(),
+            input.variantPairs().get(0),
+            input.variantPairs().get(1));
+
+        return BayesianResult.builder()
+            .value(results.get(0).value())
+            .probabilities(results)
+            .suggestedWinner(suggestABCWinner(results))
+            .build();
+    }
+
+    /**
+     * Resolves which variant could be considered as the winner of the test.
+     *
+     * @param value calculated probability that B (Test) beats A (Control)
+     * @param control control variant
+     * @param test test variant
+     * @return winner variant name
+     */
     @NotNull
-    private static String suggestWinner(final double value, final List<String> variants) {
+    private String suggestABWinner(final double value, final String control, final String test) {
         if (Double.compare(HALF, value) == 0 || Math.abs(HALF - value) <= TIE_COMPARE_DELTA) {
             return TIE;
         }
 
-        return variants
+        return value < 0.5 ? control : test;
+    }
+
+    /**
+     * Resolves which variant could be considered as the winner of the test.
+     *
+     * @param probabilities list of probabilities
+     * @return winner variant name
+     */
+    @NotNull
+    private String suggestABCWinner(final List<VariantProbability> probabilities) {
+        final VariantProbability controlProbability = probabilities.get(0);
+        if (probabilities
             .stream()
-            .filter(value < 0.5 ? DEFAULT_VARIANT_FILTER : OTHER_THAN_DEFAULT_VARIANT_FILTER)
-            .findFirst()
-            .orElse(UNKNOWN);
+            .allMatch(variantProbability -> variantProbability.value() == controlProbability.value())) {
+            return TIE;
+        }
+
+        return probabilities
+            .stream()
+            .max(VARIANT_PROBABILITY_COMPARATOR)
+            .map(VariantProbability::variant)
+            .orElse(NONE);
     }
 
     /**
@@ -103,6 +170,114 @@ public class BayesianAPIImpl implements BayesianAPI {
                     - logBeta(alphaA, betaA));
         }
         return result;
+    }
+
+    /**
+     * Calculates probability that B (Test) beats A (Control) just as main {@link #calcProbBOverA(BayesianInput)}
+     *
+     * @param control successes and failures
+     * @param test successes and failures
+     * @return result representing probability that B beats A
+     */
+    private double calcABTesting(final VariantInputPair control, final VariantInputPair test) {
+        return calcABTesting(
+            control.successes() + 1,
+            control.failures() + 1,
+            test.successes() + 1,
+            test.failures() + 1);
+    }
+
+    /**
+     * Calculates probability that C (Test) beats A (Control) and B (Test) just as main
+     * {@link #calcProbABC(BayesianInput)}
+     *
+     * @param alphaA control successes
+     * @param betaA control failures
+     * @param alphaB test B successes
+     * @param betaB test B failures
+     * @param alphaC test C successes
+     * @param betaC test C failures
+     * @return a list {@link VariantProbability} representing probability that C beats A and B
+     */
+    private Double calcABCTesting(final long alphaA, final long betaA,
+                                  final long alphaB, final long betaB,
+                                  final long alphaC, final long betaC) {
+        double total = 0.0;
+
+        for(int i = 0; i < alphaA; i++) {
+            for(int j = 0; j < alphaB; j++) {
+                total += Math.exp(
+                    logBeta(alphaC + i + j, betaA + betaB + betaC)
+                        - Math.log(betaA + i)
+                        - Math.log(betaB + j)
+                        - logBeta(1 + i, betaA)
+                        - logBeta(1 + j, betaB)
+                        - logBeta(alphaC, betaC));
+            }
+        }
+
+        final double probAOverC = calcABTesting(alphaC, betaC, alphaA, betaA);
+        final double probBOverC = calcABTesting(alphaC, betaC, alphaB, betaB);
+
+        return 1 - probAOverC - probBOverC + total;
+    }
+
+    /**
+     * Calculates probability that C (Test) beats A (Control) and B (Test) just as main
+     * {@link #calcProbABC(BayesianInput)}
+     *
+     * @param control successes and failures
+     * @param testB successes and failures
+     * @param testC successes and failures
+     * @return a list {@link VariantProbability} representing probability that C beats A and B
+     */
+    private VariantProbability calcSingleABCTesting(final VariantInputPair control,
+                                                    final VariantInputPair testB,
+                                                    final VariantInputPair testC) {
+        return toProbability(
+            testC,
+            calcABCTesting(
+                control.successes() + 1,
+                control.failures() + 1,
+                testB.successes() + 1,
+                testB.failures() + 1,
+                testC.successes() + 1,
+                testC.failures() + 1));
+    }
+
+    /**
+     * Calculates probability that C (Test) beats A (Control) and B (Test) just as main
+     * {@link #calcProbABC(BayesianInput)}
+     *
+     * @param control successes and failures
+     * @param testB successes and failures
+     * @param testC successes and failures
+     * @return a list {@link VariantProbability} representing probability that C beats A and B
+     */
+    private List<VariantProbability> calcABCTesting(final VariantInputPair control,
+                                                    final VariantInputPair testB,
+                                                    final VariantInputPair testC) {
+        return Stream
+            .of(
+                List.of(testC, testB, control),
+                List.of(control, testC, testB),
+                List.of(testB, control, testC))
+            .map(inputs -> calcSingleABCTesting(inputs.get(0), inputs.get(1), inputs.get(2)))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Converts variant pair information and the calculated probability into {@link VariantProbability} instance.
+     *
+     * @param pair variant pair
+     * @param value calculated probability
+     * @return {@link VariantProbability} instance
+     */
+    private VariantProbability toProbability(final VariantInputPair pair, final double value) {
+        return VariantProbability.builder()
+            .variant(pair.variant())
+            .value(value)
+            .build();
     }
 
     /**
@@ -238,8 +413,20 @@ public class BayesianAPIImpl implements BayesianAPI {
      *
      * @param input Bayesian calculation input
      */
-    private void validateInput(final BayesianInput input) {
+    private void validateInput(final BayesianInput input) throws DotDataException {
         Objects.requireNonNull(input, "Bayesian input is missing");
+
+        validateVariantPair(input.control());
+        input.variantPairs().forEach(this::validateVariantPair);
+
+        final List<VariantInputPair> variantPairs = new ArrayList<>(input.variantPairs());
+        variantPairs.add(input.control());
+        for (final VariantInputPair variantPair: variantPairs) {
+            validateVariantsSize(input, input.type() == ABTestingType.ABC ? 2 : 1);
+            if (variantPair.successes() + variantPair.failures() == 0) {
+                throw new DotDataException("Variant successes and failures cannot be zero");
+            }
+        }
 
         if (Objects.nonNull(input.priors().alpha()) && input.priors().alpha() <= 0.0) {
             throw new IllegalArgumentException("Prior alpha cannot have a zero or negative value");
@@ -248,24 +435,52 @@ public class BayesianAPIImpl implements BayesianAPI {
         if (Objects.nonNull(input.priors().beta()) && input.priors().beta() <= 0.0) {
             throw new IllegalArgumentException("Prior beta cannot have a zero or negative value");
         }
+    }
 
-        if (input.controlSuccesses() < 0) {
-            throw new IllegalArgumentException("Control successes cannot have negative value");
-        }
-
-        if (input.controlFailures() < 0) {
-            throw new IllegalArgumentException("Control failures cannot have negative value");
-        }
-
-        if (input.testSuccesses() < 0) {
-            throw new IllegalArgumentException("Test successes cannot have negative value");
-        }
-
-        if (input.testFailures() < 0) {
-            throw new IllegalArgumentException("Test failures cannot have negative value");
+    private void validateVariantsSize(final BayesianInput input, final int expected) {
+        if (input.variantPairs().size() != expected) {
+            throw new IllegalArgumentException(String.format("AB test must have only %d variant", expected));
         }
     }
 
+    /**
+     * Validates passed {@link VariantInputPair} instance to have the right parameters.
+     *
+     * @param variantPair variant pair
+     */
+    private void validateVariantPair(final VariantInputPair variantPair) {
+        if (variantPair.successes() < 0) {
+            throw new IllegalArgumentException("Variant successes cannot have negative value");
+        }
+
+        if (variantPair.failures() < 0) {
+            throw new IllegalArgumentException("Variant failures cannot have negative value");
+        }
+    }
+
+    /**
+     * Detects if the input has zero interactions and returns a NOOP result.
+     *
+     * @param input Bayesian calculation input
+     * @return Optional with NOOP result if input has zero interactions, empty otherwise
+     */
+    private Optional<BayesianResult> detectNoop(final BayesianInput input) {
+        try {
+            validateInput(input);
+            return Optional.empty();
+        } catch (final DotDataException e) {
+            Logger.error(
+                this,
+                String.format("Cannot calculate probability with zero interactions for input: %s", input), e);
+            return Optional.of(NOOP_RESULT);
+        }
+    }
+
+    /**
+     * Evaluates is prior is present in the input.
+     * @param input Bayesian calculation input
+     * @return true if prior is present, false otherwise
+     */
     private boolean isPriorPresent(final BayesianInput input) {
         return Objects.nonNull(input.priors().alpha()) && Objects.nonNull(input.priors().beta());
     }

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/ABTestingType.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/ABTestingType.java
@@ -1,0 +1,10 @@
+package com.dotcms.analytics.bayesian.model;
+
+/**
+ * Enum to represent the different AB testing types.
+ *
+ * @author vico
+ */
+public enum ABTestingType {
+    AB, ABC;
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractBayesianInput.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractBayesianInput.java
@@ -26,22 +26,16 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface AbstractBayesianInput {
 
+    @JsonProperty("type")
+    ABTestingType type();
+
+    @JsonProperty("control")
+    VariantInputPair control();
+
+    @JsonProperty("variantPairs")
+    List<VariantInputPair> variantPairs();
+
     @JsonProperty("priors")
     BayesianPriors priors();
-
-    @JsonProperty("controlSuccesses")
-    long controlSuccesses();
-
-    @JsonProperty("controlFailures")
-    long controlFailures();
-
-    @JsonProperty("testSuccesses")
-    long testSuccesses();
-
-    @JsonProperty("testFailures")
-    long testFailures();
-
-    @JsonProperty("variants")
-    List<String> variants();
 
 }

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractBayesianResult.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractBayesianResult.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 
 
@@ -27,6 +28,9 @@ public interface AbstractBayesianResult {
 
     @JsonProperty("suggestedWinner")
     String suggestedWinner();
+
+    @JsonProperty("probabilities")
+    List<VariantProbability> probabilities();
 
     @Nullable
     @JsonProperty("distributionPdfs")

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractVariantInputPair.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractVariantInputPair.java
@@ -1,0 +1,28 @@
+package com.dotcms.analytics.bayesian.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * Variant successes and failures pair.
+ *
+ * @author vico
+ */
+@Value.Style(typeImmutable="*", typeAbstract="Abstract*")
+@Value.Immutable
+@JsonDeserialize(as = VariantInputPair.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface AbstractVariantInputPair {
+
+    @JsonProperty("variant")
+    String variant();
+
+    @JsonProperty("successes")
+    long successes();
+
+    @JsonProperty("failures")
+    long failures();
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractVariantProbability.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/model/AbstractVariantProbability.java
@@ -1,0 +1,25 @@
+package com.dotcms.analytics.bayesian.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * Variant successes and failures pair.
+ *
+ * @author vico
+ */
+@Value.Style(typeImmutable="*", typeAbstract="Abstract*")
+@Value.Immutable
+@JsonDeserialize(as = VariantProbability.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface AbstractVariantProbability {
+
+    @JsonProperty("variant")
+    String variant();
+
+    @JsonProperty("value")
+    double value();
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
@@ -35,7 +35,7 @@ import java.util.function.BiPredicate;
  */
 public class AnalyticsHelper {
 
-    private static Lazy<AnalyticsHelper> analyticsHelper = Lazy.of(() -> new AnalyticsHelper());
+    private static final Lazy<AnalyticsHelper> analyticsHelper = Lazy.of(AnalyticsHelper::new);
 
     public static AnalyticsHelper get(){
         return analyticsHelper.get();

--- a/dotCMS/src/main/java/com/dotcms/analytics/helper/BayesianHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/helper/BayesianHelper.java
@@ -1,0 +1,147 @@
+package com.dotcms.analytics.helper;
+
+import com.dotcms.analytics.bayesian.BayesianAPI;
+import com.dotcms.analytics.bayesian.model.ABTestingType;
+import com.dotcms.analytics.bayesian.model.BayesianInput;
+import com.dotcms.analytics.bayesian.model.BayesianPriors;
+import com.dotcms.analytics.bayesian.model.VariantInputPair;
+import com.dotcms.experiments.business.result.ExperimentResults;
+import com.dotcms.experiments.business.result.GoalResults;
+import com.dotcms.experiments.business.result.VariantResults;
+import com.dotmarketing.util.Logger;
+import io.vavr.Lazy;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.dotcms.variant.VariantAPI.DEFAULT_VARIANT;
+
+/**
+ * Bayesian helper class with convenience methods to transition from Experiments realm to Bayesian.
+ *
+ * @author vico
+ */
+public class BayesianHelper {
+
+    private static final Lazy<BayesianHelper> bayesianHelper = Lazy.of(BayesianHelper::new);
+
+    public static BayesianHelper get(){
+        return bayesianHelper.get();
+    }
+
+    private BayesianHelper() {}
+
+    /**
+     * Converts {@link ExperimentResults} to {@link BayesianInput} object
+     *
+     * @param experimentResults experiment results
+     * @param goalName goal name to get results from
+     * @return {@link BayesianInput} bayesian input object
+     */
+    public BayesianInput toBayesianInput(final ExperimentResults experimentResults,
+                                         final String goalName) {
+        return getGoalResults(experimentResults, goalName)
+            .map(results -> {
+                final VariantResults controlResults = results.getVariants().get(DEFAULT_VARIANT.name());
+                if (Objects.isNull(controlResults)) {
+                    Logger.error(this, "Control results are missing");
+                    return null;
+                }
+
+                final List<VariantResults> variantsResults = results
+                    .getVariants()
+                    .keySet()
+                    .stream()
+                    .filter(BayesianAPI.OTHER_THAN_DEFAULT_VARIANT_FILTER)
+                    .map(name -> results.getVariants().get(name))
+                    .collect(Collectors.toList());
+                if (variantsResults.isEmpty()) {
+                    Logger.error(this, "Variants results are missing");
+                    return null;
+                }
+
+                return BayesianInput
+                    .builder()
+                    .type(variantsResults.size() == 1 ? ABTestingType.AB: ABTestingType.ABC)
+                    .control(toVariantPair(experimentResults, controlResults))
+                    .variantPairs(
+                        variantsResults
+                            .stream()
+                            .map(vr -> toVariantPair(experimentResults, vr))
+                            .collect(Collectors.toList()))
+                    .priors(resolvePriors(experimentResults))
+                    .build();
+            })
+            .orElse(null);
+    }
+
+    /**
+     * Resolves priors to use for Bayesian analysis.
+     * Currently, they are null since we don't support it yet.
+     *
+     * @param experimentResults experiment results
+     * @return resolved priors
+     */
+    private BayesianPriors resolvePriors(final ExperimentResults experimentResults) {
+        return BayesianAPI.NULL_PRIORS;
+    }
+
+    /**
+     * Resolves GoalResults from {@link ExperimentResults} object.
+     *
+     * @param experimentResults experiment results
+     * @param goalName goal name to get results from
+     * @return
+     */
+    private Optional<GoalResults> getGoalResults(final ExperimentResults experimentResults, final String goalName) {
+        return Optional.ofNullable(experimentResults.getGoals().get(goalName));
+    }
+
+    /**
+     * Extracts successes from {@link VariantResults} object
+     *
+     * @param variantResults variant results
+     * @return successes
+     */
+    private long extractSuccesses(final VariantResults variantResults) {
+        return variantResults.getUniqueBySession().getCount();
+    }
+
+    /**
+     * Extracts failures from {@link ExperimentResults} object
+     *
+     * @param experimentResult experiment results
+     * @param variantResults variant results
+     * @param successes successes
+     * @return failures
+     */
+    private long extractFailures(final ExperimentResults experimentResult,
+                                 final VariantResults variantResults,
+                                 final long successes) {
+        return Optional
+            .ofNullable(experimentResult.getSessions().getVariants().get(variantResults.getVariantName()))
+            .filter(total -> total != 0)
+            .map(total -> total - successes)
+            .orElse(0L);
+    }
+
+    /**
+     * Converts {@link ExperimentResults} to {@link BayesianInput} object
+     *
+     * @param experimentResults experiment results
+     * @param variantResults variant results
+     * @return {@link BayesianInput} bayesian input object
+     */
+    private VariantInputPair toVariantPair(final ExperimentResults experimentResults,
+                                           final VariantResults variantResults) {
+        final long successes = extractSuccesses(variantResults);
+        return VariantInputPair.builder()
+            .variant(variantResults.getVariantName())
+            .successes(successes)
+            .failures(extractFailures(experimentResults, variantResults, successes))
+            .build();
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 public interface ExperimentsAPI {
 
+    String PRIMARY_GOAL = "primary";
     Lazy<Integer> EXPERIMENTS_MAX_DURATION = Lazy.of(()->Config.getIntProperty("EXPERIMENTS_MAX_DURATION", 35));
     Lazy<Integer> EXPERIMENT_LOOKBACK_WINDOW = Lazy.of(()->Config.getIntProperty("EXPERIMENTS_LOOKBACK_WINDOW", 10));
 

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -17,10 +17,10 @@ import static com.dotmarketing.util.DateUtil.isTimeReach;
 import com.dotcms.analytics.app.AnalyticsApp;
 import com.dotcms.analytics.bayesian.BayesianAPI;
 import com.dotcms.analytics.bayesian.model.BayesianInput;
-import com.dotcms.analytics.bayesian.model.BayesianPriors;
 import com.dotcms.analytics.bayesian.model.BayesianResult;
 import com.dotcms.analytics.helper.AnalyticsHelper;
 
+import com.dotcms.analytics.helper.BayesianHelper;
 import com.dotcms.analytics.metrics.AbstractCondition.Operator;
 import com.dotcms.analytics.metrics.EventType;
 import com.dotcms.analytics.metrics.Metric;
@@ -39,8 +39,6 @@ import com.dotcms.experiments.business.result.ExperimentAnalyzerUtil;
 import com.dotcms.experiments.business.result.ExperimentResults;
 import com.dotcms.experiments.business.result.ExperimentResultsQueryFactory;
 import com.dotcms.exception.NotAllowedException;
-import com.dotcms.experiments.business.result.GoalResults;
-import com.dotcms.experiments.business.result.VariantResults;
 import com.dotcms.experiments.model.AbstractExperiment.Status;
 import com.dotcms.experiments.model.AbstractTrafficProportion.Type;
 import com.dotcms.experiments.model.Experiment;
@@ -108,8 +106,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class ExperimentsAPIImpl implements ExperimentsAPI {
 
-    private static final String PRIMARY_GOAL = "primary";
-    private static final int VARIANTS_NUMBER_MAX = 2;
+    private static final int VARIANTS_NUMBER_MAX = 3;
 
     final ExperimentsFactory factory = FactoryLocator.getExperimentsFactory();
     final PermissionAPI permissionAPI = APILocator.getPermissionAPI();
@@ -827,93 +824,27 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
         final ExperimentResults experimentResults = ExperimentAnalyzerUtil.INSTANCE.getExperimentResult(
             experiment,
             events);
-        experimentResults.setBayesianResult(calcBayesian(experiment, experimentResults, null));
+        experimentResults.setBayesianResult(calcBayesian(experimentResults, null));
         return experimentResults;
     }
 
     /**
      * Calculates Bayesian results based on {@link ExperimentResults} object gathered results from cube.
      *
-     * @param experiment experiment to get results from
      * @param experimentResults experiments results
      * @param goalName          goal name to get results from
      * @return {@link BayesianResult} bayesian results instance
      */
-    private BayesianResult calcBayesian(final Experiment experiment, final ExperimentResults experimentResults, final String goalName) {
+    private BayesianResult calcBayesian(final ExperimentResults experimentResults, final String goalName) {
         DotPreconditions.checkNotNull(experimentResults, "Experiment results should not be null");
-        DotPreconditions.checkArgument(
-            experimentResults.getSessions().getVariants().size() >= 2,
-            "At least two variants should be put to test");
-        DotPreconditions.checkArgument(
-            experimentResults.getSessions().getVariants().size() <= VARIANTS_NUMBER_MAX,
-            "Currently more than variant is not supported");
+        final int variantsNumber = experimentResults.getSessions().getVariants().size();
+        DotPreconditions.checkArgument(variantsNumber >= 2, "At least two variants should be put to test");
+        DotPreconditions.checkArgument(variantsNumber <= VARIANTS_NUMBER_MAX, "Currently more than variant is not supported");
 
-        return bayesianAPI.calcProbBOverA(
-            toBayesianInput(
-                experimentResults,
-                StringUtils.defaultIfBlank(goalName, PRIMARY_GOAL),
-                resolvePriors(experiment)));
-    }
+        final String goal = StringUtils.defaultIfBlank(goalName, PRIMARY_GOAL);
+        final BayesianInput bayesianInput = BayesianHelper.get().toBayesianInput(experimentResults, goal);
 
-    private BayesianPriors resolvePriors(final Experiment experiment) {
-        //TODO: if and when priors this the place we need to resolve those values
-        return BayesianAPI.NULL_PRIORS;
-    }
-
-    private Optional<GoalResults> getGoalResults(final ExperimentResults experimentResults, final String goalName) {
-        return Optional.ofNullable(experimentResults.getGoals().get(goalName));
-    }
-
-    private long extractSuccesses(final VariantResults variantResults) {
-        return variantResults.getUniqueBySession().getCount();
-    }
-
-    private long extractFailures(final ExperimentResults experimentResult,
-                                 final String goalName,
-                                 final String variantName) {
-        final long total = Optional.ofNullable(experimentResult.getSessions().getVariants().get(variantName)).orElse(0L);
-        return total != 0
-            ? total - extractSuccesses(
-                Objects.requireNonNull(Optional
-                    .ofNullable(experimentResult.getGoals().get(goalName))
-                    .map(goal -> goal.getVariants().get(variantName))
-                    .orElse(null)))
-            : 0;
-    }
-
-    private BayesianInput toBayesianInput(final ExperimentResults experimentResults,
-                                          final String goalName,
-                                          final BayesianPriors priors) {
-        return getGoalResults(experimentResults, goalName)
-            .map(results -> {
-                final VariantResults controlResults = results.getVariants().get(DEFAULT_VARIANT.name());
-                if (Objects.isNull(controlResults)) {
-                    return null;
-                }
-
-                final VariantResults testResults = results
-                    .getVariants()
-                    .keySet()
-                    .stream()
-                    .filter(name -> !name.equals(DEFAULT_VARIANT.name()))
-                    .map(name -> results.getVariants().get(name))
-                    .findFirst()
-                    .orElse(null);
-                if (Objects.isNull(testResults)) {
-                    return null;
-                }
-
-                return BayesianInput
-                    .builder()
-                    .variants(new ArrayList<>(experimentResults.getSessions().getVariants().keySet()))
-                    .priors(priors)
-                    .controlSuccesses(extractSuccesses(controlResults))
-                    .controlFailures(extractFailures(experimentResults, goalName, DEFAULT_VARIANT.name()))
-                    .testSuccesses(extractSuccesses(testResults))
-                    .testFailures(extractFailures(experimentResults, goalName, testResults.getVariantName()))
-                    .build();
-            })
-            .orElse(null);
+        return variantsNumber == 2 ? bayesianAPI.calcProbBOverA(bayesianInput) : bayesianAPI.calcProbABC(bayesianInput);
     }
 
     @Override
@@ -949,7 +880,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
 
                 currentEvents.add(new Event(resultSetItem.getAll(),
                             EventType.get(resultSetItem.get("Events.eventType")
-                                    .map(value -> value.toString())
+                                    .map(Object::toString)
                                     .orElseThrow(() -> new IllegalStateException("Type into Event is expected")))
                 ));
 

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/result/ExperimentAnalyzerUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/result/ExperimentAnalyzerUtil.java
@@ -1,10 +1,7 @@
 package com.dotcms.experiments.business.result;
 
-import static com.dotcms.util.CollectionsUtils.map;
-
 import com.dotcms.analytics.metrics.Metric;
 import com.dotcms.analytics.metrics.MetricType;
-
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.experiments.model.ExperimentVariant;
 import com.dotcms.experiments.model.Goals;
@@ -13,9 +10,12 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
+
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
+
+import static com.dotcms.util.CollectionsUtils.map;
 
 
 /**
@@ -29,8 +29,7 @@ public enum ExperimentAnalyzerUtil {
     INSTANCE;
 
     final static Lazy<Map<MetricType, MetricExperimentAnalyzer>> experimentResultQueryHelpers =
-            Lazy.of(() -> createHelpersMap());
-
+            Lazy.of(ExperimentAnalyzerUtil::createHelpersMap);
 
     private static Map<MetricType, MetricExperimentAnalyzer> createHelpersMap() {
         return map(
@@ -91,7 +90,7 @@ public enum ExperimentAnalyzerUtil {
         return builder.build();
     }
 
-    private static HTMLPageAsset getPage(String pageId) {
+    private HTMLPageAsset getPage(final String pageId) {
         try {
             return APILocator.getHTMLPageAssetAPI().fromContentlet(
                     APILocator.getContentletAPI().findContentletByIdentifierAnyLanguage(pageId)

--- a/dotCMS/src/test/java/com/dotcms/analytics/bayesian/BayesianAPIImplTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/bayesian/BayesianAPIImplTest.java
@@ -1,8 +1,10 @@
 package com.dotcms.analytics.bayesian;
 
+import com.dotcms.analytics.bayesian.model.ABTestingType;
 import com.dotcms.analytics.bayesian.model.BayesianInput;
 import com.dotcms.analytics.bayesian.model.BayesianPriors;
 import com.dotcms.analytics.bayesian.model.BayesianResult;
+import com.dotcms.analytics.bayesian.model.VariantInputPair;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,15 +41,16 @@ public class BayesianAPIImplTest {
     @Test
     public void test_calculateABTesting() {
         final BayesianInput input = BayesianInput.builder()
+            .type(ABTestingType.AB)
+            .control(VariantInputPair.builder().variant("control").successes(5).failures(3).build())
+            .addVariantPairs(VariantInputPair.builder().variant("test").successes(6).failures(2).build())
             .priors(BayesianPriors.builder().alpha(10.0).beta(10.0).build())
-            .controlSuccesses(5)
-            .controlFailures(3)
-            .testSuccesses(6)
-            .testFailures(2)
             .build();
         final BayesianResult result = bayesianAPI.calcProbBOverA(input);
         Assert.assertNotNull(result);
-        Assert.assertEquals("0.69", String.format("%.2f", result.value()));
+        Assert.assertEquals(0.31, result.probabilities().get(0).value(), 0.01);
+        Assert.assertEquals(0.69, result.probabilities().get(1).value(), 0.01);
+        Assert.assertEquals("test", result.suggestedWinner());
     }
 
     /**
@@ -57,11 +60,10 @@ public class BayesianAPIImplTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidPriorAlpha() {
         final BayesianInput input = BayesianInput.builder()
+            .type(ABTestingType.AB)
+            .control(VariantInputPair.builder().variant("control").successes(5).failures(3).build())
+            .addVariantPairs(VariantInputPair.builder().variant("test").successes(5).failures(3).build())
             .priors(BayesianPriors.builder().alpha(0.0).beta(10.0).build())
-            .controlSuccesses(5)
-            .controlFailures(3)
-            .testSuccesses(5)
-            .testFailures(3)
             .build();
         bayesianAPI.calcProbBOverA(input);
     }
@@ -73,11 +75,10 @@ public class BayesianAPIImplTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidPriorBeta() {
         final BayesianInput input = BayesianInput.builder()
+            .type(ABTestingType.AB)
+            .control(VariantInputPair.builder().variant("control").successes(5).failures(3).build())
+            .addVariantPairs(VariantInputPair.builder().variant("test").successes(5).failures(3).build())
             .priors(BayesianPriors.builder().alpha(10.0).beta(0.0).build())
-            .controlSuccesses(5)
-            .controlFailures(3)
-            .testSuccesses(5)
-            .testFailures(3)
             .build();
         bayesianAPI.calcProbBOverA(input);
     }
@@ -89,11 +90,10 @@ public class BayesianAPIImplTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidControlSuccesses() {
         final BayesianInput input = BayesianInput.builder()
+            .type(ABTestingType.AB)
+            .control(VariantInputPair.builder().variant("control").successes(-1).failures(3).build())
+            .addVariantPairs(VariantInputPair.builder().variant("test").successes(5).failures(3).build())
             .priors(BayesianPriors.builder().alpha(10.0).beta(10.0).build())
-            .controlSuccesses(-1)
-            .controlFailures(3)
-            .testSuccesses(5)
-            .testFailures(3)
             .build();
         bayesianAPI.calcProbBOverA(input);
     }
@@ -105,11 +105,10 @@ public class BayesianAPIImplTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidControlFailures() {
         final BayesianInput input = BayesianInput.builder()
+            .type(ABTestingType.AB)
+            .control(VariantInputPair.builder().variant("control").successes(5).failures(-1).build())
+            .addVariantPairs(VariantInputPair.builder().variant("test").successes(5).failures(3).build())
             .priors(BayesianPriors.builder().alpha(10.0).beta(10.0).build())
-            .controlSuccesses(5)
-            .controlFailures(-1)
-            .testSuccesses(5)
-            .testFailures(3)
             .build();
         bayesianAPI.calcProbBOverA(input);
     }
@@ -121,11 +120,10 @@ public class BayesianAPIImplTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidTestSuccesses() {
         final BayesianInput input = BayesianInput.builder()
+            .type(ABTestingType.AB)
+            .control(VariantInputPair.builder().variant("control").successes(5).failures(3).build())
+            .addVariantPairs(VariantInputPair.builder().variant("test").successes(-1).failures(3).build())
             .priors(BayesianPriors.builder().alpha(10.0).beta(10.0).build())
-            .controlSuccesses(5)
-            .controlFailures(3)
-            .testSuccesses(-1)
-            .testFailures(3)
             .build();
         bayesianAPI.calcProbBOverA(input);
     }
@@ -137,13 +135,46 @@ public class BayesianAPIImplTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_calculateABTesting_invalidTestFailures() {
         final BayesianInput input = BayesianInput.builder()
+            .type(ABTestingType.AB)
+            .control(VariantInputPair.builder().variant("control").successes(5).failures(3).build())
+            .addVariantPairs(VariantInputPair.builder().variant("test").successes(5).failures(-1).build())
             .priors(BayesianPriors.builder().alpha(10.0).beta(10.0).build())
-            .controlSuccesses(5)
-            .controlFailures(3)
-            .testSuccesses(5)
-            .testFailures(-1)
             .build();
         bayesianAPI.calcProbBOverA(input);
+    }
+
+    /**
+     * Given Bayesian input parameters with these values:
+     *
+     * <pre>
+     *     priorAlpha: 10
+     *     priorBeta: 10
+     *     controlSuccesses: 5
+     *     controlFailures: 3
+     *     testBSuccesses: 6
+     *     testBFailures: 2
+     *     testCSuccesses: 7
+     *     testCFailures: 1
+     * </pre>
+     *
+     * Expect that the probability B beats A is at least 0.69.
+     */
+    @Test
+    public void test_calculateABCTesting() {
+        final BayesianInput input = BayesianInput.builder()
+            .type(ABTestingType.ABC)
+            .control(VariantInputPair.builder().variant("control").successes(5).failures(3).build())
+            .addVariantPairs(
+                VariantInputPair.builder().variant("testB").successes(6).failures(2).build(),
+                VariantInputPair.builder().variant("testC").successes(7).failures(1).build())
+            .priors(BayesianAPI.NULL_PRIORS)
+            .build();
+        final BayesianResult result = bayesianAPI.calcProbABC(input);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(0.08, result.probabilities().get(0).value(), 0.01);
+        Assert.assertEquals(0.25, result.probabilities().get(1).value(), 0.01);
+        Assert.assertEquals(0.65, result.probabilities().get(2).value(), 0.01);
+        Assert.assertEquals("testC", result.suggestedWinner());
     }
 
 }

--- a/dotCMS/src/test/java/com/dotcms/analytics/helper/BayesianHelperTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/helper/BayesianHelperTest.java
@@ -1,0 +1,117 @@
+package com.dotcms.analytics.helper;
+
+import com.dotcms.analytics.bayesian.model.ABTestingType;
+import com.dotcms.analytics.bayesian.model.BayesianInput;
+import com.dotcms.analytics.bayesian.model.VariantInputPair;
+import com.dotcms.experiments.business.result.ExperimentResults;
+import com.dotcms.experiments.business.result.GoalResults;
+import com.dotcms.experiments.business.result.VariantResults;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.dotcms.experiments.business.ExperimentsAPI.PRIMARY_GOAL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * BayesianHelperTest tests.
+ *
+ * @author vico
+ */
+public class BayesianHelperTest {
+
+    private static final String DEFAULT_VARIANT = "DEFAULT";
+    private static final String TEST_VARIANT = "test";
+
+    private ExperimentResults experimentResults;
+    private GoalResults goalResults;
+    private VariantResults variantResultsA;
+    private VariantResults variantResultsB;
+
+    @Before
+    public void setup() {
+        experimentResults = mock(ExperimentResults.class);
+        goalResults = mock(GoalResults.class);
+        ExperimentResults.TotalSession totalSession = mock(ExperimentResults.TotalSession.class);
+        when(experimentResults.getGoals()).thenReturn(Map.of(PRIMARY_GOAL, goalResults));
+        when(experimentResults.getSessions()).thenReturn(totalSession);
+        when(totalSession.getTotal()).thenReturn(120L);
+        when(totalSession.getVariants()).thenReturn(Map.of(
+            DEFAULT_VARIANT, 60L,
+            TEST_VARIANT, 60L
+        ));
+        variantResultsA = mock(VariantResults.class);
+        variantResultsB = mock(VariantResults.class);
+        when(goalResults.getVariants()).thenReturn(Map.of(
+            DEFAULT_VARIANT, variantResultsA,
+            TEST_VARIANT, variantResultsB
+        ));
+        VariantResults.UniqueBySessionResume uniqueBySessionResumeA = mock(VariantResults.UniqueBySessionResume.class);
+        VariantResults.UniqueBySessionResume uniqueBySessionResumeB = mock(VariantResults.UniqueBySessionResume.class);
+        when(variantResultsA.getUniqueBySession()).thenReturn(uniqueBySessionResumeA);
+        when(variantResultsA.getVariantName()).thenReturn(DEFAULT_VARIANT);
+        when(variantResultsB.getVariantName()).thenReturn(TEST_VARIANT);
+        when(variantResultsB.getUniqueBySession()).thenReturn(uniqueBySessionResumeB);
+        when(uniqueBySessionResumeA.getCount()).thenReturn(16L);
+        when(uniqueBySessionResumeB.getCount()).thenReturn(50L);
+    }
+
+
+    /**
+     * Method to: Test {@link BayesianHelper#toBayesianInput(ExperimentResults, String)}
+     *
+     * Given Scenario: A valid experiment results
+     * ExpectedResult: A valid BayesianInput
+     */
+    @Test
+    public void test_toBayesianInput() {
+        final BayesianInput bayesianInput = BayesianHelper.get().toBayesianInput(experimentResults, PRIMARY_GOAL);
+        assertSame(ABTestingType.AB, bayesianInput.type());
+        assertEquals(DEFAULT_VARIANT, bayesianInput.control().variant());
+        assertEquals(16L, bayesianInput.control().successes());
+        assertEquals(44L, bayesianInput.control().failures());
+        assertEquals(1, bayesianInput.variantPairs().size());
+        final VariantInputPair testInputPair = bayesianInput.variantPairs().get(0);
+        assertEquals(TEST_VARIANT, testInputPair.variant());
+        assertEquals(50L, testInputPair.successes());
+        assertEquals(10L, testInputPair.failures());
+    }
+
+    /**
+     * Method to: Test {@link BayesianHelper#toBayesianInput(ExperimentResults, String)}
+     *
+     * Given Scenario: A valid experiment results with no goals
+     * ExpectedResult: A null BayesianInput
+     */
+    @Test
+    public void test_toBayesianInput_noDefault() {
+        when(goalResults.getVariants()).thenReturn(Map.of(
+            TEST_VARIANT, variantResultsB
+        ));
+
+        final BayesianInput bayesianInput = BayesianHelper.get().toBayesianInput(experimentResults, PRIMARY_GOAL);
+        assertNull(bayesianInput);
+    }
+
+    /**
+     * Method to: Test {@link BayesianHelper#toBayesianInput(ExperimentResults, String)}
+     *
+     * Given Scenario: A valid experiment results with no goals
+     * ExpectedResult: A null BayesianInput
+     */
+    @Test
+    public void test_toBayesianInput_noTest() {
+        when(goalResults.getVariants()).thenReturn(Map.of(
+            DEFAULT_VARIANT, variantResultsA
+        ));
+
+        final BayesianInput bayesianInput = BayesianHelper.get().toBayesianInput(experimentResults, PRIMARY_GOAL);
+        assertNull(bayesianInput);
+    }
+
+}


### PR DESCRIPTION
Original Bayesian calculation used in AB Testing does not support more than one variant and the original (clearly).
The introduced changes add the support to this calculation and more important introduce a structural change to the Bayesian input and result to support this result.
Tests were added and updated.