### PR TITLE
Add a fallback value for `this.currentContainer` to prevent errors when accessing its properties 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -399,7 +399,7 @@ export class DotEditContentHtmlService {
      * @memberof DotEditContentHtmlService
      */
     getContentModel(addedContentId: string = ''): DotPageContainer[] {
-        const { uuid, identifier } = this.currentContainer;
+        const { uuid, identifier } = this.currentContainer || {};
 
         return this.getEditPageIframe().contentWindow['getDotNgModel']({
             uuid,


### PR DESCRIPTION
## Error
<img width="480" alt="fix-currentcontainer-is-undefined-console-error" src="https://user-images.githubusercontent.com/72418962/233190496-9b4c53cb-c639-498d-90ba-1c079f1e7ec1.png">

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4e2f9e</samp>

Fix content model update bug when editing contentlets in a container. Add fallback value for `this.currentContainer` in `dot-edit-content-html.service.ts`.

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f4e2f9e</samp>

*  Add a fallback value for `this.currentContainer` to prevent errors when accessing its properties ([link](https://github.com/dotCMS/core/pull/24694/files?diff=unified&w=0#diff-803b27038de2abbfb0091318308d39df3f46e46241dc50eeb2271abeb1b45ae7L402-R402))