### PR TITLE
Disabled delete goal button when experiments status is not DRAFT

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.scss
@@ -26,7 +26,7 @@ $nav-size: 80px;
     }
 
     &.edit-page-variant-mode {
-        background-color: $color-palette-primary-300;
+        background-color: $color-palette-primary-200;
 
         a:hover {
             background-color: $color-palette-primary-100;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.html
@@ -78,7 +78,6 @@
                     label="{{ 'experiments.configure.goals.add' | dm }}"
                     pButton
                     pRipple
-                    type="submit"
                 ></button>
             </div>
         </ng-template>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.html
@@ -93,15 +93,23 @@
             <span data-testId="goal-label-name-goal">{{ vm.goals.primary.name | dm }}</span>
         </h3>
         <div class="flex-none flex align-items-center delete">
-            <button
-                class="p-button-rounded p-button-text"
-                [pTooltip]="'experiments.goal.delete' | dm"
-                (click)="deleteGoal($event, 'primary', vm.experimentId)"
-                data-testId="goal-delete-button"
-                icon="pi pi-trash"
-                pButton
-                pRipple
-            ></button>
+            <div
+                [pTooltip]="'experiment.configure.edit.only.draft.status' | dm"
+                [tooltipDisabled]="vm.isExperimentADraft"
+                data-testId="tooltip-on-disabled"
+                tooltipPosition="bottom"
+            >
+                <button
+                    class="p-button-rounded p-button-text"
+                    [disabled]="!vm.isExperimentADraft"
+                    (click)="deleteGoal($event, 'primary', vm.experimentId)"
+                    data-testId="goal-delete-button"
+                    icon="pi pi-trash"
+                    pButton
+                    pRipple
+                    pTooltip="Delete"
+                ></button>
+            </div>
         </div>
     </ng-template>
 </ng-container>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.scss
@@ -37,9 +37,7 @@ h3 {
         padding: $spacing-0;
     }
 
-    button {
-        .p-button-icon {
-            color: $color-palette-primary-500;
-        }
+    button.p-button-rounded.p-button-icon-only {
+        color: $color-palette-primary-500;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
@@ -34,6 +34,7 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.configure.goals.no.seleted.goal.message': 'empty message'
 });
 const EXPERIMENT_MOCK = getExperimentMock(0);
+const EXPERIMENT_MOCK_WITH_GOAL = getExperimentMock(2);
 describe('DotExperimentsConfigurationGoalsComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationGoalsComponent>;
     let store: DotExperimentsConfigurationStore;
@@ -177,6 +178,30 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
         confirmPopupComponent.accept();
 
         expect(store.deleteGoal).toHaveBeenCalled();
+    });
+
+    it('should disable delete button and show tooltip when experiment is nos on draft', () => {
+        const vmMock$: {
+            experimentId: string;
+            goals: Goals;
+            status: StepStatus;
+            isExperimentADraft: boolean;
+        } = {
+            experimentId: EXPERIMENT_MOCK_WITH_GOAL.id,
+            goals: EXPERIMENT_MOCK_WITH_GOAL.goals,
+            status: {
+                status: ComponentStatus.IDLE,
+                isOpen: false,
+                experimentStep: null
+            },
+            isExperimentADraft: false
+        };
+
+        spectator.component.vm$ = of(vmMock$);
+        spectator.detectComponentChanges();
+
+        expect(spectator.query(byTestId('goal-delete-button'))).toHaveAttribute('disabled');
+        expect(spectator.query(Tooltip).disabled).toEqual(false);
     });
 
     it('should disable tooltip if is on draft', () => {


### PR DESCRIPTION
### Proposed Changes
* Disabled delete goal button when experiments status is not DRAFT

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Screenshots
<img width="472" alt="Screenshot 2023-04-17 at 11 26 04 AM" src="https://user-images.githubusercontent.com/1909643/232534803-5365e3b1-a5d7-42e5-955c-ee7630db8a8b.png">

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7543d17</samp>

Improved the UI and UX of the edit page variant mode and the experiment goals components. Changed the background color of the variant mode, added a tooltip and disabled state for the delete goal button, and refined the button selector for the icon-only buttons.

## Related Issue
Fixes #24651 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7543d17</samp>

* Changed the background color of the edit page variant mode to match the design mockups and improve the contrast ([link](https://github.com/dotCMS/core/pull/24653/files?diff=unified&w=0#diff-cd1f2d10b389ac28d0bd206565a4907cea972282062cfe3a198306422bad2de1L29-R29))
* Added a tooltip and a disabled state to the delete button for the experiment goals to prevent accidental deletion and provide feedback ([link](https://github.com/dotCMS/core/pull/24653/files?diff=unified&w=0#diff-9c6a33a383c160d59916990dd94526ceb8d79b21060dab519aa60f21dc20f438L96-R112), [link](https://github.com/dotCMS/core/pull/24653/files?diff=unified&w=0#diff-f48b764eb45a85c9c10daf90422fa6f19117eb95905909a93d473aa8ab0f8e2cL40-R41))
* Made the button selector more specific to target only the rounded icon-only buttons and avoid affecting other buttons ([link](https://github.com/dotCMS/core/pull/24653/files?diff=unified&w=0#diff-f48b764eb45a85c9c10daf90422fa6f19117eb95905909a93d473aa8ab0f8e2cL40-R41))
