### PR TITLE
Delete validation on publish/expire fields related with content type

### DIFF
--- a/dotCMS/src/curl-test/Content Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Content Resource.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "64a156b5-40b4-46ce-8bab-6083e910e48a",
+		"_postman_id": "30e7c950-c42b-4489-a163-8fa82bdbbb54",
 		"name": "Content Resource",
 		"description": "Content Resource test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5403727"
+		"_exporter_id": "781456"
 	},
 	"item": [
 		{
@@ -147,7 +147,7 @@
 									}
 								},
 								"url": {
-									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
 									"host": [
 										"{{serverURL}}"
 									],
@@ -159,6 +159,12 @@
 										"default",
 										"fire",
 										"PUBLISH"
+									],
+									"query": [
+										{
+											"key": "indexPolicy",
+											"value": "WAIT_FOR"
+										}
 									]
 								},
 								"description": "Creates a test Contentlet of the previously generated Content Type."
@@ -275,7 +281,7 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeId}}",
+									"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeId}}?indexPolicy=WAIT_FOR",
 									"host": [
 										"{{serverURL}}"
 									],
@@ -285,6 +291,12 @@
 										"contenttype",
 										"id",
 										"{{contentTypeId}}"
+									],
+									"query": [
+										{
+											"key": "indexPolicy",
+											"value": "WAIT_FOR"
+										}
 									]
 								},
 								"description": "Deletes the test Content Type with the now-transformed Story Block field."
@@ -430,7 +442,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
 							"host": [
 								"{{serverURL}}"
 							],
@@ -442,6 +454,12 @@
 								"default",
 								"fire",
 								"PUBLISH"
+							],
+							"query": [
+								{
+									"key": "indexPolicy",
+									"value": "WAIT_FOR"
+								}
 							]
 						}
 					},
@@ -1637,7 +1655,7 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
 							"host": [
 								"{{serverURL}}"
 							],
@@ -1649,6 +1667,12 @@
 								"default",
 								"fire",
 								"PUBLISH"
+							],
+							"query": [
+								{
+									"key": "indexPolicy",
+									"value": "WAIT_FOR"
+								}
 							]
 						},
 						"description": "Create a test File Asset that will be used to read Metadata from."
@@ -1764,7 +1788,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/UNPUBLISH?inode={{fileInode}}&identifier={{fileId}}",
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/UNPUBLISH?inode={{fileInode}}&identifier={{fileId}}&indexPolicy=WAIT_FOR",
 							"host": [
 								"{{serverURL}}"
 							],
@@ -1785,6 +1809,10 @@
 								{
 									"key": "identifier",
 									"value": "{{fileId}}"
+								},
+								{
+									"key": "indexPolicy",
+									"value": "WAIT_FOR"
 								}
 							]
 						}
@@ -1836,7 +1864,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/ARCHIVE?inode={{fileInode}}&identifier={{fileId}}",
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/ARCHIVE?inode={{fileInode}}&identifier={{fileId}}&indexPolicy=WAIT_FOR",
 							"host": [
 								"{{serverURL}}"
 							],
@@ -1857,6 +1885,10 @@
 								{
 									"key": "identifier",
 									"value": "{{fileId}}"
+								},
+								{
+									"key": "indexPolicy",
+									"value": "WAIT_FOR"
 								}
 							]
 						}
@@ -1908,7 +1940,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/DELETE?inode={{fileInode}}&identifier={{fileId}}",
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/DELETE?inode={{fileInode}}&identifier={{fileId}}&indexPolicy=WAIT_FOR",
 							"host": [
 								"{{serverURL}}"
 							],
@@ -1929,6 +1961,10 @@
 								{
 									"key": "identifier",
 									"value": "{{fileId}}"
+								},
+								{
+									"key": "indexPolicy",
+									"value": "WAIT_FOR"
 								}
 							]
 						}
@@ -1937,6 +1973,38 @@
 				}
 			],
 			"description": "Verifies that the Metadata section in the JSON response in a File Asset is added."
