### PR TITLE
Add better reporting for dotcms-ui failed tests

### DIFF
--- a/core-web/karma.conf.js
+++ b/core-web/karma.conf.js
@@ -12,12 +12,13 @@ module.exports = () => {
             require('karma-jasmine'),
             require('karma-chrome-launcher'),
             require('karma-coverage'),
+            require('karma-spec-reporter'),
             require('karma-junit-reporter'),
-            require('karma-summary-reporter'),
             require('@angular-devkit/build-angular/plugins/karma')
         ],
         client: {
-            clearContext: false // leave Jasmine Spec Runner output visible in browser
+            clearContext: false, // leave Jasmine Spec Runner output visible in browser
+            captureConsole: false
         },
         coverageReporter: {
             dir: '../../target/core-web-reports',
@@ -25,7 +26,7 @@ module.exports = () => {
             file: 'TEST-dotcms-ui.lcov',
             reporters: [{ type: 'lcovonly' }]
         },
-        reporters: ['junit', 'summary'],
+        reporters: ['junit', 'spec'],
         port: 9876,
         colors: true,
         logLevel: constants.LOG_INFO,
@@ -54,6 +55,10 @@ module.exports = () => {
             browserList: 'always',
             // Use custom symbols to indicate success and failure
             symbols: { success: 'o', failure: 'x' }
+        },
+        specReporter: {
+            suppressPassed: true,
+            suppressSkipped: true
         },
         singleRun: true,
         browserDisconnectTimeout: 20000

--- a/core-web/package.json
+++ b/core-web/package.json
@@ -201,7 +201,7 @@
         "karma-jasmine": "5.1.0",
         "karma-jasmine-html-reporter": "2.0.0",
         "karma-junit-reporter": "^2.0.1",
-        "karma-summary-reporter": "^3.1.1",
+        "karma-spec-reporter": "^0.0.36",
         "mock-socket": "^9.0.3",
         "mockdate": "^3.0.5",
         "monaco-editor": "^0.33.0",


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 121e19f</samp>

### Summary
:wrench::x::mag:

<!--
1.  :wrench: - This emoji represents a configuration or tooling change, which is what updating the `package.json` and `karma.conf.js` files entails.
2.  :x: - This emoji represents a removal or deletion, which is what removing the `karma-summary-reporter` plugin does.
3.  :mag: - This emoji represents an improvement or enhancement, which is what replacing the `karma-summary-reporter` with the `karma-spec-reporter` plugin does.
-->
Replaced the test reporter plugin for `core-web` to improve test output. Removed `karma-summary-reporter` and added `karma-spec-reporter` in `karma.conf.js` and `package.json`.

> _Sing, O Muse, of the code review that changed the test report_
> _How the wise developer, skilled in many plugins, removed_
> _The `karma-summary-reporter`, which hid the errors and flaws_
> _And replaced it with the `karma-spec-reporter`, which revealed them all_

### Walkthrough
* Replace `karma-summary-reporter` plugin with `karma-spec-reporter` plugin for more detailed and readable test output ([link](https://github.com/dotCMS/core/pull/25458/files?diff=unified&w=0#diff-7e3b12c273292d4ed4993aa028e414c959cd3dd9e60bdc050ba328ab33853746L15-R21), [link](https://github.com/dotCMS/core/pull/25458/files?diff=unified&w=0#diff-a872cae44fcb0e8b8d97b9def0535e9fc9c7ee92a2d192e152b8db050ae00c08L204-R204))
* Add `captureConsole` option to `client` configuration in `karma.conf.js` to prevent console logs from cluttering test output ([link](https://github.com/dotCMS/core/pull/25458/files?diff=unified&w=0#diff-7e3b12c273292d4ed4993aa028e414c959cd3dd9e60bdc050ba328ab33853746L15-R21))
* Update `reporters` configuration in `karma.conf.js` to use `spec` reporter instead of `summary` reporter ([link](https://github.com/dotCMS/core/pull/25458/files?diff=unified&w=0#diff-7e3b12c273292d4ed4993aa028e414c959cd3dd9e60bdc050ba328ab33853746L28-R29))
* Add `specReporter` configuration section in `karma.conf.js` to suppress output of passed and skipped tests and focus on failed ones ([link](https://github.com/dotCMS/core/pull/25458/files?diff=unified&w=0#diff-7e3b12c273292d4ed4993aa028e414c959cd3dd9e60bdc050ba328ab33853746R59-R62))



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
