### PR TITLE
Issue 25247 fixing docker image

### DIFF
--- a/docker/dotcms/Dockerfile
+++ b/docker/dotcms/Dockerfile
@@ -40,7 +40,7 @@ RUN ln -s $(ls -d /srv/dotserver/tomcat-*) /srv/dotserver/tomcat
 # Stage 2:  Construct our container using the minimal-java image
 #           and copying the prebuilt dotcms
 # ----------------------------------------------
-FROM dotcms/java-base:11.0.16-amzn as container-base
+FROM dotcms/java-base:11.0.16-amzn-25247 as container-base
 
 WORKDIR /srv
 

--- a/docker/dotcms/Dockerfile
+++ b/docker/dotcms/Dockerfile
@@ -40,7 +40,7 @@ RUN ln -s $(ls -d /srv/dotserver/tomcat-*) /srv/dotserver/tomcat
 # Stage 2:  Construct our container using the minimal-java image
 #           and copying the prebuilt dotcms
 # ----------------------------------------------
-FROM dotcms/java-base:11.0.16-amzn-25247 as container-base
+FROM dotcms/java-base:11.0.16-amzn as container-base
 
 WORKDIR /srv
 

--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -45,7 +45,7 @@ RUN bash -c "source /root/.sdkman/bin/sdkman-init.sh && \
     /root/.sdkman/candidates/java/$JAVA_VERSION/bin/jlink \
     --verbose \
     --add-modules \
-        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml \
+        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,org.w3c.dom \
     --compress 2 \
     --no-header-files \
     --no-man-pages \

--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -45,7 +45,7 @@ RUN bash -c "source /root/.sdkman/bin/sdkman-init.sh && \
     /root/.sdkman/candidates/java/$JAVA_VERSION/bin/jlink \
     --verbose \
     --add-modules \
-        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata \
+        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml \
     --compress 2 \
     --no-header-files \
     --no-man-pages \

--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -45,7 +45,7 @@ RUN bash -c "source /root/.sdkman/bin/sdkman-init.sh && \
     /root/.sdkman/candidates/java/$JAVA_VERSION/bin/jlink \
     --verbose \
     --add-modules \
-        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml \
+        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom \
     --compress 2 \
     --no-header-files \
     --no-man-pages \

--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -45,7 +45,7 @@ RUN bash -c "source /root/.sdkman/bin/sdkman-init.sh && \
     /root/.sdkman/candidates/java/$JAVA_VERSION/bin/jlink \
     --verbose \
     --add-modules \
-        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,org.w3c.dom \
+        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml \
     --compress 2 \
     --no-header-files \
     --no-man-pages \

--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -847,7 +847,7 @@ task createDistPrep(dependsOn: ['clonePullTomcatDist', 'deployWarTomcatDist']) {
         //we need to copy the setenv.sh file
         copy {
             from "$rootDir/src/main/resources/container/tomcat9/bin"
-            into "$distLocation$distBinLocation"
+            into "$tomcatDistBase/bin"
             include 'setenv*'
         }
 

--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -844,6 +844,13 @@ task createDistPrep(dependsOn: ['clonePullTomcatDist', 'deployWarTomcatDist']) {
             }
         }
 
+        //we need to copy the setenv.sh file
+        copy {
+            from "$rootDir/src/main/resources/container/tomcat9/bin"
+            into "$distLocation$distBinLocation"
+            include 'setenv*'
+        }
+
         copy {
             from "$rootDir/../"
             into "$distLocation$distBinLocation/ant"

--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.bat
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.bat
@@ -1,4 +1,4 @@
-set "CATALINA_OPTS=%CATALINA_OPTS% --Dfile.encoding=UTF8"
+set "CATALINA_OPTS=%CATALINA_OPTS% -Dfile.encoding=UTF8"
 set "CATALINA_OPTS=%CATALINA_OPTS% --illegal-access=warn"
 set "CATALINA_OPTS=%CATALINA_OPTS% --add-opens=java.base/java.lang=ALL-UNNAMED"
 set "CATALINA_OPTS=%CATALINA_OPTS% --add-opens=java.base/java.io=ALL-UNNAMED"

--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -1,4 +1,4 @@
-export CATALINA_OPTS="$CATALINA_OPTS --Dfile.encoding=UTF8"
+export CATALINA_OPTS="$CATALINA_OPTS -Dfile.encoding=UTF8"
 export CATALINA_OPTS="$CATALINA_OPTS --illegal-access=warn"
 export CATALINA_OPTS="$CATALINA_OPTS --add-opens=java.base/java.lang=ALL-UNNAMED"
 export CATALINA_OPTS="$CATALINA_OPTS --add-opens=java.base/java.io=ALL-UNNAMED"


### PR DESCRIPTION
### Proposed Changes

- The `jdk.xml.dom` and `java.xml` modules were required to support loading svg files as file assets
- The createDist logic was modified to include the sentenv files (sh and bat) in the tomcat/bin folder. We were setting some parameters there that were being ignored when the server deployed
- There was a typo in the setenv files 
