### PR TITLE
Favorite Pages: Allow User Cross-Site Page Editing

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
@@ -54,8 +54,6 @@ describe('DotEditPageResolver', () => {
     let dotEditPageResolver: DotEditPageResolver;
     let siteService: SiteService;
 
-    const siteServiceMock = new SiteServiceMock();
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
@@ -76,7 +74,7 @@ describe('DotEditPageResolver', () => {
                 DotFavoritePageService,
                 { provide: DotRouterService, useClass: MockDotRouterService },
                 { provide: DotMessageDisplayService, useClass: DotMessageDisplayServiceMock },
-                { provide: SiteService, useValue: siteServiceMock },
+                { provide: SiteService, useClass: SiteServiceMock },
                 {
                     provide: ActivatedRouteSnapshot,
                     useValue: route
@@ -176,7 +174,7 @@ describe('DotEditPageResolver', () => {
         });
 
         it('should not switch site when host_id is equal to current site id', () => {
-            route.queryParams.host_id = siteServiceMock.currentSite.identifier;
+            route.queryParams.host_id = siteService.currentSite.identifier;
             spyOn(siteService, 'switchSiteById').and.returnValue(of(null));
             const mock = new DotPageRenderState(
                 mockUser(),

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
@@ -22,7 +22,7 @@ import {
     DotESContentService,
     DotPageRenderService
 } from '@dotcms/data-access';
-import { CoreWebService, HttpCode, LoginService } from '@dotcms/dotcms-js';
+import { CoreWebService, HttpCode, LoginService, SiteService } from '@dotcms/dotcms-js';
 import { DotPageMode, DotPageRender, DotPageRenderState } from '@dotcms/dotcms-models';
 import {
     CoreWebServiceMock,
@@ -30,7 +30,8 @@ import {
     mockDotRenderedPage,
     MockDotRouterService,
     mockResponseView,
-    mockUser
+    mockUser,
+    SiteServiceMock
 } from '@dotcms/utils-testing';
 
 import { DotEditPageResolver } from './dot-edit-page-resolver.service';
@@ -51,6 +52,9 @@ describe('DotEditPageResolver', () => {
 
     let injector: TestBed;
     let dotEditPageResolver: DotEditPageResolver;
+    let siteService: SiteService;
+
+    const siteServiceMock = new SiteServiceMock();
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -72,6 +76,7 @@ describe('DotEditPageResolver', () => {
                 DotFavoritePageService,
                 { provide: DotRouterService, useClass: MockDotRouterService },
                 { provide: DotMessageDisplayService, useClass: DotMessageDisplayServiceMock },
+                { provide: SiteService, useValue: siteServiceMock },
                 {
                     provide: ActivatedRouteSnapshot,
                     useValue: route
@@ -88,6 +93,7 @@ describe('DotEditPageResolver', () => {
         dotPageStateService = injector.get(DotPageStateService);
         dotPageStateServiceRequestPageSpy = spyOn(dotPageStateService, 'requestPage');
         dotRouterService = injector.get(DotRouterService);
+        siteService = injector.get(SiteService);
 
         spyOn(dotHttpErrorManagerService, 'handle').and.returnValue(of());
     });
@@ -142,6 +148,44 @@ describe('DotEditPageResolver', () => {
         });
 
         expect(dotPageStateServiceRequestPageSpy).not.toHaveBeenCalled();
+    });
+
+    describe('Switch Site', () => {
+        it('should switch site when host_id is present in queryparams', () => {
+            route.queryParams.host_id = '123';
+            spyOn(siteService, 'switchSiteById').and.returnValue(of(null));
+            const mock = new DotPageRenderState(
+                mockUser(),
+                new DotPageRender(mockDotRenderedPage())
+            );
+            dotPageStateServiceRequestPageSpy.and.returnValue(of(mock));
+            dotEditPageResolver.resolve(route).subscribe();
+            expect(siteService.switchSiteById).toHaveBeenCalledWith('123');
+        });
+
+        it('should not switch site when host_id is not present in queryparams', () => {
+            route.queryParams = {};
+            spyOn(siteService, 'switchSiteById').and.returnValue(of(null));
+            const mock = new DotPageRenderState(
+                mockUser(),
+                new DotPageRender(mockDotRenderedPage())
+            );
+            dotPageStateServiceRequestPageSpy.and.returnValue(of(mock));
+            dotEditPageResolver.resolve(route).subscribe();
+            expect(siteService.switchSiteById).not.toHaveBeenCalled();
+        });
+
+        it('should not switch site when host_id is equal to current site id', () => {
+            route.queryParams.host_id = siteServiceMock.currentSite.identifier;
+            spyOn(siteService, 'switchSiteById').and.returnValue(of(null));
+            const mock = new DotPageRenderState(
+                mockUser(),
+                new DotPageRender(mockDotRenderedPage())
+            );
+            dotPageStateServiceRequestPageSpy.and.returnValue(of(mock));
+            dotEditPageResolver.resolve(route).subscribe();
+            expect(siteService.switchSiteById).not.toHaveBeenCalled();
+        });
     });
 
     describe('handle layout', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
@@ -92,16 +92,17 @@ export class DotEditPageResolver implements Resolve<DotPageRenderState> {
     private setSite(id: string): Observable<Site> {
         const currentSiteId = this.siteService.currentSite?.identifier;
         const shouldSwitchSite = id && id !== currentSiteId;
-        const switchSite$ = this.siteService.switchSiteById(id).pipe(
-            catchError((err: HttpErrorResponse) => {
-                console.warn(err);
-
-                return of(null);
-            })
-        );
 
         // If we have a site id and is different from the current one, we switch
-        return shouldSwitchSite ? switchSite$ : of(null);
+        return shouldSwitchSite
+            ? this.siteService.switchSiteById(id).pipe(
+                  catchError((err: HttpErrorResponse) => {
+                      console.warn(err);
+
+                      return of(null);
+                  })
+              )
+            : of(null);
     }
 
     private getPageRenderState(

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
@@ -97,9 +97,7 @@ export class DotEditPageResolver implements Resolve<DotPageRenderState> {
         return shouldSwitchSite
             ? this.siteService.switchSiteById(id).pipe(
                   catchError((err: HttpErrorResponse) => {
-                      console.warn(err);
-
-                      return of(null);
+                      return this.dotHttpErrorManagerService.handle(err).pipe(map(() => null));
                   })
               )
             : of(null);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
@@ -31,6 +31,8 @@ export class DotEditPageResolver implements Resolve<DotPageRenderState> {
     resolve(route: ActivatedRouteSnapshot): Observable<DotPageRenderState> {
         const data = this.dotPageStateService.getInternalNavigationState();
 
+        // console.log(data);
+
         if (data) {
             return of(data);
         } else {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/resolvers/dot-experiment-experiment.resolver.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/resolvers/dot-experiment-experiment.resolver.spec.ts
@@ -54,7 +54,6 @@ describe('DotExperimentExperimentResolver', () => {
 
     let injector: TestBed;
     let dotEditPageResolver: DotEditPageResolver;
-    const siteServiceMock = new SiteServiceMock();
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -73,7 +72,7 @@ describe('DotExperimentExperimentResolver', () => {
                 DotFavoritePageService,
                 { provide: DotMessageDisplayService, useClass: DotMessageDisplayServiceMock },
                 { provide: DotRouterService, useClass: MockDotRouterService },
-                { provide: SiteService, useValue: siteServiceMock },
+                { provide: SiteService, useClass: SiteServiceMock },
                 {
                     provide: ActivatedRouteSnapshot,
                     useValue: route

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/resolvers/dot-experiment-experiment.resolver.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/shared/resolvers/dot-experiment-experiment.resolver.spec.ts
@@ -18,7 +18,13 @@ import {
     DotESContentService,
     DotPageRenderService
 } from '@dotcms/data-access';
-import { CoreWebService, HttpCode, LoginService } from '@dotcms/dotcms-js';
+import {
+    CoreWebService,
+    HttpCode,
+    LoginService,
+    SiteService,
+    SiteServiceMock
+} from '@dotcms/dotcms-js';
 import { DotPageRender, DotPageRenderState } from '@dotcms/dotcms-models';
 import {
     CoreWebServiceMock,
@@ -48,6 +54,7 @@ describe('DotExperimentExperimentResolver', () => {
 
     let injector: TestBed;
     let dotEditPageResolver: DotEditPageResolver;
+    const siteServiceMock = new SiteServiceMock();
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -66,6 +73,7 @@ describe('DotExperimentExperimentResolver', () => {
                 DotFavoritePageService,
                 { provide: DotMessageDisplayService, useClass: DotMessageDisplayServiceMock },
                 { provide: DotRouterService, useClass: MockDotRouterService },
+                { provide: SiteService, useValue: siteServiceMock },
                 {
                     provide: ActivatedRouteSnapshot,
                     useValue: route

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.component.ts
@@ -1,4 +1,4 @@
-import { of, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import {
@@ -13,7 +13,7 @@ import {
 import { Menu } from 'primeng/menu';
 
 import { Observable } from 'rxjs/internal/Observable';
-import { filter, map, skip, switchMap, take, takeUntil } from 'rxjs/operators';
+import { filter, skip, take, takeUntil } from 'rxjs/operators';
 
 import { DotMessageSeverity, DotMessageType } from '@components/dot-message-display/model';
 import { DotMessageDisplayService } from '@components/dot-message-display/services';
@@ -73,26 +73,14 @@ export class DotPagesComponent implements AfterViewInit, OnDestroy {
         const splittedUrl = url.split('?');
         const urlParams = { url: splittedUrl[0] };
         const searchParams = new URLSearchParams(splittedUrl[1]);
-        const currentSiteId = this.dotSiteService.currentSite.identifier;
 
         for (const entry of searchParams) {
             urlParams[entry[0]] = entry[1];
         }
 
-        const pageSiteId = urlParams['host_id'];
-
         this.dotPageRenderService
             .checkPermission(urlParams)
-            .pipe(
-                take(1),
-                switchMap((hasPermission: boolean) => {
-                    const obs$ = this.dotSiteService
-                        .switchSiteByIde(pageSiteId)
-                        .pipe(map(() => hasPermission));
-
-                    return currentSiteId !== pageSiteId ? obs$ : of(hasPermission);
-                })
-            )
+            .pipe(take(1))
             .subscribe(
                 (hasPermission: boolean) => {
                     if (hasPermission) {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.module.ts
@@ -19,7 +19,6 @@ import {
     DotPageTypesService,
     DotPageWorkflowsActionsService
 } from '@dotcms/data-access';
-import { SiteService } from '@dotcms/dotcms-js';
 
 import { DotPagesCreatePageDialogComponent } from './dot-pages-create-page-dialog/dot-pages-create-page-dialog.component';
 import { DotPagesFavoritePanelModule } from './dot-pages-favorite-panel/dot-pages-favorite-panel.module';
@@ -51,7 +50,6 @@ import { DotPagesComponent } from './dot-pages.component';
         DotWorkflowActionsFireService,
         DotWorkflowEventHandlerService,
         DotRouterService,
-        SiteService,
         DotFavoritePageService
     ]
 })

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.ts
@@ -39,11 +39,13 @@ export class DotToolbarComponent implements OnInit {
     }
 
     siteChange(site: Site): void {
-        this.siteService.switchSite(site).subscribe();
-
-        if (this.dotRouterService.isEditPage()) {
-            this.dotRouterService.goToSiteBrowser();
-        }
+        this.siteService.switchSite(site).subscribe(() => {
+            // wait for the site to be switched
+            // before redirecting to the site browser
+            if (this.dotRouterService.isEditPage()) {
+                this.dotRouterService.goToSiteBrowser();
+            }
+        });
     }
 
     handleMainButtonClick(): void {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.ts
@@ -39,7 +39,7 @@ export class DotToolbarComponent implements OnInit {
     }
 
     siteChange(site: Site): void {
-        this.siteService.switchSite(site);
+        this.siteService.switchSite(site).subscribe();
 
         if (this.dotRouterService.isEditPage()) {
             this.dotRouterService.goToSiteBrowser();

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.mock.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.mock.ts
@@ -1,5 +1,6 @@
-import { of as observableOf, Observable, Subject, merge } from 'rxjs';
+import { of as observableOf, Observable, Subject, merge, of } from 'rxjs';
 import { Site } from '@dotcms/dotcms-js';
+import { switchMap } from 'rxjs/operators';
 
 export const mockSites: Site[] = [
     {
@@ -37,8 +38,13 @@ export class SiteServiceMock {
         this._switchSite$.next(site || mockSites[0]);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    switchSite(_site: Site) {}
+    switchSiteById(): Observable<Site> {
+        return this.getSiteById().pipe(switchMap((site) => this.switchSite(site)));
+    }
+
+    switchSite(site: Site): Observable<Site> {
+        return of(site);
+    }
 
     getCurrentSite(): Observable<Site> {
         return merge(observableOf(mockSites[0]), this.switchSite$);

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -153,7 +153,7 @@ export class SiteService {
      * This method gets a new site by the id and switch to it
      *
      * @param {string} id
-     * @return {*}
+     * @return {*}  {Observable<Site>}
      * @memberof SiteService
      */
     switchSiteById(id: string): Observable<Site> {

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -149,8 +149,11 @@ export class SiteService {
     }
 
     /**
-     * Change the current Site by site identifier
-     * @param Site site
+     * Switch site by the id
+     * This method gets a new site by the id and switch to it
+     *
+     * @param {string} id
+     * @return {*}
      * @memberof SiteService
      */
     switchSiteById(id: string) {

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -156,11 +156,14 @@ export class SiteService {
      * @return {*}
      * @memberof SiteService
      */
-    switchSiteById(id: string) {
+    switchSiteById(id: string): Observable<Site> {
         this.loggerService.debug('Applying a Site Switch');
 
         return this.getSiteById(id).pipe(
-            switchMap((site) => this.switchSite(site)),
+            switchMap((site) => {
+                // If there is a site we switch to it
+                return site ? this.switchSite(site) : of(null);
+            }),
             take(1)
         );
     }

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -2,7 +2,7 @@ import { Observable, Subject, of, merge } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 
-import { pluck, map, take, switchMap } from 'rxjs/operators';
+import { pluck, map, take, switchMap, tap } from 'rxjs/operators';
 
 import { CoreWebService } from './core-web.service';
 import { DotcmsEventsService } from './dotcms-events.service';
@@ -70,10 +70,11 @@ export class SiteService {
         if (siteIdentifier === this.selectedSite.identifier) {
             name === 'ARCHIVE_SITE'
                 ? this.switchToDefaultSite()
-                      .pipe(take(1))
-                      .subscribe((currentSite: Site) => {
-                          this.switchSite(currentSite).subscribe();
-                      })
+                      .pipe(
+                          take(1),
+                          switchMap((site) => this.switchSite(site))
+                      )
+                      .subscribe()
                 : this.loadCurrentSite();
         }
     }
@@ -152,7 +153,7 @@ export class SiteService {
      * @param Site site
      * @memberof SiteService
      */
-    switchSiteByIde(id: string) {
+    switchSiteById(id: string) {
         this.loggerService.debug('Applying a Site Switch');
 
         return this.getSiteById(id).pipe(
@@ -176,11 +177,8 @@ export class SiteService {
             })
             .pipe(
                 take(1),
-                map(() => {
-                    this.setCurrentSite(site);
-
-                    return site;
-                })
+                tap(() => this.setCurrentSite(site)),
+                map(() => site)
             );
     }
 

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -170,7 +170,9 @@ export class SiteService {
 
     /**
      * Change the current site
-     * @param Site site
+     *
+     * @param {Site} site
+     * @return {*}  {Observable<Site>}
      * @memberof SiteService
      */
     switchSite(site: Site): Observable<Site> {

--- a/core-web/libs/utils-testing/src/lib/site-service.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/site-service.mock.ts
@@ -1,4 +1,7 @@
 import { of as observableOf, Observable, Subject, merge } from 'rxjs';
+
+import { switchMap } from 'rxjs/operators';
+
 import { Site } from '@dotcms/dotcms-js';
 
 export const mockSites: Site[] = [
@@ -17,7 +20,7 @@ export const mockSites: Site[] = [
 ];
 
 export class SiteServiceMock {
-    _currentSite: Site;
+    _currentSite!: Site;
     private _switchSite$: Subject<Site> = new Subject<Site>();
 
     get currentSite(): Site {
@@ -37,8 +40,12 @@ export class SiteServiceMock {
         this._switchSite$.next(site || mockSites[0]);
     }
 
-    switchSite(_site: Site) {
-        /* */
+    switchSiteById(_id: string): Observable<Site> {
+        return this.getSiteById().pipe(switchMap((site) => this.switchSite(site)));
+    }
+
+    switchSite(site: Site): Observable<Site> {
+        return observableOf(site);
     }
 
     get loadedSites(): Site[] {


### PR DESCRIPTION
### Proposed Changes
* Switch to the right `site` when going to `edit page`

### Checklist
- [x] Tests
- [x] Translations

### Additional Info

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d1dd4b</samp>

Refactored the `DotEditPageResolver` service and the `DotToolbarComponent` to enable editing pages from different sites. Added and modified methods in the `SiteService` and its mock class to handle site-switching logic. Removed unused import and provider from the `dot-pages.module.ts` file.

## Related Issue
Fixes #24992 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3d1dd4b</samp>

*  Refactor `resolve` method of `DotEditPageResolver` class to use `siteService` and extract logic into separate methods ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-4fac9401f4a6c5cf837e65f987b43c3aa95d70cc7144e83484321e5068427546L28-R49), [link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-4fac9401f4a6c5cf837e65f987b43c3aa95d70cc7144e83484321e5068427546R98-R123))
* Add `setSite` and `getPageRenderState` methods to `DotEditPageResolver` class to handle site switching and page state requests ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-4fac9401f4a6c5cf837e65f987b43c3aa95d70cc7144e83484321e5068427546R98-R123))
* Add `Site` and `SiteService` imports to `dot-edit-page-resolver.service.ts` file to access site information and operations ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-4fac9401f4a6c5cf837e65f987b43c3aa95d70cc7144e83484321e5068427546L7-R11))
* Add `switchSiteById` and `switchSite` methods to `SiteService` class to make HTTP requests and update current site ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-ebec7159cb4a8660492c16c6797f79029bb5fedea93d4bbad8f44c84729ca61cL151-R182))
* Add `switchMap` and `tap` imports to `site.service.ts` file to use operators in site switching methods ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-ebec7159cb4a8660492c16c6797f79029bb5fedea93d4bbad8f44c84729ca61cL5-R5))
* Modify `switchToDefaultSite` method of `SiteService` class to use `switchMap` operator instead of subscribing to observable ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-ebec7159cb4a8660492c16c6797f79029bb5fedea93d4bbad8f44c84729ca61cL73-R77))
* Modify `getSiteById` method of `SiteService` class to use correct JSDoc syntax for parameter and return types ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-ebec7159cb4a8660492c16c6797f79029bb5fedea93d4bbad8f44c84729ca61cL135-R137))
* Modify `siteChange` method of `DotToolbarComponent` class in `dot-toolbar.component.ts` file to subscribe to `siteService.switchSite` observable ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-702d70cf5d8b2d5e27374f9e33e704440cff80ff92bef64757295c2bcc6270faL42-R42))
* Remove unused and redundant `SiteService` import and provider from `dot-pages.module.ts` file ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-47e3295a5749aab684a0a476c5795118c8b83676b76c9e1aa3e5d4b365d2c6c5L22), [link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-47e3295a5749aab684a0a476c5795118c8b83676b76c9e1aa3e5d4b365d2c6c5L54))
* Add `of` import to `site.service.mock.ts` file to create observable from value in `switchSite` method ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-2252907b5ad0200016c34033f4cf8160e4c32df51e02c4b85460912179a597c2L1-R3))
* Add `switchSiteById` and `switchSite` methods to `SiteServiceMock` class in `site.service.mock.ts` file to mimic real `siteService` methods for testing ([link](https://github.com/dotCMS/core/pull/25005/files?diff=unified&w=0#diff-2252907b5ad0200016c34033f4cf8160e4c32df51e02c4b85460912179a597c2L40-R48))

### Screenshots

https://github.com/dotCMS/core/assets/72418962/36ad83c0-f291-4083-be40-0c20c64f9f67