+		},
+		{
+			"name": "invalidateSession",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{serverURL}}/api/v1/logout",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"logout"
+					]
+				}
+			},
+			"response": []
 		},
 		{
 			"name": "Save Multiple Generic Contentlets",
@@ -2018,7 +2086,7 @@
 			"response": []
 		},
 		{
-			"name": "invalidateSession",
+			"name": "invalidateSessionAgain",
 			"event": [
 				{
 					"listen": "test",
@@ -2503,12 +2571,10 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:8080/api/content/render/false/query/+contentType:host +title:default",
-					"protocol": "http",
+					"raw": "{{serverURL}}/api/content/render/false/query/+contentType:host +title:default",
 					"host": [
-						"localhost"
+						"{{serverURL}}"
 					],
-					"port": "8080",
 					"path": [
 						"api",
 						"content",

--- a/dotCMS/src/curl-test/ContentType Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/ContentType Resource.postman_collection.json
@@ -1,0 +1,2900 @@
+{
+	"info": {
+		"_postman_id": "4a7bb840-b421-4ff9-a020-4986dbd0dca1",
+		"name": "ContentType Resource",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "27636414"
+	},
+	"item": [
+		{
+			"name": "Test CRUD new columns icon and sortOrder",
+			"item": [
+				{
+					"name": "Create ContentType",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.collectionVariables.set(\"contentTypeID\", jsonData.entity[0].id);",
+									"pm.collectionVariables.set(\"contentTypeVAR\", jsonData.entity[0].variable);",
+									"pm.collectionVariables.set(\"contentTypeFieldID\", jsonData.entity[0].fields[0].id);",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"icon check\", function () {",
+									"    pm.expect(jsonData.entity[0].icon).to.eql('testIcon');",
+									"});",
+									"",
+									"pm.test(\"sortOrder check\", function () {",
+									"    pm.expect(jsonData.entity[0].sortOrder).to.eql(3);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"clazz\": \"com.dotcms.contenttype.model.type.SimpleContentType\",\n\t\"description\": \"My Structure\",\n\t\"defaultType\": false,\n\t\"system\": false,\n\t\"folder\": \"SYSTEM_FOLDER\",\n\t\"name\": \"My Custom Structure {{$randomBankAccount}}\",\n\t\"variable\": \"myStructure{{$randomBankAccount}}\",\n\t\"host\": \"SYSTEM_HOST\",\n\t\"fixed\": false,\n    \"icon\": \"testIcon\",\n    \"sortOrder\": 3,\n\t\"fields\": [\n\t\t{\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.TextField\",\n\t\t\t\"indexed\": true,\n\t\t\t\"dataType\": \"TEXT\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": true,\n\t\t\t\"searchable\": true,\n\t\t\t\"listed\": true,\n\t\t\t\"sortOrder\": 2,\n\t\t\t\"unique\": false,\n\t\t\t\"name\": \"Name\",\n\t\t\t\"variable\": \"name\",\n\t\t\t\"fixed\": true\n\t\t}\n\t],\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"]\n}"
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Given a content type payload containing field variables.\nWhen sending a POST.\nExpect that code is 200.\nExpect content type is created with the provided fields.\nExpect that new properties of content types are set (icon and sortOrder)."
+					},
+					"response": []
+				},
+				{
+					"name": "Get Content Type",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"icon check\", function () {",
+									"    pm.expect(jsonData.entity.icon).to.eql('testIcon');",
+									"});",
+									"",
+									"pm.test(\"sortOrder check\", function () {",
+									"    pm.expect(jsonData.entity.sortOrder).to.eql(3);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/40e0cb1b57b3b1b7ec34191e942316d5",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"40e0cb1b57b3b1b7ec34191e942316d5"
+							]
+						},
+						"description": "Given a content type ID. \nExpect that code is 200.\nExpect that the new content type properties (icon and sortOrder) are returned."
+					},
+					"response": []
+				},
+				{
+					"name": "Update Content Type Update Icon and SortOrder",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"icon check\", function () {",
+									"    pm.expect(jsonData.entity.icon).to.eql('icon2');",
+									"});",
+									"",
+									"pm.test(\"sortOrder check\", function () {",
+									"    pm.expect(jsonData.entity.sortOrder).to.eql(2);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"clazz\": \"com.dotcms.contenttype.model.type.SimpleContentType\",\n\t\"description\": \"My Structure\",\n\t\"defaultType\": false,\n\t\"system\": false,\n\t\"folder\": \"SYSTEM_FOLDER\",\n\t\"host\": \"SYSTEM_HOST\",\n    \"name\": \"My Custom Structure {{$randomBankAccount}}\",\n\t\"variable\": \"{{contentTypeVAR}}\",\n\t\"fixed\": false,\n    \"id\": \"{{contentTypeID}}\",\n\t\"fields\": [\n\t\t{\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextField\",\n                    \"contentTypeId\": \"{{contentTypeID}}\",\n                    \"dataType\": \"TEXT\",\n                    \"fieldType\": \"Text\",\n                    \"fieldTypeLabel\": \"Text\",\n                    \"fieldVariables\": [],\n                    \"fixed\": true,\n                    \"iDate\": 1631719532000,\n                    \"id\": \"{{contentTypeFieldID}}\",\n                    \"indexed\": true,\n                    \"listed\": true,\n                    \"modDate\": 1631719532000,\n                    \"name\": \"Name\",\n                    \"readOnly\": false,\n                    \"required\": true,\n                    \"searchable\": true,\n                    \"sortOrder\": 2,\n                    \"unique\": false,\n                    \"variable\": \"name\"\n\t\t}\n\t],\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"],\n    \"icon\": \"icon2\",\n    \"sortOrder\": 2\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeID}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"{{contentTypeID}}"
+							]
+						},
+						"description": "Given a content type ID and a payload containing content type properties.\nExpect that code is 200.\nExpect content type is updated without issues.\nExpect that the new properties (icon and sortOrder) are updated with the new values."
+					},
+					"response": []
+				},
+				{
+					"name": "Update Content Type without sending variable success",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"icon check\", function () {",
+									"    pm.expect(jsonData.entity.description).to.eql('My Structure test');",
+									"});",
+									"",
+									"pm.test(\"sortOrder check\", function () {",
+									"    pm.expect(jsonData.entity.sortOrder).to.eql(2);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"clazz\": \"com.dotcms.contenttype.model.type.SimpleContentType\",\n\t\"description\": \"My Structure test\",\n\t\"defaultType\": false,\n\t\"system\": false,\n\t\"folder\": \"SYSTEM_FOLDER\",\n\t\"host\": \"SYSTEM_HOST\",\n    \"name\": \"My Custom Structure {{$randomBankAccount}}\",\n\t\"fixed\": false,\n    \"id\": \"{{contentTypeID}}\",\n\t\"fields\": [\n\t\t{\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextField\",\n                    \"contentTypeId\": \"{{contentTypeID}}\",\n                    \"dataType\": \"TEXT\",\n                    \"fieldType\": \"Text\",\n                    \"fieldTypeLabel\": \"Text\",\n                    \"fieldVariables\": [],\n                    \"fixed\": true,\n                    \"iDate\": 1631719532000,\n                    \"id\": \"{{contentTypeFieldID}}\",\n                    \"indexed\": true,\n                    \"listed\": true,\n                    \"modDate\": 1631719532000,\n                    \"name\": \"Name\",\n                    \"readOnly\": false,\n                    \"required\": true,\n                    \"searchable\": true,\n                    \"sortOrder\": 2,\n                    \"unique\": false,\n                    \"variable\": \"name\"\n\t\t}\n\t],\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"],\n    \"icon\": \"icon2\",\n    \"sortOrder\": 2\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeID}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"{{contentTypeID}}"
+							]
+						},
+						"description": "Given a content type ID and a payload containing content type properties.\nExpect that code is 200.\nExpect content type is updated without issues.\nExpect that the new properties (icon and sortOrder) are updated with the new values."
+					},
+					"response": []
+				},
+				{
+					"name": "Delete ContentType",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeID}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"{{contentTypeID}}"
+							]
+						},
+						"description": "Given a content type ID.\nExpect that code is 200.\nExpect content type is deleted successfully."
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Test CRUD Fields",
+			"item": [
+				{
+					"name": "Create ContentType",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.collectionVariables.set(\"contentTypeID\", jsonData.entity[0].id);",
+									"pm.collectionVariables.set(\"contentTypeVAR\", jsonData.entity[0].variable);",
+									"pm.collectionVariables.set(\"contentTypeFieldID\", jsonData.entity[0].fields[0].id);",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"fields check\", function () {",
+									"    pm.expect(jsonData.entity[0].fields.length).to.eql(2);",
+									"});",
+									"",
+									"pm.test(\"description check\", function () {",
+									"    pm.expect(jsonData.entity[0].description).to.eql('THE DESCRIPTION');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"clazz\": \"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\", \n    \"defaultType\": false, \n    \"name\": \"Test Content Type\", \n    \"description\": \"THE DESCRIPTION\", \n    \"host\": \"SYSTEM_HOST\", \n    \"owner\": \"dotcms.org.1\", \n    \"fixed\": false, \n    \"system\": false, \n    \"folder\": \"SYSTEM_FOLDER\",\n    \"fields\": [\n            {\n                \"dataType\": \"SYSTEM\",\n                \"dbColumn\": \"system_field1\",\n                \"fieldVariables\": [],\n                \"fixed\": false,\n                \"iDate\": 1308941714000,\n                \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableHostFolderField\",\n                \"indexed\": true,\n                \"listed\": false,\n                \"modDate\": 1478557845000,\n                \"name\": \"Host/Folder\",\n                \"readOnly\": false,\n                \"required\": true,\n                \"searchable\": true,\n                \"sortOrder\": 1,\n                \"unique\": false,\n                \"variable\": \"hostfolder\"\n            },\n            {\n                \"dataType\": \"LONG_TEXT\",\n                \"dbColumn\": \"text_area2\",\n                \"fieldVariables\": [],\n                \"fixed\": false,\n                \"iDate\": 1453474468000,\n                \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTagField\",\n                \"indexed\": true,\n                \"listed\": false,\n                \"modDate\": 1478557845000,\n                \"name\": \"Tags\",\n                \"readOnly\": false,\n                \"required\": false,\n                \"searchable\": true,\n                \"sortOrder\": 3,\n                \"unique\": false,\n                \"variable\": \"tags\"\n            }],\n            \"workflow\": [\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"]\n}\n"
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Given a content type payload containing field variables.\nWhen sending a POST.\nExpect that code is 200.\nExpect content type is created with the provided fields.\nExpect that new properties of content types are set (icon and sortOrder)."
+					},
+					"response": []
+				},
+				{
+					"name": "Get Content Type",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"",
+									"pm.test(\"fields check\", function () {",
+									"    pm.expect(jsonData.entity.fields.length).to.eql(2);",
+									"});",
+									"",
+									"pm.test(\"description check\", function () {",
+									"    pm.expect(jsonData.entity.description).to.eql('THE DESCRIPTION');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeID}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"{{contentTypeID}}"
+							]
+						},
+						"description": "Given a content type ID. \nExpect that code is 200.\nExpect that the new content type properties (icon and sortOrder) are returned."
+					},
+					"response": []
+				},
+				{
+					"name": "Update Content Type without sending variable success",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"fields check\", function () {",
+									"    pm.expect(jsonData.entity.fields.length).to.eql(3);",
+									"});",
+									"",
+									"pm.test(\"description check\", function () {",
+									"    pm.expect(jsonData.entity.description).to.eql('THE DESCRIPTION');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"clazz\": \"com.dotcms.contenttype.model.type.SimpleContentType\",\n\t\"description\": \"THE DESCRIPTION\",\n        \"fields\": [\n            {\n                \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableHostFolderField\",\n                \"contentTypeId\": \"{{contentTypeID}}\",\n                \"dataType\": \"SYSTEM\",\n                \"fieldType\": \"Host-Folder\",\n                \"fieldTypeLabel\": \"Site or Folder\",\n                \"fieldVariables\": [],\n                \"fixed\": false,\n                \"iDate\": 1308941714000,\n                \"id\": \"{{contentTypeFieldID}}\",\n                \"indexed\": true,\n                \"listed\": false,\n                \"modDate\": 1632506750000,\n                \"name\": \"Host/Folder CHANGED\",\n                \"readOnly\": false,\n                \"required\": true,\n                \"searchable\": true,\n                \"sortOrder\": 1,\n                \"unique\": false,\n                \"variable\": \"hostfolder\"\n            }\n        ],\n\t\"defaultType\": false,\n\t\"system\": false,\n\t\"folder\": \"SYSTEM_FOLDER\",\n\t\"host\": \"SYSTEM_HOST\",\n    \"name\": \"Test Content Type\",\n\t\"fixed\": false,\n    \"id\": \"{{contentTypeID}}\",\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"],\n    \"icon\": \"icon2\",\n    \"sortOrder\": 2\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeID}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"{{contentTypeID}}"
+							]
+						},
+						"description": "Given a content type ID and a payload containing content type properties.\nExpect that code is 200.\nExpect content type is updated without issues.\nExpect that the new properties (icon and sortOrder) are updated with the new values."
+					},
+					"response": []
+				},
+				{
+					"name": "Delete ContentType",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeID}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"{{contentTypeID}}"
+							]
+						},
+						"description": "Given a content type ID.\nExpect that code is 200.\nExpect content type is deleted successfully."
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Tests For New StoryBlockField",
+			"item": [
+				{
+					"name": "Create ContentType with StoryBlockField Success",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"var contentType = jsonData.entity[0];",
+									"pm.collectionVariables.set(\"contentTypeIdWithStoryBlock\", contentType.id);",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"Content Type should have 2 fields\", function() {",
+									"    pm.expect(contentType.fields.length).to.eql(2);",
+									"});",
+									"pm.test(\"Content Type has a Story_block_field\", function() {",
+									"    pm.expect(contentType.fields[1].fieldType).to.eql(\"Story-Block\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"defaultType\":false,\n    \"fixed\":false,\n    \"system\":false,\n    \"clazz\":\"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n    \"description\":\"\",\n    \"host\": \"SYSTEM_HOST\",\n    \"folder\":\"SYSTEM_FOLDER\",\n    \"name\":\"TestContentTypeWithStoryBlockField\",\n    \"systemActionMappings\":{\"NEW\":\"\"},\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"],\n    \"fields\" : [\n        {\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.TextField\",\n\t\t\t\"indexed\": true,\n\t\t\t\"dataType\": \"TEXT\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": true,\n\t\t\t\"searchable\": true,\n\t\t\t\"listed\": true,\n\t\t\t\"sortOrder\": 2,\n\t\t\t\"unique\": false,\n\t\t\t\"name\": \"title\",\n\t\t\t\"variable\": \"title\",\n\t\t\t\"fixed\": true\n\t\t},\n        {\n            \"clazz\":\"com.dotcms.contenttype.model.field.ImmutableStoryBlockField\",\n            \"required\":false,\n            \"name\":\"block\",\n            \"defaultValue\":\"\",\n            \"hint\":\"\",\n            \"searchable\":true\n            }\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Creates a contentType with 2 fields:\n- A text field named Title\n- A story block field named block"
+					},
+					"response": []
+				},
+				{
+					"name": "Create contentlet with StoryBlockField",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"Contentlet StoryBlock has value\", function() {",
+									"    pm.expect(jsonData.entity.block.content[0].content[0].text).contains(\"Wow, this editor instance exports its content as JSON\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"contentlet\": {\n        \"contentType\": \"{{contentTypeIdWithStoryBlock}}\",\n        \"name\": \"test with data block field\",\n        \"title\": \"test with data block field\",\n        \"block\": \"{\\\"type\\\": \\\"doc\\\",\\\"content\\\": [{\\\"type\\\": \\\"paragraph\\\",\\\"content\\\": [{\\\"type\\\": \\\"text\\\",\\\"text\\\": \\\"Wow, this editor instance exports its content as JSON.\\\"}]}]}\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"workflow",
+								"actions",
+								"default",
+								"fire",
+								"PUBLISH"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Test Get ContentTypes",
+			"item": [
+				{
+					"name": "Get ContentTypes sending HostID",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype?host=8a7d5e23-da1e-420a-b4f0-471e7da8ea2d",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							],
+							"query": [
+								{
+									"key": "host",
+									"value": "8a7d5e23-da1e-420a-b4f0-471e7da8ea2d"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get ContentTypes sending SYSTEM_HOST",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Amount of ContentTypes could be greather or eql than 10\", function () {",
+									"     pm.expect(jsonData.entity.length).to.be.gte(10);",
+									"});",
+									"",
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype?host=SYSTEM_HOST",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							],
+							"query": [
+								{
+									"key": "host",
+									"value": "SYSTEM_HOST"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get ContentTypes without any param",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Amount of ContentTypes could be greather or eql than 10\", function () {",
+									"     pm.expect(jsonData.entity.length).to.be.gte(10);",
+									"});",
+									"",
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get ContentTypes sending not existing hostID",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype?host=aaaaa-aaaa-aaaa-aaaaaa",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							],
+							"query": [
+								{
+									"key": "host",
+									"value": "aaaaa-aaaa-aaaa-aaaaaa"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Test ContentType With Field Variables",
+			"item": [
+				{
+					"name": "Create ContentType with field variables",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"var contentType = jsonData.entity[0];",
+									"pm.collectionVariables.set(\"contentTypeId\", contentType.id);",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"Content Type has the provided name\", function() {",
+									"    pm.expect(contentType.name).to.eql(\"WYSIWYG-Content\");",
+									"});",
+									"pm.test(\"Content Type should have 4 fields\", function() {",
+									"    pm.expect(contentType.fields.length).to.eql(4);",
+									"});",
+									"pm.collectionVariables.set(\"contentType.host\", contentType.host);",
+									"pm.collectionVariables.set(\"contentType.field1\", contentType.fields[0].id);",
+									"pm.collectionVariables.set(\"contentType.field2\", contentType.fields[1].id);",
+									"pm.collectionVariables.set(\"contentType.field3\", contentType.fields[2].id);",
+									"pm.collectionVariables.set(\"contentType.field4\", contentType.fields[3].id);",
+									"pm.collectionVariables.set(\"contentType.divider\", contentType.layout[0].divider.id);",
+									"pm.collectionVariables.set(\"contentType.columnDivider\", contentType.layout[0].columns[0].columnDivider.id);",
+									"var wysigygField = contentType.fields[3];",
+									"var secondVar = wysigygField.fieldVariables[1];",
+									"pm.test(\"Variable should have its key and value with hello:world\", function() {",
+									"    pm.expect(secondVar.key).to.eql(\"hello\");",
+									"    pm.expect(secondVar.value).to.eql(\"world\");",
+									"});",
+									"pm.test(\"WYSIWYG must exist and have 3 variables\", function() {",
+									"    pm.expect(wysigygField.fieldType).to.eql(\"WYSIWYG\");",
+									"    pm.expect(wysigygField.fieldVariables.length).to.eql(3);",
+									"});",
+									"var tinyMcePropsVar = wysigygField.fieldVariables[2];",
+									"pm.test(\"WYSIWYG tinymceoprops variable is present with value\", function() {",
+									"    pm.expect(tinyMcePropsVar.key).to.eql(\"tinymceprops\");",
+									"    pm.expect(tinyMcePropsVar.value).to.eql(\"{toolbar:\\\"true\\\",menu:\\\"false\\\", theme:\\\"advanced\\\"}\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\t\"baseType\": \"CONTENT\",\n\t\t\"clazz\": \"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n\t\t\"defaultType\": false,\n\t\t\"fields\": [{\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableRowField\",\n\t\t\t\"dataType\": \"SYSTEM\",\n\t\t\t\"fieldContentTypeProperties\": [],\n\t\t\t\"fieldType\": \"Row\",\n\t\t\t\"fieldTypeLabel\": \"Row\",\n\t\t\t\"fieldVariables\": [],\n\t\t\t\"fixed\": false,\n\t\t\t\"iDate\": 1606168604000,\n\t\t\t\"indexed\": false,\n\t\t\t\"listed\": false,\n\t\t\t\"modDate\": 1606168642000,\n\t\t\t\"name\": \"fields-0\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": false,\n\t\t\t\"searchable\": false,\n\t\t\t\"sortOrder\": 0,\n\t\t\t\"unique\": false,\n\t\t\t\"variable\": \"fields0\"\n\t\t}, {\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableColumnField\",\n\t\t\t\"dataType\": \"SYSTEM\",\n\t\t\t\"fieldContentTypeProperties\": [],\n\t\t\t\"fieldType\": \"Column\",\n\t\t\t\"fieldTypeLabel\": \"Column\",\n\t\t\t\"fieldVariables\": [],\n\t\t\t\"fixed\": false,\n\t\t\t\"iDate\": 1606168604000,\n\t\t\t\"indexed\": false,\n\t\t\t\"listed\": false,\n\t\t\t\"modDate\": 1606168642000,\n\t\t\t\"name\": \"fields-1\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": false,\n\t\t\t\"searchable\": false,\n\t\t\t\"sortOrder\": 1,\n\t\t\t\"unique\": false,\n\t\t\t\"variable\": \"fields1\"\n\t\t}, {\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextField\",\n\t\t\t\"dataType\": \"TEXT\",\n\t\t\t\"fieldType\": \"Text\",\n\t\t\t\"fieldTypeLabel\": \"Text\",\n\t\t\t\"fieldVariables\": [],\n\t\t\t\"fixed\": false,\n\t\t\t\"iDate\": 1606168746000,\n\t\t\t\"indexed\": true,\n\t\t\t\"listed\": false,\n\t\t\t\"modDate\": 1606168746000,\n\t\t\t\"name\": \"Title\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": false,\n\t\t\t\"searchable\": true,\n\t\t\t\"sortOrder\": 2,\n\t\t\t\"unique\": false,\n\t\t\t\"variable\": \"title\"\n\t\t}, {\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableWysiwygField\",\n\t\t\t\"dataType\": \"LONG_TEXT\",\n\t\t\t\"fieldType\": \"WYSIWYG\",\n\t\t\t\"fieldTypeLabel\": \"WYSIWYG\",\n\t\t\t\"fieldVariables\": [{\n\t\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n\t\t\t\t\"key\": \"foo\",\n\t\t\t\t\"value\": \"bar\"\n\t\t\t}, {\n\t\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n\t\t\t\t\"key\": \"hello\",\n\t\t\t\t\"value\": \"world\"\n\t\t\t}, {\n\t\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n\t\t\t\t\"key\": \"tinymceprops\",\n\t\t\t\t\"value\": \"{toolbar:\\\"true\\\",menu:\\\"false\\\", theme:\\\"advanced\\\"}\"\n\t\t\t}],\n\t\t\t\"fixed\": false,\n\t\t\t\"iDate\": 1606168642000,\n\t\t\t\"indexed\": true,\n\t\t\t\"listed\": false,\n\t\t\t\"modDate\": 1606168746000,\n\t\t\t\"name\": \"component\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": false,\n\t\t\t\"searchable\": true,\n\t\t\t\"sortOrder\": 3,\n\t\t\t\"unique\": false,\n\t\t\t\"variable\": \"component\"\n\t\t}],\n\t\t\"fixed\": false,\n\t\t\"folder\": \"SYSTEM_FOLDER\",\n\t\t\"host\": \"8a7d5e23-da1e-420a-b4f0-471e7da8ea2d\",\n\t\t\"iDate\": 1606168519000,\n\t\t\"layout\": [{\n\t\t\t\"divider\": {\n\t\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableRowField\",\n\t\t\t\t\"dataType\": \"SYSTEM\",\n\t\t\t\t\"fieldContentTypeProperties\": [],\n\t\t\t\t\"fieldType\": \"Row\",\n\t\t\t\t\"fieldTypeLabel\": \"Row\",\n\t\t\t\t\"fieldVariables\": [],\n\t\t\t\t\"fixed\": false,\n\t\t\t\t\"iDate\": 1606168604000,\n\t\t\t\t\"indexed\": false,\n\t\t\t\t\"listed\": false,\n\t\t\t\t\"modDate\": 1606168642000,\n\t\t\t\t\"name\": \"fields-0\",\n\t\t\t\t\"readOnly\": false,\n\t\t\t\t\"required\": false,\n\t\t\t\t\"searchable\": false,\n\t\t\t\t\"sortOrder\": 0,\n\t\t\t\t\"unique\": false,\n\t\t\t\t\"variable\": \"fields0\"\n\t\t\t},\n\t\t\t\"columns\": [{\n\t\t\t\t\"columnDivider\": {\n\t\t\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableColumnField\",\n\t\t\t\t\t\"dataType\": \"SYSTEM\",\n\t\t\t\t\t\"fieldContentTypeProperties\": [],\n\t\t\t\t\t\"fieldType\": \"Column\",\n\t\t\t\t\t\"fieldTypeLabel\": \"Column\",\n\t\t\t\t\t\"fieldVariables\": [],\n\t\t\t\t\t\"fixed\": false,\n\t\t\t\t\t\"iDate\": 1606168604000,\n\t\t\t\t\t\"indexed\": false,\n\t\t\t\t\t\"listed\": false,\n\t\t\t\t\t\"modDate\": 1606168642000,\n\t\t\t\t\t\"name\": \"fields-1\",\n\t\t\t\t\t\"readOnly\": false,\n\t\t\t\t\t\"required\": false,\n\t\t\t\t\t\"searchable\": false,\n\t\t\t\t\t\"sortOrder\": 1,\n\t\t\t\t\t\"unique\": false,\n\t\t\t\t\t\"variable\": \"fields1\"\n\t\t\t\t},\n\t\t\t\t\"fields\": [{\n\t\t\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextField\",\n\t\t\t\t\t\"dataType\": \"TEXT\",\n\t\t\t\t\t\"fieldType\": \"Text\",\n\t\t\t\t\t\"fieldTypeLabel\": \"Text\",\n\t\t\t\t\t\"fieldVariables\": [],\n\t\t\t\t\t\"fixed\": false,\n\t\t\t\t\t\"iDate\": 1606168746000,\n\t\t\t\t\t\"indexed\": true,\n\t\t\t\t\t\"listed\": false,\n\t\t\t\t\t\"modDate\": 1606168746000,\n\t\t\t\t\t\"name\": \"Title\",\n\t\t\t\t\t\"readOnly\": false,\n\t\t\t\t\t\"required\": false,\n\t\t\t\t\t\"searchable\": true,\n\t\t\t\t\t\"sortOrder\": 2,\n\t\t\t\t\t\"unique\": false,\n\t\t\t\t\t\"variable\": \"title\"\n\t\t\t\t}, {\n\t\t\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableWysiwygField\",\n\t\t\t\t\t\"dataType\": \"LONG_TEXT\",\n\t\t\t\t\t\"fieldType\": \"WYSIWYG\",\n\t\t\t\t\t\"fieldTypeLabel\": \"WYSIWYG\",\n\t\t\t\t\t\"fieldVariables\": [{\n\t\t\t\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n\t\t\t\t\t\t\"key\": \"foo\",\n\t\t\t\t\t\t\"value\": \"bar\"\n\t\t\t\t\t}, {\n\t\t\t\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n\t\t\t\t\t\t\"key\": \"hello\",\n\t\t\t\t\t\t\"value\": \"world\"\n\t\t\t\t\t}, {\n\t\t\t\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n\t\t\t\t\t\t\"key\": \"tinymceprops\",\n\t\t\t\t\t\t\"value\": \"{toolbar:\\\"true\\\",menu:\\\"false\\\", theme:\\\"advanced\\\"}\"\n\t\t\t\t\t}],\n\t\t\t\t\t\"fixed\": false,\n\t\t\t\t\t\"iDate\": 1606168642000,\n\t\t\t\t\t\"indexed\": true,\n\t\t\t\t\t\"listed\": false,\n\t\t\t\t\t\"modDate\": 1606168746000,\n\t\t\t\t\t\"name\": \"component\",\n\t\t\t\t\t\"readOnly\": false,\n\t\t\t\t\t\"required\": false,\n\t\t\t\t\t\"searchable\": true,\n\t\t\t\t\t\"sortOrder\": 3,\n\t\t\t\t\t\"unique\": false,\n\t\t\t\t\t\"variable\": \"component\"\n\t\t\t\t}]\n\t\t\t}]\n\t\t}],\n\t\t\"modDate\": 1606177211000,\n\t\t\"multilingualable\": false,\n\t\t\"name\": \"WYSIWYG-Content\",\n\t\t\"system\": false,\n\t\t\"systemActionMappings\": {},\n\t\t\"variable\": \"WysiwygContent\",\n\t\t\"versionable\": true,\n\t\t\"workflows\": []\n\t}"
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Given a content type payload containing field variables.\nWhen sending a POST.\nExpect that code is 200.\nExpect content type is created with the provided fields.\nExpect that WYSIWYG field is created with provided field variables."
+					},
+					"response": []
+				},
+				{
+					"name": "Update ContentType with field variables",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"var contentType = jsonData.entity",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"Content Type has the provided name\", function() {",
+									"    pm.expect(contentType.name).to.eql(\"WYSIWYG-Content-Renamed\");",
+									"});",
+									"pm.test(\"Content Type should have 4 fields\", function() {",
+									"    pm.expect(contentType.fields.length).to.eql(4);",
+									"});",
+									"var wysigygField = contentType.fields[3];",
+									"pm.test(\"WYSIWYG must exist and have 2 variables\", function() {",
+									"    pm.expect(wysigygField.fieldType).to.eql(\"WYSIWYG\");",
+									"    pm.expect(wysigygField.fieldVariables.length).to.eql(2);",
+									"});",
+									"var firstVar = wysigygField.fieldVariables[0];",
+									"pm.test(\"Variable should have its key and value modified to hola:mundo\", function() {",
+									"    pm.expect(firstVar.key).to.eql(\"hola\");",
+									"    pm.expect(firstVar.value).to.eql(\"mundo\");",
+									"});",
+									"var tinyMcePropsVar = wysigygField.fieldVariables[1];",
+									"pm.test(\"WYSIWYG tinymceoprops variable is present with value\", function() {",
+									"    pm.expect(tinyMcePropsVar.key).to.eql(\"tinymceprops\");",
+									"    pm.expect(tinyMcePropsVar.value).to.eql(\"{toolbar:\\\"true\\\",menu:\\\"false\\\", theme:\\\"advanced\\\"}\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"baseType\": \"CONTENT\",\n    \"clazz\": \"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n    \"defaultType\": false,\n    \"fields\": [\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableRowField\",\n            \"contentTypeId\": \"{{contentTypeId}}\",\n            \"dataType\": \"SYSTEM\",\n            \"fieldContentTypeProperties\": [],\n            \"fieldType\": \"Row\",\n            \"fieldTypeLabel\": \"Row\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"iDate\": 1606168604000,\n            \"id\": \"{{contentType.field1}}\",\n            \"indexed\": false,\n            \"listed\": false,\n            \"modDate\": 1607013655000,\n            \"name\": \"fields-0\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 0,\n            \"unique\": false,\n            \"variable\": \"fields0\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableColumnField\",\n            \"contentTypeId\": \"{{contentTypeId}}\",\n            \"dataType\": \"SYSTEM\",\n            \"fieldContentTypeProperties\": [],\n            \"fieldType\": \"Column\",\n            \"fieldTypeLabel\": \"Column\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"iDate\": 1606168604000,\n            \"id\": \"{{contentType.field2}}\",\n            \"indexed\": false,\n            \"listed\": false,\n            \"modDate\": 1607013655000,\n            \"name\": \"fields-1\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 1,\n            \"unique\": false,\n            \"variable\": \"fields1\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextField\",\n            \"contentTypeId\": \"{{contentTypeId}}\",\n            \"dataType\": \"TEXT\",\n            \"fieldType\": \"Text\",\n            \"fieldTypeLabel\": \"Text\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"iDate\": 1606168746000,\n            \"id\": \"{{contentType.field3}}\",\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1607013655000,\n            \"name\": \"Title\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 2,\n            \"unique\": false,\n            \"variable\": \"title\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableWysiwygField\",\n            \"contentTypeId\": \"{{contentTypeId}}\",\n            \"dataType\": \"LONG_TEXT\",\n            \"fieldType\": \"WYSIWYG\",\n            \"fieldTypeLabel\": \"WYSIWYG\",\n            \"fieldVariables\": [\n                {\n                    \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n                    \"fieldId\": \"{{contentType.field4}}\",\n                    \"id\": \"6bf0f909-7f33-43a3-9b9c-fd7551fa73d7\",\n                    \"key\": \"hola\",\n                    \"value\": \"mundo\"\n                },\n                {\n                    \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n                    \"fieldId\": \"{{contentType.field4}}\",\n                    \"id\": \"6b034559-d411-49a7-be14-d3039b89bd3b\",\n                    \"key\": \"tinymceprops\",\n                    \"value\": \"{toolbar:\\\"true\\\",menu:\\\"false\\\", theme:\\\"advanced\\\"}\"\n                }\n            ],\n            \"fixed\": false,\n            \"iDate\": 1606168642000,\n            \"id\": \"{{contentType.field4}}\",\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1607013655000,\n            \"name\": \"component\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 3,\n            \"unique\": false,\n            \"variable\": \"component\"\n        }\n    ],\n    \"fixed\": false,\n    \"folder\": \"SYSTEM_FOLDER\",\n    \"host\": \"{{contentType.host}}\",\n    \"iDate\": 1606168519000,\n    \"id\": \"{{contentTypeId}}\",\n    \"layout\": [\n        {\n            \"divider\": {\n                \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableRowField\",\n                \"contentTypeId\": \"{{contentTypeId}}\",\n                \"dataType\": \"SYSTEM\",\n                \"fieldContentTypeProperties\": [],\n                \"fieldType\": \"Row\",\n                \"fieldTypeLabel\": \"Row\",\n                \"fieldVariables\": [],\n                \"fixed\": false,\n                \"iDate\": 1606168604000,\n                \"id\": \"{{contentType.divider}}\",\n                \"indexed\": false,\n                \"listed\": false,\n                \"modDate\": 1607013655000,\n                \"name\": \"fields-0\",\n                \"readOnly\": false,\n                \"required\": false,\n                \"searchable\": false,\n                \"sortOrder\": 0,\n                \"unique\": false,\n                \"variable\": \"fields0\"\n            },\n            \"columns\": [\n                {\n                    \"columnDivider\": {\n                        \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableColumnField\",\n                        \"contentTypeId\": \"{{contentTypeId}}\",\n                        \"dataType\": \"SYSTEM\",\n                        \"fieldContentTypeProperties\": [],\n                        \"fieldType\": \"Column\",\n                        \"fieldTypeLabel\": \"Column\",\n                        \"fieldVariables\": [],\n                        \"fixed\": false,\n                        \"iDate\": 1606168604000,\n                        \"id\": \"{{contentType.columnDivider}}\",\n                        \"indexed\": false,\n                        \"listed\": false,\n                        \"modDate\": 1607013655000,\n                        \"name\": \"fields-1\",\n                        \"readOnly\": false,\n                        \"required\": false,\n                        \"searchable\": false,\n                        \"sortOrder\": 1,\n                        \"unique\": false,\n                        \"variable\": \"fields1\"\n                    },\n                    \"fields\": [\n                        {\n                            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextField\",\n                            \"contentTypeId\": \"{{contentTypeId}}\",\n                            \"dataType\": \"TEXT\",\n                            \"fieldType\": \"Text\",\n                            \"fieldTypeLabel\": \"Text\",\n                            \"fieldVariables\": [],\n                            \"fixed\": false,\n                            \"iDate\": 1606168746000,\n                            \"id\": \"{{contentType.field1}}\",\n                            \"indexed\": true,\n                            \"listed\": false,\n                            \"modDate\": 1607013655000,\n                            \"name\": \"Title\",\n                            \"readOnly\": false,\n                            \"required\": false,\n                            \"searchable\": true,\n                            \"sortOrder\": 2,\n                            \"unique\": false,\n                            \"variable\": \"title\"\n                        },\n                        {\n                            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableWysiwygField\",\n                            \"contentTypeId\": \"{{contentTypeId}}\",\n                            \"dataType\": \"LONG_TEXT\",\n                            \"fieldType\": \"WYSIWYG\",\n                            \"fieldTypeLabel\": \"WYSIWYG\",\n                            \"fieldVariables\": [\n                                {\n                                    \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n                                    \"fieldId\": \"a2a11339-d40f-472a-a921-7748d7009642\",\n                                    \"id\": \"6bf0f909-7f33-43a3-9b9c-fd7551fa73d7\",\n                                    \"key\": \"hola\",\n                                    \"value\": \"mundo\"\n                                },\n                                {\n                                    \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n                                    \"fieldId\": \"a2a11339-d40f-472a-a921-7748d7009642\",\n                                    \"id\": \"6b034559-d411-49a7-be14-d3039b89bd3b\",\n                                    \"key\": \"tinymceprops\",\n                                    \"value\": \"{toolbar:\\\"true\\\",menu:\\\"false\\\", theme:\\\"advanced\\\"}\"\n                                }\n                            ],\n                            \"fixed\": false,\n                            \"iDate\": 1606168642000,\n                            \"id\": \"{{contentType.field4}}\",\n                            \"indexed\": true,\n                            \"listed\": false,\n                            \"modDate\": 1607013655000,\n                            \"name\": \"component\",\n                            \"readOnly\": false,\n                            \"required\": false,\n                            \"searchable\": true,\n                            \"sortOrder\": 3,\n                            \"unique\": false,\n                            \"variable\": \"component\"\n                        }\n                    ]\n                }\n            ]\n        }\n    ],\n    \"modDate\": 1607013655000,\n    \"multilingualable\": false,\n    \"name\": \"WYSIWYG-Content-Renamed\",\n    \"system\": false,\n    \"systemActionMappings\": {},\n    \"variable\": \"WysiwygContent\",\n    \"versionable\": true,\n    \"workflows\": [\n        {\n            \"archived\": false,\n            \"creationDate\": 1607013267018,\n            \"defaultScheme\": false,\n            \"description\": \"\",\n            \"entryActionId\": null,\n            \"id\": \"{{contentType.workflow}}\",\n            \"mandatory\": false,\n            \"modDate\": 1607013261505,\n            \"name\": \"System Workflow\",\n            \"system\": true\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"{{contentTypeId}}"
+							]
+						},
+						"description": "Given a content type payload containing field variables.\nWhen sending a PUT.\nExpect that code is 200.\nExpect content type is updated with the provided fields.\nExpect that WYSIWYG field is updated with provided field variables."
+					},
+					"response": []
+				},
+				{
+					"name": "Update ContentType with field variables - delete - update - add",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"var contentType = jsonData.entity",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"Content Type has the provided name\", function() {",
+									"    pm.expect(contentType.name).to.eql(\"WYSIWYG-Content-Renamed2\");",
+									"});",
+									"pm.test(\"Content Type should have 4 fields\", function() {",
+									"    pm.expect(contentType.fields.length).to.eql(4);",
+									"});",
+									"var wysigygField = contentType.fields[3];",
+									"pm.test(\"WYSIWYG must exist and have 2 variables\", function() {",
+									"    pm.expect(wysigygField.fieldType).to.eql(\"WYSIWYG\");",
+									"    pm.expect(wysigygField.fieldVariables.length).to.eql(2);",
+									"});",
+									"var firstVar = wysigygField.fieldVariables[0];",
+									"pm.test(\"Variable should have its key and value modified to hola:mundo\", function() {",
+									"    pm.expect(firstVar.key).to.eql(\"hi\");",
+									"    pm.expect(firstVar.value).to.eql(\"all\");",
+									"});",
+									"var tinyMcePropsVar = wysigygField.fieldVariables[1];",
+									"pm.test(\"WYSIWYG tinymceoprops variable is present with value\", function() {",
+									"    pm.expect(tinyMcePropsVar.key).to.eql(\"tinymceprops\");",
+									"    pm.expect(tinyMcePropsVar.value).to.eql(\"{toolbar:\\\"true\\\",menu:\\\"true\\\", theme:\\\"advanced\\\"}\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"baseType\": \"CONTENT\",\n    \"clazz\": \"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n    \"defaultType\": false,\n    \"fields\": [\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableRowField\",\n            \"contentTypeId\": \"{{contentTypeId}}\",\n            \"dataType\": \"SYSTEM\",\n            \"fieldContentTypeProperties\": [],\n            \"fieldType\": \"Row\",\n            \"fieldTypeLabel\": \"Row\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"iDate\": 1606168604000,\n            \"id\": \"{{contentType.field1}}\",\n            \"indexed\": false,\n            \"listed\": false,\n            \"modDate\": 1607013655000,\n            \"name\": \"fields-0\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 0,\n            \"unique\": false,\n            \"variable\": \"fields0\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableColumnField\",\n            \"contentTypeId\": \"{{contentTypeId}}\",\n            \"dataType\": \"SYSTEM\",\n            \"fieldContentTypeProperties\": [],\n            \"fieldType\": \"Column\",\n            \"fieldTypeLabel\": \"Column\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"iDate\": 1606168604000,\n            \"id\": \"{{contentType.field2}}\",\n            \"indexed\": false,\n            \"listed\": false,\n            \"modDate\": 1607013655000,\n            \"name\": \"fields-1\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 1,\n            \"unique\": false,\n            \"variable\": \"fields1\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextField\",\n            \"contentTypeId\": \"{{contentTypeId}}\",\n            \"dataType\": \"TEXT\",\n            \"fieldType\": \"Text\",\n            \"fieldTypeLabel\": \"Text\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"iDate\": 1606168746000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1607013655000,\n            \"name\": \"Title\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 2,\n            \"unique\": false,\n            \"variable\": \"titleNew\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableWysiwygField\",\n            \"contentTypeId\": \"{{contentTypeId}}\",\n            \"dataType\": \"LONG_TEXT\",\n            \"fieldType\": \"WYSIWYG\",\n            \"fieldTypeLabel\": \"WYSIWYG\",\n            \"fieldVariables\": [\n                {\n                    \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n                    \"fieldId\": \"{{contentType.field4}}\",\n                    \"key\": \"hi\",\n                    \"value\": \"all\"\n                },\n                {\n                    \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n                    \"fieldId\": \"{{contentType.field4}}\",\n                    \"id\": \"6b034559-d411-49a7-be14-d3039b89bd3b\",\n                    \"key\": \"tinymceprops\",\n                    \"value\": \"{toolbar:\\\"true\\\",menu:\\\"true\\\", theme:\\\"advanced\\\"}\"\n                }\n            ],\n            \"fixed\": false,\n            \"iDate\": 1606168642000,\n            \"id\": \"{{contentType.field4}}\",\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1607013655000,\n            \"name\": \"component\",\n            \"readOnly\": false,\n            \"required\": true,\n            \"searchable\": true,\n            \"sortOrder\": 3,\n            \"unique\": false,\n            \"variable\": \"component\"\n        }\n    ],\n    \"fixed\": false,\n    \"folder\": \"SYSTEM_FOLDER\",\n    \"host\": \"{{contentType.host}}\",\n    \"iDate\": 1606168519000,\n    \"id\": \"{{contentTypeId}}\",\n    \"layout\": [\n        {\n            \"divider\": {\n                \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableRowField\",\n                \"contentTypeId\": \"{{contentTypeId}}\",\n                \"dataType\": \"SYSTEM\",\n                \"fieldContentTypeProperties\": [],\n                \"fieldType\": \"Row\",\n                \"fieldTypeLabel\": \"Row\",\n                \"fieldVariables\": [],\n                \"fixed\": false,\n                \"iDate\": 1606168604000,\n                \"id\": \"{{contentType.divider}}\",\n                \"indexed\": false,\n                \"listed\": false,\n                \"modDate\": 1607013655000,\n                \"name\": \"fields-0\",\n                \"readOnly\": false,\n                \"required\": false,\n                \"searchable\": false,\n                \"sortOrder\": 0,\n                \"unique\": false,\n                \"variable\": \"fields0\"\n            },\n            \"columns\": [\n                {\n                    \"columnDivider\": {\n                        \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableColumnField\",\n                        \"contentTypeId\": \"{{contentTypeId}}\",\n                        \"dataType\": \"SYSTEM\",\n                        \"fieldContentTypeProperties\": [],\n                        \"fieldType\": \"Column\",\n                        \"fieldTypeLabel\": \"Column\",\n                        \"fieldVariables\": [],\n                        \"fixed\": false,\n                        \"iDate\": 1606168604000,\n                        \"id\": \"{{contentType.columnDivider}}\",\n                        \"indexed\": false,\n                        \"listed\": false,\n                        \"modDate\": 1607013655000,\n                        \"name\": \"fields-1\",\n                        \"readOnly\": false,\n                        \"required\": false,\n                        \"searchable\": false,\n                        \"sortOrder\": 1,\n                        \"unique\": false,\n                        \"variable\": \"fields1\"\n                    },\n                    \"fields\": [\n                        {\n                            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextField\",\n                            \"contentTypeId\": \"{{contentTypeId}}\",\n                            \"dataType\": \"TEXT\",\n                            \"fieldType\": \"Text\",\n                            \"fieldTypeLabel\": \"Text\",\n                            \"fieldVariables\": [],\n                            \"fixed\": false,\n                            \"iDate\": 1606168746000,\n                            \"id\": \"{{contentType.field1}}\",\n                            \"indexed\": true,\n                            \"listed\": false,\n                            \"modDate\": 1607013655000,\n                            \"name\": \"Title\",\n                            \"readOnly\": false,\n                            \"required\": false,\n                            \"searchable\": true,\n                            \"sortOrder\": 2,\n                            \"unique\": false,\n                            \"variable\": \"title\"\n                        },\n                        {\n                            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableWysiwygField\",\n                            \"contentTypeId\": \"{{contentTypeId}}\",\n                            \"dataType\": \"LONG_TEXT\",\n                            \"fieldType\": \"WYSIWYG\",\n                            \"fieldTypeLabel\": \"WYSIWYG\",\n                            \"fieldVariables\": [\n                                {\n                                    \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n                                    \"fieldId\": \"a2a11339-d40f-472a-a921-7748d7009642\",\n                                    \"id\": \"6bf0f909-7f33-43a3-9b9c-fd7551fa73d7\",\n                                    \"key\": \"hola\",\n                                    \"value\": \"mundo\"\n                                },\n                                {\n                                    \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableFieldVariable\",\n                                    \"fieldId\": \"a2a11339-d40f-472a-a921-7748d7009642\",\n                                    \"id\": \"6b034559-d411-49a7-be14-d3039b89bd3b\",\n                                    \"key\": \"tinymceprops\",\n                                    \"value\": \"{toolbar:\\\"true\\\",menu:\\\"false\\\", theme:\\\"advanced\\\"}\"\n                                }\n                            ],\n                            \"fixed\": false,\n                            \"iDate\": 1606168642000,\n                            \"id\": \"{{contentType.field4}}\",\n                            \"indexed\": true,\n                            \"listed\": false,\n                            \"modDate\": 1607013655000,\n                            \"name\": \"component\",\n                            \"readOnly\": false,\n                            \"required\": false,\n                            \"searchable\": true,\n                            \"sortOrder\": 3,\n                            \"unique\": false,\n                            \"variable\": \"component\"\n                        }\n                    ]\n                }\n            ]\n        }\n    ],\n    \"modDate\": 1607013655000,\n    \"multilingualable\": false,\n    \"name\": \"WYSIWYG-Content-Renamed2\",\n    \"system\": false,\n    \"systemActionMappings\": {},\n    \"variable\": \"WysiwygContent\",\n    \"versionable\": true,\n    \"workflows\": [\n        {\n            \"archived\": false,\n            \"creationDate\": 1607013267018,\n            \"defaultScheme\": false,\n            \"description\": \"\",\n            \"entryActionId\": null,\n            \"id\": \"{{contentType.workflow}}\",\n            \"mandatory\": false,\n            \"modDate\": 1607013261505,\n            \"name\": \"System Workflow\",\n            \"system\": true\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"{{contentTypeId}}"
+							]
+						},
+						"description": "Given a content type payload containing field variables.\nWhen sending a PUT.\nExpect that code is 200.\nExpect content type is updated with the provided fields.\nExpect that WYSIWYG field is updated with provided field variables."
+					},
+					"response": []
+				},
+				{
+					"name": "Cleanup Content Type",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"{{contentTypeId}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Test Copy ContentType",
+			"item": [
+				{
+					"name": "Copy FileAsset Success",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"var contentType = jsonData.entity;",
+									"",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"Content Type has the provided name\", function() {",
+									"    pm.expect(contentType.name).to.eql(\"File Asset Copy\");",
+									"});",
+									"pm.test(\"Content Type should have 9 fields\", function() {",
+									"    pm.expect(contentType.fields.length).to.gt(8);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"File Asset Copy\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/fileAsset/_copy",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"fileAsset",
+								"_copy"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ContentType Source does not exist",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be 400\", function() {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"File Asset Copy\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/fileAssetNotExist/_copy",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"fileAssetNotExist",
+								"_copy"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ContentType Name Not Sent",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be 400\", function() {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"variable\": \"FileAssetCopyTestNot\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/fileAsset/_copy",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"fileAsset",
+								"_copy"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ContentType Copy no body",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be 400\", function() {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/fileAsset/_copy",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"fileAsset",
+								"_copy"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Test Filtered Content Types",
+			"item": [
+				{
+					"name": "pre - Import Test Content Types",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Bundle 'bundle-with-content-types-issue-22039.tar.gz' was not uploaded!\", function () {",
+									"    pm.response.to.have.status(200);",
+									"",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"bundle-with-content-types-issue-22039.tar.gz\");",
+									"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/octet-stream"
+							},
+							{
+								"key": "Content-Disposition",
+								"type": "text",
+								"value": "attachment"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "file",
+									"type": "file",
+									"src": "resources/ContentTypeResource/bundle-with-content-types-issue-22039.tar.gz"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/bundle?sync=true",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"bundle"
+							],
+							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
+								{
+									"key": "AUTH_TOKEN",
+									"value": "",
+									"disabled": true
+								}
+							]
+						},
+						"description": "Imports a Bundle containing the Content Types that are supposed to exist for the subsequent tests to work as expected."
+					},
+					"response": []
+				},
+				{
+					"name": "Get Content Types - First page",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"pm.test(\"Status code must be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"The 'Content (Generic)' type must come first!'\", function () {",
+									"    pm.expect(\"Content (Generic)\").to.equal(jsonData.entity[0].name);",
+									"});",
+									"",
+									"pm.test(\"There must be 3 Content Types in the response only!'\", function () {",
+									"    pm.expect(3).to.equal(jsonData.entity.length);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filter\" : {\n        \"types\" : \"calendarEvent,Vanityurl,webPageContent,htmlpageasset,FileAsset\"\n    },\n    \"page\": 1,\n    \"perPage\": 3\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/_filter",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"_filter"
+							]
+						},
+						"description": "Returns the appropriate JSON data with Content Type information based on the specified list of Velocity Variable Names **and the pagination parameters**."
+					},
+					"response": []
+				},
+				{
+					"name": "Get Content Types - Second page",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"pm.test(\"Status code must be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"The 'dotAsset' type must come first!'\", function () {",
+									"    pm.expect(\"dotAsset\").to.equal(jsonData.entity[0].name);",
+									"});",
+									"",
+									"pm.test(\"There must be 2 Content Types in the response only!'\", function () {",
+									"    pm.expect(2).to.equal(jsonData.entity.length);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filter\" : {\n        \"types\" : \"calendarEvent,Vanityurl,webPageContent,DotAsset,persona\"\n    },\n    \"page\": 2,\n    \"perPage\": 3\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/_filter",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"_filter"
+							]
+						},
+						"description": "Returns the appropriate JSON data with Content Type information based on the specified list of Velocity Variable Names **and the pagination parameters**."
+					},
+					"response": []
+				},
+				{
+					"name": "Get Content Types - Not paginated",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"pm.test(\"Status code must be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"All 5 Content Types in the response only!'\", function () {",
+									"    pm.expect(5).to.equal(jsonData.entity.length);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filter\" : {\n        \"types\" : \"calendarEvent,Vanityurl,webPageContent,DotAsset,persona\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/_filter",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"_filter"
+							]
+						},
+						"description": "Returns the appropriate JSON data with Content Type information based on the specified list of Velocity Variable Names **without any pagination parameters.**"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Content Types - Filtered",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"pm.test(\"Status code must be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Only 2 Content Types with the letters 'ent' should be returned!'\", function () {",
+									"    pm.expect(2).to.equal(jsonData.entity.length);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filter\" : {\n        \"types\" : \"calendarEvent,Vanityurl,webPageContent,DotAsset,persona\",\n        \"query\": \"ent\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/_filter",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"_filter"
+							]
+						},
+						"description": "Returns the appropriate JSON data with Content Type information based on the specified list of Velocity Variable Names **and the specified filter including the letters that might be present in either the Content Type's name or Velocity Var Name.**"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Content Types - Filtered Paginated",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"pm.test(\"Status code must be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Only 1 Content Type with the letters 'set' should be returned!'\", function () {",
+									"    pm.expect(1).to.equal(jsonData.entity.length);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filter\" : {\n        \"types\" : \"calendarEvent,Vanityurl,webPageContent,DotAsset,persona\",\n        \"query\": \"set\"\n    },\n    \"page\": 1,\n    \"perPage\": 3\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/_filter",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"_filter"
+							]
+						},
+						"description": "Returns the appropriate JSON data with Content Type information based on the specified list of Velocity Variable Names **and the specified filter including the letters that might be present in either the Content Type's name or Velocity Var Name.**\n\nIn this case, the second page is being requested."
+					},
+					"response": []
+				},
+				{
+					"name": "Get Content Types - All types",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"pm.test(\"Status code must be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"At least 12 Content Types must be returned, as not filter is set!'\", function () {",
+									"    pm.expect(jsonData.entity.length).to.greaterThan(11)",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"orderBy\": \"name\",\n    \"direction\": \"ASC\",\n    \"perPage\": 40\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/_filter",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"_filter"
+							]
+						},
+						"description": "Returns the appropriate JSON data with **ALL** the Content Types in the content repo as no filtering parameters were provided."
+					},
+					"response": []
+				}
+			],
+			"description": "This Test Collection will verify that the Content Type Filtering Endpoint works as expected. This endpoint can take a list of specific Content Types and perform filtering and pagination operations on them."
+		},
+		{
+			"name": "Test Accept Site Names and Folder Path",
+			"item": [
+				{
+					"name": "createFolders Success",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"    let jsonData = pm.response.json();",
+									"    pm.expect(jsonData.entity.length).to.be.above(0);    ",
+									"    let folder = jsonData.entity[0];",
+									"    pm.expect(folder.title).eql(\"foo2\");",
+									"    pm.expect(folder.type).eql(\"folder\");",
+									"    pm.expect(folder.path).eql(\"/foo1/foo2/\");",
+									"    pm.collectionVariables.set(\"folder\", folder);",
+									"    pm.collectionVariables.set(\"folder.identifier\", folder.identifier);",
+									"    pm.collectionVariables.set(\"folder.hostId\", folder.hostId);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "[\"/foo1/foo2\"]\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/folder/createfolders/default",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"folder",
+								"createfolders",
+								"default"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create ContentType From Given Host Idenifier and Folder Identifier",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"let jsonData = pm.response.json();",
+									"let contentType = jsonData.entity[0];",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);",
+									"    let folder = pm.collectionVariables.get(\"folder\");",
+									"    pm.expect(contentType.folderPath).to.eql(\"default:/foo1/foo2/\");",
+									"    pm.expect(contentType.folder).to.eql(folder.identifier);",
+									"    pm.expect(contentType.host).to.eql(folder.hostId);",
+									"})",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"defaultType\":false,\n    \"fixed\":false,\n    \"system\":false,\n    \"clazz\":\"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n    \"description\":\"CT created using the folderPath property\",    \n    \"host\":\"8a7d5e23-da1e-420a-b4f0-471e7da8ea2d\",\n    \"folder\":\"{{folder.identifier}}\",\n    \"name\":\"SimpleContentTypeFromFolderPath\",\n    \"systemActionMappings\":{\"NEW\":\"\"},\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"],\n    \"fields\" : [\n        {\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.TextField\",\n\t\t\t\"indexed\": true,\n\t\t\t\"dataType\": \"TEXT\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": true,\n\t\t\t\"searchable\": true,\n\t\t\t\"listed\": true,\n\t\t\t\"sortOrder\": 2,\n\t\t\t\"unique\": false,\n\t\t\t\"name\": \"title\",\n\t\t\t\"variable\": \"title\",\n\t\t\t\"fixed\": true\n\t\t}\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Creates a contentType using the folderPath property\n\nExpect success."
+					},
+					"response": []
+				},
+				{
+					"name": "Create ContentType From Given Folder Path",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"let jsonData = pm.response.json();",
+									"let contentType = jsonData.entity[0];",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);",
+									"    let folder = pm.collectionVariables.get(\"folder\");",
+									"    pm.expect(contentType.folderPath).to.eql(\"default:/foo1/foo2/\");",
+									"    pm.expect(contentType.folder).to.eql(folder.identifier);",
+									"    pm.expect(contentType.host).to.eql(folder.hostId);",
+									"})",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"defaultType\":false,\n    \"fixed\":false,    \n    \"clazz\":\"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n    \"description\":\"CT created using the folderPath property\",    \n    \"folderPath\":\"default:/foo1/foo2\",\n    \"name\":\"SimpleContentTypeFromFolderPath\",\n    \"systemActionMappings\":{\"NEW\":\"\"},\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"],\n    \"fields\" : [\n        {\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.TextField\",\n\t\t\t\"indexed\": true,\n\t\t\t\"dataType\": \"TEXT\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": true,\n\t\t\t\"searchable\": true,\n\t\t\t\"listed\": true,\n\t\t\t\"sortOrder\": 2,\n\t\t\t\"unique\": false,\n\t\t\t\"name\": \"title\",\n\t\t\t\"variable\": \"title\",\n\t\t\t\"fixed\": true\n\t\t}\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Creates a contentType using the folderPath property\n\nExpect success."
+					},
+					"response": []
+				},
+				{
+					"name": "Create ContentType From Given  Host Name and Folder Path",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"let jsonData = pm.response.json();",
+									"let contentType = jsonData.entity[0];",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);",
+									"    let folder = pm.collectionVariables.get(\"folder\");",
+									"    pm.expect(contentType.folderPath).to.eql(\"default:/foo1/foo2/\");",
+									"    pm.expect(contentType.folder).to.eql(folder.identifier);",
+									"    pm.expect(contentType.host).to.eql(folder.hostId);",
+									"})",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"defaultType\":false,\n    \"fixed\":false,\n    \"system\":false,\n    \"clazz\":\"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n    \"description\":\"Here we're sending host name an the folder path separately\",    \n    \"host\":\"default\",\n    \"folderPath\":\"/foo1/foo2\",\n    \"name\":\"SimpleContentTypeUsingHostNameAndFolderPath\",\n    \"systemActionMappings\":{\"NEW\":\"\"},\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"],\n    \"fields\" : [\n        {\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.TextField\",\n\t\t\t\"indexed\": true,\n\t\t\t\"dataType\": \"TEXT\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": true,\n\t\t\t\"searchable\": true,\n\t\t\t\"listed\": true,\n\t\t\t\"sortOrder\": 2,\n\t\t\t\"unique\": false,\n\t\t\t\"name\": \"title\",\n\t\t\t\"variable\": \"title\",\n\t\t\t\"fixed\": true\n\t\t}\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Creates a contentType using a host name and folderPath\n\nHere we're sending host name and the folder path only contains the folders bit without the site name portion"
+					},
+					"response": []
+				},
+				{
+					"name": "Create ContentType From Given  Host Identifier and Folder Path (no host)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"let jsonData = pm.response.json();",
+									"let contentType = jsonData.entity[0];",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);",
+									"    let folder = pm.collectionVariables.get(\"folder\");",
+									"    pm.expect(contentType.folderPath).to.eql(\"default:/foo1/foo2/\");",
+									"    pm.expect(contentType.folder).to.eql(folder.identifier);",
+									"    pm.expect(contentType.host).to.eql(folder.hostId);",
+									"})",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"defaultType\":false,\n    \"fixed\":false,\n    \"clazz\":\"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n    \"description\":\"Here we're sending host name an the folder path separately\",    \n    \"host\":\"8a7d5e23-da1e-420a-b4f0-471e7da8ea2d\",\n    \"folderPath\":\"/foo1/foo2\",\n    \"name\":\"SimpleContentTypeUsingHostIdAndFolderPath\",\n    \"systemActionMappings\":{\"NEW\":\"\"},\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"],\n    \"fields\" : [\n        {\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.TextField\",\n\t\t\t\"indexed\": true,\n\t\t\t\"dataType\": \"TEXT\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": true,\n\t\t\t\"searchable\": true,\n\t\t\t\"listed\": true,\n\t\t\t\"sortOrder\": 2,\n\t\t\t\"unique\": false,\n\t\t\t\"name\": \"title\",\n\t\t\t\"variable\": \"title\",\n\t\t\t\"fixed\": true\n\t\t}\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Creates a contentType using a host name and folderPath\n\nHere we're sending host name and the folder path only contains the folders bit without the site name portion"
+					},
+					"response": []
+				},
+				{
+					"name": "Create FIXED ContentType  Expect System-Host and System-Folder",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"let jsonData = pm.response.json();",
+									"let contentType = jsonData.entity[0];",
+									"pm.test(\"Status code should be 200\", function() {",
+									"    pm.response.to.have.status(200);    ",
+									"    pm.expect(contentType.folderPath).to.eql(\"/\");",
+									"    pm.expect(contentType.folder).to.eql(\"SYSTEM_FOLDER\");",
+									"    pm.expect(contentType.host).to.eql(\"SYSTEM_HOST\");",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"defaultType\":false,\n    \"fixed\":true,    \n    \"clazz\":\"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n    \"description\":\"CT created using the folderPath property\",    \n    \"folderPath\":\"any:/non-existing-folder\",\n    \"name\":\"SimpleContentTypeFromFolderPathNonExistingFolder\",\n    \"systemActionMappings\":{\"NEW\":\"\"},\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"],\n    \"fields\" : [\n        {\n\t\t\t\"clazz\": \"com.dotcms.contenttype.model.field.TextField\",\n\t\t\t\"indexed\": true,\n\t\t\t\"dataType\": \"TEXT\",\n\t\t\t\"readOnly\": false,\n\t\t\t\"required\": true,\n\t\t\t\"searchable\": true,\n\t\t\t\"listed\": true,\n\t\t\t\"sortOrder\": 2,\n\t\t\t\"unique\": false,\n\t\t\t\"name\": \"title\",\n\t\t\t\"variable\": \"title\",\n\t\t\t\"fixed\": true\n\t\t}\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Creates a simple contentType, that uses the folderPath property to set the location"
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Field Data",
+			"item": [
+				{
+					"name": "Get All Field Types",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"HTTP Status must be successful\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"const expectedFieldTypes = pm.collectionVariables.get(\"fieldTypesArr\");",
+									"",
+									"pm.test(\"Checking the total number of Field Types\", function () {",
+									"    const fieldTypes = pm.response.json().entity;",
+									"    pm.expect(expectedFieldTypes.length).to.eql(fieldTypes.length, \"There must be exactly \" + expectedFieldTypes.length + \" Field Types in dotCMS\");",
+									"});",
+									"",
+									"pm.test(\"Checking the classes in all Field Types\", function () {",
+									"    const fieldTypes = pm.response.json().entity;",
+									"    fieldTypes.forEach(type => {",
+									"",
+									"        pm.expect(expectedFieldTypes.includes(type.clazz)).to.equal(true, \"Type '\" + type.clazz + \"' doesn't exist in the official Field Type list\");",
+									"",
+									"    })",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"const fieldTypesArr = [ ",
+									"    \"com.dotcms.contenttype.model.field.ImmutableBinaryField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableStoryBlockField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableCategoryField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableCheckboxField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableConstantField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableCustomField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableDateField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableDateTimeField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableFileField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableHiddenField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableImageField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableJSONField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableKeyValueField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableLineDividerField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableMultiSelectField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutablePermissionTabField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableRadioField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableRelationshipField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableRelationshipsTabField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableSelectField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableHostFolderField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableTabDividerField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableTagField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableTextField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableTextAreaField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableTimeField\",",
+									"    \"com.dotcms.contenttype.model.field.ImmutableWysiwygField\"",
+									"];",
+									"pm.collectionVariables.set(\"fieldTypesArr\", fieldTypesArr);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/fieldTypes",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"fieldTypes"
+							]
+						},
+						"description": "Verifies that there's a specific number of Field Types in dotCMS, and that they all match one of the expected Field Types."
+					},
+					"response": []
+				},
+				{
+					"name": "Site or Folder Field with No Searchable Option",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"HTTP Status must be successful\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Checking that 'Searchable' option in 'Site or Folder' field is NOT present anymore\", function () {",
+									"    const fieldTypes = pm.response.json().entity;",
+									"    var isPropertyPresent = false;",
+									"    fieldTypes.forEach(type => {",
+									"",
+									"        if (\"com.dotcms.contenttype.model.field.ImmutableHostFolderField\" === type.clazz && type.properties.includes(\"searchable\")) {",
+									"            isPropertyPresent = true;",
+									"        }",
+									"",
+									"    });",
+									"    if (isPropertyPresent) {",
+									"        pm.expect(false).to.equal(isPropertyPresent, \"The 'searchable' property must not be present for 'Site or Folder' fields\");",
+									"    }",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/fieldTypes",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"fieldTypes"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "Verifies that operations related to retrieving data from fields in Content Types are aworking as expected."
+		},
+		{
+			"name": "Test delete publish/expire field",
+			"item": [
+				{
+					"name": "Create ContentType with publish/expire fields",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.collectionVariables.set(\"contentTypeID\", jsonData.entity[0].id);",
+									"pm.collectionVariables.set(\"contentTypeVAR\", jsonData.entity[0].variable);",
+									"pm.collectionVariables.set(\"contentTypeFieldID\", jsonData.entity[0].fields[0].id);",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"icon check\", function () {",
+									"    pm.expect(jsonData.entity[0].icon).to.eql('testIcon');",
+									"});",
+									"",
+									"pm.test(\"Fields check\", function () {",
+									"    pm.expect(jsonData.entity[0].fields.length).to.eql(2);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"clazz\": \"com.dotcms.contenttype.model.type.SimpleContentType\",\n\t\"description\": \"My Structure\",\n\t\"defaultType\": false,\n\t\"system\": false,\n\t\"folder\": \"SYSTEM_FOLDER\",\n\t\"name\": \"Test dates content {{$randomBankAccount}}\",\n\t\"variable\": \"testDatesContent{{$randomBankAccount}}\",\n\t\"host\": \"SYSTEM_HOST\",\n\t\"fixed\": false,\n    \"icon\": \"testIcon\",\n    \"sortOrder\": 3,\n    \"publishDateVar\": \"publishDate\",\n    \"expireDateVar\": \"expireDate\",\n\t\"fields\": [\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableDateTimeField\",\n            \"dataType\": \"DATE\",\n            \"fieldType\": \"Date-and-Time\",\n            \"fieldTypeLabel\": \"Date and Time\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"indexed\": true,\n            \"listed\": true,\n            \"name\": \"Publish Date\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 3,\n            \"unique\": false,\n            \"variable\": \"publishDate\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableDateTimeField\",\n            \"dataType\": \"DATE\",\n            \"fieldType\": \"Date-and-Time\",\n            \"fieldTypeLabel\": \"Date and Time\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1685054935000,\n            \"indexed\": true,\n            \"listed\": true,\n            \"modDate\": 1685054935000,\n            \"name\": \"Expire Date\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 3,\n            \"unique\": false,\n            \"variable\": \"expireDate\"\n        }\n\n\t],\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"]\n}"
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Given a content type payload containing field variables.\nWhen sending a POST.\nExpect that code is 200.\nExpect content type is created with the provided fields.\nExpect that new properties of content types are set (icon and sortOrder)."
+					},
+					"response": []
+				},
+				{
+					"name": "Delete dateTime field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"fieldsID\": [\"{{contentTypeFieldID}}\"]}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v3/contenttype/{{contentTypeID}}/fields",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"contenttype",
+								"{{contentTypeID}}",
+								"fields"
+							]
+						},
+						"description": "Given a content type ID.\nExpect that code is 200.\nExpect content type is deleted successfully."
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"variable": [
+		{
+			"key": "contentTypeVariable",
+			"value": ""
+		},
+		{
+			"key": "contentTypeId",
+			"value": ""
+		},
+		{
+			"key": "contentType.columnDivider",
+			"value": ""
+		},
+		{
+			"key": "contentType.divider",
+			"value": ""
+		},
+		{
+			"key": "contentType.field1",
+			"value": ""
+		},
+		{
+			"key": "contentType.field2",
+			"value": ""
+		},
+		{
+			"key": "contentType.field3",
+			"value": ""
+		},
+		{
+			"key": "contentType.field4",
+			"value": ""
+		},
+		{
+			"key": "contentType.host",
+			"value": ""
+		},
+		{
+			"key": "contentType.workflow",
+			"value": ""
+		},
+		{
+			"key": "contentTypeID",
+			"value": ""
+		},
+		{
+			"key": "contentTypeVAR",
+			"value": ""
+		},
+		{
+			"key": "contentTypeFieldID",
+			"value": ""
+		},
+		{
+			"key": "contentTypeIdWithStoryBlock",
+			"value": ""
+		},
+		{
+			"key": "folder",
+			"value": ""
+		},
+		{
+			"key": "folder.identifier",
+			"value": ""
+		},
+		{
+			"key": "folder.hostId",
+			"value": ""
+		},
+		{
+			"key": "fieldTypesArr",
+			"value": ""
+		}
+	]
+}

