### PR TITLE
dotCMS/core#25385 [UI] Go out of edit mode when navigating to another page using nav_menu while editing a variant 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
@@ -59,15 +59,17 @@ export class DotEditPageStateControllerComponent implements OnChanges {
     ) {}
 
     ngOnChanges(changes: SimpleChanges) {
-        const pageState = changes.pageState.currentValue;
-        this.options = this.getStateModeOptions(pageState);
-        /*
-When the page is lock but the page is being load from an user that can lock the page
-we want to show the lock off so the new user can steal the lock
-*/
-        this.lock = this.isLocked(pageState);
-        this.lockWarn = this.shouldWarnLock(pageState);
-        this.mode = pageState.state.mode;
+        const pageState = changes.pageState?.currentValue;
+        if (pageState) {
+            this.options = this.getStateModeOptions(pageState);
+            /*
+    When the page is lock but the page is being load from an user that can lock the page
+    we want to show the lock off so the new user can steal the lock
+    */
+            this.lock = this.isLocked(pageState);
+            this.lockWarn = this.shouldWarnLock(pageState);
+            this.mode = pageState.state.mode;
+        }
     }
 
     /**

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.ts
@@ -2,7 +2,7 @@ import { fromEvent, merge, Observable, Subject } from 'rxjs';
 
 import { Component, ElementRef, NgZone, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, NavigationStart, Router } from '@angular/router';
 
 import { DialogService } from 'primeng/dynamicdialog';
 
@@ -133,6 +133,8 @@ browse from the page internal links
                         pageRendered
                     );
 
+                    this.variantData = null; // internal navigation, reset variant data - leave experiments.
+
                     if (this.isInternallyNavigatingToSamePage(pageRendered.page.pageURI)) {
                         this.dotPageStateService.setLocalState(dotRenderedPageState);
                     } else {
@@ -183,6 +185,18 @@ browse from the page internal links
         this.subscribeOverlayService();
         this.subscribeDraggedContentType();
         this.getExperimentResolverData();
+
+        /*This is needed when the user is in the edit mode in an experiment variant
+        and navigate to another page with the page menu and want to go back with the
+         browser back button */
+        this.router.events
+            .pipe(
+                takeUntil(this.destroy$),
+                filter((event) => event instanceof NavigationEnd)
+            )
+            .subscribe((_event: NavigationStart) => {
+                this.getExperimentResolverData();
+            });
     }
 
     ngOnDestroy(): void {


### PR DESCRIPTION
### Proposed Changes
* Need to leave experiments when doing an internal navigation in edit mode.
* Cover escenario with the back button when doing internal navigation. 
