### PR TITLE
dotCMS/core#24583 When you click Edit go straight to EDIT in Edit Page. 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
@@ -66,7 +66,7 @@ const dotVariantDataMock: DotVariantData = {
     experimentId: EXPERIMENT_MOCK.id,
     experimentStatus: EXPERIMENT_MOCK.status,
     experimentName: EXPERIMENT_MOCK.name,
-    mode: 'preview'
+    mode: DotPageMode.PREVIEW
 };
 
 const pageRenderStateMock: DotPageRenderState = new DotPageRenderState(

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.spec.ts
@@ -109,7 +109,7 @@ class MockDotPageStateService {
 export class ActivatedRouteListStoreMock {
     get queryParams() {
         return of({
-            editPageTab: 'edit',
+            mode: DotPageMode.EDIT,
             variantName: 'Original',
             experimentId: '1232121212'
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -299,7 +299,7 @@ describe('DotEditContentComponent', () => {
                             queryParams: {
                                 url: '/an/url/test',
                                 variantName: EXPERIMENT_MOCK.trafficProportion.variants[1].id,
-                                editPageTab: 'preview'
+                                mode: DotPageMode.PREVIEW
                             }
                         },
                         data: of({})
@@ -439,7 +439,7 @@ describe('DotEditContentComponent', () => {
                     experimentId: EXPERIMENT_MOCK.id,
                     experimentStatus: EXPERIMENT_MOCK.status,
                     experimentName: EXPERIMENT_MOCK.name,
-                    mode: 'preview'
+                    mode: DotPageMode.PREVIEW
                 });
             });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -209,7 +209,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
             ],
             {
                 queryParams: {
-                    editPageTab: null,
+                    mode: null,
                     variantName: null,
                     experimentId: null
                 },
@@ -656,7 +656,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
     }
 
     private getExperimentResolverData(): void {
-        const { variantName, editPageTab } = this.route.snapshot.queryParams;
+        const { variantName, mode } = this.route.snapshot.queryParams;
         this.variantData = this.route.parent.parent.data.pipe(
             take(1),
             pluck('experiment'),
@@ -677,7 +677,7 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
                     experimentId: experiment.id,
                     experimentStatus: experiment.status,
                     experimentName: experiment.name,
-                    mode: editPageTab
+                    mode: mode
                 } as DotVariantData;
             })
         );

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
@@ -143,7 +143,7 @@ describe('DotEditPageMainComponent', () => {
                                 url: '/about-us/index'
                             }
                         },
-                        queryParams: of({ editPageTab: 'a', variantName: 'b', experimentId: 'c' })
+                        queryParams: of({ mode: 'a', variantName: 'b', experimentId: 'c' })
                     }
                 },
 
