### PR TITLE
Fix #25472: Fix Path for Material Icons in Edit Mode

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -64,6 +64,8 @@ export enum DotContentletMenuAction {
 
 export const CONTENTLET_PLACEHOLDER_SELECTOR = '#contentletPlaceholder';
 
+export const MATERIAL_ICONS_PATH = 'dotAdmin/assets/material-icons.css';
+
 @Injectable()
 export class DotEditContentHtmlService {
     contentletEvents$: Subject<
@@ -420,9 +422,7 @@ export class DotEditContentHtmlService {
 
     private setMaterialIcons(): void {
         const doc = this.getEditPageDocument();
-        const link = this.dotDOMHtmlUtilService.createLinkElement(
-            '/dotAdmin/assets/material-icons.css'
-        );
+        const link = this.dotDOMHtmlUtilService.createLinkElement(MATERIAL_ICONS_PATH);
         doc.head.appendChild(link);
     }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -64,7 +64,7 @@ export enum DotContentletMenuAction {
 
 export const CONTENTLET_PLACEHOLDER_SELECTOR = '#contentletPlaceholder';
 
-export const MATERIAL_ICONS_PATH = 'dotAdmin/assets/material-icons.css';
+export const MATERIAL_ICONS_PATH = '/dotAdmin/assets/material-icons.css';
 
 @Injectable()
 export class DotEditContentHtmlService {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -421,7 +421,7 @@ export class DotEditContentHtmlService {
     private setMaterialIcons(): void {
         const doc = this.getEditPageDocument();
         const link = this.dotDOMHtmlUtilService.createLinkElement(
-            'dotAdmin/assets/material-icons.css'
+            '/dotAdmin/assets/material-icons.css'
         );
         doc.head.appendChild(link);
     }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fe525fa</samp>

### Summary
🐛🎨🔗

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  🎨 - This emoji represents an improvement to the user interface or design, which is the secondary effect of the change.
3.  🔗 - This emoji represents a link or a reference, which is the technical aspect of the change.
-->
Fixed a bug in the dotCMS edit page UI where the material icons were not loading correctly. Updated the `createLinkElement` method in `dot-edit-content-html.service.ts` to use an absolute path for the material-icons.css file.

> _`createLinkElement`_
> _Fixes icon bug with absolute path_
> _A winter solstice_

### Walkthrough
*  Fixed a bug where the material-icons.css file was not loading correctly in some scenarios by using an absolute path instead of a relative path in the `createLinkElement` method ([link](https://github.com/dotCMS/core/pull/25491/files?diff=unified&w=0#diff-803b27038de2abbfb0091318308d39df3f46e46241dc50eeb2271abeb1b45ae7L424-R424))



### Screenshots

#### Original

https://github.com/dotCMS/core/assets/63567962/aed77a87-a71e-4db0-a9f8-6f3f1eb4bcc3

#### Updated

https://github.com/dotCMS/core/assets/63567962/feee65e8-1806-4c6d-a72a-8ddf1bd9adcb







