### PR TITLE
Little reorganization of CSS and stories for the buttons

### DIFF
--- a/core-web/apps/dotcms-ui/src/stories/primeng/button/Button.stories.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/button/Button.stories.ts
@@ -3,14 +3,7 @@ import { Meta, Story } from '@storybook/angular/types-6-0';
 
 import { ButtonModule } from 'primeng/button';
 
-import {
-    BasicTemplate,
-    IconOnlyBasicTemplate,
-    IconOnlyOutlinedTemplate,
-    IconOnlyTextTemplate,
-    OutlinedTemplate,
-    TextTemplate
-} from './templates';
+import { MainTemplate, IconOnlyTemplate } from './templates';
 
 export default {
     title: 'PrimeNG/Button/Button',
@@ -29,86 +22,14 @@ export default {
     }
 } as Meta;
 
-export const MainBasic: Story = () => {
+export const Main: Story = () => {
     return {
-        template: BasicTemplate
+        template: MainTemplate
     };
 };
 
-MainBasic.parameters = {
-    docs: {
-        source: {
-            code: BasicTemplate
-        }
-    }
-};
-
-export const MainOutlined: Story = () => {
+export const IconOnly: Story = () => {
     return {
-        template: OutlinedTemplate
+        template: IconOnlyTemplate
     };
-};
-
-MainOutlined.parameters = {
-    docs: {
-        source: {
-            code: OutlinedTemplate
-        }
-    }
-};
-
-export const MainText: Story = () => {
-    return {
-        template: TextTemplate
-    };
-};
-
-MainText.parameters = {
-    docs: {
-        source: {
-            code: TextTemplate
-        }
-    }
-};
-
-export const IconOnlyBasic: Story = () => {
-    return {
-        template: IconOnlyBasicTemplate
-    };
-};
-
-IconOnlyBasic.parameters = {
-    docs: {
-        source: {
-            code: IconOnlyBasicTemplate
-        }
-    }
-};
-
-export const IconOnlyOutlined: Story = () => {
-    return {
-        template: IconOnlyOutlinedTemplate
-    };
-};
-
-IconOnlyOutlined.parameters = {
-    docs: {
-        source: {
-            code: IconOnlyOutlinedTemplate
-        }
-    }
-};
-
-export const IconOnlyText: Story = () => {
-    return {
-        template: IconOnlyTextTemplate
-    };
-};
-
-IconOnlyText.parameters = {
-    docs: {
-        source: {
-            code: IconOnlyTextTemplate
-        }
-    }
 };

--- a/core-web/apps/dotcms-ui/src/stories/primeng/button/templates.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/button/templates.ts
@@ -543,10 +543,11 @@ export const MainTemplate = `
             disabled="true"
         ></button>
     </div>
-    </div>
-    `;
+</div>
+`;
 
-export const IconOnlyBasicTemplate = `<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
+export const IconOnlyTemplate = `
+<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
     <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
         <button class="p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
         <button class="p-button-rounded" pButton icon="pi pi-ellipsis-v" disabled="true"></button>
@@ -588,137 +589,137 @@ export const IconOnlyBasicTemplate = `<div style="display: flex; gap: 24px; flex
     </div>
 </div>
 
-`;
+<hr />
 
-export const IconOnlyTemplate = `<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-outlined p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
-    <button
-        class="p-button-outlined p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-sm p-button-outlined p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-sm p-button-outlined p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-secondary p-button-outlined p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-secondary p-button-outlined p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-sm p-button-secondary p-button-outlined p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-outlined p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
+<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-outlined p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
+        <button
+            class="p-button-outlined p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-sm p-button-outlined p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+        ></button>
+        <button
+            class="p-button-sm p-button-outlined p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-secondary p-button-outlined p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+        ></button>
+        <button
+            class="p-button-secondary p-button-outlined p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-sm p-button-secondary p-button-outlined p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-outlined p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
 </div>
 
 <hr />
 
 <div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-text p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
-    <button
-        class="p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-sm p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-sm p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-secondary p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-secondary p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-text p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
+        <button
+            class="p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-sm p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+        ></button>
+        <button
+            class="p-button-sm p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-secondary p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+        ></button>
+        <button
+            class="p-button-secondary p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
 
-    <button
-        class="p-button-sm p-button-secondary p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-danger p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-danger p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-sm p-button-danger p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-sm p-button-danger p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
+        <button
+            class="p-button-sm p-button-secondary p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-danger p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+        ></button>
+        <button
+            class="p-button-danger p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-sm p-button-danger p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+        ></button>
+        <button
+            class="p-button-sm p-button-danger p-button-text p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
 </div>
 `;
 

--- a/core-web/apps/dotcms-ui/src/stories/primeng/button/templates.ts
+++ b/core-web/apps/dotcms-ui/src/stories/primeng/button/templates.ts
@@ -1,606 +1,597 @@
-export const BasicTemplate = `<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-lg" pButton label="Button"></button>
-    <button class="p-button-lg" pButton label="Button" icon="pi pi-plus"></button>
-    <button
-        class="p-button-lg"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-lg"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button class="p-button-lg" pButton label="Button" disabled="true"></button>
+export const MainTemplate = `
+<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-lg" pButton label="Button"></button>
+        <button class="p-button-lg" pButton label="Button" icon="pi pi-home"></button>
+        <button
+            class="p-button-lg"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-lg"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button class="p-button-lg" pButton label="Button" disabled="true"></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button pButton label="Button"></button>
+        <button pButton label="Button" icon="pi pi-home"></button>
+        <button pButton label="Button" icon="pi pi-home" iconPos="right"></button>
+        <button pButton label="Button" icon="pi pi-home" disabled="true"></button>
+        <button pButton label="Button" disabled="true"></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-sm" pButton label="Button"></button>
+        <button class="p-button-sm" pButton label="Button" icon="pi pi-home"></button>
+        <button
+            class="p-button-sm"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-sm"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button class="p-button-sm" pButton label="Button" disabled="true"></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-lg p-button-secondary" pButton label="Button"></button>
+        <button
+            class="p-button-lg p-button-secondary"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-secondary" pButton label="Button"></button>
+        <button class="p-button-secondary" pButton label="Button" icon="pi pi-home"></button>
+        <button
+            class="p-button-secondary"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-secondary"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button class="p-button-secondary" pButton label="Button" disabled="true"></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-sm p-button-secondary" pButton label="Button"></button>
+        <button
+            class="p-button-sm p-button-secondary"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
 </div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button pButton label="Button"></button>
-    <button pButton label="Button" icon="pi pi-plus"></button>
-    <button pButton label="Button" icon="pi pi-plus" iconPos="right"></button>
-    <button pButton label="Button" icon="pi pi-plus" disabled="true"></button>
-    <button pButton label="Button" disabled="true"></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-sm" pButton label="Button"></button>
-    <button class="p-button-sm" pButton label="Button" icon="pi pi-plus"></button>
-    <button
-        class="p-button-sm"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-sm"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button class="p-button-sm" pButton label="Button" disabled="true"></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-lg p-button-secondary" pButton label="Button"></button>
-    <button
-        class="p-button-lg p-button-secondary"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-secondary" pButton label="Button"></button>
-    <button class="p-button-secondary" pButton label="Button" icon="pi pi-plus"></button>
-    <button
-        class="p-button-secondary"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-secondary"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button class="p-button-secondary" pButton label="Button" disabled="true"></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-sm p-button-secondary" pButton label="Button"></button>
-    <button
-        class="p-button-sm p-button-secondary"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-</div>
-`;
 
-export const OutlinedTemplate = `<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-lg p-button-outlined" pButton label="Button"></button>
-    <button
-        class="p-button-lg p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-lg p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-lg p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-lg p-button-outlined"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-outlined" pButton label="Button"></button>
-    <button class="p-button-outlined" pButton label="Button" icon="pi pi-plus"></button>
-    <button
-        class="p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button class="p-button-outlined" pButton label="Button" disabled="true"></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-sm p-button-outlined" pButton label="Button"></button>
-    <button
-        class="p-button-sm p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-sm p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-sm p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-sm p-button-outlined"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-lg p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-secondary p-button-outlined" pButton label="Button"></button>
-    <button
-        class="p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-sm p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-outlined"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-</div>
-`;
+<hr />
 
-export const TextTemplate = `<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-lg p-button-text" pButton label="Button"></button>
-    <button class="p-button-lg p-button-text" pButton label="Button" icon="pi pi-plus"></button>
-    <button
-        class="p-button-lg p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-lg p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button class="p-button-lg p-button-text" pButton label="Button" disabled="true"></button>
+<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-lg p-button-outlined" pButton label="Button"></button>
+        <button
+            class="p-button-lg p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-lg p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-lg p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-lg p-button-outlined"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-outlined" pButton label="Button"></button>
+        <button class="p-button-outlined" pButton label="Button" icon="pi pi-home"></button>
+        <button
+            class="p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button class="p-button-outlined" pButton label="Button" disabled="true"></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-sm p-button-outlined" pButton label="Button"></button>
+        <button
+            class="p-button-sm p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-sm p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-sm p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-sm p-button-outlined"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-lg p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-secondary p-button-outlined" pButton label="Button"></button>
+        <button
+            class="p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-sm p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-outlined"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
 </div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-text" pButton label="Button"></button>
-    <button class="p-button-text" pButton label="Button" icon="pi pi-plus"></button>
-    <button
-        class="p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button class="p-button-text" pButton label="Button" disabled="true"></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-sm p-button-text" pButton label="Button"></button>
-    <button class="p-button-sm p-button-text" pButton label="Button" icon="pi pi-plus"></button>
-    <button
-        class="p-button-sm p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-sm p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button class="p-button-sm p-button-text" pButton label="Button" disabled="true"></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-lg p-button-secondary p-button-text"
-        pButton
-        label="Button"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-lg p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-secondary p-button-text" pButton label="Button"></button>
-    <button
-        class="p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-sm p-button-secondary p-button-text"
-        pButton
-        label="Button"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-text"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-lg p-button-danger p-button-text" pButton label="Button"></button>
-    <button
-        class="p-button-lg p-button-danger p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-lg p-button-danger p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-lg p-button-danger p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-lg p-button-danger p-button-text"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-danger p-button-text" pButton label="Button"></button>
-    <button
-        class="p-button-danger p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-danger p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-danger p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-danger p-button-text"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-sm p-button-danger p-button-text" pButton label="Button"></button>
-    <button
-        class="p-button-sm p-button-danger p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-    ></button>
-    <button
-        class="p-button-sm p-button-danger p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        iconPos="right"
-    ></button>
-    <button
-        class="p-button-sm p-button-danger p-button-text"
-        pButton
-        label="Button"
-        icon="pi pi-plus"
-        disabled="true"
-    ></button>
-    <button
-        class="p-button-sm p-button-danger p-button-text"
-        pButton
-        label="Button"
-        disabled="true"
-    ></button>
-</div>
-</div>
-`;
+
+<hr />
+
+<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-lg p-button-text" pButton label="Button"></button>
+        <button class="p-button-lg p-button-text" pButton label="Button" icon="pi pi-home"></button>
+        <button
+            class="p-button-lg p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-lg p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button class="p-button-lg p-button-text" pButton label="Button" disabled="true"></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-text" pButton label="Button"></button>
+        <button class="p-button-text" pButton label="Button" icon="pi pi-home"></button>
+        <button
+            class="p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button class="p-button-text" pButton label="Button" disabled="true"></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-sm p-button-text" pButton label="Button"></button>
+        <button class="p-button-sm p-button-text" pButton label="Button" icon="pi pi-home"></button>
+        <button
+            class="p-button-sm p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-sm p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button class="p-button-sm p-button-text" pButton label="Button" disabled="true"></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-lg p-button-secondary p-button-text"
+            pButton
+            label="Button"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-lg p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-secondary p-button-text" pButton label="Button"></button>
+        <button
+            class="p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-sm p-button-secondary p-button-text"
+            pButton
+            label="Button"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-text"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-lg p-button-danger p-button-text" pButton label="Button"></button>
+        <button
+            class="p-button-lg p-button-danger p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-lg p-button-danger p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-lg p-button-danger p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-lg p-button-danger p-button-text"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-danger p-button-text" pButton label="Button"></button>
+        <button
+            class="p-button-danger p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-danger p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-danger p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-danger p-button-text"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-sm p-button-danger p-button-text" pButton label="Button"></button>
+        <button
+            class="p-button-sm p-button-danger p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+        ></button>
+        <button
+            class="p-button-sm p-button-danger p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            iconPos="right"
+        ></button>
+        <button
+            class="p-button-sm p-button-danger p-button-text"
+            pButton
+            label="Button"
+            icon="pi pi-home"
+            disabled="true"
+        ></button>
+        <button
+            class="p-button-sm p-button-danger p-button-text"
+            pButton
+            label="Button"
+            disabled="true"
+        ></button>
+    </div>
+    </div>
+    `;
 
 export const IconOnlyBasicTemplate = `<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
-    <button class="p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
-    <button class="p-button-rounded" pButton icon="pi pi-ellipsis-v" disabled="true"></button>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
+        <button class="p-button-rounded" pButton icon="pi pi-ellipsis-v" disabled="true"></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button class="p-button-sm p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
+        <button
+            class="p-button-sm p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-secondary p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+        ></button>
+        <button
+            class="p-button-secondary p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
+    <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
+        <button
+            class="p-button-sm p-button-secondary p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+        ></button>
+        <button
+            class="p-button-sm p-button-secondary p-button-rounded"
+            pButton
+            icon="pi pi-ellipsis-v"
+            disabled="true"
+        ></button>
+    </div>
 </div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-sm p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
-    <button class="p-button-sm p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
-    <button
-        class="p-button-sm p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-secondary p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-secondary p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-secondary p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-<div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-sm p-button-secondary p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-        disabled="true"
-    ></button>
-</div>
-</div>
+
 `;
 
-export const IconOnlyOutlinedTemplate = `<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
+export const IconOnlyTemplate = `<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
 <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-outlined p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
     <button class="p-button-outlined p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
     <button
         class="p-button-outlined p-button-rounded"
@@ -619,20 +610,10 @@ export const IconOnlyOutlinedTemplate = `<div style="display: flex; gap: 24px; f
         class="p-button-sm p-button-outlined p-button-rounded"
         pButton
         icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-sm p-button-outlined p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
         disabled="true"
     ></button>
 </div>
 <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-secondary p-button-outlined p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
     <button
         class="p-button-secondary p-button-outlined p-button-rounded"
         pButton
@@ -655,20 +636,15 @@ export const IconOnlyOutlinedTemplate = `<div style="display: flex; gap: 24px; f
         class="p-button-sm p-button-secondary p-button-outlined p-button-rounded"
         pButton
         icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-sm p-button-secondary p-button-outlined p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
         disabled="true"
     ></button>
 </div>
 </div>
-`;
 
-export const IconOnlyTextTemplate = `<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
+<hr />
+
+<div style="display: flex; gap: 24px; flex-direction: column; align-items: center">
 <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button class="p-button-text p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
     <button class="p-button-text p-button-rounded" pButton icon="pi pi-ellipsis-v"></button>
     <button
         class="p-button-text p-button-rounded"
@@ -687,11 +663,6 @@ export const IconOnlyTextTemplate = `<div style="display: flex; gap: 24px; flex-
         class="p-button-sm p-button-text p-button-rounded"
         pButton
         icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-sm p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
         disabled="true"
     ></button>
 </div>
@@ -705,20 +676,11 @@ export const IconOnlyTextTemplate = `<div style="display: flex; gap: 24px; flex-
         class="p-button-secondary p-button-text p-button-rounded"
         pButton
         icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-secondary p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
         disabled="true"
     ></button>
 </div>
 <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-sm p-button-secondary p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
+
     <button
         class="p-button-sm p-button-secondary p-button-text p-button-rounded"
         pButton
@@ -741,20 +703,10 @@ export const IconOnlyTextTemplate = `<div style="display: flex; gap: 24px; flex-
         class="p-button-danger p-button-text p-button-rounded"
         pButton
         icon="pi pi-ellipsis-v"
-    ></button>
-    <button
-        class="p-button-danger p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
         disabled="true"
     ></button>
 </div>
 <div style="display: flex; gap: 8px; justify-content: center; width: fit-content">
-    <button
-        class="p-button-sm p-button-danger p-button-text p-button-rounded"
-        pButton
-        icon="pi pi-ellipsis-v"
-    ></button>
     <button
         class="p-button-sm p-button-danger p-button-text p-button-rounded"
         pButton

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_button.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_button.scss
@@ -17,44 +17,44 @@
         color: inherit;
         font-size: $icon-md;
     }
-}
 
