### PR TITLE
#23891 fix content type headers breaking in smaller screens

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.html
@@ -1,36 +1,38 @@
 <p-toolbar>
     <div class="p-toolbar-group-left">
-        <div class="toolbar__button-wrapper">
-            <dot-icon-button
-                big
-                [icon]="(dotNavigationService.collapsed$ | async) ? 'menu' : 'arrow_back'"
-                inverted
-                (click)="handleMainButtonClick()"
-            ></dot-icon-button>
-        </div>
-        <div
-            class="toolbar__logo-wrapper"
-            [class.toolbar__logo-wrapper--collapsed]="dotNavigationService.collapsed$ | async"
-            [class.toolbar__logo-wrapper--whitelabel]="logo$ | async"
-        >
-            <span
-                *ngIf="logo$ | async as logo; else toolbarLogo"
-                class="toolbar__logo--whitelabel"
-                [ngStyle]="{ 'background-image': logo }"
-            ></span>
-            <ng-template #toolbarLogo><span class="toolbar__logo"></span></ng-template>
-            <span class="toolbar__logo-bg"></span>
+        <div class="toolbar__dot-wrapper">
+            <div class="toolbar__button-wrapper">
+                <dot-icon-button
+                    [icon]="(dotNavigationService.collapsed$ | async) ? 'menu' : 'arrow_back'"
+                    (click)="handleMainButtonClick()"
+                    big
+                    inverted
+                ></dot-icon-button>
+            </div>
+            <div
+                class="toolbar__logo-wrapper"
+                [class.toolbar__logo-wrapper--collapsed]="dotNavigationService.collapsed$ | async"
+                [class.toolbar__logo-wrapper--whitelabel]="logo$ | async"
+            >
+                <span
+                    class="toolbar__logo--whitelabel"
+                    *ngIf="logo$ | async as logo; else toolbarLogo"
+                    [ngStyle]="{ 'background-image': logo }"
+                ></span>
+                <ng-template #toolbarLogo><span class="toolbar__logo"></span></ng-template>
+                <span class="toolbar__logo-bg"></span>
+            </div>
         </div>
         <dot-crumbtrail class="toolbar__crumbtrail"></dot-crumbtrail>
     </div>
     <div class="p-toolbar-group-right">
         <dot-site-selector
+            class="toolbar__site-selector"
             #siteSelector
+            [archive]="false"
             (switch)="siteChange($event)"
             (hide)="iframeOverlayService.hide()"
             (display)="iframeOverlayService.show()"
-            [archive]="false"
-            class="toolbar__site-selector"
             cssClass="d-secondary"
             width="200px"
         >

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.scss
@@ -35,12 +35,18 @@ dot-toolbar-notifications {
 }
 
 .toolbar__button-wrapper {
+    $toolbar-width: 4.375rem;
     align-items: center;
     background-color: $brand-background;
     display: flex;
     height: $toolbar-height;
     justify-content: center;
-    width: 70px;
+    width: $toolbar-width;
+    min-width: $toolbar-width;
+}
+
+.toolbar__dot-wrapper {
+    display: flex;
 }
 
 .toolbar__crumbtrail {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/dot-toolbar.component.scss
@@ -35,14 +35,14 @@ dot-toolbar-notifications {
 }
 
 .toolbar__button-wrapper {
-    $toolbar-width: 4.375rem;
+    $toolbar-button-width: 4.375rem;
     align-items: center;
     background-color: $brand-background;
     display: flex;
     height: $toolbar-height;
     justify-content: center;
-    width: $toolbar-width;
-    min-width: $toolbar-width;
+    width: $toolbar-button-width;
+    min-width: $toolbar-button-width;
 }
 
 .toolbar__dot-wrapper {


### PR DESCRIPTION
### Proposed Changes
#<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f91fbd7</samp>

Refactored the SCSS code and modified the HTML template of the `dot-toolbar` component to improve its layout and responsiveness. Added a variable for the width of the button and logo elements and a wrapper element to group them together. Moved the `big` attribute of the `dot-icon-button` to follow the code style convention.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
![image](https://github.com/dotCMS/core/assets/29465918/b93f3649-22d1-4bf8-b063-de53f69e7484)  |  ![image](https://github.com/dotCMS/core/assets/29465918/287ace7f-bcb5-4a75-a406-4774dcf753d9)
