### PR TITLE
Adding fix to validate contentlet

### DIFF
--- a/core-web/libs/block-editor/src/lib/nodes/contentlet-block/contentlet-block.node.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/contentlet-block/contentlet-block.node.ts
@@ -39,7 +39,7 @@ export const ContentletBlock = (injector: Injector): Node<ContentletBlockOptions
         },
 
         renderHTML({ HTMLAttributes }): DOMOutputSpec {
-            let img = null;
+            let img = ['span', {}];
             if (HTMLAttributes.data.hasTitleImage) {
                 img = ['img', { src: HTMLAttributes.data.image }];
             }

--- a/core-web/libs/block-editor/src/lib/nodes/contentlet-block/contentlet-block.node.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/contentlet-block/contentlet-block.node.ts
@@ -39,7 +39,7 @@ export const ContentletBlock = (injector: Injector): Node<ContentletBlockOptions
         },
 
         renderHTML({ HTMLAttributes }): DOMOutputSpec {
-            let img = [];
+            let img = null;
             if (HTMLAttributes.data.hasTitleImage) {
                 img = ['img', { src: HTMLAttributes.data.image }];
             }


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2304a73</samp>

Fixed a bug in the block editor that caused invalid HTML when rendering contentlets with missing title images. Changed the `renderHTML` method of the `ContentletBlock` class to use a `span` placeholder for the image in `contentlet-block.node.ts`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2304a73</samp>

* Fix rendering of contentlets with title images in the block editor ([link](https://github.com/dotCMS/core/pull/24889/files?diff=unified&w=0#diff-f62a376b7614884ad466c39f31239d1c91b2c5c6e3aabfbc3cb31adb9428500aL42-R42))

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
![image](https://github.com/dotCMS/core/assets/3438705/5343cf48-de61-480f-a6c4-f8d7e4db5607) |  ![image](https://github.com/dotCMS/core/assets/3438705/fde18a67-7a76-49ce-8a0f-c0476eb80c6e)
