### PR TITLE
Fix #25381: Template Builder Fix Template Portlet Issue With Required Field

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-props.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-props/dot-template-props.component.html
@@ -28,9 +28,7 @@
         </div>
         <ng-container *ngIf="form.get('theme')">
             <div class="field" data-testId="themeField">
-                <label dotFieldRequired for="theme">{{
-                    'templates.properties.form.label.theme' | dm
-                }}</label>
+                <label for="theme">{{ 'templates.properties.form.label.theme' | dm }}</label>
                 <dot-theme-selector-dropdown
                     id="theme"
                     formControlName="theme"

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.spec.ts
@@ -108,6 +108,7 @@ describe('DotThemeSelectorDropdownComponent', () => {
                         url: '',
                         paginationPerPage: '',
                         total: '',
+                        extraParams: new Map(),
 
                         set searchParam(value) {
                             this.param = value;
@@ -124,8 +125,13 @@ describe('DotThemeSelectorDropdownComponent', () => {
                         get totalRecords() {
                             return this.total || mockDotThemes.length;
                         },
-                        setExtraParams() {},
+                        setExtraParams(key: string, value: string) {
+                            this.extraParams.set(key, value);
+                        },
                         getWithOffset() {
+                            return of([...mockDotThemes]);
+                        },
+                        get() {
                             return of([...mockDotThemes]);
                         }
                     }
@@ -175,6 +181,7 @@ describe('DotThemeSelectorDropdownComponent', () => {
             paginationService = TestBed.inject(PaginatorService);
             component = fixture.componentInstance;
             spyOn(component, 'propagateChange');
+            spyOn(paginationService, 'get').and.callThrough();
             fixture.detectChanges();
         });
 
@@ -186,14 +193,22 @@ describe('DotThemeSelectorDropdownComponent', () => {
                 expect(component.themes).toEqual(mockDotThemes);
             }));
 
-            it('should not call pagination service if the url is not set', () => {
-                component.currentSiteIdentifier = '123';
-                spyOn(paginationService, 'getWithOffset');
-                component.searchableDropdown.pageChange.emit({ first: 0 } as PaginationEvent);
-                expect(paginationService.getWithOffset).not.toHaveBeenCalled();
+            it('should call paginatorService get method to System Host on init ', () => {
+                expect(paginationService.url).toEqual('v1/themes');
+                expect(paginationService.extraParams.get('hostId')).toEqual('SYSTEM_HOST');
+                expect(paginationService.get).toHaveBeenCalled();
             });
 
             it('should not call pagination service if the url is not set', () => {
+                //Paginator service is now called at least once at the beginning, that's why it has an url at the very beginning
+                component.currentSiteIdentifier = '123';
+                paginationService.url = '';
+                spyOn(paginationService, 'getWithOffset');
+                component.searchableDropdown.pageChange.emit({ first: 0 } as PaginationEvent);
+                expect(paginationService.getWithOffset).not.toHaveBeenCalledTimes(1);
+            });
+
+            it('should call pagination service if the url is set', () => {
                 component.currentSiteIdentifier = '123';
                 component.paginatorService.url = 'v1/test';
                 spyOn(paginationService, 'getWithOffset').and.callThrough();
@@ -330,9 +345,11 @@ describe('DotThemeSelectorDropdownComponent', () => {
             de = fixture.debugElement;
             dotThemesService = TestBed.inject(DotThemesService);
             fixture.detectChanges();
+            const selector = de.query(By.css('dot-theme-selector-dropdown')).componentInstance;
+            selector.value = null; // Paginator service is called once on init and it sets a default value that we need to clean to test this
+            fixture.detectChanges();
 
             expect(dotThemesService.get).not.toHaveBeenCalled();
-            const selector = de.query(By.css('dot-theme-selector-dropdown')).componentInstance;
             expect(selector.value).toBeNull();
         });
     });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
@@ -83,6 +83,17 @@ export class DotThemeSelectorDropdownComponent
                 /* */
             }
         }, 0);
+
+        // Here we set the initial value of the dropdown as System Theme
+        this.paginatorService.url = 'v1/themes';
+        this.paginatorService.paginationPerPage = 5;
+        this.paginatorService.setExtraParams('hostId', 'SYSTEM_HOST');
+        this.paginatorService
+            .get()
+            .pipe(take(1))
+            .subscribe((themes: DotTheme[]) => {
+                this.value = themes[0];
+            });
     }
 
     ngAfterViewInit(): void {
@@ -258,6 +269,7 @@ export class DotThemeSelectorDropdownComponent
 
         this.paginatorService.setExtraParams('hostId', hostId);
         this.paginatorService.searchParam = this.searchInput.nativeElement.value;
+
         this.paginatorService
             .getWithOffset(offset)
             .pipe(take(1))

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
@@ -93,6 +93,7 @@ export class DotThemeSelectorDropdownComponent
             .pipe(take(1))
             .subscribe((themes: DotTheme[]) => {
                 this.value = themes[0];
+                this.propagateChange(themes[0].identifier);
             });
     }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c5baf1b</samp>

### Summary
🗑️🧪🛠️

<!--
1.  🗑️ - for removing the directive
2.  🧪 - for adding and updating tests
3.  🛠️ - for adding logic to set the default theme
-->
Added logic to set and display the default system theme in the theme selector dropdown component for templates. Updated and added tests for the component. Removed the required indicator from the theme label.

> _`dotFieldRequired`_
> _Gone from theme label - not needed_
> _Autumn leaves fall gently_

### Walkthrough
* Remove the required directive from the theme label in the template props component ([link](https://github.com/dotCMS/core/pull/25384/files?diff=unified&w=0#diff-8665724f4afffc15e44bf3a388f19b65cdd8c6ec4ebdeae8372360a3a02a011bL31-R31))
* Add the logic to set the default value of the theme dropdown to the system theme in the theme selector dropdown component ([link](https://github.com/dotCMS/core/pull/25384/files?diff=unified&w=0#diff-9ac242ef11ac2cd6b2627f109cc3996cbea965e5977a8f441c3348214125fd47R86-R96))
* Add the `extraParams` property and the `setExtraParams` and `get` methods to the mock pagination service in the theme selector dropdown component spec ([link](https://github.com/dotCMS/core/pull/25384/files?diff=unified&w=0#diff-bedd6f88bc8484ce4b27f2e84174373a1d6e814f78a2eb63a8515c889dda5695R111), [link](https://github.com/dotCMS/core/pull/25384/files?diff=unified&w=0#diff-bedd6f88bc8484ce4b27f2e84174373a1d6e814f78a2eb63a8515c889dda5695L127-R135))
* Update the tests in the theme selector dropdown component spec to reflect the new logic of calling the pagination service `get` method on init ([link](https://github.com/dotCMS/core/pull/25384/files?diff=unified&w=0#diff-bedd6f88bc8484ce4b27f2e84174373a1d6e814f78a2eb63a8515c889dda5695R184), [link](https://github.com/dotCMS/core/pull/25384/files?diff=unified&w=0#diff-bedd6f88bc8484ce4b27f2e84174373a1d6e814f78a2eb63a8515c889dda5695L189-R211), [link](https://github.com/dotCMS/core/pull/25384/files?diff=unified&w=0#diff-bedd6f88bc8484ce4b27f2e84174373a1d6e814f78a2eb63a8515c889dda5695L333-R352))
* Add a blank line for formatting purposes in the theme selector dropdown component ([link](https://github.com/dotCMS/core/pull/25384/files?diff=unified&w=0#diff-9ac242ef11ac2cd6b2627f109cc3996cbea965e5977a8f441c3348214125fd47R272))



### Screenshots
https://github.com/dotCMS/core/assets/63567962/fa887418-3f35-4463-8f1a-9e4468a92d45



