### PR TITLE
#23528: Cache of running experiments

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -237,12 +237,10 @@ import org.junit.runners.Suite.SuiteClasses;
         StartEndScheduledExperimentsJobTest.class,
         RulesAPIImplIntegrationTest.class,
         Task220825CreateVariantFieldTest.class,
-//        AnalyticsAPIImplTest.class,
         Task221007AddVariantIntoPrimaryKeyTest.class,
         ESContentletAPIImplTest.class,
         ExperimentAPIImpIT.class,
         ExperimentWebAPIImplIT.class,
-//        AccessTokenRenewJobTest.class,
         ContentletWebAPIImplIntegrationTest.class, // moved to top because of failures on GHA
         DependencyBundlerTest.class, // moved to top because of failures on GHA
         SiteAndFolderResolverImplTest.class, //Moved up to avoid conflicts with CT deletion
@@ -648,7 +646,9 @@ import org.junit.runners.Suite.SuiteClasses;
         PopulateContentletAsJSONUtilTest.class,
         PopulateContentletAsJSONJobTest.class,
         ContentTypeDestroyAPIImplTest.class,
-        Task230328AddMarkedForDeletionColumnTest.class
+        Task230328AddMarkedForDeletionColumnTest.class,
+//        AnalyticsAPIImplTest.class,
+//        AccessTokenRenewJobTest.class,
 })
 
 public class MainSuite {

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
@@ -156,8 +156,8 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
     }
 
     private static void assertCachedRunningExperiments(final List<String> experimentIds) {
-        List<Experiment> runningExperiments = CacheLocator.getExperimentsCache().get();
-        runningExperiments
+        CacheLocator.getExperimentsCache()
+            .get(ExperimentsCache.CACHED_EXPERIMENTS_KEY)
             .forEach(experiment -> assertTrue(experimentIds.contains(experiment.getIdentifier())));
     }
 

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
@@ -156,8 +156,7 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
     }
 
     private static void assertCachedRunningExperiments(final List<String> experimentIds) {
-        List<Experiment> runningExperiments = CacheLocator.getExperimentsCache()
-            .get(ExperimentsCache.RUNNING_EXPERIMENTS_KEY);
+        List<Experiment> runningExperiments = CacheLocator.getExperimentsCache().get();
         runningExperiments
             .forEach(experiment -> assertTrue(experimentIds.contains(experiment.getIdentifier())));
     }

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
@@ -50,6 +50,7 @@ import com.dotcms.util.network.IPUtils;
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
@@ -123,23 +124,25 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
             List<Experiment> experimentRunning = APILocator.getExperimentsAPI()
                     .getRunningExperiments();
 
-            List<String> experiemtnsId = experimentRunning.stream()
+            List<String> experimentIds = experimentRunning.stream()
                     .map(Experiment::getIdentifier).collect(Collectors.toList());
 
-            assertTrue(experiemtnsId.contains(runningExperiment.getIdentifier()));
-            assertFalse(experiemtnsId.contains(draftExperiment.getIdentifier()));
-            assertTrue(experiemtnsId.contains(stoppedExperiment.getIdentifier()));
+            assertTrue(experimentIds.contains(runningExperiment.getIdentifier()));
+            assertFalse(experimentIds.contains(draftExperiment.getIdentifier()));
+            assertTrue(experimentIds.contains(stoppedExperiment.getIdentifier()));
+            assertCachedRunningExperiments(experimentIds);
 
             ExperimentDataGen.end(stoppedExperiment);
 
             experimentRunning = APILocator.getExperimentsAPI()
                     .getRunningExperiments();
-            experiemtnsId = experimentRunning.stream()
-                    .map(experiment -> experiment.getIdentifier()).collect(Collectors.toList());
+            experimentIds = experimentRunning.stream()
+                    .map(Experiment::getIdentifier).collect(Collectors.toList());
 
-            assertTrue(experiemtnsId.contains(runningExperiment.getIdentifier()));
-            assertFalse(experiemtnsId.contains(draftExperiment.getIdentifier()));
-            assertFalse(experiemtnsId.contains(stoppedExperiment.getIdentifier()));
+            assertTrue(experimentIds.contains(runningExperiment.getIdentifier()));
+            assertFalse(experimentIds.contains(draftExperiment.getIdentifier()));
+            assertFalse(experimentIds.contains(stoppedExperiment.getIdentifier()));
+            assertCachedRunningExperiments(experimentIds);
         } finally {
             ExperimentDataGen.end(runningExperiment);
 
@@ -152,6 +155,12 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
         }
     }
 
