### PR TITLE
Implement the UI for create files using code

### DIFF
--- a/core-web/apps/dotcms-ui/.storybook/main.js
+++ b/core-web/apps/dotcms-ui/.storybook/main.js
@@ -11,7 +11,8 @@ module.exports = {
         '../src/**/*.stories.mdx',
         '../src/**/*.stories.@(js|jsx|ts|tsx)',
         '../../../libs/template-builder/**/*.stories.@(js|jsx|ts|tsx|mdx)',
-        '../../../libs/block-editor/**/*.stories.@(js|jsx|ts|tsx|mdx)'
+        '../../../libs/block-editor/**/*.stories.@(js|jsx|ts|tsx|mdx)',
+        '../../../libs/dotcms-fields/**/*.stories.@(js|jsx|ts|tsx|mdx)'
     ],
     addons: ['storybook-design-token', '@storybook/addon-essentials', ...rootMain.addons],
     features: {

--- a/core-web/apps/dotcms-ui/.storybook/tsconfig.json
+++ b/core-web/apps/dotcms-ui/.storybook/tsconfig.json
@@ -7,6 +7,7 @@
     "include": [
         "../src/**/*",
         "../../../**/template-builder/**/src/lib/**/*.stories.ts",
-        "../../../**/block-editor/**/src/lib/**/*.stories.ts"
+        "../../../**/block-editor/**/src/lib/**/*.stories.ts",
+        "../../../**/dotcms-fields/**/src/lib/**/*.stories.ts"
     ]
 }

--- a/core-web/libs/dotcms-fields/.eslintrc.json
+++ b/core-web/libs/dotcms-fields/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts"],
+            "rules": {
+                "@angular-eslint/directive-selector": [
+                    "error",
+                    {
+                        "type": "attribute",
+                        "prefix": "dotcms",
+                        "style": "camelCase"
+                    }
+                ],
+                "@angular-eslint/component-selector": [
+                    "error",
+                    {
+                        "type": "element",
+                        "prefix": "dotcms",
+                        "style": "kebab-case"
+                    }
+                ]
+            },
+            "extends": [
+                "plugin:@nrwl/nx/angular",
+                "plugin:@angular-eslint/template/process-inline-templates"
+            ]
+        },
+        {
+            "files": ["*.html"],
+            "extends": ["plugin:@nrwl/nx/angular-template"],
+            "rules": {}
+        }
+    ]
+}

