### PR TITLE
Add default DOTFAVORITEPAGE_FEATURE_ENABLE

### DIFF
--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -832,3 +832,7 @@ analytics.accesstoken.renewjob.cron=0 0/1 * * * ?
 ## If You want to use the thread pool directly outside the Quartz Job, set this property to false
 ## This property is only effective if DELETE_CONTENT_TYPE_ASYNC=true
 #DELETE_CONTENT_TYPE_ASYNC_WITH_JOB=true
+
+
+## Favorite Pages Portlet
+DOTFAVORITEPAGE_FEATURE_ENABLE=false


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 21b1213</samp>

Add a new property `FAVORITE_PAGES_PORTLET_ENABLED` to `dotmarketing-config.properties` to control the favorite pages portlet feature. The feature is disabled by default and can be enabled by setting the property to true.

## Related Issue
Fixes #N/A

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 21b1213</samp>

* Add a new property `FAVORITE_PAGES_PORTLET_ENABLED` to the dotmarketing-config.properties file to disable the favorite pages portlet feature by default ([link](https://github.com/dotCMS/core/pull/24665/files?diff=unified&w=0#diff-2811adad7784fd6904fe136b6f40ab001ef040527847c1b6664178adf9bde777L835-R837))