### PR TITLE
#25239 Handle size inline edit inputs

### DIFF
--- a/core-web/libs/portlets/dot-experiments/README.md
+++ b/core-web/libs/portlets/dot-experiments/README.md
@@ -17,3 +17,19 @@ This lib contain all related to Experiments in dotCMS, has 2 main libraries:
 - For run the portlet unit test do: `nx run portlets-dot-experiments-portlet:lint`.
 - For run the data-access unit test do: `nx run portlets-dot-experiments-data-access:lint`.
 
+## Portlet Library Structure
+
+| Folder name                     | Project Name                                                               |
+|---------------------------------|----------------------------------------------------------------------------|
+| `dot-experiments-configuration` | Container of Experiment Configuration and all components related to it.    |
+| `dot-experiments-list`          | Container of Experiment List and all components related to it.             | 
+| `dot-experiments-reports`       | Container of Experiment Reports and all components related to it.          | 
+| `dot-experiments-shell`         | Shell of the Experiment Library and the Featured Component Store           | 
+| `shared`                        | Reusable components, directives and utils with specific use in Experiment. | 
+
+## Data Access Library Structure
+
+| Folder name | Project Name               |
+|-------------|----------------------------|
+| `resolvers` | Resolvers of experiments   |
+| `services`  | Main service of experiment | 

--- a/core-web/libs/portlets/dot-experiments/data-access/project.json
+++ b/core-web/libs/portlets/dot-experiments/data-access/project.json
@@ -10,12 +10,17 @@
             "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
             "options": {
                 "jestConfig": "libs/portlets/dot-experiments/data-access/jest.config.ts",
-                "passWithNoTests": true
+                "passWithNoTests": true,
+                "verbose": true,
+                "codeCoverage": true,
+                "collectCoverage": true,
+                "coverageReporters": ["json", "lcov", "text-summary"]
             },
             "configurations": {
                 "ci": {
                     "ci": true,
-                    "codeCoverage": true
+                    "codeCoverage": true,
+                    "verbose": false
                 }
             }
         },

--- a/core-web/libs/portlets/dot-experiments/portlet/project.json
+++ b/core-web/libs/portlets/dot-experiments/portlet/project.json
@@ -10,12 +10,17 @@
             "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
             "options": {
                 "jestConfig": "libs/portlets/dot-experiments/portlet/jest.config.ts",
-                "passWithNoTests": true
+                "passWithNoTests": true,
+                "verbose": true,
+                "codeCoverage": true,
+                "coverageReporters": ["json", "lcov", "text-summary"],
+                "collectCoverage": true
             },
             "configurations": {
                 "ci": {
                     "ci": true,
-                    "codeCoverage": true
+                    "codeCoverage": true,
+                    "verbose": false
                 }
             }
         },

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.html
@@ -60,13 +60,11 @@
                         <input
                             id="name"
                             [maxlength]="this.maxNameLength + 1"
+                            [placeholder]="'experiments.goal.reach_page.form.name.placeholder' | dm"
                             data-testId="goal-name-input"
                             formControlName="name"
                             name="name"
                             pInputText
-                            placeholder="{{
-                                'experiments.goal.reach_page.form.name.placeholder' | dm
-                            }}"
                             required
                             type="text"
                         />

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-goal-select/dot-experiments-configuration-goal-select.component.html
@@ -9,7 +9,6 @@
             [actionButtonTpl]="actionHeaderBtnTpl"
             dotTitle="{{ 'experiments.configure.goals.sidebar.header' | dm }}"
         />
-
         <div class="experiment-goal-select__form-wrapper flex flex-column">
             <form
                 class="p-fluid"
@@ -58,29 +57,28 @@
                         <label class="p-label-input-required">{{
                             'experiments.goal.reach_page.form.name.label' | dm
                         }}</label>
-                        <div>
-                            <input
-                                id="name"
-                                [maxlength]="this.maxNameLength + 1"
-                                data-testId="goal-name-input"
-                                formControlName="name"
-                                name="name"
-                                pInputText
-                                placeholder="{{
-                                    'experiments.goal.reach_page.form.name.placeholder' | dm
-                                }}"
-                                required
-                                type="text"
-                            />
+                        <input
+                            id="name"
+                            [maxlength]="this.maxNameLength + 1"
+                            data-testId="goal-name-input"
+                            formControlName="name"
+                            name="name"
+                            pInputText
+                            placeholder="{{
+                                'experiments.goal.reach_page.form.name.placeholder' | dm
+                            }}"
+                            required
+                            type="text"
+                        />
 
-                            <dot-field-validation-message
-                                [field]="goalNameControl"
-                            ></dot-field-validation-message>
-                        </div>
+                        <dot-field-validation-message
+                            [field]="goalNameControl"
+                        ></dot-field-validation-message>
                     </div>
                 </div>
             </form>
         </div>
+
         <dot-experiments-goals-coming-soon />
     </p-sidebar>
 

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.html
@@ -49,7 +49,7 @@
                                 {{ variant.value.name }}
                             </span>
                             <p-inputNumber
-                                class="experiment-traffic-split__variants-weight"
+                                class="experiment-traffic-split__variants-weight p-inputtext-sm"
                                 *ngIf="
                                     form.value.type === customPercentages;
                                     else splitEvenTemplate
@@ -67,7 +67,7 @@
                                 <span
                                     class="experiment-traffic-split__variants-weight"
                                     data-testId="variant-weight"
-                                    >{{ variant.value.weight | json }}</span
+                                    >{{ variant.value.weight }}</span
                                 >
                             </ng-template>
                         </div>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.scss
