### PR TITLE
[Issue-25815]: preview screen not using correct width height when rendering

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
@@ -58,18 +58,18 @@
                 class="dot-edit__page-wrapper"
                 [class.dot-edit__page-wrapper--deviced]="pageState.viewAs.device"
             >
-                <div
-                    class="dot-edit__device-wrapper"
-                    [ngStyle]="{
-                        width: pageState.viewAs.device
-                            ? pageState.viewAs.device.cssWidth + 'px'
-                            : '100%',
-                        height: pageState.viewAs.device
-                            ? pageState.viewAs.device.cssHeight + 'px'
-                            : '100%'
-                    }"
-                >
-                    <div class="dot-edit__iframe-wrapper">
+                <div class="dot-edit__device-wrapper">
+                    <div
+                        class="dot-edit__iframe-wrapper"
+                        [ngStyle]="{
+                            width: pageState.viewAs.device
+                                ? pageState.viewAs.device.cssWidth + 'px'
+                                : '100%',
+                            height: pageState.viewAs.device
+                                ? pageState.viewAs.device.cssHeight + 'px'
+                                : '100%'
+                        }"
+                    >
                         <dot-overlay-mask
                             *ngIf="showOverlay"
                             (click)="iframeOverlayService.hide()"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.scss
@@ -53,7 +53,6 @@ dot-whats-changed,
     display: flex;
     flex-direction: column;
     border: solid 1px $color-palette-gray-300;
-    width: 100%;
     height: 100%;
 
     .dot-edit__page-wrapper--deviced & {
@@ -66,7 +65,8 @@ dot-whats-changed,
         filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#f0f0f0', GradientType=1);
         margin: 0 auto;
         padding: 0 10px;
-        width: min-content;
+        width: fit-content;
+        height: fit-content;
         &:before {
             content: "";
             display: block;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.scss
@@ -53,6 +53,8 @@ dot-whats-changed,
     display: flex;
     flex-direction: column;
     border: solid 1px $color-palette-gray-300;
+    width: 100%;
+    height: 100%;
 
     .dot-edit__page-wrapper--deviced & {
         flex-grow: 0;
@@ -64,7 +66,7 @@ dot-whats-changed,
         filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#f0f0f0', GradientType=1);
         margin: 0 auto;
         padding: 0 10px;
-
+        width: min-content;
         &:before {
             content: "";
             display: block;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.spec.ts
@@ -657,7 +657,7 @@ describe('DotEditContentComponent', () => {
 
                 it('should add inline styles to device wrapper', (done) => {
                     setTimeout(() => {
-                        const deviceWraper = de.query(By.css('.dot-edit__device-wrapper'));
+                        const deviceWraper = de.query(By.css('.dot-edit__iframe-wrapper'));
                         expect(deviceWraper.styles.cssText).toEqual('width: 100px; height: 100px;');
                         done();
                     }, 100);


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 73e4ad5</samp>

### Summary
:recycle::test_tube::art:

<!--
1.  :recycle: - This emoji represents the removal of the redundant `ngStyle` directive and the simplification of the HTML template. It conveys the idea of recycling or reusing code and avoiding duplication or waste.
2. :test_tube: - This emoji represents the update of the unit test to match the HTML template change. It conveys the idea of testing or experimenting with code and ensuring its quality and functionality.
3. :art: - This emoji represents the adjustment of the CSS styles of the page wrapper and device wrapper elements. It conveys the idea of art or design and improving the appearance and usability of the page editing and previewing features.
-->
This pull request refactors the dot-edit-content component to improve the layout and responsiveness of the page editing and previewing features. It adjusts the CSS styles of the page wrapper and device wrapper elements, removes a redundant `ngStyle` directive from the HTML template, and updates the unit test accordingly.

> _We're the dot-edit-content crew, we know just what to do_
> _We tidy up the HTML and make the CSS shine through_
> _We heave away the `ngStyle` from the device wrapper div_
> _And haul it to the iframe one, that's how we like to live_

### Walkthrough
*  Simplify the HTML template by removing the `ngStyle` directive from the `dot-edit__device-wrapper` div and moving it to the `dot-edit__iframe-wrapper` div ([link](https://github.com/dotCMS/core/pull/25952/files?diff=unified&w=0#diff-bdd3ad691984c6a98ed8584d09c67080428ce8738627187e6ab67504d175529fL61-R72))
*  Adjust the SCSS styles to make the page wrapper fill the viewport height and the device wrapper fit the iframe size ([link](https://github.com/dotCMS/core/pull/25952/files?diff=unified&w=0#diff-779cfc863bc71116eaa865ff0725efe8bd4e9bf75d928b51a454a2b365c779a2R56), [link](https://github.com/dotCMS/core/pull/25952/files?diff=unified&w=0#diff-779cfc863bc71116eaa865ff0725efe8bd4e9bf75d928b51a454a2b365c779a2L67-R69))
*  Update the unit test to use the correct selector and verify the inline styles on the `dot-edit__iframe-wrapper` element ([link](https://github.com/dotCMS/core/pull/25952/files?diff=unified&w=0#diff-3e82153bca982f66944a357c7f1cdd674d9366955812bb465b1fc8198f367613L660-R660))


### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
![image](https://github.com/dotCMS/core/assets/3438705/f3b66d33-f1e9-4a89-8e67-e0073b524818)
