### PR TITLE
#24775 adding a keep alive to the log resource

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/taillog/TailLogResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/taillog/TailLogResource.java
@@ -45,6 +45,8 @@ public class TailLogResource {
 
     public static final int LINES_PER_PAGE = Config.getIntProperty("TAIL_LOG_LINES_PER_PAGE",10);
 
+    //This is in secodns
+    public static final int KEEP_ALIVE_EVENT_INTERVAL = Config.getIntProperty("KEEP_ALIVE_EVENT_INTERVAL",20);
 
     @GET
     @Path("/{fileName}/_tail")
@@ -202,7 +204,7 @@ public class TailLogResource {
                             count = 1;
                         }
                     } else {
-                        if(System.currentTimeMillis() > timeMark + TimeUnit.SECONDS.toMillis(20)){
+                        if(System.currentTimeMillis() > timeMark + TimeUnit.SECONDS.toMillis(KEEP_ALIVE_EVENT_INTERVAL)){
                             Logger.debug(this.getClass(), String.format(" Thread [%s] is sending keepAlive event for file [%s] ", getName(), fileName));
                             eventBuilder.name("keepAlive");
                             eventBuilder.data(Map.class,

--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log.jsp
@@ -830,6 +830,13 @@
             logViewManager.updateView(data);
         });
 
+        sseSource.addEventListener('keepAlive', function(e) {
+
+            // Assuming we receive JSON-encoded data payloads:
+            const data = JSON.parse(e.data);
+            console.log("keepAlive :: " + data.keepAlive);
+        });
+
         sseSource.addEventListener('failure', function(e) {
             // process error
             console.error(e);


### PR DESCRIPTION
### Proposed Changes
* We're simply adding a keep-alive event that writes to the event listener something every 20 seconds when no line are written to the log


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f5b9e9</samp>

This pull request implements a keep-alive feature for the log tailing functionality. It modifies the `TailLogResource.java` and `tail_log.jsp` files to send and receive periodic events using Server-Sent Events (SSE).

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f5b9e9</samp>

*  Add keep-alive mechanism to tail log feature to prevent client connection from closing due to inactivity ([link](https://github.com/dotCMS/core/pull/24780/files?diff=unified&w=0#diff-dc00ed2cced9563d19a592f33d3c5b83d9351f84f3b044fbff278f6f2b6cd281R6), [link](https://github.com/dotCMS/core/pull/24780/files?diff=unified&w=0#diff-dc00ed2cced9563d19a592f33d3c5b83d9351f84f3b044fbff278f6f2b6cd281R180), [link](https://github.com/dotCMS/core/pull/24780/files?diff=unified&w=0#diff-dc00ed2cced9563d19a592f33d3c5b83d9351f84f3b044fbff278f6f2b6cd281R204-R214), [link](https://github.com/dotCMS/core/pull/24780/files?diff=unified&w=0#diff-aafe64cccda7c560ffd414438cb5c174b9b23b7ebfd791f8ff3adc25d04f44f6R833-R839))
  - Import `TimeUnit` class in `TailLogResource.java` to convert seconds to milliseconds for timeout value ([link](https://github.com/dotCMS/core/pull/24780/files?diff=unified&w=0#diff-dc00ed2cced9563d19a592f33d3c5b83d9351f84f3b044fbff278f6f2b6cd281R6))
  - Declare `timeMark` variable in `MyTailerThread` class to store last time a keep-alive event was sent ([link](https://github.com/dotCMS/core/pull/24780/files?diff=unified&w=0#diff-dc00ed2cced9563d19a592f33d3c5b83d9351f84f3b044fbff278f6f2b6cd281R180))
  - Add `else` branch to `while` loop in `MyTailerThread` class to check if current time is more than 20 seconds after last keep-alive event and send a JSON event to `eventOutput` stream if so ([link](https://github.com/dotCMS/core/pull/24780/files?diff=unified&w=0#diff-dc00ed2cced9563d19a592f33d3c5b83d9351f84f3b044fbff278f6f2b6cd281R204-R214))
  - Add event listener to `sseSource` object in `tail_log.jsp` file to handle keep-alive events and log them to console ([link](https://github.com/dotCMS/core/pull/24780/files?diff=unified&w=0#diff-aafe64cccda7c560ffd414438cb5c174b9b23b7ebfd791f8ff3adc25d04f44f6R833-R839))
