### PR TITLE
[Issue-25281]: Adding links for the device selector.

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.html
@@ -9,7 +9,12 @@
                 <h3 class="dot-device-selector__header-title">
                     {{ 'editpage.device.selector.title' | dm }}
                 </h3>
-                <p-button icon="pi pi-plus" styleClass="p-button-rounded p-button-text"></p-button>
+                <a [routerLink]="linkToAddDevice" data-testId="dot-device-link-add">
+                    <p-button
+                        icon="pi pi-plus"
+                        styleClass="p-button-rounded p-button-text"
+                    ></p-button>
+                </a>
             </div>
             <div class="dot-device-selector__grid">
                 <ul class="device-list">
@@ -81,7 +86,14 @@
             </div>
         </div>
         <div class="dot-device-selector__link--container">
-            <a class="dot-device-selector__link"> {{ 'editpage.device.selector.new.tab' | dm }} </a>
+            <a
+                class="dot-device-selector__link"
+                [href]="previewUrl"
+                data-testId="dot-device-selector-link"
+                target="_blank"
+            >
+                {{ 'editpage.device.selector.new.tab' | dm }}
+            </a>
             <i class="pi pi-external-link"></i>
         </div>
     </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.html
@@ -9,7 +9,11 @@
                 <h3 class="dot-device-selector__header-title">
                     {{ 'editpage.device.selector.title' | dm }}
                 </h3>
-                <a [routerLink]="linkToAddDevice" data-testId="dot-device-link-add">
+                <a
+                    [routerLink]="linkToAddDevice"
+                    [queryParams]="linkToEditDeviceQueryParams"
+                    data-testId="dot-device-link-add"
+                >
                     <p-button
                         icon="pi pi-plus"
                         styleClass="p-button-rounded p-button-text"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.spec.ts
