### PR TITLE
Add Styles to Template Builder Storybook

### DIFF
--- a/core-web/libs/template-builder/project.json
+++ b/core-web/libs/template-builder/project.json
@@ -35,7 +35,18 @@
                 "port": 4400,
                 "configDir": "libs/template-builder/.storybook",
                 "browserTarget": "template-builder:build-storybook",
-                "compodoc": false
+                "compodoc": false,
+                "stylePreprocessorOptions": {
+                    "includePaths": ["libs/dotcms-scss/angular"]
+                },
+                "styles": [
+                    "libs/dotcms-scss/angular/styles.scss",
+                    "node_modules/primeicons/primeicons.css",
+                    "node_modules/primeicons/primeicons.css",
+                    "node_modules/primeflex/primeflex.css",
+                    "node_modules/primeng/resources/primeng.min.css",
+                    "node_modules/gridstack/dist/gridstack.min.css"
+                ]
             },
             "configurations": {
                 "ci": {
@@ -51,7 +62,17 @@
                 "configDir": "libs/template-builder/.storybook",
                 "browserTarget": "template-builder:build-storybook",
                 "compodoc": false,
-                "styles": ["node_modules/gridstack/dist/gridstack.min.css"]
+                "stylePreprocessorOptions": {
+                    "includePaths": ["libs/dotcms-scss/angular"]
+                },
+                "styles": [
+                    "libs/dotcms-scss/angular/styles.scss",
+                    "node_modules/primeicons/primeicons.css",
+                    "node_modules/primeicons/primeicons.css",
+                    "node_modules/primeflex/primeflex.css",
+                    "node_modules/primeng/resources/primeng.min.css",
+                    "node_modules/gridstack/dist/gridstack.min.css"
+                ]
             },
             "configurations": {
                 "ci": {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8ec9443</samp>

### Summary
🎨📦🚀

<!--
1.  🎨 - This emoji represents the use of SCSS variables and mixins from the `dotcms-scss` library, which improves the styling and functionality of the template builder components.
2.  📦 - This emoji represents the import of CSS files from some external dependencies, such as `react-dnd` and `react-select`, in the storybook environment. This ensures that the components that rely on these dependencies have the correct styles and behavior in the storybook environment.
3.  🚀 - This emoji represents the improvement of the consistency between the local and the CI storybook builds, which makes the development and testing process faster and smoother.
-->
This pull request enhances the template builder project by using `dotcms-scss` for styling and importing external CSS files for storybook. This improves the appearance and behavior of the template builder components and the storybook environment.

> _`template-builder`_
> _uses `dotcms-scss` now_
> _snowflakes of style_

### Walkthrough
*  Enable SCSS variables and mixins and import CSS files for template builder components in storybook ([link](https://github.com/dotCMS/core/pull/25029/files?diff=unified&w=0#diff-f83af199d6224e11442d63b1dd1a2dcc69918857de61090868210246d36027faL38-R49), [link](https://github.com/dotCMS/core/pull/25029/files?diff=unified&w=0#diff-f83af199d6224e11442d63b1dd1a2dcc69918857de61090868210246d36027faL54-R75))

