### PR TITLE
dotCMS/core#23058 fix DotPagesPortlet-Show-Archived-status-not-working

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -330,7 +330,7 @@ describe('DotPageStore', () => {
         expect(dotESContentService.get).toHaveBeenCalledWith({
             itemsPerPage: 40,
             offset: '0',
-            query: '+conhost:123-xyz-567-xxl +working:true  +(urlmap:* OR basetype:5)    ',
+            query: '+conhost:123-xyz-567-xxl +working:true  +(urlmap:* OR basetype:5)  +deleted:false  ',
             sortField: 'title',
             sortOrder: ESOrderDirection.ASC
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -460,7 +460,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
         const { keyword, languageId, archived } = this.get().pages;
         const hostId = this.siteService.currentSite.identifier;
         const langQuery = languageId ? `+languageId:${languageId}` : '';
-        const archivedQuery = archived ? `+deleted:${archived}` : '';
+        const archivedQuery = archived ? `+deleted:true` : '+deleted:false';
         const identifierQuery = identifier ? `+identifier:${identifier}` : '';
         const keywordQuery = keyword
             ? `+(title:${keyword}* OR path:*${keyword}* OR urlmap:*${keyword}*)`

--- a/core-web/libs/dotcms-models/src/lib/dot-content-state.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-content-state.model.ts
@@ -2,8 +2,9 @@
  * Represent only the properties that define the status of any type of content
  */
 export interface DotContentState {
+    archived?: string | boolean;
+    deleted?: string | boolean;
     live: string | boolean;
     working: string | boolean;
-    deleted: string | boolean;
     hasLiveVersion: string | boolean;
 }

--- a/core-web/libs/dotcms-webcomponents/src/elements/dot-state-icon/dot-state-icon.e2e.ts
+++ b/core-web/libs/dotcms-webcomponents/src/elements/dot-state-icon/dot-state-icon.e2e.ts
@@ -16,11 +16,28 @@ describe('dot-state-icon', () => {
         element = await page.find('dot-state-icon');
     });
 
-    it('should set Archived attributes', async () => {
+    it('should set Archived attributes with param "deleted"', async () => {
         const archivedState: DotContentState = {
             live: 'false',
             working: 'true',
             deleted: 'true',
+            hasLiveVersion: 'false'
+        };
+
+        element.setAttribute('size', '14px');
+        element.setProperty('state', archivedState);
+        await page.waitForChanges();
+
+        expect(element.getAttribute('aria-label')).toEqual('Archived');
+        expect(icon.getAttribute('class')).toEqual('archived');
+        expect(await tooltip.getProperty('content')).toEqual('Archived');
+    });
+
+    it('should set Archived attributes with param "archived"', async () => {
+        const archivedState: DotContentState = {
+            live: 'false',
+            working: 'true',
+            archived: 'true',
             hasLiveVersion: 'false'
         };
 

--- a/core-web/libs/dotcms-webcomponents/src/elements/dot-state-icon/dot-state-icon.tsx
+++ b/core-web/libs/dotcms-webcomponents/src/elements/dot-state-icon/dot-state-icon.tsx
@@ -37,8 +37,8 @@ export class DotStateIcon {
         );
     }
 
-    private getType({ live, working, deleted, hasLiveVersion }: DotContentState): string {
-        if (this.isTrue(deleted)) {
+    private getType({ live, working, archived, deleted, hasLiveVersion }: DotContentState): string {
+        if (this.isTrue(deleted) || this.isTrue(archived)) {
             return 'archived'; // crossed
         }
 


### PR DESCRIPTION
### Proposed Changes
* status icon is not showing the right status, because the ES endpoint only brings attribute `archived` and not `deleted` 
![image](https://user-images.githubusercontent.com/37185433/231899913-532c8e0e-1a52-4c6e-9950-03458ef36c2b.png)

* initial ES QUERY to request to load pages is not correct and is missing the query `+deleted=false`
![image](https://user-images.githubusercontent.com/37185433/231900254-a94b91c3-a812-420c-94be-65afc2fbf598.png)
 

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
