### PR TITLE
do not match initial artifact with no tests to junit reporter

### DIFF
--- a/.github/workflows/maven-cicd-pipeline.yml
+++ b/.github/workflows/maven-cicd-pipeline.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ failure() || cancelled() }}
         with:
-          name: "build-reports-Initial JDK 11 Build"
+          name: "init-build-reports-Initial JDK 11 Build" # No tests so do not pick up in Junit reporter
           path: |
             target/build-report.json
             LICENSE


### PR DESCRIPTION
### Proposed Changes
#25459 Workflow patch to prevent initial build results from being picked up for junit tests