### PR TITLE
Adding insert order to sql query

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230119MigrateContentToProperPersonaTagAndRemoveDupTags.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230119MigrateContentToProperPersonaTagAndRemoveDupTags.java
@@ -22,7 +22,7 @@ public class Task230119MigrateContentToProperPersonaTagAndRemoveDupTags extends 
             + "AND t.tagname LIKE '%:persona';";
     final String DELETE_BAD_RELS_MSSQL = "DELETE ti FROM tag_inode ti JOIN tag ON ti.tag_id = tag.tag_id\n"
             + "WHERE tag.tagname LIKE '%:persona';";
-    final String SQL = "INSERT INTO tag_inode\n"
+    final String SQL = "INSERT INTO tag_inode (tag_id, inode, field_var_name, mod_date)\n"
             + "SELECT tag.tag_id, aux.inode, aux.field_var_name, aux.mod_date\n"
             + "FROM (SELECT tag_inode.*, tag.tagname\n"
             + "      FROM tag_inode\n"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0da9e91</samp>

### Summary
🛠️🚚🗑️

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the change is part of a bug fix or a maintenance task.
2.  🚚 - This emoji represents a truck or a delivery, and can be used to indicate that the change is part of a migration or a data transfer task.
3.  🗑️ - This emoji represents a trash can or a deletion, and can be used to indicate that the change is part of a cleanup or a removal task.
-->
This change fixes a bug in the SQL query that inserts new tag_inode records for persona tags. It specifies the column names to match the values from the SELECT statement. This change is part of `Task230119MigrateContentToProperPersonaTagAndRemoveDupTags.java` in `dotCMS/core`.

### Walkthrough
*  Add column names to INSERT statement in SQL variable to avoid errors with different column order in tag_inode table ([link](https://github.com/dotCMS/core/pull/25723/files?diff=unified&w=0#diff-eeba5c63914084cdadb377c9347b3064b19b831f5b2e9560d250599a1b7ab218L25-R25))

### Extra Info
Unfortunately, it was not possible to add a test due to these changes.

