### PR TITLE
Avoid Drag and Drop of Any Object in Edit Mode

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
@@ -306,16 +306,16 @@ function initDragAndDrop () {
         if (!isDraggedContentSet()) {
             return false;
         }
-
-        const isWidget = (draggedContent.baseType.toLocaleLowerCase() === 'widget');
-
+ 
         const variable = draggedContent.variable?.toLocaleLowerCase();
         const contentType = draggedContent.contentType?.toLocaleLowerCase();
         const baseType = draggedContent.baseType?.toLocaleLowerCase();
 
-        const dotAssetIncludedContent = dotAcceptTypes.includes(variable || contentType || baseType);
+        const isWidget = baseType === 'widget';
 
-        return isWidget || dotAssetIncludedContent;
+        const dotAssetIncludesContent = dotAcceptTypes.includes(variable || contentType || baseType);
+
+        return isWidget || dotAssetIncludesContent;
     }
 
     function setPlaceholderContentlet() {
@@ -538,16 +538,6 @@ function initDragAndDrop () {
 
     /**
      * @description
-     * Clean draggedContent from window object
-     * 
-     * @returns {void}
-     */
-    function cleanDraggedContent() {
-        isDraggedContentSet() && delete window.draggedContent;
-    }
-
-    /**
-     * @description
      * Check if draggedContent is set
      * 
      * @returns {Boolean}
@@ -555,6 +545,16 @@ function initDragAndDrop () {
     function isDraggedContentSet() {
         // draggedContent is set by dotContentletEditorService.draggedContentType$ [dot-edit-content.component.ts#L585-L593]
         return window.hasOwnProperty('draggedContent');
+    }
+
+    /**
+     * @description
+     * Clean draggedContent from window object
+     * 
+     * @returns {void}
+     */
+    function cleanDraggedContent() {
+        isDraggedContentSet() && delete window.draggedContent;
     }
 
     disableDraggableHtmlElements();

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/libraries/iframe-edit-mode.js.ts
@@ -301,10 +301,21 @@ function initDragAndDrop () {
             return false;
         }
 
-        // draggedContent is set by dotContentletEditorService.draggedContentType$
         const dotAcceptTypes = container.dataset.dotAcceptTypes.toLocaleLowerCase();
-        return (window.hasOwnProperty('draggedContent') && (draggedContent.baseType.toLocaleLowerCase() === 'widget') ||
-                dotAcceptTypes.includes(draggedContent.variable?.toLocaleLowerCase() || draggedContent.contentType?.toLocaleLowerCase() || draggedContent.baseType?.toLocaleLowerCase()))
+
+        if (!isDraggedContentSet()) {
+            return false;
+        }
+
+        const isWidget = (draggedContent.baseType.toLocaleLowerCase() === 'widget');
+
+        const variable = draggedContent.variable?.toLocaleLowerCase();
+        const contentType = draggedContent.contentType?.toLocaleLowerCase();
+        const baseType = draggedContent.baseType?.toLocaleLowerCase();
+
+        const dotAssetIncludedContent = dotAcceptTypes.includes(variable || contentType || baseType);
+
+        return isWidget || dotAssetIncludedContent;
     }
 
     function setPlaceholderContentlet() {
@@ -392,7 +403,6 @@ function initDragAndDrop () {
                     insertAfterElement(contentletPlaceholder, contentlet);
                 }
             }
-
         } else if (
                 container &&
                 !container.querySelectorAll('[data-dot-object="contentlet"]').length &&
@@ -402,6 +412,7 @@ function initDragAndDrop () {
             if (isContentletPlaceholderInDOM()) {
                 removeElementById('contentletPlaceholder');
             }
+
             container.appendChild(setPlaceholderContentlet());
         }
     }
