### PR TITLE
Fix #25143: Favorite Pages fix broken LocalStorage collapsed state 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.scss
@@ -41,8 +41,6 @@
 
     dot-pages-card,
     dot-pages-card-empty {
-        min-height: 250px;
-
         p-card {
             cursor: pointer;
         }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -404,7 +404,7 @@ describe('DotPageStore', () => {
             expect(data.favoritePages.items).toEqual(expectedInputArray);
             expect(data.favoritePages.showLoadMoreButton).toEqual(true);
             expect(data.favoritePages.total).toEqual(expectedInputArray.length);
-            expect(data.favoritePages.collapsed).toEqual(undefined);
+            expect(data.favoritePages.collapsed).toEqual(true);
         });
         expect(dotFavoritePageService.get).toHaveBeenCalledTimes(1);
     });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -334,6 +334,11 @@ describe('DotPageStore', () => {
     it('should have favorites collapsed state setted when requesting favorite pages', () => {
         dotPageStore.getFavoritePages(5); // Here it sets the favorite state again
 
+        // Should retrieve the value from local storage when setting the state
+        expect(dotLocalstorageService.getItem).toHaveBeenCalledWith(
+            LOCAL_STORAGE_FAVORITES_PANEL_KEY
+        );
+
         dotPageStore.state$.subscribe((data) => {
             expect(data.favoritePages.collapsed).toEqual(true);
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -101,7 +101,7 @@ export class DialogServiceMock {
     }
 }
 
-describe('DotPageStore', () => {
+fdescribe('DotPageStore', () => {
     let dotPageStore: DotPageStore;
     let dialogService: DialogService;
     let dotESContentService: DotESContentService;
@@ -329,6 +329,14 @@ describe('DotPageStore', () => {
             LOCAL_STORAGE_FAVORITES_PANEL_KEY,
             'true'
         );
+    });
+
+    fit('should have favorites collapsed state set to true when requesting favorite pages', () => {
+        dotPageStore.getFavoritePages(5); // Here it sets the favorite state again
+
+        dotPageStore.state$.subscribe((data) => {
+            expect(data.favoritePages.collapsed).toEqual(true);
+        });
     });
 
     it('should update Pages Status', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -101,7 +101,7 @@ export class DialogServiceMock {
     }
 }
 
-fdescribe('DotPageStore', () => {
+describe('DotPageStore', () => {
     let dotPageStore: DotPageStore;
     let dialogService: DialogService;
     let dotESContentService: DotESContentService;
@@ -331,7 +331,7 @@ fdescribe('DotPageStore', () => {
         );
     });
 
-    fit('should have favorites collapsed state set to true when requesting favorite pages', () => {
+    it('should have favorites collapsed state set to true when requesting favorite pages', () => {
         dotPageStore.getFavoritePages(5); // Here it sets the favorite state again
 
         dotPageStore.state$.subscribe((data) => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -331,7 +331,7 @@ describe('DotPageStore', () => {
         );
     });
 
-    it('should have favorites collapsed state set to true when requesting favorite pages', () => {
+    it('should have favorites collapsed state setted when requesting favorite pages', () => {
         dotPageStore.getFavoritePages(5); // Here it sets the favorite state again
 
         dotPageStore.state$.subscribe((data) => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -697,7 +697,7 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
 
     private getLocalStorageFavoritePanelParams(): Observable<boolean> {
         const collapsed =
-            JSON.parse(this.dotLocalstorageService.getItem(LOCAL_STORAGE_FAVORITES_PANEL_KEY)) ||
+            JSON.parse(this.dotLocalstorageService.getItem(LOCAL_STORAGE_FAVORITES_PANEL_KEY)) ??
             true;
 
         return of(collapsed);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -831,9 +831,10 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
             items: [...items.jsonObjectView.contentlets],
             showLoadMoreButton: items.jsonObjectView.contentlets.length <= items.resultsSize,
             total: items.resultsSize,
-            collapsed: JSON.parse(
-                this.dotLocalstorageService.getItem(LOCAL_STORAGE_FAVORITES_PANEL_KEY)
-            )
+            collapsed:
+                JSON.parse(
+                    this.dotLocalstorageService.getItem(LOCAL_STORAGE_FAVORITES_PANEL_KEY)
+                ) ?? true
         };
     }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.ts
@@ -696,9 +696,9 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
     }
 
     private getLocalStorageFavoritePanelParams(): Observable<boolean> {
-        const collapsed = JSON.parse(
-            this.dotLocalstorageService.getItem(LOCAL_STORAGE_FAVORITES_PANEL_KEY)
-        );
+        const collapsed =
+            JSON.parse(this.dotLocalstorageService.getItem(LOCAL_STORAGE_FAVORITES_PANEL_KEY)) ||
+            true;
 
         return of(collapsed);
     }
@@ -826,11 +826,14 @@ export class DotPageStore extends ComponentStore<DotPagesState> {
         return actionsMenu;
     }
 
-    private getNewFavoritePages(items: ESContent) {
+    private getNewFavoritePages(items: ESContent): DotFavoritePagesInfo {
         return {
             items: [...items.jsonObjectView.contentlets],
             showLoadMoreButton: items.jsonObjectView.contentlets.length <= items.resultsSize,
-            total: items.resultsSize
+            total: items.resultsSize,
+            collapsed: JSON.parse(
+                this.dotLocalstorageService.getItem(LOCAL_STORAGE_FAVORITES_PANEL_KEY)
+            )
         };
     }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d4dd71f</samp>

### Summary
🌟🗂️🛠️

<!--
1.  🌟 - This emoji represents the addition of a feature related to favorite pages, which are marked with a star icon in the dotCMS UI. It also conveys a positive and enthusiastic tone for the new functionality.
2.  🗂️ - This emoji represents the collapsible panel that can be used to organize and access the favorite pages. It also suggests a sense of tidiness and efficiency for the UI enhancement.
3.  🛠️ - This emoji represents the minor fixes and improvements that were made to the typos and the test file. It also implies a sense of maintenance and quality assurance for the code.
-->
This pull request adds a collapsible panel for favorite pages in the dotCMS UI and tests its functionality. It modifies the `dot-pages.store.ts` and `dot-pages.store.spec.ts` files to implement and verify this feature.

> _`Collapsed` by default, the panel of doom_
> _Hiding your favorite pages in the gloom_
> _But you can expand it with a click_
> _And save your preference with `getNewFavoritePages` trick_

### Walkthrough
*  Add a collapsible panel for favorite pages in the dotCMS UI
  - Initialize the `collapsed` variable with a fallback value of `true` to ensure the panel is collapsed by default ([link](https://github.com/dotCMS/core/pull/25158/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL699-R701))
  - Include the `collapsed` property in the `getNewFavoritePages` method to update the state of the panel ([link](https://github.com/dotCMS/core/pull/25158/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL829-R837))
  - Add a test case to verify that the panel is collapsed by default when requesting favorite pages ([link](https://github.com/dotCMS/core/pull/25158/files?diff=unified&w=0#diff-b23eeff307d6d254cb33a17b3b64f937646e6f91d72778c1ac460881c0bfc980R334-R341))
* Remove the `fdescribe` and `fit` keywords from the `dot-pages.store.spec.ts` file to avoid excluding other tests from running ([link](https://github.com/dotCMS/core/pull/25158/files?diff=unified&w=0#diff-b23eeff307d6d254cb33a17b3b64f937646e6f91d72778c1ac460881c0bfc980L104-R104))



### Screenshots


https://github.com/dotCMS/core/assets/63567962/53484f14-545a-4646-8fac-cf3168c31ea7


