### PR TITLE
#25379 : Using `System Theme` in case the Template's theme is not specified

### DIFF
--- a/dotCMS/src/curl-test/Template Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Template Resource.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "dbad8b34-ca5a-49bb-a653-fc3e2c7b20b0",
+		"_postman_id": "873a1015-3bbc-4cc8-94e9-1527a13f5bff",
 		"name": "Template Resource",
 		"description": "Make the test for the template resource crud",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "1549189"
+		"_exporter_id": "5403727"
 	},
 	"item": [
 		{
@@ -5208,6 +5208,86 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Create New Template with Empty Theme",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"HTTP Status must be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"The new Template must be assigned the System Theme by default\", function () {",
+									"    var entity = pm.response.json().entity;",
+									"    pm.expect(entity.theme).to.eql('SYSTEM_THEME', 'The theme for the test Template must be SYSTEM_THEME');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"const time = new Date().getTime();",
+									"pm.collectionVariables.set(\"draftTemplateTitle\", \"My-Test-Template-\" + time);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"title\": \"{{draftTemplateTitle}}\",\n    \"friendlyName\": \"This is a test Template\",\n    \"body\": \"This is the body\",\n    \"theme\": \"\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/templates",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"templates"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -7575,6 +7655,10 @@
 		},
 		{
 			"key": "notAnonymousPageId",
+			"value": ""
+		},
+		{
+			"key": "draftTemplateTitle",
 			"value": ""
 		}
 	]

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/template/TemplateResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/template/TemplateResource.java
@@ -14,15 +14,9 @@ import com.dotcms.util.pagination.ContainerPaginator;
 import com.dotcms.util.pagination.OrderDirection;
 import com.dotcms.util.pagination.TemplatePaginator;
 import com.dotmarketing.beans.Host;
-import com.dotmarketing.business.APILocator;
-
-import com.dotmarketing.business.CacheLocator;
-import com.dotmarketing.business.PermissionAPI;
-import com.dotmarketing.business.RoleAPI;
-import com.dotmarketing.business.VersionableAPI;
+import com.dotmarketing.business.*;
 import com.dotmarketing.business.web.HostWebAPI;
 import com.dotmarketing.business.web.WebAPILocator;
-import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -32,46 +26,22 @@ import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.templates.business.TemplateAPI;
 import com.dotmarketing.portlets.templates.design.util.DesignTemplateUtil;
 import com.dotmarketing.portlets.templates.model.Template;
-import com.dotmarketing.util.ActivityLogger;
-import com.dotmarketing.util.InodeUtils;
-import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.PageMode;
-import com.dotmarketing.util.UtilMethods;
-import com.dotmarketing.util.WebKeys;
+import com.dotmarketing.util.*;
 import com.google.common.annotations.VisibleForTesting;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import org.glassfish.jersey.server.JSONP;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static com.dotcms.util.CollectionsUtils.map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * CRUD of Templates
@@ -363,16 +333,30 @@ public class TemplateResource {
         return fillAndSaveTemplate(templateForm, user, host, pageMode, template, false);
     }
 
