### PR TITLE
dotCMS/core#24568 fix Favorite Pages: Browsing in Edit mode lost trac…

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-favorite-page/dot-favorite-page.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-favorite-page/dot-favorite-page.service.spec.ts
@@ -1,0 +1,64 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { getTestBed, TestBed } from '@angular/core/testing';
+
+import { DotESContentService, ESOrderDirection } from '@dotcms/data-access';
+import { CoreWebService, CoreWebServiceMock } from '@dotcms/dotcms-js';
+
+import { DotFavoritePageService } from './dot-favorite-page.service';
+
+describe('DotFavoritePageService', () => {
+    let injector: TestBed;
+    let dotESContentService: DotESContentService;
+    let dotFavoritePageService: DotFavoritePageService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [
+                { provide: CoreWebService, useClass: CoreWebServiceMock },
+                DotESContentService,
+                DotFavoritePageService
+            ]
+        });
+        injector = getTestBed();
+        dotESContentService = injector.inject(DotESContentService);
+        dotFavoritePageService = injector.inject(DotFavoritePageService);
+        spyOn(dotESContentService, 'get').and.callThrough();
+    });
+
+    it('should get Favorite Pages based on an URL', () => {
+        dotFavoritePageService
+            .get({
+                limit: 10,
+                userId: '123',
+                url: 'index.html'
+            })
+            .subscribe();
+
+        expect(dotESContentService.get).toHaveBeenCalledWith({
+            itemsPerPage: 10,
+            offset: '0',
+            query: '+contentType:dotFavoritePage +deleted:false +working:true +owner:123 +DotFavoritePage.url_dotraw:index.html',
+            sortField: 'dotFavoritePage.order',
+            sortOrder: ESOrderDirection.ASC
+        });
+    });
+
+    it('should get Favorite Pages based on an Identifier', () => {
+        dotFavoritePageService
+            .get({
+                limit: 10,
+                userId: '123',
+                identifier: '1'
+            })
+            .subscribe();
+
+        expect(dotESContentService.get).toHaveBeenCalledWith({
+            itemsPerPage: 10,
+            offset: '0',
+            query: '+contentType:dotFavoritePage +deleted:false +working:true +owner:123 +identifier:1',
+            sortField: 'dotFavoritePage.order',
+            sortOrder: ESOrderDirection.ASC
+        });
+    });
+});

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-favorite-page/dot-favorite-page.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-favorite-page/dot-favorite-page.service.ts
@@ -1,0 +1,51 @@
+import { Observable } from 'rxjs';
+
+import { Injectable } from '@angular/core';
+
+import { DotESContentService, ESOrderDirection } from '@dotcms/data-access';
+import { ESContent } from '@dotcms/dotcms-models';
+
+const FAVORITE_PAGES_ES_QUERY = `+contentType:dotFavoritePage +deleted:false +working:true`;
+
+/**
+ * Provide method to get Dot Favorite Pages
+ * @export
+ * @class DotFavoritePageService
+ */
+@Injectable()
+export class DotFavoritePageService {
+    constructor(private dotESContentService: DotESContentService) {}
+
+    /**
+     * Return a list of DotFavoritePage.
+     * @param {string} filter
+     * @returns Observable<ESContent>
+     * @memberof DotFavoritePageService
+     */
+    get(params: {
+        limit: number;
+        userId: string;
+        identifier?: string;
+        url?: string;
+        offset?: string;
+        sortField?: string;
+        sortOrder?: ESOrderDirection;
+    }): Observable<ESContent> {
+        const { limit, userId, identifier, url, offset, sortField, sortOrder } = params;
+
+        let extraQueryParams = '';
+        if (identifier) {
+            extraQueryParams = `+identifier:${identifier}`;
+        } else if (url) {
+            extraQueryParams = `+DotFavoritePage.url_dotraw:${url}`;
+        }
+
+        return this.dotESContentService.get({
+            itemsPerPage: limit || 5,
+            offset: offset || '0',
+            query: `${FAVORITE_PAGES_ES_QUERY} +owner:${userId} ${extraQueryParams}`,
+            sortField: sortField || 'dotFavoritePage.order',
+            sortOrder: sortOrder || ESOrderDirection.ASC
+        });
+    }
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -27,6 +27,7 @@ import { DotMessageDisplayServiceMock } from '@components/dot-message-display/do
 import { DotMessageDisplayService } from '@components/dot-message-display/services';
 import { DotCustomEventHandlerService } from '@dotcms/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service';
 import { DotDownloadBundleDialogService } from '@dotcms/app/api/services/dot-download-bundle-dialog/dot-download-bundle-dialog.service';
+import { DotFavoritePageService } from '@dotcms/app/api/services/dot-favorite-page/dot-favorite-page.service';
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
 import { DotUiColorsService } from '@dotcms/app/api/services/dot-ui-colors/dot-ui-colors.service';
@@ -271,6 +272,7 @@ describe('DotEditContentComponent', () => {
                 DotESContentService,
                 DotSessionStorageService,
                 DotCopyContentModalService,
+                DotFavoritePageService,
                 {
                     provide: LoginService,
                     useClass: LoginServiceMock

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -12,6 +12,7 @@ import { DotGlobalMessageService } from '@components/_common/dot-global-message/
 import { IframeOverlayService } from '@components/_common/iframe/service/iframe-overlay.service';
 import { DotContentletEditorService } from '@components/dot-contentlet-editor/services/dot-contentlet-editor.service';
 import { DotCustomEventHandlerService } from '@dotcms/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service';
+import { DotFavoritePageService } from '@dotcms/app/api/services/dot-favorite-page/dot-favorite-page.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
 import { DotUiColorsService } from '@dotcms/app/api/services/dot-ui-colors/dot-ui-colors.service';
 import {
@@ -111,7 +112,8 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
         private dotEventsService: DotEventsService,
         private dotESContentService: DotESContentService,
         private dotSessionStorageService: DotSessionStorageService,
-        private dotCurrentUser: DotCurrentUserService
+        private dotCurrentUser: DotCurrentUserService,
+        private dotFavoritePageService: DotFavoritePageService
     ) {
         if (!this.customEventsHandler) {
             this.customEventsHandler = {
@@ -336,12 +338,8 @@ export class DotEditContentComponent implements OnInit, OnDestroy {
             .getCurrentUser()
             .pipe(
                 switchMap(({ userId }) =>
-                    this.dotESContentService
-                        .get({
-                            itemsPerPage: 10,
-                            offset: '0',
-                            query: `+contentType:DotFavoritePage +deleted:false +working:true +owner:${userId} +DotFavoritePage.url_dotraw:${pageUrl}`
-                        })
+                    this.dotFavoritePageService
+                        .get({ limit: 10, userId, url: pageUrl })
                         .pipe(take(1))
                 )
             )

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
@@ -7,6 +7,7 @@ import { ConfirmationService } from 'primeng/api';
 
 import { DotMessageDisplayServiceMock } from '@components/dot-message-display/dot-message-display.component.spec';
 import { DotMessageDisplayService } from '@components/dot-message-display/services';
+import { DotFavoritePageService } from '@dotcms/app/api/services/dot-favorite-page/dot-favorite-page.service';
 import { DotFormatDateService } from '@dotcms/app/api/services/dot-format-date-service';
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
@@ -14,7 +15,8 @@ import {
     DotAlertConfirmService,
     DotContentletLockerService,
     DotESContentService,
-    DotPageRenderService
+    DotPageRenderService,
+    ESOrderDirection
 } from '@dotcms/data-access';
 import { CoreWebService, HttpCode, LoginService } from '@dotcms/dotcms-js';
 import {
@@ -68,6 +70,7 @@ describe('DotPageStateService', () => {
                 ConfirmationService,
                 DotFormatDateService,
                 DotESContentService,
+                DotFavoritePageService,
                 { provide: DotMessageDisplayService, useClass: DotMessageDisplayServiceMock },
                 { provide: CoreWebService, useClass: CoreWebServiceMock },
                 { provide: DotRouterService, useClass: MockDotRouterService },
@@ -141,7 +144,9 @@ describe('DotPageStateService', () => {
             expect(dotESContentService.get).toHaveBeenCalledWith({
                 itemsPerPage: 10,
                 offset: '0',
-                query: `+contentType:DotFavoritePage +deleted:false +working:true +owner:dotcms.org.1 +DotFavoritePage.url_dotraw:/an/url/test?&language_id=1&device_inode=`
+                query: `+contentType:dotFavoritePage +deleted:false +working:true +owner:dotcms.org.1 +DotFavoritePage.url_dotraw:/an/url/test?&language_id=1&device_inode=`,
+                sortField: 'dotFavoritePage.order',
+                sortOrder: ESOrderDirection.ASC
             });
         });
 
@@ -399,7 +404,9 @@ describe('DotPageStateService', () => {
             expect(dotESContentService.get).toHaveBeenCalledWith({
                 itemsPerPage: 10,
                 offset: '0',
-                query: `+contentType:DotFavoritePage +deleted:false +working:true +owner:123 +DotFavoritePage.url_dotraw:/an/url/test?&language_id=1&device_inode=`
+                query: `+contentType:dotFavoritePage +deleted:false +working:true +owner:123 +DotFavoritePage.url_dotraw:/an/url/test?&language_id=1&device_inode=`,
+                sortField: 'dotFavoritePage.order',
+                sortOrder: ESOrderDirection.ASC
             });
         });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
@@ -15,8 +15,7 @@ import {
     DotAlertConfirmService,
     DotContentletLockerService,
     DotESContentService,
-    DotPageRenderService,
-    ESOrderDirection
+    DotPageRenderService
 } from '@dotcms/data-access';
 import { CoreWebService, HttpCode, LoginService } from '@dotcms/dotcms-js';
 import {
@@ -53,7 +52,7 @@ describe('DotPageStateService', () => {
     let dotPageRenderService: DotPageRenderService;
     let dotPageRenderServiceGetSpy: jasmine.Spy;
     let dotRouterService: DotRouterService;
-    let dotESContentService: DotESContentService;
+    let dotFavoritePageService: DotFavoritePageService;
     let loginService: LoginService;
     let injector: TestBed;
     let service: DotPageStateService;
@@ -87,8 +86,8 @@ describe('DotPageStateService', () => {
         dotHttpErrorManagerService = injector.get(DotHttpErrorManagerService);
         dotPageRenderService = injector.get(DotPageRenderService);
         dotRouterService = injector.get(DotRouterService);
-        dotESContentService = injector.inject(DotESContentService);
         loginService = injector.get(LoginService);
+        dotFavoritePageService = injector.get(DotFavoritePageService);
 
         dotPageRenderServiceGetSpy = spyOn(dotPageRenderService, 'get').and.returnValue(
             of(mockDotRenderedPage())
@@ -105,7 +104,7 @@ describe('DotPageStateService', () => {
             url: '/an/url/test/form/query/params'
         });
 
-        spyOn(dotESContentService, 'get').and.returnValue(
+        spyOn(dotFavoritePageService, 'get').and.returnValue(
             of({
                 contentTook: 0,
                 jsonObjectView: {
@@ -141,18 +140,16 @@ describe('DotPageStateService', () => {
                 {}
             ]);
 
-            expect(dotESContentService.get).toHaveBeenCalledWith({
-                itemsPerPage: 10,
-                offset: '0',
-                query: `+contentType:dotFavoritePage +deleted:false +working:true +owner:dotcms.org.1 +DotFavoritePage.url_dotraw:/an/url/test?&language_id=1&device_inode=`,
-                sortField: 'dotFavoritePage.order',
-                sortOrder: ESOrderDirection.ASC
+            expect(dotFavoritePageService.get).toHaveBeenCalledWith({
+                limit: 10,
+                userId: 'dotcms.org.1',
+                url: '/an/url/test?&language_id=1&device_inode='
             });
         });
 
         it('should get with url from queryParams with a Failing fetch from ES Search (favorite page)', () => {
             const error500 = mockResponseView(500, '/test', null, { message: 'error' });
-            dotESContentService.get = jasmine.createSpy().and.returnValue(throwError(error500));
+            dotFavoritePageService.get = jasmine.createSpy().and.returnValue(throwError(error500));
             service.get();
 
             const subscribeCallback = jasmine.createSpy('spy');
@@ -401,12 +398,10 @@ describe('DotPageStateService', () => {
 
             expect(service.getInternalNavigationState()).toEqual(renderedPage);
             expect(dotPageRenderServiceGetSpy).not.toHaveBeenCalled();
-            expect(dotESContentService.get).toHaveBeenCalledWith({
-                itemsPerPage: 10,
-                offset: '0',
-                query: `+contentType:dotFavoritePage +deleted:false +working:true +owner:123 +DotFavoritePage.url_dotraw:/an/url/test?&language_id=1&device_inode=`,
-                sortField: 'dotFavoritePage.order',
-                sortOrder: ESOrderDirection.ASC
+            expect(dotFavoritePageService.get).toHaveBeenCalledWith({
+                limit: 10,
+                userId: '123',
+                url: '/an/url/test?&language_id=1&device_inode='
             });
         });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
@@ -390,8 +390,17 @@ describe('DotPageStateService', () => {
             const renderedPage = getDotPageRenderStateMock(dotcmsContentletMock);
             service.setInternalNavigationState(renderedPage);
 
+            service.state$.subscribe((state: DotPageRenderState) => {
+                expect(state).toEqual(renderedPage);
+            });
+
             expect(service.getInternalNavigationState()).toEqual(renderedPage);
             expect(dotPageRenderServiceGetSpy).not.toHaveBeenCalled();
+            expect(dotESContentService.get).toHaveBeenCalledWith({
+                itemsPerPage: 10,
+                offset: '0',
+                query: `+contentType:DotFavoritePage +deleted:false +working:true +owner:123 +DotFavoritePage.url_dotraw:/an/url/test?&language_id=1&device_inode=`
+            });
         });
 
         it('should return null when internal state is not set', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
@@ -13,7 +13,6 @@ import {
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
 import {
     DotContentletLockerService,
-    DotESContentService,
     DotMessageService,
     DotPageRenderService
 } from '@dotcms/data-access';
@@ -51,7 +50,6 @@ export class DotPageStateService {
 
     constructor(
         private dotContentletLockerService: DotContentletLockerService,
-        private dotESContentService: DotESContentService,
         private dotHttpErrorManagerService: DotHttpErrorManagerService,
         private dotMessageService: DotMessageService,
         private dotPageRenderService: DotPageRenderService,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
@@ -122,6 +122,29 @@ export class DotPageStateService {
      * @memberof DotPageStateService
      */
     setInternalNavigationState(state: DotPageRenderState): void {
+        const urlParam = generateDotFavoritePageUrl({
+            deviceInode: state.viewAs.device?.inode,
+            languageId: state.viewAs.language.id,
+            pageURI: state.page.pageURI,
+            siteId: state.site?.identifier
+        });
+
+        this.dotESContentService
+            .get({
+                itemsPerPage: 10,
+                offset: '0',
+                query: `+contentType:DotFavoritePage +deleted:false +working:true +owner:${state.user.userId} +DotFavoritePage.url_dotraw:${urlParam}`
+            })
+            .pipe(take(1))
+            .subscribe((response: ESContent) => {
+                const favoritePage = response.jsonObjectView?.contentlets[0];
+
+                if (favoritePage) {
+                    state.favoritePage = favoritePage;
+                    this.setCurrentState(state);
+                }
+            });
+
         this.setCurrentState(state);
         this.isInternalNavigation = true;
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/dot-edit-page.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/dot-edit-page.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { DotFavoritePageService } from '@dotcms/app/api/services/dot-favorite-page/dot-favorite-page.service';
 import {
     DotContentletLockerService,
     DotESContentService,
@@ -40,7 +41,8 @@ import { DotEditPageResolver } from './shared/services/dot-edit-page-resolver/do
         DotPageRenderService,
         DotSessionStorageService,
         DotPageLayoutService,
-        DotFeatureFlagResolver
+        DotFeatureFlagResolver,
+        DotFavoritePageService
     ]
 })
 export class DotEditPageModule {}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
@@ -11,6 +11,7 @@ import { ConfirmationService } from 'primeng/api';
 
 import { DotMessageDisplayServiceMock } from '@components/dot-message-display/dot-message-display.component.spec';
 import { DotMessageDisplayService } from '@components/dot-message-display/services';
+import { DotFavoritePageService } from '@dotcms/app/api/services/dot-favorite-page/dot-favorite-page.service';
 import { DotFormatDateService } from '@dotcms/app/api/services/dot-format-date-service';
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
@@ -68,6 +69,7 @@ describe('DotEditPageResolver', () => {
                 ConfirmationService,
                 DotFormatDateService,
                 DotESContentService,
+                DotFavoritePageService,
                 { provide: DotRouterService, useClass: MockDotRouterService },
                 { provide: DotMessageDisplayService, useClass: DotMessageDisplayServiceMock },
                 {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/resolvers/dot-experiment-experiment.resolver.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/resolvers/dot-experiment-experiment.resolver.spec.ts
@@ -11,6 +11,7 @@ import { ConfirmationService } from 'primeng/api';
 
 import { DotMessageDisplayServiceMock } from '@components/dot-message-display/dot-message-display.component.spec';
 import { DotMessageDisplayService } from '@components/dot-message-display/services';
+import { DotFavoritePageService } from '@dotcms/app/api/services/dot-favorite-page/dot-favorite-page.service';
 import {
     DotAlertConfirmService,
     DotContentletLockerService,
@@ -62,6 +63,7 @@ describe('DotExperimentExperimentResolver', () => {
                 ConfirmationService,
                 DotFormatDateService,
                 DotESContentService,
+                DotFavoritePageService,
                 { provide: DotMessageDisplayService, useClass: DotMessageDisplayServiceMock },
                 { provide: DotRouterService, useClass: MockDotRouterService },
                 {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -102,6 +102,7 @@ describe('DotPageStore', () => {
     let dotWorkflowsActionsService: DotWorkflowsActionsService;
     let dotPageWorkflowsActionsService: DotPageWorkflowsActionsService;
     let dotHttpErrorManagerService: DotHttpErrorManagerService;
+    let dotFavoritePageService: DotFavoritePageService;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -143,6 +144,7 @@ describe('DotPageStore', () => {
         dotHttpErrorManagerService = TestBed.inject(DotHttpErrorManagerService);
         dotWorkflowsActionsService = TestBed.inject(DotWorkflowsActionsService);
         dotPageWorkflowsActionsService = TestBed.inject(DotPageWorkflowsActionsService);
+        dotFavoritePageService = TestBed.inject(DotFavoritePageService);
 
         spyOn(dialogService, 'open').and.callThrough();
         spyOn(dotHttpErrorManagerService, 'handle');
@@ -310,7 +312,7 @@ describe('DotPageStore', () => {
             ...favoritePagesInitialTestData,
             ...favoritePagesInitialTestData
         ];
-        spyOn(dotESContentService, 'get').and.returnValue(
+        spyOn(dotFavoritePageService, 'get').and.returnValue(
             of({
                 contentTook: 0,
                 jsonObjectView: {
@@ -327,7 +329,7 @@ describe('DotPageStore', () => {
             expect(data.favoritePages.showLoadMoreButton).toEqual(true);
             expect(data.favoritePages.total).toEqual(expectedInputArray.length);
         });
-        expect(dotESContentService.get).toHaveBeenCalledTimes(1);
+        expect(dotFavoritePageService.get).toHaveBeenCalledTimes(1);
     });
 
     it('should get all Page Types value in store and show dialog', () => {
@@ -505,7 +507,7 @@ describe('DotPageStore', () => {
     it('should get all Workflow actions and static actions from a contentlet', () => {
         const expectedInputArray = [{ ...dotcmsContentTypeBasicMock, ...contentTypeDataMock[0] }];
         spyOn(dotWorkflowsActionsService, 'getByInode').and.returnValue(of(mockWorkflowsActions));
-        spyOn(dotESContentService, 'get').and.returnValue(
+        spyOn(dotFavoritePageService, 'get').and.returnValue(
             of({
                 contentTook: 0,
                 jsonObjectView: {
@@ -532,12 +534,11 @@ describe('DotPageStore', () => {
             expect(data.pages.actionMenuDomId).toEqual('test1');
         });
 
-        expect(dotESContentService.get).toHaveBeenCalledWith({
-            itemsPerPage: 1,
-            offset: '0',
-            query: '+contentType:dotFavoritePage +deleted:false +working:true +owner:testId +DotFavoritePage.url_dotraw:/index1?&language_id=1&device_inode=',
-            sortField: 'dotFavoritePage.order',
-            sortOrder: ESOrderDirection.ASC
+        expect(dotFavoritePageService.get).toHaveBeenCalledWith({
+            identifier: undefined,
+            limit: 1,
+            userId: 'testId',
+            url: '/index1?&language_id=1&device_inode='
         });
         expect(dotWorkflowsActionsService.getByInode).toHaveBeenCalledWith(
             favoritePagesInitialTestData[0].inode,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -11,6 +11,7 @@ import { PushPublishServiceMock } from '@components/_common/dot-push-publish-env
 import { DotIframeService } from '@components/_common/iframe/service/dot-iframe/dot-iframe.service';
 import { DotMessageDisplayServiceMock } from '@components/dot-message-display/dot-message-display.component.spec';
 import { DotMessageDisplayService } from '@components/dot-message-display/services';
+import { DotFavoritePageService } from '@dotcms/app/api/services/dot-favorite-page/dot-favorite-page.service';
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
 import { DotWizardService } from '@dotcms/app/api/services/dot-wizard/dot-wizard.service';
@@ -118,6 +119,7 @@ describe('DotPageStore', () => {
                 DotWorkflowEventHandlerService,
                 LoggerService,
                 StringUtils,
+                DotFavoritePageService,
                 { provide: DialogService, useClass: DialogServiceMock },
                 { provide: DotcmsEventsService, useClass: DotcmsEventsServiceMock },
                 { provide: CoreWebService, useClass: CoreWebServiceMock },

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.module.ts
@@ -6,6 +6,7 @@ import { MenuModule } from 'primeng/menu';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 
 import { DotAddToBundleModule } from '@components/_common/dot-add-to-bundle';
+import { DotFavoritePageService } from '@dotcms/app/api/services/dot-favorite-page/dot-favorite-page.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
 import { DotTempFileUploadService } from '@dotcms/app/api/services/dot-temp-file-upload/dot-temp-file-upload.service';
 import { DotWorkflowEventHandlerService } from '@dotcms/app/api/services/dot-workflow-event-handler/dot-workflow-event-handler.service';
@@ -50,7 +51,8 @@ import { DotPagesComponent } from './dot-pages.component';
         DotWorkflowActionsFireService,
         DotWorkflowEventHandlerService,
         DotRouterService,
-        SiteService
+        SiteService,
+        DotFavoritePageService
     ]
 })
 export class DotPagesModule {}

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/dot-iframe-porlet-legacy-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/service/dot-iframe-porlet-legacy-resolver.service.spec.ts
@@ -8,6 +8,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { DotMessageDisplayServiceMock } from '@components/dot-message-display/dot-message-display.component.spec';
 import { DotMessageDisplayService } from '@components/dot-message-display/services';
+import { DotFavoritePageService } from '@dotcms/app/api/services/dot-favorite-page/dot-favorite-page.service';
 import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';
 import {
     DotContentletLockerService,
@@ -45,6 +46,7 @@ describe('DotIframePorletLegacyResolver', () => {
                 DotContentletLockerService,
                 DotLicenseService,
                 DotESContentService,
+                DotFavoritePageService,
                 { provide: DotMessageDisplayService, useClass: DotMessageDisplayServiceMock },
                 {
                     provide: ActivatedRouteSnapshot,


### PR DESCRIPTION
### Proposed Changes
* browsing inside the edit mode, the Favorite Page "status" should be handled and Favorite Pages should be marked as such.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
issue


![](https://user-images.githubusercontent.com/923947/230211482-6f7e5073-f779-4af4-bf18-c0dd045151de.gif)

