### PR TITLE
Issue 24911 dot favorites set collapsed panel on localstorage

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.html
@@ -1,74 +1,76 @@
-<p-panel
-    *ngIf="vm$ | async as vm"
-    [ngClass]="{
-        'dot-pages-panel__expanded': vm.favoritePages.total === vm.favoritePages.items.length,
-        'dot-pages-panel__hide-panel-actions': !vm.favoritePages.showLoadMoreButton,
-        'dot-pages-panel__empty-state': vm.favoritePages?.items?.length === 0
-    }"
-    [toggleable]="true"
-    [header]="'favoritePage.panel.header' | dm"
-    [collapsed]="vm.favoritePages.total === 0"
-    toggler="header"
-    iconPos="start"
-    expandIcon="pi pi-angle-down"
-    collapseIcon="pi pi-angle-up"
->
-    <ng-template *ngIf="vm.favoritePages.showLoadMoreButton" pTemplate="icons">
-        <button
-            class="p-button-secondary dot-pages-panel-action__button"
-            [label]="
-                vm.favoritePages.total > vm.favoritePages.items.length
-                    ? ('see.all' | dm)
-                    : ('see.less' | dm)
-            "
-            (click)="
-                toggleFavoritePagesData(
-                    $event,
-                    vm.favoritePages.total === vm.favoritePages.items.length,
-                    vm.favoritePages.total
-                )
-            "
-            pButton
-            type="button"
-            data-testid="seeAllBtn"
-        ></button>
-    </ng-template>
+<ng-container *ngIf="vm$ | async as vm">
+    <p-panel
+        [ngClass]="{
+            'dot-pages-panel__expanded': vm.favoritePages.total === vm.favoritePages.items.length,
+            'dot-pages-panel__hide-panel-actions': !vm.favoritePages.showLoadMoreButton,
+            'dot-pages-panel__empty-state': vm.favoritePages?.items?.length === 0
+        }"
+        [toggleable]="true"
+        [header]="'favoritePage.panel.header' | dm"
+        [collapsed]="vm.isFavoritePanelCollaped"
+        (onAfterToggle)="toggleFavoritePagesPanel($event)"
+        toggler="header"
+        iconPos="start"
+        expandIcon="pi pi-angle-down"
+        collapseIcon="pi pi-angle-up"
+    >
+        <ng-template *ngIf="vm.favoritePages.showLoadMoreButton" pTemplate="icons">
+            <button
+                class="p-button-secondary dot-pages-panel-action__button"
+                [label]="
+                    vm.favoritePages.total > vm.favoritePages.items.length
+                        ? ('see.all' | dm)
+                        : ('see.less' | dm)
+                "
+                (click)="
+                    toggleFavoritePagesData(
+                        $event,
+                        vm.favoritePages.total === vm.favoritePages.items.length,
+                        vm.favoritePages.total
+                    )
+                "
+                pButton
+                type="button"
+                data-testid="seeAllBtn"
+            ></button>
+        </ng-template>
 
-    <ng-template [ngIf]="vm.favoritePages?.items?.length !== 0" [ngIfElse]="emptyState">
-        <dot-pages-card
-            *ngFor="let item of vm.favoritePages.items; let i = index"
-            [actionButtonId]="'favoritePageActionButton-' + i"
-            [imageUri]="
-                item.screenshot
-                    ? item.screenshot + '?language_id=' + item.languageId + '&' + timeStamp
-                    : ''
-            "
-            [title]="item.title"
-            [url]="item.url"
-            [ownerPage]="item.owner === vm.loggedUser.id"
-            (edit)="editFavoritePage(item)"
-            (goTo)="goToUrl.emit(item.url)"
-            (showActionMenu)="
-                showActionsMenu.emit({
-                    event: $event,
-                    actionMenuDomId: 'favoritePageActionButton-' + i,
-                    item
-                })
-            "
-        ></dot-pages-card>
-    </ng-template>
+        <ng-template [ngIf]="vm.favoritePages?.items?.length !== 0" [ngIfElse]="emptyState">
+            <dot-pages-card
+                *ngFor="let item of vm.favoritePages.items; let i = index"
+                [actionButtonId]="'favoritePageActionButton-' + i"
+                [imageUri]="
+                    item.screenshot
+                        ? item.screenshot + '?language_id=' + item.languageId + '&' + timeStamp
+                        : ''
+                "
+                [title]="item.title"
+                [url]="item.url"
+                [ownerPage]="item.owner === vm.loggedUser.id"
+                (edit)="editFavoritePage(item)"
+                (goTo)="goToUrl.emit(item.url)"
+                (showActionMenu)="
+                    showActionsMenu.emit({
+                        event: $event,
+                        actionMenuDomId: 'favoritePageActionButton-' + i,
+                        item
+                    })
+                "
+            ></dot-pages-card>
+        </ng-template>
 
