### PR TITLE
Issue 24984 dot favorites archived page should not be bookmarked

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -148,7 +148,6 @@ describe('DotPageStore', () => {
         dotWorkflowActionsFireService = TestBed.inject(DotWorkflowActionsFireService);
         dotFavoritePageService = TestBed.inject(DotFavoritePageService);
 
-
         spyOn(dialogService, 'open').and.callThrough();
         spyOn(dotHttpErrorManagerService, 'handle');
 
@@ -614,12 +613,45 @@ describe('DotPageStore', () => {
         });
     });
 
-    it('should get all menu actions from a favorite page when page is archived', () => {
-        const error404 = mockResponseView(404, '/page', null, { message: 'error' });
-        spyOn(dotPageWorkflowsActionsService, 'getByUrl').and.returnValue(throwError(error404));
+    it('should not have Add/Edit Bookmark actions in context menu when contentlet is archived', () => {
+        spyOn(dotPageWorkflowsActionsService, 'getByUrl').and.returnValue(
+            of({ actions: mockWorkflowsActions, page: dotcmsContentletMock })
+        );
 
         dotPageStore.showActionsMenu({
-            item: { ...favoritePagesInitialTestData[0], contentType: 'dotFavoritePage' },
+            item: {
+                ...favoritePagesInitialTestData[1],
+                url: '/index2?host_id=A&language_id=1&device_inode=123',
+                contentType: 'dotFavoritePage',
+                archived: true
+            },
+            actionMenuDomId: 'test1'
+        });
+
+        expect(dotPageWorkflowsActionsService.getByUrl).toHaveBeenCalledWith({
+            host_id: 'A',
+            language_id: '1',
+            url: '/index2'
+        });
+
+        dotPageStore.state$.subscribe((data) => {
+            expect(data.pages.menuActions.length).toEqual(8);
+            expect(data.pages.menuActions[0].label).toEqual('favoritePage.contextMenu.action.edit');
+            expect(data.pages.menuActions[1].label).toEqual('favoritePage.dialog.delete.button');
+        });
+    });
+
+    it('should get all menu actions from a favorite page when page is archived', () => {
+        spyOn(dotPageWorkflowsActionsService, 'getByUrl').and.returnValue(
+            of({ actions: mockWorkflowsActions, page: dotcmsContentletMock })
+        );
+
+        dotPageStore.showActionsMenu({
+            item: {
+                ...favoritePagesInitialTestData[0],
+                contentType: 'dotFavoritePage',
+                archived: true
+            },
             actionMenuDomId: 'test1'
         });
 
@@ -630,9 +662,14 @@ describe('DotPageStore', () => {
         });
 
         dotPageStore.state$.subscribe((data) => {
-            expect(data.pages.menuActions.length).toEqual(2);
             expect(data.pages.menuActions[0].label).toEqual('favoritePage.contextMenu.action.edit');
             expect(data.pages.menuActions[1].label).toEqual('favoritePage.dialog.delete.button');
+            expect(data.pages.menuActions[2]).toEqual({ separator: true });
+            expect(data.pages.menuActions[3].label).toEqual('Assign Workflow');
+            expect(data.pages.menuActions[4].label).toEqual('Save');
+            expect(data.pages.menuActions[5].label).toEqual('Save / Publish');
+            expect(data.pages.menuActions[6].label).toEqual('contenttypes.content.push_publish');
+            expect(data.pages.menuActions[7].label).toEqual('contenttypes.content.add_to_bundle');
         });
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -501,14 +501,16 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
                         take(1),
                         tapResponse(
                             ({ workflowsData, dotFavorite }) => {
-                                this.setMenuActions({
-                                    actions: this.getSelectActions(
-                                        workflowsData?.actions,
-                                        workflowsData?.page,
-                                        dotFavorite.jsonObjectView.contentlets[0]
-                                    ),
-                                    actionMenuDomId
-                                });
+                                if (workflowsData) {
+                                    this.setMenuActions({
+                                        actions: this.getSelectActions(
+                                            workflowsData?.actions,
+                                            workflowsData?.page,
+                                            dotFavorite.jsonObjectView.contentlets[0]
+                                        ),
+                                        actionMenuDomId
+                                    });
+                                }
                             },
                             (error: HttpErrorResponse) => this.httpErrorManagerService.handle(error)
                         )
@@ -693,29 +695,31 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
               });
 
         // Adding DotFavorite actions
-        actionsMenu.push({
-            label: favoritePage
-                ? this.dotMessageService.get('favoritePage.contextMenu.action.edit')
-                : this.dotMessageService.get('favoritePage.contextMenu.action.add'),
-            command: () => {
-                this.dialogService.open(DotFavoritePageComponent, {
-                    header: this.dotMessageService.get('favoritePage.dialog.header'),
-                    width: '80rem',
-                    data: {
-                        page: {
-                            favoritePageUrl,
-                            favoritePage
-                        },
-                        onSave: () => {
-                            this.getFavoritePages(FAVORITE_PAGE_LIMIT);
-                        },
-                        onDelete: () => {
-                            this.getFavoritePages(FAVORITE_PAGE_LIMIT);
+        if (!item.archived) {
+            actionsMenu.push({
+                label: favoritePage
+                    ? this.dotMessageService.get('favoritePage.contextMenu.action.edit')
+                    : this.dotMessageService.get('favoritePage.contextMenu.action.add'),
+                command: () => {
+                    this.dialogService.open(DotFavoritePageComponent, {
+                        header: this.dotMessageService.get('favoritePage.dialog.header'),
+                        width: '80rem',
+                        data: {
+                            page: {
+                                favoritePageUrl,
+                                favoritePage
+                            },
+                            onSave: () => {
+                                this.getFavoritePages(FAVORITE_PAGE_LIMIT);
+                            },
+                            onDelete: () => {
+                                this.getFavoritePages(FAVORITE_PAGE_LIMIT);
+                            }
                         }
-                    }
-                });
-            }
-        });
+                    });
+                }
+            });
+        }
 
         if (favoritePage) {
             actionsMenu.push({
@@ -730,7 +734,9 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
             return actionsMenu;
         }
 
-        actionsMenu.push({ separator: true });
+        if (actionsMenu?.length > 0) {
+            actionsMenu.push({ separator: true });
+        }
 
         // Adding Edit & View actions
         const { loggedUser, isEnterprise, environments } = this.get();


### PR DESCRIPTION
### Proposed Changes
* When a user archive a page and then goes to a list that includes the archive page, they can try to add/edit that page to a bookmark from the context menu, but the page doesn't exist.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

