### PR TITLE
dotCMS/core#24561 fix when archived page needs to be removed from collection and added a empty item at the bottom's collection to keep pagination

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -451,6 +451,50 @@ describe('DotPageStore', () => {
             });
     }));
 
+    it('should remove page archived from pages collection and add undefined at the bottom', fakeAsync(() => {
+        dotPageStore.setPages(favoritePagesInitialTestData);
+        const old = {
+            contentTook: 0,
+            jsonObjectView: {
+                contentlets: favoritePagesInitialTestData as unknown as DotCMSContentlet[]
+            },
+            queryTook: 1,
+            resultsSize: 2
+        };
+
+        const updated = {
+            contentTook: 0,
+            jsonObjectView: {
+                contentlets: [] as unknown as DotCMSContentlet[]
+            },
+            queryTook: 1,
+            resultsSize: 4
+        };
+
+        const mockFunction = (times) => {
+            let count = 1;
+
+            return Observable.create((observer) => {
+                if (count++ > times) {
+                    observer.next(updated);
+                } else {
+                    observer.next(old);
+                }
+            });
+        };
+
+        spyOn(dotESContentService, 'get').and.returnValue(mockFunction(3));
+
+        dotPageStore.updateSinglePageData({ identifier: '123', isFavoritePage: false });
+
+        tick(3000);
+
+        // Testing page archived removed from pages collection and added undefined at the bottom
+        dotPageStore.state$.subscribe((data) => {
+            expect(data.pages.items).toEqual([favoritePagesInitialTestData[1], undefined]);
+        });
+    }));
+
     it('should get all Workflow actions and static actions from a contentlet', () => {
         spyOn(dotWorkflowsActionsService, 'getByInode').and.returnValue(of(mockWorkflowsActions));
         dotPageStore.showActionsMenu({

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -338,7 +338,6 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
                                         throw false;
                                     } else {
                                         // Finished fetch loop and will proceed to set data on store
-
                                         if (isFavoritePage) {
                                             const pagesData = this.get().favoritePages.items.map(
                                                 (page) => {
@@ -350,11 +349,23 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
 
                                             this.setFavoritePages(pagesData);
                                         } else {
-                                            const pagesData = this.get().pages.items.map((page) => {
-                                                return page?.identifier === identifier
-                                                    ? items.jsonObjectView.contentlets[0]
-                                                    : page;
-                                            });
+                                            let pagesData = this.get().pages.items;
+
+                                            if (items.jsonObjectView.contentlets[0] === undefined) {
+                                                pagesData = pagesData.filter((page) => {
+                                                    return page?.identifier !== identifier;
+                                                });
+
+                                                // Add undefined to keep the same length of the array,
+                                                // otherwise the pagination(endless scroll) will break
+                                                pagesData.push(undefined);
+                                            } else {
+                                                pagesData = pagesData.map((page) => {
+                                                    return page?.identifier === identifier
+                                                        ? items.jsonObjectView.contentlets[0]
+                                                        : page;
+                                                });
+                                            }
 
                                             this.setPages(pagesData);
                                         }


### PR DESCRIPTION

when a content is archived using the options in the listing, the row now has a blur like effect that never disappears.

### Proposed Changes
* when archived page needs to be removed from collection and added a empty item at the bottom's collection to keep pagination

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
![2023-04-17_12-00-58 (1)](https://user-images.githubusercontent.com/923947/232571807-735cd2df-6245-43a6-acb1-b68aa3c46ba0.gif)
