### PR TITLE
#25203 avoid double slash

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/BinaryMapTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/BinaryMapTest.java
@@ -9,6 +9,7 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -237,6 +238,43 @@ public class BinaryMapTest {
 
         assertTrue(binaryMap.getName().startsWith("image"));
         assertTrue(binaryMap.getName().endsWith(".jpg"));
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to Test:</b> {@link BinaryMap#getResizeUri(Integer, Integer)}</li>
+     *     <li><b>Given Scenario:</b> Verify that the {@link BinaryMap#getResizeUri(Integer, Integer)} method returns the URI in the
+     *     expected format.</li>
+     *     <li><b>Expected Result:</b> The URI must not contain double slash.</li>
+     * </ul>
+     */
+    @Test
+    public void test_getResizeUri() throws DotDataException {
+        final Language language = new LanguageDataGen().nextPersisted();
+
+        final Contentlet banner =
+                TestDataUtils.getBannerLikeContent(true, language.getId(), null, null);
+
+        final Field binaryField = APILocator.getContentTypeFieldAPI()
+                .byContentTypeIdAndVar(banner.getContentTypeId(), "image");
+
+        final BinaryMap binaryMap = new BinaryMap(banner, new LegacyFieldTransformer(binaryField).asOldField());
+
+        String resizeUri = binaryMap.getResizeUri(200,200);
+
+        Assert.assertFalse("Contains double slash sending both params", resizeUri.contains("//"));
+
+        resizeUri = binaryMap.getResizeUri(0,200);
+
+        Assert.assertFalse("Contains double slash sending only height", resizeUri.contains("//"));
+
+        resizeUri = binaryMap.getResizeUri(200,0);
+
+        Assert.assertFalse("Contains double slash sending only width", resizeUri.contains("//"));
+
+        resizeUri = binaryMap.getResizeUri(0,0);
+
+        Assert.assertFalse("Contains double slash sending no params", resizeUri.contains("//"));
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/BinaryMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/BinaryMap.java
@@ -171,10 +171,15 @@ public class BinaryMap {
 	    if(getName().length()==0) return "";
 	    StringBuilder uri=new StringBuilder();
 	    uri.append(getResizeUri());
-	    if(width!=null && width>0)
-	        uri.append("/").append(width).append("w");
-	    if(height!=null && height>0)
-	        uri.append("/").append(height).append("h");
+	    if(width!=null && width>0) {
+			uri.append(width).append("w");
+		}
+		if(width!=null && width>0 && height!=null && height>0) {
+			uri.append("/");
+		}
+	    if(height!=null && height>0) {
+			uri.append(height).append("h");
+		}
 	    return uri.toString();
 	}
 	


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb7178f</samp>

This pull request fixes a bug in the `getResizeUri` method of the `BinaryMap` class and adds a new integration test for it. The bug caused double slashes in the URI for resizing binary images, which could lead to errors or unexpected behavior.