### PR TITLE
Template Builder: Add Host to Container List

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/components/dot-portlet-toolbar/dot-portlet-toolbar.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/components/dot-portlet-toolbar/dot-portlet-toolbar.component.html
@@ -1,12 +1,12 @@
 <p-toolbar>
-    <div class="p-toolbar-group-left" data-testId="leftGroup">
+    <div class="p-toolbar-group-start" data-testId="leftGroup">
         <h3 *ngIf="title" data-testId="title">{{ title }}</h3>
         <div class="dot-portlet-toolbar__extra-left">
             <ng-content select="[left]"></ng-content>
         </div>
     </div>
 
-    <div class="p-toolbar-group-right" data-testId="rightGroup">
+    <div class="p-toolbar-group-end" data-testId="rightGroup">
         <div class="dot-portlet-toolbar__extra-right">
             <ng-content select="[right]"></ng-content>
         </div>

--- a/core-web/libs/dotcms-models/src/lib/shared-models.ts
+++ b/core-web/libs/dotcms-models/src/lib/shared-models.ts
@@ -23,6 +23,11 @@ export const enum FeaturedFlags {
     FEATURE_FLAG_SEO_PAGE_TOOLS = 'FEATURE_FLAG_SEO_PAGE_TOOLS'
 }
 
+export type DotDropdownGroupSelectOption<T> = {
+    label: string;
+    items: DotDropdownSelectOption<T>[];
+};
+
 export type DotDropdownSelectOption<T> = {
     label: string;
     value: T;

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_dropdown.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_dropdown.scss
@@ -20,6 +20,10 @@ p-dropdown.ng-dirty.ng-invalid > .p-dropdown {
     padding-right: 0;
     align-items: center;
 
+    cursor: pointer;
+    -webkit-user-select: none;
+    user-select: none;
+
     &:not(.p-disabled):hover {
         @extend #form-field-hover;
     }
@@ -97,6 +101,7 @@ p-dropdown.p-dropdown-sm {
 
     .p-dropdown-items {
         @extend #field-panel-items;
+
         .p-dropdown-item {
             @extend #field-panel-item;
 
@@ -132,5 +137,15 @@ p-dropdown.p-dropdown-sm {
     &.p-error,
     &.p-invalid {
         border-color: $color-alert-red;
+    }
+}
+
+// Outside the .p-dropdown because it can be appended to the body
+.p-dropdown-items-wrapper {
+    .p-dropdown-item-group {
+        // Section item
+        cursor: default;
+        -webkit-user-select: none;
+        user-select: none;
     }
 }

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_dropdown.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_dropdown.scss
@@ -125,7 +125,7 @@ p-dropdown.p-dropdown-sm {
             padding: $spacing-2;
             color: $black;
             background: $white;
-            font-weight: 400;
+            font-weight: $font-weight-bold;
         }
     }
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
@@ -34,9 +34,10 @@
                 [placeholder]="dropdownLabel"
                 [formControl]="formControl"
                 [autoDisplayFirst]="false"
+                [groupByHost]="true"
                 (onChange)="onContainerSelect($event)"
-                data-testId="btn-plus"
                 dotContainerOptions
+                data-testId="btn-plus"
                 appendTo="body"
                 dropdownIcon="pi pi-plus"
                 optionLabel="label"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
@@ -35,6 +35,7 @@
                 [formControl]="formControl"
                 [autoDisplayFirst]="false"
                 (onChange)="onContainerSelect($event)"
+                scrollHeight="25rem"
                 dotContainerOptions
                 data-testId="btn-plus"
                 appendTo="body"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
@@ -34,7 +34,6 @@
                 [placeholder]="dropdownLabel"
                 [formControl]="formControl"
                 [autoDisplayFirst]="false"
-                [groupByHost]="true"
                 (onChange)="onContainerSelect($event)"
                 dotContainerOptions
                 data-testId="btn-plus"

--- a/core-web/libs/ui/src/lib/dot-container-options/dot-container-options.directive.spec.ts
+++ b/core-web/libs/ui/src/lib/dot-container-options/dot-container-options.directive.spec.ts
@@ -63,51 +63,25 @@ describe('ContainerOptionsDirective', () => {
         ]
     });
 
-    describe('Dropdown list', () => {
-        beforeEach(() => {
-            spectator = createHost(`<dot-containers-dropdown-mock></dot-containers-dropdown-mock>`);
-            spectator.detectChanges();
-            mockMatchMedia();
-        });
-
-        it('should add the options obtained from the service', async () => {
-            const dropdownButton = spectator.query('.p-dropdown');
-            spectator.click(dropdownButton);
-            const options = spectator.debugElement.queryAll(By.css('.p-dropdown-item'));
-            expect(options.length).toEqual(containersMock.length);
-        });
-
-        it('should set the options sorted by naame', () => {
-            const dropdown = spectator.debugElement.query(By.css('p-dropdown'));
-            const dropdownInstance = dropdown.componentInstance;
-
-            expect(dropdownInstance.options).toEqual(sortedContainersMock);
-        });
+    beforeEach(() => {
+        spectator = createHost(`<dot-containers-dropdown-mock></dot-containers-dropdown-mock>`);
+        spectator.detectChanges();
+        mockMatchMedia();
     });
 
-    describe('Dropdown list group by host', () => {
-        beforeEach(() => {
-            spectator = createHost(
-                `<dot-containers-dropdown-mock [groupByHost]="true"></dot-containers-dropdown-mock>`
-            );
-            spectator.detectChanges();
-            mockMatchMedia();
-        });
+    it('should set the group property of the dropdown to true', () => {
+        // get the dropdown component
+        const dropdown = spectator.debugElement.query(By.css('p-dropdown'));
+        // Get the dropdown component instance
+        const dropdownInstance = dropdown.componentInstance;
 
-        it('should set the group property of the dropdown to true', () => {
-            // get the dropdown component
-            const dropdown = spectator.debugElement.query(By.css('p-dropdown'));
-            // Get the dropdown component instance
-            const dropdownInstance = dropdown.componentInstance;
+        expect(dropdownInstance.group).toBeTruthy();
+    });
 
-            expect(dropdownInstance.group).toBeTruthy();
-        });
+    it('should group containers by host', () => {
+        const dropdown = spectator.debugElement.query(By.css('p-dropdown'));
+        const dropdownInstance = dropdown.componentInstance;
 
-        it('should group containers by host', () => {
-            const dropdown = spectator.debugElement.query(By.css('p-dropdown'));
-            const dropdownInstance = dropdown.componentInstance;
-
-            expect(dropdownInstance.options).toEqual(getGroupByHostContainersMock());
-        });
+        expect(dropdownInstance.options).toEqual(getGroupByHostContainersMock());
     });
 });

--- a/core-web/libs/ui/src/lib/dot-container-options/dot-container-options.directive.spec.ts
+++ b/core-web/libs/ui/src/lib/dot-container-options/dot-container-options.directive.spec.ts
@@ -16,6 +16,35 @@ import {
 import { DotContainerOptionsDirective } from './dot-container-options.directive';
 import { MockContainersDropdownComponent } from './mock-containers-dropdown.component';
 
+const sortedContainersMock = containersMock
+    .map((container) => ({
+        label: container.title,
+        value: container,
+        inactive: false
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+function getGroupByHostContainersMock() {
+    const containerobj = sortedContainersMock.reduce((acc, option) => {
+        const { hostname } = option.value.parentPermissionable;
+
+        if (!acc[hostname]) {
+            acc[hostname] = { items: [] };
+        }
+
+        acc[hostname].items.push(option);
+
+        return acc;
+    }, {});
+
+    return Object.keys(containerobj).map((key) => {
+        return {
+            label: key,
+            items: containerobj[key].items
+        };
+    });
+}
+
 describe('ContainerOptionsDirective', () => {
     let spectator: SpectatorHost<MockContainersDropdownComponent>;
 
@@ -34,16 +63,51 @@ describe('ContainerOptionsDirective', () => {
         ]
     });
 
-    beforeEach(() => {
-        spectator = createHost(`<dot-containers-dropdown-mock></dot-containers-dropdown-mock>`);
-        spectator.detectChanges();
-        mockMatchMedia();
+    describe('Dropdown list', () => {
+        beforeEach(() => {
+            spectator = createHost(`<dot-containers-dropdown-mock></dot-containers-dropdown-mock>`);
+            spectator.detectChanges();
+            mockMatchMedia();
+        });
+
+        it('should add the options obtained from the service', async () => {
+            const dropdownButton = spectator.query('.p-dropdown');
+            spectator.click(dropdownButton);
+            const options = spectator.debugElement.queryAll(By.css('.p-dropdown-item'));
+            expect(options.length).toEqual(containersMock.length);
+        });
+
+        it('should set the options sorted by naame', () => {
+            const dropdown = spectator.debugElement.query(By.css('p-dropdown'));
+            const dropdownInstance = dropdown.componentInstance;
+
+            expect(dropdownInstance.options).toEqual(sortedContainersMock);
+        });
     });
 
-    it('should add the options obtained from the service', async () => {
-        const dropdownButton = spectator.query('.p-dropdown');
-        spectator.click(dropdownButton);
-        const options = spectator.debugElement.queryAll(By.css('.p-dropdown-item'));
-        expect(options.length).toEqual(containersMock.length);
+    describe('Dropdown list group by host', () => {
+        beforeEach(() => {
+            spectator = createHost(
+                `<dot-containers-dropdown-mock [groupByHost]="true"></dot-containers-dropdown-mock>`
+            );
+            spectator.detectChanges();
+            mockMatchMedia();
+        });
+
+        it('should set the group property of the dropdown to true', () => {
+            // get the dropdown component
+            const dropdown = spectator.debugElement.query(By.css('p-dropdown'));
+            // Get the dropdown component instance
+            const dropdownInstance = dropdown.componentInstance;
+
+            expect(dropdownInstance.group).toBeTruthy();
+        });
+
+        it('should group containers by host', () => {
+            const dropdown = spectator.debugElement.query(By.css('p-dropdown'));
+            const dropdownInstance = dropdown.componentInstance;
+
+            expect(dropdownInstance.options).toEqual(getGroupByHostContainersMock());
+        });
     });
 });

--- a/core-web/libs/ui/src/lib/dot-container-options/dot-container-options.directive.ts
+++ b/core-web/libs/ui/src/lib/dot-container-options/dot-container-options.directive.ts
@@ -54,7 +54,6 @@ export class DotContainerOptionsDirective implements OnInit, OnDestroy {
         );
 
         if (this.control) {
-            this.control.group = this.groupByHost;
             this.control.optionLabel = DEFAULT_LABEL_NAME_INDEX;
             this.control.optionValue = DEFAULT_VALUE_NAME_INDEX;
             this.control.optionDisabled = 'inactive';
@@ -95,7 +94,7 @@ export class DotContainerOptionsDirective implements OnInit, OnDestroy {
                     }))
                     .sort((a, b) => a.label.localeCompare(b.label));
             }),
-            map((options) => (this.groupByHost ? this.getGroupedOptionsByHost(options) : options)),
+            map((options) => (this.groupByHost ? this.getOptionsGroupedByHost(options) : options)),
             catchError(() => {
                 return this.handleContainersLoadError();
             })
@@ -125,9 +124,31 @@ export class DotContainerOptionsDirective implements OnInit, OnDestroy {
      * @return {*}
      * @memberof DotContainerOptionsDirective
      */
-    private getGroupedOptionsByHost(options: DotDropdownSelectOption<DotContainer>[]) {
-        // Group by host
-        const group = options.reduce((acc, option) => {
+    private getOptionsGroupedByHost(options: DotDropdownSelectOption<DotContainer>[]) {
+        const groupByHost = this.getContainerGroupedByHost(options);
+
+        return Object.keys(groupByHost).map((key) => {
+            return {
+                label: key,
+                items: groupByHost[key].items
+            };
+        });
+    }
+
+    /**
+     * Group containers by host
+     *
+     * @private
+     * @param {DotDropdownSelectOption<DotContainer>[]} options
+     * @return {*}  {{
+     *         [key: string]: { items: DotDropdownSelectOption<DotContainer>[] };
+     *     }}
+     * @memberof DotContainerOptionsDirective
+     */
+    private getContainerGroupedByHost(options: DotDropdownSelectOption<DotContainer>[]): {
+        [key: string]: { items: DotDropdownSelectOption<DotContainer>[] };
+    } {
+        return options.reduce((acc, option) => {
             const { hostname } = option.value.parentPermissionable;
 
             if (!acc[hostname]) {
@@ -138,14 +159,6 @@ export class DotContainerOptionsDirective implements OnInit, OnDestroy {
 
             return acc;
         }, {});
-
-        // Convert to array
-        return Object.keys(group).map((key) => {
-            return {
-                label: key,
-                items: group[key].items
-            };
-        });
     }
 
     ngOnDestroy() {

--- a/core-web/libs/ui/src/lib/dot-container-options/mock-containers-dropdown.component.ts
+++ b/core-web/libs/ui/src/lib/dot-container-options/mock-containers-dropdown.component.ts
@@ -1,7 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
     selector: 'dot-containers-dropdown-mock',
-    template: ` <p-dropdown dotContainerOptions></p-dropdown>`
+    template: ` <p-dropdown [groupByHost]="groupByHost" dotContainerOptions></p-dropdown>`
 })
-export class MockContainersDropdownComponent {}
+export class MockContainersDropdownComponent {
+    @Input() groupByHost = false;
+}

--- a/core-web/libs/ui/src/lib/dot-container-options/mock-containers-dropdown.component.ts
+++ b/core-web/libs/ui/src/lib/dot-container-options/mock-containers-dropdown.component.ts
@@ -1,9 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
     selector: 'dot-containers-dropdown-mock',
-    template: ` <p-dropdown [groupByHost]="groupByHost" dotContainerOptions></p-dropdown>`
+    template: ` <p-dropdown dotContainerOptions></p-dropdown>`
 })
-export class MockContainersDropdownComponent {
-    @Input() groupByHost = false;
-}
+export class MockContainersDropdownComponent {}

--- a/core-web/libs/utils-testing/src/lib/dot-containers.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/dot-containers.mock.ts
@@ -152,12 +152,14 @@ export const containersMockArray = [
     }
 ];
 
-export const containersMock: DotContainer[] = containersMockArray.map(({ name, identifier }) => ({
-    friendlyName: name,
-    title: name,
-    parentPermissionable: { hostname: '' },
-    identifier: identifier
-}));
+export const containersMock: DotContainer[] = containersMockArray.map(
+    ({ name, identifier, parentPermissionable }) => ({
+        friendlyName: name,
+        title: name,
+        parentPermissionable: { hostname: parentPermissionable.hostname },
+        identifier: identifier
+    })
+);
 
 export const containersMapMock: DotContainerMap = containersMock.reduce(
     (prev: DotContainerMap, curr) => ({ ...prev, [curr.identifier as string]: curr }),


### PR DESCRIPTION
### Proposed Changes
* Sorted by name and Group container by Host.

### Checklist
- [x] Tests

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e462af5</samp>

This pull request adds a new feature to the `dot-container-options` directive, which allows to group the container options by host in the dropdown component. It also adds tests, types, styles, and input properties to support this feature. It modifies the `template-builder-box` and `mock-containers-dropdown` components, and the `dot-containers.mock.ts` file, to use the new feature.

## Related Issue
Fixes #25916

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e462af5</samp>

*  Add a new input property to enable or disable the grouping of containers by host in the dropdown directive ([link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-bad3f14381a1639d24dc3958319e2ffaf13ad3342ea3276184e86b7fbd4c3e09L37-R40), [link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-b32200efd377e3c51baa64ecb0452858df24b0d88732453784562ef102f6aa17R43-R44), [link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-b32200efd377e3c51baa64ecb0452858df24b0d88732453784562ef102f6aa17R57), [link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-b32200efd377e3c51baa64ecb0452858df24b0d88732453784562ef102f6aa17R71), [link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-eb789714eb172a91093d33b8b1cdd9506f15003a726687a7fc6b2d28dd39522bL1-R9))
*  Add a new type definition for a grouped dropdown option with a label and a list of items ([link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-3f0ed89ee1cbcb925153f86b2a576abd34e5a4e0639c55669b3a1f5d205ac5afR26-R30), [link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-b32200efd377e3c51baa64ecb0452858df24b0d88732453784562ef102f6aa17L3-R22))
*  Modify the fetchContainerOptions method to return either a list of grouped options or a list of simple options, depending on the input property ([link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-b32200efd377e3c51baa64ecb0452858df24b0d88732453784562ef102f6aa17L69-R98))
*  Add a new private method, getGroupedOptionsByHost, to create a list of grouped options by host from a list of simple options, using the parentPermissionable property of the containers ([link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-b32200efd377e3c51baa64ecb0452858df24b0d88732453784562ef102f6aa17L91-R150), [link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-0ecfe3a372abab271a48300d070f7041c306166baadb86c59b1565f19ee53697L155-R162))
*  Modify the setOptions method to accept either a list of grouped options or a list of simple options, depending on the input property ([link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-b32200efd377e3c51baa64ecb0452858df24b0d88732453784562ef102f6aa17L91-R150))
*  Modify the font-weight of the dropdown items to be bold ([link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-0d55b1af3ab4da757a4d1c24e15c7e0109bbc67296646665355e2aac69517c33L128-R128))
*  Add a new function to create a mock list of grouped containers by host for testing ([link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-0f3a55c347d2d648ae8e67f13e99d88f53060db99ea643bf24fe06c97be07825R19-R47))
*  Add two new test suites to test the dropdown list with and without grouping by host, checking the options are correctly added, sorted and grouped ([link](https://github.com/dotCMS/core/pull/25923/files?diff=unified&w=0#diff-0f3a55c347d2d648ae8e67f13e99d88f53060db99ea643bf24fe06c97be07825L37-R111))

### Screenshots

https://github.com/dotCMS/core/assets/72418962/b5ef5831-9c5d-4293-8c85-e0b6ea9a43a5

### dot portlet toolbar Screenshots

<img width="1020" alt="issue-25916-template-builder-add-host-to-container-list-dot-portlet-toolbar" src="https://github.com/dotCMS/core/assets/72418962/c61e9ab1-3822-44b9-b16d-c5a1f63970d0">


