### PR TITLE
#25212 We need to make sure that the Cache for DEFAULT Variant is cle…

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -834,6 +834,11 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
             updateHTMLPageVersionTS(pageId, variantId);
             refreshPageInCache(pageId,variantId );
         }
+
+        if (!variants.contains(VariantAPI.DEFAULT_VARIANT.name())) {
+            updateHTMLPageVersionTS(pageId, VariantAPI.DEFAULT_VARIANT.name());
+            refreshPageInCache(pageId, VariantAPI.DEFAULT_VARIANT.name() );
+        }
     }
 
     @Override


### PR DESCRIPTION
### Proposed Changes
* We need to make that the cache for DEFAULT Variant is clean all the time so if it was not clean here

https://github.com/dotCMS/core/blob/74088e7414c6998487014d84ff16b7fdfff8aba8/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java#L833

we force to clean it up here:

https://github.com/dotCMS/core/pull/25215/files#diff-926e9e9e22e2c282fa305bbe50022e93d9d91d6b83a5c33c8e29cacde4a0b52cR838

We need to create a new issue to make sure that we are cleanning this cache on the right way for the different Variants, but for now is good enougth to make sure that we clean the cache for DEFAULT Variant all the time.