### PR TITLE
Allow user to edit page or master contentlet in inline editing

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-copy-content-modal/dot-copy-content-modal.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-copy-content-modal/dot-copy-content-modal.service.spec.ts
@@ -15,18 +15,18 @@ const messageServiceMock = new MockDotMessageService({
 
 const CONTENT_EDIT_OPTIONS_MOCK = {
     option1: {
-        value: 'Copy',
-        message: 'editpage.content.edit.content.in.this.page.message',
-        icon: 'article',
-        label: 'editpage.content.edit.content.in.this.page',
-        buttonLabel: 'editpage.content.edit.content.in.this.page.button.label'
-    },
-    option2: {
         value: 'NotCopy',
         message: 'editpage.content.edit.content.in.all.pages.message',
         icon: 'dynamic_feed',
         label: 'editpage.content.edit.content.in.all.pages',
         buttonLabel: 'editpage.content.edit.content.in.all.pages.button.label'
+    },
+    option2: {
+        value: 'Copy',
+        message: 'editpage.content.edit.content.in.this.page.message',
+        icon: 'article',
+        label: 'editpage.content.edit.content.in.this.page',
+        buttonLabel: 'editpage.content.edit.content.in.this.page.button.label'
     }
 };
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-copy-content-modal/dot-copy-content-modal.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-copy-content-modal/dot-copy-content-modal.service.spec.ts
@@ -71,24 +71,24 @@ describe('DotCopyContentModalService', () => {
         );
     });
 
-    it('should return true if the user select the first option', (done) => {
+    it('should return false if the user select the first option', (done) => {
         spyOn(dialogService, 'open').and.returnValue({
             onClose: of(CONTENT_EDIT_OPTIONS_MOCK.option1.value)
         } as DynamicDialogRef);
 
         service.open().subscribe((res) => {
-            expect(res.shouldCopy).toBe(true);
+            expect(res.shouldCopy).toBe(false);
             done();
         });
     });
 
-    it('should return false if the user select the second option', (done) => {
+    it('should return true if the user select the second option', (done) => {
         spyOn(dialogService, 'open').and.returnValue({
             onClose: of(CONTENT_EDIT_OPTIONS_MOCK.option2.value)
         } as DynamicDialogRef);
 
         service.open().subscribe((res) => {
-            expect(res.shouldCopy).toBe(false);
+            expect(res.shouldCopy).toBe(true);
             done();
         });
     });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-copy-content-modal/dot-copy-content-modal.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-copy-content-modal/dot-copy-content-modal.service.ts
@@ -20,18 +20,18 @@ export interface ModelCopyContentResponse {
 export class DotCopyContentModalService {
     private readonly CONTENT_EDIT_OPTIONS: BINARY_OPTION = {
         option1: {
-            value: 'Copy',
-            message: 'editpage.content.edit.content.in.this.page.message',
-            icon: 'article',
-            label: 'editpage.content.edit.content.in.this.page',
-            buttonLabel: 'editpage.content.edit.content.in.this.page.button.label'
-        },
-        option2: {
             value: 'NotCopy',
             message: 'editpage.content.edit.content.in.all.pages.message',
             icon: 'dynamic_feed',
             label: 'editpage.content.edit.content.in.all.pages',
             buttonLabel: 'editpage.content.edit.content.in.all.pages.button.label'
+        },
+        option2: {
+            value: 'Copy',
+            message: 'editpage.content.edit.content.in.this.page.message',
+            icon: 'article',
+            label: 'editpage.content.edit.content.in.this.page',
+            buttonLabel: 'editpage.content.edit.content.in.this.page.button.label'
         }
     };
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-copy-content-modal/dot-copy-content-modal.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-copy-content-modal/dot-copy-content-modal.service.ts
@@ -61,7 +61,7 @@ export class DotCopyContentModalService {
             // This will complete the observable
             filter((value) => !!value),
             map((value) => {
-                return { shouldCopy: this.CONTENT_EDIT_OPTIONS.option1.value === value };
+                return { shouldCopy: this.CONTENT_EDIT_OPTIONS.option2.value === value };
             })
         );
     }


### PR DESCRIPTION
### Proposed Changes
* Make the `All Pages` option the default one. Suggested here:
  * https://github.com/dotCMS/core/issues/24297#issuecomment-1536448257

### Checklist
- [x] Tests

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9b34c1</samp>

This pull request updates the dot-copy-content-modal component and its unit tests. It removes an unnecessary option for copying content in edit mode, and ensures the component receives the correct data from the service.

## Related Issue
Fixes #24297 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9b34c1</samp>

*  Add a new option to edit content in all pages without copying it ([link](https://github.com/dotCMS/core/pull/24884/files?diff=unified&w=0#diff-7ef705f09f4f1baa6c63b6bb0a0c29a96a6dd623c70f2b61d22b4730fd7b0256R18-R24), [link](https://github.com/dotCMS/core/pull/24884/files?diff=unified&w=0#diff-725485e1afb6ffdb35753b228418b3a32aa157473004d2b4023af1ba083067c9R23-R29))
* Remove duplicate instances of the new option from the mock data and the service array ([link](https://github.com/dotCMS/core/pull/24884/files?diff=unified&w=0#diff-7ef705f09f4f1baa6c63b6bb0a0c29a96a6dd623c70f2b61d22b4730fd7b0256L23-L29), [link](https://github.com/dotCMS/core/pull/24884/files?diff=unified&w=0#diff-725485e1afb6ffdb35753b228418b3a32aa157473004d2b4023af1ba083067c9L28-L34))

### Screenshots

<img width="1630" alt="issue-24819-template-builder-add-feature-flag-to-enabledisable-new-version" src="https://github.com/dotCMS/core/assets/72418962/0dcfd8aa-efd0-49c0-b05c-124cafb6ea4e">
