### PR TITLE
Fix #25635: Favorite Pages Create Page Takeover Border Fix

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-create-page-dialog/dot-pages-create-page-dialog.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-create-page-dialog/dot-pages-create-page-dialog.component.scss
@@ -21,6 +21,7 @@
     border-radius: $border-radius-sm;
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    overflow: hidden;
 
     ::ng-deep dot-icon i {
         color: $color-palette-primary-500;
@@ -31,18 +32,13 @@
     }
 
     .dot-pages-create-page-dialog__page-item {
-        border-left: 1px solid $color-palette-gray-300;
+        box-shadow: 1px 0 0 0 $color-palette-gray-300;
         cursor: pointer;
         display: flex;
         padding: $spacing-3;
 
         &:hover {
             background-color: $color-palette-gray-200;
-        }
-
-        &:first-child,
-        &:nth-child(3n + 1) {
-            border-left: none;
         }
     }
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c710e1c</samp>

### Summary
🎨🛠️🚀

<!--
1.  🎨 - This emoji is often used for changes related to improving the UI or the code style. In this case, it reflects the updated styles of the component and the removal of redundant code.
2.  🛠️ - This emoji is often used for changes related to fixing bugs or improving performance. In this case, it reflects the fix for the horizontal scrollbar issue, which was affecting the usability of the component.
3.  🚀 - This emoji is often used for changes related to adding new features or enhancing existing ones. In this case, it reflects the addition of the box-shadow effect, which gives the page items a more polished and dynamic look.
-->
This pull request enhances the UI of the `dot-pages-create-page-dialog` component by applying some style fixes and code cleanup. It improves the user experience of creating new pages in dotCMS.

> _No more scrolling in despair_
> _We fixed the dot-page nightmare_
> _Shadows lurk on every page_
> _We cleaned the code of redundant rage_

### Walkthrough
*  Prevent horizontal scrollbar in dialog container by adding `overflow: hidden` property ([link](https://github.com/dotCMS/core/pull/25655/files?diff=unified&w=0#diff-5b730735c9f11d53e6049f489bfa27c863b9e45a26aba4577b83ed3af8421ad0R24))
*  Improve page item design by replacing `border-left` property with `box-shadow` property ([link](https://github.com/dotCMS/core/pull/25655/files?diff=unified&w=0#diff-5b730735c9f11d53e6049f489bfa27c863b9e45a26aba4577b83ed3af8421ad0L34-R35))
*  Simplify page item style by removing unnecessary `border-left: none` property for first and every third child ([link](https://github.com/dotCMS/core/pull/25655/files?diff=unified&w=0#diff-5b730735c9f11d53e6049f489bfa27c863b9e45a26aba4577b83ed3af8421ad0L42-L46))



### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
<img width="970" alt="Screenshot 2023-07-28 at 4 15 39 PM" src="https://github.com/dotCMS/core/assets/63567962/d48f19d5-65e3-4d53-97d2-20d5dd0fb89e"> |  <img width="992" alt="Screenshot 2023-07-28 at 4 14 27 PM" src="https://github.com/dotCMS/core/assets/63567962/89f98429-6239-4cf9-bb4a-49741e53230e">

