### PR TITLE
#25031 Avoid running experiments job when no license

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -136,16 +137,16 @@ public class StartEndScheduledExperimentsJobTest extends IntegrationTestBase {
         runNoLicense(()-> {
             final ExperimentsAPI experimentsAPI1 = mock(ExperimentsAPI.class);
 
-            try {
+            try {ñ
                 new StartEndScheduledExperimentsJob(experimentsAPI1).run(null);
             } catch (JobExecutionException e) {
                 throw new RuntimeException(e);
             }
 
-            verify(experimentsAPI1, times(0)).startScheduledToStartExperiments(
+            verify(experimentsAPI1, never()).startScheduledToStartExperiments(
                     APILocator.systemUser());
 
-            verify(experimentsAPI1, times(0)).endFinalizedExperiments(APILocator.systemUser());
+            verify(experimentsAPI1, never()).endFinalizedExperiments(APILocator.systemUser());
         });
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
@@ -9,6 +9,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.LicenseTestUtil;
@@ -41,6 +44,7 @@ import org.junit.Test;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
 import org.quartz.SchedulerException;
 
 
@@ -118,5 +122,30 @@ public class StartEndScheduledExperimentsJobTest extends IntegrationTestBase {
             }
 
         }
+    }
+
+
+    /**
+     * Method to test: StartEndScheduledExperimentsJobTest.run
+     * Given scenario: No license
+     * Expected result: Should not call the api methods
+     */
+    @Test
+    public void testJob_noLicense() throws Exception {
+
+        runNoLicense(()-> {
+            final ExperimentsAPI experimentsAPI1 = mock(ExperimentsAPI.class);
+
+            try {
+                new StartEndScheduledExperimentsJob(experimentsAPI1).run(null);
+            } catch (JobExecutionException e) {
+                throw new RuntimeException(e);
+            }
+
+            verify(experimentsAPI1, times(0)).startScheduledToStartExperiments(
+                    APILocator.systemUser());
+
+            verify(experimentsAPI1, times(0)).endFinalizedExperiments(APILocator.systemUser());
+        });
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJob.java
@@ -1,8 +1,12 @@
 package com.dotmarketing.quartz.job;
 
 import com.dotcms.business.WrapInTransaction;
+import com.dotcms.enterprise.LicenseUtil;
+import com.dotcms.enterprise.license.LicenseLevel;
+import com.dotcms.experiments.business.ExperimentsAPI;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.quartz.DotStatefulJob;
+import com.google.common.annotations.VisibleForTesting;
 import io.vavr.control.Try;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -12,16 +16,28 @@ import org.quartz.JobExecutionException;
  */
 public class StartEndScheduledExperimentsJob extends DotStatefulJob {
 
+    final ExperimentsAPI experimentsAPI;
+    public StartEndScheduledExperimentsJob() {
+        this(APILocator.getExperimentsAPI());
+    }
+
+    @VisibleForTesting
+    public StartEndScheduledExperimentsJob(final ExperimentsAPI experimentsAPI) {
+        this.experimentsAPI = experimentsAPI;
+    }
+
     @Override
     @WrapInTransaction
     public void run(final JobExecutionContext jobContext)
             throws JobExecutionException {
 
-        Try.run(()->APILocator.getExperimentsAPI().startScheduledToStartExperiments(APILocator.systemUser()))
-                .getOrElseThrow((e)->new JobExecutionException(e));
+        if (LicenseUtil.getLevel() >= LicenseLevel.STANDARD.level) {
+            Try.run(() -> experimentsAPI.startScheduledToStartExperiments(APILocator.systemUser()))
+                    .getOrElseThrow((e) -> new JobExecutionException(e));
 
-        Try.run(()->APILocator.getExperimentsAPI().endFinalizedExperiments(APILocator.systemUser()))
-                .getOrElseThrow((e)->new JobExecutionException(e));
+            Try.run(() -> experimentsAPI.endFinalizedExperiments(APILocator.systemUser()))
+                    .getOrElseThrow((e) -> new JobExecutionException(e));
+        }
     }
 
 }


### PR DESCRIPTION
Avoids running the StartEndExperiments job when no license. 
Added integration test. 