### PR TITLE
dotCMS/core#25623 [UI] Verify the ConfirmPopup of Promote Variant (Experiment Reports) 

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_confirmpopup.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_confirmpopup.scss
@@ -18,12 +18,8 @@
         color: $color-palette-primary-500;
     }
 
-    .p-confirm-popup-message {
-        margin-left: $spacing-3;
-    }
-
     .p-confirm-popup-footer {
-        padding: $spacing-2 $spacing-4;
+        padding: $spacing-3;
         display: flex;
         column-gap: $confirm-popup-column-gap;
         justify-content: flex-end;
@@ -75,10 +71,11 @@
     border-bottom-color: transparent;
 }
 
-.p-confirm-popup .p-confirm-popup-content {
+div.p-confirm-popup .p-confirm-popup-content {
     display: flex;
-    align-items: center;
-    padding: $spacing-4;
+    align-items: flex-start;
+    padding: $spacing-3;
+    gap: $spacing-1;
 }
 
 .p-confirm-popup .p-button.p-button-sm {

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_confirmpopup.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_confirmpopup.scss
@@ -71,7 +71,7 @@
     border-bottom-color: transparent;
 }
 
-div.p-confirm-popup .p-confirm-popup-content {
+.p-component.p-confirm-popup .p-confirm-popup-content {
     display: flex;
     align-items: flex-start;
     padding: $spacing-3;

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.html
@@ -120,4 +120,3 @@
 </ng-container>
 
 <ng-container dotDynamic></ng-container>
-<p-confirmPopup></p-confirmPopup>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.spec.ts
@@ -11,7 +11,6 @@ import { ActivatedRoute } from '@angular/router';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { Card } from 'primeng/card';
-import { ConfirmPopup } from 'primeng/confirmpopup';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { ComponentStatus, ExperimentSteps, Goals, StepStatus } from '@dotcms/dotcms-models';
@@ -43,7 +42,7 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
     let spectator: Spectator<DotExperimentsConfigurationGoalsComponent>;
     let store: DotExperimentsConfigurationStore;
     let dotExperimentsService: SpyObject<DotExperimentsService>;
-    let confirmPopupComponent: ConfirmPopup;
+    let confirmationService: ConfirmationService;
 
     const createComponent = createComponentFactory({
         component: DotExperimentsConfigurationGoalsComponent,
@@ -70,6 +69,7 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
         store = spectator.inject(DotExperimentsConfigurationStore);
 
         dotExperimentsService = spectator.inject(DotExperimentsService);
+        confirmationService = spectator.inject(ConfirmationService);
     });
 
     describe('no goal selected yet', () => {
@@ -162,6 +162,7 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
         });
         test('should show a confirmation to delete a goal', () => {
             jest.spyOn(store, 'deleteGoal');
+            jest.spyOn(confirmationService, 'confirm');
 
             spectator.detectComponentChanges();
             const deleteIcon = spectator.query(byTestId('goal-delete-button'));
@@ -171,10 +172,7 @@ describe('DotExperimentsConfigurationGoalsComponent', () => {
             spectator.dispatchMouseEvent(deleteIcon, 'click');
             spectator.detectComponentChanges();
 
-            confirmPopupComponent = spectator.query(ConfirmPopup);
-            confirmPopupComponent.accept();
-
-            expect(store.deleteGoal).toHaveBeenCalled();
+            expect(confirmationService.confirm).toHaveBeenCalled();
         });
     });
 });

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -160,4 +160,3 @@
 </ng-container>
 
 <ng-container dotDynamic></ng-container>
-<p-confirmPopup></p-confirmPopup>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.spec.ts
@@ -73,6 +73,7 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
     let router: Router;
 
     let dotSessionStorageService: DotSessionStorageService;
+    let confirmationService: ConfirmationService;
 
     const createComponent = createComponentFactory({
         component: DotExperimentsConfigurationVariantsComponent,
@@ -107,6 +108,7 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
         router = spectator.inject(Router);
 
         dotSessionStorageService = spectator.inject(DotSessionStorageService);
+        confirmationService = spectator.inject(ConfirmationService);
 
         dotExperimentsService = spectator.inject(DotExperimentsService);
         dotExperimentsService.getById.mockReturnValue(of(EXPERIMENT_MOCK));
@@ -265,17 +267,13 @@ describe('DotExperimentsConfigurationVariantsComponent', () => {
 
         it('should confirm before delete a variant', () => {
             jest.spyOn(store, 'deleteVariant');
+            jest.spyOn(confirmationService, 'confirm');
 
             const button = spectator.queryLast(byTestId('variant-delete-button'));
 
             spectator.click(button);
 
-            spectator.query(ConfirmPopup).accept();
-
-            expect(store.deleteVariant).toHaveBeenCalledWith({
-                experimentId: EXPERIMENT_MOCK.id,
-                variant: variants[1]
-            });
+            expect(confirmationService.confirm).toHaveBeenCalled();
         });
 
         it('should disable tooltip if is on draft', () => {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/dot-experiments-configuration.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/dot-experiments-configuration.component.html
@@ -54,3 +54,4 @@
 </ng-template>
 
 <p-confirmDialog [key]="confirmDialogKey" />
+<p-confirmPopup></p-confirmPopup>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/dot-experiments-configuration.component.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/dot-experiments-configuration.component.ts
@@ -7,6 +7,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmPopupModule } from 'primeng/confirmpopup';
 import { InplaceModule } from 'primeng/inplace';
 import { InputTextModule } from 'primeng/inputtext';
 import { MenuModule } from 'primeng/menu';
@@ -52,7 +53,8 @@ import { DotExperimentsInlineEditTextComponent } from '../shared/ui/dot-experime
         InplaceModule,
         InputTextModule,
         MenuModule,
-        ConfirmDialogModule
+        ConfirmDialogModule,
+        ConfirmPopupModule
     ],
     selector: 'dot-experiments-configuration',
     templateUrl: './dot-experiments-configuration.component.html',

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/components/dot-experiments-report-daily-details/dot-experiments-report-daily-details.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/components/dot-experiments-report-daily-details/dot-experiments-report-daily-details.component.html
@@ -95,7 +95,7 @@
                 [ngClass]="{ 'prospect-winner': row.isWinner }"
             >
                 <button
-                    class="p-button-sm p-button-secondary"
+                    class="p-button-sm p-button-outlined"
                     *ngIf="!promotedVariantId && row.id !== defaultVariantId"
                     [label]="'experiments.reports.promote' | dm"
                     (click)="promoteVariant($event, experimentId, row)"
@@ -115,4 +115,3 @@
         </div>
     </ng-template>
 </dot-experiments-details-table>
-<p-confirmPopup></p-confirmPopup>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/components/dot-experiments-report-daily-details/dot-experiments-report-daily-details.component.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/components/dot-experiments-report-daily-details/dot-experiments-report-daily-details.component.spec.ts
@@ -1,7 +1,6 @@
 import { byTestId, createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { ConfirmPopup } from 'primeng/confirmpopup';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { DotExperimentVariantDetail } from '@dotcms/dotcms-models';
@@ -16,6 +15,7 @@ import { DotExperimentsReportsStore } from '../../store/dot-experiments-reports-
 describe('DotExperimentsReportDailyDetailsComponent', () => {
     let spectator: Spectator<DotExperimentsReportDailyDetailsComponent>;
     let store: DotExperimentsReportsStore;
+    let confirmationService: ConfirmationService;
 
     const createComponent = createComponentFactory({
         component: DotExperimentsReportDailyDetailsComponent,
@@ -32,9 +32,8 @@ describe('DotExperimentsReportDailyDetailsComponent', () => {
     beforeEach(() => {
         spectator = createComponent();
 
-        jest.spyOn(ConfirmPopup.prototype, 'bindScrollListener').mockImplementation(jest.fn());
-
         store = spectator.inject(DotExperimentsReportsStore, true);
+        confirmationService = spectator.inject(ConfirmationService, true);
     });
 
     it('should DotExperimentsDetailsTableComponent exist', () => {
@@ -60,18 +59,11 @@ describe('DotExperimentsReportDailyDetailsComponent', () => {
         spectator.setInput('hasEnoughSessions', true);
 
         jest.spyOn(store, 'promoteVariant');
+        jest.spyOn(confirmationService, 'confirm');
 
         spectator.click(spectator.query(byTestId('promote-variant-button')));
         spectator.detectComponentChanges();
 
-        expect(spectator.query(ConfirmPopup)).toExist();
-
-        spectator.query(ConfirmPopup).accept();
-
-        expect(store.promoteVariant).toHaveBeenCalledWith({
-            experimentId: EXPERIMENT_ID,
-            variant: variant
-        });
-        expect(spectator.queryAll(byTestId('variant-promoted-tag')).length).toEqual(0);
+        expect(confirmationService.confirm).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
### Proposed Changes
* Improve margins / styles of the `ConfirmationPopUp`
* Promote btn correct color 


### Screenshots


#### Before 

<img width="353" alt="image" src="https://github.com/dotCMS/core/assets/31667212/c676213b-abb8-4b24-903b-dc7db036632a">

<img width="432" alt="image" src="https://github.com/dotCMS/core/assets/31667212/1997288c-b003-4829-9ace-9d26a4a7fbd0">

<img width="442" alt="image" src="https://github.com/dotCMS/core/assets/31667212/65e894a0-7861-46c7-90fd-c4b6da3b43f1">



#### After 

<img width="358" alt="image" src="https://github.com/dotCMS/core/assets/31667212/86ee5e05-0ff5-4c90-ad0a-f238a0f989ad">

<img width="423" alt="image" src="https://github.com/dotCMS/core/assets/31667212/cb95d865-7b03-415b-8d21-60c638ecc714">

<img width="429" alt="image" src="https://github.com/dotCMS/core/assets/31667212/f7c7abf5-d48a-49f9-a5a6-11cc64e16b71">




