### PR TITLE
DotCMS/core#25645 [UI] Require confirmation when clicking Edit tab while Experiment is running 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
@@ -435,4 +435,36 @@ describe('DotEditPageStateControllerComponent', () => {
             );
         });
     });
+
+    describe('running experiment confirmation', () => {
+        beforeEach(() => {
+            const pageRenderStateMocked: DotPageRenderState = new DotPageRenderState(
+                { ...mockUser(), userId: '456' },
+                new DotPageRender(mockDotRenderedPage()),
+                null,
+                EXPERIMENT_MOCK
+            );
+
+            fixtureHost.componentInstance.pageState = _.cloneDeep(pageRenderStateMocked);
+        });
+
+        it('should update pageState service when confirmation dialog Success', async () => {
+            spyOn(dialogService, 'confirm').and.callFake((conf) => {
+                conf.accept();
+            });
+            fixtureHost.detectChanges();
+            const selectButton = de.query(By.css('p-selectButton'));
+            selectButton.triggerEventHandler('onChange', {
+                value: DotPageMode.EDIT
+            });
+            await fixtureHost.whenStable();
+            expect(component.modeChange.emit).toHaveBeenCalledWith(DotPageMode.EDIT);
+            expect(dialogService.confirm).toHaveBeenCalledTimes(1);
+
+            expect(dotPageStateService.setLock).toHaveBeenCalledWith(
+                { mode: DotPageMode.EDIT },
+                true
+            );
+        });
+    });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
@@ -3,15 +3,17 @@
 import * as _ from 'lodash';
 import { of } from 'rxjs';
 
+import { CommonModule } from '@angular/common';
 import { Component, DebugElement } from '@angular/core';
-import { ComponentFixture, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
+import { ConfirmationService } from 'primeng/api';
 import { InputSwitchModule } from 'primeng/inputswitch';
 import { SelectButtonModule } from 'primeng/selectbutton';
 import { TooltipModule } from 'primeng/tooltip';
 
-import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';
 import {
     DotAlertConfirmService,
     DotMessageService,
@@ -100,7 +102,7 @@ describe('DotEditPageStateControllerComponent', () => {
     let personalizeService: DotPersonalizeService;
 
     beforeEach(waitForAsync(() => {
-        DOTTestBed.configureTestingModule({
+        TestBed.configureTestingModule({
             declarations: [
                 TestHostComponent,
                 DotEditPageStateControllerComponent,
@@ -119,20 +121,23 @@ describe('DotEditPageStateControllerComponent', () => {
                     provide: DotPersonalizeService,
                     useClass: DotPersonalizeServiceMock
                 },
-                DotAlertConfirmService
+                DotAlertConfirmService,
+                ConfirmationService
             ],
             imports: [
                 InputSwitchModule,
                 SelectButtonModule,
                 TooltipModule,
                 DotPipesModule,
-                DotMessagePipe
+                DotMessagePipe,
+                CommonModule,
+                FormsModule
             ]
         });
     }));
 
     beforeEach(() => {
-        fixtureHost = DOTTestBed.createComponent(TestHostComponent);
+        fixtureHost = TestBed.createComponent(TestHostComponent);
         deHost = fixtureHost.debugElement;
         componentHost = fixtureHost.componentInstance;
         de = deHost.query(By.css('dot-edit-page-state-controller'));
@@ -439,7 +444,7 @@ describe('DotEditPageStateControllerComponent', () => {
     describe('running experiment confirmation', () => {
         beforeEach(() => {
             const pageRenderStateMocked: DotPageRenderState = new DotPageRenderState(
-                { ...mockUser(), userId: '456' },
+                mockUser(),
                 new DotPageRender(mockDotRenderedPage()),
                 null,
                 EXPERIMENT_MOCK

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5351,6 +5351,9 @@ experiments.promote.probability-to-win=Probability to win
 experiments.promote.status=Status
 experiments.reports.summary.empty.title=There is not enough data to create a Summary
 experiments.reports.summary.empty.description=In order to collect data, a longer period of time and/or higher traffic is required
+experiment.running=Experiment Running
+experiment.running.edit.confirmation=An Experiment is currently running on this Page.  If you Edit the Page, you may invalidate any results already collected. <b>Are you sure you want to continue?</b>
+experiment.running.edit.lock.confirmation.note=<p class="note"><b>NOTE:</b> An Experiment is currently running on this Page.  If you Edit the Page, you may invalidate any results already collected.</p>
 dot.common.http.error.400.experiment.run-scheduling-error.header=Running/Scheduling error
 dot.common.http.error.400.experiment.analytics-app-not-configured.header=Analytics Integration App
 dot.common.inplace.empty.text=Click to add text


### PR DESCRIPTION
### Proposed Changes
* When a page have a running experiment and the user try to edit it, we need to warn the user that changes will result in experiment results breaking. 
* In addition support the personalization and lock scenario. 


### Screenshots
### Current and new scenarios

![image](https://github.com/dotCMS/core/assets/31667212/452abab5-b292-4d42-ae7a-805d3dc25420)
