### PR TITLE
issue-25133: adding background grid guide

### DIFF
--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.html
@@ -1,3 +1,3 @@
-<div class="background-columns">
-    <div class="column" *ngFor="let _ of [].constructor(12)"></div>
+<div class="background-columns" [ngStyle]="{ gap: gridStackGap }">
+    <div class="column" *ngFor="let _ of columnList" data-testClass="column"></div>
 </div>

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.html
@@ -1,0 +1,3 @@
+<div class="background-columns">
+    <div class="column" *ngFor="let _ of [].constructor(12)"></div>
+</div>

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.scss
@@ -1,0 +1,17 @@
+@use "variables" as *;
+
+.background-columns {
+    height: 100%;
+    width: 100%;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    display: grid;
+    gap: $spacing-5;
+    left: $spacing-3;
+    padding-right: 2rem;
+    position: absolute;
+}
+
+.column {
+    height: 100%;
+    background-color: $color-palette-gray-200;
+}

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.scss
@@ -1,7 +1,7 @@
 @use "variables" as *;
 
 $offset: 3.7rem;
-$columns-padding: 3.688rem;
+$columns-padding: 3.2rem;
 
 .background-columns {
     height: 100%;

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.scss
@@ -1,6 +1,5 @@
 @use "variables" as *;
 
-$offset: 3.7rem;
 $columns-padding: 3.2rem;
 
 .background-columns {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.scss
@@ -1,12 +1,14 @@
 @use "variables" as *;
 
+$offset: 3.7rem;
+$columns-padding: 3.688rem;
+
 .background-columns {
     height: 100%;
     width: 100%;
     grid-template-columns: repeat(12, minmax(0, 1fr));
     display: grid;
-    left: 3.7rem;
-    padding-right: 7.3rem;
+    padding: 0 $columns-padding 0 $columns-padding;
     position: absolute;
 }
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.scss
@@ -5,9 +5,8 @@
     width: 100%;
     grid-template-columns: repeat(12, minmax(0, 1fr));
     display: grid;
-    gap: $spacing-5;
-    left: $spacing-3;
-    padding-right: 2rem;
+    left: 3.7rem;
+    padding-right: 7.3rem;
     position: absolute;
 }
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TemplateBuilderBackgroundColumnsComponent } from './template-builder-background-columns.component';
+
+describe('TemplateBuilderBackgroundColumnsComponent', () => {
+    let component: TemplateBuilderBackgroundColumnsComponent;
+    let fixture: ComponentFixture<TemplateBuilderBackgroundColumnsComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [TemplateBuilderBackgroundColumnsComponent]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TemplateBuilderBackgroundColumnsComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.spec.ts
@@ -1,22 +1,30 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
+
+import { NgFor, NgStyle } from '@angular/common';
+import { By } from '@angular/platform-browser';
 
 import { TemplateBuilderBackgroundColumnsComponent } from './template-builder-background-columns.component';
 
 describe('TemplateBuilderBackgroundColumnsComponent', () => {
-    let component: TemplateBuilderBackgroundColumnsComponent;
-    let fixture: ComponentFixture<TemplateBuilderBackgroundColumnsComponent>;
+    let spectator: SpectatorHost<TemplateBuilderBackgroundColumnsComponent>;
 
-    beforeEach(async () => {
-        await TestBed.configureTestingModule({
-            declarations: [TemplateBuilderBackgroundColumnsComponent]
-        }).compileComponents();
-
-        fixture = TestBed.createComponent(TemplateBuilderBackgroundColumnsComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
+    const createHost = createHostFactory({
+        component: TemplateBuilderBackgroundColumnsComponent,
+        imports: [NgFor, NgStyle]
     });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
+    beforeEach(() => {
+        spectator = createHost(
+            `<dotcms-template-builder-background-columns></dotcms-template-builder-background-columns>`
+        );
+    });
+
+    it('should create the component', () => {
+        expect(spectator.component).toBeTruthy();
+    });
+
+    it('should have 12 columns', () => {
+        const columns = spectator.debugElement.queryAll(By.css('[data-testclass="column"]'));
+        expect(columns.length).toEqual(12);
     });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+    selector: 'dotcms-template-builder-background-columns',
+    templateUrl: './template-builder-background-columns.component.html',
+    styleUrls: ['./template-builder-background-columns.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TemplateBuilderBackgroundColumnsComponent {}

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.ts
@@ -1,7 +1,7 @@
 import { NgFor, NgStyle } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
-import { GRID_STACK_MARGIN, GRID_STACK_MARGIN_UNITS } from '../../utils/gridstack-options';
+import { GRID_STACK_MARGIN, GRID_STACK_UNIT } from '../../utils/gridstack-options';
 
 @Component({
     selector: 'dotcms-template-builder-background-columns',
@@ -13,5 +13,5 @@ import { GRID_STACK_MARGIN, GRID_STACK_MARGIN_UNITS } from '../../utils/gridstac
 })
 export class TemplateBuilderBackgroundColumnsComponent {
     readonly columnList = [].constructor(12);
-    readonly gridStackGap = `${GRID_STACK_MARGIN * 2}${GRID_STACK_MARGIN_UNITS}`;
+    readonly gridStackGap = `${GRID_STACK_MARGIN * 2}${GRID_STACK_UNIT}`;
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.ts
@@ -1,9 +1,17 @@
+import { NgFor, NgStyle } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { GRID_STACK_MARGIN, GRID_STACK_MARGIN_UNITS } from '../../utils/gridstack-options';
 
 @Component({
     selector: 'dotcms-template-builder-background-columns',
     templateUrl: './template-builder-background-columns.component.html',
     styleUrls: ['./template-builder-background-columns.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    standalone: true,
+    imports: [NgFor, NgStyle]
 })
-export class TemplateBuilderBackgroundColumnsComponent {}
+export class TemplateBuilderBackgroundColumnsComponent {
+    readonly columnList = [].constructor(12);
+    readonly gridStackGap = `${GRID_STACK_MARGIN * 2}${GRID_STACK_MARGIN_UNITS}`;
+}

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -15,6 +15,7 @@
     ></dotcms-add-widget>
 </div>
 <div class="grid-stack">
+    <dotcms-template-builder-background-columns></dotcms-template-builder-background-columns>
     <dotcms-template-builder-row
         class="grid-stack-item"
         #rows
@@ -27,7 +28,6 @@
         (deleteRow)="deleteRow(row.id)"
     >
         <div class="grid-stack-item-content grid-stack">
-            <dotcms-template-builder-background-columns></dotcms-template-builder-background-columns>
             <div
                 class="grid-stack-item sub"
                 #boxes

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -15,7 +15,7 @@
     ></dotcms-add-widget>
 </div>
 <div class="grid-stack">
-    <div
+    <dotcms-template-builder-row
         class="grid-stack-item"
         #rows
         *ngFor="let row of items$ | async; trackBy: identify"
@@ -27,6 +27,7 @@
     >
         <dotcms-template-builder-row (deleteRow)="deleteRow(row.id)">
             <div class="grid-stack-item-content grid-stack">
+                <dotcms-template-builder-background-columns></dotcms-template-builder-background-columns>
                 <div
                     class="grid-stack-item sub"
                     #boxes

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -24,29 +24,28 @@
         [attr.gs-y]="row.y"
         [attr.gs-w]="row.w"
         [attr.gs-h]="row.h"
+        (deleteRow)="deleteRow(row.id)"
     >
-        <dotcms-template-builder-row (deleteRow)="deleteRow(row.id)">
-            <div class="grid-stack-item-content grid-stack">
-                <dotcms-template-builder-background-columns></dotcms-template-builder-background-columns>
-                <div
-                    class="grid-stack-item sub"
-                    #boxes
-                    *ngFor="let box of row.subGridOpts?.children; trackBy: identify"
-                    [attr.gs-id]="box.id"
-                    [attr.gs-auto]="true"
-                    [attr.gs-x]="box.x"
-                    [attr.gs-y]="box.y"
-                    [attr.gs-w]="box.w"
-                    [attr.gs-h]="box.h"
-                >
-                    <div class="grid-stack-item-content">
-                        styleClass: {{ box.styleClass?.join(' ') }}
-                        <p *ngFor="let container of box.containers">
-                            identifier: {{ container.identifier }}
-                        </p>
-                    </div>
+        <div class="grid-stack-item-content grid-stack">
+            <dotcms-template-builder-background-columns></dotcms-template-builder-background-columns>
+            <div
+                class="grid-stack-item sub"
+                #boxes
+                *ngFor="let box of row.subGridOpts?.children; trackBy: identify"
+                [attr.gs-id]="box.id"
+                [attr.gs-auto]="true"
+                [attr.gs-x]="box.x"
+                [attr.gs-y]="box.y"
+                [attr.gs-w]="box.w"
+                [attr.gs-h]="box.h"
+            >
+                <div class="grid-stack-item-content">
+                    styleClass: {{ box.styleClass?.join(' ') }}
+                    <p *ngFor="let container of box.containers">
+                        identifier: {{ container.identifier }}
+                    </p>
                 </div>
             </div>
-        </dotcms-template-builder-row>
-    </div>
+        </div>
+    </dotcms-template-builder-row>
 </div>

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -25,6 +25,7 @@
         [attr.gs-y]="row.y"
         [attr.gs-w]="row.w"
         [attr.gs-h]="row.h"
+        [ngStyle]="{ height: rowDisplayHeight }"
         (deleteRow)="deleteRow(row.id)"
     >
         <div class="grid-stack-item-content grid-stack">

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.scss
@@ -6,15 +6,6 @@
     display: block;
 }
 
-/*
-.grid-stack-item-content {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    background: repeating-linear-gradient(to right, gray, gray calc(100% / 24), white calc(100% / 24), white calc(100% / 12));
-}
-*/
-
 .background-columns-wrapper {
     padding-right: 2rem;
 }
@@ -56,21 +47,3 @@ dotcms-add-widget.ui-draggable-dragging {
     transform: rotate(-3.66deg);
     box-shadow: $md-shadow-6;
 }
-
-/*
-.background-columns {
-    height: 100%;
-    width: 100%;
-    grid-template-columns: repeat(12, minmax(0, 1fr));
-    display: grid;
-    gap: 2rem;
-    left: 1rem;
-    padding-right: 2rem;
-    position: absolute;
-}
-
-.column {
-    height: 100%;
-    background-color: $color-palette-gray-200;
-}
-*/

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.scss
@@ -6,24 +6,6 @@
     display: block;
 }
 
-.background-columns-wrapper {
-    padding-right: 2rem;
-}
-
-.background-columns {
-    background: repeating-linear-gradient(
-        -90deg,
-        transparent,
-        transparent 0.5rem,
-        #f3f3f4 0.5rem,
-        #f3f3f4 8.3333333333%
-    );
-    height: 100%;
-    width: 100%;
-    position: absolute;
-    left: 1rem;
-}
-
 .grid-stack-item.sub .grid-stack-item-content {
     background: pink;
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.scss
@@ -6,6 +6,33 @@
     display: block;
 }
 
+/*
+.grid-stack-item-content {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: repeating-linear-gradient(to right, gray, gray calc(100% / 24), white calc(100% / 24), white calc(100% / 12));
+}
+*/
+
+.background-columns-wrapper {
+    padding-right: 2rem;
+}
+
+.background-columns {
+    background: repeating-linear-gradient(
+        -90deg,
+        transparent,
+        transparent 0.5rem,
+        #f3f3f4 0.5rem,
+        #f3f3f4 8.3333333333%
+    );
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    left: 1rem;
+}
+
 .grid-stack-item.sub .grid-stack-item-content {
     background: pink;
 }
@@ -29,3 +56,21 @@ dotcms-add-widget.ui-draggable-dragging {
     transform: rotate(-3.66deg);
     box-shadow: $md-shadow-6;
 }
+
+/*
+.background-columns {
+    height: 100%;
+    width: 100%;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    display: grid;
+    gap: 2rem;
+    left: 1rem;
+    padding-right: 2rem;
+    position: absolute;
+}
+
+.column {
+    height: 100%;
+    background-color: $color-palette-gray-200;
+}
+*/

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.stories.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.stories.ts
@@ -5,6 +5,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { AddWidgetComponent } from './components/add-widget/add-widget.component';
 import { RemoveConfirmDialogComponent } from './components/remove-confirm-dialog/remove-confirm-dialog.component';
+import { TemplateBuilderBackgroundColumnsComponent } from './components/template-builder-background-columns/template-builder-background-columns.component';
 import { TemplateBuilderRowComponent } from './components/template-builder-row/template-builder-row.component';
 import { DotTemplateBuilderStore } from './store/template-builder.store';
 import { TemplateBuilderComponent } from './template-builder.component';
@@ -21,7 +22,8 @@ export default {
                 TemplateBuilderRowComponent,
                 AddWidgetComponent,
                 RemoveConfirmDialogComponent,
-                BrowserAnimationsModule
+                BrowserAnimationsModule,
+                TemplateBuilderBackgroundColumnsComponent
             ],
             providers: [DotTemplateBuilderStore]
         })

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -24,7 +24,12 @@ import { DotLayout } from '@dotcms/dotcms-models';
 import { colIcon, rowIcon } from './assets/icons';
 import { DotGridStackWidget } from './models/models';
 import { DotTemplateBuilderStore } from './store/template-builder.store';
-import { gridOptions, subGridOptions } from './utils/gridstack-options';
+import {
+    GRID_STACK_ROW_HEIGHT,
+    GRID_STACK_UNIT,
+    gridOptions,
+    subGridOptions
+} from './utils/gridstack-options';
 import { parseFromDotObjectToGridStack } from './utils/gridstack-utils';
 
 @Component({
@@ -53,6 +58,7 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
 
     public readonly rowIcon = rowIcon;
     public readonly colIcon = colIcon;
+    public readonly rowDisplayHeight = `${GRID_STACK_ROW_HEIGHT - 1}${GRID_STACK_UNIT}`; // setting a lower height to have space between rows
 
     constructor(private store: DotTemplateBuilderStore) {
         this.items$ = this.store.items$;

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/gridstack-options.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/gridstack-options.ts
@@ -2,7 +2,7 @@ import { GridStackOptions } from 'gridstack';
 
 export const WIDGET_TYPE_ATTRIBUTE = 'data-widget-type';
 
-export const GRID_STACK_MARGIN = 1;
+export const GRID_STACK_MARGIN = 0.5;
 
 export const GRID_STACK_MARGIN_UNITS = 'rem';
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/gridstack-options.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/gridstack-options.ts
@@ -4,7 +4,9 @@ export const WIDGET_TYPE_ATTRIBUTE = 'data-widget-type';
 
 export const GRID_STACK_MARGIN = 0.5;
 
-export const GRID_STACK_MARGIN_UNITS = 'rem';
+export const GRID_STACK_UNIT = 'rem';
+
+export const GRID_STACK_ROW_HEIGHT = 16.5;
 
 export enum widgetType {
     ROW = 'row',
@@ -36,7 +38,7 @@ function isARowWidget(el: Element): boolean {
 export const subGridOptions: GridStackOptions = {
     cellHeight: 224,
     column: 'auto',
-    margin: `${GRID_STACK_MARGIN}${GRID_STACK_MARGIN_UNITS}`,
+    margin: `${GRID_STACK_MARGIN}${GRID_STACK_UNIT}`,
     minRow: 1,
     maxRow: 1,
     acceptWidgets: isAColumnWidget
@@ -45,7 +47,7 @@ export const subGridOptions: GridStackOptions = {
 export const gridOptions: GridStackOptions = {
     disableResize: true,
     cellHeight: 264, // 8px more so it overflows and we can see the 8px of space between rows
-    margin: 8,
+    margin: `${GRID_STACK_ROW_HEIGHT}${GRID_STACK_UNIT}`,
     minRow: 1,
     acceptWidgets: isARowWidget,
     draggable: {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/gridstack-options.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/gridstack-options.ts
@@ -2,6 +2,10 @@ import { GridStackOptions } from 'gridstack';
 
 export const WIDGET_TYPE_ATTRIBUTE = 'data-widget-type';
 
+export const GRID_STACK_MARGIN = 1;
+
+export const GRID_STACK_MARGIN_UNITS = 'rem';
+
 export enum widgetType {
     ROW = 'row',
     COLUMN = 'col'
@@ -32,7 +36,7 @@ function isARowWidget(el: Element): boolean {
 export const subGridOptions: GridStackOptions = {
     cellHeight: 224,
     column: 'auto',
-    margin: 16,
+    margin: `${GRID_STACK_MARGIN}${GRID_STACK_MARGIN_UNITS}`,
     minRow: 1,
     maxRow: 1,
     acceptWidgets: isAColumnWidget

--- a/core-web/libs/template-builder/src/lib/template-builder.module.ts
+++ b/core-web/libs/template-builder/src/lib/template-builder.module.ts
@@ -16,7 +16,8 @@ import { TemplateBuilderComponent } from './components/template-builder/template
         RemoveConfirmDialogComponent,
         TemplateBuilderRowComponent,
         AddWidgetComponent,
-        TemplateBuilderBoxComponent
+        TemplateBuilderBoxComponent,
+        TemplateBuilderBackgroundColumnsComponent
     ],
     declarations: [TemplateBuilderComponent],
     providers: [DotTemplateBuilderStore],

--- a/core-web/libs/template-builder/src/lib/template-builder.module.ts
+++ b/core-web/libs/template-builder/src/lib/template-builder.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 
 import { AddWidgetComponent } from './components/template-builder/components/add-widget/add-widget.component';
 import { RemoveConfirmDialogComponent } from './components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component';
+import { TemplateBuilderBackgroundColumnsComponent } from './components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component';
 import { TemplateBuilderBoxComponent } from './components/template-builder/components/template-builder-box/template-builder-box.component';
 import { TemplateBuilderRowComponent } from './components/template-builder/components/template-builder-row/template-builder-row.component';
 import { DotTemplateBuilderStore } from './components/template-builder/store/template-builder.store';

--- a/core-web/libs/template-builder/src/lib/template-builder.module.ts
+++ b/core-web/libs/template-builder/src/lib/template-builder.module.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgFor } from '@angular/common';
+import { AsyncPipe, NgFor, NgStyle } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { AddWidgetComponent } from './components/template-builder/components/add-widget/add-widget.component';
@@ -17,7 +17,8 @@ import { TemplateBuilderComponent } from './components/template-builder/template
         TemplateBuilderRowComponent,
         AddWidgetComponent,
         TemplateBuilderBoxComponent,
-        TemplateBuilderBackgroundColumnsComponent
+        TemplateBuilderBackgroundColumnsComponent,
+        NgStyle
     ],
     declarations: [TemplateBuilderComponent],
     providers: [DotTemplateBuilderStore],


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f6b5be1</samp>

This pull request introduces a new component for the template builder feature, which allows users to customize the background columns of a template. It refactors the template builder component to use this new component and updates the styles and stories accordingly. It also adds a basic test for the new component. The affected files are `template-builder.component.html`, `template-builder.component.scss`, `template-builder.component.stories.ts`, `template-builder.module.ts`, and the files in the `template-builder-background-columns` folder.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
<img width="1471" alt="image" src="https://github.com/dotCMS/core/assets/29465918/4652cb74-47e5-4fef-af20-5cfc3fc1fa84">  |  <img width="1460" alt="image" src="https://github.com/dotCMS/core/assets/29465918/390d6d92-b035-426b-aead-97ddc39b199c">

