### PR TITLE
#24692 Limit characters input goal name

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.html
@@ -44,6 +44,7 @@
                         <div>
                             <input
                                 id="name"
+                                [maxlength]="this.maxNameLength + 1"
                                 data-testId="goal-name-input"
                                 formControlName="name"
                                 name="name"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.spec.ts
@@ -211,6 +211,26 @@ describe('DotExperimentsConfigurationGoalSelectComponent', () => {
         expect(store.setSelectedGoal).toHaveBeenCalledWith(expectedGoal);
     });
 
+    it('should disable submit button if the input name of the goal has more than MAX_INPUT_LENGTH constant', () => {
+        const invalidFormValues = {
+            primary: {
+                ...DefaultGoalConfiguration.primary,
+                name: 'Really really really really really long name for a goal',
+                type: GOAL_TYPES.BOUNCE_RATE
+            }
+        };
+
+        spectator.component.form.setValue(invalidFormValues);
+        spectator.component.form.updateValueAndValidity();
+        spectator.detectComponentChanges();
+
+        expect(
+            (spectator.query(byTestId('add-goal-button')) as HTMLButtonElement).disabled
+        ).toBeTrue();
+        expect(spectator.component.goalNameControl.hasError('maxlength')).toEqual(true);
+        expect(spectator.component.form.valid).toEqual(false);
+    });
+
     it('should add the class expand to an option clicked that contains content', () => {
         const reachPageOption = spectator.queryLast(byTestId('dot-options-item-header'));
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.ts
@@ -27,6 +27,7 @@ import {
     GOAL_TYPES,
     Goals,
     GOALS_METADATA_MAP,
+    MAX_INPUT_LENGTH,
     StepStatus
 } from '@dotcms/dotcms-models';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
@@ -75,8 +76,8 @@ export class DotExperimentsConfigurationGoalSelectComponent implements OnInit, O
     statusList = ComponentStatus;
     vm$: Observable<{ experimentId: string; goals: Goals; status: StepStatus }> =
         this.dotExperimentsConfigurationStore.goalsStepVm$;
+    protected readonly maxNameLength = MAX_INPUT_LENGTH;
     private destroy$: Subject<boolean> = new Subject<boolean>();
-
     private BOUNCE_RATE_LABEL = this.dotMessageService.get(
         'experiments.goal.conditions.minimize.bounce.rate'
     );
@@ -157,7 +158,7 @@ export class DotExperimentsConfigurationGoalSelectComponent implements OnInit, O
             primary: new FormGroup({
                 name: new FormControl('', {
                     nonNullable: true,
-                    validators: [Validators.required]
+                    validators: [Validators.required, Validators.maxLength(this.maxNameLength)]
                 }),
                 type: new FormControl('', {
                     nonNullable: true,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-create/dot-experiments-create.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-create/dot-experiments-create.component.ts
@@ -13,7 +13,7 @@ import { SidebarModule } from 'primeng/sidebar';
 import { DotFieldValidationMessageModule } from '@components/_common/dot-field-validation-message/dot-file-validation-message.module';
 import { UiDotIconButtonModule } from '@components/_common/dot-icon-button/dot-icon-button.module';
 import { DotAutofocusModule } from '@directives/dot-autofocus/dot-autofocus.module';
-import { DotExperiment } from '@dotcms/dotcms-models';
+import { DotExperiment, MAX_INPUT_LENGTH } from '@dotcms/dotcms-models';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
 import {
     DotExperimentsListStore,
@@ -56,7 +56,7 @@ export class DotExperimentsCreateComponent implements OnInit {
     vm$: Observable<VmCreateExperiments> = this.dotExperimentsListStore.createVm$;
 
     form: FormGroup<CreateForm>;
-    protected readonly maxNameLength = 50;
+    protected readonly maxNameLength = MAX_INPUT_LENGTH;
 
     constructor(private readonly dotExperimentsListStore: DotExperimentsListStore) {}
 

--- a/core-web/libs/dotcms-models/src/lib/dot-experiments-constants.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-experiments-constants.ts
@@ -14,6 +14,8 @@ export enum TrafficProportionTypes {
     CUSTOM_PERCENTAGES = 'CUSTOM_PERCENTAGES'
 }
 
+export const MAX_INPUT_LENGTH = 50;
+
 // Keep the order of this enum is important to respect the order of the experiment listing.
 export enum DotExperimentStatusList {
     RUNNING = 'RUNNING',


### PR DESCRIPTION
### Proposed Changes
* use `MAX_INPUT_LENGTH` value to limit the length of characters


### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Screenshots
<img width="813" alt="Screenshot 2023-04-26 at 10 54 25 AM" src="https://user-images.githubusercontent.com/1909643/234615773-a98c9c3c-cec9-4a3e-a6c8-aa3104d56ec8.png">

## Description
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fab4f37</samp>

### Summary
🔤🧪🔢

<!--
1.  🔤 - This emoji represents the change related to the `maxlength` attribute and the `Validators.maxLength` validator, which both deal with the length of the input text.
2.  🧪 - This emoji represents the change related to the unit test, which verifies the functionality of the component and the experiment feature.
3.  🔢 - This emoji represents the change related to the `MAX_INPUT_LENGTH` constant, which defines a numerical value for the input length limit.
-->
This pull request adds a `MAX_INPUT_LENGTH` constant to the `dot-experiments-constants.ts` file and applies it to the experiment name and goal name inputs in the dot-experiments components. The changes improve the consistency, maintainability, user experience, and validation of the dot-experiments feature.

> _Sing, O Muse, of the cunning code review_
> _That limited the length of goal and name_
> _By adding `MAX_INPUT_LENGTH` to the constants file_
> _And `maxlength` to the input element's frame_

### Walkthrough
*  Add `MAX_INPUT_LENGTH` constant to `dot-experiments-constants.ts` file to define a single source of truth for the maximum length of the experiment name and the goal name inputs ([link](https://github.com/dotCMS/core/pull/24757/files?diff=unified&w=0#diff-f1a1a6a6f21372c106dd50983b66d511523dd176656f6d368fe830a87a26b09cR17-R18))
* Import `MAX_INPUT_LENGTH` constant to `dot-experiments-configuration-goal-select.component.ts` and `dot-experiments-create.component.ts` files to use the same constant value across different components ([link](https://github.com/dotCMS/core/pull/24757/files?diff=unified&w=0#diff-e1586d62dab99af430d2dfa25a918712538703b64f827f8ee459b2dd8289a13aR30), [link](https://github.com/dotCMS/core/pull/24757/files?diff=unified&w=0#diff-ecb60a2e269f8139f898a00e8494e8f5ff3d1d42732ce910fe69e7ba0637765eL16-R16))
* Assign `MAX_INPUT_LENGTH` constant to `maxNameLength` properties in both components to use as a reference for the input length limit ([link](https://github.com/dotCMS/core/pull/24757/files?diff=unified&w=0#diff-e1586d62dab99af430d2dfa25a918712538703b64f827f8ee459b2dd8289a13aL78-R80), [link](https://github.com/dotCMS/core/pull/24757/files?diff=unified&w=0#diff-ecb60a2e269f8139f898a00e8494e8f5ff3d1d42732ce910fe69e7ba0637765eL59-R59))
* Add `maxlength` attribute to the input element for the goal name in `dot-experiments-configuration-goal-select.component.html` file to limit the number of characters that the user can enter ([link](https://github.com/dotCMS/core/pull/24757/files?diff=unified&w=0#diff-68dabaa4a62686c040e5519c0bafc3f729a426dd92755d27c2b3078078912a93R47))
* Add `Validators.maxLength` validator to the `name` form control in `dot-experiments-configuration-goal-select.component.ts` file to validate the length of the goal name input and set the `maxlength` error if the input exceeds the limit ([link](https://github.com/dotCMS/core/pull/24757/files?diff=unified&w=0#diff-e1586d62dab99af430d2dfa25a918712538703b64f827f8ee459b2dd8289a13aL160-R161))
* Add unit test for `dot-experiments-configuration-goal-select.component.ts` file to verify that the submit button is disabled and the form is invalid if the user enters a goal name that exceeds the `MAX_INPUT_LENGTH` constant ([link](https://github.com/dotCMS/core/pull/24757/files?diff=unified&w=0#diff-83f85c270f10e3e5fc2873e6d69c02ba9c45757f03f9fee7e826409c8fcbd506R214-R233))


