### PR TITLE
taking into consideration the field type when generating the deterministic Id.

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/DeterministicIdentifierAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/DeterministicIdentifierAPIImpl.java
@@ -288,7 +288,8 @@ public class DeterministicIdentifierAPIImpl implements DeterministicIdentifierAP
         if(UtilMethods.isNotSet(name)){
             name = field.variable();
         }
-        return name;
+        //amplify the dispersion of the seed by adding the field type
+        return  String.format("%s:%s", name, field.typeName());
     }
 
     /**


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1670b8d</samp>

### Summary
🔧🧪🚀

<!--
1.  🔧 - This emoji represents the modification of the `resolveName` method, which is the core logic that implements the requirement. It suggests that this change is a fix or improvement to the existing code.
2.  🧪 - This emoji represents the addition and modification of some integration tests, which are essential to verify the correctness and functionality of the new logic. It suggests that this change is related to testing or experimentation.
3.  🚀 - This emoji represents the overall enhancement of the deterministic identifier generator, which is the goal of this pull request. It suggests that this change is a feature or improvement that adds value or performance to the system.
-->
This pull request implements a new logic for generating deterministic identifiers for fields, taking into account the field type name. It also adds and updates some integration tests to verify the new logic. The main files affected are `DeterministicIdentifierAPIImpl.java` and `DeterministicIdentifierAPITest.java`.


### Walkthrough
*  Append the field type name to the field variable name when resolving the name of a field for the deterministic id generation ([link](https://github.com/dotCMS/core/pull/25976/files?diff=unified&w=0#diff-4eb9e8ef43defc6f2f19457623962931266834162a0a921c72449d4354670d85L291-R292)). This enhances the dispersion of the identifiers by adding more information to the seed. This change affects the `resolveName` method of the `DeterministicIdentifierAPIImpl` class.

