### PR TITLE
 #25868: adapting dotcms to new analytics infra

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/cube/CubeJSClientFactoryIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/cube/CubeJSClientFactoryIntegrationTest.java
@@ -1,0 +1,46 @@
+package com.dotcms.cube;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.analytics.AnalyticsTestUtils;
+import com.dotcms.analytics.helper.AnalyticsHelper;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.web.WebAPILocator;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class CubeJSClientFactoryIntegrationTest extends IntegrationTestBase {
+
+    private CubeJSClientFactoryImpl cubeJSClientFactory;
+    private AnalyticsHelper analyticsHelper;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        cubeJSClientFactory = new CubeJSClientFactoryImpl();
+        analyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
+        CubeJSClientFactoryImpl.setAnalyticsHelper(analyticsHelper);
+    }
+
+    @Test
+    public void testCreateWithAnalyticsApp() throws Exception {
+        final CubeJSClient cubeClient = cubeJSClientFactory.create(
+            analyticsHelper.appFromHost(
+                WebAPILocator.getHostWebAPI().getCurrentHost()));
+        assertNotNull(cubeClient);
+    }
+
+    @Test
+    public void testCreateWithUser() throws Exception {
+        final CubeJSClient cubeClient = cubeJSClientFactory.create(APILocator.systemUser());
+        assertNotNull(cubeClient);
+    }
+
+}

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAPIImpIntegrationTest.java
@@ -17,9 +17,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.dotcms.IntegrationTestBase;
-import com.dotcms.analytics.AnalyticsAPI;
 import com.dotcms.analytics.AnalyticsTestUtils;
-import com.dotcms.analytics.app.AnalyticsApp;
 import com.dotcms.analytics.bayesian.model.BayesianResult;
 import com.dotcms.analytics.helper.AnalyticsHelper;
 import com.dotcms.analytics.metrics.AbstractCondition.Operator;
@@ -30,9 +28,9 @@ import com.dotcms.analytics.metrics.MetricType;
 import com.dotcms.analytics.metrics.QueryParameter;
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.contenttype.model.field.Field;
-import com.dotcms.analytics.model.AnalyticsProperties;
 import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.cube.CubeJSClientFactoryImpl;
 import com.dotcms.datagen.ContainerDataGen;
 import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.ContentletDataGen;
@@ -52,7 +50,6 @@ import com.dotcms.experiments.business.result.ExperimentResults;
 import com.dotcms.experiments.business.result.GoalResults;
 import com.dotcms.experiments.business.result.VariantResults;
 import com.dotcms.experiments.business.result.VariantResults.ResultResumeItem;
-import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.experiments.model.AbstractExperiment.Status;
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.experiments.model.ExperimentVariant;
@@ -136,7 +133,6 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
 
     private static final String CUBEJS_SERVER_IP = "127.0.0.1";
     private static final int CUBEJS_SERVER_PORT = 5000;
-    private static final String CUBEJS_SERVER_URL = String.format("http://%s:%s", CUBEJS_SERVER_IP, CUBEJS_SERVER_PORT);
     private static final DateTimeFormatter SIMPLE_FORMATTER = DateTimeFormatter
             .ofPattern("MM/dd/yyyy")
             .withZone(ZoneId.systemDefault());
