### PR TITLE
Fix #24953: TableMessage div was being added everytime you search

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
@@ -780,6 +780,7 @@
                                 </div>
                             </div>
                         </div>
+                        <div id="tablemessage" class="contentlet-selection" style="align-self: flex-start; margin: 0.5rem;"></div>
                     </div>
 
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
@@ -2480,9 +2480,6 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
 
                     let dataViewButton = "<dot-data-view-button " + showDataViewButton +"\" value=\""+ state.view +"\"></dot-data-view-button>";
 
-                        let portletBar = document.querySelector(".portlet-toolbar");
-                        portletBar.insertAdjacentHTML('beforeend', '<div id=\"tablemessage\" class=\"contentlet-selection\" style=\"align-self: flex-start; margin: 0.5rem;\"></div>');
-
                         div = document.getElementById("matchingResultsDiv")
                         var structureInode = dijit.byId('structure_inode').value;
                         var strbuff = dataViewButton + "<div class=\"contentlet-results\"><%= LanguageUtil.get(pageContext, "Showing") %> " + begin + "-" + end + " <%= LanguageUtil.get(pageContext, "of1") %> " + num + "</div>";


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 88204df</samp>

### Summary
:wastebasket::speech_balloon::art:

<!--
1.  :wastebasket: - This emoji represents the removal of unnecessary or redundant code, which is what the first change does.
2.  :speech_balloon: - This emoji represents the addition of a message or feedback to the user interface, which is what the second change does.
3.  :art: - This emoji represents the improvement of the appearance or design of the user interface, which is what the second change also does.
-->
This pull request refactors the code that displays a message to the user when they select or deselect contentlets from the table. It moves the `tablemessage` div element from the `view_contentlets_js_inc.jsp` file to the `view_contentlets.jsp` file and removes some redundant code.

> _`tablemessage` div_
> _moved to avoid duplication_
> _cleaner code in spring_

### Walkthrough
*  Add a new div element with id `tablemessage` to display a message to the user when they select or deselect contentlets from the table ([link](https://github.com/dotCMS/core/pull/24956/files?diff=unified&w=0#diff-64336e53ea6351a1a21f62ed6b8f62a31305d6b55aa1f0ffabcf8d2536e2c11dR783))
*  Remove the code that was adding the same div element to the `view_contentlets_js_inc.jsp` file to avoid duplication and simplify the code ([link](https://github.com/dotCMS/core/pull/24956/files?diff=unified&w=0#diff-1260ed1ed8b9f22ca5c14f1e4caa3e4d3c1ada11674f6bf7572ac34cdc209497L2483-L2485))



### Screenshots

#### Original

https://github.com/dotCMS/core/assets/934364/ca1ae588-faa3-4a18-8adc-ec4050914ee5

#### Update

https://github.com/dotCMS/core/assets/63567962/1b0bd9c3-74d2-4d29-ac82-5331591628a8

