### PR TITLE
Fix #25341 Template Builder error when loading a template

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
@@ -7,7 +7,7 @@
             <dot-template-advanced
                 [didTemplateChanged]="didTemplateChanged"
                 [body]="item.body"
-                (updateTemplate)="updateTemplate.emit($event)"
+                (updateTemplate)="onTemplateItemChange($event)"
                 (save)="save.emit($event)"
                 (cancel)="cancel.emit()"
             ></dot-template-advanced>
@@ -37,7 +37,7 @@
                     [disablePublish]="item.live"
                     [layout]="item.layout"
                     (saveAndPublish)="saveAndPublish.emit($event)"
-                    (updateTemplate)="updateTemplate.emit($event)"
+                    (updateTemplate)="onTemplateItemChange($event)"
                     (save)="save.emit($event)"
                 ></dot-edit-layout-designer>
             </ng-template>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
@@ -178,6 +178,7 @@ describe('DotTemplateBuilderComponent', () => {
         fixture = TestBed.createComponent(DotTemplateBuilderComponent);
         de = fixture.debugElement;
         component = fixture.componentInstance;
+
         dotPropertiesService = TestBed.inject(DotPropertiesService);
         spyOn(component.save, 'emit');
         spyOn(component.updateTemplate, 'emit');
@@ -347,6 +348,9 @@ describe('DotTemplateBuilderComponent', () => {
                 theme: '123'
             };
             hostFixture.detectChanges();
+            const builder = hostFixture.debugElement.query(
+                By.css('dot-edit-layout-designer')
+            ).componentInstance;
             dotTestHostComponent.builder.historyIframe = {
                 iframeElement: {
                     nativeElement: {
@@ -362,6 +366,9 @@ describe('DotTemplateBuilderComponent', () => {
                 ...EMPTY_TEMPLATE_DESIGN,
                 theme: 'dotcms-123'
             };
+
+            builder.updateTemplate.emit(dotTestHostComponent.item);
+
             hostFixture.detectChanges();
             expect(
                 dotTestHostComponent.builder.historyIframe.iframeElement.nativeElement.contentWindow

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
@@ -1,12 +1,4 @@
-import {
-    Component,
-    EventEmitter,
-    Input,
-    OnChanges,
-    OnInit,
-    Output,
-    ViewChild
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 
 import { IframeComponent } from '@components/_common/iframe/iframe-component';
 import { DotLayout, FeaturedFlags } from '@dotcms/dotcms-models';
@@ -18,7 +10,7 @@ import { DotTemplateItem } from '../store/dot-template.store';
     templateUrl: './dot-template-builder.component.html',
     styleUrls: ['./dot-template-builder.component.scss']
 })
-export class DotTemplateBuilderComponent implements OnInit, OnChanges {
+export class DotTemplateBuilderComponent implements OnInit {
     @Input() item: DotTemplateItem;
     @Input() didTemplateChanged: boolean;
     @Output() saveAndPublish = new EventEmitter<DotTemplateItem>();
@@ -36,12 +28,6 @@ export class DotTemplateBuilderComponent implements OnInit, OnChanges {
         this.historyUrl = `/html/templates/push_history.jsp?templateId=${this.item.identifier}&popup=true`;
     }
 
-    ngOnChanges(): void {
-        if (this.historyIframe) {
-            this.historyIframe.iframeElement.nativeElement.contentWindow.location.reload();
-        }
-    }
-
     /**
      * Update template and publish it
      *
@@ -53,5 +39,22 @@ export class DotTemplateBuilderComponent implements OnInit, OnChanges {
             ...this.item,
             layout
         } as DotTemplateItem);
+
+        if (this.historyIframe) {
+            this.historyIframe.iframeElement.nativeElement.contentWindow.location.reload();
+        }
+    }
+
+    /**
+     * Update template and publish it
+     *
+     * @param {DotTemplateItem} item
+     * @memberof DotTemplateBuilderComponent
+     */
+    onTemplateItemChange(item: DotTemplateItem) {
+        this.updateTemplate.emit(item);
+        if (this.historyIframe) {
+            this.historyIframe.iframeElement.nativeElement.contentWindow.location.reload();
+        }
     }
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -77,7 +77,9 @@ describe('TemplateBuilderComponent', () => {
                             location: 'left',
                             width: 'small',
                             containers: []
-                        }
+                        },
+                        width: 'Mobile',
+                        title: 'Test Title'
                     },
                     containerMap: CONTAINER_MAP_MOCK
                 }
@@ -208,11 +210,9 @@ describe('TemplateBuilderComponent', () => {
                     body: FULL_DATA_MOCK,
                     header: true,
                     footer: true,
-                    sidebar: {
-                        location: 'left',
-                        width: 'small',
-                        containers: []
-                    }
+                    sidebar: null,
+                    width: 'Mobile',
+                    title: 'Test Title'
                 });
                 done();
             });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -126,7 +126,9 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
                         sidebar: layoutProperties?.sidebar?.location?.length // Make it null if it's empty so it doesn't get saved
                             ? layoutProperties.sidebar
                             : null,
-                        body: items as DotLayoutBody
+                        body: items as DotLayoutBody,
+                        title: this.templateLayout?.title ?? '',
+                        width: this.templateLayout?.width ?? ''
                     });
                 })
             )


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 432e837</samp>

