### PR TITLE
#25379 : Fall back to System Theme in case the Template's theme is not specified

### DIFF
--- a/dotCMS/src/curl-test/Template Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Template Resource.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "dbad8b34-ca5a-49bb-a653-fc3e2c7b20b0",
+		"_postman_id": "873a1015-3bbc-4cc8-94e9-1527a13f5bff",
 		"name": "Template Resource",
 		"description": "Make the test for the template resource crud",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "1549189"
+		"_exporter_id": "5403727"
 	},
 	"item": [
 		{
@@ -5204,6 +5204,86 @@
 								"v1",
 								"templates",
 								"draft"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create New Template with Empty Theme",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"HTTP Status must be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"The new Template must be assigned the System Theme by default\", function () {",
+									"    var entity = pm.response.json().entity;",
+									"    pm.expect(entity.theme).to.eql('SYSTEM_THEME', 'The theme for the test Template must be SYSTEM_THEME');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"const time = new Date().getTime();",
+									"pm.collectionVariables.set(\"draftTemplateTitle\", \"My-Test-Template-\" + time);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"title\": \"{{draftTemplateTitle}}\",\n    \"friendlyName\": \"This is a test Template\",\n    \"body\": \"This is the body\",\n    \"theme\": \"\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/templates",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"templates"
 							]
 						}
 					},

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/template/TemplateResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/template/TemplateResource.java
@@ -15,14 +15,12 @@ import com.dotcms.util.pagination.OrderDirection;
 import com.dotcms.util.pagination.TemplatePaginator;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
-
-import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.business.RoleAPI;
+import com.dotmarketing.business.Theme;
 import com.dotmarketing.business.VersionableAPI;
 import com.dotmarketing.business.web.HostWebAPI;
 import com.dotmarketing.business.web.WebAPILocator;
-import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -43,10 +41,6 @@ import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import org.glassfish.jersey.server.JSONP;
 
 import javax.servlet.http.HttpServletRequest;
@@ -70,8 +64,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static com.dotcms.util.CollectionsUtils.map;
+import java.util.stream.Collectors;
 
 /**
  * CRUD of Templates
@@ -363,16 +356,30 @@ public class TemplateResource {
         return fillAndSaveTemplate(templateForm, user, host, pageMode, template, false);
     }
 
+    /**
+     * Takes the Template information submitted to this REST Endpoint and saves it to dotCMS the database.
+     *
+     * @param templateForm The {@link TemplateForm} object with the Template's data.
+     * @param user         The {@link User} that is saving this Template.
+     * @param site         The {@link Host} that this Template belongs to.
+     * @param pageMode     The {@link PageMode} object used to determine whether anonymous permissions must be respected
+     *                     or not.
+     * @param template     The {@link Template} object that will hold the incoming data.
+     * @param draft        If the Template is being saved as draft, set this to {@code true}.
+     * @return The new Template.
+     * @throws DotSecurityException The specified User does not have permission to save this Template.
+     * @throws DotDataException     An error occurred when interacting with the data source.
+     */
     @WrapInTransaction
     private Template fillAndSaveTemplate(final TemplateForm templateForm,
             final User user,
-            final Host host,
+            final Host site,
             final PageMode pageMode,
             final Template template,
             final boolean draft) throws DotSecurityException, DotDataException {
 
         template.setInode(draft?templateForm.getInode(): StringPool.BLANK);
-        template.setTheme(templateForm.getTheme());
+        template.setTheme(UtilMethods.isSet(templateForm.getTheme()) ? templateForm.getTheme() : Theme.SYSTEM_THEME);
         template.setBody(templateForm.getBody());
         template.setCountContainers(templateForm.getCountAddContainer());
         template.setCountAddContainer(templateForm.getCountAddContainer());
@@ -399,7 +406,7 @@ public class TemplateResource {
 
         if (templateForm.isDrawed()) {
             final String themeHostId = APILocator.getFolderAPI().find(templateForm.getTheme(), user, pageMode.respectAnonPerms).getHostId();
-            final String themePath   = themeHostId.equals(host.getInode())?
+            final String themePath   = themeHostId.equals(site.getInode())?
                     Template.THEMES_PATH + template.getThemeName() + "/":
                     "//" + APILocator.getHostAPI().find(themeHostId, user, pageMode.respectAnonPerms).getHostname()
                             + Template.THEMES_PATH + template.getThemeName() + "/";
@@ -411,9 +418,9 @@ public class TemplateResource {
 
 
         if (draft) {
-            this.templateAPI.saveDraftTemplate(template, host, user, pageMode.respectAnonPerms);
+            this.templateAPI.saveDraftTemplate(template, site, user, pageMode.respectAnonPerms);
         } else {
-            this.templateAPI.saveTemplate(template, host, user, pageMode.respectAnonPerms);
+            this.templateAPI.saveTemplate(template, site, user, pageMode.respectAnonPerms);
         }
 
         if (UtilMethods.isSet(containerUUIDChanges) && UtilMethods.isSet(containerUUIDChanges.lostUUIDValues())){
@@ -422,7 +429,7 @@ public class TemplateResource {
         }
 
         ActivityLogger.logInfo(this.getClass(), "Saved Template", "User " + user.getPrimaryKey()
-                + "Template: " + template.getTitle(), host.getTitle() != null? host.getTitle():"default");
+                + "Template: " + template.getTitle(), site.getTitle() != null? site.getTitle():"default");
 
         return template;
     }


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c385d2e</samp>

*  Add a new API request to test creating a template without a theme ([link](https://github.com/dotCMS/core/pull/25395/files?diff=unified&w=0#diff-b07c04a7faff5e5c1b874053739dc3494f4fa023b46ff57dc50f36e33a33e0a4R5211-R5290))
*  Import the `Theme` class to access the system theme name ([link](https://github.com/dotCMS/core/pull/25395/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL18-R23))
*  Remove unused import statements ([link](https://github.com/dotCMS/core/pull/25395/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL46-L49))
*  Move the import statement for the `map` method to the `TemplateHelper` file ([link](https://github.com/dotCMS/core/pull/25395/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL73-R68))
*  Add a JavaDoc comment to the `fillAndSaveTemplate` method ([link](https://github.com/dotCMS/core/pull/25395/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL366-R376))
*  Assign the system theme name to the template if the theme property is not set ([link](https://github.com/dotCMS/core/pull/25395/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL375-R382))
*  Rename the `host` variable to `site` in the `fillAndSaveTemplate` method ([link](https://github.com/dotCMS/core/pull/25395/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL402-R409), [link](https://github.com/dotCMS/core/pull/25395/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL414-R423), [link](https://github.com/dotCMS/core/pull/25395/files?diff=unified&w=0#diff-448b3630547f743e0d556752c2e68b797b03e9c4b9d7e238c84889274435635eL425-R432))