### PR TITLE
Sort Template Builder Stories

### DIFF
--- a/core-web/libs/template-builder/.storybook/preview.ts
+++ b/core-web/libs/template-builder/.storybook/preview.ts
@@ -1,0 +1,7 @@
+export const parameters = {
+    options: {
+        storySort: {
+            order: ['Template Builder', 'Components']
+        }
+    }
+};

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-widget/add-widget.component.stories.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-widget/add-widget.component.stories.ts
@@ -2,10 +2,10 @@ import { moduleMetadata, Story, Meta } from '@storybook/angular';
 
 import { AddWidgetComponent } from './add-widget.component';
 
-import { rowIcon } from '../../assets/icons';
+import { rowIcon, colIcon } from '../../assets/icons';
 
 export default {
-    title: 'AddWidgetComponent',
+    title: 'Components/Add',
     component: AddWidgetComponent,
     decorators: [
         moduleMetadata({
@@ -18,16 +18,23 @@ const Template: Story<AddWidgetComponent> = (args: AddWidgetComponent) => ({
     props: args
 });
 
-export const Primary = Template.bind({});
+export const AddRow = Template.bind({});
+
+export const AddBox = Template.bind({});
 
 export const MaterialIcon = Template.bind({});
 
-Primary.args = {
+AddRow.args = {
     label: 'Add Row',
     icon: rowIcon
 };
 
-MaterialIcon.args = {
+AddBox.args = {
     label: 'Add Box',
+    icon: colIcon
+};
+
+MaterialIcon.args = {
+    label: 'Fallback Material Icon',
     icon: 'add'
 };

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.stories.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.stories.ts
@@ -7,7 +7,7 @@ import { ScrollPanelModule } from 'primeng/scrollpanel';
 import { TemplateBuilderBoxComponent } from './template-builder-box.component';
 
 export default {
-    title: 'TemplateBuilderBoxComponent',
+    title: 'Components/Box',
     component: TemplateBuilderBoxComponent,
     decorators: [
         moduleMetadata({

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-row/template-builder-row.component.stories.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-row/template-builder-row.component.stories.ts
@@ -7,7 +7,7 @@ import { DotIconModule } from '@dotcms/ui';
 import { TemplateBuilderRowComponent } from './template-builder-row.component';
 
 export default {
-    title: 'TemplateBuilderRowComponent',
+    title: 'Components/Row',
     component: TemplateBuilderRowComponent,
     decorators: [
         moduleMetadata({

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.stories.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.stories.ts
@@ -12,7 +12,7 @@ import { TemplateBuilderComponent } from './template-builder.component';
 import { FULL_DATA_MOCK } from './utils/mocks';
 
 export default {
-    title: 'TemplateBuilderComponent',
+    title: 'Template Builder',
     component: TemplateBuilderComponent,
     decorators: [
         moduleMetadata({
@@ -34,8 +34,8 @@ const Template: Story<TemplateBuilderComponent> = (args: TemplateBuilderComponen
     props: args
 });
 
-export const Primary = Template.bind({});
+export const Base = Template.bind({});
 
-Primary.args = {
+Base.args = {
     templateLayout: { body: FULL_DATA_MOCK }
 };


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1754990</samp>

### Summary
🎨📚🔧

<!--
1.  🎨 - This emoji is often used to indicate changes related to UI, design, or styling. It could represent the change that adds a global parameter to sort the stories by a custom order, as this affects the appearance and organization of the Storybook documentation.
2.  📚 - This emoji is often used to indicate changes related to documentation, examples, or tutorials. It could represent the change that improves the AddWidgetComponent storybook by adding more examples, using a consistent title format, and importing an asset icon, as this enhances the quality and clarity of the Storybook documentation.
3.  🔧 - This emoji is often used to indicate changes related to configuration, settings, or tools. It could represent the change that updates the titles of the TemplateBuilderBoxComponent and TemplateBuilderRowComponent stories to use a nested format under the Components category, as this affects the structure and hierarchy of the Storybook documentation.
-->
This pull request enhances the Storybook documentation for the template-builder library. It improves the titles, categories, and examples of the component stories, and adds a custom sorting parameter to the storybook configuration. It affects the files `add-widget.component.stories.ts`, `template-builder.component.stories.ts`, `preview.ts`, `template-builder-box.component.stories.ts`, and `template-builder-row.component.stories.ts`.

> _`Storybook` changes_
> _Sorting, nesting, improving_
> _Spring cleaning for code_

### Walkthrough
* Sort the stories by a custom order with the Template Builder story first and then the Components stories ([link](https://github.com/dotCMS/core/pull/25161/files?diff=unified&w=0#diff-c58b64184e38c9c036912a516af4ca37296e59b7eec15d86cda21a1f8a838f2dR1-R7))
* Update the titles of the component stories to use a nested format under the Components category ([link](https://github.com/dotCMS/core/pull/25161/files?diff=unified&w=0#diff-79fc6433ca278d614ffc6267c0a3bab60e8aa4cdcc0dfe2f1896f70569e10c8fL5-R8), [link](https://github.com/dotCMS/core/pull/25161/files?diff=unified&w=0#diff-3ea0f232829f5fc8214af73d0eef417cc84b65f1dfd078f45d4fafefb089850aL10-R10), [link](https://github.com/dotCMS/core/pull/25161/files?diff=unified&w=0#diff-9dd8a2c2034ab5cc594050ef841b1ad60d2845fb183d6cb0a6bd82cf52ae3592L10-R10))
* Update the title of the `template-builder.component.stories.ts` file to use the Template Builder category ([link](https://github.com/dotCMS/core/pull/25161/files?diff=unified&w=0#diff-cbdb877fac9228e73e54cf3af3465499a71c93f2c594f45769081d65d2881653L15-R15))
* Add two more variants of the `add-widget.component.stories.ts` file, one for adding a box with the colIcon, and one for showing a fallback material icon ([link](https://github.com/dotCMS/core/pull/25161/files?diff=unified&w=0#diff-79fc6433ca278d614ffc6267c0a3bab60e8aa4cdcc0dfe2f1896f70569e10c8fL21-R38))
* Rename the existing variants of the `add-widget.component.stories.ts` and `template-builder.component.stories.ts` files to be more descriptive ([link](https://github.com/dotCMS/core/pull/25161/files?diff=unified&w=0#diff-79fc6433ca278d614ffc6267c0a3bab60e8aa4cdcc0dfe2f1896f70569e10c8fL21-R38), [link](https://github.com/dotCMS/core/pull/25161/files?diff=unified&w=0#diff-cbdb877fac9228e73e54cf3af3465499a71c93f2c594f45769081d65d2881653L37-R39))
* Import the colIcon from the assets module in the `add-widget.component.stories.ts` file ([link](https://github.com/dotCMS/core/pull/25161/files?diff=unified&w=0#diff-79fc6433ca278d614ffc6267c0a3bab60e8aa4cdcc0dfe2f1896f70569e10c8fL5-R8))



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
<img width="222" alt="image" src="https://github.com/dotCMS/core/assets/751424/2e96681f-2544-4a30-95d4-e0e578d8396d">  |  <img width="223" alt="image" src="https://github.com/dotCMS/core/assets/751424/d84c2779-6f1c-4806-b5ed-7d404995f67b">
