### PR TITLE
#24775 fixing broken test per changes introduced

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/taillog/TailLogResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/taillog/TailLogResourceTest.java
@@ -1,25 +1,49 @@
 package com.dotcms.rest.api.v1.taillog;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.dotcms.rest.api.v1.taillog.TailLogResource.MyTailerListener;
 import com.dotcms.rest.api.v1.taillog.TailLogResource.MyTailerThread;
 import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.util.Logger;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.glassfish.jersey.media.sse.EventOutput;
 import org.glassfish.jersey.media.sse.OutboundEvent;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TailLogResourceTest {
 
+    static final String TAILING = "Tailing info from file";
+    static final String WRITTEN = "New Line written With Number";
+
     @BeforeClass
     public static void prepare() throws Exception {
         IntegrationTestInitService.getInstance().init();
+    }
+
+    synchronized void writeText(final Writer out, final int index) throws IOException {
+        out.write(String.format("%s (%d).  %n", WRITTEN, index));
+        out.flush();
     }
 
     /**
@@ -31,55 +55,86 @@ public class TailLogResourceTest {
      */
     @Test
     public void testTailLogResource() throws IOException, InterruptedException {
+
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
         final File file = File.createTempFile("tailLog", ".txt");
-        final TailLogResource resource = new TailLogResource();
+
+        // Create a listener and an event output
         final MyTailerListener listener = new MyTailerListener();
-        final EventOutput eventOutput = new TailerTestEventOutput();
+        final List<Tuple2<String,Map<String,?>>> collectedEvents = new ArrayList<>();
+
+        final EventOutput eventOutput = new EventOutput(){
+            @Override
+            @SuppressWarnings("unchecked")
+            public void write(final OutboundEvent outboundEvent) throws IOException {
+                super.write(outboundEvent);
+                final String name = outboundEvent.getName();
+                final Object data = outboundEvent.getData();
+                Logger.info(TailLogResourceTest.class,String.format("EventOutput.write() called with arg [%s].", name));
+                collectedEvents.add(Tuple.of(name, (Map<String, ?>) data));
+            }
+        };
         final MyTailerThread tailerThread = new MyTailerThread(file, listener, eventOutput, 300);
         tailerThread.start();
-        try {
-            //Give some time to the tailerThread to read the file
-            Thread.sleep(2000);
-            Object outputData = ((TailerTestEventOutput) eventOutput).getTestOutputData();
-            String outputName = ((TailerTestEventOutput) eventOutput).getTestOutputName();
 
-            assertEquals("success", outputName);
-            assertTrue(outputData instanceof Map);
-            assertTrue(((Map)outputData).containsKey("lines"));
-            assertTrue(((Map)outputData).get("lines").toString().contains("Tailing info from file"));
-        } finally {
-            //we force the event execution and stop the thread
-            eventOutput.close();
-            tailerThread.stopTailer();
-            //Give some time to the tailerThread to stop
-            Thread.sleep(2000);
+        //Now Let's simulate another process writing to the file
+        try(final Writer writer = new BufferedWriter(new FileWriter(file, true))) {
 
-            if (tailerThread.isAlive()){
-                fail("TailerThread should have stopped");
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                final int index = i;
+                futures.add(executor.submit(() -> {
+                    try {
+                        writeText(writer, index);
+                        // Sleeping 3 seconds ten times makes the writing process at least 30 seconds long
+                        // meaning that at least once we will see the keepAlive event which is sent every 20 seconds
+                        Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+                    } catch (IOException e) {
+                        fail("Error writing to file");
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        fail("Error attempting to sleep thread");
+                    }
+                }));
             }
+
+            for (Future<?> future : futures) {
+                try {
+                    future.get();
+                } catch (Exception e) {
+                    Thread.currentThread().interrupt();
+                    fail("Error writing to file");
+                }
+            }
+
+            final byte[] bytes = Files.readAllBytes(file.toPath());
+            Logger.info(TailLogResourceTest.class,String.format("File content:%n%s",new String(bytes)) );
+            assertTrue(bytes.length > 0);
+        }finally {
+            tailerThread.stopTailer();
         }
+
+        assertFalse("We should have collected a bunch of write events. ",collectedEvents.isEmpty());
+
+        Assert.assertTrue(collectedEvents.stream().anyMatch(t -> t._1.equals("success")));
+        Assert.assertTrue(collectedEvents.stream().anyMatch(t -> t._1.equals("keepAlive")));
+
+        collectedEvents.stream().filter(t -> t._1.equals("success")).forEach(t -> validateSuccessEvent(t._1, t._2));
+        collectedEvents.stream().filter(t -> t._1.equals("keepAlive")).forEach(t -> validateKeepAliveEvent(t._1, t._2));
     }
 
-    static class TailerTestEventOutput extends EventOutput{
+    void validateSuccessEvent(final String name, final Map<String,?> data){
+        assertEquals("success", name);
+        final String lines = data.get("lines").toString();
+        assertTrue(lines.contains(WRITTEN) || lines.contains(TAILING));
+        Number pageId = (Number)data.get("pageId");
+        assertTrue(pageId.intValue() > 0);
+    }
 
-        private Object testOutputData;
-        private String testOutputName;
-
-        TailerTestEventOutput(){
-            super();
-        }
-        public void write(final OutboundEvent outboundEvent) throws IOException {
-            testOutputData = outboundEvent.getData();
-            testOutputName = outboundEvent.getName();
-        }
-
-        public Object getTestOutputData() {
-            return testOutputData;
-        }
-
-        public String getTestOutputName(){
-            return testOutputName;
-        }
+    void validateKeepAliveEvent(final String name, final Map<String,?> data){
+        assertEquals("keepAlive", name);
+        final Boolean bool = (Boolean) data.get("keepAlive");
+        assertTrue(bool);
     }
 
 }


### PR DESCRIPTION
### Proposed Changes
* Simple test that simulates a process that writes to a file while the other reads
* We verify the events that are captured are sound 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e5398b4</samp>

This pull request improves the integration test for the `TailLogResource` class, which provides an endpoint for streaming log files. The test now uses more constants and a helper method to create and write to a test file, and checks that the endpoint returns the expected output. 
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e5398b4</samp>

* Import `assertFalse` method for testing false conditions ([link](https://github.com/dotCMS/core/pull/24833/files?diff=unified&w=0#diff-8688d73390e7f3b9082d82e0a60cb8a58f154b685decfd3b7dc82c22d958bf61R4))
* Import classes and methods for writing and tailing a file, such as `Logger`, `Tuple`, `BufferedWriter`, `ExecutorService`, `Future`, and `TimeUnit` ([link](https://github.com/dotCMS/core/pull/24833/files?diff=unified&w=0#diff-8688d73390e7f3b9082d82e0a60cb8a58f154b685decfd3b7dc82c22d958bf61L10-R30))
* Define constants `TAILING` and `WRITTEN` for file content and verification ([link](https://github.com/dotCMS/core/pull/24833/files?diff=unified&w=0#diff-8688d73390e7f3b9082d82e0a60cb8a58f154b685decfd3b7dc82c22d958bf61R36-R38))
* Add helper method `writeText` that writes a line of text to a given writer with a given index ([link](https://github.com/dotCMS/core/pull/24833/files?diff=unified&w=0#diff-8688d73390e7f3b9082d82e0a60cb8a58f154b685decfd3b7dc82c22d958bf61R44-R48)) 
