### PR TITLE
Fix #25918 Styles in template dropdown when creating new pages

### DIFF
--- a/core-web/libs/dotcms-scss/jsp/scss/dijit/_menu.scss
+++ b/core-web/libs/dotcms-scss/jsp/scss/dijit/_menu.scss
@@ -2,6 +2,19 @@
     padding: 0;
     border: 0 none;
 
+    // Template selector in create page form
+    &#templateSel_popup {
+        .dijitMenuItem {
+            height: auto;
+            padding: $spacing-1 $spacing-2;
+            gap: $spacing-0;
+
+            small {
+                color: $color-palette-gray-700;
+            }
+        }
+    }
+
     .dijitMenuItem {
         display: flex;
         padding: 0 $spacing-2;
@@ -47,6 +60,12 @@
     }
 }
 
+// http://localhost:8080/dotAdmin/#/c/maintenance
+// Specific to the maintenance page to prevent double scrollbars
+.dijitComboBoxMenuPopup#widget_cache_list_dropdown {
+    max-height: 17.5rem !important;
+}
+
 .dijitComboBoxMenuPopup {
     background: $white;
     color: $black;
@@ -55,7 +74,6 @@
     box-shadow: $md-shadow-6;
     padding: $spacing-1;
     margin-top: $spacing-1;
-    max-height: 17.5rem !important;
 
     .dijitMenuItem {
         display: flex;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/templates/ajax/TemplateAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/templates/ajax/TemplateAjax.java
@@ -162,7 +162,7 @@ public class TemplateAjax {
 			templateMap.put("hostName", parentHost.getHostname());
 			templateMap.put("hostId", parentHost.getIdentifier());
 			templateMap.put("fullTitle",   templateMap.get("title") + " (" + parentHost.getHostname() + ")" );
-			templateMap.put("htmlTitle",  "<div><div style='float:left'>" + templateMap.get("title") + "</div><div style='float:right'>" + parentHost.getHostname() + "</div></div>" );
+			templateMap.put("htmlTitle",  "<div>" + templateMap.get("title") + "</div><small>" + parentHost.getHostname() + "</div></small>" );
 		} else {
 			templateMap.put("fullTitle", templateMap.get("title"));
 			templateMap.put("htmlTitle", templateMap.get("title"));

--- a/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
+++ b/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
@@ -4974,6 +4974,14 @@
   padding: 0;
   border: 0 none;
 }
+.dijitMenu#templateSel_popup .dijitMenuItem {
+  height: auto;
+  padding: 0.5rem 0.75rem;
+  gap: 0.25rem;
+}
+.dijitMenu#templateSel_popup .dijitMenuItem small {
+  color: #6c7389;
+}
 .dijitMenu .dijitMenuItem {
   display: flex;
   padding: 0 0.75rem;
@@ -5009,6 +5017,10 @@
   border-bottom: 1px solid #d1d4db;
 }
 
+.dijitComboBoxMenuPopup#widget_cache_list_dropdown {
+  max-height: 17.5rem !important;
+}
+
 .dijitComboBoxMenuPopup {
   background: #ffffff;
   color: #14151a;
@@ -5017,7 +5029,6 @@
   box-shadow: 0px 0px 4px rgba(20, 21, 26, 0.04), 0px 8px 16px rgba(20, 21, 26, 0.08);
   padding: 0.5rem;
   margin-top: 0.5rem;
-  max-height: 17.5rem !important;
 }
 .dijitComboBoxMenuPopup .dijitMenuItem {
   display: flex;

--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/view_cms_maintenance.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/view_cms_maintenance.jsp
@@ -1341,7 +1341,7 @@ dd.leftdl {
                 <tr>
                     <td>&nbsp;</td>
                     <td align="right" style="white-space: nowrap;">
-                        <select name="cName" dojoType="dijit.form.ComboBox" autocomplete="true" value="<%= LanguageUtil.get(pageContext,"Flush-All-Caches") %>">
+                        <select id="cache_list" name="cName" dojoType="dijit.form.ComboBox" autocomplete="true" value="<%= LanguageUtil.get(pageContext,"Flush-All-Caches") %>">
                             <option selected="selected" value="all"><%= LanguageUtil.get(pageContext,"Flush-All-Caches") %></option>
                             <% Object[] caches = (Object[])CacheLocator.getCacheIndexes();
                             String[] indexValue = new String[caches.length];


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3dc15d7</samp>

### Summary
🎨🐛💄

<!--
1.  🎨 - This emoji is used for changes that improve the format or structure of the code, such as the first change that modifies the htmlTitle property of the template map. It conveys the idea of improving the appearance or design of the code.
2.  🐛 - This emoji is used for changes that fix bugs or errors in the code, such as the second change that adds an id attribute to the cache list select element. It conveys the idea of resolving a problem or issue in the code.
3.  💄 - This emoji is used for changes that update the UI or style files, such as the third and fourth changes that update the SCSS and CSS files. It conveys the idea of enhancing the look or feel of the UI.
-->
This pull request improves the UI of the template selector and the cache list dropdown in the dotCMS backend, by updating the SCSS styles, the compiled CSS code, and the HTML markup. The changes affect the files `_menu.scss`, `dotcms.css`, `TemplateAjax.java`, and `view_cms_maintenance.jsp`.

> _We are the templars of the web_
> _We wield the `htmlTitle` as our blade_
> _We slay the scrollbars of the cache_
> _We forge the `dotcms.css` in the fire_

### Walkthrough
*  Add and update styles for template selector and cache list dropdown in dotCMS UI ([link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-8ced0168f7b85d239121cce95e116f053fbd2c7c5194d010c428d27e5c4b0d39R5-R17), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-8ced0168f7b85d239121cce95e116f053fbd2c7c5194d010c428d27e5c4b0d39R63-R68), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-8ced0168f7b85d239121cce95e116f053fbd2c7c5194d010c428d27e5c4b0d39L58), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-08d797a1a8ebab0a7a24680f4640b5434967d4e29c17783a873ad53dfefad1cdR4977-R4984), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-08d797a1a8ebab0a7a24680f4640b5434967d4e29c17783a873ad53dfefad1cdR5020-R5023), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-08d797a1a8ebab0a7a24680f4640b5434967d4e29c17783a873ad53dfefad1cdL5020), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-947f255f8aa7e324dca277f689713f725448679e765be5993208aefdc2d2c4d6L1344-R1344))
  * Use SCSS variables and semantic markup for template selector in `create page` form ([link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-8ced0168f7b85d239121cce95e116f053fbd2c7c5194d010c428d27e5c4b0d39R5-R17), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-e4e40138d8e03d5f63818aa90f8451baf8b8cee811b269d409281094587112caL165-R165), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-08d797a1a8ebab0a7a24680f4640b5434967d4e29c17783a873ad53dfefad1cdR4977-R4984))
  * Fix double scrollbars issue for cache list dropdown in `maintenance` page ([link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-8ced0168f7b85d239121cce95e116f053fbd2c7c5194d010c428d27e5c4b0d39R63-R68), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-08d797a1a8ebab0a7a24680f4640b5434967d4e29c17783a873ad53dfefad1cdR5020-R5023), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-947f255f8aa7e324dca277f689713f725448679e765be5993208aefdc2d2c4d6L1344-R1344))
  * Remove redundant max-height style declaration ([link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-8ced0168f7b85d239121cce95e116f053fbd2c7c5194d010c428d27e5c4b0d39L58), [link](https://github.com/dotCMS/core/pull/25922/files?diff=unified&w=0#diff-08d797a1a8ebab0a7a24680f4640b5434967d4e29c17783a873ad53dfefad1cdL5020))



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