@@ -437,33 +448,21 @@ function initDragAndDrop () {
     }
 
     function dropEvent(event) {
-
         event.preventDefault();
         event.stopPropagation();
         const container = event.target.closest('[data-dot-object="container"]');
+        const files = event.dataTransfer?.files;
+
         if (container && !container.classList.contains('no') && isContentletPlaceholderInDOM()) {
-            setLoadingIndicator();
-            if (event.dataTransfer.files[0]) { // trying to upload an image
-                uploadFile(event.dataTransfer.files[0]).then((dotCMSTempFile) => {
-                    dotAssetCreate({
-                        file: dotCMSTempFile,
-                        url: '/api/v1/workflow/actions/default/fire/PUBLISH',
-                        folder: ''
-                    }).then((response) => {
-                        window.contentletEvents.next({
-                            name: 'add-uploaded-dotAsset',
-                            data: {
-                                contentlet: response
-                            }
-                        });
-                    }).catch(e => {
-                        handleHttpErrors(e);
-                    })
-                }).catch(e => {
-                    handleHttpErrors(e);
-                })
-            } else { // Adding specific Content Type / Contentlet
-                if (draggedContent.contentType) { // Contentlet
+        
+            if (files?.length) { // trying to upload an image
+                setLoadingIndicator();
+                loadImageToDotcms(files[0]);
+            } 
+            
+            if(isDraggedContentSet()) {
+                // Adding specific Content Type / Contentlet
+                if (draggedContent?.contentType) { // Contentlet
                     if (draggedContent.contentType === 'FORM') {
                         sendCreateFormEvent(draggedContent.id)
                     } else {
@@ -480,12 +479,17 @@ function initDragAndDrop () {
                 }
             }
         }
+
         if (container) {
-            setTimeout(()=>{
+            setTimeout(()=> {
                 container.classList.remove('no');
             }, 0);
         }
 
+        // We need to clean the dragged content after the drop event
+        // That way, if the user tries to drag & drop a invalid content
+        // It won't use an old dragged content reference
+        cleanDraggedContent();
     }
 
     function removeEvents(e) {
@@ -502,6 +506,55 @@ function initDragAndDrop () {
         for (var i = 0; i < containerAnchorsList.length; i++) {
             containerAnchorsList[i].setAttribute("draggable", "false")
         };
+    }
+
+    /**
+     * @description
+     * Uploads an image to dotCMS and returns a promise with the temp file
+     * 
+     * @param {File} file
+     * @returns {Promise}
+     */
+    function loadImageToDotcms(file) {
+        uploadFile(file).then((dotCMSTempFile) => {
+            dotAssetCreate({
+                file: dotCMSTempFile,
+                url: '/api/v1/workflow/actions/default/fire/PUBLISH',
+                folder: ''
+            }).then((response) => {
+                window.contentletEvents.next({
+                    name: 'add-uploaded-dotAsset',
+                    data: {
+                        contentlet: response
+                    }
+                });
+            }).catch(e => {
+                handleHttpErrors(e);
+            })
+        }).catch(e => {
+            handleHttpErrors(e);
+        })
+    }
+
+    /**
+     * @description
+     * Clean draggedContent from window object
+     * 
+     * @returns {void}
+     */
+    function cleanDraggedContent() {
+        isDraggedContentSet() && delete window.draggedContent;
+    }
+
+    /**
+     * @description
+     * Check if draggedContent is set
+     * 
+     * @returns {Boolean}
+     */
+    function isDraggedContentSet() {
+        // draggedContent is set by dotContentletEditorService.draggedContentType$ [dot-edit-content.component.ts#L585-L593]
+        return window.hasOwnProperty('draggedContent');
     }
 
     disableDraggableHtmlElements();


### PR DESCRIPTION
### Proposed Changes
* Avoid drag and drop of any object in Edit Mode

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c4bf93</samp>

This pull request adds a new feature to the iframe edit mode that lets users create dotAssets from image files by dragging and dropping them on the page. It also improves the code quality of `iframe-edit-mode.js.ts` by refactoring some functions.

## Related Issue
Fixes #24727

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c4bf93</samp>

*  Refactor `checkIfContainerAllowContentType` function to improve readability and avoid repeating logic ([link](https://github.com/dotCMS/core/pull/25484/files?diff=unified&w=0#diff-77dcce06b1ea346a9f5153ae2f748346ca511b46315261ca894696c11e40b230L304-R318))
*  Modify `dropEvent` function to handle image file drop and check if dragged content is set ([link](https://github.com/dotCMS/core/pull/25484/files?diff=unified&w=0#diff-77dcce06b1ea346a9f5153ae2f748346ca511b46315261ca894696c11e40b230L440-R465), [link](https://github.com/dotCMS/core/pull/25484/files?diff=unified&w=0#diff-77dcce06b1ea346a9f5153ae2f748346ca511b46315261ca894696c11e40b230L483-R492), [link](https://github.com/dotCMS/core/pull/25484/files?diff=unified&w=0#diff-77dcce06b1ea346a9f5153ae2f748346ca511b46315261ca894696c11e40b230R415), [link](https://github.com/dotCMS/core/pull/25484/files?diff=unified&w=0#diff-77dcce06b1ea346a9f5153ae2f748346ca511b46315261ca894696c11e40b230L395))
*  Add helper functions `loadImageToDotcms`, `cleanDraggedContent` and `isDraggedContentSet` to `initDragAndDrop` function ([link](https://github.com/dotCMS/core/pull/25484/files?diff=unified&w=0#diff-77dcce06b1ea346a9f5153ae2f748346ca511b46315261ca894696c11e40b230R511-R559))

### Screenshots

https://github.com/dotCMS/core/assets/72418962/05257821-c4da-471c-b519-3aa7eb51d172

