### PR TITLE
Fix #25490: Fixing Missing Feature to Save Advance Templates

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.html
@@ -20,6 +20,7 @@
                 [item]="vm.working"
                 (updateTemplate)="updateWorkingTemplate($event)"
                 (saveAndPublish)="saveAndPublishTemplate($event)"
+                (save)="saveTemplate($event)"
                 (cancel)="cancelTemplate()"
                 (custom)="onCustomEvent($event)"
             ></dot-template-builder>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.spec.ts
@@ -497,6 +497,41 @@ describe('DotTemplateCreateEditComponent', () => {
             });
 
             describe('edit layout', () => {
+                it('should save', () => {
+                    const builder = de.query(By.css('dot-template-builder'));
+                    builder.triggerEventHandler('save', {
+                        layout: {
+                            title: '',
+                            width: '',
+                            footer: true,
+                            header: false,
+                            sidebar: {},
+                            body: {
+                                rows: []
+                            }
+                        },
+                        themeId: '123'
+                    });
+                    expect(store.saveTemplate).toHaveBeenCalledWith({
+                        type: 'design',
+                        title: 'Some template',
+                        layout: {
+                            title: '',
+                            width: '',
+                            footer: true,
+                            header: false,
+                            sidebar: {},
+                            body: {
+                                rows: []
+                            }
+                        },
+                        identifier: '123',
+                        friendlyName: '',
+                        theme: '123',
+                        image: ''
+                    });
+                });
+
                 it('should call updateWorkingTemplate from store when updateTemplate', () => {
                     const builder = de.query(By.css('dot-template-builder'));
                     builder.triggerEventHandler('updateTemplate', {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-create-edit.component.ts
@@ -111,6 +111,19 @@ export class DotTemplateCreateEditComponent implements OnInit, OnDestroy {
     }
 
     /**
+     * Save template to store
+     *
+     * @param DotTemplate template
+     * @memberof DotTemplateCreateEditComponent
+     */
+    saveTemplate(template: DotTemplate): void {
+        this.store.saveTemplate({
+            ...this.form.value,
+            ...this.formatTemplateItem(template)
+        });
+    }
+
+    /**
      * Handle cancel button from designer
      *
      * @memberof DotTemplateCreateEditComponent


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 72fe08f</samp>

### Summary
💾🧪🔀

<!--
1.  💾 - This emoji represents saving data, which is the main purpose of the saveTemplate method and the event handler that calls it.
2.  🧪 - This emoji represents testing, which is what the unit test for the saveTemplate method does.
3.  🔀 - This emoji represents merging, which is what the saveTemplate method does with the template object and the form value object.
-->
This pull request adds the functionality to save a template from the dot-template-builder component in the dotCMS UI. It implements the saveTemplate method in the dot-template-create-edit component and adds an event handler and a unit test for it.

> _`saveTemplate` method_
> _merges form and template data_
> _autumn leaves fall fast_

### Walkthrough
*  Add saveTemplate method to dot-template-create-edit component to handle save events from dot-template-builder component ([link](https://github.com/dotCMS/core/pull/25530/files?diff=unified&w=0#diff-65fc5701762b720a1b4fd8afbbf0b8a0ee54827d1b9fe386f5ffc314058ce099R114-R126))
*  Call saveTemplate method from dot-template-create-edit component when dot-template-builder component emits save event with template object ([link](https://github.com/dotCMS/core/pull/25530/files?diff=unified&w=0#diff-958fb73f22ec679eb6781f4972cdc911cee640cd1b6fabd980ce14c925afa24bR23))
*  Add unit test for saveTemplate method to check that store.saveTemplate method is called with correct arguments ([link](https://github.com/dotCMS/core/pull/25530/files?diff=unified&w=0#diff-c9a69ffd01f22a129f18005abcd7ccd50369be5c9d0a1f2d0bdc342727280b30R500-R534))



### Screenshots

https://github.com/dotCMS/core/assets/63567962/812076dd-26e0-4b3e-8cb9-cf92a6305809

