### PR TITLE
Fix #23836: Spacing On Date field in Content Types Form

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
@@ -109,9 +109,12 @@
     </div>
 
     <div class="field">
-        <small class="p-field-hint" id="field-dates-hint" *ngIf="!dateVarOptions.length">{{
-            'contenttypes.form.message.no.date.fields.defined' | dm
-        }}</small>
+        <small
+            class="p-field-hint field__date-hint"
+            id="field-dates-hint"
+            *ngIf="!dateVarOptions.length"
+            >{{ 'contenttypes.form.message.no.date.fields.defined' | dm }}</small
+        >
     </div>
 
     <div class="field" *ngIf="form.get('detailPage')">

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
@@ -108,13 +108,10 @@
         </div>
     </div>
 
-    <div class="field">
-        <small
-            class="p-field-hint field__date-hint"
-            id="field-dates-hint"
-            *ngIf="!dateVarOptions.length"
-            >{{ 'contenttypes.form.message.no.date.fields.defined' | dm }}</small
-        >
+    <div class="field" *ngIf="!dateVarOptions.length">
+        <small class="p-field-hint field__date-hint" id="field-dates-hint">{{
+            'contenttypes.form.message.no.date.fields.defined' | dm
+        }}</small>
     </div>
 
     <div class="field" *ngIf="form.get('detailPage')">

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.scss
@@ -20,3 +20,9 @@
 .content-type__form {
     width: 522px;
 }
+
+.field {
+    .p-field-hint {
+        margin-top: -$spacing-3;
+    }
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.scss
@@ -22,7 +22,7 @@
 }
 
 .field {
-    .p-field-hint {
+    .field__date-hint {
         margin-top: -$spacing-3;
     }
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2ec32e5</samp>

### Summary
🎨📝🚸

<!--
1.  🎨 - This emoji is often used for changes related to improving the UI or the style of the code. In this case, the change is a visual improvement to the field component's layout.
2.  📝 - This emoji is often used for changes related to documentation or comments. In this case, the change is related to the hint text of the field component, which is a form of documentation for the user.
3.  🚸 - This emoji is often used for changes related to improving the user experience or accessibility. In this case, the change is related to reducing the gap between the field label and the hint text, which could improve the readability and usability of the form.
-->
This pull request improves the layout and usability of the content types form by adjusting the spacing and alignment of the field components. It modifies the `content-types-form.component.scss` file to add a negative margin to the hint element of the field component.

> _`hint` moves closer_
> _to `field` label, less space_
> _autumn leaves falling_

### Walkthrough
* Reduce the gap between the field label and the hint text in the content types form by adding a negative margin to the hint element ([link](https://github.com/dotCMS/core/pull/25463/files?diff=unified&w=0#diff-af169a407112c0a32d2b65cfd3f8a640e0cf549320dc52168accad06e194e11bR23-R28))



### Screenshots

#### Original

<img width="708" alt="Screenshot 2023-07-10 at 6 11 59 PM" src="https://github.com/dotCMS/core/assets/63567962/42807562-cc62-4b8c-b314-efe0a399713c">

#### Updated

<img width="668" alt="Screenshot 2023-07-10 at 6 07 43 PM" src="https://github.com/dotCMS/core/assets/63567962/1a77f333-1f00-4311-9a22-d59c6fafd9b4">