--- a/dotCMS/src/curl-test/ContentTypeResourceTests.json
+++ b/dotCMS/src/curl-test/ContentTypeResourceTests.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "de4c1a47-b07d-4b24-8b2b-d7d6c987b946",
+		"_postman_id": "4a7bb840-b421-4ff9-a020-4986dbd0dca1",
 		"name": "ContentType Resource",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5403727",
-		"_collection_link": "https://cloudy-robot-285072.postman.co/workspace/JCastro-Workspace~5bfa586e-54db-429b-b7d5-c4ff997e3a0d/collection/5403727-de4c1a47-b07d-4b24-8b2b-d7d6c987b946?action=share&creator=5403727&source=collection_link"
+		"_exporter_id": "27636414"
 	},
 	"item": [
 		{
@@ -2667,6 +2666,161 @@
 				}
 			],
 			"description": "Verifies that operations related to retrieving data from fields in Content Types are aworking as expected."
+		},
+		{
+			"name": "Test delete publish/expire field",
+			"item": [
+				{
+					"name": "Create ContentType with publish/expire fields",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.collectionVariables.set(\"contentTypeID\", jsonData.entity[0].id);",
+									"pm.collectionVariables.set(\"contentTypeVAR\", jsonData.entity[0].variable);",
+									"pm.collectionVariables.set(\"contentTypeFieldID\", jsonData.entity[0].fields[0].id);",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"icon check\", function () {",
+									"    pm.expect(jsonData.entity[0].icon).to.eql('testIcon');",
+									"});",
+									"",
+									"pm.test(\"Fields check\", function () {",
+									"    pm.expect(jsonData.entity[0].fields.length).to.eql(2);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"clazz\": \"com.dotcms.contenttype.model.type.SimpleContentType\",\n\t\"description\": \"My Structure\",\n\t\"defaultType\": false,\n\t\"system\": false,\n\t\"folder\": \"SYSTEM_FOLDER\",\n\t\"name\": \"Test dates content {{$randomBankAccount}}\",\n\t\"variable\": \"testDatesContent{{$randomBankAccount}}\",\n\t\"host\": \"SYSTEM_HOST\",\n\t\"fixed\": false,\n    \"icon\": \"testIcon\",\n    \"sortOrder\": 3,\n    \"publishDateVar\": \"publishDate\",\n    \"expireDateVar\": \"expireDate\",\n\t\"fields\": [\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableDateTimeField\",\n            \"dataType\": \"DATE\",\n            \"fieldType\": \"Date-and-Time\",\n            \"fieldTypeLabel\": \"Date and Time\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"indexed\": true,\n            \"listed\": true,\n            \"name\": \"Publish Date\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 3,\n            \"unique\": false,\n            \"variable\": \"publishDate\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableDateTimeField\",\n            \"dataType\": \"DATE\",\n            \"fieldType\": \"Date-and-Time\",\n            \"fieldTypeLabel\": \"Date and Time\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1685054935000,\n            \"indexed\": true,\n            \"listed\": true,\n            \"modDate\": 1685054935000,\n            \"name\": \"Expire Date\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 3,\n            \"unique\": false,\n            \"variable\": \"expireDate\"\n        }\n\n\t],\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"]\n}"
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Given a content type payload containing field variables.\nWhen sending a POST.\nExpect that code is 200.\nExpect content type is created with the provided fields.\nExpect that new properties of content types are set (icon and sortOrder)."
+					},
+					"response": []
+				},
+				{
+					"name": "Delete dateTime field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"fieldsID\": [\"{{contentTypeFieldID}}\"]}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v3/contenttype/{{contentTypeID}}/fields",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"contenttype",
+								"{{contentTypeID}}",
+								"fields"
+							]
+						},
+						"description": "Given a content type ID.\nExpect that code is 200.\nExpect content type is deleted successfully."
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"variable": [

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v3/contenttype/FieldResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v3/contenttype/FieldResource.java
@@ -206,6 +206,15 @@ public class FieldResource {
 
         final List<String> fieldsID = deleteFieldsForm.getFieldsID();
         final ContentType contentType = APILocator.getContentTypeAPI(user).find(typeIdOrVarName);
+        final String publishDateVar = contentType.publishDateVar();
+        final String expireDateVar = contentType.expireDateVar();
+
+        for (final String fieldId : fieldsID) {
+            final Field field = APILocator.getContentTypeFieldAPI().find(fieldId);
+            if ((publishDateVar != null && publishDateVar.equals(field.variable())) || (expireDateVar != null && expireDateVar.equals(field.variable()))) {
+                throw new DotDataException("Field is being used as Publish or Expire Field at Content Type Level. Please unlink the field before deleting it.");
+            }
+        }
 
         final ContentTypeFieldLayoutAPI.DeleteFieldResult deleteFieldResult =
                 this.contentTypeFieldLayoutAPI.deleteField(contentType, fieldsID, user);


### PR DESCRIPTION
### Proposed Changes
* Content Type is still showing after the Date and Field is removed. 

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
**This is a fix for the scenario found by QA, it was agreed that a message would pop up to inform that the field can't be deleted since it's been used by the content type as publish/expire field.**

### Screenshots
![image](https://github.com/dotCMS/core/assets/127987858/8301b3ac-c22c-4bca-833a-3bfc4034847d)

