### PR TITLE
Delete validation on publish/expire fields related with content type 

### DIFF
--- a/dotCMS/src/curl-test/ContentTypeResourceTests.json
+++ b/dotCMS/src/curl-test/ContentTypeResourceTests.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "de4c1a47-b07d-4b24-8b2b-d7d6c987b946",
+		"_postman_id": "4a7bb840-b421-4ff9-a020-4986dbd0dca1",
 		"name": "ContentType Resource",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5403727",
-		"_collection_link": "https://cloudy-robot-285072.postman.co/workspace/JCastro-Workspace~5bfa586e-54db-429b-b7d5-c4ff997e3a0d/collection/5403727-de4c1a47-b07d-4b24-8b2b-d7d6c987b946?action=share&creator=5403727&source=collection_link"
+		"_exporter_id": "27636414"
 	},
 	"item": [
 		{
@@ -2667,6 +2666,161 @@
 				}
 			],
 			"description": "Verifies that operations related to retrieving data from fields in Content Types are aworking as expected."
+		},
+		{
+			"name": "Test delete publish/expire field",
+			"item": [
+				{
+					"name": "Create ContentType with publish/expire fields",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.collectionVariables.set(\"contentTypeID\", jsonData.entity[0].id);",
+									"pm.collectionVariables.set(\"contentTypeVAR\", jsonData.entity[0].variable);",
+									"pm.collectionVariables.set(\"contentTypeFieldID\", jsonData.entity[0].fields[0].id);",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"icon check\", function () {",
+									"    pm.expect(jsonData.entity[0].icon).to.eql('testIcon');",
+									"});",
+									"",
+									"pm.test(\"Fields check\", function () {",
+									"    pm.expect(jsonData.entity[0].fields.length).to.eql(2);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"clazz\": \"com.dotcms.contenttype.model.type.SimpleContentType\",\n\t\"description\": \"My Structure\",\n\t\"defaultType\": false,\n\t\"system\": false,\n\t\"folder\": \"SYSTEM_FOLDER\",\n\t\"name\": \"Test dates content {{$randomBankAccount}}\",\n\t\"variable\": \"testDatesContent{{$randomBankAccount}}\",\n\t\"host\": \"SYSTEM_HOST\",\n\t\"fixed\": false,\n    \"icon\": \"testIcon\",\n    \"sortOrder\": 3,\n    \"publishDateVar\": \"publishDate\",\n    \"expireDateVar\": \"expireDate\",\n\t\"fields\": [\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableDateTimeField\",\n            \"dataType\": \"DATE\",\n            \"fieldType\": \"Date-and-Time\",\n            \"fieldTypeLabel\": \"Date and Time\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"indexed\": true,\n            \"listed\": true,\n            \"name\": \"Publish Date\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 3,\n            \"unique\": false,\n            \"variable\": \"publishDate\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableDateTimeField\",\n            \"dataType\": \"DATE\",\n            \"fieldType\": \"Date-and-Time\",\n            \"fieldTypeLabel\": \"Date and Time\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1685054935000,\n            \"indexed\": true,\n            \"listed\": true,\n            \"modDate\": 1685054935000,\n            \"name\": \"Expire Date\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 3,\n            \"unique\": false,\n            \"variable\": \"expireDate\"\n        }\n\n\t],\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"]\n}"
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Given a content type payload containing field variables.\nWhen sending a POST.\nExpect that code is 200.\nExpect content type is created with the provided fields.\nExpect that new properties of content types are set (icon and sortOrder)."
+					},
+					"response": []
+				},
+				{
+					"name": "Delete dateTime field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code should be 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"fieldsID\": [\"{{contentTypeFieldID}}\"]}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v3/contenttype/{{contentTypeID}}/fields",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"contenttype",
+								"{{contentTypeID}}",
+								"fields"
+							]
+						},
+						"description": "Given a content type ID.\nExpect that code is 200.\nExpect content type is deleted successfully."
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"variable": [

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v3/contenttype/FieldResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v3/contenttype/FieldResource.java
@@ -22,6 +22,10 @@ import com.liferay.portal.model.User;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static com.dotcms.util.CollectionsUtils.map;
 
 /**
@@ -206,6 +210,17 @@ public class FieldResource {
 
         final List<String> fieldsID = deleteFieldsForm.getFieldsID();
         final ContentType contentType = APILocator.getContentTypeAPI(user).find(typeIdOrVarName);
+        final String publishDateVar = contentType.publishDateVar();
+        final String expireDateVar = contentType.expireDateVar();
+        Stream<Field> cacheVals = contentType.fields().stream();
+        List<Field> filteredFields = cacheVals.filter(field -> fieldsID.contains(field.id())).collect(Collectors.toList());
+
+        for (final Field field : filteredFields) {
+            if ((publishDateVar != null && publishDateVar.equals(field.variable())) ||
+                    (expireDateVar != null && expireDateVar.equals(field.variable()))){
+                throw new DotDataException("Field is being used as Publish or Expire Field at Content Type Level. Please unlink the field before deleting it.");
+            }
+        };
 
         final ContentTypeFieldLayoutAPI.DeleteFieldResult deleteFieldResult =
                 this.contentTypeFieldLayoutAPI.deleteField(contentType, fieldsID, user);

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v3/contenttype/FieldResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v3/contenttype/FieldResource.java
@@ -212,8 +212,8 @@ public class FieldResource {
         final ContentType contentType = APILocator.getContentTypeAPI(user).find(typeIdOrVarName);
         final String publishDateVar = contentType.publishDateVar();
         final String expireDateVar = contentType.expireDateVar();
-        Stream<Field> cacheVals = contentType.fields().stream();
-        List<Field> filteredFields = cacheVals.filter(field -> fieldsID.contains(field.id())).collect(Collectors.toList());
+
+        final List<Field> filteredFields = contentType.fields().stream().filter(field -> fieldsID.contains(field.id())).collect(Collectors.toList());
 
         for (final Field field : filteredFields) {
             if ((publishDateVar != null && publishDateVar.equals(field.variable())) ||


### PR DESCRIPTION
### Proposed Changes
* Content Type is still showing after the Date and Field is removed.

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
**This is a fix for the scenario found by QA, it was agreed that a message would pop up to inform that the field can't be deleted since it's been used by the content type as publish/expire field.**

### Screenshots
![image](https://github.com/dotCMS/core/assets/127987858/99e70d06-9a2a-4d15-9c36-ca43d217e5c7)
