### PR TITLE
dotCMS/core#25965 [UI]: Don't show Archived Experiments by default 

### DIFF
--- a/core-web/libs/dotcms-models/src/lib/dot-experiments-constants.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-experiments-constants.ts
@@ -46,6 +46,10 @@ export const ExperimentsStatusList: Array<DotDropdownSelectOption<string>> = [
         value: DotExperimentStatus.DRAFT
     },
     {
+        label: 'scheduled',
+        value: DotExperimentStatus.SCHEDULED
+    },
+    {
         label: 'running',
         value: DotExperimentStatus.RUNNING
     },
@@ -56,10 +60,6 @@ export const ExperimentsStatusList: Array<DotDropdownSelectOption<string>> = [
     {
         label: 'archived',
         value: DotExperimentStatus.ARCHIVED
-    },
-    {
-        label: 'scheduled',
-        value: DotExperimentStatus.SCHEDULED
     }
 ];
 

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/store/dot-experiments-list-store.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/store/dot-experiments-list-store.spec.ts
@@ -108,6 +108,17 @@ describe('DotExperimentsListStore', () => {
         });
     });
 
+    it('should  load initial filter status with the correct states', () => {
+        store.state$.subscribe(({ filterStatus }) => {
+            expect(filterStatus).toEqual([
+                DotExperimentStatus.RUNNING,
+                DotExperimentStatus.SCHEDULED,
+                DotExperimentStatus.DRAFT,
+                DotExperimentStatus.ENDED
+            ]);
+        });
+    });
+
     it('should update status to the store', () => {
         store.setComponentStatus(ComponentStatus.LOADED);
         store.state$.subscribe(({ status }) => {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/store/dot-experiments-list-store.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/store/dot-experiments-list-store.ts
@@ -43,8 +43,7 @@ const initialState: DotExperimentsState = {
         DotExperimentStatus.RUNNING,
         DotExperimentStatus.SCHEDULED,
         DotExperimentStatus.DRAFT,
-        DotExperimentStatus.ENDED,
-        DotExperimentStatus.ARCHIVED
+        DotExperimentStatus.ENDED
     ],
     status: ComponentStatus.INIT,
     sidebar: {


### PR DESCRIPTION
### Proposed Changes
* remove Archive from the default loaded options. 
* the order of the filters in the list should be: Draft, Scheduled, Running, Ended, Archived


### Screenshots
<img width="748" alt="image" src="https://github.com/dotCMS/core/assets/31667212/9df004df-40a8-4aa3-9fa8-e4133745d58b">
