### PR TITLE
Fix #25090: Refactor of Listing Panel in Favorite Pages to be Pagination instead of Infinity Scroll

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.spec.ts
@@ -109,11 +109,14 @@ describe('DotPagesFavoritePanelComponent', () => {
         setLocalStorageFavoritePanelCollapsedParams(_collapsed: boolean): void {
             /* */
         }
+        setFavoritePages() {
+            /* */
+        }
     }
 
     describe('Empty state', () => {
-        beforeEach(() => {
-            TestBed.configureTestingModule({
+        beforeEach(async () => {
+            await TestBed.configureTestingModule({
                 declarations: [DotPagesFavoritePanelComponent, MockDotIconComponent],
                 imports: [
                     BrowserAnimationsModule,
@@ -155,6 +158,7 @@ describe('DotPagesFavoritePanelComponent', () => {
 
         it('should set panel collapsed state', () => {
             spyOn(store, 'setLocalStorageFavoritePanelCollapsedParams');
+            spyOn(store, 'setFavoritePages');
             component.toggleFavoritePagesPanel(
                 new Event('myevent', {
                     bubbles: true,
@@ -163,6 +167,7 @@ describe('DotPagesFavoritePanelComponent', () => {
                 })
             );
             expect(store.setLocalStorageFavoritePanelCollapsedParams).toHaveBeenCalledTimes(1);
+            expect(store.setFavoritePages).toHaveBeenCalledTimes(1);
         });
 
         it('should load empty pages cards container', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.ts
@@ -72,6 +72,7 @@ export class DotPagesFavoritePanelComponent {
      */
     toggleFavoritePagesPanel($event: Event): void {
         this.store.setLocalStorageFavoritePanelCollapsedParams($event['collapsed']);
+        this.store.setFavoritePages({ collapsed: $event['collapsed'] as boolean });
     }
 
     /**

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
@@ -15,11 +15,13 @@
         [paginator]="true"
         [rows]="40"
         [scrollHeight]="vm.isFavoritePanelCollaped ? 'calc(100vh - 350px)' : 'calc(100vh - 600px)'"
+        [sortOrder]="-1"
+        [showPageLinks]="false"
+        [showCurrentPageReport]="true"
         (onLazyLoad)="loadPagesLazy($event)"
         (onRowSelect)="onRowSelect($event)"
         selectionMode="single"
         sortField="modDate"
-        [sortOrder]="-1"
     >
         <ng-template pTemplate="caption">
             <div class="flex justify-content-between dot-pages-listing-header">

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
@@ -14,10 +14,10 @@
         [lazy]="true"
         [paginator]="true"
         [rows]="40"
+        [scrollHeight]="vm.isFavoritePanelCollaped ? 'calc(100vh - 350px)' : 'calc(100vh - 600px)'"
         (onLazyLoad)="loadPagesLazy($event)"
         (onRowSelect)="onRowSelect($event)"
         selectionMode="single"
-        scrollHeight="calc(100vh - 350px)"
     >
         <ng-template pTemplate="caption">
             <div class="flex justify-content-between dot-pages-listing-header">

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
@@ -18,6 +18,7 @@
         [sortOrder]="-1"
         [showPageLinks]="false"
         [showCurrentPageReport]="true"
+        [showFirstLastIcon]="false"
         (onLazyLoad)="loadPagesLazy($event)"
         (onRowSelect)="onRowSelect($event)"
         selectionMode="single"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.html
@@ -8,15 +8,16 @@
         #table
         [contextMenu]="cm"
         [value]="vm.pages.items"
+        [totalRecords]="vm.pages.total"
         [loading]="vm.isPagesLoading"
         [scrollable]="true"
-        [virtualScroll]="true"
-        [virtualScrollItemSize]="47"
         [lazy]="true"
+        [paginator]="true"
+        [rows]="40"
         (onLazyLoad)="loadPagesLazy($event)"
         (onRowSelect)="onRowSelect($event)"
         selectionMode="single"
-        scrollHeight="flex"
+        scrollHeight="calc(100vh - 350px)"
     >
         <ng-template pTemplate="caption">
             <div class="flex justify-content-between dot-pages-listing-header">
@@ -130,17 +131,6 @@
                         size="32"
                     ></dot-icon-button>
                 </td>
-            </tr>
-        </ng-template>
-        <ng-template pTemplate="loadingbody">
-            <tr style="height: 47px">
-                <td><p-skeleton [ngStyle]="{ width: '25%' }"></p-skeleton></td>
-                <td><p-skeleton [ngStyle]="{ width: '20%' }"></p-skeleton></td>
-                <td><p-skeleton [ngStyle]="{ width: '12%' }"></p-skeleton></td>
-                <td><p-skeleton [ngStyle]="{ width: '12%' }"></p-skeleton></td>
-                <td><p-skeleton [ngStyle]="{ width: '12%' }"></p-skeleton></td>
-                <td><p-skeleton [ngStyle]="{ width: '14%' }"></p-skeleton></td>
-                <td><p-skeleton [ngStyle]="{ width: '5%' }"></p-skeleton></td>
             </tr>
         </ng-template>
         <ng-template pTemplate="emptymessage">

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
@@ -35,6 +35,10 @@
 
     .p-datatable {
         .p-datatable-wrapper {
+            height: calc(
+                100vh - 350px
+            ); // To prevent the table from resizing when the results are too low to fill the page
+
             transition: max-height 400ms cubic-bezier(0.86, 0, 0.07, 1);
             -moz-transition: max-height 400ms cubic-bezier(0.86, 0, 0.07, 1);
             -webkit-transition: max-height 400ms cubic-bezier(0.86, 0, 0.07, 1);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
@@ -32,6 +32,12 @@
     .p-datatable .p-datatable-tbody tr td.dot-pages-listing__empty-content {
         text-align: center;
     }
+
+    .p-datatable {
+        .p-datatable-wrapper {
+            transition: max-height 400ms ease-in-out;
+        }
+    }
 }
 
 .dot-pages-listing-header__inputs {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
@@ -37,7 +37,7 @@
         .p-datatable-wrapper {
             height: calc(
                 100vh - 350px
-            ); // To prevent the table from resizing when the results are too low to fill the page
+            ); // To prevent the table from resizing when the results are not enough to fill the page
 
             transition: max-height 400ms cubic-bezier(0.86, 0, 0.07, 1);
             -moz-transition: max-height 400ms cubic-bezier(0.86, 0, 0.07, 1);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.scss
@@ -35,7 +35,10 @@
 
     .p-datatable {
         .p-datatable-wrapper {
-            transition: max-height 400ms ease-in-out;
+            transition: max-height 400ms cubic-bezier(0.86, 0, 0.07, 1);
+            -moz-transition: max-height 400ms cubic-bezier(0.86, 0, 0.07, 1);
+            -webkit-transition: max-height 400ms cubic-bezier(0.86, 0, 0.07, 1);
+            -o-transition: max-height 400ms cubic-bezier(0.86, 0, 0.07, 1);
         }
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.spec.ts
@@ -214,6 +214,7 @@ describe('DotPagesListingPanelComponent', () => {
             expect(elem.paginator).toEqual(true);
             expect(elem.showPageLinks).toEqual(false);
             expect(elem.showCurrentPageReport).toEqual(true);
+            expect(elem.showFirstLastIcon).toEqual(false);
         });
 
         it('should contain header with filter for keyword, language and archived', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.spec.ts
@@ -212,6 +212,8 @@ describe('DotPagesListingPanelComponent', () => {
             expect(elem.sortOrder).toEqual(-1);
             expect(elem.rows).toEqual(40);
             expect(elem.paginator).toEqual(true);
+            expect(elem.showPageLinks).toEqual(false);
+            expect(elem.showCurrentPageReport).toEqual(true);
         });
 
         it('should contain header with filter for keyword, language and archived', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.spec.ts
@@ -20,9 +20,16 @@ import { of } from 'rxjs/internal/observable/of';
 import { UiDotIconButtonModule } from '@components/_common/dot-icon-button/dot-icon-button.module';
 import { DotAutofocusModule } from '@directives/dot-autofocus/dot-autofocus.module';
 import { DotMessagePipeModule } from '@dotcms/app/view/pipes/dot-message/dot-message-pipe.module';
+import { DotRelativeDatePipe } from '@dotcms/app/view/pipes/dot-relative-date/dot-relative-date.pipe';
 import { DotMessageService } from '@dotcms/data-access';
-import { CoreWebService, CoreWebServiceMock, SiteService } from '@dotcms/dotcms-js';
 import {
+    CoreWebService,
+    CoreWebServiceMock,
+    DotcmsConfigService,
+    SiteService
+} from '@dotcms/dotcms-js';
+import {
+    DotcmsConfigServiceMock,
     dotcmsContentletMock,
     dotcmsContentTypeBasicMock,
     MockDotMessageService,
@@ -146,6 +153,7 @@ describe('DotPagesListingPanelComponent', () => {
                     DropdownModule,
                     DotAutofocusModule,
                     DotMessagePipeModule,
+                    DotRelativeDatePipe,
                     InputTextModule,
                     SkeletonModule,
                     TableModule,
@@ -155,6 +163,7 @@ describe('DotPagesListingPanelComponent', () => {
                 ],
                 providers: [
                     DialogService,
+                    { provide: DotcmsConfigService, useClass: DotcmsConfigServiceMock },
                     { provide: CoreWebService, useClass: CoreWebServiceMock },
                     { provide: DotPageStore, useClass: storeMock },
                     { provide: DotMessageService, useValue: messageServiceMock },
@@ -196,13 +205,13 @@ describe('DotPagesListingPanelComponent', () => {
             const elem = de.query(By.css('p-table')).componentInstance;
             expect(elem.scrollable).toBe(true);
             expect(elem.loading).toBe(undefined);
-            expect(elem.virtualScroll).toBe(true);
-            expect(elem.virtualScrollItemSize).toBe(47);
             expect(elem.lazy).toBe(true);
             expect(elem.selectionMode).toBe('single');
-            expect(elem.scrollHeight).toBe('flex');
+            expect(elem.scrollHeight).toBe('calc(100vh - 600px)');
             expect(elem.sortField).toEqual('modDate');
             expect(elem.sortOrder).toEqual(-1);
+            expect(elem.rows).toEqual(40);
+            expect(elem.paginator).toEqual(true);
         });
 
         it('should contain header with filter for keyword, language and archived', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.ts
@@ -64,7 +64,7 @@ export class DotPagesListingPanelComponent implements OnInit, OnDestroy, AfterVi
     }
 
     ngAfterViewInit(): void {
-        this.scrollElement = this.table.el.nativeElement.querySelector('div.p-scroller');
+        this.scrollElement = this.table.el.nativeElement.querySelector('.p-datatable-wrapper');
 
         this.scrollElement.addEventListener('scroll', () => {
             this.closeContextMenu();

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -292,7 +292,7 @@ describe('DotPageStore', () => {
     });
 
     it('should update Pages', () => {
-        dotPageStore.setPages(favoritePagesInitialTestData);
+        dotPageStore.setPages({ items: favoritePagesInitialTestData });
         dotPageStore.state$.subscribe((data) => {
             expect(data.pages.items).toEqual(favoritePagesInitialTestData);
         });
@@ -464,7 +464,7 @@ describe('DotPageStore', () => {
             }
         ];
 
-        dotPageStore.setPages(pagesData);
+        dotPageStore.setPages({ items: pagesData });
 
         spyOn(dotESContentService, 'get').and.returnValue(
             of({
@@ -497,7 +497,7 @@ describe('DotPageStore', () => {
     });
 
     it('should keep fetching Pages data until new value comes from the DB in store', fakeAsync(() => {
-        dotPageStore.setPages(favoritePagesInitialTestData);
+        dotPageStore.setPages({ items: favoritePagesInitialTestData });
         const old = {
             contentTook: 0,
             jsonObjectView: {
@@ -561,7 +561,7 @@ describe('DotPageStore', () => {
     }));
 
     it('should remove page archived from pages collection and add undefined at the bottom', fakeAsync(() => {
-        dotPageStore.setPages(favoritePagesInitialTestData);
+        dotPageStore.setPages({ items: favoritePagesInitialTestData });
         const old = {
             contentTook: 0,
             jsonObjectView: {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -210,9 +210,9 @@ describe('DotPageStore', () => {
     it('should limit Favorite Pages', () => {
         spyOn(dotPageStore, 'setFavoritePages').and.callThrough();
         dotPageStore.limitFavoritePages(5);
-        expect(dotPageStore.setFavoritePages).toHaveBeenCalledWith(
-            favoritePagesInitialTestData.slice(0, 5)
-        );
+        expect(dotPageStore.setFavoritePages).toHaveBeenCalledWith({
+            items: favoritePagesInitialTestData.slice(0, 5)
+        });
     });
 
     // Selectors
@@ -285,7 +285,7 @@ describe('DotPageStore', () => {
 
     // Updaters
     it('should update Favorite Pages', () => {
-        dotPageStore.setFavoritePages(favoritePagesInitialTestData);
+        dotPageStore.setFavoritePages({ items: favoritePagesInitialTestData });
         dotPageStore.state$.subscribe((data) => {
             expect(data.favoritePages.items).toEqual(favoritePagesInitialTestData);
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -73,9 +73,9 @@ export interface DotPagesInfo {
 
 export interface DotFavoritePagesInfo {
     collapsed?: boolean;
-    items?: DotCMSContentlet[];
-    showLoadMoreButton?: boolean;
-    total?: number;
+    items: DotCMSContentlet[];
+    showLoadMoreButton: boolean;
+    total: number;
 }
 
 export interface DotPagesState {
@@ -181,7 +181,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
 
     readonly pageTypes$ = this.select(({ pageTypes }) => pageTypes);
 
-    readonly setFavoritePages = this.updater<DotFavoritePagesInfo>(
+    readonly setFavoritePages = this.updater<Partial<DotFavoritePagesInfo>>(
         (state: DotPagesState, favoritePages: DotFavoritePagesInfo) => {
             return {
                 ...state,
@@ -193,7 +193,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
         }
     );
 
-    readonly setPages = this.updater<DotPagesInfo>(
+    readonly setPages = this.updater<Partial<DotPagesInfo>>(
         (state: DotPagesState, pagesInfo: DotPagesInfo) => {
             return {
                 ...state,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -71,13 +71,15 @@ export interface DotPagesInfo {
     total?: number;
 }
 
+export interface DotFavoritePagesInfo {
+    collapsed?: boolean;
+    items?: DotCMSContentlet[];
+    showLoadMoreButton?: boolean;
+    total?: number;
+}
+
 export interface DotPagesState {
-    favoritePages: {
-        collapsed?: boolean;
-        items: DotCMSContentlet[];
-        showLoadMoreButton: boolean;
-        total: number;
-    };
+    favoritePages: DotFavoritePagesInfo;
     environments: boolean;
     isEnterprise: boolean;
     languages: DotLanguage[];
@@ -179,13 +181,13 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
 
     readonly pageTypes$ = this.select(({ pageTypes }) => pageTypes);
 
-    readonly setFavoritePages = this.updater<DotCMSContentlet[]>(
-        (state: DotPagesState, favoritePages: DotCMSContentlet[]) => {
+    readonly setFavoritePages = this.updater<DotFavoritePagesInfo>(
+        (state: DotPagesState, favoritePages: DotFavoritePagesInfo) => {
             return {
                 ...state,
                 favoritePages: {
                     ...state.favoritePages,
-                    items: [...favoritePages]
+                    ...favoritePages
                 }
             };
         }
@@ -197,9 +199,8 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
                 ...state,
                 pages: {
                     ...state.pages,
-                    items: [...pagesInfo.items],
                     status: ComponentStatus.LOADED,
-                    total: pagesInfo.total
+                    ...pagesInfo
                 }
             };
         }
@@ -411,7 +412,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
                                                 }
                                             );
 
-                                            this.setFavoritePages(pagesData);
+                                            this.setFavoritePages({ items: pagesData });
                                         } else {
                                             let pagesData = this.get().pages.items;
 
@@ -1010,7 +1011,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
      */
     limitFavoritePages(limit: number): void {
         const favoritePages = this.get().favoritePages.items;
-        this.setFavoritePages(favoritePages.slice(0, limit));
+        this.setFavoritePages({ items: favoritePages.slice(0, limit) });
     }
 
     /**


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa3fab0</samp>

### Summary
:sparkles::bug::art:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, such as the collapsing and expanding functionality of the favorite panel, and the lazy loading and pagination of the pages table.
2. :bug: This emoji represents the fixing of a bug or an issue, such as the scrolling problem of the pages table.
3. :art: This emoji represents the improvement of the code structure or format, such as the refactoring of the `DotPageStore` class and the use of new interfaces.
-->
This pull request improves the performance and user experience of the pages listing panel in the dotCMS UI. It implements lazy loading and pagination for the `p-table` component, refactors the `DotPageStore` class to use new interfaces for the pages state, adds the functionality of collapsing and expanding the favorite panel, and fixes a bug that prevented the lazy loading of pages when scrolling the table. It also updates the template, styles, and test cases of the affected components.

> _`DotPageStore` changes_
> _Refine pages and favorites_
> _Autumn of refactor_

### Walkthrough
*  Refactor the state and the types of the `DotPageStore` class to be more consistent and flexible, and to support new features and properties for the pages and the favorite panel ([link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL62-R82), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL78-R91), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL180-R190), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL192-R203), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL411-R415), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL431-R435), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL462-R469), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL1013-R1014), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-b23eeff307d6d254cb33a17b3b64f937646e6f91d72778c1ac460881c0bfc980L213-R215), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-b23eeff307d6d254cb33a17b3b64f937646e6f91d72778c1ac460881c0bfc980L288-R288), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-b23eeff307d6d254cb33a17b3b64f937646e6f91d72778c1ac460881c0bfc980L295-R295), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-b23eeff307d6d254cb33a17b3b64f937646e6f91d72778c1ac460881c0bfc980L467-R467), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-b23eeff307d6d254cb33a17b3b64f937646e6f91d72778c1ac460881c0bfc980L500-R500), [link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-b23eeff307d6d254cb33a17b3b64f937646e6f91d72778c1ac460881c0bfc980L564-R564))
*  Update the `DotPagesListingPanelComponent` template to add pagination and total records attributes to the `p-table` element, and to change the `virtualScroll` attribute to `lazy` ([link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-1dc91e554b57df9862b7aa55f54839c49ea15c3a4caa1bf096f96e5df2e97c4eL11-R20))
*  Remove the custom loading indicator of the `p-table` element in the `DotPagesListingPanelComponent` template and use the default one instead ([link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-1dc91e554b57df9862b7aa55f54839c49ea15c3a4caa1bf096f96e5df2e97c4eL135-L145))
*  Fix a bug that prevented the lazy loading of pages when scrolling the table by assigning the `scrollElement` property to the table wrapper element in the `DotPagesListingPanelComponent` class ([link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-68cb42cd0420b2fd6a9d2f4305173ae7d75a2fd24205f2ec9bded9e298eb8784L67-R67))
*  Add a line of code to the `togglePanel` method of the `DotPagesFavoritePanelComponent` class to update the `favoritePages` state with the collapsed value of the favorite panel ([link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-b74934bcc344754ceebd040061e9852d5e34f72cde6c855d360a725280d5a13aR75))
*  Add some styles to the `p-datatable` element in the `DotPagesListingPanelComponent` class to set a fixed height and a transition effect for the table wrapper element ([link](https://github.com/dotCMS/core/pull/25101/files?diff=unified&w=0#diff-d9ee799f12b61fca94371edc845201ad366129d7dd8dacb8a35eeadbf5c68700R35-R47))



### Screenshots

https://github.com/dotCMS/core/assets/63567962/c8668f8e-8cf5-4972-9eae-e02e1041da4b

