### PR TITLE
#24785: replacing analytics app icon

### DIFF
--- a/dotCMS/src/main/resources/apps/dotAnalytics-config.yml
+++ b/dotCMS/src/main/resources/apps/dotAnalytics-config.yml
@@ -1,5 +1,5 @@
 name: "Analytics Integration"
-iconUrl: "https://static.dotcms.com/assets/icons/apps/saml.png"
+iconUrl: "https://static.dotcms.com/assets/icons/apps/analytics.png"
 allowExtraParameters: false
 description: "Analytics integration provides the ability to, given a Client Id and Client Secret, resolve an access token to be injected across all the analytics services included the resolving of the Analytics Key (Id)."
 


### PR DESCRIPTION
Analytics Integration app configuration was updated with an analytics related icon (https://static.dotcms.com/assets/icons/apps/analytics.png) provided by @Melissa-dotCMS.

Issue: https://github.com/dotCMS/core/issues/24785 