--- a/core-web/libs/dotcms-fields/README.md
+++ b/core-web/libs/dotcms-fields/README.md
@@ -1,0 +1,7 @@
+# dotcms-fields
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test dotcms-fields` to execute the unit tests.

--- a/core-web/libs/dotcms-fields/jest.config.ts
+++ b/core-web/libs/dotcms-fields/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+    displayName: 'dotcms-fields',
+    preset: '../../jest.preset.js',
+    setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+            stringifyContentPathRegex: '\\.(html|svg)$'
+        }
+    },
+    coverageDirectory: '../../coverage/libs/dotcms-fields',
+    transform: {
+        '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular'
+    },
+    transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+    snapshotSerializers: [
+        'jest-preset-angular/build/serializers/no-ng-attributes',
+        'jest-preset-angular/build/serializers/ng-snapshot',
+        'jest-preset-angular/build/serializers/html-comment'
+    ]
+};

--- a/core-web/libs/dotcms-fields/project.json
+++ b/core-web/libs/dotcms-fields/project.json
@@ -1,0 +1,31 @@
+{
+    "name": "dotcms-fields",
+    "$schema": "../node_modules/nx/schemas/project-schema.json",
+    "projectType": "library",
+    "sourceRoot": "libs/dotcms-fields/src",
+    "prefix": "dotcms",
+    "targets": {
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+            "options": {
+                "jestConfig": "libs/dotcms-fields/jest.config.ts",
+                "passWithNoTests": true
+            },
+            "configurations": {
+                "ci": {
+                    "ci": true,
+                    "codeCoverage": true
+                }
+            }
+        },
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["libs/dotcms-fields/**/*.ts", "libs/dotcms-fields/**/*.html"]
+            }
+        }
+    },
+    "tags": []
+}

--- a/core-web/libs/dotcms-fields/src/index.ts
+++ b/core-web/libs/dotcms-fields/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/dotcms-fields.module';

--- a/core-web/libs/dotcms-fields/src/lib/components/binary-code-field/binary-code-field.component.html
+++ b/core-web/libs/dotcms-fields/src/lib/components/binary-code-field/binary-code-field.component.html
@@ -1,0 +1,1 @@
+<p>binary-code-field works!</p>

--- a/core-web/libs/dotcms-fields/src/lib/components/binary-code-field/binary-code-field.component.spec.ts
+++ b/core-web/libs/dotcms-fields/src/lib/components/binary-code-field/binary-code-field.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BinaryCodeFieldComponent } from './binary-code-field.component';
+
+describe('BinaryCodeFieldComponent', () => {
+    let component: BinaryCodeFieldComponent;
+    let fixture: ComponentFixture<BinaryCodeFieldComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [BinaryCodeFieldComponent]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(BinaryCodeFieldComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/core-web/libs/dotcms-fields/src/lib/components/binary-code-field/binary-code-field.component.stories.ts
+++ b/core-web/libs/dotcms-fields/src/lib/components/binary-code-field/binary-code-field.component.stories.ts
@@ -1,0 +1,21 @@
+import { moduleMetadata, Story, Meta } from '@storybook/angular';
+
+import { BinaryCodeFieldComponent } from './binary-code-field.component';
+
+export default {
+    title: 'Dotcms fields/components/Binary Code Field Component',
+    component: BinaryCodeFieldComponent,
+    decorators: [
+        moduleMetadata({
+            imports: []
+        })
+    ]
+} as Meta<BinaryCodeFieldComponent>;
+
+const Template: Story<BinaryCodeFieldComponent> = (args: BinaryCodeFieldComponent) => ({
+    props: args
+});
+
+export const Primary = Template.bind({});
+
+Primary.args = {};

--- a/core-web/libs/dotcms-fields/src/lib/components/binary-code-field/binary-code-field.component.ts
+++ b/core-web/libs/dotcms-fields/src/lib/components/binary-code-field/binary-code-field.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+    selector: 'dotcms-binary-code-field',
+    templateUrl: './binary-code-field.component.html',
+    styleUrls: ['./binary-code-field.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BinaryCodeFieldComponent {}

--- a/core-web/libs/dotcms-fields/src/lib/dotcms-fields.module.ts
+++ b/core-web/libs/dotcms-fields/src/lib/dotcms-fields.module.ts
@@ -1,0 +1,7 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+@NgModule({
+    imports: [CommonModule]
+})
+export class DotcmsFieldsModule {}

--- a/core-web/libs/dotcms-fields/src/lib/dotcms-fields.module.ts
+++ b/core-web/libs/dotcms-fields/src/lib/dotcms-fields.module.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { BinaryCodeFieldComponent } from './components/binary-code-field/binary-code-field.component';
 
 @NgModule({
-    imports: [CommonModule]
+    imports: [CommonModule],
+    declarations: [BinaryCodeFieldComponent]
 })
 export class DotcmsFieldsModule {}

--- a/core-web/libs/dotcms-fields/src/test-setup.ts
+++ b/core-web/libs/dotcms-fields/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/core-web/libs/dotcms-fields/tsconfig.json
+++ b/core-web/libs/dotcms-fields/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "target": "es2022",
+        "useDefineForClassFields": false,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ],
+    "extends": "../../tsconfig.base.json",
+    "angularCompilerOptions": {
+        "enableI18nLegacyMessageIdFormat": false,
+        "strictInjectionParameters": true,
+        "strictInputAccessModifiers": true,
+        "strictTemplates": true
+    }
+}

--- a/core-web/libs/dotcms-fields/tsconfig.lib.json
+++ b/core-web/libs/dotcms-fields/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "declarationMap": true,
+        "inlineSources": true,
+        "types": []
+    },
+    "exclude": ["src/test-setup.ts", "src/**/*.spec.ts", "jest.config.ts", "src/**/*.test.ts"],
+    "include": ["src/**/*.ts"]
+}

--- a/core-web/libs/dotcms-fields/tsconfig.spec.json
+++ b/core-web/libs/dotcms-fields/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "files": ["src/test-setup.ts"],
+    "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/core-web/tsconfig.base.json
+++ b/core-web/tsconfig.base.json
@@ -25,6 +25,7 @@
             "@dotcms/dotcms": ["libs/dotcms/src/index.ts"],
             "@dotcms/dotcms-field-elements": ["libs/dotcms-field-elements/src/index.ts"],
             "@dotcms/dotcms-field-elements/loader": ["dist/libs/dotcms-field-elements/loader"],
+            "@dotcms/dotcms-fields": ["libs/dotcms-fields/src/index.ts"],
             "@dotcms/dotcms-js": ["libs/dotcms-js/src/public_api.ts"],
             "@dotcms/dotcms-models": ["libs/dotcms-models/src/index.ts"],
             "@dotcms/dotcms-webcomponents": ["libs/dotcms-webcomponents/src/index.ts"],


### PR DESCRIPTION
### Proposed Changes
* Implement the UI for create files using code

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c7cfb7</samp>

This pull request adds a new library called `dotcms-fields` to the `core-web` workspace. The library contains some common components and directives for dotCMS fields. It has its own ESLint, Jest, and TypeScript configurations and a README file.

## Related Issue
Fixes #24362

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c7cfb7</samp>

*  Add a new dotcms-fields library to the core-web workspace ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-aa5ecaea151a58684e6bab55a8c52253f3a89fa15d3e8ae427fc71ea63ceac7fR1-R36), [link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-62ea23f8c88bfce6132762cbcefddadcf7b47d84ddaf5b25f3e484566a55a8e1R1-R22), [link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-a427d8144245b9ebf733c8fd73e760eb5191cae35c95bf982fa0d1a570539f10R1-R31), [link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-6bf86f11a939d86cef2a7f205f1d53ab71d2b0b7f6430b5a65c5a80482dfa839R1), [link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-dddb782e6f4e0694b576812ecd8bf12a7cb9d485c13a6a548ab41f8834a0887bR1-R7), [link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-0bbb8cb30aee95f55923a2a703551c0a6d671237e1f8455a829fb31d3ca6aab2R1), [link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-d8ed52cedf66f864e8a023e98fd5519b2615ec0c1886477bd4aaa5d587c67106R1-R29), [link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-1b1a8322863e165b13845ef26b5332b9572da257a3c5b855a25ebd2586cbad18R1-R12), [link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-20a1b3c91223765cbeeb7d3c2df81778c48e4ac31d510477450d3f50276e50d7R1-R10), [link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-a96484261b73ba1eb1e119e1aa36e6be97f219d53cdbdbf3fc718cf11bfa98ebR28))
  * Create a new ESLint configuration file for the library, extending the base configuration and setting some specific rules for the selectors ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-aa5ecaea151a58684e6bab55a8c52253f3a89fa15d3e8ae427fc71ea63ceac7fR1-R36))
  * Create a new Jest configuration file for the library, setting the display name, the preset, the setup files, the globals, the coverage directory, the transform, the transform ignore patterns, and the snapshot serializers ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-62ea23f8c88bfce6132762cbcefddadcf7b47d84ddaf5b25f3e484566a55a8e1R1-R22))
  * Create a new project configuration file for the library, defining the name, the schema, the project type, the source root, the prefix, the targets, and the tags ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-a427d8144245b9ebf733c8fd73e760eb5191cae35c95bf982fa0d1a570539f10R1-R31))
    * Define test and lint targets, each with their own executor, outputs, options, and configurations ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-a427d8144245b9ebf733c8fd73e760eb5191cae35c95bf982fa0d1a570539f10R1-R31))
  * Create a new README file for the library, providing some basic information and instructions for running the unit tests using Nx ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-257471cc551842527e6f312440fc56010f0631a742cfe97a97c1dfea8d8234dfR1-R7))
  * Create a new index file for the library, exporting the module ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-6bf86f11a939d86cef2a7f205f1d53ab71d2b0b7f6430b5a65c5a80482dfa839R1))
  * Create a new module file for the library, declaring the DotcmsFieldsModule and importing the CommonModule ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-dddb782e6f4e0694b576812ecd8bf12a7cb9d485c13a6a548ab41f8834a0887bR1-R7))
  * Create a new test setup file for the library, importing the jest-preset-angular/setup-jest module ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-0bbb8cb30aee95f55923a2a703551c0a6d671237e1f8455a829fb31d3ca6aab2R1))
  * Create a new TypeScript configuration file for the library, setting the compiler options, the files, the include, the references, and the angular compiler options ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-d8ed52cedf66f864e8a023e98fd5519b2615ec0c1886477bd4aaa5d587c67106R1-R29))
    * Extend the base configuration from the workspace root ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-d8ed52cedf66f864e8a023e98fd5519b2615ec0c1886477bd4aaa5d587c67106R1-R29))
  * Create a new TypeScript configuration file for the library code, setting the compiler options, the exclude, and the include ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-1b1a8322863e165b13845ef26b5332b9572da257a3c5b855a25ebd2586cbad18R1-R12))
    * Extend the base configuration from the library root ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-1b1a8322863e165b13845ef26b5332b9572da257a3c5b855a25ebd2586cbad18R1-R12))
  * Create a new TypeScript configuration file for the test code, setting the compiler options, the files, and the include ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-20a1b3c91223765cbeeb7d3c2df81778c48e4ac31d510477450d3f50276e50d7R1-R10))
    * Extend the base configuration from the library root ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-20a1b3c91223765cbeeb7d3c2df81778c48e4ac31d510477450d3f50276e50d7R1-R10))
  * Add a new path mapping for the library in the base TypeScript configuration file of the workspace, allowing importing the library using the `@dotcms/dotcms-fields` alias ([link](https://github.com/dotCMS/core/pull/25676/files?diff=unified&w=0#diff-a96484261b73ba1eb1e119e1aa36e6be97f219d53cdbdbf3fc718cf11bfa98ebR28))