@@ -330,7 +330,7 @@ describe('DotEditPageMainComponent', () => {
     });
 
     describe('Edit Page in Variant Mode', () => {
-        it('should add class edit-page-variant-mode to the page nav if exist editPageTab, variationName, experimentId as query params', () => {
+        it('should add class edit-page-variant-mode to the page nav if exist mode, variationName, experimentId as query params', () => {
             const nav: DotEditPageNavComponent = fixture.debugElement.query(
                 By.css('dot-edit-page-nav')
             ).nativeElement;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
@@ -19,7 +19,7 @@ import {
     DotPageRenderService
 } from '@dotcms/data-access';
 import { CoreWebService, HttpCode, LoginService } from '@dotcms/dotcms-js';
-import { DotPageRender, DotPageRenderState } from '@dotcms/dotcms-models';
+import { DotPageMode, DotPageRender, DotPageRenderState } from '@dotcms/dotcms-models';
 import {
     CoreWebServiceMock,
     LoginServiceMock,
@@ -86,6 +86,7 @@ describe('DotEditPageResolver', () => {
     beforeEach(() => {
         route.queryParams.url = 'edit-page/content';
         route.queryParams.language_id = '2';
+        route.queryParams.mode = DotPageMode.EDIT;
         route.children = [
             {
                 url: [
@@ -107,6 +108,7 @@ describe('DotEditPageResolver', () => {
 
         expect<any>(dotPageStateService.requestPage).toHaveBeenCalledWith({
             url: 'edit-page/content',
+            mode: DotPageMode.EDIT,
             viewAs: {
                 language: '2'
             }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
@@ -91,14 +91,16 @@ export class DotEditPageResolver implements Resolve<DotPageRenderState> {
     }
 
     private getDotPageRenderOptions(route: ActivatedRouteSnapshot): DotPageRenderOptions {
-        return {
-            url: route.queryParams.url,
-            ...(route.queryParams.mode && { mode: route.queryParams.mode }),
-            ...(route.queryParams.language_id && {
-                viewAs: {
-                    language: route.queryParams.language_id
-                }
-            })
-        };
+        const renderOptions: DotPageRenderOptions = { url: route.queryParams.url };
+
+        if (route.queryParams.mode) {
+            renderOptions.mode = route.queryParams.mode;
+        }
+
+        if (route.queryParams.language_id) {
+            renderOptions.viewAs = { language: route.queryParams.language_id };
+        }
+
+        return renderOptions;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
@@ -91,14 +91,15 @@ export class DotEditPageResolver implements Resolve<DotPageRenderState> {
     }
 
     private getDotPageRenderOptions(route: ActivatedRouteSnapshot): DotPageRenderOptions {
-        const renderOptions: DotPageRenderOptions = { url: route.queryParams.url };
+        const queryParams = route.queryParams;
+        const renderOptions: DotPageRenderOptions = { url: queryParams.url };
 
-        if (route.queryParams.mode) {
-            renderOptions.mode = route.queryParams.mode;
+        if (queryParams.mode) {
+            renderOptions.mode = queryParams.mode;
         }
 
-        if (route.queryParams.language_id) {
-            renderOptions.viewAs = { language: route.queryParams.language_id };
+        if (queryParams.language_id) {
+            renderOptions.viewAs = { language: queryParams.language_id };
         }
 
         return renderOptions;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
@@ -34,18 +34,7 @@ export class DotEditPageResolver implements Resolve<DotPageRenderState> {
         if (data) {
             return of(data);
         } else {
-            const options: DotPageRenderOptions = {
-                url: route.queryParams.url,
-                ...(route.queryParams.language_id
-                    ? {
-                          viewAs: {
-                              language: route.queryParams.language_id
-                          }
-                      }
-                    : {})
-            };
-
-            return this.dotPageStateService.requestPage(options).pipe(
+            return this.dotPageStateService.requestPage(this.getDotPageRenderOptions(route)).pipe(
                 tap((state: DotPageRenderState) => {
                     if (!state) {
                         this.dotRouterService.goToSiteBrowser();
@@ -99,5 +88,17 @@ export class DotEditPageResolver implements Resolve<DotPageRenderState> {
         } else {
             return of(dotRenderedPageState);
         }
+    }
+
+    private getDotPageRenderOptions(route: ActivatedRouteSnapshot): DotPageRenderOptions {
+        return {
+            url: route.queryParams.url,
+            ...(route.queryParams.mode && { mode: route.queryParams.mode }),
+            ...(route.queryParams.language_id && {
+                viewAs: {
+                    language: route.queryParams.language_id
+                }
+            })
+        };
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -74,7 +74,7 @@
                     >
                         <button
                             class="p-button-sm p-button-outlined no-padding"
-                            (click)="goToEditPageVariant(variant, 'preview')"
+                            (click)="goToEditPageVariant(variant, dotPageMode.PREVIEW)"
                             data-testId="variant-preview-button"
                             label="{{ 'experiments.configure.variants.view' | dm }}"
                             pButton
@@ -110,7 +110,7 @@
             <ng-template #editableButtonTpl>
                 <button
                     class="p-button-sm p-button-outlined no-padding p-button-warning"
-                    (click)="goToEditPageVariant(variant, 'edit')"
+                    (click)="goToEditPageVariant(variant, dotPageMode.EDIT)"
                     data-testId="variant-edit-button"
                     label="{{ 'experiments.action.edit' | dm }}"
                     pButton

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -24,6 +24,7 @@ import {
     DEFAULT_VARIANT_ID,
     DEFAULT_VARIANT_NAME,
     DotExperimentStatusList,
+    DotPageMode,
     ExperimentSteps
 } from '@dotcms/dotcms-models';
 import { MockDotMessageService } from '@dotcms/utils-testing';
@@ -229,7 +230,7 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
             expect(dotSessionStorageService.setVariationId).toHaveBeenCalledWith(variants[0].id);
             expect(router.navigate).toHaveBeenCalledWith(['edit-page/content'], {
                 queryParams: {
-                    editPageTab: 'preview',
+                    mode: DotPageMode.PREVIEW,
                     variantName: variants[0].id,
                     experimentId: 'test'
                 },
@@ -243,7 +244,7 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
             expect(dotSessionStorageService.setVariationId).toHaveBeenCalledWith(variants[1].id);
             expect(router.navigate).toHaveBeenCalledWith(['edit-page/content'], {
                 queryParams: {
-                    editPageTab: 'edit',
+                    mode: DotPageMode.EDIT,
                     variantName: variants[1].id,
                     experimentId: 'test'
                 },

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
@@ -22,7 +22,7 @@ import { DotSessionStorageService } from '@dotcms/data-access';
 import {
     ComponentStatus,
     DEFAULT_VARIANT_NAME,
-    EditPageTabs,
+    DotPageMode,
     ExperimentSteps,
     MAX_VARIANTS_ALLOWED,
     SIDEBAR_STATUS,
@@ -78,6 +78,7 @@ export class DotExperimentsConfigurationVariantsComponent {
     maxVariantsAllowed = MAX_VARIANTS_ALLOWED;
     defaultVariantName = DEFAULT_VARIANT_NAME;
     experimentStepName = ExperimentSteps.VARIANTS;
+    dotPageMode = DotPageMode;
 
     @ViewChild(DotDynamicDirective, { static: true }) sidebarHost!: DotDynamicDirective;
 
@@ -153,17 +154,17 @@ export class DotExperimentsConfigurationVariantsComponent {
     /**
      * Go to Edit Page / Content, set the VariantId to SessionStorage
      * @param {Variant} variant
-     * @param {EditPageTabs} mode
+     * @param {DotPageMode} mode
      * @returns void
      * @memberof DotExperimentsConfigurationVariantsComponent
      */
-    goToEditPageVariant(variant: Variant, mode: EditPageTabs) {
+    goToEditPageVariant(variant: Variant, mode: DotPageMode) {
         this.dotSessionStorageService.setVariationId(variant.id);
         this.router.navigate(['edit-page/content'], {
             queryParams: {
-                editPageTab: mode,
                 variantName: variant.id,
-                experimentId: this.route.snapshot.params.experimentId
+                experimentId: this.route.snapshot.params.experimentId,
+                mode: mode
             },
             queryParamsHandling: 'merge'
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/dot-experiments-configuration.component.ts
@@ -47,7 +47,7 @@ export class DotExperimentsConfigurationComponent implements OnInit {
     goToExperimentList(pageId: string) {
         this.router.navigate(['/edit-page/experiments/', pageId], {
             queryParams: {
-                editPageTab: null,
+                mode: null,
                 variantName: null,
                 experimentId: null
             },

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.component.spec.ts
@@ -184,7 +184,7 @@ describe('ExperimentsListComponent', () => {
             ['/edit-page/experiments/reports/', EXPERIMENT_MOCK.id],
             {
                 queryParams: {
-                    editPageTab: null,
+                    mode: null,
                     variantName: null,
                     experimentId: null
                 },

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/dot-experiments-list.component.ts
@@ -89,7 +89,7 @@ export class DotExperimentsListComponent {
     goToBrowserBack(): void {
         this.router.navigate(['edit-page/content'], {
             queryParams: {
-                editPageTab: null,
+                mode: null,
                 variantName: null,
                 experimentId: null
             },
@@ -107,7 +107,7 @@ export class DotExperimentsListComponent {
     goToViewExperimentReport(experiment: DotExperiment) {
         this.router.navigate(['/edit-page/experiments/reports/', experiment.id], {
             queryParams: {
-                editPageTab: null,
+                mode: null,
                 variantName: null,
                 experimentId: null
             },

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-reports/dot-experiments-reports.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-reports/dot-experiments-reports.component.spec.ts
@@ -135,7 +135,7 @@ describe('DotExperimentsReportsComponent', () => {
             ['/edit-page/experiments/', EXPERIMENT_MOCK.pageId],
             {
                 queryParams: {
-                    editPageTab: null,
+                    mode: null,
                     variantName: null,
                     experimentId: null
                 },

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-reports/dot-experiments-reports.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-reports/dot-experiments-reports.component.ts
@@ -115,7 +115,7 @@ export class DotExperimentsReportsComponent implements OnInit {
     goToExperimentList(pageId: string) {
         this.router.navigate(['/edit-page/experiments/', pageId], {
             queryParams: {
-                editPageTab: null,
+                mode: null,
                 variantName: null,
                 experimentId: null
             },

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-shell/dot-experiments-shell.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-shell/dot-experiments-shell.component.ts
@@ -17,7 +17,7 @@ export class DotExperimentsShellComponent implements OnInit {
     private removeVariantQueryParams() {
         this.router.navigate([], {
             queryParams: {
-                editPageTab: null,
+                mode: null,
                 variantName: null,
                 experimentId: null
             },

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/directives/dot-experiment-class.directive.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/directives/dot-experiment-class.directive.ts
@@ -43,9 +43,9 @@ export class DotExperimentClassDirective implements OnDestroy {
     }
 
     private isEditPageVariant(queryParams: Params) {
-        const { editPageTab, variantName, experimentId } = queryParams;
+        const { mode, variantName, experimentId } = queryParams;
 
-        return !!experimentId && !!editPageTab && !!variantName;
+        return !!experimentId && !!mode && !!variantName;
     }
 
     private setNavBarComponentIsVariantMode(state: boolean) {

--- a/core-web/libs/dotcms-models/src/lib/dot-experiments.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-experiments.model.ts
@@ -110,8 +110,6 @@ export type StepStatus = SidebarStatus & {
     experimentStep: ExperimentSteps | null;
 };
 
-export type EditPageTabs = 'edit' | 'preview';
-
 export enum ExperimentSteps {
     VARIANTS = 'variants',
     GOAL = 'goal',

--- a/core-web/libs/dotcms-models/src/lib/dot-page.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-page.model.ts
@@ -1,6 +1,6 @@
 import { DotCMSContentType } from './dot-content-types.model';
 import { DotExperimentStatusList } from './dot-experiments-constants';
-import { EditPageTabs } from './dot-experiments.model';
+import { DotPageMode } from './dot-page-mode.enum';
 
 // TODO: we need to see why the endpoints are returning different "Pages" objects.
 export interface DotPage {
@@ -86,5 +86,5 @@ export interface DotVariantData {
     experimentId: string;
     experimentStatus: DotExperimentStatusList;
     experimentName: string;
-    mode: EditPageTabs;
+    mode: DotPageMode;
 }


### PR DESCRIPTION
### Proposed Changes
* Allow "deeplink" with the edit mode tabs.
* The configuration screen in experiments the edit button in each variant show load the edit mode in the edit tab
* remove `editPageTab ` and `EditPageTabs ` since we already have `mode` and `DotPageMode `

