### PR TITLE
#25459 create separate post job report workflow for security

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -1,0 +1,25 @@
+name: CICD Reports
+on:
+  workflow_run:
+    workflows: ['Maven CICD Pipeline']
+    types: [completed]
+
+permissions:
+  checks: write
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Test Report
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: 'build-reports-.*'
+          name_is_regexp: true
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        with:
+          commit: ${{github.event.workflow_run.head_sha}}
+          report_paths: '**/target/*-reports/**/TEST-*.xml'

--- a/.github/workflows/maven-cicd-pipeline.yml
+++ b/.github/workflows/maven-cicd-pipeline.yml
@@ -106,6 +106,15 @@ jobs:
         shell: bash
         run: rm -r ~/.m2/repository/com/dotcms
 
+      - name: Upload build reports (if build failed)
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: "build-reports-Initial JDK 11 Build"
+          path: |
+            target/build-report.json
+            LICENSE
+          retention-days: 2
   linux-jvm-tests:
     name: JVM Unit Tests - JDK ${{matrix.java.name}}
     runs-on: ubuntu-latest
@@ -144,24 +153,25 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build
         run: eval ./mvnw $JVM_TEST_MAVEN_OPTS test -pl :dotcms-core ${{ matrix.java.maven_args}}
-      - name: Prepare reports archive #(if maven failed)
-        if: always() #failure()
+      - name: Prepare reports archive (if maven failed)
+        if: failure()
         shell: bash
         run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
       - name: Upload reports Archive (if maven failed)
         uses: actions/upload-artifact@v3
-        if: always() #failure()
+        if: failure()
         with:
           name: test-reports-linux-jvm${{matrix.java.name}}
           path: 'test-reports.tgz'
-      - name: core-maven-unit-tests #(if build failed)
+      - name: core-maven-unit-tests (if build failed)
         uses: actions/upload-artifact@v3
-        if: always() #${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() }}
         with:
-          name: "surefire-reports-JVM Tests - JDK ${{matrix.java.name}}"
+          name: "build-reports-JVM Tests - JDK ${{matrix.java.name}}"
           path: |
             **/target/*-reports/TEST-*.xml
             target/build-report.json
+            LICENSE
           retention-days: 2
 
   linux-frontend-tests:
@@ -198,24 +208,25 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build
         run: eval ./mvnw $JVM_TEST_MAVEN_OPTS -pl :core-web test
-      - name: Prepare failure archive #(if maven failed)
-        if: always() #failure()
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
         shell: bash
         run: find . -name 'surefire-reports' -type d | tar -czf test-reports.tgz -T -
-      - name: Upload failure Archive #(if maven failed)
+      - name: Upload failure Archive (if maven failed)
         uses: actions/upload-artifact@v3
-        if: always() #failure()
+        if: failure()
         with:
           name: test-reports-frontend
           path: 'test-reports.tgz'
       - name: frontend-unit-tests
         uses: actions/upload-artifact@v3
-        if: always() #${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() }}
         with:
-          name: "frontend unit tests"
+          name: "build-reports-Frontend unit tests"
           path: |
             **/target/*-reports/**/TEST-*.xml
             target/build-report.json
+            LICENSE
           retention-days: 2
 
   linux-integration-tests:
@@ -240,22 +251,22 @@ jobs:
         suites:
           - {
               name: "MainSuite 1a",
-              pathName: "mainsuite1",
+              pathName: "mainsuite1a",
               maven_args: '"-Dit.test=MainSuite1a" -Dit.test.forkcount=1'
           }
           - {
               name: "MainSuite 1b",
-              pathName: "mainsuite1",
+              pathName: "mainsuite1b",
               maven_args: '"-Dit.test=MainSuite1b" -Dit.test.forkcount=1'
           }
           - {
               name: "MainSuite 2a",
-              pathName: "mainsuite2",
+              pathName: "mainsuite2a",
               maven_args: '"-Dit.test=MainSuite2a" -Dit.test.forkcount=1'
           }
           - {
               name: "MainSuite 2b",
-              pathName: "mainsuite2",
+              pathName: "mainsuite2b",
               maven_args: '"-Dit.test=MainSuite2b" -Dit.test.forkcount=1'
           }
     steps:
@@ -283,43 +294,23 @@ jobs:
         env:
           DOT_DOTCMS_LICENSE: ${{ secrets.DOTCMS_LICENSE }}
         run: eval ./mvnw $JVM_TEST_MAVEN_OPTS verify -pl :dotcms-integration ${{ matrix.suites.maven_args}} ${{ matrix.java.maven_args}}
-      - name: Prepare reports archive #(if maven failed)
-        if: always() #failure()
+      - name: Prepare reports archive (if maven failed)
+        if: failure()
         shell: bash
         run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
-      - name: Upload failure Archive #(if maven failed)
+      - name: Upload failure Archive (if maven failed)
         uses: actions/upload-artifact@v3
-        if: always() #failure()
+        if: failure()
         with:
           name: test-reports-linux-jvm${{matrix.java.name}}-${{matrix.suites.pathName}}
           path: 'test-reports.tgz'
       - name: failsafe-it-tests  # Uploads will be merged with same name
         uses: actions/upload-artifact@v3
-        if: always() # #${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() }}
         with:
-          name: "failsafe- IT Tests - JDK ${{matrix.java.name}} - ${{matrix.suites.name}}"
+          name: "build-reports-IT Tests - JDK ${{matrix.java.name}} - ${{matrix.suites.name}}"
           path: |
             **/target/*-reports/TEST-*.xml
             target/build-report.json
+            LICENSE
           retention-days: 2
-
-  build-report:
-    runs-on: ubuntu-latest
-    name: Build report
-    needs: [ build-jdk11,linux-jvm-tests,linux-integration-tests,linux-frontend-tests ]
-    if: always()
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          path: build-reports-artifacts
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17
-      - name: Publish Test Report
-        if: always()
-        uses: mikepenz/action-junit-report@v3.7.7
-        with:
-          check_name: Java CI / Test Report
-          report_paths: '**/target/*-reports/TEST-*.xml'


### PR DESCRIPTION

### Proposed Changes


Following guides and documentation on reporting plugin [mikepenz/action-junit-report ](https://github.com/mikepenz/action-junit-report#pr-run-permissions) there are security risks and issues if a report action needs write permission token to create a Check workflow run in particular if anyone can fork the repository and run the work.

We can set a workflow to automatically run after another has completed and this can process using properties and artifacts of the workflow before it.   This workflow will only run if on the master branch.  This way we can safely use write permissions and have insecure pull requests not able to access the elevated permissions directly.

Note that this new workflow will only run off the master branch so testing any changes to it will require pushing to master without being able to test in the pull request first.     