-    <ng-template #emptyState>
-        <div class="dot-pages-empty__container">
-            <i class="pi pi-star"></i>
-            <div class="dot-pages-empty__header">
-                {{ 'favoritePage.listing.empty.header' | dm }}
+        <ng-template #emptyState>
+            <div class="dot-pages-empty__container">
+                <i class="pi pi-star"></i>
+                <div class="dot-pages-empty__header">
+                    {{ 'favoritePage.listing.empty.header' | dm }}
+                </div>
+                <p
+                    class="dot-pages-empty__content"
+                    data-testid="dot-pages-empty__content"
+                    innerHTML="{{ 'favoritePage.listing.empty.content' | dm }}"
+                ></p>
             </div>
-            <p
-                class="dot-pages-empty__content"
-                data-testid="dot-pages-empty__content"
-                innerHTML="{{ 'favoritePage.listing.empty.content' | dm }}"
-            ></p>
-        </div>
-    </ng-template>
-</p-panel>
+        </ng-template>
+    </p-panel>
+</ng-container>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.spec.ts
@@ -106,6 +106,9 @@ describe('DotPagesFavoritePanelComponent', () => {
                 }
             });
         }
+        setLocalStorageFavoritePanelCollapsedParams(_collapsed: boolean): void {
+            /* */
+        }
     }
 
     describe('Empty state', () => {
@@ -150,6 +153,18 @@ describe('DotPagesFavoritePanelComponent', () => {
             ).toBeTruthy();
         });
 
+        it('should set panel collapsed state', () => {
+            spyOn(store, 'setLocalStorageFavoritePanelCollapsedParams');
+            component.toggleFavoritePagesPanel(
+                new Event('myevent', {
+                    bubbles: true,
+                    cancelable: true,
+                    composed: false
+                })
+            );
+            expect(store.setLocalStorageFavoritePanelCollapsedParams).toHaveBeenCalledTimes(1);
+        });
+
         it('should load empty pages cards container', () => {
             expect(
                 de
@@ -191,6 +206,9 @@ describe('DotPagesFavoritePanelComponent', () => {
                 });
             }
             getFavoritePages(_itemsPerPage: number): void {
+                /* */
+            }
+            setLocalStorageFavoritePanelCollapsedParams(_collapsed: boolean): void {
                 /* */
             }
         }
@@ -380,6 +398,9 @@ describe('DotPagesFavoritePanelComponent', () => {
                 /* */
             }
             limitFavoritePages(_limit: number): void {
+                /* */
+            }
+            setLocalStorageFavoritePanelCollapsedParams(_collapsed: boolean): void {
                 /* */
             }
         }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.ts
@@ -65,6 +65,16 @@ export class DotPagesFavoritePanelComponent {
     }
 
     /**
+     * Event to collapse or not Favorite Page panel
+     *
+     * @param {Event} event
+     * @memberof DotPagesComponent
+     */
+    toggleFavoritePagesPanel($event: Event): void {
+        this.store.setLocalStorageFavoritePanelCollapsedParams($event['collapsed']);
+    }
+
+    /**
      * Event that opens dialog to edit/delete Favorite Page
      *
      * @param {DotCMSContentlet} favoritePage

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -24,6 +24,7 @@ import {
     DotEventsService,
     DotLanguagesService,
     DotLicenseService,
+    DotLocalstorageService,
     DotPageTypesService,
     DotPageWorkflowsActionsService,
     DotRenderMode,
@@ -61,7 +62,11 @@ import {
     mockWorkflowsActions
 } from '@dotcms/utils-testing';
 
-import { DotPageStore, SESSION_STORAGE_FAVORITES_KEY } from './dot-pages.store';
+import {
+    DotPageStore,
+    LOCAL_STORAGE_FAVORITES_PANEL_KEY,
+    SESSION_STORAGE_FAVORITES_KEY
+} from './dot-pages.store';
 
 import { contentTypeDataMock } from '../../dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.spec';
 import { DotLicenseServiceMock } from '../../dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.spec';
@@ -103,6 +108,7 @@ describe('DotPageStore', () => {
     let dotPageWorkflowsActionsService: DotPageWorkflowsActionsService;
     let dotHttpErrorManagerService: DotHttpErrorManagerService;
     let dotFavoritePageService: DotFavoritePageService;
+    let dotLocalstorageService: DotLocalstorageService;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -121,6 +127,7 @@ describe('DotPageStore', () => {
                 LoggerService,
                 StringUtils,
                 DotFavoritePageService,
+                DotLocalstorageService,
                 { provide: DialogService, useClass: DialogServiceMock },
                 { provide: DotcmsEventsService, useClass: DotcmsEventsServiceMock },
                 { provide: CoreWebService, useClass: CoreWebServiceMock },
@@ -145,9 +152,11 @@ describe('DotPageStore', () => {
         dotWorkflowsActionsService = TestBed.inject(DotWorkflowsActionsService);
         dotPageWorkflowsActionsService = TestBed.inject(DotPageWorkflowsActionsService);
         dotFavoritePageService = TestBed.inject(DotFavoritePageService);
+        dotLocalstorageService = TestBed.inject(DotLocalstorageService);
 
         spyOn(dialogService, 'open').and.callThrough();
         spyOn(dotHttpErrorManagerService, 'handle');
+        spyOn(dotLocalstorageService, 'getItem').and.returnValue(`true`);
 
         dotPageStore.setInitialStateData(5);
         dotPageStore.setKeyword('test');
@@ -254,6 +263,12 @@ describe('DotPageStore', () => {
         });
     });
 
+    it('should get isFavoritePanelCollaped Params', () => {
+        dotPageStore.isFavoritePanelCollaped$.subscribe((data) => {
+            expect(data).toEqual(true);
+        });
+    });
+
     it('should get pages loading status', () => {
         dotPageStore.isPagesLoading$.subscribe((data) => {
             expect(data).toEqual(true);
@@ -308,6 +323,15 @@ describe('DotPageStore', () => {
         expect(sessionStorage.setItem).toHaveBeenCalledWith(
             SESSION_STORAGE_FAVORITES_KEY,
             '{"keyword":"test","languageId":"1","archived":true}'
+        );
+    });
+
+    it('should update Local Storage Panel Collapsed Params', () => {
+        spyOn(dotLocalstorageService, 'setItem').and.callThrough();
+        dotPageStore.setLocalStorageFavoritePanelCollapsedParams(true);
+        expect(dotLocalstorageService.setItem).toHaveBeenCalledWith(
+            LOCAL_STORAGE_FAVORITES_PANEL_KEY,
+            'true'
         );
     });
 
@@ -371,6 +395,7 @@ describe('DotPageStore', () => {
             expect(data.favoritePages.items).toEqual(expectedInputArray);
             expect(data.favoritePages.showLoadMoreButton).toEqual(true);
             expect(data.favoritePages.total).toEqual(expectedInputArray.length);
+            expect(data.favoritePages.collapsed).toEqual(undefined);
         });
         expect(dotFavoritePageService.get).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
### Proposed Changes
* The open/closed state of the favorites accordion should be remembered (local storage). I close it, leave the page and come back and it is open again

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
https://github.com/dotCMS/core/assets/37185433/4ea278ad-f76f-40b1-805c-464b791b3ef1
