### PR TITLE
Fix #23816: Overflow Bug in Firefox for Content Type Fields

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-field-dragabble-item/content-type-field-dragabble-item.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-field-dragabble-item/content-type-field-dragabble-item.component.scss
@@ -46,8 +46,7 @@
 .field-properties {
     display: flex;
     flex-direction: column;
-    overflow-x: clip;
-    overflow-y: visible;
+    overflow: hidden;
     padding-right: $spacing-1;
     flex-grow: 1;
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4d695cd</samp>

### Summary
🐛🛠️🎨

<!--
1.  🐛 - This emoji represents a bug or an error, and can be used to indicate that the change was made to fix a bug in the UI.
2.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the change was made to improve the functionality or appearance of the UI.
3.  🎨 - This emoji represents art or design, and can be used to indicate that the change was made to enhance the aesthetics or style of the UI.
-->
Fixed a UI bug that caused field names to overflow in the content type editor. Simplified the CSS rules for `content-type-field-dragabble-item.component.scss` to use `overflow: hidden`.

> _`overflow` hidden_
> _field name stays in its place_
> _a UI bug fixed_

### Walkthrough
*  Prevent field name from overflowing container and creating horizontal scrollbar by replacing `overflow-x` and `overflow-y` properties with `overflow: hidden` ([link](https://github.com/dotCMS/core/pull/24901/files?diff=unified&w=0#diff-8908c3793147d83ddebeb59621a90877a0deb2a4200bb1f09ead44a4951b7c4bL49-R49))



### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
![image](https://github.com/dotCMS/core/assets/63567962/7ed783e5-0599-41d7-b6a2-0c6a8c8afb18)  | <img width="1512" alt="Screenshot 2023-05-10 at 1 52 41 PM" src="https://github.com/dotCMS/core/assets/63567962/cc730363-1819-4dbc-b066-2698bbf39f08">

