### PR TITLE
22706 cli testcontainers configuration improvements

### DIFF
--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -19,6 +19,44 @@ jobs:
       - id: checkout-core
         name: Checkout core
         uses: actions/checkout@v3
+
+      -
+        id: meta
+        name: Docker meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            dotcms/dotcms
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha,enable=true,priority=100,prefix=master_,suffix=_SNAPSHOT,format=short
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: false
+          context: docker/dotcms
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          pull: true
+          no-cache: true
+          build-args: |
+            BUILD_ID=${{ github.sha }}
+            BUILD_FROM=COMMIT 
+
       - id: prepare-license
         name: Prepare license
         working-directory: ./tools/dotcms-cli/

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -49,8 +49,9 @@ jobs:
           ./mvnw clean verify -Dtest.failure.ignore=true
           
           FAILURES=$(find . -name TEST-*.xml | xargs grep '<failure' | wc -l)
+          ERRORS=$(find . -name TEST-*.xml | xargs grep '<error' | wc -l)
           
-          if [ $FAILURES -eq 0 ]; then
+          if [[ $FAILURES -gt 0 || $ERRORS -gt 0 ]]; then
               OUTPUT_STATUS="PASSED"
           else
               OUTPUT_STATUS="FAILED"

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -8,13 +8,33 @@ on:
       docker_build_push:
         description: 'Docker build push'
         default: 'false'
-  pull_request:
-    paths:
-      - 'tools/dotcms-cli/**'
   push:
     branches:
       - master
       - release-*
+    paths-ignore:
+      - '.gitignore'
+      - '.dockerignore'
+      - 'dotCMS/src/main/webapp/html'
+      - '!docker/**'
+      - 'cicd/**'
+      - '.cicd/**'
+      - '*.md'
+      - '*.adoc'
+      - '*.txt'
+      - '.github/ISSUE_TEMPLATE/**'
+  pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - '.dockerignore'
+      - 'dotCMS/src/main/webapp/html'
+      - '!docker/**'
+      - 'cicd/**'
+      - '.cicd/**'
+      - '*.md'
+      - '*.adoc'
+      - '*.txt'
+      - '.github/ISSUE_TEMPLATE/**'
 jobs:
   cli_tests:
     name: CLI tests

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -53,7 +53,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           pull: true
           no-cache: true
-
+          build-args: |
+            BUILD_ID=${{ github.head_ref }}
+            BUILD_FROM=COMMIT 
+            
       - id: prepare-license
         name: Prepare license
         working-directory: ./tools/dotcms-cli/

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -97,7 +97,7 @@ jobs:
           
           echo "status=$OUTPUT_STATUS" >> $GITHUB_OUTPUT
           
-          ./mvnw surefire-report:report-only surefire-report:failsafe-report-only  
+          ./mvnw surefire-report:failsafe-report-only  
                
           DOT_CLI_PATH=${{ github.workspace }}/tools/dotcms-cli
           RESULTS_PATH=${DOT_CLI_PATH}/target/test-results
@@ -115,15 +115,12 @@ jobs:
           for module in $MODULES
           do
             mkdir -p ${XML_REPORTS_PATH}/${module}
-            cp -r ${module}/target/surefire-reports ${XML_REPORTS_PATH}/${module}
             cp -r ${module}/target/failsafe-reports ${XML_REPORTS_PATH}/${module}
             mkdir -p ${HTML_REPORTS_PATH}/${module}
             cp -r ${module}/target/site/* ${HTML_REPORTS_PATH}/${module}
+          
+            echo "<tr><td>${module}</td><td><a href=\"${module}/failsafe-report.html\">failsafe report</a></td></tr>" >> ${INDEX_FILE}
             
-            for report in surefire failsafe
-            do
-              echo "<tr><td>${module}</td><td><a href=\"${module}/${report}-report.html\">${report} report</a></td></tr>" >> ${INDEX_FILE}
-            done
           done
           
           cat ${CICD_RES_PATH}/cli/cli-results-footer.html >> ${INDEX_FILE}

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -1,5 +1,13 @@
 name: CLI tests
 on:
+  workflow_dispatch:
+    inputs:
+      docker_build_cache:
+        description: 'Docker build cache'
+        default: 'false'
+      docker_build_push:
+        description: 'Docker build push'
+        default: 'false'
   pull_request:
     paths:
       - 'tools/dotcms-cli/**'
@@ -47,12 +55,12 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v4
         with:
-          push: false
+          push: ${{ github.event.inputs.docker_build_push || 'false' }}
           context: docker/dotcms
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           pull: true
-          no-cache: true
+          no-cache: ${{ github.event.inputs.docker_build_cache || 'false' }}
           build-args: |
             BUILD_ID=${{ github.head_ref }}
             BUILD_FROM=COMMIT 

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -89,7 +89,7 @@ jobs:
           FAILURES=$(find . -name TEST-*.xml | xargs grep '<failure' | wc -l)
           ERRORS=$(find . -name TEST-*.xml | xargs grep '<error' | wc -l)
           
-          if [[ $FAILURES -gt 0 || $ERRORS -gt 0 ]]; then
+          if [[ $FAILURES -eq 0 && $ERRORS -eq 0 ]]; then
               OUTPUT_STATUS="PASSED"
           else
               OUTPUT_STATUS="FAILED"

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -53,9 +53,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           pull: true
           no-cache: true
-          build-args: |
-            BUILD_ID=${{ github.sha }}
-            BUILD_FROM=COMMIT 
 
       - id: prepare-license
         name: Prepare license

--- a/tools/dotcms-cli/api-data-model/pom.xml
+++ b/tools/dotcms-cli/api-data-model/pom.xml
@@ -21,10 +21,8 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>2.9.1.Final</quarkus.platform.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <testcontainers.version>1.17.6</testcontainers.version>
-        <skip.surefire.tests>false</skip.surefire.tests>
-        <skip.failsafe.tests>false</skip.failsafe.tests>
+        <failsafe-plugin.version>3.0.0-M5</failsafe-plugin.version>
         <test.failure.ignore>false</test.failure.ignore>
         <maven.plugin.jar.version>3.3.0</maven.plugin.jar.version>
     </properties>
@@ -148,29 +146,13 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
-                <configuration>
-                    <testFailureIgnore>${test.failure.ignore}</testFailureIgnore>
-                    <skipTests>${skip.surefire.tests}</skipTests>
-                    <excludes>
-                        <exclude>**/*IntegrationTest.java</exclude>
-                    </excludes>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <maven.home>${maven.home}</maven.home>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
+                <version>${failsafe-plugin.version}</version>
                 <configuration>
                     <testFailureIgnore>${test.failure.ignore}</testFailureIgnore>