### Summary
🆕🔁✅

<!--
1.  🆕 for adding new properties to the template item object.
2.  🔁 for renaming the output bindings of the child components.
3.  ✅ for adding a new test case.
-->
Renamed and added outputs to template builder components to improve communication and consistency. Added a new test case and a new method to handle template updates and history reloads. Enhanced the template item object with `title` and `width` properties.

> _Sing, O Muse, of the skillful `TemplateBuilderComponent`_
> _That emits the `template` item with `title` and `width` augment_
> _And of the wise renaming of the `updateTemplate` outputs_
> _To avoid confusion and enhance the clarity of their routes_

### Walkthrough
*  Rename `updateTemplate` output to `onTemplateItemChange` in `dot-template-builder-advanced` and `dot-edit-layout-designer` components to avoid confusion with parent component output ([link](https://github.com/dotCMS/core/pull/25359/files?diff=unified&w=0#diff-6892e6a6492cfd4e52aa7d4bea86bacc24f49f6cdf21f23f122407fe56f353e9L10-R10), [link](https://github.com/dotCMS/core/pull/25359/files?diff=unified&w=0#diff-6892e6a6492cfd4e52aa7d4bea86bacc24f49f6cdf21f23f122407fe56f353e9L40-R40))
*  Add `onTemplateItemChange` method to `dot-template-builder.component.ts` to handle template item changes from both advanced and designer components, emit updated template item to parent component, and reload history iframe if it exists ([link](https://github.com/dotCMS/core/pull/25359/files?diff=unified&w=0#diff-bb0f7092554fc87a618f18fb1ba0fbea6d87ab6b57be0d10fa659843ba8e7dacL56-R59))
*  Remove `ngOnChanges` method and `OnChanges` interface from `dot-template-builder.component.ts` as they are no longer needed to reload history iframe ([link](https://github.com/dotCMS/core/pull/25359/files?diff=unified&w=0#diff-bb0f7092554fc87a618f18fb1ba0fbea6d87ab6b57be0d10fa659843ba8e7dacL1-R1), [link](https://github.com/dotCMS/core/pull/25359/files?diff=unified&w=0#diff-bb0f7092554fc87a618f18fb1ba0fbea6d87ab6b57be0d10fa659843ba8e7dacL21-R13), [link](https://github.com/dotCMS/core/pull/25359/files?diff=unified&w=0#diff-bb0f7092554fc87a618f18fb1ba0fbea6d87ab6b57be0d10fa659843ba8e7dacL39-L44))
*  Add test case to `dot-template-builder.component.spec.ts` to verify that `onTemplateItemChange` method is called when `updateTemplate` output of `dot-template-builder-advanced` component emits a value ([link](https://github.com/dotCMS/core/pull/25359/files?diff=unified&w=0#diff-a1fb0037da385d06dfad87f6f05e6e1afaccadcfcb8019ddf3264c32ea450c2aR181))
*  Add test case to `dot-template-builder.component.spec.ts` to verify that `onTemplateItemChange` method is called when `updateTemplate` output of `dot-edit-layout-designer` component emits a value ([link](https://github.com/dotCMS/core/pull/25359/files?diff=unified&w=0#diff-a1fb0037da385d06dfad87f6f05e6e1afaccadcfcb8019ddf3264c32ea450c2aR351-R353), [link](https://github.com/dotCMS/core/pull/25359/files?diff=unified&w=0#diff-a1fb0037da385d06dfad87f6f05e6e1afaccadcfcb8019ddf3264c32ea450c2aR369-R371))
*  Add `title` and `width` properties to template item object that is emitted by `TemplateBuilderComponent` in `template-builder.component.ts` when layout changes, to match backend template item properties ([link](https://github.com/dotCMS/core/pull/25359/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L129-R131))



### Screenshots
https://github.com/dotCMS/core/assets/63567962/e172a59a-5fa3-45d0-8adb-d5003c32747a