-// Shared but not icon only
-.p-button:not(.p-button-icon-only, .p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
-    border-radius: $border-radius-md;
-    font-size: $font-size-md;
-    gap: $spacing-1;
-    height: $field-height-md;
-    padding: 0 $spacing-3;
-    text-transform: capitalize;
+    // Shared but not icon only
+    &:not(.p-button-icon-only, .p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
+        border-radius: $border-radius-md;
+        font-size: $font-size-md;
+        gap: $spacing-1;
+        height: $field-height-md;
+        padding: 0 $spacing-3;
+        text-transform: capitalize;
 
-    &.p-button-lg {
-        height: $field-height-lg;
-        border-radius: $border-radius-lg;
-        font-size: $font-size-lg;
+        &.p-button-lg {
+            height: $field-height-lg;
+            border-radius: $border-radius-lg;
+            font-size: $font-size-lg;
 
-        .p-button-label {
-            font-size: inherit;
+            .p-button-label {
+                font-size: inherit;
+            }
+
+            .p-button-icon.pi {
+                font-size: $icon-lg;
+            }
         }
 
-        .p-button-icon.pi {
-            font-size: $icon-lg;
-        }
-    }
+        &.p-button-sm {
+            border-radius: $border-radius-sm;
+            font-size: $font-size-sm;
+            gap: $spacing-0;
+            height: $field-height-sm;
+            padding: 0 $spacing-1;
 
-    &.p-button-sm {
-        border-radius: $border-radius-sm;
-        font-size: $font-size-sm;
-        gap: $spacing-0;
-        height: $field-height-sm;
-        padding: 0 $spacing-1;
+            .p-button-label {
+                font-size: inherit;
+            }
 
-        .p-button-label {
-            font-size: inherit;
-        }
-
-        .p-button-icon.pi {
-            font-size: $icon-sm;
+            .p-button-icon.pi {
+                font-size: $icon-sm;
+            }
         }
     }
 }

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_button.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_button.scss
@@ -19,7 +19,7 @@
     }
 
     // Shared but not icon only
-    &:not(.p-button-icon-only, .p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
+    &:not(.p-button-icon-only) {
         border-radius: $border-radius-md;
         font-size: $font-size-md;
         gap: $spacing-1;

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_button.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_button.scss
@@ -2,16 +2,10 @@
 @use "variables" as *;
 @import "mixins";
 
-// Shared styles between all buttons
-.p-button:not(.p-button-icon-only, .p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
-    gap: $spacing-1;
-    padding: 0 $spacing-3;
-    height: $field-height-md;
-    border-radius: $border-radius-md;
+// Shared all buttons
+.p-button:not(.p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
     border: none;
     color: $white;
-    font-size: $font-size-md;
-    text-transform: capitalize;
 
     .p-button-label {
         color: inherit;
@@ -19,11 +13,20 @@
         text-transform: capitalize;
     }
 
-    .p-button-icon,
-    .pi {
-        color: $white;
+    .p-button-icon.pi {
+        color: inherit;
         font-size: $icon-md;
     }
+}
+
+// Shared but not icon only
+.p-button:not(.p-button-icon-only, .p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
+    border-radius: $border-radius-md;
+    font-size: $font-size-md;
+    gap: $spacing-1;
+    height: $field-height-md;
+    padding: 0 $spacing-3;
+    text-transform: capitalize;
 
     &.p-button-lg {
         height: $field-height-lg;
@@ -34,25 +37,23 @@
             font-size: inherit;
         }
 
-        .p-button-icon,
-        .pi {
+        .p-button-icon.pi {
             font-size: $icon-lg;
         }
     }
 
     &.p-button-sm {
-        height: $field-height-sm;
-        gap: $spacing-0;
-        padding: 0 $spacing-1;
         border-radius: $border-radius-sm;
         font-size: $font-size-sm;
+        gap: $spacing-0;
+        height: $field-height-sm;
+        padding: 0 $spacing-1;
 
         .p-button-label {
             font-size: inherit;
         }
 
-        .p-button-icon,
-        .pi {
+        .p-button-icon.pi {
             font-size: $icon-sm;
         }
     }
@@ -62,12 +63,7 @@
 .p-button:disabled:not(.p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
     background-color: $color-palette-gray-op-20;
     color: $color-palette-gray-500;
-    opacity: 1;
-
-    .p-button-label,
-    .p-button-icon {
-        color: inherit;
-    }
+    opacity: 1; // Override opacity from primeng
 
     &.p-button-outlined {
         border: 1.5px solid $color-palette-gray-300;
@@ -115,16 +111,6 @@
     border: 1.5px solid $color-palette-primary;
     color: $color-palette-primary;
 
-    &.p-button-sm {
-        border: 1px solid $color-palette-primary;
-    }
-
-    .p-button-label,
-    .p-button-icon,
-    .pi {
-        color: inherit;
-    }
-
     &:hover {
         background-color: $color-palette-primary-op-10;
     }
@@ -138,6 +124,10 @@
         @include field-focus;
     }
 
+    &.p-button-sm {
+        border: 1px solid $color-palette-primary;
+    }
+
     &.p-button-secondary {
         background-color: transparent;
         border: 1.5px solid $color-palette-secondary;
@@ -145,12 +135,6 @@
 
         &.p-button-sm {
             border: 1px solid $color-palette-secondary;
-        }
-
-        .p-button-label,
-        .p-button-icon,
-        .pi {
-            color: inherit;
         }
 
         &:hover {
@@ -180,8 +164,8 @@ a.p-button.p-button-text {
         color: inherit;
         @include truncate-text;
     }
-    .p-button-icon,
-    .pi {
+
+    .p-button-icon.pi {
         color: $color-palette-primary;
     }
 
@@ -206,8 +190,7 @@ a.p-button.p-button-text {
             color: inherit;
         }
 
-        .p-button-icon,
-        .pi {
+        .p-button-icon.pi {
             color: $color-palette-secondary;
         }
 
@@ -229,12 +212,6 @@ a.p-button.p-button-text {
         background-color: transparent;
         color: $color-accessible-text-red;
 
-        .p-button-label,
-        .p-button-icon,
-        .pi {
-            color: inherit;
-        }
-
         &:hover {
             background-color: $color-accessible-text-red-op-10;
         }
@@ -247,6 +224,10 @@ a.p-button.p-button-text {
             background-color: transparent;
             @include field-focus;
         }
+
+        .p-button-icon.pi {
+            color: inherit;
+        }
     }
 }
 
@@ -256,9 +237,8 @@ a.p-button.p-button-text {
     width: $field-height-md;
     border: none;
 
-    .p-button-icon {
-        color: $white;
-        font-size: $font-size-lg;
+    .p-button-icon.pi {
+        font-size: $icon-lg;
     }
 
     &.p-button-sm {
@@ -266,7 +246,7 @@ a.p-button.p-button-text {
         width: $field-height-sm;
 
         .p-button-icon {
-            font-size: $font-size-md;
+            font-size: $icon-md;
         }
     }
 }

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_button.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_button.scss
@@ -2,9 +2,7 @@
 @use "variables" as *;
 @import "mixins";
 
-// Main buttons
-
-// Main Buttons sizes
+// Shared styles between all buttons
 .p-button:not(.p-button-icon-only, .p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
     gap: $spacing-1;
     padding: 0 $spacing-3;
@@ -24,7 +22,7 @@
     .p-button-icon,
     .pi {
         color: $white;
-        font-size: $font-size-lg;
+        font-size: $icon-md;
     }
 
     &.p-button-lg {
@@ -38,7 +36,7 @@
 
         .p-button-icon,
         .pi {
-            font-size: $font-size-xl;
+            font-size: $icon-lg;
         }
     }
 
@@ -55,12 +53,28 @@
 
         .p-button-icon,
         .pi {
-            font-size: $font-size-md;
+            font-size: $icon-sm;
         }
     }
 }
 
-// Severity colors for main basic button
+// Shared disabled styles
+.p-button:disabled:not(.p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
+    background-color: $color-palette-gray-op-20;
+    color: $color-palette-gray-500;
+    opacity: 1;
+
+    .p-button-label,
+    .p-button-icon {
+        color: inherit;
+    }
+
+    &.p-button-outlined {
+        border: 1.5px solid $color-palette-gray-300;
+    }
+}
+
+// Severity for basic button
 .p-button:enabled:not(.p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
     background-color: $color-palette-primary;
 
@@ -112,11 +126,11 @@
     }
 
     &:hover {
-        background-color: $color-palette-primary-100;
+        background-color: $color-palette-primary-op-10;
     }
 
     &:active {
-        background-color: $color-palette-primary-200;
+        background-color: $color-palette-primary-op-20;
     }
 
     &:focus {
@@ -140,11 +154,11 @@
         }
 
         &:hover {
-            background-color: $color-palette-secondary-100;
+            background-color: $color-palette-secondary-op-10;
         }
 
         &:active {
-            background-color: $color-palette-secondary-200;
+            background-color: $color-palette-secondary-op-20;
         }
 
         &:focus {
@@ -172,7 +186,7 @@ a.p-button.p-button-text {
     }
 
     &:hover {
-        background-color: $color-palette-primary-100;
+        background-color: $color-palette-primary-op-10;
     }
 
     &:active {
@@ -198,7 +212,7 @@ a.p-button.p-button-text {
         }
 
         &:hover {
-            background-color: $color-palette-secondary-100;
+            background-color: $color-palette-secondary-op-10;
         }
 
         &:active {
@@ -222,11 +236,11 @@ a.p-button.p-button-text {
         }
 
         &:hover {
-            background-color: rgb($color-accessible-text-red, 0.08);
+            background-color: $color-accessible-text-red-op-10;
         }
 
         &:active {
-            background-color: rgb($color-accessible-text-red, 0.15);
+            background-color: $color-accessible-text-red-op-20;
         }
 
         &:focus {
@@ -236,27 +250,7 @@ a.p-button.p-button-text {
     }
 }
 
-// Buttons disabled styles
-.p-button:disabled:not(.p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
-    background-color: $color-palette-gray-200;
-    color: $color-palette-gray-500;
-    opacity: 1;
-
-    .p-button-label,
-    .p-button-icon {
-        color: inherit;
-    }
-
-    &.p-button-outlined {
-        border: 1.5px solid $color-palette-gray-300;
-    }
-
-    &.p-button-text {
-        background-color: $white;
-    }
-}
-
-// Icon Only Buttons Sizes
+// Icon Only Sizes
 .p-button-icon-only:not(.p-splitbutton-menubutton) {
     height: $field-height-md;
     width: $field-height-md;

--- a/core-web/libs/dotcms-scss/shared/_colors.scss
+++ b/core-web/libs/dotcms-scss/shared/_colors.scss
@@ -74,6 +74,16 @@ $color-palette-gray-800: #515667;
 $color-palette-gray-900: #3d404d;
 $color-palette-gray: #afb3c0;
 
+$color-palette-gray-op-10: rgba($color-palette-gray, 0.1);
+$color-palette-gray-op-20: rgba($color-palette-gray, 0.2);
+$color-palette-gray-op-30: rgba($color-palette-gray, 0.3);
+$color-palette-gray-op-40: rgba($color-palette-gray, 0.4);
+$color-palette-gray-op-50: rgba($color-palette-gray, 0.5);
+$color-palette-gray-op-60: rgba($color-palette-gray, 0.6);
+$color-palette-gray-op-70: rgba($color-palette-gray, 0.7);
+$color-palette-gray-op-80: rgba($color-palette-gray, 0.8);
+$color-palette-gray-op-90: rgba($color-palette-gray, 0.9);
+
 $color-alert-blue: $color-palette-primary-500;
 $color-alert-blue-light: $color-palette-primary-100;
 $color-alert-yellow: #ffb444;
@@ -85,14 +95,21 @@ $color-alert-red-light: #fff6f6;
 
 $color-accessible-text-red: #d82b2e;
 $color-accessible-text-red-bg: $color-alert-red-light;
+$color-accessible-text-red-op-10: rgba($color-accessible-text-red, 0.1);
+$color-accessible-text-red-op-20: rgba($color-accessible-text-red, 0.2);
+
 $color-accessible-text-green: #0b6948;
 $color-accessible-text-green-bg: $color-alert-green-light;
+
 $color-accessible-text-purple: $color-palette-secondary-600;
 $color-accessible-text-purple-bg: $color-palette-secondary-100;
+
 $color-accessible-text-blue: $color-palette-primary-500;
 $color-accessible-text-blue-bg: $color-palette-primary-200;
+
 $color-accessible-text-yellow: #bc5b0d; // TODO: why?
 $color-accessible-text-yellow-bg: $color-alert-yellow-light;
+
 $color-accessible-text-gray: $color-palette-gray-600;
 $color-accessible-text-gray-bg: $color-palette-gray-100;
 

--- a/core-web/libs/dotcms-scss/shared/_common.scss
+++ b/core-web/libs/dotcms-scss/shared/_common.scss
@@ -12,3 +12,7 @@ $field-height: 40px;
 $field-height-sm: 2rem;
 $field-height-md: 2.5rem;
 $field-height-lg: 3rem;
+
+$icon-sm: 14px;
+$icon-md: 16px;
+$icon-lg: 18px;


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9b37086</samp>

### Summary
🎨📐♻️

<!--
1.  🎨 - This emoji represents the addition of the color variables and the use of variables for colors, font sizes and other properties in the button styles.
2.  📐 - This emoji represents the addition of the variables for the different sizes of the icons and the simplification of the button stories by using templates.
3.  ♻️ - This emoji represents the refactoring of the button styles to simplify the selectors and inheritance, and to improve the consistency, readability and maintainability of the code.
-->
Refactored the button component and styles in `core-web` to use templates, variables and simplified selectors. Added new color and icon size variables to the shared SCSS files. Updated the button stories in `Button.stories.ts` to demonstrate the button variants.

> _To make button styles more concise_
> _We refactored them with some spice_
> _We used variables_
> _For colors and icons_
> _And simplified the stories nice_

### Walkthrough
*  Simplify button stories to use only two templates and two stories ([link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-e9683a7beb56278068d4a40e151209d3cd29dc634a9533437b72b402702b6dddL6-R6), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-e9683a7beb56278068d4a40e151209d3cd29dc634a9533437b72b402702b6dddL32-R35))
*  Refactor button styles to use variables, shared styles and opacity for hover and active states ([link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L5-R8), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L24-R30), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L39-R50), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L56-R73), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L104-R119), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187R127-R130), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L136-R145), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L169-R173), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L195-R198), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L218-R220), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L236-R234), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L265-R241), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-6f8b74847e0ed7761e15eb27e3a92e988f2d91e52df19923bbb1177913c71187L275-R249))
*  Add variables for gray and red opacities and icon sizes in `_colors.scss` and `_common.scss` ([link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-a673541496e37f0c8d73eef81a2026235e3d621daf64af8bf35a97881cb2dce5R77-R86), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-a673541496e37f0c8d73eef81a2026235e3d621daf64af8bf35a97881cb2dce5L88-R112), [link](https://github.com/dotCMS/core/pull/25575/files?diff=unified&w=0#diff-560fcfc492a8e2e54af1146b4ad7c9336d90c60ef64c673e8b5be2f2163de929R15-R18))



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
