### PR TITLE
#24466 Show just Variant version in the History tab inside Experiment

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_versions_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_versions_inc.jsp
@@ -27,7 +27,12 @@
 	Identifier ident = APILocator.getIdentifierAPI().find(id);
 	boolean isImage = UtilMethods.isImage(ident.getAssetName());
 
-	List<Contentlet> versions = APILocator.getContentletAPI().findAllVersions(ident, VariantAPI.DEFAULT_VARIANT, user, false);
+	final String variantNameParameter = request.getParameter("variantName");
+	final Variant variant = variantNameParameter == null || VariantAPI.DEFAULT_VARIANT.equals(variantNameParameter) ?
+			VariantAPI.DEFAULT_VARIANT :
+			APILocator.getVariantAPI().get(variantNameParameter).orElse(VariantAPI.DEFAULT_VARIANT);
+
+	List<Contentlet> versions = APILocator.getContentletAPI().findAllVersions(ident,  variant, user, false);
 	boolean canEdit  = false;
 
 	if(versions.size() > 0){

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_js_inc.jsp
@@ -746,19 +746,22 @@
         var x = dijit.byId("versions");
         var y =Math.floor(Math.random()*1123213213);
 
+		const variantName = window.sessionStorage.getItem('variantName') || 'DEFAULT';
+
         var myCp = dijit.byId("contentletVersionsCp");
         if (myCp) {
-            myCp.attr("href", "/html/portlet/ext/contentlet/contentlet_versions_inc.jsp?contentletId=" +contentAdmin.contentletIdentifier + "&r=" + y);
+            myCp.attr("href", "/html/portlet/ext/contentlet/contentlet_versions_inc.jsp?variantName=" +  variantName + "&contentletId=" +contentAdmin.contentletIdentifier + "&r=" + y);
             return;
         }
         var myDiv = dijit.byId("contentletVersionsDiv");
         if (myDiv) {
             dojo.empty(myDiv);
         }
-        myCp = new dijit.layout.ContentPane({
+
+		myCp = new dijit.layout.ContentPane({
             id : "contentletVersionsCp",
             style: "height:100%",
-            href: "/html/portlet/ext/contentlet/contentlet_versions_inc.jsp?contentletId=" +contentAdmin.contentletIdentifier + "&r=" + y
+            href: "/html/portlet/ext/contentlet/contentlet_versions_inc.jsp?variantName=" +  variantName + "&contentletId=" +contentAdmin.contentletIdentifier + "&r=" + y
         }).placeAt("contentletVersionsDiv");
     }
 


### PR DESCRIPTION
We need to show only the DEFAULT versions of the Contentlet inside the Edit Contentlet dialog History tab when try to edit a Contentlet outside an Experiment.

Also when you are into an Experiment and go to the History tab we need to show just the versions of the Contentlet inside the Experiment's variant.

### Proposed Changes
* Take the variantName from the sessionStorage and sent it as a Query param when click in the History tab

https://github.com/dotCMS/core/pull/24570/files#diff-30035fadab1873324da0061912beafb411367ed539e701868ffa1b5cd3875b21R753

* Filter by the variantName into the History tab
* 
https://github.com/dotCMS/core/pull/24570/files#diff-050a4d2b08396dc5a9690983ad87be4edd3201d24d057304030982f481612de3R30