### PR TITLE
Template Builder: Implement Theme Selector

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.stories.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.stories.ts
@@ -15,7 +15,7 @@ import { PanelModule } from 'primeng/panel';
 
 import { DotDevicesService, DotMessageService } from '@dotcms/data-access';
 import { CoreWebService, CoreWebServiceMock } from '@dotcms/dotcms-js';
-import { DotIconModule, DotMessagePipeModule } from '@dotcms/ui';
+import { DotIconModule, DotMessagePipe } from '@dotcms/ui';
 import { MockDotMessageService, mockDotDevices } from '@dotcms/utils-testing';
 import { DotPipesModule } from '@pipes/dot-pipes.module';
 
@@ -49,7 +49,7 @@ export default {
                 OverlayPanelModule,
                 PanelModule,
                 DividerModule,
-                DotMessagePipeModule,
+                DotMessagePipe,
                 BrowserAnimationsModule
             ],
             providers: [

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_dropdown.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_dropdown.scss
@@ -23,7 +23,6 @@
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
-    border: none;
 }
 
 .p-dropdown.p-dropdown-clearable .p-dropdown-label {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.html
@@ -4,6 +4,7 @@
         [filter]="true"
         [showClear]="true"
         [showClear]="false"
+        [style]="{ width: '12rem' }"
         (onChange)="siteChange($event.value)"
         dotSiteSelector
         optionLabel="name"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.scss
@@ -7,13 +7,6 @@
 
 .theme-header__search-box {
     position: relative;
-
-    input {
-        font-size: $font-size-lg;
-        border: 1px solid $color-palette-gray-500;
-        padding: $spacing-3;
-        border-radius: $spacing-1;
-    }
 }
 
 .theme__header {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.spec.ts
@@ -10,6 +10,7 @@ import { ButtonModule } from 'primeng/button';
 import { DataViewModule } from 'primeng/dataview';
 import { DropdownModule } from 'primeng/dropdown';
 import { DialogService, DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { InputTextModule } from 'primeng/inputtext';
 
 import { DotEventsService, DotThemesService, PaginatorService } from '@dotcms/data-access';
 import { CoreWebService, mockSites, SiteService } from '@dotcms/dotcms-js';
@@ -29,6 +30,7 @@ describe('TemplateBuilderThemeSelectorComponent', () => {
             CommonModule,
             ButtonModule,
             DropdownModule,
+            InputTextModule,
             DataViewModule,
             DotMessagePipe,
             DotSiteSelectorDirective,

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.ts
@@ -18,6 +18,7 @@ import { ButtonModule } from 'primeng/button';
 import { DataView, DataViewModule } from 'primeng/dataview';
 import { DropdownModule } from 'primeng/dropdown';
 import { DialogService, DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { InputTextModule } from 'primeng/inputtext';
 
 import { debounceTime, take, takeUntil } from 'rxjs/operators';
 
@@ -41,7 +42,8 @@ import { DotMessagePipe, DotSiteSelectorDirective } from '@dotcms/ui';
         DotSiteSelectorDirective,
         DataViewModule,
         CommonModule,
-        DotMessagePipe
+        DotMessagePipe,
+        InputTextModule
     ],
     standalone: true,
     templateUrl: './template-builder-theme-selector.component.html',
@@ -95,7 +97,10 @@ export class TemplateBuilderThemeSelectorComponent implements OnInit, OnDestroy 
     }
 
     ngOnInit() {
-        const hostId = this.currentTheme?.hostId || this.siteService.currentSite?.identifier;
+        const hostId =
+            this.currentTheme?.hostId ||
+            this.siteService.currentSite?.identifier ||
+            'HOLA COMO ESTAS DSAD';
         this.paginatorService.url = 'v1/themes';
         this.paginatorService.paginationPerPage = 8;
         this.paginatorService.setExtraParams('hostId', hostId);

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.ts
@@ -97,10 +97,7 @@ export class TemplateBuilderThemeSelectorComponent implements OnInit, OnDestroy 
     }
 
     ngOnInit() {
-        const hostId =
-            this.currentTheme?.hostId ||
-            this.siteService.currentSite?.identifier ||
-            'HOLA COMO ESTAS DSAD';
+        const hostId = this.currentTheme?.hostId || this.siteService.currentSite?.identifier;
         this.paginatorService.url = 'v1/themes';
         this.paginatorService.paginationPerPage = 8;
         this.paginatorService.setExtraParams('hostId', hostId);


### PR DESCRIPTION
### Proposed Changes
* Fix dropdown and input styles on the Theme selector mentioned in this comment: https://github.com/dotCMS/core/issues/25201#issuecomment-1634878987

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74e761e</samp>

This pull request updates and improves the template builder theme selector component and its related files. It adds the `InputTextModule` from PrimeNG to use a consistent input component for entering theme names. It also fixes some style issues with the dropdown and input components, and updates the story and test files accordingly.

## Related Issue
Fixes #25201

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74e761e</samp>

* Replace deprecated `DotMessagePipeModule` with `DotMessagePipe` from `DotIconModule` in the imports and module declarations of the `DotDeviceSelectorSeoComponent` story ([link](https://github.com/dotCMS/core/pull/25526/files?diff=unified&w=0#diff-9d9dcbd8c15376938e7e220789fec014b153dad1c1a2e2e5703ac063c7f213c2L18-R18),[link](https://github.com/dotCMS/core/pull/25526/files?diff=unified&w=0#diff-9d9dcbd8c15376938e7e220789fec014b153dad1c1a2e2e5703ac063c7f213c2L52-R52))
* Remove `border: none` style from the dropdown component to fix visual inconsistency with the input component ([link](https://github.com/dotCMS/core/pull/25526/files?diff=unified&w=0#diff-0480bcafd47bc80c0f86719bb9d5185ea55e2b6f558b2a37ecba8c1b02777d05L26))
* Add `width` style to the input component in the `template-builder-theme-selector.component.html` to match design specifications and avoid overflowing the container ([link](https://github.com/dotCMS/core/pull/25526/files?diff=unified&w=0#diff-8f6c55e210d1b6a90041cb46fef292f4ca07430ccc782388443f550a2bef6df5R7))
* Remove redundant and conflicting input styles from the `template-builder-theme-selector.component.scss` ([link](https://github.com/dotCMS/core/pull/25526/files?diff=unified&w=0#diff-726d052085aaa58af15fe8f8fd0c17a25dddfdc6cfc321d1fddafeba338dfcbaL10-L16))
* Import `InputTextModule` from PrimeNG in the `template-builder-theme-selector.component.ts`, the `template-builder-theme-selector.component.spec.ts`, and the test bed configuration, to use the input component from PrimeNG instead of the native one and enable testing it ([link](https://github.com/dotCMS/core/pull/25526/files?diff=unified&w=0#diff-1144665f2f21fbdbada9e28b2e1cdbd48ff2b6f35eefcb36039153dd9044c3eaR13),[link](https://github.com/dotCMS/core/pull/25526/files?diff=unified&w=0#diff-1144665f2f21fbdbada9e28b2e1cdbd48ff2b6f35eefcb36039153dd9044c3eaR33),[link](https://github.com/dotCMS/core/pull/25526/files?diff=unified&w=0#diff-b3bc9c86951bb44b262cfd18948e1903bbfe9ff63d49c6ee7f27defee8be0242R21),[link](https://github.com/dotCMS/core/pull/25526/files?diff=unified&w=0#diff-b3bc9c86951bb44b262cfd18948e1903bbfe9ff63d49c6ee7f27defee8be0242L44-R46))
* Remove dummy string from the hostId assignment in the `template-builder-theme-selector.component.ts`, as it was probably not intended to be part of the pull request and could affect the pagination service ([link](https://github.com/dotCMS/core/pull/25526/files?diff=unified&w=0#diff-b3bc9c86951bb44b262cfd18948e1903bbfe9ff63d49c6ee7f27defee8be0242L98-R103))

### Screenshots


https://github.com/dotCMS/core/assets/72418962/f2116048-81db-4c11-b9e6-7b117fb2ed1a


