### PR TITLE
Issue 25400: new pg-base Docker image - PR 1 of 2

### DIFF
--- a/docker/dotcms/Dockerfile
+++ b/docker/dotcms/Dockerfile
@@ -87,7 +87,7 @@ COPY --chown=$USER_NAME:$USER_GROUP ROOT/ /
 # ----------------------------------------------
 # Stage 3:  Copy pg_dump binary
 # ----------------------------------------------
-FROM dotcms/pg-base:15.3 as pg-base
+FROM dotcms/pg-base:15 as pg-base
 
 
 # ----------------------------------------------
@@ -103,17 +103,12 @@ ARG USER_UID="65001"
 ARG USER_GID="65001"
 
 COPY --from=container-base / /
-COPY --from=pg-base /usr/local/pgsql /usr/local/pgsql
-
-# confirm that required postgres client shared libraries are present
-RUN for shared_library in `ldd /usr/local/pgsql/bin/* | awk '{print $3}' | grep '^/' | sort -u`; \
-    do [ -f $shared_library ] || exit 1; \
-    done
+COPY --from=pg-base / /
 
 # Switching to non-root user to install SDKMAN!
 USER $USER_UID:$USER_GID
 ENV JAVA_HOME="/java"
-ENV PATH=$PATH:/java/bin:/usr/local/pgsql/bin
+ENV PATH=$PATH:/java/bin
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/srv/entrypoint.sh"]
 CMD ["dotcms"]

--- a/docker/dotcms/Dockerfile
+++ b/docker/dotcms/Dockerfile
@@ -87,7 +87,7 @@ COPY --chown=$USER_NAME:$USER_GROUP ROOT/ /
 # ----------------------------------------------
 # Stage 3:  Copy pg_dump binary
 # ----------------------------------------------
-FROM dotcms/pg-base:15 as pg-base
+FROM dotcms/pg-base:15.3 as pg-base
 
 
 # ----------------------------------------------
@@ -103,12 +103,17 @@ ARG USER_UID="65001"
 ARG USER_GID="65001"
 
 COPY --from=container-base / /
-COPY --from=pg-base / /
+COPY --from=pg-base /usr/local/pgsql /usr/local/pgsql
+
+# confirm that required postgres client shared libraries are present
+RUN for shared_library in `ldd /usr/local/pgsql/bin/* | awk '{print $3}' | grep '^/' | sort -u`; \
+    do [ -f $shared_library ] || exit 1; \
+    done
 
 # Switching to non-root user to install SDKMAN!
 USER $USER_UID:$USER_GID
 ENV JAVA_HOME="/java"
-ENV PATH=$PATH:/java/bin
+ENV PATH=$PATH:/java/bin:/usr/local/pgsql/bin
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/srv/entrypoint.sh"]
 CMD ["dotcms"]

--- a/docker/pg-base/Dockerfile
+++ b/docker/pg-base/Dockerfile
@@ -1,28 +1,46 @@
 # ----------------------------------------------
-# Stage 1:  Minimal java image with pg_dump and its dependencies + Ubuntu LTS
+# Stage 1:  Minimal image with pg_dump and psql built from source 
 # ----------------------------------------------
 FROM ubuntu:20.04 as pg-base-builder
 
-ENV DEBIAN_FRONTEND=noninteractive
-ARG PG_VERSION=15
-ENV PG_VERSION=$PG_VERSION
+SHELL ["/bin/bash", "-c"] 
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -y \
-  && apt-get install -y gnupg gnupg1 gnupg2 wget lsb-release \
-  && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
-  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && apt-get update -y \
-  && apt-get install -y postgresql-$PG_VERSION \
-  && export ARCH=$(uname -m) \
-  && echo "ARCH: $ARCH" \
-  && find /usr/lib/postgresql/$PG_VERSION/bin -type f -not -name "pg_dump" -delete \
-  && rm -rf /usr/lib/postgresql/$PG_VERSION/lib/pgxs /usr/lib/postgresql/$PG_VERSION/lib/bitcode \
-  && apt purge --allow-remove-essential -y \
+# see https://www.postgresql.org/ftp/source/ for versions
+ARG POSTGRES_VERSION=15.3
+
+ARG POSTGRES_TARBALL=postgresql-${POSTGRES_VERSION}.tar.bz2
+ARG FTP_PATH=https://ftp.postgresql.org/pub/source/v${POSTGRES_VERSION}
+
+# zlib1g-dev is required for pg_dump to support compression
+ARG BUILD_DEPS="build-essential ca-certificates curl zlib1g-dev"
+
+# './configure --without-readline' currently means we won't have shared library
+# dependencies that are not present in the dotcms image
+ARG CONFIGURE_OPTS="--without-readline"
+
+# builds client only - see https://www.postgresql.org/docs/current/install-procedure.html
+RUN apt update -y \
+  && apt upgrade -y \
+  && apt install -y --no-install-recommends ${BUILD_DEPS} \
+  && mkdir -p /postgres/build \
+  && cd /postgres/build \
+  && curl -o ${POSTGRES_TARBALL} ${FTP_PATH}/${POSTGRES_TARBALL} \
+  && diff <(md5sum postgresql-${POSTGRES_VERSION}.tar.bz2) <(curl -s ${FTP_PATH}/${POSTGRES_TARBALL}.md5) || exit 1 \
+  && tar xf ${POSTGRES_TARBALL} \
+  && cd /postgres/build/postgresql-${POSTGRES_VERSION} \
+  && ./configure ${CONFIGURE_OPTS} \
+  && make -C src/bin/pg_dump install \
+  && make -C src/bin/psql install \
+  && make -C src/include install \
+  && make -C src/interfaces install \
+  && rm -rf /postgres/build \
+  && apt remove -y ${BUILD_DEPS} \
+  && apt purge -y \
   && apt autoremove -y \
   && apt clean \
-  && rm -rf /var/lib/apt/lists/* \
-  && /usr/lib/postgresql/$PG_VERSION/bin/pg_dump --version
-
+  && rm -rf /var/lib/apt/lists/
+RUN /usr/local/pgsql/bin/pg_dump --version || exit 1
 
 # ----------------------------------------------
 # Stage 2:  Flatten everything to 1 layer


### PR DESCRIPTION
### Proposed Changes
This PR is the first two needed to fix #25400 - build a new `pg-base` Docker image. 

This new image should have a unique Dockerhub tag, perhaps `dotcms/pg-base:15.3-src`. The new image should not replace the existing `dotcms/pg-base:15` image else builds with the current `dotcms` Dockerfile will fail.

Once a new pg_dump image exists we can reference it in the `dotcms` Dockerfile:
```
COPY --from=pg-base /usr/local/pgsql /usr/local/pgsql
ENV PATH=$PATH:/java/bin:/usr/local/pgsql/bin
```

#### Postgresql build notes
Using
```
./configure --without-readline
```
eliminated the dependency on readline shared library which does not exist in the `dotcms` image.

We compile the `pg_dump` and `psql` clients only - no need to build the server.
```
make -C src/bin/pg_dump install
make -C src/bin/psql install
```
which builds to `/usr/local/pgsql/bin` though we need to copy `/usr/local/pgsql` to the final image for dependencies.