### PR TITLE
Fix #24834: Enhance responsiveness on Content Search Portlet Toolbar

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
@@ -751,33 +751,35 @@
                     <!-- START Listing Results -->
                     <input type="hidden" name="referer" value="<%=referer%>">
                     <input type="hidden" name="cmd" value="prepublish">
-                    <div class="portlet-toolbar" style="height: 48px; margin-top: 16px;">
-                        <div class="portlet-toolbar__actions-secondary" style="display: flex; align-items: center; padding-left: 0.5rem;">
-                            <div class="portlet-toolbar__actions-search" style="width: 270px;">
-                                <input type="text" dojoType="dijit.form.TextBox" tabindex="1" placeholder="<%= LanguageUtil.get(pageContext, "Type-To-Search").replace("\"", "'") %>" onKeyUp='doSearch()' name="allFieldTB" id="allFieldTB" value="<%=_allValue %>">
-                            </div>
-                            <div id="matchingResultsDiv" style="display: none" class="portlet-toolbar__info"></div>
-                        </div>
-                        <div class="portlet-toolbar__actions-primary">
-                            <button id="bulkAvailableActions" dojoType="dijit.form.Button" data-dojo-props="onClick: doShowAvailableActions" iconClass="actionIcon" >
-                                <%= LanguageUtil.get(pageContext, "Available-actions")%>
-                            </button>
-                            <div data-dojo-type="dijit/form/DropDownButton" data-dojo-props='iconClass:"fa-plus", class:"dijitDropDownActionButton"'>
-                                <span></span>
-                                <script type="text/javascript">
-                                    function importContent() {
-                                        window.location = '/c/portal/layout?p_l_id=<%= layout.getId() %>&dm_rlout=1&p_p_id=<%=PortletID.CONTENT%>&p_p_action=1&p_p_state=maximized&_<%=PortletID.CONTENT%>_struts_action=/ext/contentlet/import_contentlets&selectedStructure=' + document.getElementById('structureInode').value;
-                                    }
-                                </script>
-                                <ul data-dojo-type="dijit/Menu" id="actionPrimaryMenu" style="display: none;">
-                                    <li data-dojo-type="dijit/MenuItem" data-dojo-props="onClick:function() {addNewContentlet()}"><%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Add-New-Content" )) %></li>
-                                    <li data-dojo-type="dijit/MenuItem" data-dojo-props="onClick:importContent">
-                                        <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Import-Content" )) %>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
+                    <div class="portlet-toolbar" style="min-height: 48px; margin-top: 16px; flex-direction: column; margin-bottom: 0.5rem;">
+                        <div style="display: flex; align-self: flex-start; justify-content: space-between; width: 100%;">
+                            <div class="portlet-toolbar__actions-secondary" style="display: flex; align-items: center; padding-left: 0.5rem;">
+                                <div class="portlet-toolbar__actions-search" style="width: 270px;">
+                                    <input type="text" dojoType="dijit.form.TextBox" tabindex="1" placeholder="<%= LanguageUtil.get(pageContext, "Type-To-Search").replace("\"", "'") %>" onKeyUp='doSearch()' name="allFieldTB" id="allFieldTB" value="<%=_allValue %>">
+                                </div>
+                                <div id="matchingResultsDiv" style="display: none" class="portlet-toolbar__info"></div>
 
