### PR TITLE
issue-25080: content type item of DotFavoritePages has entry point to broken portlet

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
@@ -55,7 +55,7 @@
             [attr.data-testRowId]="rowData.identifier"
             [pContextMenuRow]="rowData"
             [pSelectableRow]="rowData"
-            [attr.data-testId]="rowData.variable ? 'row-' + rowData.variable : null"
+            [attr.data-testId]="rowData?.variable ? 'row-' + rowData.variable : null"
             (click)="handleRowClick(rowData)"
             (keyup.enter)="handleRowClick(rowData)"
             data-testClass="testTableRow"
@@ -118,7 +118,7 @@
             {{ rowData[col.fieldName] | dotRelativeDate : true }}
         </span>
         <a
-            *ngIf="col.fieldName === 'nEntries' && rowData.variable !== 'dotFavoritePage'"
+            *ngIf="col.fieldName === 'nEntries' && !rowData?.system"
             [queryParams]="rowData.variable === 'Host' ? {} : { filter: rowData.variable }"
             [routerLink]="rowData.variable === 'Host' ? '/c/sites' : '/c/content'"
             (click)="$event.stopPropagation()"

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
@@ -55,6 +55,7 @@
             [attr.data-testRowId]="rowData.identifier"
             [pContextMenuRow]="rowData"
             [pSelectableRow]="rowData"
+            [attr.data-testId]="'row-' + rowData.variable"
             (click)="handleRowClick(rowData)"
             (keyup.enter)="handleRowClick(rowData)"
             data-testClass="testTableRow"
@@ -101,7 +102,11 @@
 </ng-template>
 
 <ng-template #defaultRowTemplate let-rowData="rowData">
-    <td *ngFor="let col of columns" [ngStyle]="{ width: col.width, 'text-align': getAlign(col) }">
+    <td
+        *ngFor="let col of columns"
+        [ngStyle]="{ width: col.width, 'text-align': getAlign(col) }"
+        [attr.data-testId]="col.fieldName"
+    >
         <div class="listing-datatable__column-icon" *ngIf="col.icon">
             <dot-icon name="{{ col.icon(rowData) }}"></dot-icon>
             <span>{{ col.textContent || rowData[col.fieldName] }}</span>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
@@ -55,7 +55,7 @@
             [attr.data-testRowId]="rowData.identifier"
             [pContextMenuRow]="rowData"
             [pSelectableRow]="rowData"
-            [attr.data-testId]="'row-' + rowData.variable"
+            [attr.data-testId]="rowData.variable ? 'row-' + rowData.variable : null"
             (click)="handleRowClick(rowData)"
             (keyup.enter)="handleRowClick(rowData)"
             data-testClass="testTableRow"

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
@@ -113,7 +113,7 @@
             {{ rowData[col.fieldName] | dotRelativeDate : true }}
         </span>
         <a
-            *ngIf="col.fieldName === 'nEntries'"
+            *ngIf="col.fieldName === 'nEntries' && rowData.variable !== 'dotFavoritePage'"
             [queryParams]="rowData.variable === 'Host' ? {} : { filter: rowData.variable }"
             [routerLink]="rowData.variable === 'Host' ? '/c/sites' : '/c/content'"
             (click)="$event.stopPropagation()"

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.spec.ts
@@ -227,6 +227,13 @@ describe('DotListingDataTableComponent', () => {
                 field3: 'item7-value3',
                 nEntries: 'item1-value4',
                 variable: 'Banner'
+            },
+            {
+                field1: 'item7-value1',
+                field2: 'item7-value2',
+                field3: 'item7-value3',
+                nEntries: 'item1-value4',
+                variable: 'dotFavoritePage'
             }
         ];
 
@@ -562,6 +569,16 @@ describe('DotListingDataTableComponent', () => {
         hostFixture.detectChanges();
         const noResults = de.query(By.css('[data-testid="listing-datatable__empty"]'));
         expect(noResults.nativeElement.innerText).toEqual('No Results Found');
+    }));
+
+    it('should hide entries for favorite pages content type', fakeAsync(() => {
+        setRequestSpy(items);
+        hostFixture.detectChanges();
+        tick(1);
+        hostFixture.detectChanges();
+        const row = de.query(By.css('[data-testId="row-dotFavoritePage"]'));
+        const entriesColumn = row.query(By.css('[data-testId="nEntries"]'));
+        expect(entriesColumn.nativeElement.textContent).toBeFalsy();
     }));
 
     function setRequestSpy(response: any): void {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.spec.ts
@@ -111,7 +111,8 @@ describe('DotListingDataTableComponent', () => {
         field2: 'item7-value2',
         field3: 'item7-value3',
         nEntries: 'item1-value4',
-        variable: 'dotFavoritePage'
+        variable: 'dotFavoritePage',
+        system: true
     };
 
     beforeEach(() => {
@@ -571,7 +572,7 @@ describe('DotListingDataTableComponent', () => {
         expect(noResults.nativeElement.innerText).toEqual('No Results Found');
     }));
 
-    it('should hide entries for favorite pages content type', fakeAsync(() => {
+    it('should hide entries for system content types', fakeAsync(() => {
         setRequestSpy([...items, favoritePagesItem]);
         hostFixture.detectChanges();
         tick(1);

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.spec.ts
@@ -106,6 +106,13 @@ describe('DotListingDataTableComponent', () => {
     let enabledItems;
     let disabledItems;
     let coreWebService: CoreWebService;
+    const favoritePagesItem = {
+        field1: 'item7-value1',
+        field2: 'item7-value2',
+        field3: 'item7-value3',
+        nEntries: 'item1-value4',
+        variable: 'dotFavoritePage'
+    };
 
     beforeEach(() => {
         const messageServiceMock = new MockDotMessageService({
@@ -227,13 +234,6 @@ describe('DotListingDataTableComponent', () => {
                 field3: 'item7-value3',
                 nEntries: 'item1-value4',
                 variable: 'Banner'
-            },
-            {
-                field1: 'item7-value1',
-                field2: 'item7-value2',
-                field3: 'item7-value3',
-                nEntries: 'item1-value4',
-                variable: 'dotFavoritePage'
             }
         ];
 
@@ -572,7 +572,7 @@ describe('DotListingDataTableComponent', () => {
     }));
 
     it('should hide entries for favorite pages content type', fakeAsync(() => {
-        setRequestSpy(items);
+        setRequestSpy([...items, favoritePagesItem]);
         hostFixture.detectChanges();
         tick(1);
         hostFixture.detectChanges();


### PR DESCRIPTION
### Proposed Changes
* Remove navigation to broken portlet

### Checklist
- [x] Tests
- [X] Translations
- [X] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
![image](https://github.com/dotCMS/core/assets/29465918/1e3f5f73-3897-4692-ab5f-4653d923acf9)  | ![image](https://github.com/dotCMS/core/assets/29465918/7c49dc24-04dd-44d8-aeb3-ce7b0af4cc6e)

