### PR TITLE
Enable Template Builder v2 feature flag

### DIFF
--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -837,3 +837,6 @@ analytics.accesstoken.renewjob.cron=0 0/1 * * * ?
 
 ## Favorite Pages Portlet
 DOTFAVORITEPAGE_FEATURE_ENABLE=true
+
+## Template builder v2
+DOT_FEATURE_FLAG_TEMPLATE_BUILDER_2=true


### PR DESCRIPTION

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e9c7260</samp>

### Summary
🆕🎨🔧

<!--
1.  🆕 - This emoji represents the addition of a new feature or functionality, in this case the template builder v2.
2.  🎨 - This emoji represents the improvement or enhancement of the UI or UX, in this case the new template builder v2 UI.
3.  🔧 - This emoji represents the configuration or setting of a feature or functionality, in this case the feature flag property.
-->
Add a feature flag for the template builder v2 UI. The new property `TEMPLATE_BUILDER_V2` in `dotmarketing-config.properties` controls whether the new or old template builder is used.

> _`Template builder v2`_
> _New UI for dotCMS_
> _Enabled by default_

### Walkthrough
* Enable the template builder v2 feature flag by adding a new property to the dotmarketing-config.properties file ([link](https://github.com/dotCMS/core/pull/25788/files?diff=unified&w=0#diff-2811adad7784fd6904fe136b6f40ab001ef040527847c1b6664178adf9bde777R840-R842))

