### PR TITLE
Issue 25008 dateformat on content resource

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotTransformerBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotTransformerBuilder.java
@@ -5,6 +5,7 @@ import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformO
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CATEGORIES_INFO;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CATEGORIES_NAME;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CATEGORIES_VIEW;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.DATETIME_FIELDS_TO_TIMESTAMP;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.FILEASSET_VIEW;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.IDENTIFIER_VIEW;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.COMMON_PROPS;
@@ -198,7 +199,8 @@ public class DotTransformerBuilder {
      */
     public DotTransformerBuilder contentResourceOptions(final boolean allCategoriesInfo){
         optionsHolder.clear();
-        optionsHolder.addAll(EnumSet.of(COMMON_PROPS, CONSTANTS, VERSION_INFO, LOAD_META, BINARIES, CATEGORIES_NAME));
+        optionsHolder.addAll(EnumSet.of(COMMON_PROPS, CONSTANTS, VERSION_INFO, LOAD_META, BINARIES, CATEGORIES_NAME,
+                DATETIME_FIELDS_TO_TIMESTAMP));
         if(allCategoriesInfo){
           optionsHolder.remove(CATEGORIES_NAME);
           optionsHolder.add(CATEGORIES_INFO);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DateTimeFieldsToTimeStampStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DateTimeFieldsToTimeStampStrategy.java
@@ -1,0 +1,56 @@
+package com.dotmarketing.portlets.contentlet.transform.strategy;
+
+import com.dotcms.api.APIProvider;
+import com.dotcms.contenttype.model.field.DateField;
+import com.dotcms.contenttype.model.field.DateTimeField;
+import com.dotcms.contenttype.model.field.Field;
+import com.dotcms.contenttype.model.field.TimeField;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.liferay.portal.model.User;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This strategy will transform all DateTime fields into Timestamps.
+ * We had an issue where old ContentResource would show Datetime in an incorrect format.
+ * The error was originated by the fields loaded from contentlet as json which are mapped into a Date object.
+ * But the JSONObject formats Dates and TimeStamps differently.
+ */
+public class DateTimeFieldsToTimeStampStrategy extends AbstractTransformStrategy<Contentlet> {
+
+    DateTimeFieldsToTimeStampStrategy(APIProvider toolBox) {
+        super(toolBox);
+    }
+
+    @Override
+    protected Map<String, Object> transform(Contentlet source, Map<String, Object> map,
+            Set<TransformOptions> options, User user)
+            throws DotDataException, DotSecurityException {
+        final ContentType contentType = source.getContentType();
+        convertFieldsToTimestamp(contentType.fields(TimeField.class), map);
+        convertFieldsToTimestamp(contentType.fields(DateField.class), map);
+        convertFieldsToTimestamp(contentType.fields(DateTimeField.class), map);
+        return map;
+    }
+
+    /**
+     * This method will convert all Date fields into Timestamps.
+     * @param fields list of fields to convert
+     * @param map map containing the values to convert
+     */
+    private void convertFieldsToTimestamp(final List<Field> fields, Map<String, Object> map){
+        fields.forEach(field -> {
+            final Object o = map.get(field.variable());
+            if (o instanceof Date) {
+                map.put(field.variable(), new Timestamp(((Date) o).getTime()));
+            }
+        });
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/StrategyResolverImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/StrategyResolverImpl.java
@@ -69,7 +69,8 @@ public class StrategyResolverImpl implements StrategyResolver {
                  SITE_VIEW,       ()-> new  SiteViewStrategy(toolBox),
                  STORY_BLOCK_VIEW,()-> new  StoryBlockViewStrategy(toolBox),
                  RENDER_FIELDS,   ()-> new  RenderFieldStrategy(toolBox),
-                 JSON_VIEW,   ()-> new  JSONViewStrategy(toolBox)
+                 JSON_VIEW,   ()-> new  JSONViewStrategy(toolBox),
+                 DATETIME_FIELDS_TO_TIMESTAMP,   ()-> new DateTimeFieldsToTimeStampStrategy(toolBox)
              ),
              ()-> new DefaultTransformStrategy(toolBox)
         );

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/TransformOptions.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/TransformOptions.java
@@ -29,7 +29,8 @@ public enum TransformOptions {
 
     AVOID_MAP_SUFFIX_FOR_VIEWS,
     RENDER_FIELDS, // will velocity-render the render-able fields
-    JSON_VIEW;
+    JSON_VIEW,
+    DATETIME_FIELDS_TO_TIMESTAMP;
 
     private boolean defaultProperty;
 


### PR DESCRIPTION
### Proposed Changes
* date, dateTime and Time fields are presented in an incorrect format through the old contentresource
* The Old resource which uses JSONObject to accomplish the JSON transformation was expecting Timestamps 
* Here we're adding a new transform-strategy to convert all relevant fields coming in represented through Date into Timestamp


