### PR TITLE
#24444 add showDefaultLangItems to BrowserQuery

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/browser/BrowserAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/browser/BrowserAPITest.java
@@ -487,6 +487,36 @@ public class BrowserAPITest extends IntegrationTestBase {
                 ImmutableSet.of(
                         testlink.getName()))
         );
+
+        // When requesting content in the folder for non the default language,
+        //should return the content in the language requested + the content in the
+        //default language
+        testCases.add( Tuple.of(
+                "Request Content No default lang, should return content also in default lang",
+
+                BrowserQuery.builder()
+                        .withHostOrFolderId(testFolder.getInode())
+                        .showWorking(true)
+                        .showArchived(false)
+                        .showFolders(true)
+                        .showPages(true)
+                        .showFiles(true)
+                        .showLinks(true)
+                        .showDefaultLangItems(true)
+                        .showDotAssets(true)
+                        .withLanguageId(testLanguage.getId())
+                        .build()
+                ,
+                ImmutableSet.of(
+                        testFileAsset.getName(),
+                        testFileAsset2.getName(),
+                        testFileAsset2MultiLingual.getName(),
+                        testSubFolder.getName(),
+                        testlink.getName(),
+                        testDotAsset.getTitle(),
+                        testPage.getPageUrl()
+                ))
+        );
         
         return testCases;
     }