@@ -529,7 +525,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link ExperimentsAPI#getEvents(Experiment, User, AnalyticsApp, AccessToken)}
+     * Method to test: {@link ExperimentsAPI#getEvents(Experiment, User)}
      * When: You have 4 pages let call them: A, B, C and D and:
      * - We create a Experiment with the B page.
      * - We mock in the test 4 Browser Session with different lookBackWindows, each of this session
@@ -547,7 +543,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
      * Session 3: 2
      * Session 4: 4
      *
-     * If we call the {@link ExperimentsAPI#getEvents(Experiment, User, AnalyticsApp, AccessToken)} now
+     * If we call the {@link ExperimentsAPI#getEvents(Experiment, User)} now
      *
      * Should: Return 4 {@link BrowserSession} each one with the right numbers of {@link com.dotcms.experiments.business.result.Event}
      *
@@ -614,22 +610,10 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
 
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
-            final AnalyticsProperties analyticsProperties = AnalyticsProperties.builder()
-                .clientId("clientId")
-                .clientSecret("clientSecret")
-                .analyticsKey("analyticsKey")
-                .analyticsConfigUrl("http://localhost:8088/c/customer1/cluster1/keys")
-                .analyticsWriteUrl("http://localhost:8081/api/v1/event")
-                .analyticsReadUrl(CUBEJS_SERVER_URL)
-                .build();
-            final AnalyticsApp mockAnalyticsApp = mock(AnalyticsApp.class);
-            when(mockAnalyticsApp.getAnalyticsProperties()).thenReturn(analyticsProperties);
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
             final List<BrowserSession> browserSessions = experimentsAPIImpl.getEvents(
                     experimentStarted,
-                    APILocator.systemUser(),
-                    mockAnalyticsApp,
-                    AnalyticsAPI.DUMMY_TOKEN);
+                    APILocator.systemUser());
 
             mockHttpServer.validate();
 
@@ -735,7 +719,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         final MockHttpServer mockhttpServer = new MockHttpServer(CUBEJS_SERVER_IP, CUBEJS_SERVER_PORT);
 
         final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
-        ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+        setAnalyticsHelper(mockAnalyticsHelper);
 
         final Experiment experimentStarted = ExperimentDataGen.start(experiment);
 
@@ -829,7 +813,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
 
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
 
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
 
@@ -964,7 +948,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
 
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
 
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
 
@@ -1098,7 +1082,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
 
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
 
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
 
@@ -1276,7 +1260,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
 
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
 
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
 
@@ -1412,7 +1396,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
 
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
@@ -1505,7 +1489,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -1597,7 +1581,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
 
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
@@ -1695,7 +1679,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -1809,7 +1793,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -1925,7 +1909,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -2030,7 +2014,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -2136,7 +2120,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -2235,7 +2219,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -2328,7 +2312,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -2426,7 +2410,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -2524,7 +2508,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -2619,7 +2603,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -2721,7 +2705,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -2825,7 +2809,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -2929,7 +2913,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -3025,7 +3009,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -3119,7 +3103,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -3494,7 +3478,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -3594,7 +3578,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -3709,7 +3693,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -3814,7 +3798,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -3919,7 +3903,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -4022,7 +4006,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -4129,7 +4113,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -4232,7 +4216,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -4338,7 +4322,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -4438,7 +4422,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -4541,7 +4525,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -4678,7 +4662,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -4786,7 +4770,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
 
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
@@ -4886,7 +4870,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -4984,7 +4968,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResult = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -5087,7 +5071,8 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
 
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
+            CubeJSClientFactoryImpl.setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
 
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
@@ -5784,7 +5769,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
 
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
 
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
 
@@ -5884,7 +5869,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -5970,7 +5955,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -6041,7 +6026,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -6114,7 +6099,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
 
             APILocator.getExperimentsAPI().end(experiment.getIdentifier(), APILocator.systemUser());
 
@@ -6196,7 +6181,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
 
         try {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
@@ -6231,7 +6216,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         final HTMLPageAsset pageC = new HTMLPageDataGen(host, template).nextPersisted();
         final Experiment experiment = createExperimentWithReachPageGoalAndVariant(pageA, pageC, "variantB", "variantC");
         final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockInvalidAnalyticsHelper();
-        ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+        setAnalyticsHelper(mockAnalyticsHelper);
         final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
         experimentsAPIImpl.getResults(experiment, APILocator.systemUser());
     }
@@ -6417,7 +6402,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(
                     mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -6537,7 +6522,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(
                     mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -6647,7 +6632,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(
                     mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -6763,7 +6748,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
             final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
             final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(
                     mockAnalyticsHelper);
-            ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+            setAnalyticsHelper(mockAnalyticsHelper);
             final ExperimentResults experimentResults = experimentsAPIImpl.getResults(
                     experiment,
                     APILocator.systemUser());
@@ -7790,7 +7775,7 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
 
            final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
 
-           ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+           setAnalyticsHelper(mockAnalyticsHelper);
 
            final ExperimentsAPIImpl experimentsAPIImpl = new ExperimentsAPIImpl(mockAnalyticsHelper);
 
@@ -8508,6 +8493,11 @@ public class ExperimentAPIImpIntegrationTest extends IntegrationTestBase {
         } finally {
             APILocator.getExperimentsAPI().end(experiment.getIdentifier(), APILocator.systemUser());
         }
+    }
+
+    private void setAnalyticsHelper(final AnalyticsHelper mockAnalyticsHelper) {
+        ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+        CubeJSClientFactoryImpl.setAnalyticsHelper(mockAnalyticsHelper);
     }
 }
 

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAnalyzerUtilIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAnalyzerUtilIntegrationTest.java
@@ -4,12 +4,16 @@ import static com.dotcms.util.CollectionsUtils.map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.dotcms.analytics.AnalyticsTestUtils;
+import com.dotcms.analytics.helper.AnalyticsHelper;
 import com.dotcms.analytics.metrics.AbstractCondition.Operator;
 import com.dotcms.analytics.metrics.Condition;
 import com.dotcms.analytics.metrics.EventType;
 import com.dotcms.analytics.metrics.Metric;
 import com.dotcms.analytics.metrics.MetricType;
 
+import com.dotcms.analytics.model.AccessToken;
+import com.dotcms.analytics.model.TokenStatus;
 import com.dotcms.datagen.ExperimentDataGen;
 import com.dotcms.datagen.HTMLPageDataGen;
 import com.dotcms.datagen.SiteDataGen;
@@ -53,7 +57,7 @@ public class ExperimentAnalyzerUtilIntegrationTest {
     }
 
     /**
-     * Method to test: {@link ExperimentAnalyzerUtil#getExperimentResult(Experiment, List)}
+     * Method to test: {@link ExperimentAnalyzerUtil#getExperimentResult(Experiment, List, AccessToken)}
      * When:
      * - You have 4 pages: A, B, C and D
      * - Create a Experiment with a PAGE_REACH goal where:
@@ -72,6 +76,9 @@ public class ExperimentAnalyzerUtilIntegrationTest {
      */
     @Test
     public void analyzerDataReachPage() throws DotDataException, DotSecurityException {
+        final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
+        ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+
         final Host host = new SiteDataGen().nextPersisted();
         final Template template = new TemplateDataGen().host(host).nextPersisted();
 
@@ -121,7 +128,7 @@ public class ExperimentAnalyzerUtilIntegrationTest {
                 browserSession_5);
 
         final ExperimentResults experimentResults = ExperimentAnalyzerUtil.INSTANCE
-                .getExperimentResult(experiment, browserSessions);
+                .getExperimentResult(experiment, browserSessions, getAccessToken());
 
         assertEquals(3, experimentResults.getSessions());
 
@@ -149,6 +156,17 @@ public class ExperimentAnalyzerUtilIntegrationTest {
             }
         }
 
+    }
+
+    private static AccessToken getAccessToken() {
+        return AnalyticsTestUtils.createAccessToken(
+            "123456789",
+            "client",
+            null,
+            "some-scope",
+            "Bearer",
+            TokenStatus.OK,
+            Instant.now());
     }
 
     private static List<BrowserSession> createBrowserSessions(
@@ -179,7 +197,7 @@ public class ExperimentAnalyzerUtilIntegrationTest {
     }
 
     /**
-     * Method to test: {@link ExperimentAnalyzerUtil#getExperimentResult(Experiment, List)}
+     * Method to test: {@link ExperimentAnalyzerUtil#getExperimentResult(Experiment, List, AccessToken)}
      * When:
      * - You have 4 pages: A, B, and C
      * - Create an Experiment with a EXIT_RATE goal where:
@@ -195,6 +213,9 @@ public class ExperimentAnalyzerUtilIntegrationTest {
      */
     @Test
     public void analyzerDataExitRate() throws DotDataException, DotSecurityException {
+        final AnalyticsHelper mockAnalyticsHelper = AnalyticsTestUtils.mockAnalyticsHelper();
+        ExperimentAnalyzerUtil.setAnalyticsHelper(mockAnalyticsHelper);
+
         final Host host = new SiteDataGen().nextPersisted();
         final Template template = new TemplateDataGen().host(host).nextPersisted();
 
@@ -246,7 +267,7 @@ public class ExperimentAnalyzerUtilIntegrationTest {
                 browserSession_3.stream().map(eventMap -> new Event(eventMap, EventType.PAGE_VIEW)).collect(Collectors.toList())));
 
         final ExperimentResults experimentResult = ExperimentAnalyzerUtil.INSTANCE
-                .getExperimentResult(experiment, browserSessions);
+                .getExperimentResult(experiment, browserSessions, getAccessToken());
 
         assertEquals(2, experimentResult.getSessions());
 

--- a/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAnalyzerUtilIntegrationTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/experiments/business/ExperimentAnalyzerUtilIntegrationTest.java
@@ -12,8 +12,6 @@ import com.dotcms.analytics.metrics.EventType;
 import com.dotcms.analytics.metrics.Metric;
 import com.dotcms.analytics.metrics.MetricType;
 
-import com.dotcms.analytics.model.AccessToken;
-import com.dotcms.analytics.model.TokenStatus;
 import com.dotcms.datagen.ExperimentDataGen;
 import com.dotcms.datagen.HTMLPageDataGen;
 import com.dotcms.datagen.SiteDataGen;
@@ -57,7 +55,7 @@ public class ExperimentAnalyzerUtilIntegrationTest {
     }
 
     /**
-     * Method to test: {@link ExperimentAnalyzerUtil#getExperimentResult(Experiment, List, AccessToken)}
+     * Method to test: {@link ExperimentAnalyzerUtil#getExperimentResult(Experiment, List)}
      * When:
      * - You have 4 pages: A, B, C and D
      * - Create a Experiment with a PAGE_REACH goal where:
@@ -128,7 +126,7 @@ public class ExperimentAnalyzerUtilIntegrationTest {
                 browserSession_5);
 
         final ExperimentResults experimentResults = ExperimentAnalyzerUtil.INSTANCE
-                .getExperimentResult(experiment, browserSessions, getAccessToken());
+                .getExperimentResult(experiment, browserSessions);
 
         assertEquals(3, experimentResults.getSessions());
 
@@ -156,17 +154,6 @@ public class ExperimentAnalyzerUtilIntegrationTest {
             }
         }
 
-    }
-
-    private static AccessToken getAccessToken() {
-        return AnalyticsTestUtils.createAccessToken(
-            "123456789",
-            "client",
-            null,
-            "some-scope",
-            "Bearer",
-            TokenStatus.OK,
-            Instant.now());
     }
 
     private static List<BrowserSession> createBrowserSessions(
@@ -197,7 +184,7 @@ public class ExperimentAnalyzerUtilIntegrationTest {
     }
 
     /**
-     * Method to test: {@link ExperimentAnalyzerUtil#getExperimentResult(Experiment, List, AccessToken)}
+     * Method to test: {@link ExperimentAnalyzerUtil#getExperimentResult(Experiment, List)}
      * When:
      * - You have 4 pages: A, B, and C
      * - Create an Experiment with a EXIT_RATE goal where:
@@ -267,7 +254,7 @@ public class ExperimentAnalyzerUtilIntegrationTest {
                 browserSession_3.stream().map(eventMap -> new Event(eventMap, EventType.PAGE_VIEW)).collect(Collectors.toList())));
 
         final ExperimentResults experimentResult = ExperimentAnalyzerUtil.INSTANCE
-                .getExperimentResult(experiment, browserSessions, getAccessToken());
+                .getExperimentResult(experiment, browserSessions);
 
         assertEquals(2, experimentResult.getSessions());
 

--- a/dotCMS/src/integration-test/resources/it-dotmarketing-config.properties
+++ b/dotCMS/src/integration-test/resources/it-dotmarketing-config.properties
@@ -868,6 +868,7 @@ dartsass.compiler.deprecation.warnings.from.dependencies=false
 EVENT_LOG_TOKEN=js.cluster1.customer1.3c7ftd589dwax9eqpz
 EVENT_LOG_POSTING_URL=http://localhost:8081/api/v1/event
 
+analytics.use.dummy.token=true
 analytics.idp.url=http://localhost:61111/realms/dotcms/protocol/openid-connect/token
 analytics.app.config.url=http://localhost:8088/c/customer1/cluster1/keys
 #analytics.app.write.url=http://jitsu

--- a/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPI.java
@@ -3,10 +3,13 @@ package com.dotcms.analytics;
 import com.dotcms.analytics.app.AnalyticsApp;
 import com.dotcms.analytics.model.AccessToken;
 import com.dotcms.analytics.model.AccessTokenFetchMode;
+import com.dotcms.analytics.model.AccessTokenStatus;
+import com.dotcms.analytics.model.TokenStatus;
 import com.dotcms.exception.AnalyticsException;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.util.Config;
 
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -16,6 +19,7 @@ import java.util.concurrent.TimeUnit;
  */
 public interface AnalyticsAPI {
 
+    String ANALYTICS_USE_DUMMY_TOKEN_KEY = "analytics.use.dummy.token";
     String ANALYTICS_IDP_URL_KEY = "analytics.idp.url";
 
     String ANALYTICS_ACCESS_TOKEN_TTL_KEY = "analytics.accesstoken.ttl";
@@ -39,6 +43,15 @@ public interface AnalyticsAPI {
     int ANALYTICS_KEY_RENEW_TIMEOUT = Config.getIntProperty(ANALYTICS_KEY_RENEW_TIMEOUT_KEY, 4000);
 
     String ANALYTICS_ACCESS_TOKEN_THREAD_NAME = "access-token-renew";
+
+    AccessToken DUMMY_TOKEN = AccessToken.builder()
+        .accessToken("dummy_token")
+        .clientId("dummy")
+        .tokenType("Bearer")
+        .expiresIn(Integer.MAX_VALUE)
+        .status(AccessTokenStatus.builder().tokenStatus(TokenStatus.OK).build())
+        .issueDate(Instant.now())
+        .build();
 
     /**
      * Fetches an {@link AccessToken} instance from cache falling back to get the access token

--- a/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPIImpl.java
@@ -43,10 +43,12 @@ public class AnalyticsAPIImpl implements AnalyticsAPI {
 
     private final String analyticsIdpUrl;
     private final AnalyticsCache analyticsCache;
+    private final boolean useDummyToken;
 
     public AnalyticsAPIImpl(final String analyticsIdpUrl, final AnalyticsCache analyticsCache) {
         this.analyticsIdpUrl = analyticsIdpUrl;
         this.analyticsCache = analyticsCache;
+        useDummyToken = Config.getBooleanProperty(ANALYTICS_USE_DUMMY_TOKEN_KEY, false);
     }
 
     public AnalyticsAPIImpl() {
@@ -58,6 +60,10 @@ public class AnalyticsAPIImpl implements AnalyticsAPI {
      */
     @Override
     public AccessToken getAccessToken(final AnalyticsApp analyticsApp) {
+        if (useDummyToken) {
+            return DUMMY_TOKEN;
+        }
+
         return analyticsCache
             .getAccessToken(
                 analyticsApp.getAnalyticsProperties().clientId(),
@@ -290,19 +296,6 @@ public class AnalyticsAPIImpl implements AnalyticsAPI {
     }
 
     /**
-     * Prepares access token request headers in a {@link Map} with values found in a {@link AccessToken} instance.
-     *
-     * @param accessToken access token
-     * @return map representation of http headers
-     */
-    private Map<String, String> analyticsKeyHeaders(final AccessToken accessToken) throws AnalyticsException {
-        return ImmutableMap.<String, String>builder()
-            .put(HttpHeaders.AUTHORIZATION, AnalyticsHelper.get().formatBearer(accessToken))
-            .put(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
-            .build();
-    }
-
-    /**
      * Logs analytics key response from a http interaction.
      *
      * @param response http response
@@ -344,6 +337,19 @@ public class AnalyticsAPIImpl implements AnalyticsAPI {
         logKeyResponse(response, analyticsApp);
 
         return response;
+    }
+
+    /**
+     * Prepares access token request headers in a {@link Map} with values found in a {@link AccessToken} instance.
+     *
+     * @param accessToken access token
+     * @return map representation of http headers
+     */
+    private Map<String, String> analyticsKeyHeaders(final AccessToken accessToken) throws AnalyticsException {
+        return ImmutableMap.<String, String>builder()
+            .put(HttpHeaders.AUTHORIZATION, AnalyticsHelper.get().formatBearer(accessToken))
+            .put(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+            .build();
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
@@ -196,7 +196,7 @@ public class AnalyticsHelper {
      * @param tokenStatus token status
      * @return true if it has a {@link TokenStatus#OK} or {@link TokenStatus#IN_WINDOW}
      */
-    private static boolean canUseToken(final TokenStatus tokenStatus) {
+    private boolean canUseToken(final TokenStatus tokenStatus) {
         return tokenStatus.matchesAny(TokenStatus.OK, TokenStatus.IN_WINDOW);
     }
 
@@ -402,7 +402,7 @@ public class AnalyticsHelper {
      * @param exception provided exception
      * @return missing analytics properties
      */
-    public static String extractMissingAnalyticsProps(final IllegalStateException exception) {
+    public String extractMissingAnalyticsProps(final IllegalStateException exception) {
         final int openBracket = exception.getMessage().indexOf("[");
         final int closeBracket = exception.getMessage().indexOf("]");
 

--- a/dotCMS/src/main/java/com/dotcms/analytics/model/AbstractAccessToken.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/model/AbstractAccessToken.java
@@ -44,6 +44,7 @@ public interface AbstractAccessToken extends Serializable {
     @JsonProperty(value = "refresh_token", access = JsonProperty.Access.WRITE_ONLY)
     String refreshToken();
 
+    @Nullable
     @JsonProperty("scope")
     String scope();
 

--- a/dotCMS/src/main/java/com/dotcms/cube/CubeJSClientFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/cube/CubeJSClientFactory.java
@@ -1,0 +1,28 @@
+package com.dotcms.cube;
+
+import com.dotcms.analytics.app.AnalyticsApp;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.liferay.portal.model.User;
+
+public interface CubeJSClientFactory {
+
+    /**
+     * Creates a {@link CubeJSClient} instance for the given {@link AnalyticsApp}.
+     *
+     * @param analyticsApp analytics app to use to fetch the access token
+     * @return cube js client instance
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    CubeJSClient create(final AnalyticsApp analyticsApp) throws DotDataException, DotSecurityException;
+
+    /**
+     * Creates a {@link CubeJSClient} instance.
+     *
+     * @param user user to use to fetch the access token
+     * @return cube js client instance
+     */
+    CubeJSClient create(final User user) throws DotDataException, DotSecurityException;
+
+}

--- a/dotCMS/src/main/java/com/dotcms/cube/CubeJSClientFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/cube/CubeJSClientFactory.java
@@ -5,6 +5,11 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.liferay.portal.model.User;
 
+/**
+ * Factory to create {@link CubeJSClient} instances.
+ *
+ * @author vico
+ */
 public interface CubeJSClientFactory {
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/cube/CubeJSClientFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/cube/CubeJSClientFactoryImpl.java
@@ -1,0 +1,45 @@
+package com.dotcms.cube;
+
+import com.dotcms.analytics.AnalyticsAPI;
+import com.dotcms.analytics.app.AnalyticsApp;
+import com.dotcms.analytics.helper.AnalyticsHelper;
+import com.dotcms.analytics.model.AccessToken;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.google.common.annotations.VisibleForTesting;
+import com.liferay.portal.model.User;
+
+/**
+ * Factory to create {@link CubeJSClient} instances.
+ *
+ * @author vico
+ */
+public class CubeJSClientFactoryImpl implements CubeJSClientFactory {
+
+    private static AnalyticsHelper analyticsHelper = AnalyticsHelper.get();
+    private final AnalyticsAPI analyticsAPI = APILocator.getAnalyticsAPI();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CubeJSClient create(final AnalyticsApp analyticsApp) throws DotDataException, DotSecurityException {
+        final AccessToken accessToken = analyticsAPI.getAccessToken(analyticsApp);
+        return new CubeJSClient(analyticsApp.getAnalyticsProperties().analyticsReadUrl(), accessToken);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CubeJSClient create(final User user) throws DotDataException, DotSecurityException {
+        return create(analyticsHelper.resolveAnalyticsApp(user));
+    }
+
+    @VisibleForTesting
+    public static void setAnalyticsHelper(final AnalyticsHelper analyticsHelper) {
+        CubeJSClientFactoryImpl.analyticsHelper = analyticsHelper;
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
@@ -209,14 +209,9 @@ public interface ExperimentsAPI {
      *
      * @param experiment
      * @param user
-     * @param analyticsApp
-     * @param accessToken
      * @return
      */
-    List<BrowserSession> getEvents(Experiment experiment,
-                                   User user,
-                                   AnalyticsApp analyticsApp,
-                                   AccessToken accessToken) throws DotDataException;
+    List<BrowserSession> getEvents(Experiment experiment, User user) throws DotDataException, DotSecurityException;
 
     /*
      * Ends finalized {@link com.dotcms.experiments.model.Experiment}s

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
@@ -1,5 +1,7 @@
 package com.dotcms.experiments.business;
 
+import com.dotcms.analytics.app.AnalyticsApp;
+import com.dotcms.analytics.model.AccessToken;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.experiments.business.result.BrowserSession;
@@ -197,7 +199,7 @@ public interface ExperimentsAPI {
      * @param user
      * @return
      */
-    ExperimentResults getResults(final Experiment experiment, User user)
+    ExperimentResults getResults(Experiment experiment, User user)
             throws DotDataException, DotSecurityException;
 
     List<Experiment> cacheRunningExperiments() throws DotDataException;
@@ -207,9 +209,14 @@ public interface ExperimentsAPI {
      *
      * @param experiment
      * @param user
+     * @param analyticsApp
+     * @param accessToken
      * @return
      */
-    List<BrowserSession> getEvents(final Experiment experiment, User user) throws DotDataException;
+    List<BrowserSession> getEvents(Experiment experiment,
+                                   User user,
+                                   AnalyticsApp analyticsApp,
+                                   AccessToken accessToken) throws DotDataException;
 
     /*
      * Ends finalized {@link com.dotcms.experiments.model.Experiment}s

--- a/dotCMS/src/main/java/com/dotcms/jitsu/EventLogRunnable.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/EventLogRunnable.java
@@ -9,7 +9,6 @@ import com.dotcms.http.CircuitBreakerUrl.Method;
 import com.dotcms.http.CircuitBreakerUrl.Response;
 import com.dotcms.http.CircuitBreakerUrlBuilder;
 import com.dotcms.jitsu.EventsPayload.EventPayload;
-import com.dotcms.rest.ResponseEntityView;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.json.JSONObject;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/experiments/ExperimentsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/experiments/ExperimentsResource.java
@@ -1,8 +1,5 @@
 package com.dotcms.rest.api.v1.experiments;
 
-import static com.dotcms.jitsu.EventLogRunnable.POSTING_HEADERS;
-import static com.dotcms.util.CollectionsUtils.map;
-
 import com.dotcms.analytics.app.AnalyticsApp;
 import com.dotcms.analytics.helper.AnalyticsHelper;
 import com.dotcms.experiments.business.ExperimentFilter;
@@ -12,13 +9,7 @@ import com.dotcms.experiments.model.AbstractExperiment.Status;
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.experiments.model.Scheduling;
 import com.dotcms.experiments.model.TargetingCondition;
-import com.dotcms.http.CircuitBreakerUrl;
-import com.dotcms.http.CircuitBreakerUrl.Method;
-import com.dotcms.http.CircuitBreakerUrl.Response;
-import com.dotcms.http.CircuitBreakerUrlBuilder;
 import com.dotcms.jitsu.EventLogRunnable;
-import com.dotcms.jitsu.EventsPayload;
-import com.dotcms.jitsu.EventsPayload.EventPayload;
 import com.dotcms.rest.*;
 import com.dotcms.rest.annotation.NoCache;
 import com.dotcms.rest.exception.NotFoundException;
@@ -29,7 +20,6 @@ import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.UtilMethods;
-import com.dotmarketing.util.json.JSONObject;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
 import com.liferay.portal.model.User;

--- a/dotCMS/src/main/java/com/dotmarketing/business/FactoryLocator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/FactoryLocator.java
@@ -11,6 +11,8 @@ import com.dotcms.contenttype.business.FieldFactory;
 import com.dotcms.contenttype.business.FieldFactoryImpl;
 import com.dotcms.contenttype.business.RelationshipFactory;
 import com.dotcms.contenttype.business.RelationshipFactoryImpl;
+import com.dotcms.cube.CubeJSClientFactory;
+import com.dotcms.cube.CubeJSClientFactoryImpl;
 import com.dotcms.enterprise.DashboardProxy;
 import com.dotcms.enterprise.RulesFactoryProxy;
 import com.dotcms.enterprise.ServerActionFactoryImplProxy;
@@ -262,6 +264,10 @@ public class FactoryLocator extends Locator<FactoryIndex>{
         return (SystemTableFactory) getInstance(FactoryIndex.SYSTEM_TABLE_FACTORY);
     }
 
+    public static CubeJSClientFactory getCubeJSClientFactory() {
+        return (CubeJSClientFactory) getInstance(FactoryIndex.CUBEJS_CLIENT_FACTORY);
+    }
+
     private static Object getInstance(FactoryIndex index) {
 
 		if(instance == null){
@@ -338,7 +344,8 @@ enum FactoryIndex
     FileAsset_Factory,
     VARIANT_FACTORY,
     EXPERIMENTS_FACTORY,
-    SYSTEM_TABLE_FACTORY;
+    SYSTEM_TABLE_FACTORY,
+    CUBEJS_CLIENT_FACTORY;
 
 	Object create() {
 		switch(this) {
@@ -380,6 +387,7 @@ enum FactoryIndex
             case VARIANT_FACTORY:_FACTORY : return new VariantFactoryImpl();
             case EXPERIMENTS_FACTORY: return new ExperimentsFactoryImpl();
             case SYSTEM_TABLE_FACTORY: return new SystemTableFactoryImpl();
+            case CUBEJS_CLIENT_FACTORY: return new CubeJSClientFactoryImpl();
 		}
 		throw new AssertionError("Unknown Factory Index: " + this);
 	}

--- a/dotCMS/src/test/java/com/dotcms/analytics/AnalyticsTestUtils.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/AnalyticsTestUtils.java
@@ -15,12 +15,14 @@ import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.Config;
+import com.liferay.portal.model.User;
 
 import java.time.Instant;
 
 import static com.dotcms.analytics.app.AnalyticsApp.ANALYTICS_APP_CONFIG_URL_KEY;
 import static com.dotcms.analytics.app.AnalyticsApp.ANALYTICS_APP_READ_URL_KEY;
 import static com.dotcms.analytics.app.AnalyticsApp.ANALYTICS_APP_WRITE_URL_KEY;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +96,7 @@ public class AnalyticsTestUtils {
 
         final AnalyticsHelper mockAnalyticsHelper = mock(AnalyticsHelper.class);
         when(mockAnalyticsHelper.appFromHost(currentHost)).thenReturn(mockAnalyticsApp);
+        when(mockAnalyticsHelper.resolveAnalyticsApp(any(User.class))).thenReturn(mockAnalyticsApp);
 
         return mockAnalyticsHelper;
     }

--- a/dotCMS/src/test/java/com/dotcms/analytics/cache/AnalyticsCacheTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/cache/AnalyticsCacheTest.java
@@ -9,6 +9,8 @@ import com.dotmarketing.business.DotStateException;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Instant;
+
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -44,7 +46,8 @@ public class AnalyticsCacheTest extends UnitTestBase {
             null,
             "some-scope",
             "some-token-type",
-            TokenStatus.OK);
+            TokenStatus.OK,
+            Instant.now());
         analyticsCache.putAccessToken(accessToken);
 
         final String clientId = "some-client-id";

--- a/dotCMS/src/test/java/com/dotcms/analytics/helper/AnalyticsHelperTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/helper/AnalyticsHelperTest.java
@@ -436,11 +436,12 @@ public class AnalyticsHelperTest extends UnitTestBase {
         return AnalyticsTestUtils
             .createAccessToken(
                 "a1b2c3d4e5f6",
-                "some-client-i",
+                "some-client-id",
                 "some-audience",
                 "some-scope",
                 "some-token-type",
-                tokenStatus)
+                tokenStatus,
+                null)
             .withExpiresIn(ANALYTICS_ACCESS_TOKEN_TTL);
     }
 

--- a/dotCMS/src/test/java/com/dotcms/cube/CubeJSClientTest.java
+++ b/dotCMS/src/test/java/com/dotcms/cube/CubeJSClientTest.java
@@ -8,20 +8,15 @@ import com.dotcms.analytics.AnalyticsTestUtils;
 import com.dotcms.analytics.model.AccessToken;
 import com.dotcms.analytics.model.TokenStatus;
 import com.dotcms.cube.CubeJSQuery.Builder;
-
-
 import com.dotcms.cube.CubeJSResultSet.ResultSetItem;
 import com.dotcms.http.server.mock.MockHttpServer;
 import com.dotcms.http.server.mock.MockHttpServerContext;
-
 import com.dotcms.util.JsonUtil;
 import com.dotcms.util.network.IPUtils;
 
 import com.liferay.util.StringPool;
 
-
 import java.net.HttpURLConnection;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;

--- a/dotCMS/src/test/java/com/dotcms/cube/CubeJSClientTest.java
+++ b/dotCMS/src/test/java/com/dotcms/cube/CubeJSClientTest.java
@@ -4,6 +4,9 @@ import static com.dotcms.util.CollectionsUtils.list;
 import static com.dotcms.util.CollectionsUtils.map;
 import static org.junit.Assert.assertEquals;
 
+import com.dotcms.analytics.AnalyticsTestUtils;
+import com.dotcms.analytics.model.AccessToken;
+import com.dotcms.analytics.model.TokenStatus;
 import com.dotcms.cube.CubeJSQuery.Builder;
 
 
@@ -19,9 +22,10 @@ import com.liferay.util.StringPool;
 
 import java.net.HttpURLConnection;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import org.junit.Ignore;
+
 import org.junit.Test;
 
 public class CubeJSClientTest {
@@ -79,7 +83,9 @@ public class CubeJSClientTest {
             mockhttpServer.addContext(mockHttpServerContext);
             mockhttpServer.start();
 
-            final CubeJSClient cubeClient =  new CubeJSClient(String.format("http://%s:%s", cubeServerIp, cubeJsServerPort));
+            final CubeJSClient cubeClient =  new CubeJSClient(
+                String.format("http://%s:%s", cubeServerIp, cubeJsServerPort),
+                getAccessToken());
             final CubeJSResultSet cubeJSResultSet = cubeClient.send(cubeJSQuery);
 
             mockhttpServer.validate();
@@ -98,6 +104,17 @@ public class CubeJSClientTest {
             IPUtils.disabledIpPrivateSubnet(false);
             mockhttpServer.stop();
         }
+    }
+
+    private static AccessToken getAccessToken() {
+            return AnalyticsTestUtils.createAccessToken(
+                "a1b2c3d4e5f6",
+                "some-client",
+                null,
+                "some-scope",
+                "some-token-type",
+                TokenStatus.OK,
+                Instant.now());
     }
 
     /**
@@ -122,7 +139,8 @@ public class CubeJSClientTest {
                     .build();
 
             final CubeJSClient cubeClient = new CubeJSClient(
-                    String.format("http://%s:%s", cubeServerIp, cubeJsServerPort));
+                    String.format("http://%s:%s", cubeServerIp, cubeJsServerPort),
+                    getAccessToken());
             final CubeJSResultSet cubeJSResultSet = cubeClient.send(cubeJSQuery);
 
             assertEquals(0, cubeJSResultSet.size());
@@ -155,7 +173,9 @@ public class CubeJSClientTest {
             mockhttpServer.addContext(mockHttpServerContext);
             mockhttpServer.start();
 
-            final CubeJSClient cubeClient =  new CubeJSClient(String.format("http://%s:%s", cubeServerIp, cubeJsServerPort));
+            final CubeJSClient cubeClient =  new CubeJSClient(
+                    String.format("http://%s:%s", cubeServerIp, cubeJsServerPort),
+                    getAccessToken());
 
             try {
                 cubeClient.send(null);


### PR DESCRIPTION
- Change access_token field 'scope' to be optional.
- Adding dummy token concept to make ExperimentAPI and its integratiosn tests to run with a fake (dummy) token to bypass all validations. Unit and integration tests were updated to support this