### PR TITLE
Fix #24834: Small layout change on Content Search

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
@@ -752,7 +752,7 @@
                     <input type="hidden" name="referer" value="<%=referer%>">
                     <input type="hidden" name="cmd" value="prepublish">
                     <div class="portlet-toolbar" style="height: 48px; margin-top: 16px;">
-                        <div class="portlet-toolbar__actions-secondary" style="display: flex; align-items: center;">
+                        <div class="portlet-toolbar__actions-secondary" style="display: flex; align-items: center; padding-left: 0.5rem;">
                             <div class="portlet-toolbar__actions-search" style="width: 270px;">
                                 <input type="text" dojoType="dijit.form.TextBox" tabindex="1" placeholder="<%= LanguageUtil.get(pageContext, "Type-To-Search").replace("\"", "'") %>" onKeyUp='doSearch()' name="allFieldTB" id="allFieldTB" value="<%=_allValue %>">
                             </div>

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
@@ -752,11 +752,11 @@
                     <input type="hidden" name="referer" value="<%=referer%>">
                     <input type="hidden" name="cmd" value="prepublish">
                     <div class="portlet-toolbar" style="height: 48px; margin-top: 16px;">
-                        <div class="portlet-toolbar__actions-secondary">
+                        <div class="portlet-toolbar__actions-secondary" style="display: flex; align-items: center;">
+                            <div class="portlet-toolbar__actions-search" style="width: 270px;">
+                                <input type="text" dojoType="dijit.form.TextBox" tabindex="1" placeholder="<%= LanguageUtil.get(pageContext, "Type-To-Search").replace("\"", "'") %>" onKeyUp='doSearch()' name="allFieldTB" id="allFieldTB" value="<%=_allValue %>">
+                            </div>
                             <div id="matchingResultsDiv" style="display: none" class="portlet-toolbar__info"></div>
-                        </div>
-                        <div class="portlet-toolbar__actions-search" style="width: 270px;">
-                            <input type="text" dojoType="dijit.form.TextBox" tabindex="1" placeholder="<%= LanguageUtil.get(pageContext, "Type-To-Search").replace("\"", "'") %>" onKeyUp='doSearch()' name="allFieldTB" id="allFieldTB" value="<%=_allValue %>">
                         </div>
                         <div class="portlet-toolbar__actions-primary">
                             <button id="bulkAvailableActions" dojoType="dijit.form.Button" data-dojo-props="onClick: doShowAvailableActions" iconClass="actionIcon" >


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a62b2b0</samp>

Moved and aligned the search input in the contentlet portlet toolbar. This improves the toolbar's usability and consistency. The change fixes issue `#20376` in file `view_contentlets.jsp`.

## Related Issue
Fixes #24834 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a62b2b0</samp>

*  Moved the search input to the left and aligned it with the matching results div in the portlet toolbar ([link](https://github.com/dotCMS/core/pull/24838/files?diff=unified&w=0#diff-64336e53ea6351a1a21f62ed6b8f62a31305d6b55aa1f0ffabcf8d2536e2c11dL755-R760))

### Screenshots 

#### Original
<img width="1512" alt="Screenshot 2023-05-05 at 2 02 02 PM" src="https://user-images.githubusercontent.com/63567962/236521030-5b12a4d7-634f-48c5-a139-cfc8452c5c9c.png">

#### Updated

<img width="1512" alt="Screenshot 2023-05-05 at 2 04 36 PM" src="https://user-images.githubusercontent.com/63567962/236521487-592cbb16-720a-4af0-a49b-092d767aee8e.png">
