### PR TITLE
#25556 throw event only for the user instead of global

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/util/jackson/PayloadDeserializer.java
+++ b/dotCMS/src/main/java/com/dotcms/util/jackson/PayloadDeserializer.java
@@ -18,7 +18,7 @@ public class PayloadDeserializer extends JsonDeserializer<Payload> {
 
     public static final String TYPE = "type";
     public static final String DATA = "data";
-
+    public static final String VISIBILITY = "visibility";
     public static final String VISIBILITY_VALUE = "visibilityValue";
     public static final String VISIBILITY_TYPE = "visibilityType";
 
@@ -34,7 +34,7 @@ public class PayloadDeserializer extends JsonDeserializer<Payload> {
 
         Object visibilityValue = null;
 
-        final Visibility visibility = Try.of(()->  Visibility.valueOf(node.get(VISIBILITY_VALUE).asText())).getOrElse(Visibility.GLOBAL);
+        final Visibility visibility = Try.of(()->  Visibility.valueOf(node.get(VISIBILITY).asText())).getOrElse(Visibility.GLOBAL);
         final String visibilityType = Try.of(()-> node.get(VISIBILITY_TYPE).asText()).getOrNull();
         if(null != visibilityType) {
             final Class<?> visibilityClazz = getClassFor(visibilityType);

--- a/dotCMS/src/main/java/com/dotmarketing/business/RoleAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/RoleAPIImpl.java
@@ -2,6 +2,7 @@ package com.dotmarketing.business;
 
 import com.dotcms.api.system.event.Payload;
 import com.dotcms.api.system.event.SystemEventType;
+import com.dotcms.api.system.event.Visibility;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
@@ -459,7 +460,7 @@ public class RoleAPIImpl implements RoleAPI {
 	public void removeRoleFromUser(final Role role, final User user) throws DotDataException, DotStateException {
 		final Role roleFromDb = loadRoleById(role.getId());
 		roleFactory.removeRoleFromUser(roleFromDb, user);
-	    APILocator.getSystemEventsAPI().pushAsync(SystemEventType.UPDATE_PORTLET_LAYOUTS, new Payload());
+		APILocator.getSystemEventsAPI().pushAsync(SystemEventType.UPDATE_PORTLET_LAYOUTS, new Payload(Visibility.USER, user.getUserId()));
 	}
 
 	@Override
@@ -469,7 +470,7 @@ public class RoleAPIImpl implements RoleAPI {
 		for(Role role : roles) {
 			removeRoleFromUser(role, user);
 		}
-        APILocator.getSystemEventsAPI().pushAsync(SystemEventType.UPDATE_PORTLET_LAYOUTS, new Payload());
+		APILocator.getSystemEventsAPI().pushAsync(SystemEventType.UPDATE_PORTLET_LAYOUTS, new Payload(Visibility.USER, user.getUserId()));
 	}
 
 	@WrapInTransaction


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 79ebd80</samp>

### Summary
🛠️🚀🎨

<!--
1.  🛠️ - This emoji represents a fix or improvement to existing code or functionality. The `PayloadDeserializer` class was updated to use a more consistent and accurate constant for the visibility field, which could be considered a minor fix or improvement.
2.  🚀 - This emoji represents a new feature or enhancement that adds value or functionality to the system. The `RoleAPIImpl` class was updated to use the `Visibility` enum when creating system event payloads, which could be considered a new feature or enhancement that allows the system to send more targeted and relevant notifications to users about role changes.
3.  🎨 - This emoji represents a change or improvement to the code style, structure, or design. The use of the `Visibility` enum in the `RoleAPIImpl` class could also be seen as a change or improvement to the code style, structure, or design, as it makes the code more readable, consistent, and expressive.
-->
This pull request updates the system event handling for role changes. It uses the `Visibility` enum to specify the audience of the events and the `PayloadDeserializer` class to parse the event data.

> _Sing, O Muse, of the skillful coder who updated the code_
> _To align the `Payload` and `PayloadDeserializer` classes_
> _With a new constant for the visibility of system events_
> _Like Hephaestus who forged the shield of Achilles with artful designs_

### Walkthrough
*  Added a new constant `VISIBILITY` to the `PayloadDeserializer` class to read the visibility value from the JSON node of a system event payload ([link](https://github.com/dotCMS/core/pull/25683/files?diff=unified&w=0#diff-faa83ff5598e79dbdf5e2e7c5422cbe5e365c451daa41adb6d58b5d9315252aaL21-R21))
*  Replaced the old constant `VISIBILITY_VALUE` with the new constant `VISIBILITY` in the `PayloadDeserializer` class to get the visibility value from the JSON node ([link](https://github.com/dotCMS/core/pull/25683/files?diff=unified&w=0#diff-faa83ff5598e79dbdf5e2e7c5422cbe5e365c451daa41adb6d58b5d9315252aaL37-R37))
*  Imported the `Visibility` enum in the `RoleAPIImpl` class to specify the visibility of a system event payload ([link](https://github.com/dotCMS/core/pull/25683/files?diff=unified&w=0#diff-5c941a7ed32f9372b35c617fd40eb7ec46f7298ff42ef397fd5f39a3c1a24b0dR5))
*  Passed a new parameter with a `Visibility.USER` value and the user ID of the user who was removed from a role to the `Payload` constructor when pushing a system event of type `UPDATE_PORTLET_LAYOUTS` in the `RoleAPIImpl` class ([link](https://github.com/dotCMS/core/pull/25683/files?diff=unified&w=0#diff-5c941a7ed32f9372b35c617fd40eb7ec46f7298ff42ef397fd5f39a3c1a24b0dL462-R463))
*  Passed a new parameter with a `Visibility.USER` value and the user ID of the user who was removed from all roles to the `Payload` constructor when pushing a system event of type `UPDATE_PORTLET_LAYOUTS` in the `RoleAPIImpl` class ([link](https://github.com/dotCMS/core/pull/25683/files?diff=unified&w=0#diff-5c941a7ed32f9372b35c617fd40eb7ec46f7298ff42ef397fd5f39a3c1a24b0dL472-R473))


