### PR TITLE
#24644 : Clicking a Container as File is not taking you to the right location in the Site Browser

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/MainSuite.java
@@ -119,6 +119,7 @@ import com.dotmarketing.image.filter.ImageFilterAPIImplTest;
 import com.dotmarketing.image.focalpoint.FocalPointAPITest;
 import com.dotmarketing.osgi.GenericBundleActivatorTest;
 import com.dotmarketing.portlets.browser.BrowserUtilTest;
+import com.dotmarketing.portlets.browser.ajax.BrowserAjaxTest;
 import com.dotmarketing.portlets.categories.business.CategoryFactoryTest;
 import com.dotmarketing.portlets.cmsmaintenance.factories.CMSMaintenanceFactoryTest;
 import com.dotmarketing.portlets.containers.business.ContainerFactoryImplTest;
@@ -131,24 +132,6 @@ import com.dotmarketing.portlets.fileassets.business.FileAssetAPIImplIntegration
 import com.dotmarketing.portlets.fileassets.business.FileAssetFactoryIntegrationTest;
 import com.dotmarketing.portlets.folders.business.FolderFactoryImplTest;
 import com.dotmarketing.portlets.folders.model.FolderTest;
-import com.dotmarketing.portlets.rules.actionlet.PersonaActionletTest;
-import com.dotmarketing.portlets.rules.actionlet.SendRedirectActionletTest;
-import com.dotmarketing.portlets.rules.actionlet.SetRequestAttributeActionletTest;
-import com.dotmarketing.portlets.rules.actionlet.StopProcessingActionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.DateTimeConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.HttpMethodConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.PagesViewedConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.PersonaConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.ReferrerURLConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.RequestAttributeConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.RequestHeaderConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.RequestParameterConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.SessionAttributeConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.UsersBrowserConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.UsersCountryConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.UsersPlatformConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.VisitorsCurrentURLConditionletTest;
-import com.dotmarketing.portlets.rules.conditionlet.VisitorsGeolocationConditionletTest;
 import com.dotmarketing.portlets.templates.business.FileAssetTemplateUtilTest;
 import com.dotmarketing.portlets.templates.business.TemplateFactoryImplTest;
 import com.dotmarketing.portlets.workflows.actionlet.MoveContentActionletTest;
@@ -638,7 +621,8 @@ import org.junit.runners.Suite.SuiteClasses;
         HashedLocalFileRepositoryManagerTest.class,
         ManifestUtilTest.class,
         ZipUtilTest.class,
