### PR TITLE
Unable to Reorder Contents Editing a Page

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -7,7 +7,6 @@ import { catchError, filter, switchMap, take, tap } from 'rxjs/operators';
 
 import { DotGlobalMessageService } from '@components/_common/dot-global-message/dot-global-message.service';
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';
-import { MODEL_VAR_NAME } from '@dotcms/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js';
 import { INLINE_TINYMCE_SCRIPTS } from '@dotcms/app/portlets/dot-edit-page/content/services/html/libraries/inline-edit-mode.js';
 import {
     DotAlertConfirmService,
@@ -157,7 +156,8 @@ export class DotEditContentHtmlService {
             const iframeElement = this.getEditPageIframe();
 
             iframeElement.addEventListener('load', () => {
-                iframeElement.contentWindow[MODEL_VAR_NAME] = this.pageModel$;
+                iframeElement.contentWindow['handlerContentReorder'] =
+                    this.handlerContentReorder.bind(this);
                 iframeElement.contentWindow['contentletEvents'] = this.contentletEvents$;
 
                 this.bindGlobalEvents();
@@ -379,6 +379,24 @@ export class DotEditContentHtmlService {
                     }
                 });
         }
+    }
+
+    /**
+     * handler move/reorder contentlet
+     *
+     * @private
+     * @param {DotPageContainer[]} model
+     * @memberof DotEditContentHtmlService
+     */
+    handlerContentReorder(model: DotPageContainer[]) {
+        this.savePage(model)
+            .pipe(take(1))
+            .subscribe(() => {
+                this.pageModel$.next({
+                    type: PageModelChangeEventType.MOVE_CONTENT,
+                    model
+                });
+            });
     }
 
     /**

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/dot-contentlets-events.model.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/dot-contentlets-events.model.ts
@@ -12,6 +12,8 @@ export type DotContentletEventAddContentType = DotContentletEvent<DotAddContentT
 
 export type DotContentletEventRelocate = DotContentletEvent<DotRelocatePayload>;
 
+export type DotContentletEventReorder = DotContentletEvent<DotPageContainer>;
+
 export type DotContentletEventSelect = DotContentletEvent<DotPageContent>;
 
 export type DotContentletEventSave = DotContentletEvent<DotPageContent>;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
@@ -1,5 +1,3 @@
-export const MODEL_VAR_NAME = 'dotNgModel';
-
 export const EDIT_PAGE_JS = `
 (function () {
     var forbiddenTarget;
@@ -18,7 +16,7 @@ function initDragAndDrop () {
         return containers;
     }
 
-    function getDotNgModel(data) {
+    function getDotNgModel(data = {}) {
         const { identifier, uuid, addedContentId } = data;
         const model = [];
         getContainers().forEach(function(container) {
@@ -130,13 +128,11 @@ function initDragAndDrop () {
     drake.on('drop', function(el, target, source, sibling) {
         const updatedModel = getDotNgModel();
         if (JSON.stringify(updatedModel) !== JSON.stringify(currentModel)) {
-            window.${MODEL_VAR_NAME}.next({
-                model: getDotNgModel(),
-                type: 'MOVE_CONTENT',
-            });
+            window?.handlerContentReorder(getDotNgModel());
         }
 
         if (target !== source) {
+            console.log('relocate');
             window.contentletEvents.next({
                 name: 'relocate',
                 data: {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
@@ -128,11 +128,13 @@ function initDragAndDrop () {
     drake.on('drop', function(el, target, source, sibling) {
         const updatedModel = getDotNgModel();
         if (JSON.stringify(updatedModel) !== JSON.stringify(currentModel)) {
-            window?.handlerContentReorder(getDotNgModel());
+            window.contentletEvents.next({
+                name: 'reorder',
+                data: updatedModel
+            });
         }
 
         if (target !== source) {
-            console.log('relocate');
             window.contentletEvents.next({
                 name: 'relocate',
                 data: {

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
@@ -728,7 +728,7 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
                  // Set the previous selected value of the tree or the conHostValue after the tree is loaded. 
                  setTimeout(()=> {
                         const newTree = dijit.byId('FolderHostSelector-tree');
-                        newTree.set('path', oldTre?.path ||  "<%= conHostValue %>");
+                        newTree.set('path', oldTree?.path ||  "<%= conHostValue %>");
                         newTree.set('selectedItem', oldTree?.selectedItem ||   "<%= conHostValue %>");
                  },1000);
 


### PR DESCRIPTION
## Video

https://user-images.githubusercontent.com/72418962/233159865-5af8249f-618d-4823-8050-74faa13b77ce.mov

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbb4b35</samp>

Refactored the dot-edit-content-html service and the iframe-edit-mode.js.ts file to improve the drag and drop feature in the edit page mode. Fixed a typo in the view_contentlets_js_inc.jsp file that caused an error in the content search dialog.

## Related Issue
Fixes #24678

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dbb4b35</samp>

*  Refactor the drag and drop feature in the edit page mode to improve performance and reliability ([link](https://github.com/dotCMS/core/pull/24685/files?diff=unified&w=0#diff-803b27038de2abbfb0091318308d39df3f46e46241dc50eeb2271abeb1b45ae7L160-R160), [link](https://github.com/dotCMS/core/pull/24685/files?diff=unified&w=0#diff-803b27038de2abbfb0091318308d39df3f46e46241dc50eeb2271abeb1b45ae7R385-R402), [link](https://github.com/dotCMS/core/pull/24685/files?diff=unified&w=0#diff-77dcce06b1ea346a9f5153ae2f748346ca511b46315261ca894696c11e40b230L133-R135))
  * Remove the unused import of the constant `EDIT_PAGE_IFRAME_PAGE_MODEL` from `dot-edit-content-html.service.ts` ([link](https://github.com/dotCMS/core/pull/24685/files?diff=unified&w=0#diff-803b27038de2abbfb0091318308d39df3f46e46241dc50eeb2271abeb1b45ae7L10))
  * Remove the declaration of the same constant from `iframe-edit-mode.js.ts` ([link](https://github.com/dotCMS/core/pull/24685/files?diff=unified&w=0#diff-77dcce06b1ea346a9f5153ae2f748346ca511b46315261ca894696c11e40b230L1-L2))
  * Replace the assignment of the page model to the iframe window with a call to the `handlerContentReorder` function in `dot-edit-content-html.service.ts` ([link](https://github.com/dotCMS/core/pull/24685/files?diff=unified&w=0#diff-803b27038de2abbfb0091318308d39df3f46e46241dc50eeb2271abeb1b45ae7L160-R160), [link](https://github.com/dotCMS/core/pull/24685/files?diff=unified&w=0#diff-77dcce06b1ea346a9f5153ae2f748346ca511b46315261ca894696c11e40b230L133-R135))
  * Add the `handlerContentReorder` function in `dot-edit-content-html.service.ts` that saves the page model after a content reorder event and emits a new page model change event ([link](https://github.com/dotCMS/core/pull/24685/files?diff=unified&w=0#diff-803b27038de2abbfb0091318308d39df3f46e46241dc50eeb2271abeb1b45ae7R385-R402))
* Add a default value for the data parameter in the `getDotNgModel` function in `iframe-edit-mode.js.ts` ([link](https://github.com/dotCMS/core/pull/24685/files?diff=unified&w=0#diff-77dcce06b1ea346a9f5153ae2f748346ca511b46315261ca894696c11e40b230L21-R19))
* Fix a typo in the variable name `oldTree` in `view_contentlets_js_inc.jsp` ([link](https://github.com/dotCMS/core/pull/24685/files?diff=unified&w=0#diff-1260ed1ed8b9f22ca5c14f1e4caa3e4d3c1ada11674f6bf7572ac34cdc209497L731-R731))
