### PR TITLE
Fix #25485: Template Builder Add Container to ContainerMap when Adding it to Sidebar

### DIFF
--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-sidebar/template-builder-sidebar.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-sidebar/template-builder-sidebar.component.ts
@@ -58,7 +58,7 @@ export class TemplateBuilderSidebarComponent {
     /**
      * @description Delete a container from the sidebar
      *
-     * @param {DotContainer} container
+     * @param {number} index
      * @memberof TemplateBuilderSidebarComponent
      */
     deleteContainer(index: number) {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.spec.ts
@@ -35,6 +35,9 @@ describe('DotTemplateBuilderStore', () => {
     let containerMap$: Observable<DotContainerMap>;
     let initialState: DotGridStackWidget[];
     const mockContainer = containersMock[0];
+    const minDataMockContainer = {
+        identifier: mockContainer.identifier
+    };
 
     const addContainer = () => {
         const parentRow = initialState[0];
@@ -423,20 +426,27 @@ describe('DotTemplateBuilderStore', () => {
         expect.assertions(1);
         service.addSidebarContainer(mockContainer);
         service.vm$.subscribe(({ layoutProperties }) => {
-            expect(layoutProperties.sidebar.containers).toContain(mockContainer);
+            expect(layoutProperties.sidebar.containers[0]).toEqual(minDataMockContainer);
+            done();
         });
-        done();
+    });
+
+    it('should add a container to container map when adding it to sidebar', (done) => {
+        expect.assertions(1);
+        service.addSidebarContainer(mockContainer);
+        service.vm$.subscribe(({ containerMap }) => {
+            expect(containerMap[mockContainer.identifier]).toEqual(mockContainer);
+            done();
+        });
     });
 
     it('should delete a container from the sidebar', (done) => {
         expect.assertions(2);
         service.addSidebarContainer(mockContainer);
         service.vm$.pipe(take(1)).subscribe(({ layoutProperties }) => {
-            expect(layoutProperties.sidebar.containers).toContainEqual({
-                identifier: mockContainer.identifier
-            });
+            expect(layoutProperties.sidebar.containers).toContainEqual(minDataMockContainer);
             service.deleteSidebarContainer(0);
-            expect(layoutProperties.sidebar.containers).not.toContain(mockContainer);
+            expect(layoutProperties.sidebar.containers).not.toContain(minDataMockContainer);
             done();
         });
     });
@@ -447,9 +457,7 @@ describe('DotTemplateBuilderStore', () => {
 
         items$.subscribe((items) => {
             const row = items.find((item) => item.id === initialState[0].id);
-            expect(row?.subGridOpts?.children[0]?.containers).toContainEqual({
-                identifier: mockContainer.identifier
-            });
+            expect(row?.subGridOpts?.children[0]?.containers).toContainEqual(minDataMockContainer);
             done();
         });
     });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.ts
@@ -365,7 +365,8 @@ export class DotTemplateBuilderStore extends ComponentStore<DotTemplateBuilderSt
                         }
                     ]
                 }
-            }
+            },
+            containerMap: { ...state.containerMap, [container.identifier]: container }
         };
     });
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4350a2f</samp>

### Summary
🛠️🧪🗺️

<!--
1.  🛠️ - This emoji represents a tool or a fix, and it can be used to indicate the change that updates the reducer function to also update the container map.
2.  🧪 - This emoji represents a test or an experiment, and it can be used to indicate the change that refactors the tests and adds a new test for the container map feature.
3.  🗺️ - This emoji represents a map or a location, and it can be used to indicate the change that introduces the container map property in the store.
-->
This pull request enhances the template builder store by adding a container map property and refactoring the tests. The container map holds the full data of the containers by their identifiers and is updated when a container is added to the sidebar.

> _The template builder store had a flaw_
> _It didn't update the `containerMap` at all_
> _So they fixed the reducer_
> _And refactored the tester_
> _To make the `addSidebarContainer` call_

### Walkthrough
*  Add a new property `containerMap` to the store that stores the full data of the containers by their identifiers ([link](https://github.com/dotCMS/core/pull/25599/files?diff=unified&w=0#diff-a32a0fcbcf1b026389eade1b0cd88e8838bbfacb92905fe9da2bea7f72b7c9abL368-R369), [link](https://github.com/dotCMS/core/pull/25599/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24L426-R449))
*  Update the `addSidebarContainer` reducer function to also update the `containerMap` when a container is added to the sidebar ([link](https://github.com/dotCMS/core/pull/25599/files?diff=unified&w=0#diff-a32a0fcbcf1b026389eade1b0cd88e8838bbfacb92905fe9da2bea7f72b7c9abL368-R369))
*  Create a variable `minDataMockContainer` that contains only the identifier of the mock container for simplifying the assertions in the tests ([link](https://github.com/dotCMS/core/pull/25599/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24R38-R40))
*  Add a new test case that verifies that the `containerMap` is updated when a container is added to the sidebar ([link](https://github.com/dotCMS/core/pull/25599/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24L426-R449))
*  Modify the existing test cases to use the `minDataMockContainer` variable instead of the full mock container object for the assertions ([link](https://github.com/dotCMS/core/pull/25599/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24L426-R449), [link](https://github.com/dotCMS/core/pull/25599/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24L450-R460))

 

## Screenshots

https://github.com/dotCMS/core/assets/63567962/c2d1d59e-3ab4-4c8b-ac3e-fa215b34a4fd