--- a/dotCMS/src/main/java/com/dotcms/browser/BrowserAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/browser/BrowserAPIImpl.java
@@ -290,9 +290,19 @@ public class BrowserAPIImpl implements BrowserAPI {
             luceneQuery.append("+contentType:(").append(String.join(" OR ", baseTypesNames)).append(") ");
         }
         if (browserQuery.languageId > 0) {
-            sqlQuery.append(" and cvi.lang = ? ");
-            parameters.add(browserQuery.languageId);
-            luceneQuery.append("+languageId:").append(browserQuery.languageId).append(" ");
+            sqlQuery.append(" and cvi.lang in (").append(browserQuery.languageId);
+            luceneQuery.append("+languageId:(").append(browserQuery.languageId);
+
+            final long defaultLang = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+            if(browserQuery.showDefaultLangItems && browserQuery.languageId != defaultLang){
+                sqlQuery.append(",").append(defaultLang);
+                luceneQuery.append(" OR ").append(defaultLang).append(" ");
+            }
+
+            sqlQuery.append(")");
+            luceneQuery.append(") ");
+
+
         }
         if (browserQuery.site != null) {
             sqlQuery.append(" and (id.host_inode = ?) ");

--- a/dotCMS/src/main/java/com/dotcms/browser/BrowserQuery.java
+++ b/dotCMS/src/main/java/com/dotcms/browser/BrowserQuery.java
@@ -43,7 +43,7 @@ public class BrowserQuery {
     final User user;
     final String  filter, sortBy;
     final int offset, maxResults;
-    final boolean showWorking, showArchived, showFolders, sortByDesc, showLinks,showMenuItemsOnly,showContent, showShorties;
+    final boolean showWorking, showArchived, showFolders, sortByDesc, showLinks,showMenuItemsOnly,showContent, showShorties,showDefaultLangItems;
     final long languageId;
     final String luceneQuery;
     final Set<BaseContentType> baseTypes;
@@ -57,7 +57,7 @@ public class BrowserQuery {
     public String toString() {
         return "BrowserQuery {user:" + user + ", site:" + site + ", folder:" + folder + ", filter:" + filter + ", sortBy:" + sortBy
                 + ", offset:" + offset + ", maxResults:" + maxResults + ", showWorking:" + showWorking + ", showArchived:"
-                + showArchived + ", showFolders:" + showFolders + ", sortByDesc:" + sortByDesc + ", showLinks:"
+                + showArchived + ", showFolders:" + showFolders + ", showDefaultLangItems:" + showDefaultLangItems + ", sortByDesc:" + sortByDesc + ", showLinks:"
                 + showLinks + ", showContent:" + showContent + ", showShorties:" + showShorties + ", languageId:" + languageId + ", luceneQuery:" + luceneQuery
                 + ", baseTypes:" + baseTypes + "}";
     }
@@ -79,6 +79,7 @@ public class BrowserQuery {
         this.extensions    = builder.extensions;
         this.sortByDesc = UtilMethods.isEmpty(builder.sortBy) ? true : builder.sortByDesc;
         this.showLinks = builder.showLinks;
+        this.showDefaultLangItems = builder.showDefaultLangItems;
 
         this.baseTypes = builder.baseTypes.isEmpty()
                 ? ImmutableSet.of(BaseContentType.ANY)
@@ -179,6 +180,7 @@ public class BrowserQuery {
         private boolean sortByDesc = false;
         private boolean showLinks = false;
         private boolean showMenuItemsOnly = false;
+        private boolean showDefaultLangItems = false;
         private long languageId = 0;
         private final StringBuilder luceneQuery = new StringBuilder();
         private Set<BaseContentType> baseTypes = new HashSet<>();
@@ -212,6 +214,7 @@ public class BrowserQuery {
             this.extensions = browserQuery.extensions;
             this.showContent = browserQuery.showContent;
             this.showShorties = browserQuery.showShorties;
+            this.showDefaultLangItems = browserQuery.showDefaultLangItems;
         }
 
         public Builder withUser(@Nonnull User user) {
@@ -344,6 +347,11 @@ public class BrowserQuery {
 
         public Builder hostIdSystemFolder(@Nonnull String hostIdSystemFolder) {
             this.hostIdSystemFolder = hostIdSystemFolder;
+            return this;
+        }
+
+        public Builder showDefaultLangItems(@Nonnull boolean showDefaultLangItems) {
+            this.showDefaultLangItems = showDefaultLangItems;
             return this;
         }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
@@ -456,10 +456,12 @@ public class BrowserAjax {
 						   .sortByDesc(sortByDesc)
 						   .showLinks(!excludeLinks)
 						   .withLanguageId(language)
+						   .showDefaultLangItems(true)
 						   .showDotAssets(dotAssets)
 						   .build());
 
-	        listCleanup((List<Map<String, Object>>) results.get("list"), getContentSelectedLanguageId(req));
+		   listCleanup((List<Map<String, Object>>) results.get("list"), language);
+
 
 	        return results;
 	   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ce55b96</samp>

### Summary
🧪🚀🛠️

<!--
1.  🧪 for adding a new test case to the `BrowserAPITest` class.
2.  🚀 for modifying the `BrowserAPIImpl` class to implement the core functionality of the `BrowserAPI` feature.
3.  🛠️ for modifying the `BrowserAjax` class to support the legacy and UI aspects of the `BrowserAPI` feature.
-->
This pull request adds a new feature to the `BrowserAPI` that allows fetching content in a folder for a specific language and the default language. It updates the data model, the core logic, the integration tests, and the legacy AJAX endpoints to support this feature. It affects the files `BrowserQuery.java`, `BrowserAPITest.java`, `BrowserAPIImpl.java`, and `BrowserAjax.java`.

> _There once was a feature called `BrowserAPI`_
> _That needed some tests and some logic to apply_
> _It also required a flag_
> _To show items in default lang_
> _And some changes in `BrowserAjax` to comply_

### Walkthrough
*  Implement the `showDefaultLangItems` flag for the `BrowserAPI` feature, which allows requesting content in a folder for a non-default language and also getting the content in the default language ([link](https://github.com/dotCMS/core/pull/24880/files?diff=unified&w=0#diff-bf8151158d087844f299503dc61ea3da47dc5449ca564ea49e1d9847cc0a2ef3L293-R305), [link](https://github.com/dotCMS/core/pull/24880/files?diff=unified&w=0#diff-ba08d9df93b41994d8ccf0eaf5c2dfa837a33c28463c5c08da0c8814c4ff5d82L46-R46), [link](https://github.com/dotCMS/core/pull/24880/files?diff=unified&w=0#diff-ba08d9df93b41994d8ccf0eaf5c2dfa837a33c28463c5c08da0c8814c4ff5d82L60-R60), [link](https://github.com/dotCMS/core/pull/24880/files?diff=unified&w=0#diff-ba08d9df93b41994d8ccf0eaf5c2dfa837a33c28463c5c08da0c8814c4ff5d82R82), [link](https://github.com/dotCMS/core/pull/24880/files?diff=unified&w=0#diff-ba08d9df93b41994d8ccf0eaf5c2dfa837a33c28463c5c08da0c8814c4ff5d82R183), [link](https://github.com/dotCMS/core/pull/24880/files?diff=unified&w=0#diff-ba08d9df93b41994d8ccf0eaf5c2dfa837a33c28463c5c08da0c8814c4ff5d82R217), [link](https://github.com/dotCMS/core/pull/24880/files?diff=unified&w=0#diff-ba08d9df93b41994d8ccf0eaf5c2dfa837a33c28463c5c08da0c8814c4ff5d82R353-R357), [link](https://github.com/dotCMS/core/pull/24880/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L459-R465))
* Add a new test case to the `BrowserAPITest` class to verify the behavior of the `showDefaultLangItems` flag ([link](https://github.com/dotCMS/core/pull/24880/files?diff=unified&w=0#diff-b27353119d542802b7fa15ec1d7e89a3b2443e7170780e516cb86efd8289ef02R490-R519))
* Update the `toString` method of the `BrowserQuery` class to include the `showDefaultLangItems` field ([link](https://github.com/dotCMS/core/pull/24880/files?diff=unified&w=0#diff-ba08d9df93b41994d8ccf0eaf5c2dfa837a33c28463c5c08da0c8814c4ff5d82L60-R60))


