### PR TITLE
Fix focus test and add rules to prevent push focus tests

### DIFF
--- a/core-web/.eslintrc.json
+++ b/core-web/.eslintrc.json
@@ -1,7 +1,7 @@
 {
     "root": true,
     "ignorePatterns": ["**/*"],
-    "plugins": ["@nrwl/nx", "eslint-plugin-import"],
+    "plugins": ["@nrwl/nx", "eslint-plugin-import", "ban"],
     "overrides": [
         {
             "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
@@ -67,6 +67,15 @@
                     }
                 ],
                 "no-duplicate-imports": "error",
+                "ban/ban": [
+                    2,
+                    { "name": ["describe", "only"], "message": "don't focus tests" },
+                    { "name": "fdescribe", "message": "don't focus tests" },
+                    { "name": ["it", "only"], "message": "don't focus tests" },
+                    { "name": "fit", "message": "don't focus tests" },
+                    { "name": ["test", "only"], "message": "don't focus tests" },
+                    { "name": "ftest", "message": "don't focus tests" }
+                ],
                 "import/order": [
                     "error",
                     {

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-ui-colors/dot-ui-colors.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-ui-colors/dot-ui-colors.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { DEFAULT_COLORS, DotUiColorsService } from './dot-ui-colors.service';
 
-fdescribe('DotUiColorsService', () => {
+describe('DotUiColorsService', () => {
     let service: DotUiColorsService;
     let injector;
     let setPropertySpy;
@@ -144,7 +144,7 @@ fdescribe('DotUiColorsService', () => {
         expect(html.style.setProperty).not.toHaveBeenCalled();
     });
 
-    fit('should set manual picked colors', () => {
+    it('should set manual picked colors', () => {
         service.setColors(document.querySelector('html'), {
             primary: DEFAULT_COLORS.primary,
             secondary: DEFAULT_COLORS.secondary,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/directives/dot-edit-page-nav.directive.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/directives/dot-edit-page-nav.directive.ts
@@ -54,8 +54,10 @@ export class DotEditPageNavDirective implements OnDestroy {
 
     private addPortletClass(url: string) {
         const key = Object.keys(urlPortletRules).find((key) => url.includes(key));
-        this.removePortletsClasses();
-        this.renderer.addClass(this.hostElement.nativeElement, urlPortletRules[key].clazz);
+        if (key) {
+            this.removePortletsClasses();
+            this.renderer.addClass(this.hostElement.nativeElement, urlPortletRules[key].clazz);
+        }
     }
 
     private removePortletsClasses() {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.spec.ts
@@ -178,7 +178,7 @@ describe('DotCreatePersonaFormComponent', () => {
 
             const removeButton: DebugElement = fixture.debugElement.query(By.css('button'));
             removeButton.triggerEventHandler('click', {});
-            expect(removeButton.nativeElement.innerText).toBe('REMOVE');
+            expect(removeButton.nativeElement.innerText).toBe('Remove');
             expect(component.form.get('photo').value).toEqual('');
             expect(component.tempUploadedFile).toEqual(null);
         });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-input-row/dot-key-value-table-input-row.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-input-row/dot-key-value-table-input-row.component.spec.ts
@@ -79,8 +79,8 @@ describe('DotKeyValueTableInputRowComponent', () => {
 
             expect(inputs[0].nativeElement.placeholder).toContain('Enter Key');
             expect(inputs[1].nativeElement.placeholder).toContain('Enter Value');
-            expect(btns[0].nativeElement.innerText).toContain('CANCEL');
-            expect(btns[1].nativeElement.innerText).toContain('SAVE');
+            expect(btns[0].nativeElement.innerText).toContain('Cancel');
+            expect(btns[1].nativeElement.innerText).toContain('Save');
             expect(comp.saveDisabled).toBe(true);
         });
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selector-option/dot-persona-selector-option.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selector-option/dot-persona-selector-option.component.spec.ts
@@ -72,7 +72,7 @@ describe('DotPersonaSelectorOptionComponent', () => {
 
         it('should have personalized button with right properties', () => {
             const btnElement: DebugElement = de.query(By.css('button'));
-            expect(btnElement.nativeElement.innerText).toBe('PERSONALIZED');
+            expect(btnElement.nativeElement.innerText).toBe('Personalized');
             expect(btnElement.attributes.icon).toBe('pi pi-times');
             expect(btnElement.attributes.iconPos).toBe('right');
         });

--- a/core-web/package.json
+++ b/core-web/package.json
@@ -177,6 +177,7 @@
         "dotenv": "10.0.0",
         "eslint": "8.15.0",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-ban": "^1.6.0",
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-plugin-import": "^2.26.0",
         "flatpickr": "^4.5.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,49 @@
     "name": "core",
     "lockfileVersion": 2,
     "requires": true,
-    "packages": {}
+    "packages": {
+        "": {
+            "devDependencies": {
+                "eslint-plugin-ban": "^1.6.0"
+            }
+        },
+        "node_modules/eslint-plugin-ban": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-ban/-/eslint-plugin-ban-1.6.0.tgz",
+            "integrity": "sha512-gZptoV+SFHOHO57/5lmPvizMvSXrjFatP9qlVQf3meL/WHo9TxSoERygrMlESl19CPh95U86asTxohT8OprwDw==",
+            "dev": true,
+            "dependencies": {
+                "requireindex": "~1.2.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/requireindex": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+            "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.5"
+            }
+        }
+    },
+    "dependencies": {
+        "eslint-plugin-ban": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-ban/-/eslint-plugin-ban-1.6.0.tgz",
+            "integrity": "sha512-gZptoV+SFHOHO57/5lmPvizMvSXrjFatP9qlVQf3meL/WHo9TxSoERygrMlESl19CPh95U86asTxohT8OprwDw==",
+            "dev": true,
+            "requires": {
+                "requireindex": "~1.2.0"
+            }
+        },
+        "requireindex": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+            "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+            "dev": true
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "eslint-plugin-ban": "^1.6.0"
+    }
+}


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1083a5b</samp>

### Summary
:package::no_entry_sign::white_check_mark:

<!--
1.  :package: This emoji represents adding a new dependency to the project, which is a common task for developers.
2.  :no_entry_sign: This emoji represents banning or prohibiting something, which is the purpose of the custom eslint rule.
3.  :white_check_mark: This emoji represents passing or improving tests, which is the outcome of the test file refactoring.
-->
Added a custom eslint rule to enforce full test coverage and refactored the test file for `DotUiColorsService`. This change improves the code quality and consistency of the `core-web` module.

> _`ban` plugin added_
> _No more focused tests allowed_
> _Winter of coverage_

### Walkthrough
*  Add `eslint-plugin-ban` dependency to `package.json` ([link](https://github.com/dotCMS/core/pull/25368/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R1-R5)) to enable custom rules for banning expressions or patterns in the code



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
