### PR TITLE
#23396 escape double quotes

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp
@@ -171,8 +171,8 @@
                } else {
                    fieldValue = "";
                }
-			   fieldValue = UtilMethods.escapeDoubleQuotes(fieldValue);
-               return String.format("%s: \"%s\"", key, fieldValue);
+			   fieldValue = UtilMethods.makeHtmlSafe(fieldValue);
+			   return String.format("%s: \"%s\"", key, fieldValue);
            })
            .collect(Collectors.joining(","));
 %>

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp
@@ -171,6 +171,7 @@
                } else {
                    fieldValue = "";
                }
+			   fieldValue = UtilMethods.escapeDoubleQuotes(fieldValue);
                return String.format("%s: \"%s\"", key, fieldValue);
            })
            .collect(Collectors.joining(","));


### PR DESCRIPTION
When a title field has double quotes it breaks the relationship field, so we need to escape them.

Since changes are in JSP no test was done.
