### PR TITLE
Fixing unit test

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/cube/CubeJSClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cube/CubeJSClient.java
@@ -107,6 +107,8 @@ public class CubeJSClient {
      * @see #sendWithPagination(CubeJSQuery)
      */
     public CubeJSResultSet send(final CubeJSQuery query) {
+        DotPreconditions.notNull(query, "Query not must be NULL");
+        
         final CircuitBreakerUrl cubeJSClient = CircuitBreakerUrl.builder()
                 .setMethod(Method.GET)
                 .setUrl(String.format("%s/cubejs-api/v1/load", url))

--- a/dotCMS/src/test/java/com/dotcms/cube/CubeJSClientTest.java
+++ b/dotCMS/src/test/java/com/dotcms/cube/CubeJSClientTest.java
@@ -163,6 +163,13 @@ public class CubeJSClientTest {
             }  catch (IllegalArgumentException e) {
                 mockhttpServer.mustNeverCalled("/cubejs-api/v1/load");
             }
+
+            try {
+                cubeClient.sendWithPagination(null);
+                throw new AssertionError("NullPointerException Expected");
+            }  catch (IllegalArgumentException e) {
+                mockhttpServer.mustNeverCalled("/cubejs-api/v1/load");
+            }
         } finally {
             IPUtils.disabledIpPrivateSubnet(false);
             mockhttpServer.stop();

--- a/dotCMS/src/test/java/com/dotcms/cube/CubeJSClientTest.java
+++ b/dotCMS/src/test/java/com/dotcms/cube/CubeJSClientTest.java
@@ -159,14 +159,14 @@ public class CubeJSClientTest {
 
             try {
                 cubeClient.send(null);
-                throw new AssertionError("NullPointerException Expected");
+                throw new AssertionError("IllegalArgumentException Expected");
             }  catch (IllegalArgumentException e) {
                 mockhttpServer.mustNeverCalled("/cubejs-api/v1/load");
             }
 
             try {
                 cubeClient.sendWithPagination(null);
-                throw new AssertionError("NullPointerException Expected");
+                throw new AssertionError("IllegalArgumentException Expected");
             }  catch (IllegalArgumentException e) {
                 mockhttpServer.mustNeverCalled("/cubejs-api/v1/load");
             }


### PR DESCRIPTION
### Proposed Changes
* Throwing NullPointerException in the send method when the query param is null