### PR TITLE
Issue 24969 handle remaining contentlets without contentlet as json value

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtilTest.java
@@ -16,7 +16,6 @@ import org.apache.felix.framework.OSGIUtil;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -83,13 +82,13 @@ public class PopulateContentletAsJSONUtilTest extends IntegrationTestBase {
     /**
      * <b>Method to test:</b> {@link PopulateContentletAsJSONUtil#populateForAssetSubType(String)}
      * <p>
-     * <b>Given sceneario:</b> We create some hosts, then we drop the contentlet_as_json column, and we add it again to simulate
+     * <b>Given scenario:</b> We create some hosts, then we drop the contentlet_as_json column, and we add it again to simulate
      * contlentlets without data in the contentlet_as_json, to finally run the populateForAssetSubType method.
      * <p>
      * <b>Expected result:</b> We should have the contentlet_as_json column populated with the contentlet data in the test hosts.
      */
     @Test
-    public void Test_populate_host() throws SQLException, DotDataException, IOException {
+    public void Test_populate_host() throws DotDataException {
 
         Collection<Host> hosts = new ArrayList<>();
 
@@ -152,14 +151,14 @@ public class PopulateContentletAsJSONUtilTest extends IntegrationTestBase {
     /**
      * <b>Method to test:</b> {@link PopulateContentletAsJSONUtil#populateExcludingAssetSubType(String)}
      * <p>
-     * <b>Given sceneario:</b> We create some contentlets, then we drop the contentlet_as_json column, and we add it again to
+     * <b>Given scenario:</b> We create some contentlets, then we drop the contentlet_as_json column, and we add it again to
      * simulate contlentlets without data in the contentlet_as_json, to finally run the populateExcludingAssetSubType method.
      * <p>
      * <b>Expected result:</b> We should have the contentlet_as_json column populated with the contentlet data in the test
      * contentlets.
      */
     @Test
-    public void Test_populate_All_excluding_host() throws SQLException, DotDataException, IOException {
+    public void Test_populate_All_excluding_host() throws DotDataException {
 
         Collection<Contentlet> contents = new ArrayList<>();
 
@@ -188,7 +187,7 @@ public class PopulateContentletAsJSONUtilTest extends IntegrationTestBase {
                             "WHERE i.asset_subtype <> 'Host' AND asset_type = 'contentlet'")
                     .loadObjectResults();
 
-            // Make sure we have the right number of hosts
+            // Make sure we have the right number of contentlets
             assertTrue(results.size() >= 10);
 
             results.forEach(rowMap -> {
@@ -206,6 +205,66 @@ public class PopulateContentletAsJSONUtilTest extends IntegrationTestBase {
                             "                                            (c.inode = cv.working_inode OR c.inode = cv.live_inode) " +
                             "WHERE i.asset_subtype <> 'Host' AND asset_type = 'contentlet'")
                     .loadObjectResults();
+
+            // Make sure we have the right number of hosts again
+            assertTrue(results.size() >= 10);
+
+            // This time contentlet_as_json can not be null
+            results.forEach(rowMap -> {
+                assertTrue(rowMap.containsKey("contentlet_as_json"));
+                assertNotNull(rowMap.get("contentlet_as_json"));
+            });
+        } finally {
+            // Clean up
+            contents.forEach(ContentletDataGen::destroy);
+        }
+    }
+
+    /**
+     * <b>Method to test:</b> {@link PopulateContentletAsJSONUtil#populateEverything()}
+     * <p>
+     * <b>Given scenario:</b> We create some contentlets, then we drop the contentlet_as_json column, and we add it again to
+     * simulate contlentlets without data in the contentlet_as_json, to finally run the populateEverything method.
+     * <p>
+     * <b>Expected result:</b> We should have the contentlet_as_json column populated with the contentlet data in the test
+     * contentlets.
+     */
+    @Test
+    public void Test_populate_everything() throws DotDataException {
+
+        Collection<Contentlet> contents = new ArrayList<>();
+
+        try {
+
+            var defaultLanguageId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+
+            // First we need to create some contentlets
+            for (int i = 0; i < 10; i++) {
+                contents.add(TestDataUtils.getGenericContentContent(true, defaultLanguageId));
+            }
+
+            // We drop the contentlet_as_json column
+            removeContentletAsJSONColumn();
+
+            // And we add it again
+            createContentletAsJSONColumn();
+
+            // Make sure we have the column but with not content
+            final DotConnect dotConnect = new DotConnect();
+            var results = dotConnect.setSQL("select * from contentlet").loadObjectResults();
+
+            // Make sure we have the right number of contentlets
+            assertTrue(results.size() >= 10);
+
+            results.forEach(rowMap -> {
+                assertTrue(rowMap.containsKey("contentlet_as_json"));
+                assertNull(rowMap.get("contentlet_as_json"));
+            });
+
+            // Now we execute the task
+            new PopulateContentletAsJSONUtil().populateEverything();
+
+            results = dotConnect.setSQL("select * from contentlet").loadObjectResults();
 
             // Make sure we have the right number of hosts again
             assertTrue(results.size() >= 10);

--- a/dotCMS/src/main/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtil.java
@@ -18,14 +18,12 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.Ints;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
 import org.apache.commons.lang3.mutable.MutableInt;
 
 import javax.annotation.Nullable;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -33,7 +31,6 @@ import java.sql.Statement;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Utility class to populate the contentlet_as_json column in the contentlet table.
@@ -67,36 +64,54 @@ public class PopulateContentletAsJSONUtil {
             "   WHERE i.asset_subtype <> '%s' AND i.asset_type = 'contentlet' AND c.contentlet_as_json IS NULL;";
 
     // Query to update the contentlet_as_json column of the contentlet table
-    private final String UPDATE_CONTENTLET_AS_JSON = "UPDATE contentlet SET contentlet_as_json = ? " +
-            "WHERE inode = ? AND contentlet_as_json IS NULL";
+    private final String UPDATE_CONTENTLET_AS_JSON =
+            "UPDATE contentlet SET contentlet_as_json = ? " +
+                    "WHERE inode = ? AND contentlet_as_json IS NULL";
+
+    // Temporal table related queries
+    private final String CREATE_TEMP_TABLE = "CREATE TEMP TABLE tmp_contentlet_json ("
+            + "     inode varchar(36) not null,"
+            + "     json text not null"
+            + ");";
+
+    private final String DROP_TEMP_TABLE = "DROP TABLE IF EXISTS tmp_contentlet_json;";
+
+    private final String INSERT_INTO_TEMP_TABLE = "INSERT INTO tmp_contentlet_json (inode, json) "
+            + "VALUES (?,?);";
 
     // Cursor related queries
     private final String DECLARE_CURSOR = "DECLARE missingContentletAsJSONCursor CURSOR FOR %s";
-    private final String FETCH_CURSOR_POSTGRES = "FETCH FORWARD %s FROM missingContentletAsJSONCursor";
-    private final String FETCH_CURSOR_MSSQL = "FETCH NEXT FROM missingContentletAsJSONCursor";
-    private final String OPEN_CURSOR_MSSQL = "OPEN missingContentletAsJSONCursor";
+    private final String DECLARE_CURSOR_FOR_TEMPORAL_TABLE =
+            "DECLARE tmpContentletJSONCursor CURSOR "
+                    + "FOR SELECT inode, json FROM tmp_contentlet_json;";
+    private final String FETCH_CURSOR = "FETCH FORWARD %s FROM missingContentletAsJSONCursor";
+    private final String FETCH_CURSOR_FOR_TEMPORAL_TABLE = "FETCH FORWARD %s FROM tmpContentletJSONCursor";
     private final String CLOSE_CURSOR = "CLOSE missingContentletAsJSONCursor";
-    private final String DEALLOCATE_CURSOR_MSSQL = "DEALLOCATE missingContentletAsJSONCursor";
+    private final String CLOSE_CURSOR_FOR_TEMPORAL_TABLE = "CLOSE tmpContentletJSONCursor";
 
-    private static final int MAX_UPDATE_BATCH_SIZE = Config.getIntProperty("task.230320.maxupdatebatchsize", 100);
-    private static final int MAX_CURSOR_FETCH_SIZE = Config.getIntProperty("task.230320.maxcursorfetchsize", 100);
+    private static final int MAX_UPDATE_BATCH_SIZE = Config.getIntProperty(
+            "task.230320.maxupdatebatchsize", 100);
+    private static final int MAX_CURSOR_FETCH_SIZE = Config.getIntProperty(
+            "task.230320.maxcursorfetchsize", 100);
 
     public PopulateContentletAsJSONUtil() {
         this.contentletJsonAPI = APILocator.getContentletJsonAPI();
     }
 
     /**
-     * Finds all the contentlets that need to be updated with the contentlet_as_json column for a given
-     * assetSubtype (Content Type).
+     * Finds all the contentlets that need to be updated with the contentlet_as_json column for a
+     * given assetSubtype (Content Type).
      *
-     * @param assetSubtype Asset subtype (Content Type) to filter the contentlets to process, if null then all
-     *                     the contentlets will be processed.
+     * @param assetSubtype Asset subtype (Content Type) to filter the contentlets to process, if
+     *                     null then all the contentlets will be processed.
      * @throws SQLException
-     * @throws DotDataException
      * @throws IOException
      */
-    public void populateForAssetSubType(final String assetSubtype) throws SQLException, DotDataException, IOException {
-        Logger.info(this, String.format("Populate Contentlet as JSON task started for asset subtype [%s]", assetSubtype));
+    public void populateForAssetSubType(final String assetSubtype)
+            throws SQLException, IOException {
+        Logger.info(this,
+                String.format("Populate Contentlet as JSON task started for asset subtype [%s]",
+                        assetSubtype));
         populate(assetSubtype, null);
     }
 
@@ -115,74 +130,88 @@ public class PopulateContentletAsJSONUtil {
     }
 
     /**
-     * Finds all the contentlets that need to be updated with the contentlet_as_json column for the given
-     * assetSubtype and excludingAssetSubtype.
+     * Finds all the contentlets that need to be updated with the contentlet_as_json column for the
+     * given assetSubtype and excludingAssetSubtype.
      *
-     * @param assetSubtype          Optional asset subtype (Content Type) to filter the contentlets to process, if null then all
-     *                              the contentlets will be processed unless the excludingAssetSubtype is provided.
-     * @param excludingAssetSubtype Optional asset subtype (Content Type) use to exclude contentlets from the query
-     * @throws IOException
+     * @param assetSubtype          Optional asset subtype (Content Type) to filter the contentlets
+     *                              to process, if null then all the contentlets will be processed
+     *                              unless the excludingAssetSubtype is provided.
+     * @param excludingAssetSubtype Optional asset subtype (Content Type) use to exclude contentlets
+     *                              from the query
      */
     @LogTime(loggingLevel = "INFO")
-    private void populate(@Nullable String assetSubtype, @Nullable String excludingAssetSubtype) throws IOException {
-
-        final File populateJSONTaskDataFile = File.createTempFile("rows-task-230320", "tmp");
-
-        Logger.debug(this, "File created: " + populateJSONTaskDataFile.getAbsolutePath());
+    private void populate(@Nullable String assetSubtype, @Nullable String excludingAssetSubtype) {
 
         Runnable findAndStore = () -> {
             try {
                 // First we need to find all the contentlets to process and write them into a file
-                findAndStoreToDisk(assetSubtype, excludingAssetSubtype, populateJSONTaskDataFile);
-            } catch (SQLException | DotDataException | IOException e) {
-                throw new DotRuntimeException("Error finding, generating JSON representation of Contentlets " +
-                        "and storing them in file.", e);
+                findAndStore(assetSubtype, excludingAssetSubtype);
+            } catch (SQLException | DotDataException e) {
+                throw new DotRuntimeException("Error finding, generating JSON representation of "
+                        + "Contentlets and storing them into a temporal table.", e);
             }
         };
 
         Runnable processFile = () -> {
             try {
                 // Now we need to process the file and each record on it
-                processFile(populateJSONTaskDataFile);
-            } catch (IOException e) {
-                throw new DotRuntimeException("Error processing file with the JSON representation of Contentlets to " +
-                        "update.", e);
+                processRecords();
+            } catch (SQLException | DotDataException e) {
+                throw new DotRuntimeException(
+                        "Error processing records with the JSON representation "
+                                + "of Contentlets to update.", e);
             }
         };
 
         CompletableFuture.
                 runAsync(findAndStore).
                 thenRunAsync(processFile).
-                thenAccept(unused -> Logger.info(this, String.format("Contentlet as JSON migration task " +
-                                "DONE for assetSubtype: [%s] / excludingAssetSubtype [%s].",
-                        assetSubtype, excludingAssetSubtype))).
-                join();// Block the current thread and wait for the CompletableFuture to complete
+                thenAccept((unused) -> {
+
+                            if (!Strings.isNullOrEmpty(assetSubtype)) {
+
+                                Logger.info(this, String.format("Contentlet as JSON migration task " +
+                                        "DONE for assetSubtype: [%s].", assetSubtype));
+                            } else if (!Strings.isNullOrEmpty(excludingAssetSubtype)) {
+
+                                Logger.info(this, String.format("Contentlet as JSON migration task " +
+                                        "DONE for excludingAssetSubtype [%s].", excludingAssetSubtype));
+                            } else {
+
+                                Logger.info(this, "Contentlet as JSON migration task DONE");
+                            }
+
+                        }
+                ).join();// Block the current thread and wait for the CompletableFuture to complete
     }
 
     /**
-     * Searches for all the contentlets of a given asset subtype (Content Type) that have a null contentlet_as_json. This
-     * method uses a cursor to avoid loading all the contentlets into memory.
-     * Each found contentlet is written into a file for a later processing.
+     * Searches for all the contentlets of a given asset subtype (Content Type) that have a null
+     * contentlet_as_json. This method uses a cursor to avoid loading all the contentlets into
+     * memory. Each found contentlet is written into a temporal table for a later processing.
      *
-     * @param assetSubtype             The asset subtype (Content Type) to search for, if null all the contentlets will be searched.
-     * @param excludingAssetSubtype    The asset subtype (Content Type) to exclude in the search, if null no Content Type will be excluded.
-     * @param populateJSONTaskDataFile The file where the contentlets will be written.
+     * @param assetSubtype          The asset subtype (Content Type) to search for, if null all the
+     *                              contentlets will be searched.
+     * @param excludingAssetSubtype The asset subtype (Content Type) to exclude in the search, if
+     *                              null no Content Type will be excluded.
      * @throws SQLException
      * @throws DotDataException
-     * @throws IOException
      */
     @WrapInTransaction
-    private void findAndStoreToDisk(@Nullable final String assetSubtype,
-                                    @Nullable final String excludingAssetSubtype,
-                                    final File populateJSONTaskDataFile) throws
-            SQLException, DotDataException, IOException {
+    private void findAndStore(@Nullable final String assetSubtype,
+                              @Nullable final String excludingAssetSubtype) throws
+            SQLException, DotDataException {
+
+        Logger.info(this, "Finding records with missing Contentlet as JSON");
 
         int recordsProcessed = 0;
 
         final Connection conn = DbConnectionFactory.getConnection();
 
-        try (var fileWriter = new BufferedWriter(new FileWriter(populateJSONTaskDataFile));
-             var stmt = conn.createStatement()) {
+        // Creating the temporal table to hold the contentlets and json to process
+        createTempTable(conn);
+
+        try (var stmt = conn.createStatement()) {
 
             // Declaring the cursor
             declareCursor(stmt, assetSubtype, excludingAssetSubtype);
@@ -191,12 +220,8 @@ public class PopulateContentletAsJSONUtil {
 
             do {
 
-                if (DbConnectionFactory.isMsSql()) {
-                    stmt.execute(FETCH_CURSOR_MSSQL);
-                } else {
-                    // Fetching batches of 100 records
-                    stmt.execute(String.format(FETCH_CURSOR_POSTGRES, MAX_CURSOR_FETCH_SIZE));
-                }
+                // Fetching batches of 100 records
+                stmt.execute(String.format(FETCH_CURSOR, MAX_CURSOR_FETCH_SIZE));
 
                 try (ResultSet rs = stmt.getResultSet()) {
 
@@ -222,13 +247,16 @@ public class PopulateContentletAsJSONUtil {
                                 )// Transform the contentlets into a list of json strings
                                 .orElse(Collections.emptyList());
 
+                        var internalDotConnect = new DotConnect();
                         for (var jsonData : jsonDataArray) {
-                            // Write the json representation of the contentlet into the file
-                            fileWriter.write(jsonData);
-                            fileWriter.newLine();
+                            // Insert the json representation of the contentlet into the temp table
+                            insertIntoTempTable(internalDotConnect, jsonData);
                         }
 
-                        Logger.debug(this, String.format("Added [%s] records for update to temp file", jsonDataArray.size()));
+                        Logger.debug(this, String.format(
+                                "Added [%s] records for update to temp table [%s]",
+                                jsonDataArray.size(),
+                                "tmp_contentlet_json"));
 
                     } else {
                         hasRows = false;
@@ -237,41 +265,76 @@ public class PopulateContentletAsJSONUtil {
 
             } while (hasRows);
 
-            // Flush the writer to the file
-            fileWriter.flush();
-
             // Close the cursor
             stmt.execute(CLOSE_CURSOR);
-            if (DbConnectionFactory.isMsSql()) {
-                stmt.execute(DEALLOCATE_CURSOR_MSSQL);
-            }
         }
 
         Logger.info(this, "-- Records found to process: " + recordsProcessed);
     }
 
     /**
-     * This method processes a file that contains all the contentlets that need to be updated with the contentlet_as_json
+     * This method processes a temporal table that contains all the contentlets that need to be
+     * updated with the contentlet_as_json
      *
-     * @param taskDataFile
-     * @throws IOException
+     * @throws SQLException     If there is an error in the SQL execution.
+     * @throws DotDataException If there is an error related to data handling.
      */
     @WrapInTransaction
-    private void processFile(final File taskDataFile) throws IOException {
-
-        Logger.info(this, "Updating records with missing Contentlet as JSON");
+    private void processRecords() throws SQLException, DotDataException {
 
         final Collection<Params> paramsUpdate = new ArrayList<>();
         final MutableInt totalUpdateAffected = new MutableInt(0);
 
-        try (final Stream<String> streamLines = Files.lines(taskDataFile.toPath())) {
+        Logger.info(this, "Updating records with missing Contentlet as JSON");
 
-            streamLines.forEachOrdered(line -> this.processLine(paramsUpdate, line, totalUpdateAffected));
+        final Connection conn = DbConnectionFactory.getConnection();
 
-            if (!paramsUpdate.isEmpty()) {
-                this.doUpdateBatch(paramsUpdate, totalUpdateAffected);
-            }
-        } finally {
+        try (var stmt = conn.createStatement()) {
+
+            // Declaring the cursor
+            stmt.execute(DECLARE_CURSOR_FOR_TEMPORAL_TABLE);
+
+            boolean hasRows;
+
+            do {
+
+                // Fetching batches of 100 records
+                stmt.execute(String.format(FETCH_CURSOR_FOR_TEMPORAL_TABLE, MAX_CURSOR_FETCH_SIZE));
+
+                try (ResultSet rs = stmt.getResultSet()) {
+
+                    // Now we want to write the found Contentlets into a file for a later processing
+                    var dotConnect = new DotConnect();
+                    dotConnect.fromResultSet(rs);
+
+                    var loadedResults = dotConnect.loadObjectResults();
+
+                    if (!loadedResults.isEmpty()) {
+
+                        hasRows = true;
+
+                        loadedResults.forEach(
+                                record -> this.processRecord(
+                                        (String) record.get("inode"),
+                                        (String) record.get("json"),
+                                        paramsUpdate,
+                                        totalUpdateAffected)
+                        );
+
+                        if (!paramsUpdate.isEmpty()) {
+                            this.doUpdateBatch(paramsUpdate, totalUpdateAffected);
+                        }
+
+                    } else {
+                        hasRows = false;
+                    }
+                }
+
+            } while (hasRows);
+
+            // Close the cursor
+            stmt.execute(CLOSE_CURSOR_FOR_TEMPORAL_TABLE);
+
             Logger.info(this, "-- total updates: " + totalUpdateAffected.intValue());
         }
 
@@ -301,61 +364,92 @@ public class PopulateContentletAsJSONUtil {
             var selectQuery = String.format(SUBTYPE_WITH_NO_JSON, assetSubtype);
             stmt.execute(String.format(DECLARE_CURSOR, selectQuery));
         }
+    }
 
-        if (DbConnectionFactory.isMsSql()) {
-            stmt.execute(OPEN_CURSOR_MSSQL);
+    /**
+     * Processes a record by preparing the parameters for a batch update.
+     *
+     * @param inode               The inode of the contentlet.
+     * @param json                The JSON representation of the contentlet.
+     * @param paramsUpdate        A collection of Params objects used for batch updates. The Params
+     *                            object contains the contentlet JSON and inode.
+     * @param totalInsertAffected A MutableInt object to keep track of the total number of affected
+     *                            rows in batch updates.
+     * @throws JsonProcessingException If there is an error while processing the JSON.
+     */
+    private void processRecord(
+            final String inode,
+            final String json,
+            final Collection<Params> paramsUpdate,
+            final MutableInt totalInsertAffected
+    ) {
+
+        final Object contentletAsJSON;
+        if (DbConnectionFactory.isPostgres()) {
+            contentletAsJSON = new DotPGobject.Builder()
+                    .jsonValue(json)
+                    .build();
+        } else {
+            contentletAsJSON = json;
+        }
+
+        paramsUpdate.add(new Params(contentletAsJSON, inode));
+
+        // Execute the batch for the updates if we have reached the max batch size
+        if (paramsUpdate.size() >= MAX_UPDATE_BATCH_SIZE) {
+            this.doUpdateBatch(paramsUpdate, totalInsertAffected);
         }
     }
 
     /**
-     * Processes the given line preparing the params for the batch update.
+     * Creates a temporary table in the database.
      *
-     * @param line Line with the json representation of the contentlet.
-     * @throws JsonProcessingException
+     * @throws DotDataException If there is an error related to data handling.
+     * @throws SQLException     If there is an error in the SQL execution.
      */
-    private void processLine(final Collection<Params> paramsUpdate, final String line,
-                             final MutableInt totalInsertAffected) {
+    private void createTempTable(final Connection conn) throws DotDataException, SQLException {
 
-        try {
-            var contentlet = ContentletJsonHelper.INSTANCE.get().immutableFromJson(line);
-
-            final Object contentletAsJSON;
-            if (DbConnectionFactory.isPostgres()) {
-                contentletAsJSON = new DotPGobject.Builder()
-                        .jsonValue(line)
-                        .build();
-            } else {
-                contentletAsJSON = line;
-            }
-
-            paramsUpdate.add(new Params(contentletAsJSON, contentlet.inode()));
-
-            // Execute the batch for the updates if we have reached the max batch size
-            if (paramsUpdate.size() >= MAX_UPDATE_BATCH_SIZE) {
-                this.doUpdateBatch(paramsUpdate, totalInsertAffected);
-            }
-        } catch (JsonProcessingException e) {
-            throw new DotRuntimeException("Error processing line", e);
-        }
+        new DotConnect().setSQL(DROP_TEMP_TABLE).loadResult(conn);
+        new DotConnect().setSQL(CREATE_TEMP_TABLE).loadResult(conn);
     }
 
     /**
-     * Converts the contentlet to an immutable contentlet and then builds a json representation of it.
+     * Inserts data into the temporary table.
      *
-     * @param contentlet
-     * @return The Contentlet with the json representation attached to it.
+     * @param dotConnect     The DotConnect object used for database connection and operations.
+     * @param contentletData The contentlet data to be inserted into the temporary table. It should
+     *                       be a Tuple2 object with two String values.
+     * @throws DotDataException If there is an error related to data handling.
      */
-    private String toJSON(Contentlet contentlet) {
+    private void insertIntoTempTable(final DotConnect dotConnect,
+                                     final Tuple2<String, String> contentletData)
+            throws DotDataException {
+
+        dotConnect.setSQL(INSERT_INTO_TEMP_TABLE).
+                addParam(contentletData._1()).
+                addParam(contentletData._2()).
+                loadResult();
+    }
+
+    /**
+     * Converts the given {@link Contentlet} to an immutable contentlet and then builds a json
+     * representation of it.
+     *
+     * @param contentlet The contentlet to convert.
+     * @return A tuple containing the inode of the contentlet and its JSON representation.
+     */
+    private Tuple2<String, String> toJSON(Contentlet contentlet) {
 
         try {
             // Converts the given contentlet to an immutable contentlet and then builds a json representation of it.
-            var contentletAsJSON = ContentletJsonHelper.INSTANCE.get().writeAsString(this.contentletJsonAPI.toImmutable(contentlet));
+            var contentletAsJSON = ContentletJsonHelper.INSTANCE.get()
+                    .writeAsString(this.contentletJsonAPI.toImmutable(contentlet));
 
-            // I need to have the JSON in a single line, so I can write it into a file
-            return contentletAsJSON.replaceAll("[\\t\\n\\r]", "");
+            return Tuple.of(contentlet.getInode(), contentletAsJSON);
         } catch (JsonProcessingException e) {
-            throw new DotRuntimeException(String.format("Error creating the JSON representation of Contentlet - " +
-                    "inode [%s]", contentlet.getInode()), e);
+            throw new DotRuntimeException(
+                    String.format("Error creating the JSON representation of Contentlet - " +
+                            "inode [%s]", contentlet.getInode()), e);
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtil.java
@@ -176,7 +176,7 @@ public class PopulateContentletAsJSONUtil {
         while (true) {
 
             CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() ->
-                    internalPopulate(assetSubtype, excludingAssetSubtype, allVersions, totalRecordsAffected));
+                    populateWrapper(assetSubtype, excludingAssetSubtype, allVersions, totalRecordsAffected));
 
             try {
                 Boolean foundRecords = future.get();
@@ -222,10 +222,10 @@ public class PopulateContentletAsJSONUtil {
      * @return True if contentlets were found and processed, false otherwise.
      */
     @WrapInTransaction
-    private boolean internalPopulate(@Nullable String assetSubtype,
-                                     @Nullable String excludingAssetSubtype,
-                                     final Boolean allVersions,
-                                     final MutableInt totalRecords) {
+    private boolean populateWrapper(@Nullable String assetSubtype,
+                                    @Nullable String excludingAssetSubtype,
+                                    final Boolean allVersions,
+                                    final MutableInt totalRecords) {
 
         var foundRecords = false;
 

--- a/dotCMS/src/main/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtil.java
@@ -100,11 +100,11 @@ public class PopulateContentletAsJSONUtil {
     private final String CLOSE_CURSOR_FOR_TEMPORAL_TABLE = "CLOSE tmpContentletJSONCursor";
 
     private static final int MAX_BATCH_SIZE = Config.getIntProperty(
-            "task.populateContentletAsJSON.maxupdatebatchsize", 200);
+            "task.populateContentletAsJSON.maxbatchsize", 200);
     private static final int MAX_CURSOR_FETCH_SIZE = Config.getIntProperty(
             "task.populateContentletAsJSON.maxcursorfetchsize", 200);
-    private static final int LIMIT_FOR_SELECTS = Config.getIntProperty(
-            "task.populateContentletAsJSON.maxcursorfetchsize", 5000);
+    private static final int LIMIT_SIZE_FOR_SELECTS = Config.getIntProperty(
+            "task.populateContentletAsJSON.selectslimitsize", 5000);
 
     public PopulateContentletAsJSONUtil() {
         this.contentletJsonAPI = APILocator.getContentletJsonAPI();
@@ -427,16 +427,16 @@ public class PopulateContentletAsJSONUtil {
 
         // Declaring the cursor
         if (allVersions) {
-            var selectQuery = String.format(CONTENTS_WITH_NO_JSON_ALL_VERSIONS, LIMIT_FOR_SELECTS);
+            var selectQuery = String.format(CONTENTS_WITH_NO_JSON_ALL_VERSIONS, LIMIT_SIZE_FOR_SELECTS);
             stmt.execute(String.format(DECLARE_CURSOR, selectQuery));
         } else if (!Strings.isNullOrEmpty(assetSubtype)) {
-            var selectQuery = String.format(SUBTYPE_WITH_NO_JSON, assetSubtype, LIMIT_FOR_SELECTS);
+            var selectQuery = String.format(SUBTYPE_WITH_NO_JSON, assetSubtype, LIMIT_SIZE_FOR_SELECTS);
             stmt.execute(String.format(DECLARE_CURSOR, selectQuery));
         } else if (!Strings.isNullOrEmpty(excludingAssetSubtype)) {
-            var selectQuery = String.format(CONTENTS_WITH_NO_JSON_AND_EXCLUDE, excludingAssetSubtype, LIMIT_FOR_SELECTS);
+            var selectQuery = String.format(CONTENTS_WITH_NO_JSON_AND_EXCLUDE, excludingAssetSubtype, LIMIT_SIZE_FOR_SELECTS);
             stmt.execute(String.format(DECLARE_CURSOR, selectQuery));
         } else {
-            var selectQuery = String.format(CONTENTS_WITH_NO_JSON, LIMIT_FOR_SELECTS);
+            var selectQuery = String.format(CONTENTS_WITH_NO_JSON, LIMIT_SIZE_FOR_SELECTS);
             stmt.execute(String.format(DECLARE_CURSOR, selectQuery));
         }
     }

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateContentletAsJSONJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateContentletAsJSONJob.java
@@ -1,7 +1,6 @@
 package com.dotmarketing.quartz.job;
 
 import com.dotcms.util.content.json.PopulateContentletAsJSONUtil;
-import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.quartz.DotStatefulJob;
 import com.dotmarketing.quartz.QuartzUtils;
@@ -11,9 +10,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
 import org.quartz.*;
-
-import java.io.IOException;
-import java.sql.SQLException;
 
 /**
  * Job created to populate in the Contentlet table missing contentlet_as_json columns.
@@ -43,9 +39,6 @@ public class PopulateContentletAsJSONJob extends DotStatefulJob {
 
             // Removing the job if everything went well
             removeJob();
-        } catch (SQLException | DotDataException | IOException e) {
-            Logger.error(this, "Error executing Contentlet as JSON population job", e);
-            throw new DotRuntimeException(e);
         } catch (SchedulerException e) {
             Logger.error(this, String.format("Unable to remove [%s] job",
                     PopulateContentletAsJSONJob.class.getName()), e);

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230320FixMissingContentletAsJSON.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230320FixMissingContentletAsJSON.java
@@ -7,9 +7,6 @@ import com.dotmarketing.quartz.job.PopulateContentletAsJSONJob;
 import com.dotmarketing.startup.StartupTask;
 import com.dotmarketing.util.Logger;
 
-import java.io.IOException;
-import java.sql.SQLException;
-
 public class Task230320FixMissingContentletAsJSON implements StartupTask {
 
     @Override
@@ -26,13 +23,8 @@ public class Task230320FixMissingContentletAsJSON implements StartupTask {
         // will execute a background stateful quartz job
         PopulateContentletAsJSONJob.fireJob("Host");
 
-        try {
-            // Now we populate the contentlet as JSON for Hosts, this will execute in the same thread
-            new PopulateContentletAsJSONUtil().populateForAssetSubType("Host");
-        } catch (SQLException | IOException e) {
-            Logger.error(this, "Error populating Contentlet as JSON population column for Hosts", e);
-            throw new DotDataException(e.getMessage(), e);
-        }
+        // Now we populate the contentlet as JSON for Hosts, this will execute in the same thread
+        new PopulateContentletAsJSONUtil().populateForAssetSubType("Host");
     }
 
 }


### PR DESCRIPTION
As part of the existing upgrade task `Task230320FixMissingContentletAsJSON`, we have already handled Sites, and Working and Live versions of the contentlets. However, there are remaining contentlets that need to be addressed (non working and live contentlets). This PR handles those remaining contentlets once the migration of sites and live and working versions is complete using another quartz job that will be running in the background migrating the remaining of the contentlets.

We also improved how the migration process is handled, changing the use of temporal files to store the contents and data to modify for a temporal table.

Another change to notice is we have implemented a refined approach to handle the migration of contents. Our goal was to improve the efficiency of the process and ensure faster reflection of changes in the system. To achieve this, we divided the migration process into smaller batches and "small" transactions. By doing so, we are now able to isolate individual sets of changes within these smaller transactions. This approach has several advantages over having everything in a single transaction, minimizing the risk of failure affecting the entire migration process. If something goes wrong in one batch, only that specific batch needs to be rolled back.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1aff635</samp>

This pull request improves the code quality and test coverage of the `contentlet_as_json` feature, which stores the JSON representation of contentlets in the database. It adds a new test method for the `populateEverything` method, refactors and documents the `PopulateContentletAsJSONJob` class, and simplifies the `Task230320FixMissingContentletAsJSON` class.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1aff635</samp>

*  Add a new method `populateEverything` to the `PopulateContentletAsJSONUtil` class that populates the `contentlet_as_json` column for all contentlets and all versions, regardless of the asset sub-type. (                                                                                                                                                                                                                                                                                     F3L169