### PR TITLE
#25322 template builder ui adjustments add padding depending on feature flag

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
@@ -1,4 +1,6 @@
-<p-tabView>
+<p-tabView
+    [styleClass]="(featureFlagIsOn$ | async) && 'dot-template-builder__new-template-builder'"
+>
     <p-tabPanel
         [header]="item.type === 'advanced' ? ('code' | dm) : ('design' | dm)"
         data-testId="builder"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.scss
@@ -30,8 +30,10 @@
             overflow-y: hidden;
         }
 
-        .p-tabview-nav {
-            padding: 0 $spacing-5;
+        .dot-template-builder__new-template-builder {
+            .p-tabview-nav {
+                padding: 0 $spacing-5;
+            }
         }
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
@@ -22,7 +22,7 @@ import { IframeComponent } from '@components/_common/iframe/iframe-component';
 import { DotPortletBoxModule } from '@components/dot-portlet-base/components/dot-portlet-box/dot-portlet-box.module';
 import { DotShowHideFeatureDirective } from '@dotcms/app/shared/directives/dot-show-hide-feature/dot-show-hide-feature.directive';
 import { DotEventsService, DotMessageService, DotPropertiesService } from '@dotcms/data-access';
-import { DotLayout, DotTemplateDesigner } from '@dotcms/dotcms-models';
+import { DotContainerMap, DotLayout, DotTemplateDesigner } from '@dotcms/dotcms-models';
 import { DotIconModule, DotMessagePipeModule } from '@dotcms/ui';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 
@@ -33,6 +33,7 @@ import {
     EMPTY_TEMPLATE_ADVANCED,
     EMPTY_TEMPLATE_DESIGN
 } from '../store/dot-template.store';
+import { TabViewModule } from 'primeng/tabview';
 
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
@@ -99,7 +100,9 @@ export class IframeMockComponent {
     selector: 'p-tabView',
     template: '<ng-content></ng-content>'
 })
-export class TabViewMockComponent {}
+export class TabViewMockComponent {
+    @Input() styleClass: string;
+}
 
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
@@ -128,7 +131,7 @@ class DotTestHostComponent {
     item: DotTemplateItem;
 }
 
