### PR TITLE
Show report icon when experiment is ended

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.html
@@ -49,14 +49,6 @@
 
 <ng-template #actionButtonTpl let-experiment>
     <dot-icon-button-tooltip
-        *ngIf="experiment.status === experimentStatus.ENDED"
-        [icon]="'archive'"
-        (click)="archive($event, experiment)"
-        data-testId="experiment-row-archive-button"
-        tooltipText="{{ 'experiments.action.archive' | dm }}"
-    ></dot-icon-button-tooltip>
-
-    <dot-icon-button-tooltip
         *ngIf="
             experiment.status === experimentStatus.DRAFT ||
             experiment.status === experimentStatus.SCHEDULED
@@ -68,11 +60,22 @@
     ></dot-icon-button-tooltip>
 
     <dot-icon-button-tooltip
-        *ngIf="experiment.status === experimentStatus.RUNNING"
+        *ngIf="
+            experiment.status === experimentStatus.RUNNING ||
+            experiment.status === experimentStatus.ENDED
+        "
         [icon]="'bar_chart'"
         (click)="viewReports(experiment)"
         data-testId="experiment-row-report-button"
         tooltipText="{{ 'experiments.action.reports' | dm }}"
+    ></dot-icon-button-tooltip>
+
+    <dot-icon-button-tooltip
+        *ngIf="experiment.status === experimentStatus.ENDED"
+        [icon]="'archive'"
+        (click)="archive($event, experiment)"
+        data-testId="experiment-row-archive-button"
+        tooltipText="{{ 'experiments.action.archive' | dm }}"
     ></dot-icon-button-tooltip>
 </ng-template>
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
@@ -206,6 +206,20 @@ describe('DotExperimentsListTableComponent', () => {
                 uiDotIconButtonTooltipComponent = spectator.query(UiDotIconButtonTooltipComponent);
                 expect(uiDotIconButtonTooltipComponent.icon).toBe('bar_chart');
             });
+
+            it('should the row  has REPORTS icon when is RUNNING', () => {
+                const groupedExperimentByStatus: GroupedExperimentByStatus[] = [
+                    {
+                        status: DotExperimentStatusList.ENDED,
+                        experiments: [RUNNING_EXPERIMENT_MOCK]
+                    }
+                ];
+
+                spectator.setInput('experimentGroupedByStatus', groupedExperimentByStatus);
+
+                uiDotIconButtonTooltipComponent = spectator.query(UiDotIconButtonTooltipComponent);
+                expect(uiDotIconButtonTooltipComponent.icon).toBe('bar_chart');
+            });
         });
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
@@ -175,8 +175,10 @@ describe('DotExperimentsListTableComponent', () => {
 
                 spectator.setInput('experimentGroupedByStatus', groupedExperimentByStatus);
 
-                uiDotIconButtonTooltipComponent = spectator.query(UiDotIconButtonTooltipComponent);
-                expect(uiDotIconButtonTooltipComponent.icon).toBe('archive');
+                expect(spectator.queryAll(UiDotIconButtonTooltipComponent)[0].icon).toBe(
+                    'bar_chart'
+                );
+                expect(spectator.queryAll(UiDotIconButtonTooltipComponent)[1].icon).toBe('archive');
             });
 
             it('should the row not has any icon in action column', () => {


### PR DESCRIPTION
### Proposed Changes
* Show the icon of` go to reports` when experiment status is `ENDED`

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
N/A

### Screenshots

<img width="1055" alt="Screenshot 2023-04-18 at 1 42 51 PM" src="https://user-images.githubusercontent.com/1909643/232860106-9bc5e916-5ee3-4619-85e7-7100690450a2.png">

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19a62ef</samp>

This pull request improves the dot-experiments-list-table component by removing duplicate code, enabling reports for ended experiments, and adding an archive button for ended experiments. It also adds a test case for the reports button logic.

## Related Issue
Fixes #24670 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19a62ef</samp>

*  Remove duplicated code for archive button ([link](https://github.com/dotCMS/core/pull/24671/files?diff=unified&w=0#diff-599b22db09a38536a5bc7487212c0bbc533763b1c554c32ab2f855a03fa99174L52-L59))
*  Enable reports button for both running and ended experiments ([link](https://github.com/dotCMS/core/pull/24671/files?diff=unified&w=0#diff-599b22db09a38536a5bc7487212c0bbc533763b1c554c32ab2f855a03fa99174L71-R66), [link](https://github.com/dotCMS/core/pull/24671/files?diff=unified&w=0#diff-fb926036ff03df5c46dfe63dd03ba42b9484b439a35fa949c0bfaeddb2976c0fR209-R222))
*  Add archive button for ended experiments ([link](https://github.com/dotCMS/core/pull/24671/files?diff=unified&w=0#diff-599b22db09a38536a5bc7487212c0bbc533763b1c554c32ab2f855a03fa99174R72-R79))