### PR TITLE
 #25216: adding force reset access token and timeouts to fetch tokens and analytics keys

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/quartz/job/AccessTokenRenewJobTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/quartz/job/AccessTokenRenewJobTest.java
@@ -8,6 +8,7 @@ import com.dotcms.analytics.app.AnalyticsApp;
 import com.dotcms.analytics.cache.AnalyticsCache;
 import com.dotcms.analytics.helper.AnalyticsHelper;
 import com.dotcms.analytics.model.AccessToken;
+import com.dotcms.analytics.model.AccessTokenFetchMode;
 import com.dotcms.analytics.model.TokenStatus;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.util.IntegrationTestInitService;
@@ -112,7 +113,11 @@ public class AccessTokenRenewJobTest extends IntegrationTestBase {
         analyticsAPI.resetAccessToken(analyticsApp);
 
         final Instant issueDate = Instant.now().minusSeconds(ANALYTICS_ACCESS_TOKEN_TTL);
-        AccessToken accessToken = analyticsAPI.getAccessToken(analyticsApp, true).withIssueDate(issueDate);
+        AccessToken accessToken = analyticsAPI
+            .getAccessToken(
+                analyticsApp,
+                AccessTokenFetchMode.FORCE_RENEW)
+            .withIssueDate(issueDate);
         analyticsCache.putAccessToken(accessToken);
 
         accessTokenRenewJob.execute(getJobContext());
@@ -125,7 +130,7 @@ public class AccessTokenRenewJobTest extends IntegrationTestBase {
 
     /**
      * Given an {@link AnalyticsApp}
-     * Then try to renew the about to expire {@link AccessToken} associated with it
+     * Then try to renew soon to be expired {@link AccessToken} associated with it
      * And verify it is created
      */
     @Test
@@ -133,7 +138,11 @@ public class AccessTokenRenewJobTest extends IntegrationTestBase {
         analyticsAPI.resetAccessToken(analyticsApp);
 
         final Instant issueDate = Instant.now().minusSeconds(ANALYTICS_ACCESS_TOKEN_TTL).plusSeconds(30);
-        AccessToken accessToken = analyticsAPI.getAccessToken(analyticsApp, true).withIssueDate(issueDate);
+        AccessToken accessToken = analyticsAPI
+            .getAccessToken(
+                analyticsApp,
+                AccessTokenFetchMode.FORCE_RENEW)
+            .withIssueDate(issueDate);
         analyticsCache.putAccessToken(accessToken);
 
         accessTokenRenewJob.execute(getJobContext());
@@ -190,7 +199,7 @@ public class AccessTokenRenewJobTest extends IntegrationTestBase {
     @Test
     public void test_accessTokenRenew_whenOk() throws Exception {
         analyticsAPI.resetAccessToken(analyticsApp);
-        analyticsAPI.getAccessToken(analyticsApp, true);
+        analyticsAPI.getAccessToken(analyticsApp, AccessTokenFetchMode.FORCE_RENEW);
 
         accessTokenRenewJob.execute(getJobContext());
         Thread.sleep(2000);

--- a/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPI.java
@@ -2,12 +2,12 @@ package com.dotcms.analytics;
 
 import com.dotcms.analytics.app.AnalyticsApp;
 import com.dotcms.analytics.model.AccessToken;
+import com.dotcms.analytics.model.AccessTokenFetchMode;
 import com.dotcms.exception.AnalyticsException;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.util.Config;
 
 import java.util.concurrent.TimeUnit;
-
 
 /**
  * Analytics functionality interface.
@@ -30,11 +30,13 @@ public interface AnalyticsAPI {
 
     String ANALYTICS_ACCESS_TOKEN_RENEW_ATTEMPTS_KEY = "analytics.accesstoken.renewattempts";
     int ANALYTICS_ACCESS_TOKEN_RENEW_ATTEMPTS = Config.getIntProperty(ANALYTICS_ACCESS_TOKEN_RENEW_ATTEMPTS_KEY, 3);
-    int ANALYTICS_ACCESS_TOKEN_RENEW_TIMEOUT = 1000;
+    String ANALYTICS_ACCESS_TOKEN_RENEW_TIMEOUT_KEY = "analytics.accesstoken.renewtimeout";
+    int ANALYTICS_ACCESS_TOKEN_RENEW_TIMEOUT = Config.getIntProperty(ANALYTICS_ACCESS_TOKEN_RENEW_TIMEOUT_KEY, 4000);
 
     String ANALYTICS_KEY_RENEW_ATTEMPTS_KEY = "analytics.key.renewattempts";
     int ANALYTICS_KEY_RENEW_ATTEMPTS = Config.getIntProperty(ANALYTICS_KEY_RENEW_ATTEMPTS_KEY, 3);
-    int ANALYTICS_KEY_RENEW_TIMEOUT = 1000;
+    String ANALYTICS_KEY_RENEW_TIMEOUT_KEY = "analytics.key.renewtimeout";
+    int ANALYTICS_KEY_RENEW_TIMEOUT = Config.getIntProperty(ANALYTICS_KEY_RENEW_TIMEOUT_KEY, 4000);
 
     String ANALYTICS_ACCESS_TOKEN_THREAD_NAME = "access-token-renew";
 
@@ -53,11 +55,11 @@ public interface AnalyticsAPI {
      * from analytics IDP when not found.
      *
      * @param analyticsApp app to associate app's data with
-     * @param fetchWhenNotCached when token is not found in cache layer, get ot from backend
+     * @param fetchMode   fetch mode to use
      * @return the access token if found, otherwise null
      * @throws AnalyticsException if access token cannot be fetched
      */
-    AccessToken getAccessToken(AnalyticsApp analyticsApp, boolean fetchWhenNotCached) throws AnalyticsException;
+    AccessToken getAccessToken(AnalyticsApp analyticsApp, AccessTokenFetchMode fetchMode) throws AnalyticsException;
 
     /**
      * Requests an {@link AccessToken} with associated analytics app data and saves it to be accessible when found.
@@ -92,13 +94,5 @@ public interface AnalyticsAPI {
      * @throws AnalyticsException if analytics key cannot be extracted from response or when saving to app storage
      */
     void resetAnalyticsKey(AnalyticsApp analyticsApp, boolean force) throws AnalyticsException;
-
-    /**
-     * Reset analytics key to the app storage by requesting it again to the configuration server.
-     *
-     * @param analyticsApp resolved analytics app
-     * @throws AnalyticsException if analytics key cannot be extracted from response or when saving to app storage
-     */
-    void resetAnalyticsKey(AnalyticsApp analyticsApp) throws AnalyticsException;
 
 }

--- a/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
@@ -154,7 +154,7 @@ public class AnalyticsHelper {
      * @return resolved token status
      */
     public TokenStatus resolveTokenStatus(final AccessToken accessToken) {
-        if (accessToken == null) {
+        if (Objects.isNull(accessToken)) {
             return TokenStatus.NONE;
         }
 
@@ -169,6 +169,7 @@ public class AnalyticsHelper {
 
             return TokenStatus.OK;
         }
+
         return Optional.ofNullable(accessToken.status()).map(AccessTokenStatus::tokenStatus).orElse(TokenStatus.NONE);
     }
 
@@ -196,7 +197,7 @@ public class AnalyticsHelper {
      * @return true if it has a {@link TokenStatus#OK} or {@link TokenStatus#IN_WINDOW}
      */
     private static boolean canUseToken(final TokenStatus tokenStatus) {
-        return tokenStatus == TokenStatus.OK || tokenStatus == TokenStatus.IN_WINDOW;
+        return tokenStatus.matchesAny(TokenStatus.OK, TokenStatus.IN_WINDOW);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/analytics/listener/AnalyticsAppListener.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/listener/AnalyticsAppListener.java
@@ -77,12 +77,13 @@ public final class AnalyticsAppListener implements EventSubscriber<AppSecretSave
         // detect blank analytics key to reset it
         resolveAnalyticsKey(event)
             .map(AbstractProperty::getString)
-            .filter(StringUtils::isWhitespace)
+            .filter(StringUtils::isEmpty)
             .ifPresent(analyticsKey -> {
                 final Host host = Try
                     .of(() -> hostAPI.find(event.getHostIdentifier(), APILocator.systemUser(), false))
                     .getOrElse((Host) null);
-                Optional.ofNullable(host)
+                Optional
+                    .ofNullable(host)
                     .map(site -> AnalyticsHelper.get().appFromHost(site))
                     .ifPresent(app -> {
                         try {
@@ -90,8 +91,9 @@ public final class AnalyticsAppListener implements EventSubscriber<AppSecretSave
                             analyticsAPI.resetAnalyticsKey(app, true);
 
                             // reset access token when is NOOP, is this the right place?
-                            Optional.ofNullable(analyticsAPI.getAccessToken(app))
-                                .filter(appplication -> AnalyticsHelper.get().isTokenNoop(appplication))
+                            Optional
+                                .ofNullable(analyticsAPI.getAccessToken(app))
+                                .filter(application -> AnalyticsHelper.get().isTokenNoop(application))
                                 .ifPresent(token -> analyticsAPI.resetAccessToken(app));
                         } catch (AnalyticsException e) {
                             Logger.error(

--- a/dotCMS/src/main/java/com/dotcms/analytics/model/AccessTokenFetchMode.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/model/AccessTokenFetchMode.java
@@ -1,0 +1,12 @@
+package com.dotcms.analytics.model;
+
+/**
+ * Access Token fetch mode.
+ *
+ * @author vico
+ */
+public enum AccessTokenFetchMode {
+
+    BACKEND_FALLBACK, FORCE_RENEW
+
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/model/TokenStatus.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/model/TokenStatus.java
@@ -1,5 +1,8 @@
 package com.dotcms.analytics.model;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 /**
  * Token Status possible values.
  *
@@ -12,6 +15,13 @@ public enum TokenStatus {
     EXPIRED,
     BLOCKED,
     NOOP,
-    NONE
+    NONE;
+
+    public boolean matchesAny(final TokenStatus... statuses) {
+        return Optional
+            .ofNullable(statuses)
+            .map(s -> Arrays.stream(s).anyMatch(status -> status == this))
+            .orElse(false);
+    }
 
 }

--- a/dotCMS/src/test/java/com/dotcms/analytics/bayesian/BayesianAPIImplTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/bayesian/BayesianAPIImplTest.java
@@ -62,7 +62,7 @@ public class BayesianAPIImplTest {
         assertEquals(1000, result.differenceData().controlData().length);
         assertEquals(1000, result.differenceData().testData().length);
         assertEquals(1000, result.differenceData().differences().length);
-        assertEquals(0.03, result.differenceData().relativeDifference(), 0.001);
+        assertEquals(0.03, result.differenceData().relativeDifference(), 0.01);
         assertEquals(11, result.quantiles().size());
         assertEquals(2, result.distributionPdfs().samples().size());
         assertEquals(1000, result.distributionPdfs().samples().get("control").size());


### PR DESCRIPTION
When setting the analytics key as a empty string it will force the access token renewal.
For this matter longer timeouts have been defined as config variables.