### PR TITLE
dotCMS/core#24761 Fix Incorrect URLContentPage Title When Adding

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.spec.ts
@@ -384,6 +384,45 @@ describe('DotFavoritePageStore', () => {
             expect(dotPageRenderService.get).toHaveBeenCalledTimes(1);
         });
 
+        it('should set right title if it is urlContentMap', (done) => {
+            spyOn(dotPageRenderService, 'checkPermission').and.returnValue(of(true));
+
+            dotPageRenderService.get = jasmine
+                .createSpy()
+                .and.returnValue(
+                    of({ ...mockDotRenderedPage(), urlContentMap: { title: 'test urlContentMap' } })
+                );
+
+            dotFavoritePageStore.setInitialStateData({
+                favoritePageUrl: existingDataMock.url,
+                favoritePage: { ...existingDataMock }
+            });
+
+            const expectedInitialState = {
+                formState: {
+                    inode: '',
+                    order: 1,
+                    thumbnail: existingDataMock.screenshot,
+                    title: 'test urlContentMap',
+                    url: existingDataMock.url
+                },
+                imgWidth: 1024,
+                imgHeight: 768.192048012003,
+                renderThumbnail: false,
+                loading: false,
+                pageRenderedHtml: '<html><head></header><body><p>Hello World</p></body></html>',
+                showFavoriteEmptySkeleton: false,
+                closeDialog: false,
+                actionState: null
+            };
+
+            dotFavoritePageStore.state$.subscribe((state) => {
+                expect(state).toEqual(expectedInitialState);
+                done();
+            });
+            expect(dotPageRenderService.get).toHaveBeenCalledTimes(1);
+        });
+
         it('should set initial data for an unknown 404 page', (done) => {
             const error404 = mockResponseView(404);
             dotPageRenderService.checkPermission = jasmine

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/store/dot-favorite-page.store.ts
@@ -242,7 +242,10 @@ export class DotFavoritePageStore extends ComponentStore<DotFavoritePageState> {
                         loading: false,
                         formState: {
                             ...formInitialState,
-                            title: favoritePage?.title || pageRender.page.title
+                            title:
+                                pageRender.urlContentMap?.title ||
+                                favoritePage?.title ||
+                                pageRender.page.title
                         },
                         imgHeight:
                             parseInt(pageRender.viewAs.device?.cssHeight, 10) ||

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
@@ -1,6 +1,10 @@
 @use "variables" as *;
 
 ::ng-deep {
+    .p-datatable .p-datatable-thead th.p-sortable-column:hover {
+        background-color: $white;
+    }
+
     .p-datatable .p-datatable-tbody tr td {
         white-space: nowrap;
         overflow: hidden;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
@@ -1,10 +1,6 @@
 @use "variables" as *;
 
 ::ng-deep {
-    .p-datatable .p-datatable-thead th.p-sortable-column:hover {
-        background-color: $white;
-    }
-
     .p-datatable .p-datatable-tbody tr td {
         white-space: nowrap;
         overflow: hidden;

--- a/core-web/libs/dotcms-models/src/lib/dot-rendered-page.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-rendered-page.model.ts
@@ -19,7 +19,7 @@ export interface DotPageRenderParameters {
     canCreateTemplate: boolean;
     viewAs: DotEditPageViewAs;
     numberContents: number;
-    urlContentMap?: { title?: string };
+    urlContentMap?: { title: string };
 }
 
 export class DotPageRender {

--- a/core-web/libs/dotcms-models/src/lib/dot-rendered-page.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-rendered-page.model.ts
@@ -1,9 +1,9 @@
-import { DotPage } from './dot-page.model';
+import { DotContainer, DotContainerStructure } from './dot-container.model';
 import { DotEditPageViewAs } from './dot-edit-page-view-as.model';
 import { DotLayout } from './dot-layout.model';
-import { DotContainer, DotContainerStructure } from './dot-container.model';
-import { DotTemplate } from './dot-template.model';
+import { DotPage } from './dot-page.model';
 import { DotSite } from './dot-site.model';
+import { DotTemplate } from './dot-template.model';
 
 export interface DotPageRenderParameters {
     layout?: DotLayout;
@@ -19,6 +19,7 @@ export interface DotPageRenderParameters {
     canCreateTemplate: boolean;
     viewAs: DotEditPageViewAs;
     numberContents: number;
+    urlContentMap?: { title?: string };
 }
 
 export class DotPageRender {

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_datatable.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_datatable.scss
@@ -80,7 +80,6 @@ $datatable-bg-hover: rgba($color-palette-secondary, 0.05);
 }
 
 .p-datatable .p-sortable-column:not(.p-highlight):hover {
-    background: $datatable-bg-hover;
     color: $text-color-hover;
 }
 


### PR DESCRIPTION
### Proposed Changes
* When adding a URLContentPage to favorites, the title is not correct and instead displays the title of the detail page instead of the content.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
![image](https://user-images.githubusercontent.com/37185433/234951770-d7674312-5351-4eba-80da-36a3a67f6104.png)
