### PR TITLE
25019: Fix loading state of run experiment button

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.spec.ts
@@ -587,8 +587,9 @@ describe('DotExperimentsConfigurationStore', () => {
 
             store.startExperiment(experimentWithGoalsAndVariant);
 
-            store.state$.subscribe(({ experiment }) => {
+            store.state$.subscribe(({ experiment, status }) => {
                 expect(experiment.status).toEqual(DotExperimentStatusList.RUNNING);
+                expect(status).toEqual(ComponentStatus.IDLE);
                 done();
             });
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/store/dot-experiments-configuration-store.ts
@@ -142,7 +142,8 @@ export class DotExperimentsConfigurationStore extends ComponentStore<DotExperime
     // Updaters
     readonly setExperiment = this.updater((state, experiment: DotExperiment) => ({
         ...state,
-        experiment
+        experiment,
+        status: ComponentStatus.IDLE
     }));
 
     readonly setComponentStatus = this.updater((state, status: ComponentStatus) => ({


### PR DESCRIPTION
### Proposed Changes
* Fix the loading state of the run experiment button

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed2179e</samp>

This pull request improves the store logic and testing for the dot-experiments-configuration module. It ensures that the store status is set to `IDLE` when starting or updating an experiment.

## Related Issue
Fixes #25019

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed2179e</samp>

*  Set the store status to IDLE when starting or updating an experiment ([link](https://github.com/dotCMS/core/pull/25022/files?diff=unified&w=0#diff-73ae23f695077400bcda34fad2e21b077a7f32d2c781d76aca1f437b1829b6beL590-R592), [link](https://github.com/dotCMS/core/pull/25022/files?diff=unified&w=0#diff-7a90616a0732d0f6b7355c5fc0be32eb154c777900d8d29d700960e9dbaeb5a0L145-R146))
*  Add an assertion to check the store status after starting an experiment ([link](https://github.com/dotCMS/core/pull/25022/files?diff=unified&w=0#diff-73ae23f695077400bcda34fad2e21b077a7f32d2c781d76aca1f437b1829b6beL590-R592))