+    /**
+     * Takes the Template information submitted to this REST Endpoint and saves it to dotCMS the database.
+     *
+     * @param templateForm The {@link TemplateForm} object with the Template's data.
+     * @param user         The {@link User} that is saving this Template.
+     * @param site         The {@link Host} that this Template belongs to.
+     * @param pageMode     The {@link PageMode} object used to determine whether anonymous permissions must be respected
+     *                     or not.
+     * @param template     The {@link Template} object that will hold the incoming data.
+     * @param draft        If the Template is being saved as draft, set this to {@code true}.
+     * @return The new Template.
+     * @throws DotSecurityException The specified User does not have permission to save this Template.
+     * @throws DotDataException     An error occurred when interacting with the data source.
+     */
     @WrapInTransaction
     private Template fillAndSaveTemplate(final TemplateForm templateForm,
             final User user,
-            final Host host,
+            final Host site,
             final PageMode pageMode,
             final Template template,
             final boolean draft) throws DotSecurityException, DotDataException {
 
         template.setInode(draft?templateForm.getInode(): StringPool.BLANK);
-        template.setTheme(templateForm.getTheme());
+        template.setTheme(UtilMethods.isSet(templateForm.getTheme()) ? templateForm.getTheme() : Theme.SYSTEM_THEME);
         template.setBody(templateForm.getBody());
         template.setCountContainers(templateForm.getCountAddContainer());
         template.setCountAddContainer(templateForm.getCountAddContainer());
@@ -399,7 +383,7 @@ public class TemplateResource {
 
         if (templateForm.isDrawed()) {
             final String themeHostId = APILocator.getFolderAPI().find(templateForm.getTheme(), user, pageMode.respectAnonPerms).getHostId();
-            final String themePath   = themeHostId.equals(host.getInode())?
+            final String themePath   = themeHostId.equals(site.getInode())?
                     Template.THEMES_PATH + template.getThemeName() + "/":
                     "//" + APILocator.getHostAPI().find(themeHostId, user, pageMode.respectAnonPerms).getHostname()
                             + Template.THEMES_PATH + template.getThemeName() + "/";
@@ -411,9 +395,9 @@ public class TemplateResource {
 
 
         if (draft) {
-            this.templateAPI.saveDraftTemplate(template, host, user, pageMode.respectAnonPerms);
+            this.templateAPI.saveDraftTemplate(template, site, user, pageMode.respectAnonPerms);
         } else {
-            this.templateAPI.saveTemplate(template, host, user, pageMode.respectAnonPerms);
+            this.templateAPI.saveTemplate(template, site, user, pageMode.respectAnonPerms);
         }
 
         if (UtilMethods.isSet(containerUUIDChanges) && UtilMethods.isSet(containerUUIDChanges.lostUUIDValues())){
@@ -422,7 +406,7 @@ public class TemplateResource {
         }
 
         ActivityLogger.logInfo(this.getClass(), "Saved Template", "User " + user.getPrimaryKey()
-                + "Template: " + template.getTitle(), host.getTitle() != null? host.getTitle():"default");
+                + "Template: " + template.getTitle(), site.getTitle() != null? site.getTitle():"default");
 
         return template;
     }


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 437c3aa</samp>

### Summary
📝🧹🔠

<!--
1.  📝 - This emoji represents the enhancement of the postman collection with a new test case and a collection variable, as well as the documentation improvements in the `TemplateResource.java` class.
2.  🧹 - This emoji represents the simplification and cleanup of the import statements and the logic of the `fillAndSaveTemplate` method in the `TemplateResource.java` class.
3.  🔠 - This emoji represents the renaming of the `host` parameter to `site` in the `TemplateResource.java` class, which is a minor but meaningful change in terminology.
-->
This pull request updates the `TemplateResource.java` class and the `Template Resource.postman_collection.json` file. It enhances the Postman tests for the template resource, improves the code readability and documentation, and fixes a parameter name.

> _`TemplateResource`_
> _Enhanced and simplified_
> _Autumn of refactoring_

### Walkthrough
*  Simplify import statements in `TemplateResource.java` by using wildcard imports and removing unused imports ([link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL17-R19), [link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL35-R29), [link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL46-R45))
*  Add javadoc comment to `fillAndSaveTemplate` method in `TemplateResource.java` to explain its purpose, parameters and return value ([link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL366-R353))
*  Rename `host` parameter to `site` in `fillAndSaveTemplate` method in `TemplateResource.java` and update references accordingly to avoid confusion and be consistent with naming convention ([link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL402-R386), [link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL414-R400), [link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL425-R409))
*  Modify logic of `fillAndSaveTemplate` method in `TemplateResource.java` to assign default system theme to template when theme is empty or null ([link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL375-R359))
*  Add new test case to Template Resource postman collection to verify that template is created with default system theme when theme is empty ([link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-b07c04a7faff5e5c1b874053739dc3494f4fa023b46ff57dc50f36e33a33e0a4R5211-R5290))
*  Add `draftTemplateTitle` variable to Template Resource postman collection and use it to generate unique title for new template in test case ([link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-b07c04a7faff5e5c1b874053739dc3494f4fa023b46ff57dc50f36e33a33e0a4R7659-R7662))
*  Update postman_id and exporter_id of Template Resource postman collection ([link](https://github.com/dotCMS/core/pull/25383/files?diff=unified&w=0#diff-b07c04a7faff5e5c1b874053739dc3494f4fa023b46ff57dc50f36e33a33e0a4L3-R7))