-        Task230110MakeSomeSystemFieldsRemovableByBaseTypeTest.class
+        Task230110MakeSomeSystemFieldsRemovableByBaseTypeTest.class,
+        BrowserAjaxTest.class
 })
 
 public class MainSuite {

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/browser/ajax/BrowserAjaxTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/browser/ajax/BrowserAjaxTest.java
@@ -1,0 +1,251 @@
+package com.dotmarketing.portlets.browser.ajax;
+
+import com.dotcms.datagen.FolderDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.repackage.org.directwebremoting.WebContext;
+import com.dotcms.repackage.org.directwebremoting.WebContextFactory;
+import com.dotcms.rest.api.v1.browsertree.BrowserTreeHelper;
+import com.dotcms.util.CollectionsUtils;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.portlets.folders.model.Folder;
+import com.liferay.portal.util.WebKeys;
+import com.liferay.util.servlet.SessionMessages;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This test class validates the correct behavior of the methods exposed in the {@link BrowserAjax} class.
+ *
+ * @author Jose Castro
+ * @since Apr 18th, 2023
+ */
+public class BrowserAjaxTest {
+
+    private static Host testSite = null;
+    private static Folder parentFolderOne = null;
+    private static Folder parentFolderTwo = null;
+    private static Folder childFolderOne = null;
+    private static Folder childFolderTwo = null;
+
+    private static HttpSession session = null;
+
+    /**
+     * Set up the DWR context and data for this test. The Site's folder tree looks like this:
+     *
+     * |_test-site
+     *      |_ parent-one
+     *          |_child-one
+     *              |_child-two
+     *      |_parent-two
+     *
+     * @throws Exception An error occurred during the setup.
+     */
+    @BeforeClass
+    public static void prepare() throws Exception {
+        // Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+        final long time = System.currentTimeMillis();
+        testSite = new SiteDataGen().name("browserajaxtest." + time).nextPersisted();
+
+        parentFolderOne = new FolderDataGen().site(testSite).name("parent-one").nextPersisted();
+        parentFolderTwo = new FolderDataGen().site(testSite).name("parent-two").nextPersisted();
+
+        childFolderOne = new FolderDataGen().site(testSite).parent(parentFolderOne).name("child-one").nextPersisted();
+        childFolderTwo = new FolderDataGen().site(testSite).parent(childFolderOne).name("child-two").nextPersisted();
+
+        setUpDwrContext();
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link BrowserAjax#getTree(String)}</li>
+     *     <li><b>Given Scenario:</b> Display the folder tree for a specific Site in the Site Browser.</li>
+     *     <li><b>Expected Result:</b> If a Site is set to be displayed in the Site Browser, the returned data tree must
+     *     reflect only the direct child Folders under such a Site in the UI.</li>
+     * </ul>
+     * This is how the folder tree must look like:
+     * <pre>
+     *      --> test-site [open]
+     *          |_ parent-one
+     *          |_ parent-two
+     * </pre>
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSelectingSiteRoot() throws Exception {
+        // Set test values in session
+        when(session.getAttribute(BrowserTreeHelper.ACTIVE_FOLDER_ID)).thenReturn(null);
+        when(session.getAttribute(BrowserTreeHelper.OPEN_FOLDER_IDS)).thenReturn(new HashSet<>());
+
+        final BrowserAjax browserAjax = new BrowserAjax();
+        final List<Map> folderTree = browserAjax.getTree(testSite.getIdentifier());
+
+        // Check the main Site folder tree structure
+        // Site MUST be "open"
+        assertNotNull("Folder tree must never be null", folderTree);
+        assertEquals("There must be only one Site folder tree", 1, folderTree.size());
+        final Map<String, Object> siteFolderTree = folderTree.get(0);
+        assertEquals("The returned Site ID [" + siteFolderTree.get("identifier") + "] doesn't match the ID of the " +
+                             "test Site [" + testSite.getIdentifier() + "]", testSite.getIdentifier(),
+                siteFolderTree.get("identifier"));
+        assertTrue("The Site node must be open", (boolean) siteFolderTree.get("open"));
+
+        // Only parent-one MUST be open
+        // parent-two MUST NOT be neither "open" nor "selected"
+        final List<Map<String, Object>> parentFolders = (List<Map<String, Object>>) siteFolderTree.get("childrenFolders");
+        assertEquals("There must be two parent Folders for the Test Site", 2, parentFolders.size());
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link BrowserAjax#getTree(String)}</li>
+     *     <li><b>Given Scenario:</b> The grandchild of a folder has been selected via the HTTP Session so that the Site
+     *     Browser displays it in the UI.</li>
+     *     <li><b>Expected Result:</b> If a sub-folder is set to be displayed in the Site Browser, the returned data
+     *     tree must reflect both its selected status and open up all the respective parent folders so that it can be
+     *     seen correctly in the UI.</li>
+     * </ul>
+     * This is how the folder tree must look like:
+     * <pre>
+     *      --> test-site [open]
+     *          |_ parent-one [open]
+     *              |_child-one [open]
+     *                  |_child-two [open, selected]
+     *          |_ parent-two
+     * </pre>
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testExpectedFolderTreeInfo() throws Exception {
+        // Set test values in session
+        when(session.getAttribute(BrowserTreeHelper.ACTIVE_FOLDER_ID)).thenReturn(childFolderTwo.getIdentifier());
+        final Set<String> openFolderIds = CollectionsUtils.set(parentFolderOne.getIdentifier(),
+                childFolderOne.getIdentifier(), childFolderTwo.getIdentifier());
+        when(session.getAttribute(BrowserTreeHelper.OPEN_FOLDER_IDS)).thenReturn(openFolderIds);
+
+        final BrowserAjax browserAjax = new BrowserAjax();
+        final List<Map> folderTree = browserAjax.getTree(testSite.getIdentifier());
+
+        // Only parent-one MUST be open
+        // parent-two MUST NOT be neither "open" nor "selected"
+        final Map<String, Object> siteFolderTree = folderTree.get(0);
+        final List<Map<String, Object>> parentFolders = (List<Map<String, Object>>) siteFolderTree.get("childrenFolders");
+        assertEquals("There must be two parent Folders for the Test Site", 2, parentFolders.size());
+        assertTrue("Folder '" + parentFolderOne.getPath() + "' must be open", (boolean) parentFolders.get(0).get("open"));
+        assertFalse("Folder '" + parentFolderOne.getPath() + "' must NOT be selected", (boolean) parentFolders.get(0).get("selected"));
+
+        assertFalse("Folder '" + parentFolderTwo.getPath() + "' must NOT be open", (boolean) parentFolders.get(1).get("open"));
+        assertFalse("Folder '" + parentFolderTwo.getPath() + "' must NOT be selected", (boolean) parentFolders.get(1).get("selected"));
+
+        // Check the parent-one folder tree structure
+        final List<Map<String, Object>> parentFolderOneData = (List<Map<String, Object>>) parentFolders.get(0).get("childrenFolders");
+        assertEquals("There must be only one child folder under '" + parentFolderOne.getPath() + "'", 1,
+                parentFolderOneData.size());
+
+        // Check the child-one folder tree structure
+        // child-one MUST be "open" but NOT "selected"
+        final Map<String, Object> childFolderOneData = parentFolderOneData.get(0);
+        assertEquals("The returned Child One ID [" + childFolderOneData.get("identifier") + "] doesn't match the ID of the " +
+                             "test Child One [" + childFolderOne.getIdentifier() + "]", childFolderOne.getIdentifier(),
+                childFolderOneData.get("identifier"));
+        assertTrue("Folder '" + childFolderOne.getPath() + "' must be open", (boolean) childFolderOneData.get("open"));
+        assertFalse("Folder '" + childFolderOne.getPath() + "' must NOT be selected", (boolean) childFolderOneData.get("selected"));
+
+        // Check the child-one folder tree structure
+        final List<Map<String, Object>> parentFolderTwoData = (List<Map<String, Object>>) childFolderOneData.get("childrenFolders");
+        assertEquals("There must be only one child folder under '" + childFolderOne.getPath() + "'", 1,
+                parentFolderOneData.size());
+
+        // Check the child-two folder tree structure
+        // child-two MUST be "open" AND "selected"
+        final Map<String, Object> childFolderTwoData = parentFolderTwoData.get(0);
+        assertEquals("The returned Child Two ID [" + childFolderTwoData.get("identifier") + "] doesn't match the ID of the " +
+                             "test Child Two [" + childFolderTwo.getIdentifier() + "]", childFolderTwo.getIdentifier(),
+                childFolderTwoData.get("identifier"));
+        assertTrue("Folder '" + childFolderTwo.getPath() + "' must be open", (boolean) childFolderTwoData.get("open"));
+        assertTrue("Folder '" + childFolderTwo.getPath() + "' must be selected", (boolean) childFolderTwoData.get("selected"));
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link BrowserAjax#getTree(String)}</li>
+     *     <li><b>Given Scenario:</b> The grandchild of a folder has been selected via the HTTP Session so that the Site
+     *     Browser displays it in the UI.</li>
+     *     <li><b>Expected Result:</b> If a sub-folder is set to be displayed in the Site Browser, the returned data
+     *     tree must reflect both its selected status and open up all the respective parent folders so that it can be
+     *     seen correctly in the UI.</li>
+     * </ul>
+     * This is how the folder tree must look like:
+     * <pre>
+     *      --> test-site [open]
+     *          |_ parent-one
+     *          |_ parent-two
+     * </pre>
+     * @throws Exception
+     */
+    @Test
+    public void testFolderTreeInfoWithInvalidFolderId() throws Exception {
+        // Set test values in session
+        when(session.getAttribute(BrowserTreeHelper.ACTIVE_FOLDER_ID)).thenReturn("123");
+        when(session.getAttribute(BrowserTreeHelper.OPEN_FOLDER_IDS)).thenReturn(new HashSet<>());
+
+        final BrowserAjax browserAjax = new BrowserAjax();
+        final List<Map> folderTree = browserAjax.getTree(testSite.getIdentifier());
+
+        // Only parent-one MUST be open
+        // parent-two MUST NOT be neither "open" nor "selected"
+        final Map<String, Object> siteFolderTree = folderTree.get(0);
+        final List<Map<String, Object>> parentFolders = (List<Map<String, Object>>) siteFolderTree.get("childrenFolders");
+        assertEquals("There must be two parent Folders for the Test Site", 2, parentFolders.size());
+        assertFalse("Folder '" + parentFolderOne.getPath() + "' must NOT be open", (boolean) parentFolders.get(0).get("open"));
+        assertFalse("Folder '" + parentFolderOne.getPath() + "' must NOT be selected", (boolean) parentFolders.get(0).get("selected"));
+
+        assertFalse("Folder '" + parentFolderTwo.getPath() + "' must NOT be open", (boolean) parentFolders.get(1).get("open"));
+        assertFalse("Folder '" + parentFolderTwo.getPath() + "' must NOT be selected", (boolean) parentFolders.get(1).get("selected"));
+    }
+
+    /**
+     * Sets up the DWR context using Mockito so that the {@link BrowserAjax} class can be tested correctly.
+     */
+    private static void setUpDwrContext() {
+        session = mock(HttpSession.class);
+        when(session.getAttribute(SessionMessages.KEY)).thenReturn(new LinkedHashMap());
+
+        final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        when(httpServletRequest.getSession()).thenReturn(session);
+        when(httpServletRequest.getAttribute(WebKeys.USER)).thenReturn(APILocator.systemUser());
+
+        final WebContext webContext = mock(WebContext.class);
+        when(webContext.getHttpServletRequest()).thenReturn(httpServletRequest);
+
+        final WebContextFactory.WebContextBuilder webContextBuilderMock =
+                mock(WebContextFactory.WebContextBuilder.class);
+        when(webContextBuilderMock.get()).thenReturn(webContext);
+
+        final com.dotcms.repackage.org.directwebremoting.Container containerMock =
+                mock(com.dotcms.repackage.org.directwebremoting.Container.class);
+        when(containerMock.getBean(WebContextFactory.WebContextBuilder.class)).thenReturn(webContextBuilderMock);
+
+        WebContextFactory.attach(containerMock);
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavTool.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavTool.java
@@ -1,12 +1,10 @@
 package com.dotcms.rendering.velocity.viewtools.navigation;
 
 
-import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
-import com.dotmarketing.business.Versionable;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -335,7 +333,7 @@ public class NavTool implements ViewTool {
 
     public NavResult getNav(String path) throws DotDataException, DotSecurityException {
         if(path.contains("/api/v1/containers")){
-            final String folderInode = ((BrowserAjax)this.request.getSession().getAttribute("BrowserAjax")).getActiveFolderInode();
+            final String folderInode = ((BrowserAjax)this.request.getSession().getAttribute("BrowserAjax")).getActiveFolderId();
             final String folderIdentifier = APILocator.getFolderAPI().find(folderInode,systemUser,false).getIdentifier();
             path = APILocator.getIdentifierAPI().find(folderIdentifier).getPath();
         }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/browser/BrowserResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/browser/BrowserResource.java
@@ -7,20 +7,14 @@ import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
 import com.dotcms.rest.api.v1.browsertree.BrowserTreeHelper;
-import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.portlets.browser.ajax.BrowserAjax;
-import com.dotmarketing.portlets.folders.model.Folder;
-import com.dotmarketing.util.HostUtil;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
-import com.dotmarketing.util.WebKeys;
 import com.google.common.annotations.VisibleForTesting;
 import com.liferay.portal.model.User;
-import com.liferay.util.StringPool;
 import org.glassfish.jersey.server.JSONP;
 
 import javax.servlet.http.HttpServletRequest;
@@ -34,6 +28,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Optional;
+
+import static com.dotcms.rest.api.v1.browsertree.BrowserTreeHelper.ACTIVE_FOLDER_ID;
 
 /**
  * Expose the Browser functionality such as get the contents in a folder
@@ -79,11 +75,12 @@ public class BrowserResource {
 
         final User user = initDataObject.getUser();
 
-        final Optional<String> selectedPathOpt = BrowserTreeHelper.getInstance().findSelectedFolder(request);
+        final Optional<String> selectedPathOpt = Optional.ofNullable((String) request.getSession().getAttribute(ACTIVE_FOLDER_ID));
         return selectedPathOpt.isPresent()?
                 Response.ok(new ResponseEntityView(APILocator.getFolderAPI().find(selectedPathOpt.get(), user, false))).build():
                 Response.status(Response.Status.NOT_FOUND).build();
     }
+
     /**
      * Set the select folder into the site browser, next time the site browser is opened will expand to selected folder
      * @param request  {@link HttpServletRequest}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/browsertree/BrowserTreeHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/browsertree/BrowserTreeHelper.java
@@ -85,17 +85,6 @@ public class BrowserTreeHelper {
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Tries to find the select folder
-     * @return Optional String, present if the folder select exists
-     */
-    public Optional<String> findSelectedFolder (final HttpServletRequest request) {
-        final String activeFolderId = (String) DwrUtil.getSession().getAttribute(ACTIVE_FOLDER_ID);
-        String siteBrowserActiveFolderInode = (String)request.getSession().getAttribute("siteBrowserActiveFolderInode");
-        return Optional.ofNullable(null == siteBrowserActiveFolderInode && null != activeFolderId?
-                                           activeFolderId: siteBrowserActiveFolderInode);
-    }
-
     private Optional<Host> findHostFromPath(final String folderPath, final User user) {
 
         final int hostIndicatorIndex = folderPath.indexOf(HostUtil.HOST_INDICATOR);

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/browsertree/BrowserTreeHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/browsertree/BrowserTreeHelper.java
@@ -5,10 +5,10 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Permissionable;
 import com.dotmarketing.business.Treeable;
+import com.dotmarketing.business.ajax.DwrUtil;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.portlets.browser.ajax.BrowserAjax;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
@@ -90,11 +90,10 @@ public class BrowserTreeHelper {
      * @return Optional String, present if the folder select exists
      */
     public Optional<String> findSelectedFolder (final HttpServletRequest request) {
-
-        final BrowserAjax browserAjax = (BrowserAjax)request.getSession().getAttribute("BrowserAjax");
+        final String activeFolderId = (String) DwrUtil.getSession().getAttribute(ACTIVE_FOLDER_ID);
         String siteBrowserActiveFolderInode = (String)request.getSession().getAttribute("siteBrowserActiveFolderInode");
-        return Optional.ofNullable(null == siteBrowserActiveFolderInode && null != browserAjax?
-                browserAjax.getActiveFolderId(): siteBrowserActiveFolderInode);
+        return Optional.ofNullable(null == siteBrowserActiveFolderInode && null != activeFolderId?
+                                           activeFolderId: siteBrowserActiveFolderInode);
     }
 
     private Optional<Host> findHostFromPath(final String folderPath, final User user) {

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/browsertree/BrowserTreeHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/browsertree/BrowserTreeHelper.java
@@ -1,11 +1,11 @@
 package com.dotcms.rest.api.v1.browsertree;
 
-import com.dotcms.rest.ResponseEntityView;
+import com.dotcms.util.TreeableNameComparator;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.Permissionable;
 import com.dotmarketing.business.Treeable;
 import com.dotmarketing.business.UserAPI;
-import com.dotcms.util.TreeableNameComparator;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -15,13 +15,12 @@ import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.HostUtil;
 import com.dotmarketing.util.UtilMethods;
-import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
+import javax.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +34,9 @@ public class BrowserTreeHelper {
     private final HostAPI hostAPI;
     private final FolderAPI folderAPI;
     private final UserAPI userAPI;
+
+    public static final String OPEN_FOLDER_IDS = "siteBrowserOpenFolderIds";
+    public static final String ACTIVE_FOLDER_ID = "siteBrowserActiveFolderInode";
 
     private final static TreeableNameComparator TREEABLE_NAME_COMPARATOR =
             new TreeableNameComparator();
@@ -140,34 +142,34 @@ public class BrowserTreeHelper {
      * @throws DotDataException
      * @throws DotSecurityException
      */
-    public void selectFolder (final HttpServletRequest request, final String fullFolderPath,
-                              final User user, final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
-
-        final Optional<Host> hostOpt = findHostFromPath(fullFolderPath, user);
-        final Host host              = hostOpt.isPresent()? hostOpt.get(): APILocator.getHostAPI().findDefaultHost(user, respectFrontendRoles);
-        final Host currentHost       = WebAPILocator.getHostWebAPI().getCurrentHostNoThrow(request);
-        final String folderPath      = getFolderPath(fullFolderPath);
-        final Folder folder          = APILocator.getFolderAPI().findFolderByPath(folderPath, host, user, respectFrontendRoles);
-
-        if (null != folder && UtilMethods.isSet(folder.getIdentifier()) && null != host) {
-
-            if (null == currentHost || !host.getIdentifier().equals(currentHost.getIdentifier())) {
-
-                HostUtil.switchSite(request, host);
+    public void selectFolder(final HttpServletRequest request, final String fullFolderPath, final User user,
+                             final boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
+        final Optional<Host> siteOpt = this.findHostFromPath(fullFolderPath, user);
+        final Host site              = siteOpt.isPresent()? siteOpt.get(): this.hostAPI.findDefaultHost(user, respectFrontendRoles);
+        final Host currentSite       = WebAPILocator.getHostWebAPI().getCurrentHostNoThrow(request);
+        final String folderPath      = this.getFolderPath(fullFolderPath);
+        final Folder folder          = this.folderAPI.findFolderByPath(folderPath, site, user, respectFrontendRoles);
+        if (null == folder || !UtilMethods.isSet(folder.getIdentifier()) || null == site || !UtilMethods.isSet(site.getIdentifier())) {
+            throw new IllegalArgumentException(String.format("Path '%s' is pointing to an invalid Site or an invalid " +
+                                                                     "Folder path", fullFolderPath));
+        }
+        if (null == currentSite || !site.getIdentifier().equals(currentSite.getIdentifier())) {
+            HostUtil.switchSite(request, site);
+        }
+        final HttpSession session = request.getSession();
+        session.setAttribute(ACTIVE_FOLDER_ID, folder.getInode());
+        final Folder leafFolder = this.folderAPI.find(folder.getInode(), user, false);
+        if (null != leafFolder && UtilMethods.isSet(leafFolder.getIdentifier())) {
+            final List<String> openFolderIds = new ArrayList<>();
+            openFolderIds.add(folder.getInode());
+            session.setAttribute(OPEN_FOLDER_IDS, openFolderIds);
+            Permissionable parent = leafFolder.getParentPermissionable();
+            while (parent != null) {
+                if (parent instanceof Folder) {
+                    openFolderIds.add(((Folder) parent).getIdentifier());
+                }
+                parent = parent.getParentPermissionable();
             }
-
-            BrowserAjax browserAjax = (BrowserAjax)request.getSession().getAttribute("BrowserAjax");
-            if (null == browserAjax) {
-
-                browserAjax = new BrowserAjax();
-                request.getSession().setAttribute("BrowserAjax", browserAjax);
-            }
-
-            browserAjax.setCurrentOpenFolder(folder.getInode(), host.getIdentifier(), user);
-            request.getSession().setAttribute("siteBrowserActiveFolderInode", folder.getInode());
-        } else {
-
-            throw new IllegalArgumentException("The path seems to be not valid: " + fullFolderPath);
         }
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/browsertree/BrowserTreeHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/browsertree/BrowserTreeHelper.java
@@ -5,7 +5,6 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Permissionable;
 import com.dotmarketing.business.Treeable;
-import com.dotmarketing.business.ajax.DwrUtil;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;

--- a/dotCMS/src/main/java/com/dotmarketing/business/ajax/DwrUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/ajax/DwrUtil.java
@@ -3,14 +3,24 @@ package com.dotmarketing.business.ajax;
 import com.dotcms.repackage.org.directwebremoting.WebContext;
 import com.dotcms.repackage.org.directwebremoting.WebContextFactory;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.business.Permissionable;
+import com.dotmarketing.business.Role;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.browser.ajax.BrowserAjax;
+import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.SecurityLogger;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
 import com.liferay.portal.model.User;
+
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Jonathan Gamba 11/29/17
@@ -92,6 +102,58 @@ public class DwrUtil {
             throw new DotSecurityException("not authorized");
         }
         return loggedInUser;
+    }
+
+    /**
+     * Returns the Roles that are assigned to a given user in the form of an array.
+     *
+     * @param user The {@link User} whose Roles are being retrieved.
+     *
+     * @return The array or {@link Role} objects.
+     */
+    public static Role[] getUserRoles(final User user) {
+        Role[] roles = new Role[]{};
+        try {
+            roles = com.dotmarketing.business.APILocator.getRoleAPI().loadRolesForUser(user.getUserId()).toArray(new Role[0]);
+        } catch (final DotDataException e) {
+            Logger.error(BrowserAjax.class, String.format("Could not get Roles for User '%s': %s", user.getUserId(),
+                    e.getMessage()), e);
+        }
+        return roles;
+    }
+
+    /**
+     * Returns the list of permissions that a given User has on a given Permissionable object, based on an array of
+     * specific Roles. The Permissionable object can be a Site or a Folder.
+     *
+     * @param permissionable The {@link Permissionable} whose User permissions will be checked.
+     * @param roles          The array of {@link Role} objects that will be used to check the User permissions.
+     * @param user           The {@link User} whose permissions will be checked.
+     *
+     * @return The {@link Optional} containing the list of permissions that the User has on the Permissionable object.
+     */
+    public static Optional<List<Integer>> getPermissions(final Permissionable permissionable, final Role[] roles, final User user) {
+        final PermissionAPI permissionAPI = APILocator.getPermissionAPI();
+        try {
+            final List<Integer> permissions = permissionAPI.getPermissionIdsFromRoles(permissionable, roles, user);
+            return Optional.of(permissions);
+        } catch (final DotDataException e) {
+            Logger.error(DwrUtil.class, String.format("Failed to retrieve permissions of User '%s' on parent '%s' for" +
+                                                              " Roles [ %s ]: %s", user.getUserId(),
+                    permissionable.getPermissionId(), Arrays.toString(roles), e.getMessage()), e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns the current HTTP Session object from the Web Context Factory.
+     *
+     * @return The {@link HttpSession} object.
+     */
+    public static HttpSession getSession() {
+        final WebContext ctx = WebContextFactory.get();
+        final HttpServletRequest request = ctx.getHttpServletRequest();
+        return request.getSession();
     }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
@@ -110,6 +110,7 @@ public class BrowserAjax {
 	private final IdentifierAPI identifierAPI = APILocator.getIdentifierAPI();
 
 	String activeHostId = "";
+	private static final String ALL_SITES_ID = "allHosts";
 
     private static final String SELECTED_BROWSER_PATH_OBJECT = "SELECTED_BROWSER_PATH_OBJECT";
 
@@ -163,7 +164,7 @@ public class BrowserAjax {
 		final User user = DwrUtil.getLoggedInUser();
         siteId = UtilMethods.isSet(siteId) ? siteId : this.getCurrentHost();
         final Role[] roles = DwrUtil.getUserRoles(user);
-		final List<Host> siteList = !UtilMethods.isSet(siteId) || siteId.equals("allHosts")
+		final List<Host> siteList = !UtilMethods.isSet(siteId) || siteId.equals(ALL_SITES_ID)
 										 ? this.hostAPI.findAllFromCache(user, false)
 										 : List.of(this.hostAPI.find(siteId, user, false));
 
@@ -846,7 +847,7 @@ public class BrowserAjax {
 			folderDataMap.put("open", false);
 			// For backwards compatibility, we need to check the folder-selected status using both folder Inode and
 			// Identifier
-			if (null != openFolderIds && (openFolderIds.contains(folder.getIdentifier()) || openFolderIds.contains(folder.getInode()))) {
+			if (openFolderIds.contains(folder.getIdentifier()) || openFolderIds.contains(folder.getInode())) {
         		final List<Map> childrenMaps = this.getFoldersTree(folder, roles);
         		folderDataMap.put("open", true);
         		folderDataMap.put("childrenFolders", childrenMaps);
@@ -2189,7 +2190,7 @@ public class BrowserAjax {
 		if(permissions.contains(PERMISSION_READ)){
 			Host allHosts = new Host();
 			allHosts.setHostname("All Hosts");
-			allHosts.setIdentifier("allHosts");
+			allHosts.setIdentifier(ALL_SITES_ID);
 			hostsToReturn.add(hostMap(allHosts));
 		}
 
@@ -2198,7 +2199,7 @@ public class BrowserAjax {
 
 
 	public List<Map<String, Object>> getHostSubfolders(String hostId) throws PortalException, SystemException, DotDataException, DotSecurityException {
-		if(hostId.equals("allHosts")){
+		if(hostId.equals(ALL_SITES_ID)){
 			return  new ArrayList<Map<String,Object>>();
 		}
     	UserWebAPI userWebAPI = WebAPILocator.getUserWebAPI();
@@ -2373,7 +2374,7 @@ public class BrowserAjax {
 	}
 
 	public List<Map<String, Object>> getHostThemes(String hostId) throws PortalException, SystemException, DotDataException, DotSecurityException {
-		if(hostId.equals("allHosts")){
+		if(hostId.equals(ALL_SITES_ID)){
 			return  new ArrayList<Map<String,Object>>();
 		}
     	UserWebAPI userWebAPI = WebAPILocator.getUserWebAPI();


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 954cbd6</samp>

The pull request improves the functionality and code quality of the browser tree feature, which allows users to navigate and select folders and sites in the dotCMS UI. It refactors the `selectFolder` method in `BrowserTreeHelper.java` and the `BrowserAjax.java` class, and adds new utility methods to `DwrUtil.java` for folder tree operations. It also applies code style and documentation standards to the modified files.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 954cbd6</samp>

*  Reorder and add imports to follow code style guidelines and use new classes ([link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-ed592e4d521552ac42576b554030295927c520d45a10994232e9fdf48f408f5eL3-R8), [link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-ed592e4d521552ac42576b554030295927c520d45a10994232e9fdf48f408f5eL18), [link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-ed592e4d521552ac42576b554030295927c520d45a10994232e9fdf48f408f5eL24-R23), [link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-e3b7aa4830b195711eeebbf00eebe65af56103156b2fcc08aed92a82546895cdL6-R23), [link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L22-R24))
*  Add constants for session attribute names related to folder tree state ([link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-ed592e4d521552ac42576b554030295927c520d45a10994232e9fdf48f408f5eR38-R40), [link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9R85-R86))
*  Add utility methods to DwrUtil.java to get user roles, permissions, and session from web context ([link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-e3b7aa4830b195711eeebbf00eebe65af56103156b2fcc08aed92a82546895cdL97-R157))
*  Modify selectFolder method in BrowserTreeHelper.java to use new constants, utility methods, and logic to handle folder and site selection ([link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-ed592e4d521552ac42576b554030295927c520d45a10994232e9fdf48f408f5eL143-R172))
*  Modify getTree method in BrowserAjax.java to use new constants, utility methods, and logic to get the folder tree for a host or folder ([link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L144-R192))
*  Remove unused setCurrentOpenFolder method in BrowserAjax.java ([link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L279-L307))
*  Modify getFolders method in BrowserAjax.java to use new constants, utility methods, and logic to get the contents of a site or folder ([link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L339-R300), [link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L422-R378), [link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L437-R391))
*  Modify getFoldersTree methods in BrowserAjax.java to use new utility methods, logic, and javadoc comments to get the sub-folders of a host or folder ([link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L849-R832), [link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L873-R881))
*  Remove private getUserRoles method in BrowserAjax.java as it is replaced by the utility method in DwrUtil.java ([link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L2311-R2285), [link](https://github.com/dotCMS/core/pull/24664/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L2525-L2542))
