### PR TITLE
Issue-24918: Favorite pages: print the error message from the HTML2Canvas lib to the console

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.scss
@@ -42,7 +42,7 @@
     }
 
     ::ng-deep dot-html-to-image {
-        min-height: 353px;
+        height: 353px;
 
         img {
             background-color: $white;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.ts
@@ -59,7 +59,6 @@ export class DotFavoritePageComponent implements OnInit, OnDestroy {
     ngOnInit(): void {
         // Needed to avoid browser to cache thumbnail img when reloaded, since it's fetched from the same URL
         this.timeStamp = new Date().getTime().toString();
-
         this.store.formState$
             .pipe(
                 takeUntil(this.destroy$),
@@ -165,6 +164,10 @@ export class DotFavoritePageComponent implements OnInit, OnDestroy {
                 } else {
                     this.form.get('thumbnail').setValue('');
                     this.store.setShowFavoriteEmptySkeleton(true);
+                    console.warn(
+                        'We apologize for the inconvenience. The following error occurred while generating a thumbnail for this page:',
+                        event?.detail?.error
+                    );
                 }
             });
         }

--- a/core-web/libs/dotcms-webcomponents/src/components/dot-html-to-image/dot-html-to-image.scss
+++ b/core-web/libs/dotcms-webcomponents/src/components/dot-html-to-image/dot-html-to-image.scss
@@ -13,5 +13,7 @@ dot-html-to-image {
 
     mwc-circular-progress {
         --mdc-theme-primary: var(--color-main);
+        position: absolute;
+        z-index: 1;
     }
 }

--- a/core-web/libs/dotcms-webcomponents/src/components/dot-html-to-image/dot-html-to-image.tsx
+++ b/core-web/libs/dotcms-webcomponents/src/components/dot-html-to-image/dot-html-to-image.tsx
@@ -56,10 +56,13 @@ export class DotHtmlToImage {
             doc.open();
             doc.write(this.value);
             doc.close();
-
             const scriptLib = document.createElement('script') as HTMLScriptElement;
             scriptLib.src = '/html/js/html2canvas/html2canvas.min.js';
             scriptLib.type = 'text/javascript';
+
+            doc.addEventListener('DOMContentLoaded', () => {
+                doc.body.appendChild(scriptLib);
+            });
 
             scriptLib.onload = () => {
                 iframe.addEventListener('load', () => {
@@ -74,8 +77,6 @@ export class DotHtmlToImage {
                     doc.body.appendChild(script);
                 });
             };
-
-            doc.body.append(scriptLib);
             this.boundOnMessageHandler = this.onMessageHandler.bind(null, iframe, this);
             window.addEventListener('message', this.boundOnMessageHandler);
         } catch (error) {


### PR DESCRIPTION
### Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2550ba3</samp>

Improved the functionality and appearance of the `dot-favorite-page` component and the `dot-html-to-image` component. Fixed an unused import and added error handling in the former, and enhanced iframe loading and rendering in the latter. Adjusted the height and position of the components to avoid extra space and overlapping.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots

![image](https://github.com/dotCMS/core/assets/3438705/12193ca1-9c74-448e-8602-ad50f3b9417a)

![image](https://github.com/dotCMS/core/assets/3438705/c2ef16fa-3f17-4709-a3bb-e67127cc1e2d)

<img width="1823" alt="image" src="https://github.com/dotCMS/core/assets/3438705/4bf9e579-7501-4b90-b11d-2d5933a42d95">



https://github.com/dotCMS/core/assets/3438705/fad952b3-c6fc-4e85-8443-2ca41e82e3aa


https://github.com/dotCMS/core/assets/3438705/7d45d3cc-00b2-4db0-9183-53ced004f616


