### PR TITLE
Favorite Pages: Notifying the user when a workflow action request fails

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -1,5 +1,6 @@
 import { Observable, of, throwError } from 'rxjs';
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Injectable } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
@@ -59,7 +60,8 @@ import {
     mockDotLanguage,
     MockDotRouterService,
     mockResponseView,
-    mockWorkflowsActions
+    mockWorkflowsActions,
+    mockPublishAction
 } from '@dotcms/utils-testing';
 
 import {
@@ -757,6 +759,36 @@ describe('DotPageStore', () => {
         expect(dotESContentService.get).toHaveBeenCalledTimes(1);
         expect(dotWorkflowActionsFireService.deleteContentlet).toHaveBeenCalledWith({
             inode: testInode
+        });
+    });
+
+    it('should handle error when a Workflow Action Request fails', (done) => {
+        const actions = [mockPublishAction];
+        const page = dotcmsContentletMock;
+        const error: HttpErrorResponse = new HttpErrorResponse({
+            error: {
+                message: 'Workflow Action is not available for current step'
+            }
+        });
+        const item = {
+            ...favoritePagesInitialTestData[0],
+            contentType: 'dotFavoritePage',
+            archived: true
+        };
+
+        spyOn(dotPageWorkflowsActionsService, 'getByUrl').and.returnValue(of({ actions, page }));
+        spyOn(dotWorkflowActionsFireService, 'fireTo').and.returnValue(throwError(error));
+
+        dotPageStore.showActionsMenu({ item, actionMenuDomId: 'test1' });
+
+        dotPageStore.state$.subscribe(({ pages }) => {
+            const menuAction = pages.menuActions;
+            const publishAction = menuAction.find(
+                (action) => action.label === mockPublishAction.name
+            );
+            publishAction.command();
+            expect(dotHttpErrorManagerService.handle).toHaveBeenCalledWith(error, true);
+            done();
         });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -788,14 +788,15 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
                         };
                         this.dotWorkflowEventHandlerService.open(wfActionEvent);
                     } else {
-                        this.dotWorkflowActionsFireService
-                            .fireTo(item.inode, action.id)
-                            .subscribe((item) => {
+                        this.dotWorkflowActionsFireService.fireTo(item.inode, action.id).subscribe(
+                            (item) => {
                                 this.dotEventsService.notify('save-page', {
                                     payload: item,
                                     value: this.dotMessageService.get('Workflow-executed')
                                 });
-                            });
+                            },
+                            (error) => this.httpErrorManagerService.handle(error, true)
+                        );
                     }
                 }
             });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -783,25 +783,20 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
             actionsMenu.push({
                 label: `${this.dotMessageService.get(action.name)}`,
                 command: () => {
-                    if (action.actionInputs?.length > 0) {
-                        const wfActionEvent: DotCMSWorkflowActionEvent = {
-                            workflow: action,
-                            callback: 'ngWorkflowEventCallback',
-                            inode: item.inode,
-                            selectedInodes: null
-                        };
-                        this.dotWorkflowEventHandlerService.open(wfActionEvent);
-                    } else {
-                        this.dotWorkflowActionsFireService.fireTo(item.inode, action.id).subscribe(
-                            (item) => {
-                                this.dotEventsService.notify('save-page', {
-                                    payload: item,
-                                    value: this.dotMessageService.get('Workflow-executed')
-                                });
-                            },
-                            (error) => this.httpErrorManagerService.handle(error, true)
-                        );
+                    if (!(action.actionInputs?.length > 0)) {
+                        this.fireWorkflowAction(item.inode, action.id);
+
+                        return;
                     }
+
+                    const wfActionEvent: DotCMSWorkflowActionEvent = {
+                        workflow: action,
+                        callback: 'ngWorkflowEventCallback',
+                        inode: item.inode,
+                        selectedInodes: null
+                    };
+
+                    this.dotWorkflowEventHandlerService.open(wfActionEvent);
                 }
             });
         });
@@ -1073,5 +1068,20 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
             canUserWritePage,
             canUserWriteContent
         };
+    }
+    /**
+     * Fire workflow action
+     *
+     * @private
+     * @param {string} contentletInode
+     * @param {string} actionId
+     * @memberof DotPageStore
+     */
+    private fireWorkflowAction(contentletInode: string, actionId: string): void {
+        const value = this.dotMessageService.get('Workflow-executed');
+        this.dotWorkflowActionsFireService.fireTo(contentletInode, actionId).subscribe(
+            (payload) => this.dotEventsService.notify('save-page', { payload, value }),
+            (error) => this.httpErrorManagerService.handle(error, true)
+        );
     }
 }

--- a/core-web/libs/utils-testing/src/lib/dot-workflows-actions.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/dot-workflows-actions.mock.ts
@@ -67,3 +67,21 @@ export const mockWorkflowsActions: DotCMSWorkflowAction[] = [
         actionInputs: []
     }
 ];
+
+export const mockPublishAction = {
+    assignable: false,
+    commentable: false,
+    condition: '',
+    icon: 'workflowIcon',
+    id: 'b9d89c80-3d88-4311-8365-187323c96436',
+    name: 'Publish',
+    nextAssign: '654b0931-1027-41f7-ad4d-173115ed8ec1',
+    nextStep: 'dc3c9cd0-8467-404b-bf95-cb7df3fbc293',
+    nextStepCurrentStep: false,
+    order: 0,
+    owner: null,
+    roleHierarchyForAssign: false,
+    schemeId: 'd61a59e1-a49c-46f2-a929-db2b4bfa88b2',
+    showOn: ['LOCKED'],
+    actionInputs: []
+};


### PR DESCRIPTION
### Proposed Changes
* Notifying the user when a workflow action request fails on page portlet

### Checklist
- [x] Tests
- [x] Translations

## Additional Info

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b655d2</samp>

Added error handling logic to dot-pages store when firing a workflow action to a page. Modified `dot-pages.store.ts` and `dot-pages.store.spec.ts` to implement and test the logic. Added `mockPublishAction` object to `dot-workflows-actions.mock.ts` to simulate a publish action in the test.

## Related Issue
Fixes #25096 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b655d2</samp>

*  Add error handling logic to dot-pages store when a workflow action request fails ([link](https://github.com/dotCMS/core/pull/25102/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL791-R799))
*  Add test case to dot-pages store spec file to verify error handling logic ([link](https://github.com/dotCMS/core/pull/25102/files?diff=unified&w=0#diff-b23eeff307d6d254cb33a17b3b64f937646e6f91d72778c1ac460881c0bfc980R764-R793))
*  Add `mockPublishAction` object to dot-workflows-actions mock file ([link](https://github.com/dotCMS/core/pull/25102/files?diff=unified&w=0#diff-7b3c8f4445bdd8968d4c0c89da1fa32424154d6399b4b2f388fd1461613be98bR70-R87))

### Screenshots

https://github.com/dotCMS/core/assets/72418962/11b35adb-eca9-44e0-aa93-6ca633c7f415

