### PR TITLE
Fixing test

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
@@ -489,7 +489,7 @@ describe('DotEditPageStateControllerSeoComponent', () => {
             expect(dotPageStateService.setSeoMedia).toHaveBeenCalledWith('Google');
         });
 
-        it('should call  changeSeoMedia event', async () => {
+        it('should call selected event', async () => {
             spyOn(dotPageStateService, 'setDevice');
             const dotSelector = de.query(By.css('[data-testId="dot-device-selector"]'));
             const event = {

--- a/core-web/libs/utils-testing/src/lib/dot-page-state.service.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/dot-page-state.service.mock.ts
@@ -32,4 +32,8 @@ export class DotPageStateServiceMock {
     setPersona(_persona: DotPersona): void {
         /* */
     }
+
+    setSeoMedia(_seoMedia: string): void {
+        /* */
+    }
 }


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b827da4</samp>

* Update the page state with the selected seo media from the dot-device-selector component ([link](https://github.com/dotCMS/core/pull/25911/files?diff=unified&w=0#diff-1d2c7b1233cd3e09b6d3a05a5fd4905f512aa0256e44c8eb6316fc0a33a41c60L492-R492), [link](https://github.com/dotCMS/core/pull/25911/files?diff=unified&w=0#diff-a4f241157055888c64529b6b972a704c3c33b3da9738573c0e21ac03ac036856R35-R38))
  - Add a setSeoMedia method to the mock dotPageStateService in `dot-page-state.service.mock.ts` ([link](https://github.com/dotCMS/core/pull/25911/files?diff=unified&w=0#diff-a4f241157055888c64529b6b972a704c3c33b3da9738573c0e21ac03ac036856R35-R38))
  - Emit a `deviceChange` event from the dot-device-selector component in the test of the dot-edit-page-state-controller-seo component in `dot-edit-page-state-controller-seo.component.spec.ts` ([link](https://github.com/dotCMS/core/pull/25911/files?diff=unified&w=0#diff-1d2c7b1233cd3e09b6d3a05a5fd4905f512aa0256e44c8eb6316fc0a33a41c60L492-R492))
  - Expect the setSeoMedia method to be called with the selected device in the test ([link](https://github.com/dotCMS/core/pull/25911/files?diff=unified&w=0#diff-1d2c7b1233cd3e09b6d3a05a5fd4905f512aa0256e44c8eb6316fc0a33a41c60L492-R492))

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