+                            </div>
+                            <div class="portlet-toolbar__actions-primary">
+                                <button id="bulkAvailableActions" dojoType="dijit.form.Button" data-dojo-props="onClick: doShowAvailableActions" iconClass="actionIcon" >
+                                    <%= LanguageUtil.get(pageContext, "Available-actions")%>
+                                </button>
+                                <div data-dojo-type="dijit/form/DropDownButton" data-dojo-props='iconClass:"fa-plus", class:"dijitDropDownActionButton"'>
+                                    <span></span>
+                                    <script type="text/javascript">
+                                        function importContent() {
+                                            window.location = '/c/portal/layout?p_l_id=<%= layout.getId() %>&dm_rlout=1&p_p_id=<%=PortletID.CONTENT%>&p_p_action=1&p_p_state=maximized&_<%=PortletID.CONTENT%>_struts_action=/ext/contentlet/import_contentlets&selectedStructure=' + document.getElementById('structureInode').value;
+                                        }
+                                    </script>
+                                    <ul data-dojo-type="dijit/Menu" id="actionPrimaryMenu" style="display: none;">
+                                        <li data-dojo-type="dijit/MenuItem" data-dojo-props="onClick:function() {addNewContentlet()}"><%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Add-New-Content" )) %></li>
+                                        <li data-dojo-type="dijit/MenuItem" data-dojo-props="onClick:importContent">
+                                            <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Import-Content" )) %>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
@@ -1776,7 +1776,7 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
         }
 
         function clearAllContentsMessage()      {
-                $('tablemessage').innerHTML = " &nbsp ";
+                $('tablemessage').innerHTML = "";
                 unCheckedInodes = "";
                 document.getElementById('allUncheckedContentsInodes').value = "";
                 document.getElementById("fullCommand").value = "false";
@@ -2480,9 +2480,12 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
 
                     let dataViewButton = "<dot-data-view-button " + showDataViewButton +"\" value=\""+ state.view +"\"></dot-data-view-button>";
 
+                        let portletBar = document.querySelector(".portlet-toolbar");
+                        portletBar.insertAdjacentHTML('beforeend', '<div id=\"tablemessage\" class=\"contentlet-selection\" style=\"align-self: flex-start; margin: 0.5rem;\"></div>');
+
                         div = document.getElementById("matchingResultsDiv")
                         var structureInode = dijit.byId('structure_inode').value;
-                        var strbuff = dataViewButton + "<div id=\"tablemessage\" class=\"contentlet-selection\"></div><div class=\"contentlet-results\"><%= LanguageUtil.get(pageContext, "Showing") %> " + begin + "-" + end + " <%= LanguageUtil.get(pageContext, "of1") %> " + num + "</div>";
+                        var strbuff = dataViewButton + "<div class=\"contentlet-results\"><%= LanguageUtil.get(pageContext, "Showing") %> " + begin + "-" + end + " <%= LanguageUtil.get(pageContext, "of1") %> " + num + "</div>";
                         var actionPrimaryMenu = dijit.byId('actionPrimaryMenu');
                         var donwloadToExcelMenuItem = dijit.byId('donwloadToExcel');
                         if (num > 0 && structureInode != "catchall") {


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 909ada2</samp>

This pull request improves the user interface and code quality of the contentlet view portlet. It refactors the code for displaying the contentlet selection message and modifies the layout of the portlet toolbar to make it more responsive and consistent.

## Related Issue
Fixes #24834

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 909ada2</samp>

*  Remove whitespace and duplicate code from contentlet selection message ([link](https://github.com/dotCMS/core/pull/24863/files?diff=unified&w=0#diff-1260ed1ed8b9f22ca5c14f1e4caa3e4d3c1ada11674f6bf7572ac34cdc209497L1779-R1779), [link](https://github.com/dotCMS/core/pull/24863/files?diff=unified&w=0#diff-1260ed1ed8b9f22ca5c14f1e4caa3e4d3c1ada11674f6bf7572ac34cdc209497L2483-R2488))
*  Insert contentlet selection message div after portlet toolbar using JavaScript and style it to align with toolbar ([link](https://github.com/dotCMS/core/pull/24863/files?diff=unified&w=0#diff-1260ed1ed8b9f22ca5c14f1e4caa3e4d3c1ada11674f6bf7572ac34cdc209497L2483-R2488))
*  Modify portlet toolbar layout to use flex container with column direction and adjust margins and heights ([link](https://github.com/dotCMS/core/pull/24863/files?diff=unified&w=0#diff-64336e53ea6351a1a21f62ed6b8f62a31305d6b55aa1f0ffabcf8d2536e2c11dL754-R782))
*  Move contentlet selection message code from `view_contentlets_selection_message.jsp` to `view_contentlets_js_inc.jsp` to avoid duplication and improve readability ([link](https://github.com/dotCMS/core/pull/24863/files?diff=unified&w=0#diff-1260ed1ed8b9f22ca5c14f1e4caa3e4d3c1ada11674f6bf7572ac34cdc209497L1779-R1779), [link](https://github.com/dotCMS/core/pull/24863/files?diff=unified&w=0#diff-1260ed1ed8b9f22ca5c14f1e4caa3e4d3c1ada11674f6bf7572ac34cdc209497L2483-R2488))

## Screenshots

#### Original

<img width="1512" alt="Screenshot 2023-05-08 at 1 08 06 PM" src="https://user-images.githubusercontent.com/63567962/236874141-76a2e470-7aa7-4587-9fa3-4b4259a496d4.png">

#### Update
<img width="1512" alt="Screenshot 2023-05-08 at 1 08 49 PM" src="https://user-images.githubusercontent.com/63567962/236874273-ef4d8848-afd5-47e8-9c53-3734339fd7ff.png">

