### PR TITLE
Fix #25916: Template Builder Box dropdown had too much scroll height

### DIFF
--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
@@ -35,7 +35,7 @@
                 [formControl]="formControl"
                 [autoDisplayFirst]="false"
                 (onChange)="onContainerSelect($event)"
-                scrollHeight="25rem"
+                scrollHeight="18.75rem"
                 dotContainerOptions
                 data-testId="btn-plus"
                 appendTo="body"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6907016</samp>

### Summary
🐛🎨🔧

<!--
1.  🐛 - This emoji represents a bug fix, since the original dropdown height was causing a UI issue that needed to be resolved.
2.  🎨 - This emoji represents a UI improvement, since the new dropdown height is more aesthetically pleasing and consistent with the rest of the template builder UI.
3.  🔧 - This emoji represents a configuration change, since the dropdown height is a CSS property that can be adjusted according to the design specifications.
-->
Reduced the height of the autocomplete dropdown in the template builder box component. This improved the UI layout and avoided overlapping with the footer.

> _`scrollHeight` shrinks_
> _dropdown no longer covers_
> _autumn's template box_

### Walkthrough
* Reduced the `scrollHeight` attribute of the `dot-autocomplete-dropdown` component to fix a UI issue where the dropdown was overlapping the footer of the template builder box ([link](https://github.com/dotCMS/core/pull/25932/files?diff=unified&w=0#diff-bad3f14381a1639d24dc3958319e2ffaf13ad3342ea3276184e86b7fbd4c3e09L38-R38))



### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
<img width="1512" alt="Screenshot 2023-08-29 at 1 37 01 PM" src="https://github.com/dotCMS/core/assets/63567962/3292a6d3-c75b-435d-b219-4fee2885e513">  |  <img width="1512" alt="Screenshot 2023-08-29 at 1 48 03 PM" src="https://github.com/dotCMS/core/assets/63567962/1cb64dd4-b14f-4440-a2e0-1f403b9038a6">

