### PR TITLE
#25666 limit of the sublist should be limit+offset

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtilsTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtilsTest.java
@@ -1103,6 +1103,86 @@ public class ContentUtilsTest {
         }
     }
 
+
+    /**
+     * Method to test: {@link ContentUtils#pullRelatedField(Relationship, String, String, int, int, String, User, String, boolean, long, Boolean)}
+     * Given Scenario: Pulling related content when the offset is greater than the limit
+     * ExpectedResult: Should return results, if they're available.
+     *
+     * In this test 5 items are related, and we're passing offset = 3 and limit = 1, so 1 item should be returned.
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    @Test
+    public void testPullRelatedField_withOffsetGreaterThanLimit()
+            throws DotDataException, DotSecurityException {
+
+        final long languageId = languageAPI.getDefaultLanguage().getId();
+        final ContentType news = getNewsLikeContentType("News");
+        final ContentType comments = getCommentsLikeContentType("Comments");
+        relateContentTypes(news, comments);
+
+        final ContentType newsContentType = contentTypeAPI.find("News");
+        final ContentType commentsContentType = contentTypeAPI.find("Comments");
+
+        Contentlet newsContentlet = null;
+        Contentlet commentsContentlet;
+        final List<Contentlet> relatedComments = new ArrayList<>();
+
+        try {
+            //creates parent contentlet
+            ContentletDataGen dataGen = new ContentletDataGen(newsContentType.id());
+
+            //English version
+            newsContentlet = dataGen.languageId(languageId)
+                    .setProperty("title", "News Test")
+                    .setProperty("urlTitle", "news-test").setProperty("byline", "news-test")
+                    .setProperty("sysPublishDate", new Date()).setProperty("story", "news-test")
+                    .next();
+
+            //creates child contentlet
+            dataGen = new ContentletDataGen(commentsContentType.id());
+
+            for (int i=1; i<5 ;i++){
+                commentsContentlet = dataGen
+                        .languageId(languageId)
+                        .setProperty("title", "Comment for News " + i)
+                        .setProperty("email", "testing@dotcms.com")
+                        .setProperty("comment", "Comment for News " + i)
+                        .setPolicy(IndexPolicy.FORCE).nextPersisted();
+                relatedComments.add(commentsContentlet);
+
+            }
+
+            //Saving relationship
+            final Relationship relationship = relationshipAPI.byTypeValue("News-Comments");
+
+            newsContentlet.setIndexPolicy(IndexPolicy.FORCE);
+
+            newsContentlet = contentletAPI.checkin(newsContentlet,
+                    map(relationship, relatedComments),
+                    null, user, false);
+
+            //Pull related content from comment child
+            List<Contentlet> result = ContentUtils.
+                    pullRelatedField(relationship, newsContentlet.getIdentifier(), "+languageId:1",
+                            1, 3, "", user, null, false, languageId, false);
+
+            assertNotNull(result);
+            assertEquals(1,result.size());
+
+        } finally {
+            if (null != newsContentlet && UtilMethods.isSet(newsContentlet.getInode())) {
+                ContentletDataGen.remove(newsContentlet);
+            }
+
+            for (final Contentlet contentlet: relatedComments){
+                ContentletDataGen.remove(contentlet);
+            }
+        }
+    }
+
+
     /**
      * Method to test: {@link ContentUtils#addRelationships(Contentlet, User, PageMode, long, int, HttpServletRequest, HttpServletResponse)} 
      * Given Scenario: Creates a content parent with a children many to many relationship, create a few instances of the child type and related to the parent

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
@@ -643,7 +643,7 @@ public class ContentUtils {
 					final List<Contentlet> filteredList = relatedContent.stream().filter(c->results.contains(c.getIdentifier()))
 							.collect(Collectors.toList());
                     
-                    return filteredList.subList(offset>=0?offset:0, (limit > 0 && limit <= filteredList.size())? limit: filteredList.size());
+                    return filteredList.subList(offset>=0?offset:0, (limit > 0 && offset+limit <= filteredList.size() )? offset+limit: filteredList.size());
                 } 
                 
                 //pulling parents

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
@@ -593,7 +593,7 @@ public class ContentUtils {
      * Logic used for `pullRelated` and `pullRelatedField` methods
      */
     public static List<Contentlet> getPullResults(final Relationship relationship,
-            String contentletIdentifier, final String condition, final int limit, final int offset,
+            String contentletIdentifier, final String condition, final int limit, int offset,
             String sort, final User user, final String tmDate, final boolean pullParents,
             final long language, final Boolean live) {
 
@@ -642,8 +642,9 @@ public class ContentUtils {
 
 					final List<Contentlet> filteredList = relatedContent.stream().filter(c->results.contains(c.getIdentifier()))
 							.collect(Collectors.toList());
-                    
-                    return filteredList.subList(offset>=0?offset:0, (limit > 0 && offset+limit <= filteredList.size() )? offset+limit: filteredList.size());
+
+					offset = offset >=0 ? offset : 0;
+					return filteredList.subList(offset, (limit <= 0 || limit >= filteredList.size() ) ? filteredList.size() : offset+limit);
                 } 
                 
                 //pulling parents


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c335bc</samp>

Fixed a bug in the `subList` method of the `ContentUtils` class that caused incorrect pagination of content lists. The bug affected the rendering of content in velocity templates and was reported in issue #20384.
