### PR TITLE
dotCMS/core#25645 [UI] Require confirmation when clicking Edit tab while Experiment is running 

### DIFF
--- a/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.spec.ts
+++ b/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.spec.ts
@@ -56,13 +56,13 @@ describe('DotTabButtonsComponent', () => {
 
     it('should emit clickOption event when onClickOption is called with a PREVIEW value', () => {
         const clickOptionSpy = spyOn(spectator.component.clickOption, 'emit');
+        spectator.component.mode = DotPageMode.EDIT;
         spectator.component.onClickOption({ target: { value: DotPageMode.PREVIEW } });
         expect(clickOptionSpy).toHaveBeenCalled();
     });
 
     it('should not emit clickOption event when onClickOption is called if the user is in the same tab', () => {
         const clickOptionSpy = spyOn(spectator.component.clickOption, 'emit');
-        spectator.component.mode = DotPageMode.PREVIEW;
         spectator.component.onClickOption({ target: { value: DotPageMode.PREVIEW } });
         expect(clickOptionSpy).not.toHaveBeenCalled();
     });

--- a/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.spec.ts
+++ b/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.spec.ts
@@ -60,6 +60,13 @@ describe('DotTabButtonsComponent', () => {
         expect(clickOptionSpy).toHaveBeenCalled();
     });
 
+    it('should not emit clickOption event when onClickOption is called if the user is in the same tab', () => {
+        const clickOptionSpy = spyOn(spectator.component.clickOption, 'emit');
+        spectator.component.mode = DotPageMode.PREVIEW;
+        spectator.component.onClickOption({ target: { value: DotPageMode.PREVIEW } });
+        expect(clickOptionSpy).not.toHaveBeenCalled();
+    });
+
     it('should call showMenu when onClickOption is called with OPEN_MENU value', () => {
         const showMenuSpy = spyOn(spectator.component, 'showMenu');
         spectator.component.onClickOption({ target: { value: spectator.component.OPEN_MENU } });

--- a/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.ts
+++ b/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.ts
@@ -41,7 +41,7 @@ export class DotTabButtonsComponent {
     onClickOption(event) {
         if (event.target.value === this.OPEN_MENU) {
             this.showMenu(event);
-        } else {
+        } else if (event.target.value !== this.mode) {
             this.clickOption.emit(event);
         }
     }


### PR DESCRIPTION
### Proposed Changes
* Disabled tab button action if the user is in the same tab. 
* Match old toolbar behavior. 
* Fix this: https://github.com/dotCMS/core/issues/25645#issuecomment-1692350485 

