### PR TITLE
#22672  fix command switch

### DIFF
--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/site/SiteSwitch.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/site/SiteSwitch.java
@@ -3,9 +3,11 @@ package com.dotcms.cli.command.site;
 import com.dotcms.api.SiteAPI;
 import com.dotcms.model.ResponseEntityView;
 import com.dotcms.model.site.SiteView;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import javax.enterprise.context.control.ActivateRequestContext;
+import org.apache.commons.lang3.BooleanUtils;
 import picocli.CommandLine;
 
 @ActivateRequestContext
@@ -20,7 +22,7 @@ public class SiteSwitch extends AbstractSiteCommand implements Callable<Integer>
 
     static final String NAME = "switch";
 
-    @CommandLine.Option(names = { "-in", "--idOrName" }, arity = "1", paramLabel = "idOrName", description = "Site name or Id.", required = true)
+    @CommandLine.Parameters(index = "0", arity = "1", paramLabel = "idOrName", description = "Site name Or Id.")
     String siteNameOrId;
 
     @Override
@@ -41,12 +43,13 @@ public class SiteSwitch extends AbstractSiteCommand implements Callable<Integer>
 
         final SiteAPI siteAPI = clientFactory.getClient(SiteAPI.class);
         final SiteView siteView = site.get();
-        ResponseEntityView<Boolean> switchSite = siteAPI.switchSite(siteView.identifier());
-        if(Boolean.TRUE.equals(switchSite.entity())) {
-            output.info(String.format("Successfully switched to site: [%s]. ",siteView.hostName()));
+        ResponseEntityView<Map<String,String>> switchSite = siteAPI.switchSite(siteView.identifier());
+        final Map<String, String> entity = switchSite.entity();
+        if(null != entity &&  BooleanUtils.toBoolean(entity.get("hostSwitched"))) {
+            output.info(String.format("Successfully switching to site: [%s]. ",siteView.hostName()));
             return CommandLine.ExitCode.OK;
         } else {
-            output.info(String.format("switched to site: [%s] failed. ",siteView.hostName()));
+            output.info(String.format("switching to site: [%s] failed. ",siteView.hostName()));
             return CommandLine.ExitCode.SOFTWARE;
         }
 


### PR DESCRIPTION
Fixing site switch command 
We had the wrong return type mapped in the response 
Also adding the respective test 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc0ef4a</samp>

Improved the site switch command in the dotCMS CLI tool. The command now accepts a site name or ID as a positional parameter, and handles the new map response from the API. Added a test method to verify the site creation and switching functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc0ef4a</samp>

*  Add imports for handling new response format of `switchSite` method ([link](https://github.com/dotCMS/core/pull/24747/files?diff=unified&w=0#diff-babb30dc55c39f7fc28bd917e45fc09c4893903be98ba7223fc856e9881ac0bbL6-R10))
*  Change `siteNameOrId` field to a positional parameter for simpler syntax ([link](https://github.com/dotCMS/core/pull/24747/files?diff=unified&w=0#diff-babb30dc55c39f7fc28bd917e45fc09c4893903be98ba7223fc856e9881ac0bbL23-R25))
*  Update `call` method to check and print the status of site switching ([link](https://github.com/dotCMS/core/pull/24747/files?diff=unified&w=0#diff-babb30dc55c39f7fc28bd917e45fc09c4893903be98ba7223fc856e9881ac0bbL44-R52))
*  Add imports for testing output and switching functionality of site commands ([link](https://github.com/dotCMS/core/pull/24747/files?diff=unified&w=0#diff-96cd7a72db6901e72f70867ba26057e1632417d9a775644d79007a61406b45ebL7-R11))
*  Add test method for creating, switching, and cleaning up a new site ([link](https://github.com/dotCMS/core/pull/24747/files?diff=unified&w=0#diff-96cd7a72db6901e72f70867ba26057e1632417d9a775644d79007a61406b45ebR198-R237))


