### PR TITLE
Template Builder: Fixing Style Class Dialog UI/UX

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_autocomplete.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_autocomplete.scss
@@ -15,10 +15,16 @@
 
 .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container {
     padding: 0.375rem $spacing-2;
+    max-height: 13rem; // 208px
+    overflow: auto; // Make it scrollable
 }
 
 .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled):hover {
     border-color: $black;
+}
+
+.p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled):hover {
+    border-color: $color-palette-primary;
 }
 
 .p-autocomplete.p-autocomplete-multiple
@@ -49,7 +55,7 @@
 .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container .p-autocomplete-token {
     padding: 0.375rem $spacing-2;
     margin-right: $spacing-1;
-    background: rgba(63, 81, 181, 0.12);
+    background: $color-palette-primary;
     color: $color-palette-primary;
     border-radius: $field-border-radius;
 }

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_autocomplete.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_autocomplete.scss
@@ -55,7 +55,7 @@
 .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container .p-autocomplete-token {
     padding: 0.375rem $spacing-2;
     margin-right: $spacing-1;
-    background: $color-palette-primary;
+    background: $color-palette-primary-200;
     color: $color-palette-primary;
     border-radius: $field-border-radius;
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.html
@@ -1,8 +1,5 @@
 <ng-container *ngIf="vm$ | async as vm">
     <div class="dialog__auto-complete-container field">
-        <label class="auto-complete-container__label" htmlFor="auto-complete-input">{{
-            'dot.template.builder.classes.dialog.autocomplete.label' | dm
-        }}</label>
         <div class="p-fluid">
             <p-autoComplete
                 [ngModel]="vm.selectedClasses"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.scss
@@ -5,10 +5,6 @@
 }
 
 .dialog__auto-complete-container {
-    padding: $spacing-1 $spacing-7;
-    overflow: auto;
-    max-height: 5rem;
-
     .auto-complete-container__label {
         margin: 0;
         color: $black;

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
@@ -296,6 +296,15 @@ export const MOCK_SELECTED_STYLE_CLASSES = [
     'd-flex',
     'flex-column',
     'justify-content-center',
+    'align-items-center',
+    'justify-content-start',
+    'justify-content-end',
+    'justify-content-center',
+    'justify-content-between',
+    'justify-content-around',
+    'justify-content-evenly',
+    'align-items-start',
+    'align-items-end',
     'align-items-center'
 ];
 


### PR DESCRIPTION
### Proposed Changes
*  Fixing styles class dialog `UI/UX`.

## Additional Info

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b427c97</samp>

This pull request enhances the autocomplete component in the dotCMS theme and the template builder. It improves the styling, scrolling, and usability of the component, and removes unnecessary elements and properties. It also updates the test data with more mock style classes.

## Related Issue
Fixes #25376

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b427c97</samp>

*  Limit and scroll the autocomplete panel when there are many options ([link](https://github.com/dotCMS/core/pull/25443/files?diff=unified&w=0#diff-524561eb0a9864050d94ec27c3a2c2df74f5423f3305e278e4a995675b1e08e9R18-R19))
*  Add a hover effect to the multiple autocomplete container with the primary color ([link](https://github.com/dotCMS/core/pull/25443/files?diff=unified&w=0#diff-524561eb0a9864050d94ec27c3a2c2df74f5423f3305e278e4a995675b1e08e9R26-R29))
*  Use the primary color for the background and text of the multiple autocomplete tokens ([link](https://github.com/dotCMS/core/pull/25443/files?diff=unified&w=0#diff-524561eb0a9864050d94ec27c3a2c2df74f5423f3305e278e4a995675b1e08e9L52-R58))
*  Remove the redundant label element for the autocomplete input in `add-style-classes-dialog.component.html` ([link](https://github.com/dotCMS/core/pull/25443/files?diff=unified&w=0#diff-ad38fd507e948aab0702b09038a51398d2751e9070676c7c562182f78748eacdL3-L5))
*  Adjust the padding, overflow and max-height of the autocomplete input in `add-style-classes-dialog.component.scss` ([link](https://github.com/dotCMS/core/pull/25443/files?diff=unified&w=0#diff-8b84f5fdb2071a26374ae41f88ef831a4ddb6370be8990650031ca7cc0ed1b37L8-L11))
*  Add more mock style classes to the test data in `mocks.ts` ([link](https://github.com/dotCMS/core/pull/25443/files?diff=unified&w=0#diff-98de89ac988dbfd17c912bb493096714d7c139835179a99162b4df2eb3c309e5R299-R307))

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
