### PR TITLE
#25618 Basic metadata can be extended, never overwritten

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/storage/FileMetadataAPITest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/storage/FileMetadataAPITest.java
@@ -9,7 +9,7 @@ import static com.dotcms.datagen.TestDataUtils.getMultipleImageBinariesContent;
 import static com.dotcms.datagen.TestDataUtils.removeAnyMetadata;
 import static com.dotcms.rest.api.v1.temp.TempFileAPITest.mockHttpServletRequest;
 import static com.dotcms.storage.FileMetadataAPI.BINARY_METADATA_VERSION;
-import static com.dotcms.storage.FileMetadataAPIImpl.BASIC_METADATA_OVERRIDE_KEYS;
+import static com.dotcms.storage.FileMetadataAPIImpl.BASIC_METADATA_EXTENDED_KEYS;
 import static com.dotcms.storage.StoragePersistenceProvider.DEFAULT_STORAGE_TYPE;
 import static com.dotcms.storage.model.Metadata.CUSTOM_PROP_PREFIX;
 import static org.junit.Assert.assertEquals;
@@ -98,23 +98,40 @@ public class FileMetadataAPITest {
 
     /**
      * <b>Method to test:</b> {@link FileMetadataAPI#generateContentletMetadata(Contentlet)} <br>
-     * <b>Given scenario:</b> The property {@link FileMetadataAPIImpl#BASIC_METADATA_OVERRIDE_KEYS} is set<br>
-     * <b>Expected Result:</b> The basic metadata must get the value set in {@link FileMetadataAPIImpl#BASIC_METADATA_OVERRIDE_KEYS}
+     * <b>Given scenario:</b> The property {@link FileMetadataAPIImpl#BASIC_METADATA_EXTENDED_KEYS} is set<br>
+     * <b>Expected Result:</b> The basic metadata must include the value set in {@link FileMetadataAPIImpl#BASIC_METADATA_EXTENDED_KEYS}
      * @throws Exception
      */
     @Test
-    public void Test_Get_BasicMetadataWhenOverridePropertyIsSet() throws Exception {
+    public void Test_Get_BasicMetadataWhenExtendedPropertyIsSet() throws Exception {
         prepareIfNecessary();
-        final FileMetadataAPI metadataAPI = new FileMetadataAPIImpl(APILocator.getFileStorageAPI(),
-                CacheLocator.getMetadataCache(), () -> CollectionsUtils.set("keywords"));
-        final Contentlet fileAssetContent = getFileAssetContent(true, 1, TestFile.PDF);
-        Metadata metadata = metadataAPI.generateContentletMetadata(
-                fileAssetContent).getBasicMetadataMap().get("fileAsset");
-        
-        //we get the keywords from the pdf file. It should have this value: keyword1,keyword2
-        assertNotNull(metadata);
-        assertEquals(1, metadata.getMap().size());
-        assertEquals("keyword1,keyword2", metadata.getMap().get("keywords"));
+
+        final String originalStringProperty = Config.getStringProperty(DEFAULT_STORAGE_TYPE);
+        try {
+            Config.setProperty(BASIC_METADATA_EXTENDED_KEYS, "keywords");
+            final FileMetadataAPI metadataAPI = new FileMetadataAPIImpl();
+            final Contentlet fileAssetContent = getFileAssetContent(true, 1, TestFile.PDF);
+            Metadata metadata = metadataAPI.generateContentletMetadata(
+                    fileAssetContent).getBasicMetadataMap().get("fileAsset");
+
+            assertNotNull(metadata);
+
+            final Set<String> basicMetadataKeys = BasicMetadataFields.keyMap().keySet();
+            final Set<String> metadataKeySetReturned = metadata.getMap().keySet();
+
+            assertTrue(metadataKeySetReturned.size() > 1);
+
+            //we make sure the BasicMetadataFields and keywords are included
+            assertTrue(metadataKeySetReturned.stream()
+                    .allMatch(key -> (key.equals("keywords") || basicMetadataKeys.contains(key))));
+
+            //we get the keywords from the pdf file. It should have this value: keyword1,keyword2
+            assertEquals("keyword1,keyword2", metadata.getMap().get("keywords"));
+        } finally{
+            Config.setProperty(BASIC_METADATA_EXTENDED_KEYS, originalStringProperty);
+            //We need to force a clean up of the fileMetadataAPI instance to reset the lazy initialization of the basicMetadataKeySet
+            fileMetadataAPI = new FileMetadataAPIImpl();
+        }
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/storage/FileMetadataAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileMetadataAPIImpl.java
@@ -55,7 +55,8 @@ import java.util.stream.Stream;
  */
 public class FileMetadataAPIImpl implements FileMetadataAPI {
 
-    public static final String BASIC_METADATA_OVERRIDE_KEYS = "BASIC_METADATA_OVERRIDE_KEYS";
+    //This property is a comma-separated list that contains all the metadata keys that will be stored as basic in addition to the ones defined in {@link BasicMetadataFields}
+    public static final String BASIC_METADATA_EXTENDED_KEYS = "BASIC_METADATA_EXTENDED_KEYS";
     private final FileStorageAPI fileStorageAPI;
     private final MetadataCache metadataCache;
 
@@ -66,14 +67,19 @@ public class FileMetadataAPIImpl implements FileMetadataAPI {
     }
 
     private FileMetadataAPIImpl(final FileStorageAPI fileStorageAPI, final MetadataCache metadataCache) {
-        this(fileStorageAPI, metadataCache, () -> Arrays.stream(
-                        Config.getStringProperty(BASIC_METADATA_OVERRIDE_KEYS,
-                                String.join(",", BasicMetadataFields.keyMap().keySet())).split(","))
-                .map(String::trim).collect(Collectors.toSet()));
+        this(fileStorageAPI, metadataCache, () -> {
+            //we are including additional keys to the basic metadata if `BASIC_METADATA_EXTENDED_KEYS` exists
+            String extendedKeys = Config.getStringProperty(BASIC_METADATA_EXTENDED_KEYS, null);
+            Set<String> basicMetadataKeys = new HashSet<>(BasicMetadataFields.keyMap().keySet());
+            if (UtilMethods.isSet(extendedKeys)){
+                basicMetadataKeys.addAll(Arrays.stream(extendedKeys.split(",")).map(String::trim).collect(Collectors.toSet()));
+            }
+            return basicMetadataKeys;
+        }
+        );
     }
 
-    @VisibleForTesting
-    FileMetadataAPIImpl(final FileStorageAPI fileStorageAPI, final MetadataCache metadataCache,
+    private FileMetadataAPIImpl(final FileStorageAPI fileStorageAPI, final MetadataCache metadataCache,
             Supplier<? extends Set<String>> basicMetadataKeySetSupplier) {
         this.fileStorageAPI = fileStorageAPI;
         this.metadataCache = metadataCache;


### PR DESCRIPTION
### Proposed Changes
* With a[ recent change](https://github.com/dotCMS/core/pull/25745), basic metadata could be overwritten, but if a wrong basic metadata value is provided, the system crashes. That's why we are now limiting this feature so a user can only extend the existing basic metadata (that is required by default to avoid system errors)
* A test was updated to consider the new use case
