### PR TITLE
Include weight for each Variant inside the Result Endpoint Response

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/datagen/ExperimentDataGen.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/datagen/ExperimentDataGen.java
@@ -4,6 +4,7 @@ import com.dotcms.analytics.metrics.AbstractCondition.Operator;
 import com.dotcms.analytics.metrics.Condition;
 import com.dotcms.analytics.metrics.Metric;
 import com.dotcms.analytics.metrics.MetricType;
+import com.dotcms.experiments.business.ExperimentsAPI;
 import com.dotcms.experiments.model.AbstractExperiment.Status;
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.experiments.model.Experiment.Builder;
@@ -131,14 +132,15 @@ public class ExperimentDataGen  extends AbstractDataGen<Experiment> {
     @Override
     public Experiment persist(final Experiment experiment) {
         try {
-            Experiment experimentSaved = APILocator.getExperimentsAPI().save(experiment, APILocator.systemUser());
+            final ExperimentsAPI experimentsAPI = APILocator.getExperimentsAPI();
+            Experiment experimentSaved = experimentsAPI.save(experiment, APILocator.systemUser());
 
             if (UtilMethods.isSet(targetingConditions)) {
                 final Experiment experimentWithTargeting = Experiment.builder()
                     .from(experimentSaved)
                     .targetingConditions(targetingConditions)
                     .build();
-                experimentSaved = APILocator.getExperimentsAPI().save(experimentWithTargeting, user);
+                experimentSaved = experimentsAPI.save(experimentWithTargeting, user);
             }
 
             if (!UtilMethods.isSet(variants)) {
@@ -146,10 +148,10 @@ public class ExperimentDataGen  extends AbstractDataGen<Experiment> {
             }
 
             for (Variant variant : variants) {
-                APILocator.getExperimentsAPI().addVariant(experimentSaved.getIdentifier(), variant.name(), user);
+                experimentsAPI.addVariant(experimentSaved.getIdentifier(), variant.name(), user);
             }
 
-            return APILocator.getExperimentsAPI().find(experimentSaved.id().get(), APILocator.systemUser()).get();
+            return experimentsAPI.find(experimentSaved.id().get(), APILocator.systemUser()).get();
         } catch (DotSecurityException | DotDataException e) {
             throw new RuntimeException(e);
         }

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
@@ -469,25 +469,31 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
         final Template template = new TemplateDataGen().host(host).nextPersisted();
 
         final Experiment experiment = new ExperimentDataGen().addVariant("V1").nextPersisted();
-        ExperimentDataGen.start(experiment);
 
-        final String noDefaultVariantName = experiment.trafficProportion().variants().stream()
-                .map(experimentVariant -> experimentVariant.id())
-                .filter(id -> !id.equals("DEFAULT"))
-                .findFirst()
-                .orElseThrow();
+        try {
+            ExperimentDataGen.start(experiment);
 
-        System.out.println("Experiment: " + experiment);
-        final ExperimentResults results = APILocator.getExperimentsAPI().getResults(experiment);
+            final String noDefaultVariantName = experiment.trafficProportion().variants().stream()
+                    .map(experimentVariant -> experimentVariant.id())
+                    .filter(id -> !id.equals("DEFAULT"))
+                    .findFirst()
+                    .orElseThrow();
 
-        final Map<String, VariantResults> variants = results.getGoals().get("primary").getVariants();
-        assertEquals(2, variants.size());
+            System.out.println("Experiment: " + experiment);
+            final ExperimentResults results = APILocator.getExperimentsAPI().getResults(experiment);
 
-        final VariantResults variantResults = variants.get(noDefaultVariantName);
-        assertEquals(50f, variantResults.weight());
+            final Map<String, VariantResults> variants = results.getGoals().get("primary")
+                    .getVariants();
+            assertEquals(2, variants.size());
 
-        final VariantResults controlResults = variants.get("DEFAULT");
-        assertEquals(50f, controlResults.weight());
+            final VariantResults variantResults = variants.get(noDefaultVariantName);
+            assertEquals(50f, variantResults.weight());
+
+            final VariantResults controlResults = variants.get("DEFAULT");
+            assertEquals(50f, controlResults.weight());
+        } finally {
+            ExperimentDataGen.end(experiment);
+        }
     }
 
 

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
@@ -463,7 +463,7 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
      * Should: get the Split traffic too
      */
     @Test
-    public void getSplitTrafficInsiExperimentResults()
+    public void getSplitTrafficInsideExperimentResults()
             throws DotDataException, DotSecurityException {
         final Host host = new SiteDataGen().nextPersisted();
         final Template template = new TemplateDataGen().host(host).nextPersisted();

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
@@ -471,6 +471,10 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
         final Experiment experiment = new ExperimentDataGen().addVariant("V1").nextPersisted();
 
         try {
+
+            final AnalyticsHelper mockAnalyticsHelper = mockAnalyticsHelper();
+            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+
             ExperimentDataGen.start(experiment);
 
             final String noDefaultVariantName = experiment.trafficProportion().variants().stream()
@@ -478,8 +482,7 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
                     .filter(id -> !id.equals("DEFAULT"))
                     .findFirst()
                     .orElseThrow();
-
-            System.out.println("Experiment: " + experiment);
+            
             final ExperimentResults results = APILocator.getExperimentsAPI().getResults(experiment);
 
             final Map<String, VariantResults> variants = results.getGoals().get("primary")

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIT.java
@@ -482,8 +482,10 @@ public class ExperimentAPIImpIT extends IntegrationTestBase {
                     .filter(id -> !id.equals("DEFAULT"))
                     .findFirst()
                     .orElseThrow();
+
+            final ExperimentsAPIImpl experimentsAPI = new ExperimentsAPIImpl(mockAnalyticsHelper);
             
-            final ExperimentResults results = APILocator.getExperimentsAPI().getResults(experiment);
+            final ExperimentResults results = experimentsAPI.getResults(experiment);
 
             final Map<String, VariantResults> variants = results.getGoals().get("primary")
                     .getVariants();

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/result/ExperimentAnalyzerUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/result/ExperimentAnalyzerUtil.java
@@ -101,6 +101,8 @@ public enum ExperimentAnalyzerUtil {
             builder.goal(goal).variant(variantId).pageView(pageViews);
         });
 
+        builder.trafficProportion(experiment.trafficProportion());
+
         final String pageId = experiment.pageId();
         final HTMLPageAsset page = getPage(pageId);
 

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/result/ExperimentResults.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/result/ExperimentResults.java
@@ -4,6 +4,7 @@ import com.dotcms.analytics.bayesian.model.BayesianResult;
 import com.dotcms.analytics.metrics.Metric;
 
 import com.dotcms.experiments.model.ExperimentVariant;
+import com.dotcms.experiments.model.TrafficProportion;
 import com.dotcms.util.DotPreconditions;
 import java.util.Collection;
 import java.util.HashMap;
@@ -69,6 +70,7 @@ public class ExperimentResults {
         private final TotalSessionBuilder totalSessionsBuilder;
         private final Map<String, GoalResultsBuilder> goals = new HashMap<>();
         private final Collection<ExperimentVariant> variants;
+        private TrafficProportion trafficProportion;
 
         public Builder(final Collection<ExperimentVariant> variants){
             this.variants = variants;
@@ -85,7 +87,7 @@ public class ExperimentResults {
 
             final Map<String, GoalResults> goalResultMap = goals.entrySet().stream()
                     .collect(Collectors.toMap(Entry::getKey,
-                            entry -> entry.getValue().build(totalSessions)));
+                            entry -> entry.getValue().build(totalSessions, trafficProportion)));
 
             return new ExperimentResults(totalSessions, goalResultMap);
         }
@@ -101,6 +103,10 @@ public class ExperimentResults {
         public void addSession(final BrowserSession browserSession) {
             final String variantName = browserSession.getVariant().orElseThrow();
             totalSessionsBuilder.count(variantName);
+        }
+
+        public void trafficProportion(final TrafficProportion trafficProportion) {
+            this.trafficProportion = trafficProportion;
         }
 
         private static class TotalSessionBuilder {

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/result/GoalResultsBuilder.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/result/GoalResultsBuilder.java
@@ -3,6 +3,7 @@ package com.dotcms.experiments.business.result;
 import com.dotcms.analytics.metrics.Metric;
 import com.dotcms.experiments.business.result.ExperimentResults.TotalSession;
 import com.dotcms.experiments.model.ExperimentVariant;
+import com.dotcms.experiments.model.TrafficProportion;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -37,7 +38,10 @@ public class GoalResultsBuilder {
         variantResultsBuilder.success(lookBackWindow, event);
     }
 
-    public GoalResults build(final TotalSession totalSessions) {
+    public GoalResults build(final TotalSession totalSessions, final TrafficProportion trafficProportion) {
+
+        final Map<String, Float> trafficProportionMap = trafficProportion.variants().stream()
+                .collect(Collectors.toMap(ExperimentVariant::id, ExperimentVariant::weight));
 
         final List<Instant> allDates = variants.values().stream()
                 .map(variantResultsBuilder -> variantResultsBuilder.getEventDates())
@@ -52,6 +56,7 @@ public class GoalResultsBuilder {
                     variantResultsBuilder.setTotalSession(totalSessions.getTotal());
                     variantResultsBuilder.setTotalSessionToVariant(
                             totalSessions.getVariants().get(variantId));
+                    variantResultsBuilder.weight(trafficProportionMap.get(variantId));
                     return variantResultsBuilder;
                 })
                 .map(variantResultsBuilder -> variantResultsBuilder.build(allDates))

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/result/VariantResults.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/result/VariantResults.java
@@ -16,6 +16,8 @@ import java.util.Map;
  *
  */
 public class VariantResults {
+
+    private final float weight;
     ;
     private String variantName;
     private String variantDescription;
@@ -26,13 +28,14 @@ public class VariantResults {
 
     public VariantResults(final String variantName, final String description, final long multiBySession,
             final UniqueBySessionResume uniqueBySession, final Map<String, ResultResumeItem> details,
-            final long totalPageViews) {
+            final long totalPageViews, float weight) {
         this.variantName = variantName;
         this.multiBySession = multiBySession;
         this.uniqueBySession = uniqueBySession;
         this.details = details;
         this.variantDescription = description;
         this.totalPageViews = totalPageViews;
+        this.weight = weight;
     }
 
     public String getVariantDescription() {
@@ -57,6 +60,14 @@ public class VariantResults {
 
     public long getTotalPageViews() {
         return totalPageViews;
+    }
+
+    public float weight() {
+        return weight;
+    }
+
+    public float getWeight() {
+        return weight;
     }
 
     public static class UniqueBySessionResume {

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/result/VariantResultsBuilder.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/result/VariantResultsBuilder.java
@@ -30,6 +30,7 @@ public class VariantResultsBuilder {
     private long totalSessions;
     private long totalVariantSessions;
     private long pageViews;
+    private float weight;
 
     VariantResultsBuilder(final ExperimentVariant experimentVariant) {
         this.experimentVariant = experimentVariant;
@@ -76,7 +77,7 @@ public class VariantResultsBuilder {
         return new VariantResults(experimentVariant.id(), experimentVariant.description(),
                 totalMultiBySession(eventsByLookBackWindow),
                 uniqueBySessionResume,
-                details, pageViews);
+                details, pageViews, weight);
     }
 
     private Map<String, ResultResumeItem> getDetails(List<Instant> allDates) {
@@ -161,5 +162,9 @@ public class VariantResultsBuilder {
 
     public void setTotalSessionToVariant(final long total) {
         this.totalVariantSessions = total;
+    }
+
+    public void weight(final float weight) {
+        this.weight = weight;
     }
 }


### PR DESCRIPTION
### Proposed Changes
* We need to include the weight of the Variant inside the ExperimentResult

https://github.com/dotCMS/core/pull/24826/files#diff-dceceabfd37a1dd630c7fab22a6ce17664fd6d5a39dd30366e22f4aa11e3643cR65

* We need to set the weight in the VariantREsultBuilder

https://github.com/dotCMS/core/pull/24826/files#diff-76e611bd72975f32c09111e2271a289c12747c71daa9b841b77f9160b29f419fR167

* ... but first we ned to set it inside the ExprimeentResultBuilder and GoalResultBuilder

https://github.com/dotCMS/core/pull/24826/files#diff-640f35cbf0cfbfe8f83a40233ceb94d934228a48ac2e269bc3b1f138b04e6363R108

https://github.com/dotCMS/core/pull/24826/files#diff-c344390af71188fae79256148827c3cff25c4b23af6eec4b60e77f82cce4dee8R41
