### PR TITLE
#25680 default sort is modDate, remove sort from jsp since it's always applying it

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/browser/ajax/BrowserAjax.java
@@ -114,8 +114,8 @@ public class BrowserAjax {
 
     private static final String SELECTED_BROWSER_PATH_OBJECT = "SELECTED_BROWSER_PATH_OBJECT";
 
-    String lastSortBy = "name";
-    boolean lastSortDirectionDesc = false;
+    String lastSortBy = "modDate";
+    boolean lastSortDirectionDesc = true;
 	private final String imageMimetype = "image";
 
 	final static private Comparator<Map> nameComparator = new Comparator<Map>() {
@@ -279,8 +279,8 @@ public class BrowserAjax {
 													   final boolean showArchived, final long languageId) throws
 			DotSecurityException, DotDataException {
 		DwrUtil.getSession().setAttribute(ACTIVE_FOLDER_ID, parentId);
-		this.lastSortBy = sortBy;
 		if (UtilMethods.isSet(sortBy)) {
+			this.lastSortBy = sortBy;
 			if (sortBy.equals(lastSortBy)) {
 				this.lastSortDirectionDesc = !this.lastSortDirectionDesc;
 			}

--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
@@ -745,32 +745,16 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
         contentDraggables = new Array();
     }
 
-    function sortContentByNameAndDate(unsortedArray){
-        // First, separate folders and files into separate arrays
-        const folders = unsortedArray.filter(item => item.type === 'folder');
-        const files = unsortedArray.filter(item => item.type !== 'folder');
-
-        // Sort folders by name
-        folders.sort((a, b) => (a.name > b.name) ? 1 : -1);
-
-        // Sort files by date
-        files.sort((a, b) => (a.modDate > b.modDate) ? 1 : -1);
-        // Merge the sorted arrays back into one array
-        return [...folders, ...files];
-    }
-
     //AJAX callback to load the left hand side of the browser
     function selectFolderContentCallBack (content) {
-
-        const filteredContent = sortContentByNameAndDate(content)
 
         var subFoldersCount = 0;
 
         //Loading the contents table at the rigth hand side
         var table = $('assetListBody');
-        for (var i = 0; i < filteredContent.length; i++) {
+        for (var i = 0; i < content.length; i++) {
 
-            var asset = filteredContent[i];
+            var asset = content[i];
             inodes[asset.inode] = asset;
 
             contentInodes[contentInodes.length] = asset;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7be71d3</samp>

### Summary
:fire::white_check_mark::bug:

<!--
1.  :fire: This emoji represents the removal of code or functionality, as in the case of the `sortContentByNameAndDate` function and its invocation, which were no longer needed and deleted from the JSP file.
2. :white_check_mark: This emoji represents the addition of tests or the improvement of code quality, as in the case of the new integration test for the BrowserAjax class, which verifies the expected behavior of the default sorting of folder items by modDate.
3. :bug: This emoji represents the fixing of a bug or an error, as in the case of the default sorting criteria of folder items and the bug that ignored the default value when the sortBy parameter was not given, which were corrected to address the issue #20183.
-->
This pull request adds a new integration test for the `BrowserAjax` class and changes the default sorting of folder items by modification date. It also removes some redundant code from the `view_browser_js_inc.jsp` file. These changes aim to fix  inconsistent and incorrect sorting of folder items in the browser portlet.

> _Oh we are the coders of the `BrowserAjax` class_
> _We sort the folder items by the modDate at last_
> _We heave and we ho and we fix the bugs we know_
> _And we sing this shanty as we push our code_

### Walkthrough
* Change the default sorting behavior of the folder items to modDate descending by default ([link](https://github.com/dotCMS/core/pull/25684/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L117-R118), [link](https://github.com/dotCMS/core/pull/25684/files?diff=unified&w=0#diff-0947ca188a7d8785100a58970fa5567353acd19519d555eb51cdf70a257864f9L282-R283))
* Remove the `sortContentByNameAndDate` function and its invocation from the `view_browser_js_inc.jsp` file, as it is no longer needed ([link](https://github.com/dotCMS/core/pull/25684/files?diff=unified&w=0#diff-b9d4591d7e6a8a8bf44069e0c2e1203c8f8a358ce966eed89c4b7c86ba9f3f3aL748-R757))
* Add a new test case `test_openFolderContent_defaultBehavior` to the `BrowserAjaxTest` class to verify the new default sorting behavior ([link](https://github.com/dotCMS/core/pull/25684/files?diff=unified&w=0#diff-1caa0ef336b51a61d0d58225cd80200d5977a67a2db3616959649728a5972e38R256-R286))
* Update the imports in the `BrowserAjaxTest` class to include the classes needed for the new test case, such as `ContentType`, `LinkDataGen`, `HTMLPageDataGen`, etc. ([link](https://github.com/dotCMS/core/pull/25684/files?diff=unified&w=0#diff-1caa0ef336b51a61d0d58225cd80200d5977a67a2db3616959649728a5972e38L3-R4), [link](https://github.com/dotCMS/core/pull/25684/files?diff=unified&w=0#diff-1caa0ef336b51a61d0d58225cd80200d5977a67a2db3616959649728a5972e38L10-R17))

