### PR TITLE
#25401 allow deletion without confirmation of boxes with no containers

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.stories.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.stories.ts
@@ -15,7 +15,7 @@ import { PanelModule } from 'primeng/panel';
 
 import { DotDevicesService, DotMessageService } from '@dotcms/data-access';
 import { CoreWebService, CoreWebServiceMock } from '@dotcms/dotcms-js';
-import { DotIconModule, DotMessagePipeModule } from '@dotcms/ui';
+import { DotIconModule, DotMessagePipe } from '@dotcms/ui';
 import { MockDotMessageService, mockDotDevices } from '@dotcms/utils-testing';
 import { DotPipesModule } from '@pipes/dot-pipes.module';
 
@@ -49,7 +49,7 @@ export default {
                 OverlayPanelModule,
                 PanelModule,
                 DividerModule,
-                DotMessagePipeModule,
+                DotMessagePipe,
                 BrowserAnimationsModule
             ],
             providers: [

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.spec.ts
@@ -67,13 +67,23 @@ describe('RemoveConfirmDialogComponent', () => {
         expect(rejectEventSpy).toHaveBeenCalled();
     });
 
-    it('should emit request when button is clicked if skipConfirmation is set to true', () => {
+    it('should emit confirmation when button is clicked and skipConfirmation is set to true', () => {
         spectator.component.skipConfirmation = true;
-        const requestEventSpy = jest.spyOn(spectator.component.deleteConfirmed, 'emit');
+        const confirmEventSpy = jest.spyOn(spectator.component.deleteConfirmed, 'emit');
 
         const deleteButton = spectator.query(byTestId('btn-remove-item'));
         spectator.dispatchMouseEvent(deleteButton, 'onClick');
 
-        expect(requestEventSpy).toHaveBeenCalled();
+        expect(confirmEventSpy).toHaveBeenCalled();
+    });
+
+    it('should not emit confirmation when button is clicked and skipConfirmation is set to false', () => {
+        spectator.component.skipConfirmation = false;
+        const confirmEventSpy = jest.spyOn(spectator.component.deleteConfirmed, 'emit');
+
+        const deleteButton = spectator.query(byTestId('btn-remove-item'));
+        spectator.dispatchMouseEvent(deleteButton, 'onClick');
+
+        expect(confirmEventSpy).toHaveBeenCalledTimes(0);
     });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.spec.ts
@@ -66,4 +66,13 @@ describe('RemoveConfirmDialogComponent', () => {
         spectator.component.onEscapePress();
         expect(rejectEventSpy).toHaveBeenCalled();
     });
+
+    it('should emit request when button is clicked', () => {
+        const requestEventSpy = jest.spyOn(spectator.component.deleteRequested, 'emit');
+
+        const deleteButton = spectator.query(byTestId('btn-remove-item'));
+        spectator.dispatchMouseEvent(deleteButton, 'onClick');
+
+        expect(requestEventSpy).toHaveBeenCalled();
+    });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.spec.ts
@@ -67,8 +67,9 @@ describe('RemoveConfirmDialogComponent', () => {
         expect(rejectEventSpy).toHaveBeenCalled();
     });
 
-    it('should emit request when button is clicked', () => {
-        const requestEventSpy = jest.spyOn(spectator.component.deleteRequested, 'emit');
+    it('should emit request when button is clicked if skipConfirmation is set to true', () => {
+        spectator.component.skipConfirmation = true;
+        const requestEventSpy = jest.spyOn(spectator.component.deleteConfirmed, 'emit');
 
         const deleteButton = spectator.query(byTestId('btn-remove-item'));
         spectator.dispatchMouseEvent(deleteButton, 'onClick');

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.ts
@@ -3,6 +3,7 @@ import {
     Component,
     EventEmitter,
     HostListener,
+    Input,
     Output
 } from '@angular/core';
 
@@ -22,9 +23,9 @@ import { DotMessagePipe } from '@dotcms/ui';
     providers: [ConfirmationService, DotMessagePipe]
 })
 export class RemoveConfirmDialogComponent {
+    @Input() skipConfirmation: boolean;
     @Output() deleteConfirmed: EventEmitter<void> = new EventEmitter();
     @Output() deleteRejected: EventEmitter<void> = new EventEmitter();
-    @Output() deleteRequested: EventEmitter<void> = new EventEmitter();
     private currentPopup: ConfirmationService;
 
     constructor(
@@ -42,20 +43,23 @@ export class RemoveConfirmDialogComponent {
     }
 
     openConfirmationDialog(event: Event): void {
-        this.deleteRequested.emit();
-        this.currentPopup = this.confirmationService.confirm({
-            closeOnEscape: true,
-            target: event.target,
-            message: this.dotMessagePipe.transform(
-                'dot.template.builder.comfirmation.popup.message'
-            ),
-            icon: 'pi pi-info-circle',
-            accept: () => {
-                this.deleteConfirmed.emit();
-            },
-            reject: () => {
-                this.deleteRejected.emit();
-            }
-        });
+        if (this.skipConfirmation) {
+            this.deleteConfirmed.emit();
+        } else {
+            this.currentPopup = this.confirmationService.confirm({
+                closeOnEscape: true,
+                target: event.target,
+                message: this.dotMessagePipe.transform(
+                    'dot.template.builder.comfirmation.popup.message'
+                ),
+                icon: 'pi pi-info-circle',
+                accept: () => {
+                    this.deleteConfirmed.emit();
+                },
+                reject: () => {
+                    this.deleteRejected.emit();
+                }
+            });
+        }
     }
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.ts
@@ -24,6 +24,7 @@ import { DotMessagePipe } from '@dotcms/ui';
 export class RemoveConfirmDialogComponent {
     @Output() deleteConfirmed: EventEmitter<void> = new EventEmitter();
     @Output() deleteRejected: EventEmitter<void> = new EventEmitter();
+    @Output() deleteRequested: EventEmitter<void> = new EventEmitter();
     private currentPopup: ConfirmationService;
 
     constructor(
@@ -41,6 +42,7 @@ export class RemoveConfirmDialogComponent {
     }
 
     openConfirmationDialog(event: Event): void {
+        this.deleteRequested.emit();
         this.currentPopup = this.confirmationService.confirm({
             closeOnEscape: true,
             target: event.target,

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
@@ -58,9 +58,9 @@
 
                 <dotcms-remove-confirm-dialog
                     *ngIf="actions.includes('delete')"
-                    (deleteConfirmed)="deleteColumn.emit()"
+                    [skipConfirmation]="items.length === 0"
+                    (deleteConfirmed)="requestColumnDelete()"
                     (deleteRejected)="deleteColumnRejected.emit()"
-                    (deleteRequested)="requestColumnDelete()"
                 >
                 </dotcms-remove-confirm-dialog>
             </div>
@@ -102,9 +102,9 @@
         ></p-button>
         <dotcms-remove-confirm-dialog
             *ngIf="actions.includes('delete')"
+            [skipConfirmation]="items.length === 0"
             (deleteConfirmed)="deleteColumn.emit()"
             (deleteRejected)="deleteColumnRejected.emit()"
-            (deleteRequested)="requestColumnDelete()"
         >
         </dotcms-remove-confirm-dialog>
     </div>

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
@@ -60,6 +60,7 @@
                     *ngIf="actions.includes('delete')"
                     (deleteConfirmed)="deleteColumn.emit()"
                     (deleteRejected)="deleteColumnRejected.emit()"
+                    (deleteRequested)="requestColumnDelete()"
                 >
                 </dotcms-remove-confirm-dialog>
             </div>
@@ -103,6 +104,7 @@
             *ngIf="actions.includes('delete')"
             (deleteConfirmed)="deleteColumn.emit()"
             (deleteRejected)="deleteColumnRejected.emit()"
+            (deleteRequested)="requestColumnDelete()"
         >
         </dotcms-remove-confirm-dialog>
     </div>

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.spec.ts
@@ -259,5 +259,18 @@ describe('TemplateBuilderBoxComponent', () => {
                 expect(spectator.component.dialogVisible).toBeFalsy();
             });
         });
+
+        it('should emit a delete request without needing confirmation when there are no containers', () => {
+            spectator.component.items = [];
+            const deleteMock = jest.spyOn(spectator.component.deleteColumn, 'emit');
+
+            const deleteButton = spectator.query(byTestId('btn-remove-item'));
+
+            spectator.dispatchFakeEvent(deleteButton, 'onClick');
+
+            spectator.detectChanges();
+
+            expect(deleteMock).toHaveBeenCalled();
+        });
     });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.spec.ts
@@ -208,6 +208,20 @@ describe('TemplateBuilderBoxComponent', () => {
         done();
     });
 
+    it('should trigger deleteColumn when clicking on deleteColumn button and there are no containers', () => {
+        spectator.component.items = [];
+        spectator.detectComponentChanges();
+        const deleteMock = jest.spyOn(spectator.component.deleteColumn, 'emit');
+
+        const deleteButton = spectator.query(byTestId('btn-remove-item'));
+
+        spectator.dispatchFakeEvent(deleteButton, 'onClick');
+
+        spectator.detectChanges();
+
+        expect(deleteMock).toHaveBeenCalled();
+    });
+
     describe('Dialog', () => {
         it('should open dialog when click on edit button', () => {
             spectator.setInput('width', 1);
@@ -258,19 +272,6 @@ describe('TemplateBuilderBoxComponent', () => {
                 expect(templateBuilderBox).not.toExist();
                 expect(spectator.component.dialogVisible).toBeFalsy();
             });
-        });
-
-        it('should emit a delete request without needing confirmation when there are no containers', () => {
-            spectator.component.items = [];
-            const deleteMock = jest.spyOn(spectator.component.deleteColumn, 'emit');
-
-            const deleteButton = spectator.query(byTestId('btn-remove-item'));
-
-            spectator.dispatchFakeEvent(deleteButton, 'onClick');
-
-            spectator.detectChanges();
-
-            expect(deleteMock).toHaveBeenCalled();
         });
     });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.ts
@@ -91,8 +91,6 @@ export class TemplateBuilderBoxComponent implements OnChanges {
     }
 
     requestColumnDelete() {
-        if (this.items.length === 0) {
-            this.deleteColumn.emit();
-        }
+        this.deleteColumn.emit();
     }
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.ts
@@ -89,4 +89,10 @@ export class TemplateBuilderBoxComponent implements OnChanges {
         this.addContainer.emit(value);
         this.formControl.setValue(null);
     }
+
+    requestColumnDelete() {
+        if (this.items.length === 0) {
+            this.deleteColumn.emit();
+        }
+    }
 }


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bff2734</samp>

This pull request adds new features and tests to the template builder component and updates the storybook file for the device selector component. It allows the user to delete columns and rows from the template layout, and emits events to notify the parent component of the deletion requests. It also removes the deprecated `DotMessagePipeModule` and imports the `DotMessagePipe` directly.

### Checklist
- [X] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
