### PR TITLE
dotCMS/core#24940 Limit name & mark steps as required.

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.html
@@ -3,7 +3,7 @@
         <ng-template pTemplate="title">
             <div class="flex justify-content-between">
                 <h2 class="flex align-items-center gap-1 uppercase">
-                    <span data-testId="goals-card-name">{{
+                    <span class="p-label-input-required" data-testId="goals-card-name">{{
                         'experiments.configure.goals.name' | dm
                     }}</span>
                     <dot-icon

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
@@ -84,6 +84,7 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
     it('should render the card', () => {
         expect(spectator.queryAll(Card).length).toEqual(1);
         expect(spectator.query(byTestId('goals-card-name'))).toContainText('Goals');
+        expect(spectator.query(byTestId('goals-card-name'))).toHaveClass('p-label-input-required');
         expect(spectator.query(byTestId('goals-add-button'))).toExist();
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.html
@@ -20,6 +20,7 @@
                     <input
                         id="name"
                         [tabindex]="1"
+                        [maxlength]="this.maxNameLength + 1"
                         data-testId="add-experiment-description-input"
                         dotAutofocus
                         formControlName="name"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.spec.ts
@@ -105,7 +105,7 @@ describe('DotExperimentsConfigurationVariantsAddComponent', () => {
 
     it('should disable submit button if the form is invalid', () => {
         const invalidFormValues = {
-            name: ''
+            name: 'this is more than 50 characters test - this is more than 50 characters test'
         };
 
         spectator.component.form.setValue(invalidFormValues);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.ts
@@ -85,7 +85,7 @@ export class DotExperimentsConfigurationVariantsAddComponent implements OnInit {
         this.form = new FormGroup({
             name: new FormControl<string>('', {
                 nonNullable: true,
-                validators: [Validators.required, Validators.maxLength(255)]
+                validators: [Validators.required, Validators.maxLength(50)]
             })
         });
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.ts
@@ -10,7 +10,12 @@ import { SidebarModule } from 'primeng/sidebar';
 
 import { DotFieldValidationMessageModule } from '@components/_common/dot-field-validation-message/dot-file-validation-message.module';
 import { DotAutofocusModule } from '@directives/dot-autofocus/dot-autofocus.module';
-import { ComponentStatus, StepStatus, TrafficProportion } from '@dotcms/dotcms-models';
+import {
+    ComponentStatus,
+    MAX_INPUT_LENGTH,
+    StepStatus,
+    TrafficProportion
+} from '@dotcms/dotcms-models';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
 import { DotExperimentsConfigurationStore } from '@portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store';
 import { DotSidebarDirective } from '@portlets/shared/directives/dot-sidebar.directive';
@@ -39,6 +44,7 @@ import { DotSidebarHeaderComponent } from '@shared/dot-sidebar-header/dot-sideba
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotExperimentsConfigurationVariantsAddComponent implements OnInit {
+    protected readonly maxNameLength = MAX_INPUT_LENGTH;
     stepStatus = ComponentStatus;
 
     form: FormGroup;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -3,7 +3,9 @@
         <ng-template pTemplate="title">
             <div class="flex justify-content-between">
                 <h2 class="flex align-items-center gap-1 uppercase">
-                    {{ 'experiments.configure.variants.name' | dm }}
+                    <span class="p-label-input-required" data-testId="variants-card-header">{{
+                        'experiments.configure.variants.name' | dm
+                    }}</span>
                     <dot-icon
                         [ngClass]="{ isDone: vm.trafficProportion.variants?.length > 1 }"
                         data-testId="variant-title-step-done"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -139,6 +139,7 @@
                                     editVariantName(variantName.value, variant, vm.experimentId)
                                 "
                                 data-testId="inplace-input"
+                                maxlength="maxNameLength"
                                 dotAutofocus
                                 pInputText
                                 type="text"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -118,6 +118,9 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
     describe('should render', () => {
         it('a DEFAULT variant', () => {
             expect(spectator.queryAll(byTestId('variant-name')).length).toBe(1);
+            expect(spectator.query(byTestId('variants-card-header'))).toHaveClass(
+                'p-label-input-required'
+            );
 
             expect(spectator.query(byTestId('variant-weight'))).toHaveText(
                 EXPERIMENT_MOCK.trafficProportion.variants[0].weight + '.00% weight'

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
@@ -24,6 +24,7 @@ import {
     DEFAULT_VARIANT_NAME,
     DotPageMode,
     ExperimentSteps,
+    MAX_INPUT_LENGTH,
     MAX_VARIANTS_ALLOWED,
     SIDEBAR_STATUS,
     StepStatus,
@@ -73,6 +74,7 @@ export class DotExperimentsConfigurationVariantsComponent {
         tap(({ status }) => this.handleSidebar(status))
     );
 
+    protected readonly maxNameLength = MAX_INPUT_LENGTH;
     statusList = ComponentStatus;
     sidebarStatusList = SIDEBAR_STATUS;
     maxVariantsAllowed = MAX_VARIANTS_ALLOWED;


### PR DESCRIPTION
### Proposed Changes
* Limit the variant Name yo 50 characters.
* Add asterisk to the titles of required steps of Experiment configuration screen.


### Additional Info
https://github.com/dotCMS/core/issues/24940

### Screenshots

<img width="650" alt="image" src="https://github.com/dotCMS/core/assets/31667212/547f4db4-4b62-4d02-8e7a-0d525c7d6449">

<img width="318" alt="image" src="https://github.com/dotCMS/core/assets/31667212/88a9a8ea-efb5-4f37-9cfc-708c836f602c">

