### PR TITLE
Fix #25840: Template Builder Fix Autosave for Layout Properties

### DIFF
--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-row/template-builder-row.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-row/template-builder-row.component.spec.ts
@@ -72,6 +72,17 @@ describe('TemplateBuilderRowComponent', () => {
 
         store = TestBed.inject(DotTemplateBuilderStore);
 
+        store.setState({
+            rows: [],
+            layoutProperties: {
+                header: false,
+                footer: false,
+                sidebar: null
+            },
+            resizingRowID: '',
+            containerMap: {}
+        });
+
         fixture.detectChanges();
     });
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -90,11 +90,7 @@ describe('TemplateBuilderComponent', () => {
                     body: FULL_DATA_MOCK,
                     header: true,
                     footer: true,
-                    sidebar: {
-                        location: 'left',
-                        width: 'small',
-                        containers: []
-                    },
+                    sidebar: null,
                     width: 'Mobile',
                     title: 'Test Title'
                 },
@@ -243,6 +239,14 @@ describe('TemplateBuilderComponent', () => {
         mainDiv.dispatchEvent(new MouseEvent('mousemove'));
 
         expect(fixGridStackNodeOptionsMock).toHaveBeenCalled();
+    });
+
+    it('should set layoutProperties to default values if sidebar null', () => {
+        expect(spectator.component.layoutProperties).toEqual({
+            header: true,
+            footer: true,
+            sidebar: { location: '', width: 'medium', containers: [] }
+        });
     });
 
     describe('layoutChange', () => {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -128,7 +128,9 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
             header: this.layout.header,
             footer: this.layout.footer,
             sidebar: this.layout.sidebar ?? {
-                location: ''
+                location: '',
+                width: 'medium',
+                containers: []
             }
         };
     }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3fcc52b</samp>

### Summary
🛠️🔄🎨

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the change sets the initial state of the store mock, which is a tool for testing the template builder functionality.
2.  🔄 - This emoji represents a change or an update, and can be used to indicate that the change updates the default value of the sidebar property, which is a modification of the existing template builder logic and UI.
3.  🎨 - This emoji represents a design or a style, and can be used to indicate that the change affects the appearance and layout of the template builder, which is a visual aspect of the component.
-->
This pull request improves the testing and default values of the template builder feature. It sets the initial state of the store mock in `template-builder-row.component.spec.ts` and updates the default value of the sidebar property in `template-builder.component.ts`.

> _Mocking the store_
> _`TemplateBuilder` updates_
> _Winter of testing_

### Walkthrough
* Set the default value of the sidebar property in the `TemplateBuilderComponent` class to include width and containers ([link](https://github.com/dotCMS/core/pull/25841/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L131-R133), `template-builder.component.ts`)



## Screenshots

https://github.com/dotCMS/core/assets/63567962/61973c79-b643-43d7-8d39-1f31a29def3f

