### PR TITLE
rollback to avoid navigation break

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/dot-edit-page-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/dot-edit-page-routing.module.ts
@@ -21,6 +21,7 @@ const dotEditPage: Routes = [
         data: {
             featuredFlagToCheck: FeaturedFlags.LOAD_FRONTEND_EXPERIMENTS
         },
+        // needed to allow navigation from the page menu in the edit mode. See https://github.com/dotCMS/core/pull/25509
         runGuardsAndResolvers: 'always',
         children: [
             {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/dot-edit-page-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/dot-edit-page-routing.module.ts
@@ -21,7 +21,7 @@ const dotEditPage: Routes = [
         data: {
             featuredFlagToCheck: FeaturedFlags.LOAD_FRONTEND_EXPERIMENTS
         },
-
+        runGuardsAndResolvers: 'always',
         children: [
             {
                 path: '',


### PR DESCRIPTION
### Proposed Changes
* Put Back `runGuardsAndResolvers: 'always' to avoid browser navegation break


### Screenshots




#### Internal Navigation break

https://github.com/dotCMS/core/assets/31667212/03259cc0-c541-4fa1-8725-8a1c88242547


https://github.com/dotCMS/core/assets/31667212/0aadc40f-755f-4c99-ac0a-5b3892d733e4

