### PR TITLE
Fix #25375: Remove Guard for Autosave in Templates Portlet

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-templates-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-templates-routing.module.ts
@@ -1,8 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-import { LayoutEditorCanDeactivateGuardService } from '@dotcms/app/api/services/guards/layout-editor-can-deactivate-guard.service';
-
 import { DotTemplateCreateEditResolver } from './dot-template-create-edit/resolvers/dot-template-create-edit.resolver';
 import { DotTemplateListResolver } from './dot-template-list/dot-template-list-resolver.service';
 import { DotTemplateListComponent } from './dot-template-list/dot-template-list.component';
@@ -27,7 +25,7 @@ const routes: Routes = [
     },
     {
         path: 'edit/:id',
-        canDeactivate: [LayoutEditorCanDeactivateGuardService],
+
         loadChildren: () =>
             import(
                 '@portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.module'


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 56803ae</samp>

### Summary
🐛🚚🛠️

<!--
1.  🐛 - This emoji represents a bug fix, as the navigation bug was preventing the user from editing templates smoothly.
2.  🚚 - This emoji represents a removal of code, as the unused import was deleted from the module file.
3.  🛠️ - This emoji represents a maintenance or improvement of code quality, as the changes make the module more consistent and readable.
-->
Fixed a bug in `dot-templates-routing.module.ts` that affected template editing. Removed an unused import to improve code quality.

> _`dot-templates-routing` is the path to power_
> _No more errors or prompts to cower_
> _Edit the templates, unleash your creativity_
> _The navigation bug is gone, you have the liberty_

### Walkthrough
*  Removed unused import of `LayoutEditorCanDeactivateGuardService` from `dot-templates-routing.module.ts` ([link](https://github.com/dotCMS/core/pull/25474/files?diff=unified&w=0#diff-1f2d06fbc6a0d0f390ecaaba987033130e9337121e3f9f5f7e22d7fe4f7f3397L4-L5))



## Screenshot

https://github.com/dotCMS/core/assets/63567962/0b3c25aa-165d-44eb-a220-b5b535b278ce

