### PR TITLE
UI - Favorite Page: Contentlets infinite scroll table on Pages Portlet

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
@@ -78,7 +78,6 @@
         </ng-template>
         <ng-template pTemplate="body" let-rowData let-rowIndex="rowIndex">
             <tr
-                class="dot-pages-listing-content__row"
                 id="tableRow-{{ rowIndex }}"
                 [pSelectableRow]="rowData"
                 (contextmenu)="

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
@@ -88,6 +88,7 @@
                         item: rowData
                     })
                 "
+                style="height: 47px"
                 pContextMenuRow
             >
                 <td>{{ rowData['title'] }}</td>
@@ -127,13 +128,13 @@
                             })
                         "
                         icon="more_vert"
-                        size="32"
+                        size="28"
                     ></dot-icon-button>
                 </td>
             </tr>
         </ng-template>
         <ng-template pTemplate="loadingbody">
-            <tr>
+            <tr style="height: 47px">
                 <td><p-skeleton [ngStyle]="{ width: '25%' }"></p-skeleton></td>
                 <td><p-skeleton [ngStyle]="{ width: '20%' }"></p-skeleton></td>
                 <td><p-skeleton [ngStyle]="{ width: '12%' }"></p-skeleton></td>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
@@ -128,7 +128,7 @@
                             })
                         "
                         icon="more_vert"
-                        size="28"
+                        size="32"
                     ></dot-icon-button>
                 </td>
             </tr>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
@@ -25,10 +25,6 @@
         padding: $spacing-3;
     }
 
-    .p-datatable .p-datatable-tbody tr.dot-pages-listing-content__row {
-        height: 47px;
-    }
-
     .dot-pages-listing-header__language-input .p-dropdown-label.p-inputtext {
         min-width: 115px;
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
@@ -6,18 +6,12 @@
 }
 
 ::ng-deep {
-    .p-datatable .p-datatable-tbody > tr > td {
-        text-align: left;
-        border: 1px solid $color-palette-gray-300;
-        border-width: 0 0 1px 0;
-        padding: 0 $spacing-2;
-    }
-
     .p-datatable .p-datatable-tbody tr td {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
         max-width: 0;
+        padding: 0 $spacing-2;
 
         &:last-child {
             padding-right: $spacing-2;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
@@ -6,6 +6,13 @@
 }
 
 ::ng-deep {
+    .p-datatable .p-datatable-tbody > tr > td {
+        text-align: left;
+        border: 1px solid $color-palette-gray-300;
+        border-width: 0 0 1px 0;
+        padding: 0 $spacing-2;
+    }
+
     .p-datatable .p-datatable-tbody tr td {
         white-space: nowrap;
         overflow: hidden;


### PR DESCRIPTION
### Proposed Changes
* Fix pages table scroll

### Checklist
- [x] Tests

### Additional Info

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9645b60</samp>

This pull request improves the styles of the `dot-pages-listing-panel` component, which displays a table of pages in the dotCMS UI. It fixes some issues with the table layout and appearance, and makes the actions menu icon smaller.

## Related Issue
Fixes #23792

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9645b60</samp>

*  Adjust the table header and body row heights to prevent content shifting when loading ([link](https://github.com/dotCMS/core/pull/24985/files?diff=unified&w=0#diff-1dc91e554b57df9862b7aa55f54839c49ea15c3a4caa1bf096f96e5df2e97c4eR91), [link](https://github.com/dotCMS/core/pull/24985/files?diff=unified&w=0#diff-1dc91e554b57df9862b7aa55f54839c49ea15c3a4caa1bf096f96e5df2e97c4eL136-R137))
*  Reduce the size of the actions menu icon button to match the design and other icons ([link](https://github.com/dotCMS/core/pull/24985/files?diff=unified&w=0#diff-1dc91e554b57df9862b7aa55f54839c49ea15c3a4caa1bf096f96e5df2e97c4eL130-R131))
*  Apply custom styles to the table cells to improve alignment, border, and padding ([link](https://github.com/dotCMS/core/pull/24985/files?diff=unified&w=0#diff-d9ee799f12b61fca94371edc845201ad366129d7dd8dacb8a35eeadbf5c68700R9-R15))

### Screenshots
https://github.com/dotCMS/core/assets/72418962/26740771-73bf-43da-b99d-6a3a227e5881



