### PR TITLE
Limit to 50 characters at the name of the experiment

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-create/dot-experiments-create.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-create/dot-experiments-create.component.html
@@ -20,6 +20,7 @@
                     }}</label>
                     <input
                         id="name"
+                        [maxlength]="this.maxNameLength + 1"
                         [tabindex]="1"
                         data-testId="add-experiment-name-input"
                         dotAutofocus

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-create/dot-experiments-create.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-create/dot-experiments-create.component.ts
@@ -7,6 +7,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';
 import { InputTextareaModule } from 'primeng/inputtextarea';
+import { RippleModule } from 'primeng/ripple';
 import { SidebarModule } from 'primeng/sidebar';
 
 import { DotFieldValidationMessageModule } from '@components/_common/dot-field-validation-message/dot-file-validation-message.module';
@@ -44,7 +45,8 @@ interface CreateForm {
         InputTextareaModule,
         InputTextModule,
         SidebarModule,
-        ButtonModule
+        ButtonModule,
+        RippleModule
     ],
     templateUrl: './dot-experiments-create.component.html',
     styleUrls: ['./dot-experiments-create.component.scss'],
@@ -54,6 +56,7 @@ export class DotExperimentsCreateComponent implements OnInit {
     vm$: Observable<VmCreateExperiments> = this.dotExperimentsListStore.createVm$;
 
     form: FormGroup<CreateForm>;
+    protected readonly maxNameLength = 50;
 
     constructor(private readonly dotExperimentsListStore: DotExperimentsListStore) {}
 
@@ -92,7 +95,7 @@ export class DotExperimentsCreateComponent implements OnInit {
             }),
             name: new FormControl<string>('', {
                 nonNullable: true,
-                validators: [Validators.required, Validators.maxLength(50)]
+                validators: [Validators.required, Validators.maxLength(this.maxNameLength)]
             }),
             description: new FormControl<string>('', {
                 validators: [Validators.maxLength(255)]


### PR DESCRIPTION
### Proposed Changes
* Limit to 50 characters at the name of the experiment

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
N/A

### Screenshots
Updated

<img width="646" alt="Screenshot 2023-04-14 at 1 31 45 PM" src="https://user-images.githubusercontent.com/1909643/232116291-7eb67746-b067-4327-b2cf-ff19fb81b6c5.png">

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f599a4e</samp>

This pull request enhances the `DotExperimentsCreateComponent` by adding a ripple effect to the buttons, and enforcing a 50-character limit for the experiment name. These changes improve the user experience and the code quality of the component.

## Related Issue
Fixes #

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f599a4e</samp>

*  Add `maxlength` attribute to experiment name input element to limit user input to 50 characters ([link](https://github.com/dotCMS/core/pull/24643/files?diff=unified&w=0#diff-52cf30c4e290e88bf6f1404e5119a23b7f58685f01ac76a33b10fdea30fb1ec8R23))
*  Import and use `RippleModule` from `primeng` to add ripple effect to buttons in `dot-experiments-create.component.html` ([link](https://github.com/dotCMS/core/pull/24643/files?diff=unified&w=0#diff-ecb60a2e269f8139f898a00e8494e8f5ff3d1d42732ce910fe69e7ba0637765eR10), [link](https://github.com/dotCMS/core/pull/24643/files?diff=unified&w=0#diff-ecb60a2e269f8139f898a00e8494e8f5ff3d1d42732ce910fe69e7ba0637765eL47-R49))
*  Define and use `maxNameLength` constant in `dot-experiments-create.component.ts` to store and apply the maximum length of experiment name ([link](https://github.com/dotCMS/core/pull/24643/files?diff=unified&w=0#diff-ecb60a2e269f8139f898a00e8494e8f5ff3d1d42732ce910fe69e7ba0637765eR59), [link](https://github.com/dotCMS/core/pull/24643/files?diff=unified&w=0#diff-ecb60a2e269f8139f898a00e8494e8f5ff3d1d42732ce910fe69e7ba0637765eL95-R98))
