### PR TITLE
Add Persona Form File Upload Failed

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/shared/models/dot-file-upload/dot-file-upload.model.ts
+++ b/core-web/apps/dotcms-ui/src/app/shared/models/dot-file-upload/dot-file-upload.model.ts
@@ -1,9 +1,18 @@
+import { HttpResponse } from '@angular/common/http';
+
+import { DotCMSTempFile } from '@dotcms/dotcms-models';
+
 /**
  * Interface used for the response of FileUpload of primeng
+ * https://primeng.org/fileupload/#api.fileupload.events.FileUploadEvent
  *
  * @interface
  */
 export interface DotFileUpload {
+    originalEvent: HttpResponse<DotFileUploadEvent>;
     files: File[];
-    xhr: XMLHttpRequest;
+}
+
+export interface DotFileUploadEvent {
+    tempFiles: File[] | DotCMSTempFile[];
 }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.spec.ts
@@ -41,7 +41,7 @@ export const mockDotCMSTempFile = {
 
 const mockFileUploadResponse = {
     files: [{ name: 'fileName.png' }],
-    xhr: { response: `{ "tempFiles": [${JSON.stringify(mockDotCMSTempFile)}]}` }
+    originalEvent: { body: { tempFiles: [mockDotCMSTempFile] } }
 };
 
 describe('DotCreatePersonaFormComponent', () => {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-add-persona-dialog/dot-create-persona-form/dot-create-persona-form.component.ts
@@ -42,8 +42,8 @@ export class DotCreatePersonaFormComponent implements OnInit, OnDestroy {
      * @memberof DotCreatePersonaFormComponent
      */
     onFileUpload(event: DotFileUpload) {
-        const response = JSON.parse(event.xhr.response);
-        this.tempUploadedFile = response.tempFiles[0];
+        const body = event.originalEvent.body;
+        this.tempUploadedFile = body.tempFiles[0] as DotCMSTempFile;
         this.form.get('photo').setValue(this.tempUploadedFile.id);
     }
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selected-item/dot-persona-selected-item.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selected-item/dot-persona-selected-item.component.html
@@ -4,18 +4,15 @@
     [tooltipPosition]="disabled ? 'bottom' : null"
 >
     <p-avatar
-        *ngIf="persona?.personalized"
-        [text]="persona?.name || ('modes.persona.no.persona' | dm)"
+        *ngIf="persona"
+        [text]="persona?.name"
         [image]="persona?.photo"
+        [badgeDisabled]="!persona?.personalized"
         pBadge
         dotAvatar
     ></p-avatar>
-    <p-avatar
-        *ngIf="!persona?.personalized"
-        [text]="persona?.name || ('modes.persona.no.persona' | dm)"
-        [image]="persona?.photo"
-        dotAvatar
-    ></p-avatar>
+
+    <p-avatar *ngIf="!persona" [text]="'modes.persona.no.persona' | dm" dotAvatar></p-avatar>
 
     <span class="dot-persona-selector__name">{{
         persona?.name || ('modes.persona.no.persona' | dm)


### PR DESCRIPTION
### Proposed Changes
* Fix the upload file field on the add persona form.

### Checklist
- [x] Tests

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d034751</samp>

Updated the file upload feature to use the primeng FileUploadEvent interface and a new DotFileUpload interface. This improved the type safety and readability of the code and the test data.

## Related Issue
Fixes #25810

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d034751</samp>

*  Update `DotFileUpload` interface and add `DotFileUploadEvent` interface to match primeng FileUploadEvent interface ([link](https://github.com/dotCMS/core/pull/25956/files?diff=unified&w=0#diff-4ee4ce34dbb200111e2b53e1060d693fc7c88205351ccefc0fa00b3b49d91909L1-R18))
*  Remove `xhr` property and JSON parsing from file upload logic and tests, and use `originalEvent` property instead ([link](https://github.com/dotCMS/core/pull/25956/files?diff=unified&w=0#diff-e818d57554628dfeb2352aa90de1676eaf03fb32f476e2ae6a6726a86b3b09deL44-R44), [link](https://github.com/dotCMS/core/pull/25956/files?diff=unified&w=0#diff-b585d526987a93376aa59aaf9d8a91ee577d3329680d477a46aea0378ed89eadL45-R46))
*  Cast `tempUploadedFile` to `DotCMSTempFile` to access `folder` and `id` properties in `dot-create-persona-form.component.ts` ([link](https://github.com/dotCMS/core/pull/25956/files?diff=unified&w=0#diff-b585d526987a93376aa59aaf9d8a91ee577d3329680d477a46aea0378ed89eadL45-R46))

### Screenshots

#### Original

https://github.com/dotCMS/core/assets/72418962/2ffc7672-6cbe-4c01-b1b7-7ffc50acaf73


#### Updated


https://github.com/dotCMS/core/assets/72418962/9233ad11-b36f-49a4-87c6-c45330f641b0

