### PR TITLE
Adding video fix for css as well as removing data

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.scss
@@ -43,8 +43,9 @@
             }
 
             video {
+                aspect-ratio: 16/9;
                 max-width: 100%;
-                height: auto;
+                height: 300px;
             }
         }
 

--- a/core-web/apps/dotcms-ui/src/app/view/pipes/dot-diff/dot-diff.pipe.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/pipes/dot-diff/dot-diff.pipe.ts
@@ -2,6 +2,15 @@ import HtmlDiff from 'htmldiff-js';
 
 import { Pipe, PipeTransform } from '@angular/core';
 
+/**
+ * HtmlDiff library breaks the data attribute, so we need to remove it before.
+ * @param html
+ * @returns
+ */
+const removeDataAttr = function (html: string): string {
+    return html.replace(/(<[^>]+) data=".*?"/gi, '$1');
+};
+
 @Pipe({
     name: 'dotDiff'
 })
@@ -9,6 +18,8 @@ export class DotDiffPipe implements PipeTransform {
     transform(oldValue: string, newValue: string, showDiff = true): string {
         newValue = newValue || '';
 
-        return showDiff ? HtmlDiff.execute(oldValue ? oldValue : '', newValue) : newValue;
+        return showDiff
+            ? HtmlDiff.execute(oldValue ? removeDataAttr(oldValue) : '', removeDataAttr(newValue))
+            : newValue;
     }
 }


### PR DESCRIPTION
### Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d06868</samp>

This pull request fixes two issues related to content comparison in the dotCMS UI. It improves the dot-diff pipe to handle data attributes in HTML, and adjusts the CSS style for video elements in the dot-content-compare-table component.


### Additional Info

Removed the data attribute because the HTML diff library, detects that as a diff and breaks the HTML tag.


### Screenshots

https://user-images.githubusercontent.com/3438705/234961670-0824200c-e374-4df8-91e2-b399d83ba935.mov




