### PR TITLE
Goal name max length  to 255 characters

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.spec.ts
@@ -214,11 +214,11 @@ describe('DotExperimentsConfigurationGoalSelectComponent', () => {
         expect(store.setSelectedGoal).toHaveBeenCalledWith(expectedGoal);
     });
 
-    it('should disable submit button if the input name of the goal has more than MAX_INPUT_LENGTH constant', () => {
+    it('should disable submit button if the input name of the goal has more than MAX_INPUT_DESCRIPTIVE_LENGTH constant', () => {
         const invalidFormValues = {
             primary: {
                 ...DefaultGoalConfiguration.primary,
-                name: 'Really really really really really long name for a goal',
+                name: 'Really really really really really Really really really really really Really really Really really really really really Really really really really really Really really Really really really really really Really really really really really Really really Really really really really really Really really really really really Really really Really really really really really Really really really really really Really really Really really really really really Really really really really really Really really really really really long name for a goal',
                 type: GOAL_TYPES.BOUNCE_RATE
             }
         };

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.ts
@@ -27,7 +27,7 @@ import {
     GOAL_TYPES,
     Goals,
     GOALS_METADATA_MAP,
-    MAX_INPUT_LENGTH,
+    MAX_INPUT_DESCRIPTIVE_LENGTH,
     StepStatus
 } from '@dotcms/dotcms-models';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
@@ -76,7 +76,7 @@ export class DotExperimentsConfigurationGoalSelectComponent implements OnInit, O
     statusList = ComponentStatus;
     vm$: Observable<{ experimentId: string; goals: Goals; status: StepStatus }> =
         this.dotExperimentsConfigurationStore.goalsStepVm$;
-    protected readonly maxNameLength = MAX_INPUT_LENGTH;
+    protected readonly maxNameLength = MAX_INPUT_DESCRIPTIVE_LENGTH;
     private destroy$: Subject<boolean> = new Subject<boolean>();
     private BOUNCE_RATE_LABEL = this.dotMessageService.get(
         'experiments.goal.conditions.minimize.bounce.rate'

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component.ts
@@ -12,7 +12,7 @@ import { DotFieldValidationMessageModule } from '@components/_common/dot-field-v
 import { DotAutofocusModule } from '@directives/dot-autofocus/dot-autofocus.module';
 import {
     ComponentStatus,
-    MAX_INPUT_LENGTH,
+    MAX_INPUT_TITLE_LENGTH,
     StepStatus,
     TrafficProportion
 } from '@dotcms/dotcms-models';
@@ -44,17 +44,15 @@ import { DotSidebarHeaderComponent } from '@shared/dot-sidebar-header/dot-sideba
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotExperimentsConfigurationVariantsAddComponent implements OnInit {
-    protected readonly maxNameLength = MAX_INPUT_LENGTH;
     stepStatus = ComponentStatus;
-
     form: FormGroup;
-
     vm$: Observable<{
         experimentId: string;
         trafficProportion: TrafficProportion;
         status: StepStatus;
         isExperimentADraft: boolean;
     }> = this.dotExperimentsConfigurationStore.variantsStepVm$;
+    protected readonly maxNameLength = MAX_INPUT_TITLE_LENGTH;
 
     constructor(
         private readonly dotExperimentsConfigurationStore: DotExperimentsConfigurationStore

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
@@ -24,7 +24,7 @@ import {
     DEFAULT_VARIANT_NAME,
     DotPageMode,
     ExperimentSteps,
-    MAX_INPUT_LENGTH,
+    MAX_INPUT_TITLE_LENGTH,
     MAX_VARIANTS_ALLOWED,
     SIDEBAR_STATUS,
     StepStatus,
@@ -73,17 +73,14 @@ export class DotExperimentsConfigurationVariantsComponent {
     }> = this.dotExperimentsConfigurationStore.variantsStepVm$.pipe(
         tap(({ status }) => this.handleSidebar(status))
     );
-
-    protected readonly maxNameLength = MAX_INPUT_LENGTH;
     statusList = ComponentStatus;
     sidebarStatusList = SIDEBAR_STATUS;
     maxVariantsAllowed = MAX_VARIANTS_ALLOWED;
     defaultVariantName = DEFAULT_VARIANT_NAME;
     experimentStepName = ExperimentSteps.VARIANTS;
     dotPageMode = DotPageMode;
-
     @ViewChild(DotDynamicDirective, { static: true }) sidebarHost!: DotDynamicDirective;
-
+    protected readonly maxNameLength = MAX_INPUT_TITLE_LENGTH;
     private componentRef: ComponentRef<DotExperimentsConfigurationVariantsAddComponent>;
 
     constructor(

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-create/dot-experiments-create.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-experiments/dot-experiments-list/components/dot-experiments-create/dot-experiments-create.component.ts
@@ -12,7 +12,7 @@ import { SidebarModule } from 'primeng/sidebar';
 import { DotFieldValidationMessageModule } from '@components/_common/dot-field-validation-message/dot-file-validation-message.module';
 import { UiDotIconButtonModule } from '@components/_common/dot-icon-button/dot-icon-button.module';
 import { DotAutofocusModule } from '@directives/dot-autofocus/dot-autofocus.module';
-import { DotExperiment, MAX_INPUT_LENGTH } from '@dotcms/dotcms-models';
+import { DotExperiment, MAX_INPUT_TITLE_LENGTH } from '@dotcms/dotcms-models';
 import { DotMessagePipeModule } from '@pipes/dot-message/dot-message-pipe.module';
 import {
     DotExperimentsListStore,
@@ -54,7 +54,7 @@ export class DotExperimentsCreateComponent implements OnInit {
     vm$: Observable<VmCreateExperiments> = this.dotExperimentsListStore.createVm$;
 
     form: FormGroup<CreateForm>;
-    protected readonly maxNameLength = MAX_INPUT_LENGTH;
+    protected readonly maxNameLength = MAX_INPUT_TITLE_LENGTH;
 
     constructor(private readonly dotExperimentsListStore: DotExperimentsListStore) {}
 

--- a/core-web/libs/dotcms-models/src/lib/dot-experiments-constants.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-experiments-constants.ts
@@ -25,7 +25,9 @@ export enum TrafficProportionTypes {
     CUSTOM_PERCENTAGES = 'CUSTOM_PERCENTAGES'
 }
 
-export const MAX_INPUT_LENGTH = 50;
+export const MAX_INPUT_TITLE_LENGTH = 50;
+
+export const MAX_INPUT_DESCRIPTIVE_LENGTH = 255;
 
 // Keep the order of this enum is important to respect the order of the experiment listing.
 export enum DotExperimentStatusList {


### PR DESCRIPTION
### Proposed Changes
* Change constant to use MAX_INPUT_DESCRIPTIVE_LENGTH

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 175e02f</samp>

Updated the input length validation and constants for the experiments and goals components. This is to improve the user experience and the consistency with the backend constraints. Changed the `MAX_INPUT_LENGTH` constant to `MAX_INPUT_TITLE_LENGTH` and added a new constant `MAX_INPUT_DESCRIPTIVE_LENGTH` in the `dot-experiments-constants.ts` file.

## Related Issue
Fixes #24197 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 175e02f</samp>

*  Rename `MAX_INPUT_LENGTH` constant to `MAX_INPUT_TITLE_LENGTH` and add `MAX_INPUT_DESCRIPTIVE_LENGTH` constant in `dot-experiments-constants.ts` file to differentiate input lengths for title and descriptive fields ([link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-f1a1a6a6f21372c106dd50983b66d511523dd176656f6d368fe830a87a26b09cL28-R31))
* Replace import of `MAX_INPUT_LENGTH` with `MAX_INPUT_TITLE_LENGTH` in `dot-experiments-create.component.ts`, `dot-experiments-configuration-variants-add.component.ts`, and `dot-experiments-configuration-variants.component.ts` files to use the appropriate constant for the experiment and variant title fields ([link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-ecb60a2e269f8139f898a00e8494e8f5ff3d1d42732ce910fe69e7ba0637765eL15-R15), [link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-d902cf3b34e036e9d3e7990833b59126329637c68c0bf49f219055ed10c81600L15-R15), [link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-68d220bc9a497c32a6008264b602b56ab9a41fd5c34db9b0b2512c1bfcd892d3L27-R27))
* Replace import of `MAX_INPUT_LENGTH` with `MAX_INPUT_DESCRIPTIVE_LENGTH` in `dot-experiments-configuration-goal-select.component.ts` file to use the appropriate constant for the descriptive goal field ([link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-e1586d62dab99af430d2dfa25a918712538703b64f827f8ee459b2dd8289a13aL30-R30))
* Change `maxNameLength` property to use `MAX_INPUT_TITLE_LENGTH` in `DotExperimentsCreateComponent` class to set the correct validation for the experiment title input ([link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-ecb60a2e269f8139f898a00e8494e8f5ff3d1d42732ce910fe69e7ba0637765eL57-R57))
* Change `maxNameLength` property to use `MAX_INPUT_DESCRIPTIVE_LENGTH` in `DotExperimentsConfigurationGoalSelectComponent` class to set the correct validation for the descriptive goal input ([link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-e1586d62dab99af430d2dfa25a918712538703b64f827f8ee459b2dd8289a13aL79-R79))
* Remove `maxNameLength` property from `DotExperimentsConfigurationVariantsComponent` class declaration and add it after `sidebarHost` property to pass the input length to the variants add component through the sidebar host directive and to avoid linting error ([link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-68d220bc9a497c32a6008264b602b56ab9a41fd5c34db9b0b2512c1bfcd892d3L76-L77), [link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-68d220bc9a497c32a6008264b602b56ab9a41fd5c34db9b0b2512c1bfcd892d3L84-R83))
* Move `maxNameLength` property from `DotExperimentsConfigurationVariantsAddComponent` class declaration to after `form` property to avoid linting error of having a protected property before a public one ([link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-d902cf3b34e036e9d3e7990833b59126329637c68c0bf49f219055ed10c81600L47-R48), [link](https://github.com/dotCMS/core/pull/25146/files?diff=unified&w=0#diff-d902cf3b34e036e9d3e7990833b59126329637c68c0bf49f219055ed10c81600R55))