### PR TITLE
fix #25177 show container names in box container list

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.ts
@@ -46,7 +46,7 @@ export class DotTemplatesService {
 
         return this.request<DotTemplate>({
             url
-        });
+        }).pipe(map((template) => this.addContainerInfo(template)));
     }
 
     /**
@@ -184,5 +184,17 @@ export class DotTemplatesService {
                 );
             })
         );
+    }
+
+    private addContainerInfo(template: DotTemplate): DotTemplate {
+        for (const row of template.layout.body.rows) {
+            for (const column of row.columns) {
+                for (const container of column.containers) {
+                    container.title = template.containers[container.identifier].title;
+                }
+            }
+        }
+
+        return template;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.ts
@@ -187,15 +187,37 @@ export class DotTemplatesService {
     }
 
     private addContainerInfo(template: DotTemplate): DotTemplate {
-        if (template?.layout?.body?.rows)
-            for (const row of template.layout.body.rows) {
-                if (row.columns)
-                    for (const column of row.columns) {
-                        for (const container of column.containers) {
-                            container.title = template.containers[container.identifier].title;
-                        }
+        if (template?.layout?.body?.rows) {
+            const updatedRows = template.layout.body.rows.map((row) => {
+                if (!row.columns) return row;
+
+                return {
+                    ...row,
+                    columns: row.columns.map((column) => {
+                        if (!column.containers) return column;
+
+                        return {
+                            ...column,
+                            containers: column.containers.map((container) => ({
+                                ...container,
+                                title: template.containers[container.identifier].title
+                            }))
+                        };
+                    })
+                };
+            });
+
+            return {
+                ...template,
+                layout: {
+                    ...template.layout,
+                    body: {
+                        ...template.layout.body,
+                        rows: updatedRows
                     }
-            }
+                }
+            };
+        }
 
         return template;
     }

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-templates/dot-templates.service.ts
@@ -187,13 +187,15 @@ export class DotTemplatesService {
     }
 
     private addContainerInfo(template: DotTemplate): DotTemplate {
-        for (const row of template.layout.body.rows) {
-            for (const column of row.columns) {
-                for (const container of column.containers) {
-                    container.title = template.containers[container.identifier].title;
-                }
+        if (template?.layout?.body?.rows)
+            for (const row of template.layout.body.rows) {
+                if (row.columns)
+                    for (const column of row.columns) {
+                        for (const container of column.containers) {
+                            container.title = template.containers[container.identifier].title;
+                        }
+                    }
             }
-        }
 
         return template;
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.ts
@@ -26,6 +26,10 @@ export class DotTemplateCreateEditResolver implements Resolve<DotTemplate> {
                       }
                   })
               )
-            : this.service.getById(route.paramMap.get('id'));
+            : this.service.getById(route.paramMap.get('id')).pipe(
+                  map((template) => {
+                      return template;
+                  })
+              );
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.ts
@@ -26,10 +26,6 @@ export class DotTemplateCreateEditResolver implements Resolve<DotTemplate> {
                       }
                   })
               )
-            : this.service.getById(route.paramMap.get('id')).pipe(
-                  map((template) => {
-                      return template;
-                  })
-              );
+            : this.service.getById(route.paramMap.get('id'));
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/dot-edit-layout-designer.component.spec.ts
@@ -348,7 +348,8 @@ describe('DotEditLayoutDesignerComponent', () => {
             expect(component.form.value.layout.sidebar.containers).toEqual([
                 {
                     identifier: 'fc193c82-8c32-4abe-ba8a-49522328c93e',
-                    uuid: 'LEGACY_RELATION_TYPE'
+                    uuid: 'LEGACY_RELATION_TYPE',
+                    title: 'A Container'
                 }
             ]);
         });

--- a/core-web/libs/dotcms-models/src/lib/dot-page-container.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-page-container.model.ts
@@ -6,6 +6,7 @@ export interface DotPageContainer {
     uuid?: string;
     contentletsId?: string[];
     path?: string;
+    title?: string;
 }
 
 export interface DotPageContainerPersonalized extends DotPageContainer {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
@@ -42,7 +42,7 @@
     </div>
     <p-scrollPanel [style]="{ width: '100%', height: '10.9375rem' }">
         <div class="template-builder-box__item" *ngFor="let item of items; let i = index">
-            <p>{{ item.identifier }}</p>
+            <p>{{ item.title }}</p>
             <dotcms-remove-confirm-dialog
                 (deleteConfirmed)="deleteContainer.emit(i)"
                 data-testId="btn-trash-container"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/models/models.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/models/models.ts
@@ -20,6 +20,7 @@ export interface DotGridStackOptions extends GridStackOptions {
 export interface DotTemplateBuilderContainer {
     identifier: string;
     uuid?: string;
+    title: string;
 }
 
 /**

--- a/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.spec.ts
@@ -103,7 +103,7 @@ describe('DotTemplateBuilderStore', () => {
         const updatedRow: DotGridStackWidget = {
             ...initialState[0],
             styleClass: ['new-class', 'flex-mock'],
-            containers: [{ identifier: 'mock-container', uuid: uuid() }]
+            containers: [{ identifier: 'mock-container', uuid: uuid(), title: 'Mock Container' }]
         };
 
         service.updateRow(updatedRow);

--- a/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.ts
@@ -286,7 +286,8 @@ export class DotTemplateBuilderStore extends ComponentStore<DotTemplateBuilderSt
                 const updatedChildren = row.subGridOpts.children.map((child) => {
                     if (affectedColumn.id === child.id)
                         child.containers.push({
-                            identifier: container.identifier
+                            identifier: container.identifier,
+                            title: container.title
                         });
 
                     return child;

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
@@ -46,11 +46,13 @@ export const MINIMAL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/banner/',
-                            uuid: '1'
+                            uuid: '1',
+                            title: 'Banner'
                         },
                         {
                             identifier: 'another-identifier',
-                            uuid: '2'
+                            uuid: '2',
+                            title: 'Another Container'
                         }
                     ],
                     leftOffset: 1,
@@ -61,6 +63,11 @@ export const MINIMAL_DATA_MOCK: DotLayoutBody = {
             styleClass: 'p-0 banner-tall'
         }
     ]
+};
+
+const DEFAULT_CONTAINER_INFO = {
+    identifier: '//demo.dotcms.com/application/containers/default/',
+    title: 'Default'
 };
 
 export const FULL_DATA_MOCK: DotLayoutBody = {
@@ -87,9 +94,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                 {
                     containers: [
                         {
-                            identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '1',
-                            title: 'Default'
+                            ...DEFAULT_CONTAINER_INFO,
+                            uuid: '1'
                         }
                     ],
                     leftOffset: 1,
@@ -104,9 +110,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                 {
                     containers: [
                         {
-                            identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '2',
-                            title: 'Default'
+                            ...DEFAULT_CONTAINER_INFO,
+                            uuid: '2'
                         }
                     ],
                     leftOffset: 1,
@@ -116,9 +121,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                 {
                     containers: [
                         {
-                            identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '3',
-                            title: 'Default'
+                            ...DEFAULT_CONTAINER_INFO,
+                            uuid: '3'
                         }
                     ],
                     leftOffset: 4,
@@ -128,9 +132,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                 {
                     containers: [
                         {
-                            identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '4',
-                            title: 'Default'
+                            ...DEFAULT_CONTAINER_INFO,
+                            uuid: '4'
                         }
                     ],
                     leftOffset: 7,
@@ -140,9 +143,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                 {
                     containers: [
                         {
-                            identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '5',
-                            title: 'Default'
+                            ...DEFAULT_CONTAINER_INFO,
+                            uuid: '5'
                         }
                     ],
                     leftOffset: 10,
@@ -157,9 +159,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                 {
                     containers: [
                         {
-                            identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '6',
-                            title: 'Default'
+                            ...DEFAULT_CONTAINER_INFO,
+                            uuid: '6'
                         }
                     ],
                     leftOffset: 1,
@@ -169,9 +170,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                 {
                     containers: [
                         {
-                            identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '7',
-                            title: 'Default'
+                            ...DEFAULT_CONTAINER_INFO,
+                            uuid: '7'
                         }
                     ],
                     leftOffset: 7,
@@ -181,9 +181,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                 {
                     containers: [
                         {
-                            identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '8',
-                            title: 'Default'
+                            ...DEFAULT_CONTAINER_INFO,
+                            uuid: '8'
                         }
                     ],
                     leftOffset: 10,
@@ -198,9 +197,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                 {
                     containers: [
                         {
-                            identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '9',
-                            title: 'Default'
+                            ...DEFAULT_CONTAINER_INFO,
+                            uuid: '9'
                         }
                     ],
                     leftOffset: 1,
@@ -215,9 +213,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                 {
                     containers: [
                         {
-                            identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '10',
-                            title: 'Default'
+                            ...DEFAULT_CONTAINER_INFO,
+                            uuid: '10'
                         }
                     ],
                     leftOffset: 1,

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
@@ -339,5 +339,6 @@ export function mockMatchMedia() {
 
 export const mockTemplateBuilderContainer: DotTemplateBuilderContainer = {
     identifier: '1',
-    uuid: '1'
+    uuid: '1',
+    title: 'A Container'
 };

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
@@ -71,7 +71,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/banner/',
-                            uuid: '1'
+                            uuid: '1',
+                            title: 'Banner'
                         }
                     ],
                     leftOffset: 1,
@@ -87,7 +88,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '1'
+                            uuid: '1',
+                            title: 'Default'
                         }
                     ],
                     leftOffset: 1,
@@ -103,7 +105,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '2'
+                            uuid: '2',
+                            title: 'Default'
                         }
                     ],
                     leftOffset: 1,
@@ -114,7 +117,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '3'
+                            uuid: '3',
+                            title: 'Default'
                         }
                     ],
                     leftOffset: 4,
@@ -125,7 +129,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '4'
+                            uuid: '4',
+                            title: 'Default'
                         }
                     ],
                     leftOffset: 7,
@@ -136,7 +141,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '5'
+                            uuid: '5',
+                            title: 'Default'
                         }
                     ],
                     leftOffset: 10,
@@ -152,7 +158,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '6'
+                            uuid: '6',
+                            title: 'Default'
                         }
                     ],
                     leftOffset: 1,
@@ -163,7 +170,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '7'
+                            uuid: '7',
+                            title: 'Default'
                         }
                     ],
                     leftOffset: 7,
@@ -174,7 +182,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '8'
+                            uuid: '8',
+                            title: 'Default'
                         }
                     ],
                     leftOffset: 10,
@@ -190,7 +199,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '9'
+                            uuid: '9',
+                            title: 'Default'
                         }
                     ],
                     leftOffset: 1,
@@ -206,7 +216,8 @@ export const FULL_DATA_MOCK: DotLayoutBody = {
                     containers: [
                         {
                             identifier: '//demo.dotcms.com/application/containers/default/',
-                            uuid: '10'
+                            uuid: '10',
+                            title: 'Default'
                         }
                     ],
                     leftOffset: 1,

--- a/core-web/libs/utils-testing/src/lib/dot-page-render.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/dot-page-render.mock.ts
@@ -1,5 +1,3 @@
-import { mockDotLanguage } from './dot-language.mock';
-import { dotcmsContentTypeBasicMock } from './dot-content-types.mock';
 import {
     DotPage,
     DotLayout,
@@ -9,6 +7,9 @@ import {
     DotTemplate,
     DotPageContainerStructure
 } from '@dotcms/dotcms-models';
+
+import { dotcmsContentTypeBasicMock } from './dot-content-types.mock';
+import { mockDotLanguage } from './dot-language.mock';
 
 export const mockDotPage = (): DotPage => {
     return {
@@ -57,7 +58,8 @@ export const mockDotLayout = (): DotLayout => {
             containers: [
                 {
                     identifier: 'fc193c82-8c32-4abe-ba8a-49522328c93e',
-                    uuid: 'LEGACY_RELATION_TYPE'
+                    uuid: 'LEGACY_RELATION_TYPE',
+                    title: 'A Container'
                 }
             ]
         },


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d0d65a4</samp>

This pull request adds the `title` property to the container objects in the template builder UI, and displays it instead of the `identifier` property. This is done to improve the user experience and the design of the template builder UI. The pull request also updates the related interfaces, mock data, services, resolvers, and store logic to include the `title` property. Additionally, it removes some unused imports and reorders some existing imports in some files.

### Checklist
- [X] Tests
- [X] Translations
- [X] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
![image](https://github.com/dotCMS/core/assets/29465918/a0661ed7-fcb8-4562-8603-1a25dc597442)  | <img width="1488" alt="image" src="https://github.com/dotCMS/core/assets/29465918/af7bd9ab-3bcf-4704-bfc8-0a4806a7cacc">