+    private static void assertCachedRunningExperiments(final List<String> experimentIds) {
+        List<Experiment> runningExperiments = CacheLocator.getExperimentsCache()
+            .get(ExperimentsCache.RUNNING_EXPERIMENTS_KEY);
+        runningExperiments
+            .forEach(experiment -> assertTrue(experimentIds.contains(experiment.getIdentifier())));
+    }
 
     /**
      * Method to test: {@link ExperimentsAPI#start(String, User)}
@@ -209,6 +218,11 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
                     .setContentlet(content2Live).nextPersisted();
 
             ExperimentDataGen.start(newExperiment);
+            assertCachedRunningExperiments(APILocator.getExperimentsAPI()
+                .getRunningExperiments()
+                .stream()
+                .map(Experiment::getIdentifier)
+                .collect(Collectors.toList()));
 
             List<Contentlet> experimentContentlets = APILocator.getContentletAPI()
                     .getAllContentByVariants(APILocator.systemUser(),
@@ -226,6 +240,11 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
         }finally {
             APILocator.getExperimentsAPI().end(newExperiment.id().orElseThrow()
                     , APILocator.systemUser());
+            assertCachedRunningExperiments(APILocator.getExperimentsAPI()
+                .getRunningExperiments()
+                .stream()
+                .map(Experiment::getIdentifier)
+                .collect(Collectors.toList()));
         }
 
     }

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
@@ -157,7 +157,7 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
 
     private static void assertCachedRunningExperiments(final List<String> experimentIds) {
         CacheLocator.getExperimentsCache()
-            .get(ExperimentsCache.CACHED_EXPERIMENTS_KEY)
+            .getList(ExperimentsCache.CACHED_EXPERIMENTS_KEY)
             .forEach(experiment -> assertTrue(experimentIds.contains(experiment.getIdentifier())));
     }
 

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentsCacheTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentsCacheTest.java
@@ -1,0 +1,123 @@
+package com.dotcms.experiments.business;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.datagen.ExperimentDataGen;
+import com.dotcms.experiments.model.Experiment;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotcms.variant.business.VariantCacheImpl;
+import com.dotmarketing.business.CacheLocator;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Test for {@link ExperimentsCache}
+ *
+ * @author vico
+ */
+public class ExperimentsCacheTest extends IntegrationTestBase {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Method to test: {@link ExperimentsCacheImpl#put(String, List)} and {@link ExperimentsCacheImpl#get(String)}
+     * When: Add a Experiment
+     * Should: be able to get it by Name
+     */
+    @Test
+    public void test_putExperiment_andGetExperiment() {
+        final Experiment experiment = new ExperimentDataGen().nextPersisted();
+
+        CacheLocator.getExperimentsCache().put(ExperimentsCache.RUNNING_EXPERIMENTS_KEY, List.of(experiment));
+
+        final List<Experiment> cached = CacheLocator.getExperimentsCache().get(ExperimentsCache.RUNNING_EXPERIMENTS_KEY);
+
+        assertFalse(cached.isEmpty());
+        final Experiment cachedExperiment = cached.get(0);
+        assertEquals(experiment.id(), cachedExperiment.id());
+        assertEquals(experiment.name(), cachedExperiment.name());
+    }
+
+    /**
+     * Method to test: {@link VariantCacheImpl#get(String)}
+     * When: Call the method with a Name that not was put before
+     * Should: return null
+     */
+    @Test
+    public void getExperiments_doesNotExist() {
+        assertNull(CacheLocator.getExperimentsCache().get("NotExists"));
+    }
+
+    /**
+     * Method to test: {@link ExperimentsCacheImpl#remove(String)}
+     * When: Remove a Experiment from cache
+     * Should: get Null when call {@link ExperimentsCacheImpl#get(String)}
+     */
+    @Test
+    public void test_remove() {
+        final Experiment experiment1 = new ExperimentDataGen().nextPersisted();
+        final Experiment experiment2 = new ExperimentDataGen().nextPersisted();
+
+        final String name = "some-experiments";
+        CacheLocator.getExperimentsCache().put(name, List.of(experiment1, experiment2));
+        checkFromCacheNotNull(name, 2);
+
+        CacheLocator.getExperimentsCache().remove(name);
+        checkFromCacheNull(name);
+    }
+
+    /**
+     * Method to test: {@link ExperimentsCacheImpl#get(String)}
+     * When: Call the method with null
+     * Should: throw a {@link NullPointerException}
+     */
+    @Test(expected = NullPointerException.class)
+    public void test_nullName(){
+        assertNull(CacheLocator.getExperimentsCache().get(null));
+    }
+
+    /**
+     * Method to test: {@link ExperimentsCacheImpl#clearCache()}
+     * When: Put two lists {@link Experiment} into cache and then clear the cache
+     * Should: Return null for the two {@link Experiment}s
+     */
+    @Test
+    public void clear() {
+        final Experiment experiment1 = new ExperimentDataGen().nextPersisted();
+        final Experiment experiment2 = new ExperimentDataGen().nextPersisted();
+        final Experiment experiment3 = new ExperimentDataGen().nextPersisted();
+
+        final String name1 = "some-experiments";
+        CacheLocator.getExperimentsCache().put(name1, List.of(experiment1));
+        checkFromCacheNotNull(name1, 1);
+
+        final String name2 = "more-experiments";
+        CacheLocator.getExperimentsCache().put(name2, List.of(experiment2, experiment3));
+        checkFromCacheNotNull(name2, 2);
+
+        CacheLocator.getExperimentsCache().clearCache();
+
+        checkFromCacheNull(name1);
+        checkFromCacheNull(name2);
+    }
+
+    private void checkFromCacheNotNull(final String name, final int size) {
+        final List<Experiment> experiments = CacheLocator.getExperimentsCache().get(name);
+        assertNotNull(experiments);
+        assertEquals(size, experiments.size());
+    }
+
+    private void checkFromCacheNull(final String name) {
+        assertNull(CacheLocator.getExperimentsCache().get(name));
+    }
+
+}

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentsCacheTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentsCacheTest.java
@@ -4,7 +4,6 @@ import com.dotcms.IntegrationTestBase;
 import com.dotcms.datagen.ExperimentDataGen;
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.util.IntegrationTestInitService;
-import com.dotcms.variant.business.VariantCacheImpl;
 import com.dotmarketing.business.CacheLocator;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,7 +28,7 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link ExperimentsCacheImpl#put(String, List)} and {@link ExperimentsCacheImpl#get(String)}
+     * Method to test: {@link ExperimentsCacheImpl#put(List)} and {@link ExperimentsCacheImpl#get()}
      * When: Add a Experiment
      * Should: be able to get it by Name
      */
@@ -37,9 +36,9 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     public void test_putExperiment_andGetExperiment() {
         final Experiment experiment = new ExperimentDataGen().nextPersisted();
 
-        CacheLocator.getExperimentsCache().put(ExperimentsCache.RUNNING_EXPERIMENTS_KEY, List.of(experiment));
+        CacheLocator.getExperimentsCache().put(List.of(experiment));
 
-        final List<Experiment> cached = CacheLocator.getExperimentsCache().get(ExperimentsCache.RUNNING_EXPERIMENTS_KEY);
+        final List<Experiment> cached = CacheLocator.getExperimentsCache().get();
 
         assertFalse(cached.isEmpty());
         final Experiment cachedExperiment = cached.get(0);
@@ -48,41 +47,20 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link VariantCacheImpl#get(String)}
-     * When: Call the method with a Name that not was put before
-     * Should: return null
-     */
-    @Test
-    public void getExperiments_doesNotExist() {
-        assertNull(CacheLocator.getExperimentsCache().get("NotExists"));
-    }
-
-    /**
-     * Method to test: {@link ExperimentsCacheImpl#remove(String)}
+     * Method to test: {@link ExperimentsCacheImpl#remove()}
      * When: Remove a Experiment from cache
-     * Should: get Null when call {@link ExperimentsCacheImpl#get(String)}
+     * Should: get Null when call {@link ExperimentsCacheImpl#get()}
      */
     @Test
     public void test_remove() {
         final Experiment experiment1 = new ExperimentDataGen().nextPersisted();
         final Experiment experiment2 = new ExperimentDataGen().nextPersisted();
 
-        final String name = "some-experiments";
-        CacheLocator.getExperimentsCache().put(name, List.of(experiment1, experiment2));
-        checkFromCacheNotNull(name, 2);
+        CacheLocator.getExperimentsCache().put(List.of(experiment1, experiment2));
+        checkFromCacheNotNull(2);
 
-        CacheLocator.getExperimentsCache().remove(name);
-        checkFromCacheNull(name);
-    }
-
-    /**
-     * Method to test: {@link ExperimentsCacheImpl#get(String)}
-     * When: Call the method with null
-     * Should: throw a {@link NullPointerException}
-     */
-    @Test(expected = NullPointerException.class)
-    public void test_nullName(){
-        assertNull(CacheLocator.getExperimentsCache().get(null));
+        CacheLocator.getExperimentsCache().remove();
+        checkFromCacheNull();
     }
 
     /**
@@ -94,30 +72,23 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     public void clear() {
         final Experiment experiment1 = new ExperimentDataGen().nextPersisted();
         final Experiment experiment2 = new ExperimentDataGen().nextPersisted();
-        final Experiment experiment3 = new ExperimentDataGen().nextPersisted();
 
-        final String name1 = "some-experiments";
-        CacheLocator.getExperimentsCache().put(name1, List.of(experiment1));
-        checkFromCacheNotNull(name1, 1);
-
-        final String name2 = "more-experiments";
-        CacheLocator.getExperimentsCache().put(name2, List.of(experiment2, experiment3));
-        checkFromCacheNotNull(name2, 2);
+        CacheLocator.getExperimentsCache().put(List.of(experiment1, experiment2));
+        checkFromCacheNotNull(2);
 
         CacheLocator.getExperimentsCache().clearCache();
 
-        checkFromCacheNull(name1);
-        checkFromCacheNull(name2);
+        checkFromCacheNull();
     }
 
-    private void checkFromCacheNotNull(final String name, final int size) {
-        final List<Experiment> experiments = CacheLocator.getExperimentsCache().get(name);
+    private void checkFromCacheNotNull(final int size) {
+        final List<Experiment> experiments = CacheLocator.getExperimentsCache().get();
         assertNotNull(experiments);
         assertEquals(size, experiments.size());
     }
 
-    private void checkFromCacheNull(final String name) {
-        assertNull(CacheLocator.getExperimentsCache().get(name));
+    private void checkFromCacheNull() {
+        assertNull(CacheLocator.getExperimentsCache().get());
     }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentsCacheTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentsCacheTest.java
@@ -28,17 +28,37 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link ExperimentsCacheImpl#put(List)} and {@link ExperimentsCacheImpl#get(String)}
-     * When: Add a Experiment
-     * Should: be able to get it by Name
+     * Method to test: {@link ExperimentsCacheImpl#put(Experiment)} and {@link ExperimentsCacheImpl#get(String)}
+     * When: Add an Experiment
+     * Should: be able to get it by key
      */
     @Test
     public void test_putExperiment_andGetExperiment() {
         final Experiment experiment = new ExperimentDataGen().nextPersisted();
 
-        CacheLocator.getExperimentsCache().put(List.of(experiment));
+        CacheLocator.getExperimentsCache().put(experiment);
 
-        final List<Experiment> cached = CacheLocator.getExperimentsCache().get(ExperimentsCache.CACHED_EXPERIMENTS_KEY);
+        Experiment cached = CacheLocator
+            .getExperimentsCache()
+            .get(experiment.id().get());
+
+        assertEquals(experiment.id().get(), cached.id().get());
+    }
+
+    /**
+     * Method to test: {@link ExperimentsCacheImpl#putList(String, List)} and {@link ExperimentsCacheImpl#getList(String)}
+     * When: Add a list of Experiment
+     * Should: be able to get it by key
+     */
+    @Test
+    public void test_putExperiments_andGetExperiments() {
+        final Experiment experiment = new ExperimentDataGen().nextPersisted();
+
+        CacheLocator.getExperimentsCache().putList(ExperimentsCache.CACHED_EXPERIMENTS_KEY, List.of(experiment));
+
+        final List<Experiment> cached = CacheLocator
+            .getExperimentsCache()
+            .getList(ExperimentsCache.CACHED_EXPERIMENTS_KEY);
 
         assertFalse(cached.isEmpty());
         final Experiment cachedExperiment = cached.get(0);
@@ -47,19 +67,21 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link ExperimentsCacheImpl#remove()}
+     * Method to test: {@link ExperimentsCacheImpl#removeList()}
      * When: Remove a Experiment from cache
-     * Should: get Null when call {@link ExperimentsCacheImpl#get(String)}
+     * Should: get Null when call {@link ExperimentsCacheImpl#getList(String)}
      */
     @Test
     public void test_remove() {
         final Experiment experiment1 = new ExperimentDataGen().nextPersisted();
         final Experiment experiment2 = new ExperimentDataGen().nextPersisted();
 
-        CacheLocator.getExperimentsCache().put(List.of(experiment1, experiment2));
+        CacheLocator
+            .getExperimentsCache()
+            .putList(ExperimentsCache.CACHED_EXPERIMENTS_KEY, List.of(experiment1, experiment2));
         checkFromCacheNotNull(2);
 
-        CacheLocator.getExperimentsCache().remove();
+        CacheLocator.getExperimentsCache().removeList();
         checkFromCacheNull();
     }
 
@@ -73,7 +95,9 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
         final Experiment experiment1 = new ExperimentDataGen().nextPersisted();
         final Experiment experiment2 = new ExperimentDataGen().nextPersisted();
 
-        CacheLocator.getExperimentsCache().put(List.of(experiment1, experiment2));
+        CacheLocator
+            .getExperimentsCache()
+            .putList(ExperimentsCache.CACHED_EXPERIMENTS_KEY, List.of(experiment1, experiment2));
         checkFromCacheNotNull(2);
 
         CacheLocator.getExperimentsCache().clearCache();
@@ -84,13 +108,13 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     private void checkFromCacheNotNull(final int size) {
         final List<Experiment> experiments = CacheLocator
             .getExperimentsCache()
-            .get(ExperimentsCache.CACHED_EXPERIMENTS_KEY);
+            .getList(ExperimentsCache.CACHED_EXPERIMENTS_KEY);
         assertNotNull(experiments);
         assertEquals(size, experiments.size());
     }
 
     private void checkFromCacheNull() {
-        assertNull(CacheLocator.getExperimentsCache().get(ExperimentsCache.CACHED_EXPERIMENTS_KEY));
+        assertNull(CacheLocator.getExperimentsCache().getList(ExperimentsCache.CACHED_EXPERIMENTS_KEY));
     }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentsCacheTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentsCacheTest.java
@@ -28,7 +28,7 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link ExperimentsCacheImpl#put(List)} and {@link ExperimentsCacheImpl#get()}
+     * Method to test: {@link ExperimentsCacheImpl#put(List)} and {@link ExperimentsCacheImpl#get(String)}
      * When: Add a Experiment
      * Should: be able to get it by Name
      */
@@ -38,7 +38,7 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
 
         CacheLocator.getExperimentsCache().put(List.of(experiment));
 
-        final List<Experiment> cached = CacheLocator.getExperimentsCache().get();
+        final List<Experiment> cached = CacheLocator.getExperimentsCache().get(ExperimentsCache.CACHED_EXPERIMENTS_KEY);
 
         assertFalse(cached.isEmpty());
         final Experiment cachedExperiment = cached.get(0);
@@ -49,7 +49,7 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     /**
      * Method to test: {@link ExperimentsCacheImpl#remove()}
      * When: Remove a Experiment from cache
-     * Should: get Null when call {@link ExperimentsCacheImpl#get()}
+     * Should: get Null when call {@link ExperimentsCacheImpl#get(String)}
      */
     @Test
     public void test_remove() {
@@ -82,13 +82,15 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     }
 
     private void checkFromCacheNotNull(final int size) {
-        final List<Experiment> experiments = CacheLocator.getExperimentsCache().get();
+        final List<Experiment> experiments = CacheLocator
+            .getExperimentsCache()
+            .get(ExperimentsCache.CACHED_EXPERIMENTS_KEY);
         assertNotNull(experiments);
         assertEquals(size, experiments.size());
     }
 
     private void checkFromCacheNull() {
-        assertNull(CacheLocator.getExperimentsCache().get());
+        assertNull(CacheLocator.getExperimentsCache().get(ExperimentsCache.CACHED_EXPERIMENTS_KEY));
     }
 
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/variant/business/VariantCacheTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/variant/business/VariantCacheTest.java
@@ -66,7 +66,6 @@ public class VariantCacheTest {
         assertNull(CacheLocator.getVariantCache().get("NotExists"));
     }
 
-
     /**
      * Method to test: {@link VariantCacheImpl#get(String)}
      * When: Call the method with null

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -59,6 +59,7 @@ import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.PermissionableProxy;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.FactoryLocator;
 import com.dotmarketing.business.PermissionAPI;
@@ -109,6 +110,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
     private static final int VARIANTS_NUMBER_MAX = 3;
 
     final ExperimentsFactory factory = FactoryLocator.getExperimentsFactory();
+    final ExperimentsCache experimentsCache = CacheLocator.getExperimentsCache();
     final PermissionAPI permissionAPI = APILocator.getPermissionAPI();
     final ContentletAPI contentletAPI = APILocator.getContentletAPI();
     final VariantAPI variantAPI = APILocator.getVariantAPI();
@@ -471,9 +473,10 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
             final Scheduling scheduling = startNowScheduling(persistedExperiment);
             toReturn = save(persistedExperiment.withScheduling(scheduling).withStatus(RUNNING), user);
             publishContentOnExperimentVariants(user, toReturn);
+            cacheRunningExperiments();
         } else {
             Scheduling scheduling = persistedExperiment.scheduling().get();
-            toReturn = save(persistedExperiment.withScheduling(scheduling).withStatus(SCHEDULED),user);
+            toReturn = save(persistedExperiment.withScheduling(scheduling).withStatus(SCHEDULED), user);
         }
 
         return toReturn;
@@ -551,7 +554,11 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
 
         final Experiment ended = persistedExperimentOpt.get().withStatus(ENDED)
                 .withScheduling(endedScheduling);
-        return save(ended, user);
+        final Experiment saved = save(ended, user);
+
+        cacheRunningExperiments();
+
+        return saved;
     }
 
     @WrapInTransaction
@@ -776,12 +783,14 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
 
     }
 
-    @CloseDBIfOpened
     @Override
     public List<Experiment> getRunningExperiments() throws DotDataException {
-        return FactoryLocator.getExperimentsFactory().list(
-                ExperimentFilter.builder().statuses(set(Status.RUNNING)).build()
-        );
+        final List<Experiment> cached = experimentsCache.get(ExperimentsCache.RUNNING_EXPERIMENTS_KEY);
+        if (Objects.nonNull(cached)) {
+            return cached;
+        }
+
+        return cacheRunningExperiments();
     }
 
     @Override
@@ -826,6 +835,15 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
             events);
         experimentResults.setBayesianResult(calcBayesian(experimentResults, null));
         return experimentResults;
+    }
+
+    @CloseDBIfOpened
+    private List<Experiment> cacheRunningExperiments() throws DotDataException {
+        final List<Experiment> experiments = FactoryLocator
+            .getExperimentsFactory()
+            .list(ExperimentFilter.builder().statuses(set(Status.RUNNING)).build());
+        experimentsCache.put(ExperimentsCache.RUNNING_EXPERIMENTS_KEY, experiments);
+        return experiments;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -294,7 +294,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
         Condition condition = targetingCondition.id().isPresent()
             ? Try.of(()->rulesAPI.getConditionById(targetingCondition.id().get(), user, false))
                 .getOrElseThrow(()->new IllegalArgumentException("Invalid targeting Condition Id provided. Id: " + targetingCondition.id().get()))
-            : createCondition(experimentRule, targetingCondition);
+            : createCondition(experimentRule);
 
         condition.setOperator(targetingCondition.operator());
         condition.setConditionletId(targetingCondition.conditionKey());
@@ -308,8 +308,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
                         + condition.getConditionletId()));
     }
 
-    private Condition createCondition(final Rule experimentRule,
-            final TargetingCondition targetingCondition) {
+    private Condition createCondition(final Rule experimentRule) {
         final Condition condition = new Condition();
         condition.setConditionGroup(experimentRule.getGroups().get(0).getId());
         return condition;
@@ -785,7 +784,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
 
     @Override
     public List<Experiment> getRunningExperiments() throws DotDataException {
-        final List<Experiment> cached = experimentsCache.get(ExperimentsCache.CACHED_EXPERIMENTS_KEY);
+        final List<Experiment> cached = experimentsCache.getList(ExperimentsCache.CACHED_EXPERIMENTS_KEY);
         if (Objects.nonNull(cached)) {
             return cached;
         }
@@ -842,7 +841,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
         final List<Experiment> experiments = FactoryLocator
             .getExperimentsFactory()
             .list(ExperimentFilter.builder().statuses(set(Status.RUNNING)).build());
-        experimentsCache.put(experiments);
+        experimentsCache.putList(ExperimentsCache.CACHED_EXPERIMENTS_KEY, experiments);
         return experiments;
     }
 

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -785,7 +785,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
 
     @Override
     public List<Experiment> getRunningExperiments() throws DotDataException {
-        final List<Experiment> cached = experimentsCache.get();
+        final List<Experiment> cached = experimentsCache.get(ExperimentsCache.CACHED_EXPERIMENTS_KEY);
         if (Objects.nonNull(cached)) {
             return cached;
         }

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -785,7 +785,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
 
     @Override
     public List<Experiment> getRunningExperiments() throws DotDataException {
-        final List<Experiment> cached = experimentsCache.get(ExperimentsCache.RUNNING_EXPERIMENTS_KEY);
+        final List<Experiment> cached = experimentsCache.get();
         if (Objects.nonNull(cached)) {
             return cached;
         }
@@ -842,7 +842,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
         final List<Experiment> experiments = FactoryLocator
             .getExperimentsFactory()
             .list(ExperimentFilter.builder().statuses(set(Status.RUNNING)).build());
-        experimentsCache.put(ExperimentsCache.RUNNING_EXPERIMENTS_KEY, experiments);
+        experimentsCache.put(experiments);
         return experiments;
     }
 

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCache.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCache.java
@@ -12,7 +12,7 @@ import java.util.List;
  */
 public interface ExperimentsCache extends Cachable {
 
-    String RUNNING_EXPERIMENTS_KEY = "RUNNING_EXPERIMENTS";
+    String CACHED_EXPERIMENTS_KEY = "CACHED_EXPERIMENTS";
 
     /**
      * Add a list of {@link Experiment} into the cache.
@@ -26,7 +26,7 @@ public interface ExperimentsCache extends Cachable {
      *
      * @return
      */
-    List<Experiment> get();
+    List<Experiment> get(String key);
 
     /**
      * Remove a list of {@link Experiment} from cache identified by the provided name.

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCache.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCache.java
@@ -1,0 +1,41 @@
+package com.dotcms.experiments.business;
+
+import com.dotcms.experiments.model.Experiment;
+import com.dotmarketing.business.Cachable;
+
+import java.util.List;
+
+/**
+ * Cache for {@link Experiment}
+ *
+ * @author vico
+ */
+public interface ExperimentsCache extends Cachable {
+
+    String RUNNING_EXPERIMENTS_KEY = "RUNNING_EXPERIMENTS";
+
+    /**
+     * Add a list of {@link Experiment} into the cache.
+     *
+     * @param name name to use as key
+     * @param experiments to be stored
+     */
+    void put(String name, final List<Experiment> experiments);
+
+    /**
+     * Get a list of {@link Experiment} from cache by name.
+     *
+     * @param name
+     * @return
+     */
+    List<Experiment> get(String name);
+
+    /**
+     * Remove a list of {@link Experiment} from cache identified by the provided name.
+     *
+     * @param name name to use as key
+     * @return
+     */
+    void remove(final String name);
+
+}

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCache.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCache.java
@@ -17,25 +17,22 @@ public interface ExperimentsCache extends Cachable {
     /**
      * Add a list of {@link Experiment} into the cache.
      *
-     * @param name name to use as key
      * @param experiments to be stored
      */
-    void put(String name, final List<Experiment> experiments);
+    void put(final List<Experiment> experiments);
 
     /**
      * Get a list of {@link Experiment} from cache by name.
      *
-     * @param name
      * @return
      */
-    List<Experiment> get(String name);
+    List<Experiment> get();
 
     /**
      * Remove a list of {@link Experiment} from cache identified by the provided name.
      *
-     * @param name name to use as key
      * @return
      */
-    void remove(final String name);
+    void remove();
 
 }

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCache.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCache.java
@@ -15,24 +15,41 @@ public interface ExperimentsCache extends Cachable {
     String CACHED_EXPERIMENTS_KEY = "CACHED_EXPERIMENTS";
 
     /**
-     * Add a list of {@link Experiment} into the cache.
+     * Add a {@link Experiment} into the cache.
      *
-     * @param experiments to be stored
+     * @param experiment to be stored
      */
-    void put(final List<Experiment> experiments);
+    void put(Experiment experiment);
 
     /**
      * Get a list of {@link Experiment} from cache by name.
      *
+     * @param experimentId experiment id to be used as cache key
      * @return
      */
-    List<Experiment> get(String key);
+    Experiment get(String experimentId);
+
+    /**
+     * Add a list of {@link Experiment} into the cache.
+     *
+     * @param key experiments cache key
+     * @param experiments to be stored
+     */
+    void putList(String key, List<Experiment> experiments);
+
+    /**
+     * Get a list of {@link Experiment} from cache by name.
+     *
+     * @param key experiments cache key
+     * @return
+     */
+    List<Experiment> getList(String key);
 
     /**
      * Remove a list of {@link Experiment} from cache identified by the provided name.
      *
      * @return
      */
-    void remove();
+    void removeList();
 
 }

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCacheImpl.java
@@ -1,0 +1,87 @@
+package com.dotcms.experiments.business;
+
+import com.dotcms.experiments.model.Experiment;
+import com.dotcms.util.DotPreconditions;
+import com.dotmarketing.business.CacheLocator;
+import com.dotmarketing.business.DotCacheAdministrator;
+import com.dotmarketing.business.DotCacheException;
+
+import java.util.List;
+
+/**
+ * Cache for {@link Experiment}
+ *
+ * @author vico
+ */
+public class ExperimentsCacheImpl implements ExperimentsCache {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void put(final String name, final List<Experiment> experiments) {
+        DotPreconditions.checkNotNull(name);
+
+        DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
+        cache.put(name, experiments, getPrimaryGroup());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Experiment> get(final String name) {
+        DotPreconditions.checkNotNull(name);
+
+        DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
+
+        try {
+            @SuppressWarnings("unchecked")
+            final List<Experiment> experiments = (List<Experiment>) cache.get(name, getPrimaryGroup());
+            return experiments;
+        } catch (DotCacheException e) {
+            return null;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void remove(final String name) {
+        DotPreconditions.checkNotNull(name);
+
+        DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
+        cache.remove(name, getPrimaryGroup());
+    }
+
+    /**
+     * Use to get the primary group/region for the concrete cache.
+     *
+     * @return String
+     */
+    @Override
+    public String getPrimaryGroup() {
+        return getClass().getSimpleName();
+    }
+
+    /**
+     * Use to get all groups the concrete cache belongs to.
+     *
+     * @return String[]
+     */
+    @Override
+    public String[] getGroups() {
+        return new String[0];
+    }
+
+    /**
+     * Clears experiment cache.
+     */
+    @Override
+    public void clearCache() {
+        DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
+        cache.flushGroup(getPrimaryGroup());
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCacheImpl.java
@@ -18,16 +18,39 @@ public class ExperimentsCacheImpl implements ExperimentsCache {
      * {@inheritDoc}
      */
     @Override
-    public void put(final List<Experiment> experiments) {
+    public void put(Experiment experiment) {
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-        cache.put(CACHED_EXPERIMENTS_KEY, experiments, getPrimaryGroup());
+        experiment.id().ifPresent(id -> cache.put(id, experiment, getPrimaryGroup()));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public List<Experiment> get(final String key) {
+    public Experiment get(String experimentId) {
+        DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
+
+        try {
+            return (Experiment) cache.get(experimentId, getPrimaryGroup());
+        } catch (DotCacheException e) {
+            return null;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void putList(final String key, final List<Experiment> experiments) {
+        DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
+        cache.put(key, experiments, getPrimaryGroup());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Experiment> getList(final String key) {
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
 
         try {
@@ -43,7 +66,7 @@ public class ExperimentsCacheImpl implements ExperimentsCache {
      * {@inheritDoc}
      */
     @Override
-    public void remove() {
+    public void removeList() {
 
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
         cache.remove(CACHED_EXPERIMENTS_KEY, getPrimaryGroup());

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCacheImpl.java
@@ -20,21 +20,19 @@ public class ExperimentsCacheImpl implements ExperimentsCache {
     @Override
     public void put(final List<Experiment> experiments) {
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-        cache.put(RUNNING_EXPERIMENTS_KEY, experiments, getPrimaryGroup());
+        cache.put(CACHED_EXPERIMENTS_KEY, experiments, getPrimaryGroup());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public List<Experiment> get() {
+    public List<Experiment> get(final String key) {
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
 
         try {
             @SuppressWarnings("unchecked")
-            final List<Experiment> experiments = (List<Experiment>) cache.get(
-                RUNNING_EXPERIMENTS_KEY,
-                getPrimaryGroup());
+            final List<Experiment> experiments = (List<Experiment>) cache.get(key, getPrimaryGroup());
             return experiments;
         } catch (DotCacheException e) {
             return null;
@@ -48,7 +46,7 @@ public class ExperimentsCacheImpl implements ExperimentsCache {
     public void remove() {
 
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-        cache.remove(RUNNING_EXPERIMENTS_KEY, getPrimaryGroup());
+        cache.remove(CACHED_EXPERIMENTS_KEY, getPrimaryGroup());
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCacheImpl.java
@@ -1,7 +1,6 @@
 package com.dotcms.experiments.business;
 
 import com.dotcms.experiments.model.Experiment;
-import com.dotcms.util.DotPreconditions;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.DotCacheAdministrator;
 import com.dotmarketing.business.DotCacheException;
@@ -19,25 +18,23 @@ public class ExperimentsCacheImpl implements ExperimentsCache {
      * {@inheritDoc}
      */
     @Override
-    public void put(final String name, final List<Experiment> experiments) {
-        DotPreconditions.checkNotNull(name);
-
+    public void put(final List<Experiment> experiments) {
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-        cache.put(name, experiments, getPrimaryGroup());
+        cache.put(RUNNING_EXPERIMENTS_KEY, experiments, getPrimaryGroup());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public List<Experiment> get(final String name) {
-        DotPreconditions.checkNotNull(name);
-
+    public List<Experiment> get() {
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
 
         try {
             @SuppressWarnings("unchecked")
-            final List<Experiment> experiments = (List<Experiment>) cache.get(name, getPrimaryGroup());
+            final List<Experiment> experiments = (List<Experiment>) cache.get(
+                RUNNING_EXPERIMENTS_KEY,
+                getPrimaryGroup());
             return experiments;
         } catch (DotCacheException e) {
             return null;
@@ -48,11 +45,10 @@ public class ExperimentsCacheImpl implements ExperimentsCache {
      * {@inheritDoc}
      */
     @Override
-    public void remove(final String name) {
-        DotPreconditions.checkNotNull(name);
+    public void remove() {
 
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-        cache.remove(name, getPrimaryGroup());
+        cache.remove(RUNNING_EXPERIMENTS_KEY, getPrimaryGroup());
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/variant/business/VariantCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/business/VariantCacheImpl.java
@@ -6,7 +6,7 @@ import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.DotCacheAdministrator;
 import com.dotmarketing.business.DotCacheException;
 
-public class VariantCacheImpl implements VariantCache{
+public class VariantCacheImpl implements VariantCache {
 
     static final String VARIANT_BY_ID = "VARIANT_BY_ID_";
     static final String VARIANT_BY_NAME = "VARIANT_BY_NAME_";
@@ -72,8 +72,7 @@ public class VariantCacheImpl implements VariantCache{
     @Override
     public void put(final String name, final Variant variant) {
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-        cache.put(getKeyByName(name), variant, getPrimaryGroup());
-
+        cache.put(getKeyById(name), variant, getPrimaryGroup());
         cache.put(getKeyByName(name), variant, getPrimaryGroup());
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/CacheLocator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/CacheLocator.java
@@ -12,6 +12,8 @@ import com.dotcms.contenttype.business.ContentTypeCache2;
 import com.dotcms.contenttype.business.ContentTypeCache2Impl;
 import com.dotcms.csspreproc.CSSCache;
 import com.dotcms.csspreproc.CSSCacheImpl;
+import com.dotcms.experiments.business.ExperimentsCache;
+import com.dotcms.experiments.business.ExperimentsCacheImpl;
 import com.dotcms.graphql.GraphQLCache;
 import com.dotcms.graphql.business.GraphQLSchemaCache;
 import com.dotcms.notifications.business.NewNotificationCache;
@@ -335,6 +337,14 @@ public class CacheLocator extends Locator<CacheIndex>{
 	}
 
 	/**
+	 * This will get you an instance of the {@link ExperimentsCache} singleton cache.
+	 * @return
+	 */
+	public static ExperimentsCache getExperimentsCache() {
+		return (ExperimentsCache) getInstance(CacheIndex.ExperimentsCache);
+	}
+
+	/**
 	 * This will get you an instance of the {@link AnalyticsCache} singleton cache.
 	 * @return
 	 */
@@ -451,6 +461,7 @@ enum CacheIndex
 	Metadata("Metadata"),
 	GraphQLCache("GraphQLCache"),
 	VariantCache("VariantCache"),
+	ExperimentsCache("ExperimentsCache"),
 	AnalyticsCache("AnalyticsCache");
 
 	Cachable create() {
@@ -504,6 +515,7 @@ enum CacheIndex
 			case Metadata: return new MetadataCacheImpl();
 			case GraphQLCache: return new GraphQLCache();
 			case VariantCache: return new VariantCacheImpl();
+			case ExperimentsCache: return new ExperimentsCacheImpl();
 			case AnalyticsCache: return new AnalyticsCache();
 
 		}


### PR DESCRIPTION
Adding `ExperimentsCache` order components to be consumed by `ExperimentsAPIImpl` to refresh running experiments list when an experiment is started/ended and when `getRunningExperiments()` is called.