### PR TITLE
Fix #25134: Small CSS Fix on Bookmarks Panel

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.scss
@@ -33,6 +33,7 @@
         position: relative;
         padding-left: $spacing-3;
         padding-right: $spacing-3;
+        padding-bottom: $spacing-4;
     }
 
     .dot-pages-panel__empty-state .p-toggleable-content .p-panel-content {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3cda5b4</samp>

### Summary
🌟📃📏

<!--
1.  🌟 - This emoji can represent the concept of favorites, as it is often used to indicate something that is liked or rated highly. It can also suggest a positive or rewarding outcome, as stars are often associated with achievements or rewards. This emoji could be used to summarize the feature or functionality of the dot-pages-favorite-panel component.
2. 📃 - This emoji can represent the concept of pages, as it resembles a sheet of paper with text or writing on it. It can also suggest a document, report, or file, which are common types of pages that users might want to mark as favorites. This emoji could be used to summarize the content or data of the dot-pages-favorite-panel component.
3. 📏 - This emoji can represent the concept of padding, as it resembles a ruler or a measuring tool. It can also suggest a dimension, size, or layout, which are related to the padding-bottom property that was added to the selector. This emoji could be used to summarize the style or appearance of the dot-pages-favorite-panel component.
-->
Added padding to the list of favorite pages in the dot-pages-favorite-panel component. This improves the layout and usability of the component, which shows the user's favorite pages in a panel.

> _`padding-bottom` adds_
> _space for favorite pages_
> _autumn leaves more room_

### Walkthrough
*  Added padding-bottom to the list of favorite pages to increase the spacing from the bottom of the panel ([link](https://github.com/dotCMS/core/pull/25167/files?diff=unified&w=0#diff-5d011539a476529c01c1795362899128c13e5df5baedca383234d50586624bd2R36)). This improves the layout and usability of the `dot-pages-favorite-panel` component, which displays a list of pages that the user has marked as favorites in the `dot-pages` portlet.



### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
<img width="1394" alt="Screenshot 2023-06-07 at 10 46 14 AM" src="https://github.com/dotCMS/core/assets/63567962/eaa73e9a-b1d8-44fa-87fd-f185a1e7c390">  |  <img width="1422" alt="Screenshot 2023-06-07 at 10 45 51 AM" src="https://github.com/dotCMS/core/assets/63567962/e1a901e2-24b3-4731-9817-94d04b11dc93">