-describe('DotTemplateBuilderComponent', () => {
+fdescribe('DotTemplateBuilderComponent', () => {
     let component: DotTemplateBuilderComponent;
     let fixture: ComponentFixture<DotTemplateBuilderComponent>;
     let de: DebugElement;
@@ -167,7 +170,10 @@ describe('DotTemplateBuilderComponent', () => {
                 {
                     provide: DotPropertiesService,
                     useValue: {
-                        getKey: () => of('false')
+                        getKey: () => {
+                            console.log('running original mock');
+                            return of('true');
+                        }
                     }
                 },
                 DotEventsService
@@ -282,6 +288,15 @@ describe('DotTemplateBuilderComponent', () => {
 
             (btnsave.nativeElement as HTMLElement).click();
             expect(component.saveAndPublish.emit).toHaveBeenCalled();
+        });
+
+        it('should add style classes if new template builder feature flag is on', () => {
+            fixture.detectChanges();
+            const tabView = de.query(By.css('p-tabView'));
+            const tabViewComponent: TabViewMockComponent = tabView.componentInstance;
+            expect(tabViewComponent.styleClass).toEqual(
+                'dot-template-builder__new-template-builder'
+            );
         });
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
@@ -33,7 +33,6 @@ import {
     EMPTY_TEMPLATE_ADVANCED,
     EMPTY_TEMPLATE_DESIGN
 } from '../store/dot-template.store';
-import { TabViewModule } from 'primeng/tabview';
 
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
@@ -131,7 +130,13 @@ class DotTestHostComponent {
     item: DotTemplateItem;
 }
 
-fdescribe('DotTemplateBuilderComponent', () => {
+const ITEM_FOR_NEW_TEMPLATE_BUILDER = {
+    ...EMPTY_TEMPLATE_DESIGN,
+    theme: '123',
+    live: true
+};
+
+describe('DotTemplateBuilderComponent', () => {
     let component: DotTemplateBuilderComponent;
     let fixture: ComponentFixture<DotTemplateBuilderComponent>;
     let de: DebugElement;
@@ -170,10 +175,7 @@ fdescribe('DotTemplateBuilderComponent', () => {
                 {
                     provide: DotPropertiesService,
                     useValue: {
-                        getKey: () => {
-                            console.log('running original mock');
-                            return of('true');
-                        }
+                        getKey: () => of('false')
                     }
                 },
                 DotEventsService
@@ -194,11 +196,7 @@ fdescribe('DotTemplateBuilderComponent', () => {
 
     describe('design', () => {
         beforeEach(() => {
-            component.item = {
-                ...EMPTY_TEMPLATE_DESIGN,
-                theme: '123',
-                live: true
-            };
+            component.item = ITEM_FOR_NEW_TEMPLATE_BUILDER;
             fixture.detectChanges();
         });
 
@@ -291,8 +289,10 @@ fdescribe('DotTemplateBuilderComponent', () => {
         });
 
         it('should add style classes if new template builder feature flag is on', () => {
+            fixture = TestBed.createComponent(DotTemplateBuilderComponent); // new fixture as async pipe was running before function was replaced
+            fixture.componentInstance.item = ITEM_FOR_NEW_TEMPLATE_BUILDER;
             fixture.detectChanges();
-            const tabView = de.query(By.css('p-tabView'));
+            const tabView = fixture.debugElement.query(By.css('p-tabView'));
             const tabViewComponent: TabViewMockComponent = tabView.componentInstance;
             expect(tabViewComponent.styleClass).toEqual(
                 'dot-template-builder__new-template-builder'

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
@@ -22,7 +22,7 @@ import { IframeComponent } from '@components/_common/iframe/iframe-component';
 import { DotPortletBoxModule } from '@components/dot-portlet-base/components/dot-portlet-box/dot-portlet-box.module';
 import { DotShowHideFeatureDirective } from '@dotcms/app/shared/directives/dot-show-hide-feature/dot-show-hide-feature.directive';
 import { DotEventsService, DotMessageService, DotPropertiesService } from '@dotcms/data-access';
-import { DotContainerMap, DotLayout, DotTemplateDesigner } from '@dotcms/dotcms-models';
+import { DotLayout, DotTemplateDesigner } from '@dotcms/dotcms-models';
 import { DotIconModule, DotMessagePipeModule } from '@dotcms/ui';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
@@ -1,7 +1,10 @@
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 
+import { map } from 'rxjs/operators';
+
 import { IframeComponent } from '@components/_common/iframe/iframe-component';
-import { FeaturedFlags } from '@dotcms/dotcms-models';
+import { DotPropertiesService } from '@dotcms/data-access';
+import { DotLayout, FeaturedFlags } from '@dotcms/dotcms-models';
 
 import { DotTemplateItem } from '../store/dot-template.store';
 
@@ -21,7 +24,12 @@ export class DotTemplateBuilderComponent implements OnInit {
     @ViewChild('historyIframe') historyIframe: IframeComponent;
     permissionsUrl = '';
     historyUrl = '';
-    featureFlag = FeaturedFlags.FEATURE_FLAG_TEMPLATE_BUILDER;
+    readonly featureFlag = FeaturedFlags.FEATURE_FLAG_TEMPLATE_BUILDER;
+    featureFlagIsOn$ = this.propertiesService
+        .getKey(this.featureFlag)
+        .pipe(map((result) => result && result === 'true'));
+
+    constructor(private propertiesService: DotPropertiesService) {}
 
     ngOnInit() {
         this.permissionsUrl = `/html/templates/permissions.jsp?templateId=${this.item.identifier}&popup=true`;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
@@ -4,7 +4,7 @@ import { map } from 'rxjs/operators';
 
 import { IframeComponent } from '@components/_common/iframe/iframe-component';
 import { DotPropertiesService } from '@dotcms/data-access';
-import { DotLayout, FeaturedFlags } from '@dotcms/dotcms-models';
+import { FeaturedFlags } from '@dotcms/dotcms-models';
 
 import { DotTemplateItem } from '../store/dot-template.store';
 


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3740ca0</samp>

Added feature flag logic and styling to the dot-template-builder component to enable or disable the new template builder UI. The feature flag is controlled by a property in the `DotPropertiesService`.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
