### PR TITLE
#25044 fix to pp archved multi language content

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
@@ -137,7 +137,7 @@ public class StartEndScheduledExperimentsJobTest extends IntegrationTestBase {
         runNoLicense(()-> {
             final ExperimentsAPI experimentsAPI1 = mock(ExperimentsAPI.class);
 
-            try {ñ
+            try {
                 new StartEndScheduledExperimentsJob(experimentsAPI1).run(null);
             } catch (JobExecutionException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b0b7e3</samp>

*  Add a condition to check if the content exists in the receiver before archiving it in `handleContents` method in `ContentHandler` class, and save it first if not, to avoid losing the content data ([link](https://github.com/dotCMS/core/pull/25180/files?diff=unified&w=0#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL334-R358))
*  Add the code that checks if the content has been pushed as archived to the receiver using the `pushedIdsToIgnore` set of  content id/language pairs in `handleContents` method in `ContentHandler` class, and skip the content if true ([link](https://github.com/dotCMS/core/pull/25180/files?diff=unified&w=0#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beR401-R410))
*  Modify the logic of the `unpublish` method in `ContentHandler` class to check if the content is live before unpublishing it, and to find the existing content version info based on the `existingContentMap` map if there are unique fields that cause the pushed content being mapped to an existing content with a different identifier ([link](https://github.com/dotCMS/core/pull/25180/files?diff=unified&w=0#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL1136-R1201))

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
Using a content identifier/language pair for the `pushedIdsToIgnore` set, fixes the problem when there are multiple language versions for the content being pushed, and one of the versions is archived. Before the fix, the publishing of live versions was skipped by the `handleContents` method.