### PR TITLE
dotCMS/core#25520  [UI] Move detail table to be reusable #25520

### DIFF
--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/dot-experiments-reports.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/dot-experiments-reports.component.html
@@ -16,7 +16,7 @@
                 [suggestedWinner]="vm.winnerLegendSummary"
             />
 
-            <div class="flex align-items-center flex-column w-full container">
+            <div class="flex align-items-center flex-column w-full container gap-3">
                 <p-tabView>
                     <p-tabPanel header="{{ 'experiments.reports.chart.title' | dm }}">
                         <div class="flex flex-column gap-2 content">

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/dot-experiments-reports.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/dot-experiments-reports.component.html
@@ -16,7 +16,7 @@
                 [suggestedWinner]="vm.winnerLegendSummary"
             />
 
-            <div class="flex justify-content-center w-full container">
+            <div class="flex align-items-center flex-column w-full container">
                 <p-tabView>
                     <p-tabPanel header="{{ 'experiments.reports.chart.title' | dm }}">
                         <div class="flex flex-column gap-2 content">
@@ -26,13 +26,6 @@
                                 [isEmpty]="!vm.hasEnoughSessions"
                                 [isLoading]="vm.isLoading"
                                 data-testId="daily-chart"
-                            />
-
-                            <dot-experiments-report-daily-details
-                                [detailData]="vm.detailData"
-                                [experimentId]="vm.experiment.id"
-                                [hasEnoughSessions]="vm.hasEnoughSessions"
-                                [promotedVariantId]="vm.promotedVariant"
                             />
                         </div>
                     </p-tabPanel>
@@ -50,6 +43,12 @@
                         </div>
                     </p-tabPanel>
                 </p-tabView>
+                <dot-experiments-report-daily-details
+                    [detailData]="vm.detailData"
+                    [experimentId]="vm.experiment.id"
+                    [hasEnoughSessions]="vm.hasEnoughSessions"
+                    [promotedVariantId]="vm.promotedVariant"
+                />
             </div>
         </ng-container>
     </div>


### PR DESCRIPTION
### Proposed Changes
User same table for both charts. 

<img width="1164" alt="image" src="https://github.com/dotCMS/core/assets/31667212/3d9568d1-1f68-4c54-a7a6-6fa6acce98d5">


<img width="1133" alt="image" src="https://github.com/dotCMS/core/assets/31667212/fae4dff8-cdca-4517-98c6-72e9215a4809">

