### PR TITLE
#25396 add class to template with enter

### DIFF
--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.html
@@ -15,6 +15,7 @@
                 (onUnselect)="onUnselect()"
                 (completeMethod)="filterClasses($event)"
                 (onKeyUp)="onKeyUp($event)"
+                dataKey="cssClass"
                 field="cssClass"
                 appendTo="body"
                 inputId="auto-complete-input"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.html
@@ -14,6 +14,7 @@
                 (onSelect)="onSelect($event)"
                 (onUnselect)="onUnselect()"
                 (completeMethod)="filterClasses($event)"
+                (onKeyUp)="onKeyUp($event)"
                 field="cssClass"
                 appendTo="body"
                 inputId="auto-complete-input"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.spec.ts
@@ -17,6 +17,7 @@ import { AddStyleClassesDialogComponent } from './add-style-classes-dialog.compo
 import { DotAddStyleClassesDialogStore } from './store/add-style-classes-dialog.store';
 
 import {
+    CLASS_NAME_MOCK,
     DOT_MESSAGE_SERVICE_TB_MOCK,
     MOCK_SELECTED_STYLE_CLASSES,
     MOCK_STYLE_CLASSES_FILE,
@@ -86,7 +87,7 @@ describe('AddStyleClassesDialogComponent', () => {
 
     it('should trigger filterClasses when focusing on the input', () => {
         const filterMock = jest.spyOn(store, 'filterClasses');
-        const query = 'custom-class';
+        const query = CLASS_NAME_MOCK;
 
         input.value = query;
 
@@ -131,5 +132,16 @@ describe('AddStyleClassesDialogComponent', () => {
         spectator.detectChanges();
 
         expect(closeMock).toHaveBeenCalled();
+    });
+
+    it('should trigger addClass when enter is pressed', () => {
+        const addClassMock = jest.spyOn(store, 'addClass');
+
+        spectator.typeInElement(CLASS_NAME_MOCK, input);
+        spectator.keyboard.pressEnter(input);
+
+        spectator.detectChanges();
+
+        expect(addClassMock).toHaveBeenCalledWith({ cssClass: CLASS_NAME_MOCK });
     });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
@@ -6,11 +6,12 @@ import {
     ChangeDetectionStrategy,
     Component,
     OnDestroy,
-    OnInit
+    OnInit,
+    ViewChild
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { AutoCompleteModule } from 'primeng/autocomplete';
+import { AutoComplete, AutoCompleteModule } from 'primeng/autocomplete';
 import { ButtonModule } from 'primeng/button';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -34,6 +35,9 @@ export class AddStyleClassesDialogComponent implements OnInit, AfterViewInit, On
     private destroy$: Subject<void> = new Subject<void>();
 
     public vm$ = this.store.vm$;
+
+    @ViewChild(AutoComplete)
+    autoComplete: AutoComplete;
 
     constructor(
         private ref: DynamicDialogRef,
@@ -111,8 +115,7 @@ export class AddStyleClassesDialogComponent implements OnInit, AfterViewInit, On
      */
     onKeyUp(event: KeyboardEvent): void {
         if (event.key === 'Enter' && this.autoCompleteInput.value) {
-            this.onSelect({ cssClass: this.autoCompleteInput.value });
-            this.autoCompleteInput.value = '';
+            this.autoComplete.selectItem({ cssClass: this.autoCompleteInput.value });
         }
     }
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
@@ -102,4 +102,17 @@ export class AddStyleClassesDialogComponent implements OnInit, AfterViewInit, On
     onUnselect(): void {
         this.store.removeLastClass();
     }
+
+    /**
+     * @description Used to listen for enter presses
+     *
+     * @param {KeyboardEvent} event
+     * @memberof AddStyleClassesDialogComponent
+     */
+    onKeyUp(event: KeyboardEvent): void {
+        if (event.key === 'Enter' && this.autoCompleteInput.value) {
+            this.onSelect({ cssClass: this.autoCompleteInput.value });
+            this.autoCompleteInput.value = '';
+        }
+    }
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
@@ -409,3 +409,5 @@ export const SIDEBAR_MOCK = {
 };
 
 export const STYLE_CLASS_MOCK = ['test', 'mock-class'];
+
+export const CLASS_NAME_MOCK = 'custom-class';


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2719a8</samp>

This pull request improves the user experience and the test coverage of the `add-style-classes-dialog` component. It enables the user to select a class name by pressing 'Enter' on the input field, and it updates the unit tests to use a mock class name and to check for the enter key event. It also modifies the HTML template and the mock data file to support these changes.

### Checklist
- [X] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
