### PR TITLE
#25401 Template Builder: Esc key should close the confirmation dialog when deleting a box/row  

### DIFF
--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.spec.ts
@@ -54,4 +54,17 @@ describe('RemoveConfirmDialogComponent', () => {
 
         expect(rejectEventSpy).toHaveBeenCalled();
     });
+
+    it('should call reject function when esc is pressed', () => {
+        const rejectEventSpy = jest.spyOn(spectator.component.deleteRejected, 'emit');
+
+        const deleteButton = spectator.query(byTestId('btn-remove-item'));
+        spectator.dispatchMouseEvent(deleteButton, 'onClick');
+
+        const confirmAccept = spectator.query('.p-confirm-popup-accept');
+        expect(confirmAccept).toBeTruthy();
+
+        spectator.component.onEscapePress();
+        expect(rejectEventSpy).toHaveBeenCalled();
+    });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    EventEmitter,
+    HostListener,
+    Output
+} from '@angular/core';
 
 import { ConfirmationService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
@@ -18,13 +24,25 @@ import { DotMessagePipe, DotMessagePipeModule } from '@dotcms/ui';
 export class RemoveConfirmDialogComponent {
     @Output() deleteConfirmed: EventEmitter<void> = new EventEmitter();
     @Output() deleteRejected: EventEmitter<void> = new EventEmitter();
+    private currentPopup: ConfirmationService;
+
+    @HostListener('document:keydown.escape', ['$event'])
+    onEscapePress() {
+        if (this.currentPopup) {
+            this.currentPopup.close();
+            this.deleteRejected.emit();
+            this.currentPopup = null;
+        }
+    }
+
     constructor(
         private confirmationService: ConfirmationService,
         private dotMessagePipe: DotMessagePipe
     ) {}
 
     openConfirmationDialog(event: Event): void {
-        this.confirmationService.confirm({
+        this.currentPopup = this.confirmationService.confirm({
+            closeOnEscape: true,
             target: event.target,
             message: this.dotMessagePipe.transform(
                 'dot.template.builder.comfirmation.popup.message'


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 105c25d</samp>

This pull request enhances the user experience of the `RemoveConfirmDialogComponent` by allowing the user to cancel the deletion of a template by pressing the escape key. It also adds a unit test to verify this functionality.

### Checklist
- [X] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