@@ -30,7 +30,7 @@
             justify-content: space-between;
             align-items: center;
             margin-bottom: $spacing-2;
-            min-height: 40.5px;
+            min-height: 2.7rem;
 
             &.experiment-traffic-split__variants-header {
                 font-size: $font-size-lg;

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.scss
@@ -30,6 +30,7 @@
             justify-content: space-between;
             align-items: center;
             margin-bottom: $spacing-2;
+            min-height: 40.5px;
 
             &.experiment-traffic-split__variants-header {
                 font-size: $font-size-lg;

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="vm$ | async as vm">
     <p-card>
         <ng-template pTemplate="title">
-            <div class="flex justify-content-between">
+            <div class="variant--title__wrapper flex justify-content-between">
                 <h2 class="flex align-items-center gap-1 uppercase">
                     <dot-icon
                         [ngClass]="{ isDone: vm.trafficProportion.variants?.length > 1 }"
@@ -30,9 +30,9 @@
         >
             <p-card [ngClass]="{ first: first, last: last }" data-testId="variant-row-card">
                 <div
-                    class="variant-row-wrapper flex flex-row align-items-center align-content-between gap-2"
+                    class="variant--row__wrapper flex flex-row align-items-center align-content-between gap-2"
                 >
-                    <div class="title flex flex-grow-1 flex-row align-items-center gap-2">
+                    <div class="flex flex-grow-1 flex-row align-items-center gap-2">
                         <ng-container
                             *ngIf="
                                 variant.name === defaultVariantName || !vm.isExperimentADraft;
@@ -49,7 +49,6 @@
                             [tooltipText]="'dot.common.message.pageurl.copy.clipboard' | dm"
                         ></dot-copy-button>
                     </div>
-
                     <span class="separator">|</span>
 
                     <div

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -39,7 +39,7 @@
                                 else editVariantNameTpl
                             "
                         >
-                            <span data-testId="variant-name"> {{ variant.name }} </span>
+                            <span data-testId="variant-name-original"> {{ variant.name }} </span>
                         </ng-container>
 
                         <dot-copy-button

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -29,7 +29,9 @@
             "
         >
             <p-card [ngClass]="{ first: first, last: last }" data-testId="variant-row-card">
-                <div class="flex flex-row align-items-center align-content-between gap-2">
+                <div
+                    class="variant-row-wrapper flex flex-row align-items-center align-content-between gap-2"
+                >
                     <div class="title flex flex-grow-1 flex-row align-items-center gap-2">
                         <ng-container
                             *ngIf="
@@ -117,45 +119,15 @@
                     type="button"
                 ></button>
             </ng-template>
+
             <ng-template #editVariantNameTpl>
-                <p-inplace #editName>
-                    <ng-template pTemplate="display">
-                        <span data-testId="variant-name">{{ variant.name }}</span>
-                        <i class="pi pi-pencil cursor-pointer"></i>
-                    </ng-template>
-                    <ng-template pTemplate="content">
-                        <span class="p-input-icon-right">
-                            <i
-                                class="pi pi-times cursor-pointer"
-                                (click)="editName.deactivate()"
-                                data-testId="variant-inplace-button"
-                            ></i>
-                            <input
-                                class="dot-container-properties__title-input w-20rem"
-                                #variantName
-                                [required]="true"
-                                [value]="variant.name"
-                                (keydown.enter)="
-                                    editVariantName(variantName.value, variant, vm.experimentId)
-                                "
-                                data-testId="inplace-input"
-                                dotAutofocus
-                                maxlength="maxNameLength"
-                                pInputText
-                                type="text"
-                            />
-                        </span>
-                        <button
-                            class="p-button-rounded p-button-text"
-                            [loading]="vm.status && vm.status.status === statusList.SAVING"
-                            (click)="editVariantName(variantName.value, variant, vm.experimentId)"
-                            data-testId="variant-save-name-btn"
-                            icon="pi pi-save"
-                            pButton
-                            type="button"
-                        ></button>
-                    </ng-template>
-                </p-inplace>
+                <dot-experiments-inplace-edit-text
+                    [isLoading]="vm.status && vm.status.status === statusList.SAVING"
+                    [maxCharacterLength]="maxInputTitleLength"
+                    [required]="true"
+                    [text]="variant.name"
+                    (textChanged)="editVariantName($event, variant, vm.experimentId)"
+                />
             </ng-template>
         </ng-container>
 

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.scss
@@ -1,5 +1,9 @@
 @use "variables" as *;
 
+.variant-row-wrapper {
+    min-height: 2.2rem;
+}
+
 h2 {
     margin: 0;
     font-size: $font-size-lg;

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.scss
@@ -1,26 +1,28 @@
 @use "variables" as *;
 
-.variant-row-wrapper {
+.variant--title__wrapper {
+    h2 {
+        margin: 0;
+        font-size: $font-size-lg;
+        font-weight: $font-weight-bold;
+    }
+
+    .variant-name dot-icon {
+        display: inline;
+        color: $color-palette-primary;
+    }
+}
+
+.variant--row__wrapper {
     min-height: 2.2rem;
-}
 
-h2 {
-    margin: 0;
-    font-size: $font-size-lg;
-    font-weight: $font-weight-bold;
-}
+    .separator {
+        color: $color-palette-gray-300;
+    }
 
-.variant-name dot-icon {
-    display: inline;
-    color: $color-palette-primary;
-}
-
-.separator {
-    color: $color-palette-gray-300;
-}
-
-button {
-    min-width: 55px;
+    button {
+        min-width: 55px;
+    }
 }
 
 :host ::ng-deep {
@@ -53,27 +55,6 @@ button {
 
         .p-card-footer .p-button-link {
             padding: $spacing-0;
-        }
-    }
-
-    p-inplace .p-inplace {
-        .p-inplace-display {
-            padding: 0;
-
-            i {
-                margin-left: $spacing-1;
-                margin-right: $spacing-1;
-                font-size: 0.85rem;
-            }
-
-            &:hover {
-                background: transparent;
-            }
-        }
-
-        .p-inplace-content {
-            display: flex;
-            gap: $spacing-1;
         }
     }
 }

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -35,6 +35,7 @@ import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot
 
 import { DotExperimentsConfigurationVariantsComponent } from './dot-experiments-configuration-variants.component';
 
+import { DotExperimentsInlineEditTextComponent } from '../../../shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component';
 import { DotExperimentsConfigurationStore } from '../../store/dot-experiments-configuration-store';
 
 const messageServiceMock = new MockDotMessageService({
@@ -114,7 +115,7 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
 
     describe('should render', () => {
         it('a DEFAULT variant', () => {
-            expect(spectator.queryAll(byTestId('variant-name')).length).toBe(1);
+            expect(spectator.queryAll(byTestId('variant-name-original')).length).toBe(1);
             expect(spectator.query(byTestId('variants-card-header'))).toHaveClass(
                 'p-label-input-required'
             );
@@ -144,10 +145,10 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
             expect(spectator.query(byTestId('variant-title-step-done'))).toHaveClass('isDone');
             expect(spectator.queryAll(Card).length).toBe(4);
 
-            const variantsName = spectator.queryAll(byTestId('variant-name'));
-            expect(variantsName[0]).toContainText(variants[0].name);
-            expect(variantsName[1]).toContainText(variants[1].name);
-            expect(variantsName[2]).toContainText(variants[2].name);
+            expect(spectator.query(byTestId('variant-name-original'))).toContainText(
+                variants[0].name
+            );
+            expect(spectator.queryAll(DotExperimentsInlineEditTextComponent).length).toBe(2);
 
             expect(spectator.queryAll(DotCopyButtonComponent).length).toBe(3);
 
@@ -254,56 +255,8 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
             });
         });
 
-        it('should edit output emit the new name', () => {
-            jest.spyOn(store, 'editVariant');
-
-            const newVariantName = 'new name';
-
-            spectator.query(Inplace).activate();
-
-            spectator.detectComponentChanges();
-
-            const viewButton = spectator.query(
-                byTestId('variant-save-name-btn')
-            ) as HTMLButtonElement;
-
-            const inplaceInput = spectator.query(byTestId('inplace-input')) as HTMLInputElement;
-            inplaceInput.value = newVariantName;
-            spectator.detectComponentChanges();
-
-            expect(viewButton.disabled).not.toBe(true);
-
-            spectator.click(viewButton);
-
-            spectator.detectComponentChanges();
-
-            expect(store.editVariant).toHaveBeenCalledWith({
-                data: { ...variants[1], name: newVariantName },
-                experimentId: EXPERIMENT_MOCK.id
-            });
-        });
-
-        it('should save when press enter', async () => {
-            jest.spyOn(store, 'editVariant');
-
-            spectator.query(Inplace).activate();
-
-            spectator.detectComponentChanges();
-
-            await spectator.fixture.whenStable();
-
-            const inplaceInput = spectator.query(byTestId('inplace-input')) as HTMLInputElement;
-            inplaceInput.value = 'new value';
-            spectator.detectComponentChanges();
-
-            spectator.dispatchKeyboardEvent(inplaceInput, 'keydown', 'Enter');
-
-            spectator.detectComponentChanges();
-
-            expect(store.editVariant).toHaveBeenCalledWith({
-                data: { ...variants[1], name: 'new value' },
-                experimentId: EXPERIMENT_MOCK.id
-            });
+        it('should has `DotExperimentsInlineEditTextComponent` component', () => {
+            expect(spectator.query(DotExperimentsInlineEditTextComponent)).not.toBeNull();
         });
 
         it('should confirm before delete a variant', () => {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
@@ -21,8 +21,10 @@ import { DotSessionStorageService } from '@dotcms/data-access';
 import {
     ComponentStatus,
     DEFAULT_VARIANT_NAME,
+    DotExperimentStatusList,
     DotPageMode,
     ExperimentSteps,
+    MAX_INPUT_TITLE_LENGTH,
     MAX_VARIANTS_ALLOWED,
     StepStatus,
     TrafficProportion,
@@ -36,6 +38,7 @@ import {
 } from '@dotcms/ui';
 import { DotDynamicDirective } from '@portlets/shared/directives/dot-dynamic.directive';
 
+import { DotExperimentsInlineEditTextComponent } from '../../../shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component';
 import { DotExperimentsConfigurationStore } from '../../store/dot-experiments-configuration-store';
 import { DotExperimentsConfigurationItemsCountComponent } from '../dot-experiments-configuration-items-count/dot-experiments-configuration-items-count.component';
 import { DotExperimentsConfigurationVariantsAddComponent } from '../dot-experiments-configuration-variants-add/dot-experiments-configuration-variants-add.component';
@@ -61,7 +64,8 @@ import { DotExperimentsConfigurationVariantsAddComponent } from '../dot-experime
         InputTextModule,
         TooltipModule,
         ConfirmPopupModule,
-        AutoFocusModule
+        AutoFocusModule,
+        DotExperimentsInlineEditTextComponent
     ],
     templateUrl: './dot-experiments-configuration-variants.component.html',
     styleUrls: ['./dot-experiments-configuration-variants.component.scss'],
@@ -76,12 +80,13 @@ export class DotExperimentsConfigurationVariantsComponent {
     }> = this.dotExperimentsConfigurationStore.variantsStepVm$.pipe(
         tap(({ status }) => this.handleSidebar(status))
     );
-    statusList = ComponentStatus;
-    maxVariantsAllowed = MAX_VARIANTS_ALLOWED;
-    defaultVariantName = DEFAULT_VARIANT_NAME;
     dotPageMode = DotPageMode;
     @ViewChild(DotDynamicDirective, { static: true }) sidebarHost!: DotDynamicDirective;
-
+    protected readonly statusList = ComponentStatus;
+    protected readonly maxVariantsAllowed = MAX_VARIANTS_ALLOWED;
+    protected readonly defaultVariantName = DEFAULT_VARIANT_NAME;
+    protected readonly maxInputTitleLength = MAX_INPUT_TITLE_LENGTH;
+    protected readonly DotExperimentStatusList = DotExperimentStatusList;
     private componentRef: ComponentRef<DotExperimentsConfigurationVariantsAddComponent>;
 
     constructor(

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.html
@@ -78,7 +78,7 @@
     <ng-container *ngIf="experiment.status === experimentStatus.ENDED">
         <button
             class="p-button-rounded p-button-text"
-            (click)="goToConfiguration.emit(experiment)"
+            (click)="archive($event, experiment)"
             data-testId="experiment-row-archive-button"
             icon="pi pi-briefcase"
             pButton

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/dot-experiments-reports.component.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/dot-experiments-reports.component.spec.ts
@@ -5,13 +5,14 @@ import {
     Spectator,
     SpyObject
 } from '@ngneat/spectator/jest';
+import { ChartData } from 'chart.js';
 import { of } from 'rxjs';
 
+import { Component, Input } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ButtonModule } from 'primeng/button';
-import { ConfirmPopup, ConfirmPopupModule } from 'primeng/confirmpopup';
+import { ConfirmPopup } from 'primeng/confirmpopup';
 
 import { DotMessageService } from '@dotcms/data-access';
 import {
@@ -26,7 +27,6 @@ import {
     getExperimentResultsMock,
     MockDotMessageService
 } from '@dotcms/utils-testing';
-import { DotDynamicDirective } from '@portlets/shared/directives/dot-dynamic.directive';
 import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
 
 import { DotExperimentsReportsChartComponent } from './components/dot-experiments-reports-chart/dot-experiments-reports-chart.component';
@@ -37,7 +37,6 @@ import {
     VmReportExperiment
 } from './store/dot-experiments-reports-store';
 
-import { DotExperimentsDetailsTableComponent } from '../shared/ui/dot-experiments-details-table/dot-experiments-details-table.component';
 import { DotExperimentsExperimentSummaryComponent } from '../shared/ui/dot-experiments-experiment-summary/dot-experiments-experiment-summary.component';
 import { DotExperimentsUiHeaderComponent } from '../shared/ui/dot-experiments-header/dot-experiments-ui-header.component';
 
@@ -72,6 +71,24 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.configure.scheduling.name': 'xx'
 });
 
+// TODO: Use ng-mocks to mock the component automatically
+@Component({
+    standalone: true,
+    selector: 'dot-experiments-reports-chart',
+    template: 'chart - mocked component'
+})
+class MockDotExperimentsReportsChartComponent {
+    options;
+    @Input()
+    isEmpty = true;
+    @Input()
+    isLoading = true;
+    @Input()
+    config: { xAxisLabel: string; yAxisLabel: string; title: string };
+    @Input()
+    data: ChartData<'line'>;
+}
+
 describe('DotExperimentsReportsComponent', () => {
     let spectator: Spectator<DotExperimentsReportsComponent>;
     let router: SpyObject<Router>;
@@ -80,17 +97,16 @@ describe('DotExperimentsReportsComponent', () => {
     let confirmPopupComponent: ConfirmPopup;
 
     const createComponent = createComponentFactory({
-        imports: [
-            DotExperimentsUiHeaderComponent,
-            DotExperimentsReportsChartComponent,
-            DotExperimentsReportsSkeletonComponent,
-            DotExperimentsExperimentSummaryComponent,
-            DotExperimentsDetailsTableComponent,
-            DotDynamicDirective,
-            ConfirmPopupModule,
-            ButtonModule
-        ],
         component: DotExperimentsReportsComponent,
+        overrideComponents: [
+            [
+                DotExperimentsReportsComponent,
+                {
+                    remove: { imports: [DotExperimentsReportsChartComponent] },
+                    add: { imports: [MockDotExperimentsReportsChartComponent] }
+                }
+            ]
+        ],
         componentProviders: [DotExperimentsReportsStore],
         providers: [
             ConfirmationService,
@@ -113,14 +129,6 @@ describe('DotExperimentsReportsComponent', () => {
         spectator = createComponent({
             detectChanges: false
         });
-
-        window.ResizeObserver =
-            window.ResizeObserver ||
-            jest.fn().mockImplementation(() => ({
-                disconnect: jest.fn(),
-                observe: jest.fn(),
-                unobserve: jest.fn()
-            }));
 
         store = spectator.inject(DotExperimentsReportsStore, true);
 
@@ -150,8 +158,7 @@ describe('DotExperimentsReportsComponent', () => {
     it('should show DotExperimentsReportsChartComponent when no loading', () => {
         spectator.component.vm$ = of({ ...defaultVmMock, isLoading: false });
         spectator.detectChanges();
-
-        expect(spectator.query(DotExperimentsReportsChartComponent)).toExist();
+        expect(spectator.query(MockDotExperimentsReportsChartComponent)).toExist();
     });
 
     it('should show the SummaryComponent', () => {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiment-options/dot-experiment-options.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiment-options/dot-experiment-options.component.scss
@@ -45,7 +45,7 @@
         }
 
         &.active {
-            background-color: $color-palette-primary-200;
+            background-color: $color-palette-primary-100;
 
             header {
                 padding-bottom: $spacing-2;
@@ -58,7 +58,7 @@
         }
 
         &:hover {
-            background-color: $color-palette-primary-200;
+            background-color: $color-palette-primary-100;
         }
     }
 }

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-goals-coming-soon/dot-experiments-goals-coming-soon.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-goals-coming-soon/dot-experiments-goals-coming-soon.component.scss
@@ -31,7 +31,7 @@
             .p-card-header {
                 min-height: 5rem;
                 padding: 0;
-                background-color: $color-palette-secondary-200;
+                background-color: $color-palette-primary-100;
                 display: flex;
                 align-items: center;
                 justify-content: center;
@@ -39,7 +39,7 @@
 
                 i {
                     font-size: $font-size-xl;
-                    color: $color-palette-secondary-500;
+                    color: $color-palette-primary-500;
                 }
             }
 

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component.html
@@ -1,14 +1,16 @@
-<p-inplace [disabled]="disabled">
+<p-inplace class="flex w-full" [disabled]="disabled">
     <ng-template pTemplate="display">
-        <div class="flex">
-            <span *ngIf="text; else noTextDefinedTpl" data-testId="text-input">
+        <div class="flex flex-wrap align-items-center gap-2">
+            <ng-container *ngIf="text; else noTextDefinedTpl" data-testId="text-input">
                 {{ text }}
-            </span>
-            <i
-                class="pi pi-pencil cursor-pointer"
+            </ng-container>
+            <button
+                class="p-button-rounded p-button-sm p-button-text"
                 *ngIf="!disabled"
-                data-testId="text-input-icon"
-            ></i>
+                [class]="inplaceSizes[inputSize].button"
+                icon="pi pi-pencil"
+                pButton
+            ></button>
         </div>
 
         <ng-template #noTextDefinedTpl>
@@ -19,36 +21,39 @@
     </ng-template>
 
     <ng-template pTemplate="content">
-        <form [formGroup]="form" novalidate>
-            <div class="flex gap-2 control">
-                <div class="p-input-icon-right flex flex-column w-full">
-                    <input
-                        data-testId="inplace-input"
-                        dotAutofocus
-                        formControlName="text"
-                        pInputText
-                    />
-                    <i
-                        class="pi pi-times cursor-pointer"
-                        (click)="deactivateInplace()"
-                        data-testId="variant-inplace-button"
-                    ></i>
-                </div>
-                <button
-                    class="p-button-rounded p-button-text"
-                    [disabled]="form.invalid || textControl.pristine"
-                    [loading]="isLoading"
-                    (click)="saveAction()"
-                    data-testId="text-save-btn"
-                    icon="pi pi-save"
-                    pButton
-                    type="button"
-                ></button>
+        <form class="flex flex-grow-1 gap-2" [class]="inputSize" [formGroup]="form" novalidate>
+            <div class="flex-grow-1 flex p-input-icon-right">
+                <input
+                    class="w-full"
+                    [class]="inplaceSizes[inputSize].input"
+                    (keydown.enter)="saveAction()"
+                    (keydown.escape)="deactivateInplace()"
+                    data-testId="inplace-input"
+                    dotAutofocus
+                    formControlName="text"
+                    pInputText
+                />
+                <i
+                    class="pi pi-times cursor-pointer"
+                    (click)="deactivateInplace()"
+                    data-testId="variant-inplace-button"
+                ></i>
             </div>
-
-            <div class="validation-error">
-                <dot-field-validation-message [field]="textControl"></dot-field-validation-message>
-            </div>
+            <button
+                class="p-button-rounded p-button-sm p-button-text"
+                [class]="inplaceSizes[inputSize].button"
+                [disabled]="form.invalid || textControl.pristine"
+                [loading]="isLoading"
+                (click)="saveAction()"
+                data-testId="text-save-btn"
+                icon="pi pi-save"
+                pButton
+                type="button"
+            ></button>
         </form>
+
+        <ng-container *ngIf="form.invalid">
+            <dot-field-validation-message [field]="textControl"></dot-field-validation-message>
+        </ng-container>
     </ng-template>
 </p-inplace>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component.html
@@ -1,13 +1,14 @@
 <p-inplace class="flex w-full" [disabled]="disabled">
     <ng-template pTemplate="display">
         <div class="flex flex-wrap align-items-center gap-2">
-            <ng-container *ngIf="text; else noTextDefinedTpl" data-testId="text-input">
-                {{ text }}
+            <ng-container *ngIf="text; else noTextDefinedTpl">
+                <span data-testId="text-input">{{ text }}</span>
             </ng-container>
             <button
                 class="p-button-rounded p-button-sm p-button-text"
                 *ngIf="!disabled"
                 [class]="inplaceSizes[inputSize].button"
+                data-testId="text-input-button"
                 icon="pi pi-pencil"
                 pButton
             ></button>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component.scss
@@ -1,40 +1,64 @@
 @use "variables" as *;
 
-.text-muted {
-    color: $color-palette-gray-600;
-}
+:host {
+    display: flex;
+    min-height: 2.2rem;
+    flex-wrap: wrap;
+    align-content: center;
+    position: relative;
 
-:host ::ng-deep {
-    .p-disabled,
-    .p-component:disabled {
-        opacity: 0.8;
+    .text-muted {
+        color: $color-palette-gray-600;
     }
 
-    p-inplace .p-inplace {
-        .p-inplace-display {
-            padding: 0;
-            white-space: pre-wrap;
-
+    form {
+        &.small {
             i {
-                margin-left: $spacing-1;
-                margin-right: $spacing-1;
-                font-size: 0.85rem;
+                font-size: 0.75rem;
+                margin-top: -0.375rem;
             }
+        }
+    }
 
-            &.p-disabled {
-                color: $color-palette-gray-800;
-            }
+    dot-field-validation-message {
+        position: absolute;
+        bottom: -1.125rem;
+    }
 
-            &:not(.p-disabled):hover {
-                background: transparent;
-                text-decoration: underline;
+    &::ng-deep {
+        .p-disabled,
+        .p-component {
+            width: 100%;
+
+            &:disabled {
+                opacity: 0.8;
             }
         }
 
-        .p-inplace-content {
-            display: flex;
-            gap: $spacing-1;
-            flex-direction: column;
+        p-inplace .p-inplace {
+            .p-inplace-display {
+                padding: 0;
+                white-space: pre-wrap;
+
+                i {
+                    margin-left: $spacing-1;
+                    margin-right: $spacing-1;
+                    font-size: 0.85rem;
+                }
+
+                &.p-disabled {
+                    color: $color-palette-gray-800;
+                }
+
+                &:not(.p-disabled):hover {
+                    background: transparent;
+                }
+            }
+
+            .p-inplace-content {
+                display: flex;
+                flex-direction: column;
+            }
         }
     }
 }

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component.scss
@@ -14,7 +14,7 @@
     form {
         &.small {
             i {
-                font-size: 0.75rem;
+                font-size: $font-size-xs;
                 margin-top: -0.375rem;
             }
         }
@@ -43,7 +43,7 @@
                 i {
                     margin-left: $spacing-1;
                     margin-right: $spacing-1;
-                    font-size: 0.85rem;
+                    font-size: $font-size-sm;
                 }
 
                 &.p-disabled {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-inline-edit-text/dot-experiments-inline-edit-text.component.spec.ts
@@ -15,6 +15,7 @@ const messageServiceMock = new MockDotMessageService({
     'experiments.configure.scheduling.start': 'When the experiment start'
 });
 
+const EMPTY_TEXT = '';
 const SHORT_TEXT = 'short text';
 const LONG_TEXT =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed condimentum eros sit amet malesuada mattis. Morbi ac congue lectus, ut vestibulum velit. Ut sed ornare metus. Proin a orci lacus. Aenean odio lacus, fringilla eu ipsum non, pellentesque sagittis purus. Integer non.';
@@ -23,9 +24,7 @@ const NEW_EXPERIMENT_DESCRIPTION = 'new experiment description';
 describe('DotExperimentsExperimentSummaryComponent', () => {
     let spectator: Spectator<DotExperimentsInlineEditTextComponent>;
     const createComponent = createComponentFactory({
-        imports: [],
         component: DotExperimentsInlineEditTextComponent,
-
         providers: [
             {
                 provide: DotMessageService,
@@ -74,7 +73,7 @@ describe('DotExperimentsExperimentSummaryComponent', () => {
 
         it('should show a icon to edit', () => {
             expect(spectator.query(byTestId('text-input'))).toExist();
-            expect(spectator.query(byTestId('text-input-icon'))).toExist();
+            expect(spectator.query(byTestId('text-input-button'))).toExist();
         });
 
         it('should change the `maxLength` Validator if the `@Input maxCharacterLength` is sent', () => {
@@ -85,10 +84,37 @@ describe('DotExperimentsExperimentSummaryComponent', () => {
             expect(spectator.component.form.invalid).toEqual(true);
         });
 
+        it('should add the Validator `required` if the `@Input required` is true', () => {
+            spectator.setInput('text', EMPTY_TEXT);
+            spectator.setInput('required', true);
+
+            spectator.component.form.controls['text'].setValue(SHORT_TEXT);
+            expect(spectator.component.form.invalid).toEqual(false);
+
+            spectator.component.form.controls['text'].setValue(EMPTY_TEXT);
+            expect(spectator.component.form.invalid).toEqual(true);
+        });
+
         describe('/interactions', () => {
             it('should show an input if you click on edit', () => {
-                spectator.dispatchMouseEvent(byTestId('text-input'), 'click');
+                spectator.click(byTestId('text-input'));
                 expect(spectator.query(byTestId('inplace-input'))).toExist();
+            });
+
+            it('should not show an input if you press `ESC` in the keyboard', () => {
+                jest.spyOn(spectator.component, 'deactivateInplace');
+
+                spectator.click(byTestId('text-input'));
+                expect(spectator.query(byTestId('inplace-input'))).toExist();
+
+                spectator.dispatchKeyboardEvent(
+                    spectator.query(byTestId('inplace-input')),
+                    'keydown',
+                    'Escape'
+                );
+
+                expect(spectator.component.deactivateInplace).toHaveBeenCalled();
+                expect(spectator.query(byTestId('inplace-input'))).not.toExist();
             });
 
             it('should save button be disabled if the input has more than `MAX_INPUT_DESCRIPTIVE_LENGTH` ', () => {

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5231,6 +5231,7 @@ experiments.goal.reach_page.form.conditions.operator.label=Operator
 experiments.goal.reach_page.form.conditions.operator.placeholder=Select an operator
 experiments.goal.reach_page.form.conditions.value.label=Value
 experiments.goal.reach_page.form.conditions.value.placeholder=Set a value
+<<<<<<< Updated upstream
 experiments.goal.url_parameter.form.conditions.parameter.label=Parameter Name
 experiments.goal.url_parameter.form.conditions.parameter.placeholder=Add a parameter name
 experiments.goal.url_parameter.form.conditions.operator.label=Operator

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5231,7 +5231,6 @@ experiments.goal.reach_page.form.conditions.operator.label=Operator
 experiments.goal.reach_page.form.conditions.operator.placeholder=Select an operator
 experiments.goal.reach_page.form.conditions.value.label=Value
 experiments.goal.reach_page.form.conditions.value.placeholder=Set a value
-<<<<<<< Updated upstream
 experiments.goal.url_parameter.form.conditions.parameter.label=Parameter Name
 experiments.goal.url_parameter.form.conditions.parameter.placeholder=Add a parameter name
 experiments.goal.url_parameter.form.conditions.operator.label=Operator


### PR DESCRIPTION
### Proposed Changes
* Fix jump when you edit an input inline at Experiment description, Variant Name, and Traffic Split 

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ecec0ef</samp>

This pull request improves the UI, functionality, and testability of the `dot-experiments` library, which provides the portlet for managing A/B testing experiments in dotCMS. It includes changes to the template, style, and spec files of several components, as well as the addition of a custom component for inline editing of variant names. It also updates the README file of the library and fixes a merge conflict in the `Language.properties` file.

## Related Issue
Fixes #25239 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ecec0ef</samp>

*  Add a new section to the documentation of the `dot-experiments` library, explaining the structure and purpose of each subfolder and project ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-fcc23edc3bf707bc4490b399f61dcbc63fb896e55db438447b26c4bfc6a90b0aR20-R35))
*  Replace the `p-inplace` element with the custom `dot-experiments-inplace-edit-text` component for the inline editing of the variant name in the `dot-experiments-configuration-variants` component, and emit the changed value ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-f87f95949e5719b6bc13b751f89074af7f822e136be08a5c84973e195ce9ecb1L120-R130), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-474ea846c597331705596804e9f966ceb814a6855f3ad5b1c68e40dcd09f7d1dR41), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-474ea846c597331705596804e9f966ceb814a6855f3ad5b1c68e40dcd09f7d1dL64-R68), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-733821b17300f0c7dd10ccad76f3f376d4d5c9cfbff7950144ec2d4ee6962f56L88-R119), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-4665eb4639984363d439a7f16a812c9d61acdaef734c793e2dae6b6b0e5df232L51-R111), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-4665eb4639984363d439a7f16a812c9d61acdaef734c793e2dae6b6b0e5df232R137-R140), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-4665eb4639984363d439a7f16a812c9d61acdaef734c793e2dae6b6b0e5df232L107-R154))
*  Modify the `dot-experiments-inline-edit-text` component, adding some `@Input` properties for the `isEmpty`, `isLoading`, `config`, and `data` values, and dynamically applying the required validation to the input field ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-4665eb4639984363d439a7f16a812c9d61acdaef734c793e2dae6b6b0e5df232L20-R22), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-4665eb4639984363d439a7f16a812c9d61acdaef734c793e2dae6b6b0e5df232L28-R37), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-4665eb4639984363d439a7f16a812c9d61acdaef734c793e2dae6b6b0e5df232L38-R53), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-4665eb4639984363d439a7f16a812c9d61acdaef734c793e2dae6b6b0e5df232L73-R122), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-4665eb4639984363d439a7f16a812c9d61acdaef734c793e2dae6b6b0e5df232R178))
*  Modify the template and style files of the `dot-experiments-inline-edit-text` component, changing the layout and content of the display mode, and improving the appearance and responsiveness of the component ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-712259052dae3d68ae013bbfce2f832e82c0596399a06ef2d4cc0b32135d3ac2L1-R14), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-712259052dae3d68ae013bbfce2f832e82c0596399a06ef2d4cc0b32135d3ac2L22-R58), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-f95f904546653293c6007dbd46e2c48ede229ffcb3cf210df651eecfe39848e8L3-R61))
*  Modify the spec files of the `dot-experiments-inline-edit-text` component, adding a test for the `ESC` key press behavior, and removing the `imports` array from the `createComponentFactory` function call ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-733821b17300f0c7dd10ccad76f3f376d4d5c9cfbff7950144ec2d4ee6962f56R18), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-733821b17300f0c7dd10ccad76f3f376d4d5c9cfbff7950144ec2d4ee6962f56L26-R27), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-733821b17300f0c7dd10ccad76f3f376d4d5c9cfbff7950144ec2d4ee6962f56L77-R76), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-733821b17300f0c7dd10ccad76f3f376d4d5c9cfbff7950144ec2d4ee6962f56L88-R119))
*  Modify the template and style files of the `dot-experiment-options` component, using a lighter shade of blue for the active and hovered option cards ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-770b7d69682b4c90b6313a8d3381a74d2881fec33c3227253047ea5f7523c253L48-R48), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-770b7d69682b4c90b6313a8d3381a74d2881fec33c3227253047ea5f7523c253L61-R61))
*  Modify the `dot-experiments-reports-chart` component, adding a mock component and module for the `p-chart` component, and removing the Jest mock for the `ResizeObserver` ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-7292542bd2c6451174342242f27aba1cd4b12eb857c67e21030252785f012863L3-R6), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-7292542bd2c6451174342242f27aba1cd4b12eb857c67e21030252785f012863L11), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-7292542bd2c6451174342242f27aba1cd4b12eb857c67e21030252785f012863R21-R43), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-7292542bd2c6451174342242f27aba1cd4b12eb857c67e21030252785f012863L25-R57), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-7292542bd2c6451174342242f27aba1cd4b12eb857c67e21030252785f012863L37-R69), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-7292542bd2c6451174342242f27aba1cd4b12eb857c67e21030252785f012863L63-R86), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-7292542bd2c6451174342242f27aba1cd4b12eb857c67e21030252785f012863L86))
*  Modify the `dot-experiments-reports` component, adding a mock component for the `dot-experiments-reports-chart` component, and removing some unused import statements ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-0672d1e1f3b4f3999837b29ddbcdc39c08ea2655c1f993e9614f1df8e8bbb6daL8-R15), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-0672d1e1f3b4f3999837b29ddbcdc39c08ea2655c1f993e9614f1df8e8bbb6daL29), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-0672d1e1f3b4f3999837b29ddbcdc39c08ea2655c1f993e9614f1df8e8bbb6daL40), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-0672d1e1f3b4f3999837b29ddbcdc39c08ea2655c1f993e9614f1df8e8bbb6daR74-R91), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-0672d1e1f3b4f3999837b29ddbcdc39c08ea2655c1f993e9614f1df8e8bbb6daL83-R109), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-0672d1e1f3b4f3999837b29ddbcdc39c08ea2655c1f993e9614f1df8e8bbb6daL117-L124), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-0672d1e1f3b4f3999837b29ddbcdc39c08ea2655c1f993e9614f1df8e8bbb6daL153-R161))
*  Modify the `dot-experiments-configuration-variants` component, adding some import statements for some constants from the `dot-experiments-constants.ts` file, and changing the order, visibility, and values of some constants ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-474ea846c597331705596804e9f966ceb814a6855f3ad5b1c68e40dcd09f7d1dL24-R27), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-474ea846c597331705596804e9f966ceb814a6855f3ad5b1c68e40dcd09f7d1dL79-R89))
*  Modify the spec file of the `dot-experiments-configuration-variants` component, adding an import statement for the `DotExperimentsInlineEditTextComponent`, adding a `f` prefix to the `describe` block, changing the `data-testId` attribute of the `span` element that displays the variant name, changing the way the variant names are queried and asserted, and commenting out some `it` blocks ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-28158d1e413714e3873c21ce3e9aeca29043b1bda1652a58bfe883ccd1a1e8abR38), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-28158d1e413714e3873c21ce3e9aeca29043b1bda1652a58bfe883ccd1a1e8abL64-R65), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-28158d1e413714e3873c21ce3e9aeca29043b1bda1652a58bfe883ccd1a1e8abL117-R118), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-28158d1e413714e3873c21ce3e9aeca29043b1bda1652a58bfe883ccd1a1e8abL147-R151), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-28158d1e413714e3873c21ce3e9aeca29043b1bda1652a58bfe883ccd1a1e8abL257-R312))
*  Modify the template file of the `dot-experiments-configuration-variants` component, adding a `variant-row-wrapper` class and some flex properties to the `div` element that wraps the variant card title, and adding a `-original` suffix to the `data-testId` attribute of the `span` element that displays the variant name ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-f87f95949e5719b6bc13b751f89074af7f822e136be08a5c84973e195ce9ecb1L32-R34), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-f87f95949e5719b6bc13b751f89074af7f822e136be08a5c84973e195ce9ecb1L40-R42))
*  Modify the style file of the `dot-experiments-configuration-variants` component, adding a `variant-row-wrapper` class with a `min-height` property ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-10ebdd9b8627b2113ebd45d4b719ce5444c0faf19415f9a6a0daadd3f8334461R3-R6))
*  Modify the template file of the `dot-experiments-configuration-traffic-split-add` component, adding a `p-inputtext-sm` class to the `p-inputNumber` element, and removing the `| json` pipe ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-46049ffcf187469ef813bddff9c03bf50e1ca042a44e24fc0112b7e6decd4962L52-R52), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-46049ffcf187469ef813bddff9c03bf50e1ca042a44e24fc0112b7e6decd4962L70-R70))
*  Modify the style file of the `dot-experiments-configuration-traffic-split-add` component, adding a `min-height` property to the `.experiment-traffic-split__variants-weight` class ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-346dc9e1b1d63bf25a54274f32998c63dc6e69a740c889af0e60d8d994b934fdR33))
*  Modify the template file of the `dot-experiments-configuration-goal-select` component, removing an empty line, removing an unnecessary `div` element, and adding a `p-inputtext-sm` class to the `input` element ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-2d233739b679a4e33026a89a245b8a88a6b247d6eaf6e367739847208b1bcf52L12), [link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-2d233739b679a4e33026a89a245b8a88a6b247d6eaf6e367739847208b1bcf52L61-R81))
*  Modify the `dot-experiments-list-table` component, changing the method name from `goToConfiguration` to `archive` for the archive button ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-47ff8e7da16ff598a09d04b521a054c50ccbca38ae913fec184a9440695f8b3fL81-R81))
*  Add an empty line to the end of the `dot-experiments-constants.ts` file ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-f1a1a6a6f21372c106dd50983b66d511523dd176656f6d368fe830a87a26b09cR150))
*  Add a merge conflict marker to the `Language.properties` file ([link](https://github.com/dotCMS/core/pull/25349/files?diff=unified&w=0#diff-21db9723fa4c52389731b7575f1e19bd364aa992b7e549e22c08a33456994e94R5233))
