### PR TITLE
Fix 24565 save block editor x2

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -243,6 +243,12 @@
                     const field = document.querySelector('#editor-input-value-<%=field.getVelocityVarName()%>');
 
                     /**
+                     * Safeguard just in case the editor changes are not triggering the 
+                     * "valueChange" event.
+                     */
+                    field.value = "<%=textValue%>"
+
+                    /**
                      * We need to listen to the "valueChange" event BEFORE setting the value
                      * to the editor.
                      */

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -246,7 +246,11 @@
                      * Safeguard just in case the editor changes are not triggering the 
                      * "valueChange" event.
                      */
-                    field.value = "<%=textValue%>"
+                    if (typeof <%=textValue%> === 'object') {
+                        field.value = JSON.stringify(<%=textValue%>);
+                    } else {
+                        field.value = <%=textValue%>;
+                    }
 
                     /**
                      * We need to listen to the "valueChange" event BEFORE setting the value
@@ -257,11 +261,11 @@
                         // https://github.com/ueberdosis/tiptap/issues/154
                         // By default Editor Initialize with default node p even if you clear nodes
                         // block.editor.isEmpty not working in our block editor
-                        if(block.editor.getHTML().toLowerCase() === "<p></p>"){
-                            field.value = null;
-                        } else {
-                            field.value = JSON.stringify(event.detail);
-                        }
+                        // if(block.editor.getHTML().toLowerCase() === "<p></p>"){
+                        //     field.value = null;
+                        // } else {
+                        //     field.value = JSON.stringify(event.detail);
+                        // }
                     });
 
                     if (content) {

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -261,11 +261,11 @@
                         // https://github.com/ueberdosis/tiptap/issues/154
                         // By default Editor Initialize with default node p even if you clear nodes
                         // block.editor.isEmpty not working in our block editor
-                        // if(block.editor.getHTML().toLowerCase() === "<p></p>"){
-                        //     field.value = null;
-                        // } else {
-                        //     field.value = JSON.stringify(event.detail);
-                        // }
+                        if(block.editor.getHTML().toLowerCase() === "<p></p>"){
+                            field.value = null;
+                        } else {
+                            field.value = JSON.stringify(event.detail);
+                        }
                     });
 
                     if (content) {


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 42ef83d</samp>

### Summary
🐛📝🛠️

<!--
1.  🐛 - This emoji represents a bug or an issue that needs to be fixed. It can be used to indicate that the change is part of a bug fix or a workaround for a problem.
2.  📝 - This emoji represents a comment or a documentation update. It can be used to indicate that the change adds or modifies a comment to explain the code or the logic behind it.
3.  🛠️ - This emoji represents a tool or a configuration change. It can be used to indicate that the change modifies a line of code to use a different variable or function, or to adjust the behavior of the editor.
-->
This change safeguard in case a bug where the block editor did not save the content field changes. It adds a line of code and a comment to `edit_field.jsp` to update the field value variable.

> _`textValue` gets field_
> _Editor may not fire event_
> _A fix for winter_

### Walkthrough
* Fix an issue where the TinyMCE editor was not saving the changes made to the content fields ([link](https://github.com/dotCMS/core/pull/24605/files?diff=unified&w=0#diff-56d86f13aa386cb1827964028808b975ede83f83670e89874ab7afa4207ed103R246-R251))



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
