### PR TITLE
Limit header title to 50 characters

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-create/dot-experiments-create.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-create/dot-experiments-create.component.ts
@@ -92,7 +92,7 @@ export class DotExperimentsCreateComponent implements OnInit {
             }),
             name: new FormControl<string>('', {
                 nonNullable: true,
-                validators: [Validators.required, Validators.maxLength(255)]
+                validators: [Validators.required, Validators.maxLength(50)]
             }),
             description: new FormControl<string>('', {
                 validators: [Validators.maxLength(255)]

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/ui/dot-experiments-header/dot-experiments-ui-header.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/ui/dot-experiments-header/dot-experiments-ui-header.component.html
@@ -1,4 +1,4 @@
-<div class="wrapper flex flex-row align-items-center gap-4">
+<div class="wrapper flex flex-row align-items-center gap-2">
     <a class="flex cursor-pointer" (click)="goBack.emit(true)" data-testId="goback-link">
         <i class="pi pi-angle-left"></i>
     </a>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/ui/dot-experiments-header/dot-experiments-ui-header.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/ui/dot-experiments-header/dot-experiments-ui-header.component.scss
@@ -1,4 +1,5 @@
 @use "variables" as *;
+@use "mixins" as *;
 
 .wrapper {
     padding: 0 $spacing-5 0 $spacing-5;
@@ -9,11 +10,11 @@
     border-bottom: 1px solid $color-palette-gray-300;
 
     a {
-        color: $color-palette-gray-700;
+        color: $color-alert-blue;
         font-weight: $font-weight-regular-bold;
 
         i {
-            font-size: $md-icon-size-extra-big;
+            font-size: $md-icon-size-big;
         }
     }
 }

--- a/core-web/libs/dotcms-scss/angular/_variables.scss
+++ b/core-web/libs/dotcms-scss/angular/_variables.scss
@@ -63,7 +63,7 @@ $navigation-item-height: 48px;
 $navigation-width: 200px;
 $navigation-width-collased: 70px;
 $content-palette-width: 16rem;
-$experiment-header-height: 68px;
+$experiment-header-height: 60px;
 
 //Dot Secondary Toolbar
 $dot-secondary-toolbar-height: 52px;

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5231,7 +5231,6 @@ experiments.report.promote.variant=Promote variant
 experiments.report.promote.variant.text=When a Variant is assigned as Default, the current Default variant will be removed, and the new variant will take its place
 experiments.report.promote.assign.variant=Assign Variant
 winner=winnner
-
 dot.experimental.reports.variants=Variants
 dot.experimental.reports.pageview=Pageviews
 dot.experimental.reports.sessions=Sessions
@@ -5239,4 +5238,4 @@ dot.experimental.reports.clicks=Clicks
 dot.experimental.reports.best-variant=Best variant
 dot.experimental.reports.improvement=Improvement
 dot.experimental.reports.baseline=Baseline
-dot.experimental.reports.resume=Resume
+dot.experimental.reports.resume=Summary


### PR DESCRIPTION
### Proposed Changes
* Limit to 50 characters an Experiment name

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea0d4b4</samp>

Improved the UI and UX of the dot-experiments portlet by fixing some styling, accessibility, and validation issues. Modified the `Language.properties`, `dot-experiments-ui-header.component.scss`, `dot-experiments-create.component.ts`, `dot-experiments-list-table.component.html`, and `dot-experiments-ui-header.component.html` files.

## Related Issue
Fixes #24546

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea0d4b4</samp>

*  Reduce the maximum length of the experiment name field to 50 characters to match the backend validation ([link](https://github.com/dotCMS/core/pull/24566/files?diff=unified&w=0#diff-ecb60a2e269f8139f898a00e8494e8f5ff3d1d42732ce910fe69e7ba0637765eL95-R95))
*  Fix the styling issue with the table cell overflow by wrapping the experiment name in a `<span>` element ([link](https://github.com/dotCMS/core/pull/24566/files?diff=unified&w=0#diff-599b22db09a38536a5bc7487212c0bbc533763b1c554c32ab2f855a03fa99174L27-R27))
*  Improve the layout and alignment of the header component by reducing the gap between the back button and the title, changing the color and size of the back icon, and importing the `mixins` module ([link](https://github.com/dotCMS/core/pull/24566/files?diff=unified&w=0#diff-dbcf6b9fb7fe5018295b3bb916e9a56146bc7184e29c0fda0cec5cd20f9a912cL1-R1), [link](https://github.com/dotCMS/core/pull/24566/files?diff=unified&w=0#diff-6aa57ead08b6cf8b041708ccc7dc42e50aecb8246ac727672e1fe42cefe85804R2), [link](https://github.com/dotCMS/core/pull/24566/files?diff=unified&w=0#diff-6aa57ead08b6cf8b041708ccc7dc42e50aecb8246ac727672e1fe42cefe85804L12-R17), [link](https://github.com/dotCMS/core/pull/24566/files?diff=unified&w=0#diff-2728d896cd6de95b52033ed77ebb0e002a807f786c31802032738931ea1c462bL66-R66))
*  Change the label for the report summary section from "Resume" to "Summary" to avoid confusion and better describe the content ([link](https://github.com/dotCMS/core/pull/24566/files?diff=unified&w=0#diff-21db9723fa4c52389731b7575f1e19bd364aa992b7e549e22c08a33456994e94L5242-R5241))
*  Remove the empty line in the language properties file to improve readability ([link](https://github.com/dotCMS/core/pull/24566/files?diff=unified&w=0#diff-21db9723fa4c52389731b7575f1e19bd364aa992b7e549e22c08a33456994e94L5234))

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ea0d4b4</samp>

> _Sing, O Muse, of the skillful coder who refined the form_
> _Of the noble experiment, and made its name more brief and firm_
> _He also fixed the overflow of the table with a span_
> _And beautified the header with a button and a plan_