### PR TITLE
#24954 prevent styling problem when reopening window

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelectorContent.jsp
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelectorContent.jsp
@@ -8,7 +8,7 @@
 
     .related-content-form {
         width: 90vw;
-        height: 90vw;
+        height: 90vh;
     }
 </style>
 <form


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 894b2ec</samp>

Fixed content selector dialog height and other issues. Changed the CSS height property of `.related-content-form` in `ContentSelectorContent.jsp` to use viewport height instead of width.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
