### PR TITLE
Invalidate Cache for Reindex

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -101,7 +101,7 @@ export class DialogServiceMock {
     }
 }
 
-describe('DotPageStore', () => {
+fdescribe('DotPageStore', () => {
     let dotPageStore: DotPageStore;
     let dialogService: DialogService;
     let dotESContentService: DotESContentService;
@@ -503,80 +503,8 @@ describe('DotPageStore', () => {
         expect(dotHttpErrorManagerService.handle).toHaveBeenCalledWith(error500, true);
     });
 
-    it('should keep fetching Pages data until new value comes from the DB in store', fakeAsync(() => {
-        dotPageStore.setPages({ items: favoritePagesInitialTestData });
-        const old = {
-            contentTook: 0,
-            jsonObjectView: {
-                contentlets: favoritePagesInitialTestData as unknown as DotCMSContentlet[]
-            },
-            queryTook: 1,
-            resultsSize: 2
-        };
-
-        const updated = {
-            contentTook: 0,
-            jsonObjectView: {
-                contentlets: [
-                    { ...favoritePagesInitialTestData[0], modDate: '2020-09-02 16:50:15.569' },
-                    { ...favoritePagesInitialTestData[1] }
-                ] as unknown as DotCMSContentlet[]
-            },
-            queryTook: 1,
-            resultsSize: 4
-        };
-
-        const mockFunction = (times) => {
-            let count = 1;
-
-            return Observable.create((observer) => {
-                if (count++ > times) {
-                    observer.next(updated);
-                } else {
-                    observer.next(old);
-                }
-            });
-        };
-
-        spyOn(dotESContentService, 'get').and.returnValue(mockFunction(3));
-        spyOn(dotPageStore, 'setPagesStatus').and.callThrough();
-
-        dotPageStore.updateSinglePageData({ identifier: '123', isFavoritePage: false });
-
-        tick(3000);
-
-        // dotESContentService.get only is called 1 time, but "retryWhen" operator makes several request to the SpyOn
-        expect(dotESContentService.get).toHaveBeenCalledTimes(1);
-
-        // Testing to setPagesStatus to LOADING on the first fetch
-        expect((dotPageStore.setPagesStatus as jasmine.Spy).calls.argsFor(0).toString()).toBe(
-            ComponentStatus.LOADING
-        );
-
-        // Testing to pages.status to be LOADED on the last fetch (there can only be 2 calls during the whole process)
-        dotPageStore.state$.subscribe((data) => {
-            expect(data.pages.status).toBe(ComponentStatus.LOADED);
-        });
-
-        // Since dotESContentService.get can only be called 1 time (and once called the data will be changed on "mockFunction"),
-        // we test that the last fetch contains the updated data
-        (dotESContentService.get as jasmine.Spy).calls
-            .mostRecent()
-            .returnValue.subscribe((data) => {
-                expect(data).toEqual(updated);
-            });
-    }));
-
     it('should remove page archived from pages collection and add undefined at the bottom', fakeAsync(() => {
         dotPageStore.setPages({ items: favoritePagesInitialTestData });
-        const old = {
-            contentTook: 0,
-            jsonObjectView: {
-                contentlets: favoritePagesInitialTestData as unknown as DotCMSContentlet[]
-            },
-            queryTook: 1,
-            resultsSize: 2
-        };
 
         const updated = {
             contentTook: 0,
@@ -587,19 +515,7 @@ describe('DotPageStore', () => {
             resultsSize: 4
         };
 
-        const mockFunction = (times) => {
-            let count = 1;
-
-            return Observable.create((observer) => {
-                if (count++ > times) {
-                    observer.next(updated);
-                } else {
-                    observer.next(old);
-                }
-            });
-        };
-
-        spyOn(dotESContentService, 'get').and.returnValue(mockFunction(3));
+        spyOn(dotESContentService, 'get').and.returnValue(of(updated));
 
         dotPageStore.updateSinglePageData({ identifier: '123', isFavoritePage: false });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-store/dot-pages.store.spec.ts
@@ -101,7 +101,7 @@ export class DialogServiceMock {
     }
 }
 
-fdescribe('DotPageStore', () => {
+describe('DotPageStore', () => {
     let dotPageStore: DotPageStore;
     let dialogService: DialogService;
     let dotESContentService: DotESContentService;


### PR DESCRIPTION
### Proposed Changes
* Avoid doing multiple requests when `unpublishing` a page from the page list on the page portlet.

### Checklist
- [x] Tests
- [x] Translations

## Additional Info

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bdc69dc</samp>

This pull request enhances the dot-pages store by using web sockets for live reload and refactoring the code to get page data. It affects the file `dot-pages.store.ts`.

## Related Issue
Fixes #25076

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bdc69dc</samp>

*  Replace polling with web sockets to get the latest page data from the server ([link](https://github.com/dotCMS/core/pull/25165/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL403-R422))
*  Simplify the logic to get the local page data from the store and avoid redundant loading ([link](https://github.com/dotCMS/core/pull/25165/files?diff=unified&w=0#diff-1145b6e61f8f24833b827ae5f3fe939586964551b15aab913ba530cd44808f0eL383-R386))

### Screenshots

**BEFORE**

https://github.com/dotCMS/core/assets/72418962/7973d45d-e3eb-4441-acc9-1dd1ee45be3f


**After**



https://github.com/dotCMS/core/assets/72418962/0b0aa34d-afb6-48a4-a60d-cf64e778d585



