### PR TITLE
Fix #25072: Add border to remove button on Add Bookmark Dialog

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-favorite-page/dot-favorite-page.component.html
@@ -87,7 +87,7 @@
     </form>
 
     <button
-        class="p-button-danger p-button-text dot-favorite-dialog-footer__delete-button"
+        class="p-button-danger p-button-outlined dot-favorite-dialog-footer__delete-button"
         [disabled]="!vm.formState?.inode"
         [label]="'favoritePage.dialog.delete.button' | dm"
         (click)="onDelete(vm.formState?.inode)"

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_button.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_button.scss
@@ -471,6 +471,9 @@
     background-color: transparent !important;
     border-color: $color-palette-gray-500;
     color: $color-palette-gray-500;
+    .pi {
+        color: $button-text-color-disabled;
+    }
 }
 
 .p-button.p-button-raised:enabled:focus {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2410d9f</samp>

### Summary
🎨🛠️♿

<!--
1.  🎨 - This emoji can be used to indicate a change in the appearance or style of something, such as a button or an icon. It conveys the idea of improving the visual design or aesthetics of the UI.
2.  🛠️ - This emoji can be used to indicate a change in the functionality or behavior of something, such as a class or a property. It conveys the idea of fixing or adjusting something that was not working as expected or needed improvement.
3.  ♿ - This emoji can be used to indicate a change that improves the accessibility or usability of something, such as a color or a contrast. It conveys the idea of making the UI more inclusive and user-friendly for people with different needs or preferences.
-->
This pull request improves the appearance and accessibility of the buttons in the favorite page dialog and other components that use the `p-button-outlined` class. It changes the class of the delete button in `dot-favorite-page.component.html` and the color of the icon in disabled buttons in `_button.scss`.

> _`p-button-outlined`_
> _A subtle change for buttons_
> _Winter's muted hues_

### Walkthrough
*  Changed the class of the delete button in the favorite page dialog to make it more consistent with the design and the other buttons ([link](https://github.com/dotCMS/core/pull/25109/files?diff=unified&w=0#diff-9022f9626cb257f27a4ff7fc695f16544c7a1d607b0999d92dd39b14858fdae6L90-R90))



### Screenshots

<img width="1512" alt="Screenshot 2023-06-01 at 1 02 19 PM" src="https://github.com/dotCMS/core/assets/63567962/61d67914-abfe-4d55-8cbb-cde07e21e611">