@@ -148,6 +148,6 @@ describe('DotDeviceSelectorSeoComponent', () => {
         fixtureHost.detectChanges();
 
         const link = de.query(By.css('[data-testId="dot-device-link-add"]'));
-        expect(link.properties.href).toContain('/c/c_Devices');
+        expect(link.properties.href).toContain('/c/content');
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.spec.ts
@@ -5,6 +5,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { OverlayPanelModule } from 'primeng/overlaypanel';
 
@@ -20,10 +21,13 @@ import { DotDeviceSelectorSeoComponent } from './dot-device-selector-seo.compone
 
 @Component({
     selector: 'dot-test-host-component',
-    template: `<button (click)="op.openMenu($event)" type="text"></button>
-        <dot-device-selector-seo #op></dot-device-selector-seo> `
+    template: `<button (click)="op.openMenu($event)" type="text">Open</button>
+        <dot-device-selector-seo #op [apiLink]="apiLink"></dot-device-selector-seo> `
 })
-class TestHostComponent {}
+class TestHostComponent {
+    apiLink = 'api/v1/page/render/an/url/test?language_id=1';
+    linkToAddDevice = '/c/c_Devices';
+}
 
 describe('DotDeviceSelectorSeoComponent', () => {
     let fixtureHost: ComponentFixture<TestHostComponent>;
@@ -51,7 +55,8 @@ describe('DotDeviceSelectorSeoComponent', () => {
                 DotDeviceSelectorSeoComponent,
                 HttpClientTestingModule,
                 OverlayPanelModule,
-                BrowserAnimationsModule
+                BrowserAnimationsModule,
+                RouterTestingModule
             ],
             providers: [
                 {
@@ -80,12 +85,11 @@ describe('DotDeviceSelectorSeoComponent', () => {
         spyOn(component, 'getOptions').and.returnValue(of(mockDotDevices));
 
         fixtureHost.detectChanges();
+        const buttonEl = fixtureHost.debugElement.query(By.css('button')).nativeElement;
+        buttonEl.click();
     });
 
     it('should emit selected device on change', async () => {
-        const buttonEl = fixtureHost.debugElement.query(By.css('button')).nativeElement;
-        buttonEl.click();
-
         await fixtureHost.whenStable();
         fixtureHost.detectChanges();
         spyOn(component.selected, 'emit');
@@ -101,9 +105,6 @@ describe('DotDeviceSelectorSeoComponent', () => {
     });
 
     it('should set user devices', async () => {
-        const buttonEl = fixtureHost.debugElement.query(By.css('button')).nativeElement;
-        buttonEl.click();
-
         await fixtureHost.whenStable();
         fixtureHost.detectChanges();
 
@@ -126,14 +127,27 @@ describe('DotDeviceSelectorSeoComponent', () => {
     });
 
     it('should close the overlayPanel', () => {
-        const buttonEl = fixtureHost.debugElement.query(By.css('button')).nativeElement;
-        buttonEl.click();
-
         const devicesSelector: DebugElement = de.query(
             By.css('[data-testId="dot-devices-selector"]')
         );
-
-        fixtureHost.detectChanges();
         expect(devicesSelector).toBeNull();
+    });
+
+    it('should have link to open in a new tab', () => {
+        fixtureHost.detectChanges();
+
+        const addContent: DebugElement = de.query(
+            By.css('[data-testId="dot-device-selector-link"]')
+        );
+        expect(addContent.nativeElement.href).toContain(
+            '/an/url/test?language_id=1&disabledNavigateMode=true'
+        );
+    });
+
+    it('should have a link to add device', () => {
+        fixtureHost.detectChanges();
+
+        const link = de.query(By.css('[data-testId="dot-device-link-add"]'));
+        expect(link.properties.href).toContain('/c/c_Devices');
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.ts
@@ -11,6 +11,7 @@ import {
     ViewChild
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
 
 import { ButtonModule } from 'primeng/button';
 import { DividerModule } from 'primeng/divider';
@@ -36,7 +37,8 @@ import { DotPipesModule } from '@pipes/dot-pipes.module';
         OverlayPanelModule,
         PanelModule,
         DividerModule,
-        DotMessagePipe
+        DotMessagePipe,
+        RouterLink
     ],
     providers: [DotDevicesService],
     selector: 'dot-device-selector-seo',
@@ -48,6 +50,8 @@ export class DotDeviceSelectorSeoComponent implements OnInit {
     @Input() value: DotDevice;
     @Output() selected = new EventEmitter<DotDevice>();
     @ViewChild('op') overlayPanel: OverlayPanel;
+    previewUrl: string;
+    protected readonly linkToAddDevice = '/c/c_Devices';
 
     options$: Observable<DotDevice[]>;
     socialMediaTiles = [
@@ -144,5 +148,16 @@ export class DotDeviceSelectorSeoComponent implements OnInit {
             filter((device: DotDevice) => +device.cssHeight > 0 && +device.cssWidth > 0),
             toArray()
         );
+    }
+
+    @Input()
+    set apiLink(value: string) {
+        if (value) {
+            const frontEndUrl = `${value.replace('api/v1/page/render', '')}`;
+
+            this.previewUrl = `${frontEndUrl}${
+                frontEndUrl.indexOf('?') != -1 ? '&' : '?'
+            }disabledNavigateMode=true`;
+        }
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.ts
@@ -51,7 +51,10 @@ export class DotDeviceSelectorSeoComponent implements OnInit {
     @Output() selected = new EventEmitter<DotDevice>();
     @ViewChild('op') overlayPanel: OverlayPanel;
     previewUrl: string;
-    protected readonly linkToAddDevice = '/c/c_Devices';
+    protected linkToAddDevice = '/c/content';
+    protected linkToEditDeviceQueryParams = {
+        devices: null
+    };
 
     options$: Observable<DotDevice[]>;
     socialMediaTiles = [
@@ -144,7 +147,11 @@ export class DotDeviceSelectorSeoComponent implements OnInit {
     public getOptions(): Observable<DotDevice[]> {
         return this.dotDevicesService.get().pipe(
             take(1),
-            mergeMap((devices: DotDevice[]) => devices),
+            mergeMap((devices: DotDevice[]) => {
+                this.linkToEditDeviceQueryParams.devices = devices[0].stInode;
+
+                return devices;
+            }),
             filter((device: DotDevice) => +device.cssHeight > 0 && +device.cssWidth > 0),
             toArray()
         );

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-info-seo/dot-edit-page-info-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-info-seo/dot-edit-page-info-seo.component.spec.ts
@@ -73,13 +73,6 @@ describe('DotEditPageInfoSeoComponent', () => {
             expect(button.componentInstance.tooltipText).toBe('Copy url page');
         });
 
-        it('should have api link', () => {
-            const apiLink: DebugElement = de.query(By.css('dot-api-link'));
-            expect(apiLink.componentInstance.href).toBe(
-                'api/v1/page/render/an/url/test?language_id=1'
-            );
-        });
-
         it('should not have preview link', () => {
             const previewLink: DebugElement = de.query(By.css('dot-link[icon="pi-eye"]'));
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-info-seo/dot-edit-page-info-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-info-seo/dot-edit-page-info-seo.component.ts
@@ -36,7 +36,6 @@ export class DotEditPageInfoSeoComponent {
     @Input() title: string;
     @Input() url: string;
     innerApiLink: string;
-    previewUrl: string;
     baseUrl: string;
     seoImprovements: boolean;
 
@@ -44,20 +43,5 @@ export class DotEditPageInfoSeoComponent {
         this.baseUrl = document.defaultView.location.href.includes('edit-page')
             ? document.defaultView.location.origin
             : '';
-    }
-
-    @Input()
-    set apiLink(value: string) {
-        if (value) {
-            const frontEndUrl = `${value.replace('api/v1/page/render', '')}`;
-
-            this.previewUrl = `${frontEndUrl}${
-                frontEndUrl.indexOf('?') != -1 ? '&' : '?'
-            }disabledNavigateMode=true`;
-        } else {
-            this.previewUrl = value;
-        }
-
-        this.innerApiLink = value;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.html
@@ -1,6 +1,7 @@
 <dot-device-selector-seo
     #deviceSelector
     [pTooltip]="pageState.viewAs.device?.name || ('editpage.viewas.default.device' | dm)"
+    [apiLink]="apiLink"
     (selected)="changeDeviceHandler($event)"
     appendTo="body"
     tooltipPosition="bottom"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
@@ -7,6 +7,7 @@ import { DecimalPipe } from '@angular/common';
 import { Component, DebugElement, LOCALE_ID } from '@angular/core';
 import { ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { InputSwitchModule } from 'primeng/inputswitch';
 import { SelectButtonModule } from 'primeng/selectbutton';
@@ -124,7 +125,8 @@ describe('DotEditPageStateControllerSeoComponent', () => {
                 TooltipModule,
                 DotPipesModule,
                 DotEditPageStateControllerSeoComponent,
-                DotEditPageLockInfoSeoComponent
+                DotEditPageLockInfoSeoComponent,
+                RouterTestingModule
             ]
         });
     }));

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
@@ -71,6 +71,7 @@ export class DotEditPageStateControllerSeoComponent implements OnChanges {
     @Input() pageState: DotPageRenderState;
     @Output() modeChange = new EventEmitter<DotPageMode>();
     @Input() variant: DotVariantData | null = null;
+    @Input() apiLink: string;
 
     lock: boolean;
     lockWarn = false;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-toolbar-seo/dot-edit-page-toolbar-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-toolbar-seo/dot-edit-page-toolbar-seo.component.html
@@ -32,6 +32,7 @@
         <dot-edit-page-state-controller-seo
             [pageState]="pageState"
             [variant]="variant"
+            [apiLink]="apiLink"
             (modeChange)="stateChange()"
         ></dot-edit-page-state-controller-seo>
     </div>
@@ -56,7 +57,6 @@
 <ng-template #defaultHeaderLeftTpl>
     <dot-edit-page-info-seo
         class="flex gap-2"
-        [apiLink]="apiLink"
         [title]="pageState.page.title"
         [url]="pageState.page.pageURI"
     ></dot-edit-page-info-seo>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-toolbar-seo/dot-edit-page-toolbar-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-toolbar-seo/dot-edit-page-toolbar-seo.component.spec.ts
@@ -279,9 +279,6 @@ describe('DotEditPageToolbarSeoComponent', () => {
             const dotEditPageInfo = de.query(By.css('dot-edit-page-info-seo')).componentInstance;
             expect(dotEditPageInfo.title).toBe('A title');
             expect(dotEditPageInfo.url).toBe('/an/url/test');
-            expect(dotEditPageInfo.innerApiLink).toBe(
-                'api/v1/page/render/an/url/test?language_id=1'
-            );
         });
     });
 

--- a/core-web/libs/dotcms-models/src/lib/dot-device.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-device.model.ts
@@ -4,6 +4,7 @@ export interface DotDevice {
     cssWidth: string;
     name: string;
     inode: string;
+    stInode?: string;
 }
 
 export interface DotDeviceListItem extends DotDevice {

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
@@ -125,9 +125,13 @@
 
 
     if (!InodeUtils.isSet(structureSelected)) {
-
         structureSelected = "catchall";
+    }
 
+    String devices = (String) request.getParameter("devices");
+
+    if (devices != null) {
+        structureSelected = devices;
     }
 
 


### PR DESCRIPTION
Refs #25281

### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f5f6b5</samp>

This pull request improves the user experience of the SEO analysis portlet by adding router links to the device selector component. The router links allow the user to open the page preview and the devices portlet from the SEO portlet. It also removes some redundant code and properties related to the page preview from other components. It updates the tests and templates accordingly.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots


https://github.com/dotCMS/core/assets/3438705/b41eeb4b-688c-49fa-b773-b14a21250f7b

