### PR TITLE
issue-25080: content type item of DotFavoritePages has entry point to broken portlet

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
@@ -113,7 +113,7 @@
             {{ rowData[col.fieldName] | dotRelativeDate : true }}
         </span>
         <a
-            *ngIf="col.fieldName === 'nEntries'"
+            *ngIf="col.fieldName === 'nEntries' && rowData.variable !== 'dotFavoritePage'"
             [queryParams]="rowData.variable === 'Host' ? {} : { filter: rowData.variable }"
             [routerLink]="rowData.variable === 'Host' ? '/c/sites' : '/c/content'"
             (click)="$event.stopPropagation()"


### PR DESCRIPTION
### Proposed Changes
* Remove navigation to broken portlet

### Checklist
- [ ] Tests
- [X] Translations
- [X] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
![image](https://github.com/dotCMS/core/assets/29465918/1e3f5f73-3897-4692-ab5f-4653d923acf9)  | ![image](https://github.com/dotCMS/core/assets/29465918/7c49dc24-04dd-44d8-aeb3-ce7b0af4cc6e)

