### PR TITLE
 Templater Builder: Fixing Wrong Classes Deletion

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -1195,7 +1195,7 @@ dot.template.builder.sidebar.header.title=Sidebar
 dot.template.builder.row.box.wont.fit=Minimum 1 column needed for box drop.
 dot.template.builder.autocomplete.has.suggestions=Type and hit enter or select from suggestions to add a class
 dot.template.builder.autocomplete.no.suggestions=Type and hit enter to add a class
-dot.template.builder.autocomplete.setup.suggestions=You can set up predefined class suggestions. <a href="https://www.dotcms.com/docs/latest/designing-a-template-with-a-theme#ClassSuggestions">Get the setup guide</a>
+dot.template.builder.autocomplete.setup.suggestions=You can set up predefined class suggestions. <a target="_blank" href="https://www.dotcms.com/docs/latest/designing-a-template-with-a-theme#ClassSuggestions">Get the setup guide</a>
 dotCMS-Enterprise-comes-with-an-advanced-Image-Editor-tool=Advanced Image Tools is a <a href="https://dotcms.com/features" target="_blank">dotCMS Enterprise</a> only feature.
 dotCMS-Image-Clipboard=dotCMS Image Clipboard
 dotCMS-is-dedicated-to-quality-assurance=dotCMS is dedicated to delivering high quality and extremely reliable enterprise software, and we make extensive efforts to perform thorough quality assurance and resolve all issues before release.  However software is complex, and if you feel you have found a problem with dotCMS, we would very much like you to report it so we can resolve it in a future release; please click the link below to report it.


### PR DESCRIPTION
### Proposed Changes
* Fix **_Get the setup guide_** link

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b66cdf</samp>

Added `target="_blank"` to a link in `Language.properties` to improve the template builder UI. This was part of a pull request for various template builder enhancements and fixes.

## Related Issue
Fixes #25926 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b66cdf</samp>

* Added `target="_blank"` attribute to the link in the template builder autocomplete setup suggestions message ([link](https://github.com/dotCMS/core/pull/25968/files?diff=unified&w=0#diff-21db9723fa4c52389731b7575f1e19bd364aa992b7e549e22c08a33456994e94L1198-R1198))