### PR TITLE
Fix #24938: Add Groups to Favorite Pages Context Menu

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -519,7 +519,6 @@ describe('DotPageStore', () => {
         });
 
         dotPageStore.state$.subscribe((data) => {
-            // Filter the separator
             const menuActions = data.pages.menuActions;
 
             expect(menuActions.length).toEqual(8);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -519,23 +519,19 @@ describe('DotPageStore', () => {
         });
 
         dotPageStore.state$.subscribe((data) => {
-            const [favoritePageMenu, pagesMenu] = data.pages.menuActions;
+            // Filter the separator
+            const menuActions = data.pages.menuActions;
 
-            expect(data.pages.menuActions.length).toEqual(2);
+            expect(menuActions.length).toEqual(8);
 
-            expect(favoritePageMenu.label).toEqual('favoritePage.panel.header');
-            expect(favoritePageMenu.items.length).toEqual(1);
-            expect(favoritePageMenu.items[0].label).toEqual('favoritePage.contextMenu.action.edit');
-
-            expect(pagesMenu.items.length).toEqual(6);
-            expect(pagesMenu.label).toEqual('com.dotcms.repackage.javax.portlet.title.pages');
-
-            expect(pagesMenu.items[0].label).toEqual('Edit');
-            expect(pagesMenu.items[1].label).toEqual(mockWorkflowsActions[0].name);
-            expect(pagesMenu.items[2].label).toEqual(mockWorkflowsActions[1].name);
-            expect(pagesMenu.items[3].label).toEqual(mockWorkflowsActions[2].name);
-            expect(pagesMenu.items[4].label).toEqual('contenttypes.content.push_publish');
-            expect(pagesMenu.items[5].label).toEqual('contenttypes.content.add_to_bundle');
+            expect(menuActions[0].label).toEqual('favoritePage.contextMenu.action.edit');
+            expect(menuActions[1].label).toEqual(undefined);
+            expect(menuActions[2].label).toEqual('Edit');
+            expect(menuActions[3].label).toEqual(mockWorkflowsActions[0].name);
+            expect(menuActions[4].label).toEqual(mockWorkflowsActions[1].name);
+            expect(menuActions[5].label).toEqual(mockWorkflowsActions[2].name);
+            expect(menuActions[6].label).toEqual('contenttypes.content.push_publish');
+            expect(menuActions[7].label).toEqual('contenttypes.content.add_to_bundle');
 
             expect(data.pages.actionMenuDomId).toEqual('test1');
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -519,14 +519,24 @@ describe('DotPageStore', () => {
         });
 
         dotPageStore.state$.subscribe((data) => {
-            expect(data.pages.menuActions.length).toEqual(7);
-            expect(data.pages.menuActions[0].label).toEqual('favoritePage.contextMenu.action.edit');
-            expect(data.pages.menuActions[1].label).toEqual('Edit');
-            expect(data.pages.menuActions[2].label).toEqual(mockWorkflowsActions[0].name);
-            expect(data.pages.menuActions[3].label).toEqual(mockWorkflowsActions[1].name);
-            expect(data.pages.menuActions[4].label).toEqual(mockWorkflowsActions[2].name);
-            expect(data.pages.menuActions[5].label).toEqual('contenttypes.content.push_publish');
-            expect(data.pages.menuActions[6].label).toEqual('contenttypes.content.add_to_bundle');
+            const [favoritePageMenu, pagesMenu] = data.pages.menuActions;
+
+            expect(data.pages.menuActions.length).toEqual(2);
+
+            expect(favoritePageMenu.label).toEqual('favoritePage.panel.header');
+            expect(favoritePageMenu.items.length).toEqual(1);
+            expect(favoritePageMenu.items[0].label).toEqual('favoritePage.contextMenu.action.edit');
+
+            expect(pagesMenu.items.length).toEqual(6);
+            expect(pagesMenu.label).toEqual('com.dotcms.repackage.javax.portlet.title.pages');
+
+            expect(pagesMenu.items[0].label).toEqual('Edit');
+            expect(pagesMenu.items[1].label).toEqual(mockWorkflowsActions[0].name);
+            expect(pagesMenu.items[2].label).toEqual(mockWorkflowsActions[1].name);
+            expect(pagesMenu.items[3].label).toEqual(mockWorkflowsActions[2].name);
+            expect(pagesMenu.items[4].label).toEqual('contenttypes.content.push_publish');
+            expect(pagesMenu.items[5].label).toEqual('contenttypes.content.add_to_bundle');
+
             expect(data.pages.actionMenuDomId).toEqual('test1');
         });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -622,10 +622,17 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
         item: DotCMSContentlet,
         favoritePage?: DotCMSContentlet
     ): MenuItem[] {
-        const selectItems: MenuItem[] = [];
+        const favoritePageGroup: MenuItem = {
+            label: this.dotMessageService.get('favoritePage.panel.header'),
+            items: []
+        };
+        const pagesGroup: MenuItem = {
+            label: this.dotMessageService.get('com.dotcms.repackage.javax.portlet.title.pages'),
+            items: []
+        };
 
         // Adding DotFavorite actions
-        selectItems.push({
+        favoritePageGroup.items.push({
             label: favoritePage
                 ? this.dotMessageService.get('favoritePage.contextMenu.action.edit')
                 : this.dotMessageService.get('favoritePage.contextMenu.action.add'),
@@ -662,7 +669,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
                 (item.baseType === 'CONTENT' && loggedUser.canRead.contentlets == true)) &&
             !item.deleted
         ) {
-            selectItems.push({
+            pagesGroup.items.push({
                 label:
                     (item.baseType === 'HTMLPAGE' && loggedUser.canWrite.htmlPages == true) ||
                     (item.baseType === 'CONTENT' && loggedUser.canWrite.contentlets == true)
@@ -676,7 +683,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
 
         // Adding Workflow actions
         actions.forEach((action: DotCMSWorkflowAction) => {
-            selectItems.push({
+            pagesGroup.items.push({
                 label: `${this.dotMessageService.get(action.name)}`,
                 command: () => {
                     if (action.actionInputs?.length > 0) {
@@ -703,7 +710,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
 
         // Adding Push Publish action
         if (isEnterprise && environments) {
-            selectItems.push({
+            pagesGroup.items.push({
                 label: this.dotMessageService.get('contenttypes.content.push_publish'),
                 command: (item) =>
                     this.dotPushPublishDialogService.open({
@@ -715,13 +722,13 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
 
         // Adding Add To Bundle action
         if (isEnterprise) {
-            selectItems.push({
+            pagesGroup.items.push({
                 label: this.dotMessageService.get('contenttypes.content.add_to_bundle'),
                 command: () => this.showAddToBundle(item.identifier)
             });
         }
 
-        return selectItems;
+        return [favoritePageGroup, pagesGroup];
     }
 
     constructor(

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -622,17 +622,10 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
         item: DotCMSContentlet,
         favoritePage?: DotCMSContentlet
     ): MenuItem[] {
-        const favoritePageGroup: MenuItem = {
-            label: this.dotMessageService.get('favoritePage.panel.header'),
-            items: []
-        };
-        const pagesGroup: MenuItem = {
-            label: this.dotMessageService.get('com.dotcms.repackage.javax.portlet.title.pages'),
-            items: []
-        };
+        const actionsMenu: MenuItem[] = [];
 
         // Adding DotFavorite actions
-        favoritePageGroup.items.push({
+        actionsMenu.push({
             label: favoritePage
                 ? this.dotMessageService.get('favoritePage.contextMenu.action.edit')
                 : this.dotMessageService.get('favoritePage.contextMenu.action.add'),
@@ -660,6 +653,8 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
             }
         });
 
+        actionsMenu.push({ separator: true });
+
         // Adding Edit & View actions
         const { loggedUser, isEnterprise, environments } = this.get();
 
@@ -669,7 +664,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
                 (item.baseType === 'CONTENT' && loggedUser.canRead.contentlets == true)) &&
             !item.deleted
         ) {
-            pagesGroup.items.push({
+            actionsMenu.push({
                 label:
                     (item.baseType === 'HTMLPAGE' && loggedUser.canWrite.htmlPages == true) ||
                     (item.baseType === 'CONTENT' && loggedUser.canWrite.contentlets == true)
@@ -683,7 +678,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
 
         // Adding Workflow actions
         actions.forEach((action: DotCMSWorkflowAction) => {
-            pagesGroup.items.push({
+            actionsMenu.push({
                 label: `${this.dotMessageService.get(action.name)}`,
                 command: () => {
                     if (action.actionInputs?.length > 0) {
@@ -710,7 +705,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
 
         // Adding Push Publish action
         if (isEnterprise && environments) {
-            pagesGroup.items.push({
+            actionsMenu.push({
                 label: this.dotMessageService.get('contenttypes.content.push_publish'),
                 command: (item) =>
                     this.dotPushPublishDialogService.open({
@@ -722,13 +717,13 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
 
         // Adding Add To Bundle action
         if (isEnterprise) {
-            pagesGroup.items.push({
+            actionsMenu.push({
                 label: this.dotMessageService.get('contenttypes.content.add_to_bundle'),
                 command: () => this.showAddToBundle(item.identifier)
             });
         }
 
-        return [favoritePageGroup, pagesGroup];
+        return actionsMenu;
     }
 
     constructor(

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_menu.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_menu.scss
@@ -64,7 +64,7 @@
     padding: $spacing-2;
     color: $black;
     background: $white;
-    font-weight: 400;
+    font-weight: $font-weight-bold;
     border-top-right-radius: 0;
     border-top-left-radius: 0;
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 22f18f5</samp>

### Summary
🧪🖊️🗂️

<!--
1.  🧪 for the unit test update, since this emoji is often used to indicate testing or experimentation.
2.  🖊️ for the font-weight increase, since this emoji is often used to indicate writing or editing.
3.  🗂️ for the variable rename and separator item addition, since this emoji is often used to indicate organization or filing.
-->
This pull request enhances the menu actions for dotCMS pages and the menu items in the dotCMS UI. It adds a separator item in the menu actions array, updates the unit test accordingly, and increases the font-weight of the menu items using a theme variable.

> _We are the pages of dotCMS_
> _We defy the tyranny of the font_
> _We edit and we workflow with a separator_
> _We are the bold and the readable ones_

### Walkthrough
*  Renamed `selectItems` variable to `actionsMenu` in `getMenuActions` method of `DotPageStore` class to avoid confusion and improve readability ([link](https://github.com/dotCMS/core/pull/24942/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL625-R628), [link](https://github.com/dotCMS/core/pull/24942/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL665-R667), [link](https://github.com/dotCMS/core/pull/24942/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL679-R681), [link](https://github.com/dotCMS/core/pull/24942/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL706-R708), [link](https://github.com/dotCMS/core/pull/24942/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL718-R720), [link](https://github.com/dotCMS/core/pull/24942/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL724-R726))
* Added a separator item to the `actionsMenu` array in `getMenuActions` method of `DotPageStore` class to visually separate the edit action from the workflow actions in the menu ([link](https://github.com/dotCMS/core/pull/24942/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eR656-R657))
* Updated the unit test for the `getMenuActions` method of `DotPageStore` class to reflect the addition of the separator item and assign the menu actions array to a variable for readability ([link](https://github.com/dotCMS/core/pull/24942/files?diff=unified&w=0#diff-b23eeff307d6d254cb33a17b3b64f937646e6f91d72778c1ac460881c0bfc980L522-R534))
* Increased the font-weight of the menu items in the dotCMS UI from 400 to 700 using the `$font-weight-bold` variable from the dotCMS theme in `_menu.scss` file to improve the readability and contrast of the menu items ([link](https://github.com/dotCMS/core/pull/24942/files?diff=unified&w=0#diff-85ff914aff6d899177263bf013db2b7cbc624493532674874136e05295b2089fL67-R67))



### Screenshots

#### Original

https://github.com/dotCMS/core/assets/63567962/6840db97-b00f-4ae4-bba4-841a0fe3d5cc

#### Updated

https://github.com/dotCMS/core/assets/63567962/550ed316-02ec-4cb6-8c8a-839ea2b8e273

