### PR TITLE
fix: overaggressive cleaning from #25817

### DIFF
--- a/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
+++ b/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
@@ -11122,4 +11122,14 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.listingThumbDiv{
+  height: 60px;
+  width: 80px;
+  position: relative;
+  border-radius: 5px;
+  overflow: hidden;
+  cursor: pointer;
+
+}
+
 /*# sourceMappingURL=dotcms.css.map */


### PR DESCRIPTION
adding back thumbnail div wrapper class that was accidentally removed when deleting bootstrap classes.

