### PR TITLE
dotCMS/core#24553 Avoid validating scheduling when archiving an Experiment 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/store/dot-experiments-list-store.ts
@@ -283,10 +283,10 @@ export class DotExperimentsListStore
                             this.messageService.add({
                                 severity: 'info',
                                 summary: this.dotMessageService.get(
-                                    'experiments.action.archived.confirm-title'
+                                    'experiments.action.archive.confirm-title'
                                 ),
                                 detail: this.dotMessageService.get(
-                                    'experiments.action.archived.confirm-message',
+                                    'experiments.action.archive.confirm-message',
                                     experiment.name
                                 )
                             });


### PR DESCRIPTION
### Proposed Changes
* correct labels reference to display archived notification.
