### PR TITLE
Favorite Pages: Portlet still showing up even after being removed

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/app-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/app-routing.module.ts
@@ -138,7 +138,7 @@ const PORTLETS_IFRAME = [
         ]
     },
     {
-        canActivate: [PagesGuardService, MenuGuardService],
+        canActivate: [MenuGuardService, PagesGuardService],
         path: 'pages',
         loadChildren: () =>
             import('@portlets/dot-pages/dot-pages.module').then((m) => m.DotPagesModule)

--- a/core-web/apps/dotcms-ui/src/app/app-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/app-routing.module.ts
@@ -138,7 +138,7 @@ const PORTLETS_IFRAME = [
         ]
     },
     {
-        canActivate: [PagesGuardService],
+        canActivate: [PagesGuardService, MenuGuardService],
         path: 'pages',
         loadChildren: () =>
             import('@portlets/dot-pages/dot-pages.module').then((m) => m.DotPagesModule)


### PR DESCRIPTION
### Proposed Changes
*  Redirect users to the first portlet when their permissions are revoked.

### Checklist
- [x] Tests
- [x] Translations

## Additional Info

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bac5410</samp>

Added a guard service to the portlet iframe route to check menu access. This improves the security and usability of the pages portlet.

## Related Issue
Fixes #24986

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bac5410</samp>

*  Add `MenuGuardService` to `canActivate` array of `PORTLETS_IFRAME` route to check user access to menu portlet ([link](https://github.com/dotCMS/core/pull/25135/files?diff=unified&w=0#diff-6c7f381c5033c96909090cb6d24c4507c999ed3ccec1ec3b74958152f21a572fL141-R141))

### Screenshots


https://github.com/dotCMS/core/assets/72418962/afa6a98e-c87d-4351-b0b2-c4af6a658f72

