### PR TITLE
Fix #25660: Block Editor Add VTLs for new Headings

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading4.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading4.vtl
@@ -1,0 +1,5 @@
+#parse( "static/storyblock/render.vtl" )
+<h4#if($item.attrs.textAlign) style="text-align: $item.attrs.textAlign;"#end>
+#renderContentBlock($item.content)
+
+</h4>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading5.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading5.vtl
@@ -1,0 +1,5 @@
+#parse( "static/storyblock/render.vtl" )
+<h5#if($item.attrs.textAlign) style="text-align: $item.attrs.textAlign;"#end>
+#renderContentBlock($item.content)
+
+</h5>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading6.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/heading6.vtl
@@ -1,0 +1,5 @@
+#parse( "static/storyblock/render.vtl" )
+<h6#if($item.attrs.textAlign) style="text-align: $item.attrs.textAlign;"#end>
+#renderContentBlock($item.content)
+
+</h6>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/render.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/render.vtl
@@ -17,8 +17,7 @@
 #*              *#<h3#if($element.attrs.textAlign) style="text-align: $element.attrs.textAlign;"#end>#*
                     *##renderContentBlock($element.content)#*
                 *#</h3>
-#*          *##end#*
-            *##if($element.attrs.level == "4")
+#*          *##elseif($element.attrs.level == "4")
 #*              *#<h4#if($element.attrs.textAlign) style="text-align: $element.attrs.textAlign;"#end>#*
                     *##renderContentBlock($element.content)#*
                 *#</h4>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/render.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/render.vtl
@@ -18,6 +18,19 @@
                     *##renderContentBlock($element.content)#*
                 *#</h3>
 #*          *##end#*
+            *##if($element.attrs.level == "4")
+#*              *#<h4#if($element.attrs.textAlign) style="text-align: $element.attrs.textAlign;"#end>#*
+                    *##renderContentBlock($element.content)#*
+                *#</h4>
+#*          *##elseif($element.attrs.level == "5")
+#*              *#<h5#if($element.attrs.textAlign) style="text-align: $element.attrs.textAlign;"#end>#*
+                    *##renderContentBlock($element.content)#*
+                *#</h5>
+#*          *##elseif($element.attrs.level == "6")
+#*              *#<h6#if($element.attrs.textAlign) style="text-align: $element.attrs.textAlign;"#end>#*
+                    *##renderContentBlock($element.content)#*
+                *#</h6>
+#*          *##end#*
         *##elseif( $element.type == "listItem" )
 #*        *#  <li#{if}(${element.attrs.textAlign}) style="text-align: ${element.attrs.textAlign};"#{end}>#*
                 *##renderContentBlock($element.content)#*


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 85320c4</samp>

### Summary
🆕🎨📝

<!--
1.  🆕 for adding new template files for heading 4, 5 and 6 elements.
2.  🎨 for modifying the render.vtl file to handle the new elements and improve the appearance of the storyblock.
3.  📝 for updating the documentation to reflect the new elements and how to use them.
-->
This pull request adds support for heading 4, 5 and 6 elements in storyblocks. It creates new template files for each heading level and updates the render.vtl file to handle them.

> _New templates added_
> _`render.vtl` handles them_
> _Autumn of headings_

### Walkthrough
*  Add new template files for rendering heading 4, 5 and 6 elements in a storyblock ([link](https://github.com/dotCMS/core/pull/25751/files?diff=unified&w=0#diff-1fcebf4745bb91d667cc90d3d0417a1652e5ecb68f2539e9cde635745fcd01adR1-R5), [link](https://github.com/dotCMS/core/pull/25751/files?diff=unified&w=0#diff-1b516b4a23806a30c74e3f2ae96dc90dbc8d0433f3d6c9b4bae8e0efc93aea2aR1-R5), [link](https://github.com/dotCMS/core/pull/25751/files?diff=unified&w=0#diff-245c6ff9f1a9ecd7092dfd268793d8d39a30f40f2eecf7f6cdcb8bde29ae9ab0R1-R5))
*  Update `render.vtl` file to handle the new heading elements and apply optional text-align style attribute ([link](https://github.com/dotCMS/core/pull/25751/files?diff=unified&w=0#diff-08812271299d63247cdbbbd213ca70b9c78bb37133db9f9253f4f67faec22eb0R21-R33))



### Screenshots


https://github.com/dotCMS/core/assets/63567962/f0e3f3e9-d509-4420-b2fa-c9bbc3256b64

