### PR TITLE
Sync SEO Angular components with experiments changes 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
@@ -171,8 +171,7 @@ describe('DotEditPageStateControllerSeoComponent', () => {
                 expect(dotTabButtons).toBeDefined();
                 expect(dotTabButtons.options).toEqual([
                     { label: 'Edit', value: 'EDIT_MODE', disabled: false },
-                    { label: 'Preview', value: 'PREVIEW_MODE', disabled: false },
-                    { label: 'Live', value: 'ADMIN_MODE', disabled: false }
+                    { label: 'Preview', value: 'PREVIEW_MODE', disabled: false }
                 ]);
             });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
@@ -43,7 +43,8 @@ import { DotDeviceSelectorSeoComponent } from '../dot-device-selector-seo/dot-de
 
 enum DotConfirmationType {
     LOCK,
-    PERSONALIZATION
+    PERSONALIZATION,
+    RUNNING_EXPERIMENT
 }
 
 @Component({
@@ -86,15 +87,17 @@ export class DotEditPageStateControllerSeoComponent implements OnChanges {
     ) {}
 
     ngOnChanges(changes: SimpleChanges) {
-        const pageState = changes.pageState.currentValue;
-        this.options = this.getStateModeOptions(pageState);
-        /*
-When the page is lock but the page is being load from an user that can lock the page
-we want to show the lock off so the new user can steal the lock
-*/
-        this.lock = this.isLocked(pageState);
-        this.lockWarn = this.shouldWarnLock(pageState);
-        this.mode = pageState.state.mode;
+        const pageState = changes.pageState?.currentValue;
+        if (pageState) {
+            this.options = this.getStateModeOptions(pageState);
+            /*
+            When the page is lock but the page is being load from an user that can lock the page
+            we want to show the lock off so the new user can steal the lock
+            */
+            this.lock = this.isLocked(pageState);
+            this.lockWarn = this.shouldWarnLock(pageState);
+            this.mode = pageState.state.mode;
+        }
     }
 
     /**
@@ -203,7 +206,7 @@ we want to show the lock off so the new user can steal the lock
     }
 
     private getStateModeOptions(pageState: DotPageRenderState): SelectItem[] {
-        const items = this.variant ? this.getModesBasedOnVariant() : ['edit', 'preview'];
+        const items = this.variant ? this.getModesBasedOnVariant() : ['edit', 'preview', 'live'];
 
         return items.map((mode: string) => this.getModeOption(mode, pageState));
     }
@@ -244,13 +247,20 @@ we want to show the lock off so the new user can steal the lock
         return this.pageState.page.canLock && this.pageState.state.lockedByAnotherUser;
     }
 
+    private shouldAskOnRunningExperiment(): boolean {
+        return !!this.pageState.state.runningExperiment;
+    }
+
     private shouldAskPersonalization(): boolean {
         return this.pageState.viewAs.persona && !this.isPersonalized();
     }
 
     private shouldShowConfirmation(mode: DotPageMode): boolean {
         return (
-            mode === DotPageMode.EDIT && (this.shouldAskToLock() || this.shouldAskPersonalization())
+            mode === DotPageMode.EDIT &&
+            (this.shouldAskToLock() ||
+                this.shouldAskPersonalization() ||
+                this.shouldAskOnRunningExperiment())
         );
     }
 
@@ -261,18 +271,22 @@ we want to show the lock off so the new user can steal the lock
     private showConfirmation(): Observable<DotConfirmationType> {
         return from(
             new Promise<DotConfirmationType>((resolve, reject) => {
-                if (this.shouldAskToLock()) {
-                    this.showLockConfirmDialog()
-                        .then(() => {
-                            resolve(DotConfirmationType.LOCK);
-                        })
-                        .catch(() => reject());
-                }
-
                 if (this.shouldAskPersonalization()) {
                     this.showPersonalizationConfirmDialog()
                         .then(() => {
                             resolve(DotConfirmationType.PERSONALIZATION);
+                        })
+                        .catch(() => reject());
+                } else if (this.shouldAskOnRunningExperiment()) {
+                    this.showRunningExperimentConfirmDialog()
+                        .then(() => {
+                            resolve(DotConfirmationType.RUNNING_EXPERIMENT);
+                        })
+                        .catch(() => reject());
+                } else if (this.shouldAskToLock()) {
+                    this.showLockConfirmDialog()
+                        .then(() => {
+                            resolve(DotConfirmationType.LOCK);
                         })
                         .catch(() => reject());
                 }
@@ -306,6 +320,17 @@ we want to show the lock off so the new user can steal the lock
         });
     }
 
+    private showRunningExperimentConfirmDialog(): Promise<string> {
+        return new Promise((resolve, reject) => {
+            this.dotAlertConfirmService.confirm({
+                accept: resolve,
+                reject: reject,
+                header: this.dotMessageService.get('experiment.running'),
+                message: this.getRunningExperimentConfirmMessage()
+            });
+        });
+    }
+
     private getPersonalizationConfirmMessage(): string {
         let message = this.dotMessageService.get(
             'editpage.personalization.confirm.message',
@@ -313,13 +338,38 @@ we want to show the lock off so the new user can steal the lock
         );
 
         if (this.shouldAskToLock()) {
-            message += this.dotMessageService.get(
-                'editpage.personalization.confirm.with.lock',
-                this.pageState.page.lockedByName
-            );
+            message += this.getBlockedPageNote();
+        }
+
+        if (this.shouldAskOnRunningExperiment()) {
+            message += this.getRunningExperimentNote();
         }
 
         return message;
+    }
+
+    private getRunningExperimentConfirmMessage(): string {
+        let message = this.dotMessageService.get('experiment.running.edit.confirmation');
+
+        if (this.shouldAskToLock()) {
+            message += this.getBlockedPageNote();
+        }
+
+        return message;
+    }
+
+    private getBlockedPageNote(): string {
+        return this.dotMessageService.get(
+            'editpage.personalization.confirm.with.lock',
+            this.pageState.page.lockedByName
+        );
+    }
+
+    private getRunningExperimentNote(): string {
+        return this.dotMessageService.get(
+            'experiment.running.edit.lock.confirmation.note',
+            this.pageState.page.lockedByName
+        );
     }
 
     private updatePageState(options: DotPageRenderOptions, lock: boolean = null) {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
@@ -206,7 +206,7 @@ export class DotEditPageStateControllerSeoComponent implements OnChanges {
     }
 
     private getStateModeOptions(pageState: DotPageRenderState): SelectItem[] {
-        const items = this.variant ? this.getModesBasedOnVariant() : ['edit', 'preview', 'live'];
+        const items = this.variant ? this.getModesBasedOnVariant() : ['edit', 'preview'];
 
         return items.map((mode: string) => this.getModeOption(mode, pageState));
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-view-as-controller-seo/dot-edit-page-view-as-controller-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-view-as-controller-seo/dot-edit-page-view-as-controller-seo.component.html
@@ -1,7 +1,6 @@
 <ng-container *ngIf="isEnterpriseLicense$ | async as isEnterpriseLicense; else language">
     <dot-language-selector
         [pTooltip]="pageState.viewAs.language.language"
-        [readonly]="!!variant"
         [value]="pageState.viewAs.language"
         (selected)="changeLanguageHandler($event)"
         appendTo="body"
@@ -12,7 +11,6 @@
     <dot-persona-selector
         [disabled]="(dotPageStateService.haveContent$ | async) === false"
         [pageState]="pageState"
-        [readonly]="!!variant"
         (delete)="deletePersonalization($event)"
         (selected)="changePersonaHandler($event)"
     ></dot-persona-selector>


### PR DESCRIPTION
### Proposed Changes
* Sync experiment changes in `dot-edit-page-state-controller-seo.component` and `dot-edit-page-view-as-controller-seo.component.html`

* Experiments affected tasks: #25645 and #25688