-                    <skipTests>${skip.failsafe.tests}</skipTests>
                     <includes>
-                        <include>**/*IntegrationTest.java</include>
+                        <include>**/*Test.java</include>
                     </includes>
                 </configuration>
                 <executions>
@@ -216,7 +198,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${surefire-plugin.version}</version>
+                        <version>${failsafe-plugin.version}</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/tools/dotcms-cli/api-data-model/pom.xml
+++ b/tools/dotcms-cli/api-data-model/pom.xml
@@ -153,6 +153,9 @@
                 <configuration>
                     <testFailureIgnore>${test.failure.ignore}</testFailureIgnore>
                     <skipTests>${skip.surefire.tests}</skipTests>
+                    <excludes>
+                        <exclude>**/*IntegrationTest.java</exclude>
+                    </excludes>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>

--- a/tools/dotcms-cli/cli/pom.xml
+++ b/tools/dotcms-cli/cli/pom.xml
@@ -21,10 +21,8 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>2.9.1.Final</quarkus.platform.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <testcontainers.version>1.17.6</testcontainers.version>
-        <skip.surefire.tests>false</skip.surefire.tests>
-        <skip.failsafe.tests>false</skip.failsafe.tests>
+        <failsafe-plugin.version>3.0.0-M5</failsafe-plugin.version>
         <test.failure.ignore>false</test.failure.ignore>
     </properties>
     <dependencyManagement>
@@ -134,29 +132,13 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
-                <configuration>
-                    <testFailureIgnore>${test.failure.ignore}</testFailureIgnore>
-                    <skipTests>${skip.surefire.tests}</skipTests>
-                    <excludes>
-                        <exclude>**/*IntegrationTest.java</exclude>
-                    </excludes>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <maven.home>${maven.home}</maven.home>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
+                <version>${failsafe-plugin.version}</version>
                 <configuration>
                     <testFailureIgnore>${test.failure.ignore}</testFailureIgnore>
-                    <skipTests>${skip.failsafe.tests}</skipTests>
                     <includes>
-                        <include>**/*IntegrationTest.java</include>
+                        <include>**/*Test.java</include>
                     </includes>
                 </configuration>
                 <executions>

--- a/tools/dotcms-cli/cli/pom.xml
+++ b/tools/dotcms-cli/cli/pom.xml
@@ -139,6 +139,9 @@
                 <configuration>
                     <testFailureIgnore>${test.failure.ignore}</testFailureIgnore>
                     <skipTests>${skip.surefire.tests}</skipTests>
+                    <excludes>
+                        <exclude>**/*IntegrationTest.java</exclude>
+                    </excludes>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>

--- a/tools/dotcms-cli/pom.xml
+++ b/tools/dotcms-cli/pom.xml
@@ -19,7 +19,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.9.1.Final</quarkus.platform.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <failsafe-plugin.version>3.0.0-M5</failsafe-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -43,7 +43,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${surefire-plugin.version}</version>
+          <version>${failsafe-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
### Proposed Changes
* Building CORE docker image for current commit before running cli testcontainers tests.
* Fixing cli tests reporting status (error cases).
* Excluding integration tests of surefire plugin.

### Fixes
#22706 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79feafa</samp>

This pull request improves the GitHub workflow for building and testing the dotcms image and skips the integration tests in the `api-data-model` and `cli` modules to reduce the build time.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 79feafa</samp>

*  Add steps to build and push multi-platform Docker image based on commit sha ([link](https://github.com/dotCMS/core/pull/25963/files?diff=unified&w=0#diff-8d1d6a5b6e3ac11e5bae87e4a0670bf96a060d80ad414701b7e8b025a3b96a8eR22-R59))
*  Modify test job to count and fail on errors in test results ([link](https://github.com/dotCMS/core/pull/25963/files?diff=unified&w=0#diff-8d1d6a5b6e3ac11e5bae87e4a0670bf96a060d80ad414701b7e8b025a3b96a8eL52-R92))
*  Exclude integration tests from `api-data-model` and `cli` modules to speed up build process ([link](https://github.com/dotCMS/core/pull/25963/files?diff=unified&w=0#diff-5dfff11042c513b18898055e9b67ae650016aaaf2a1645804ba3323401ad48ebR156-R158), [link](https://github.com/dotCMS/core/pull/25963/files?diff=unified&w=0#diff-73a27979af1cf948c5e900d405672ffdfa8373a0fbc85aa73e2c256356a2c65cR142-R144))
