### PR TITLE
Update _button.scss disabled serverity state

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/buttons/_button.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/buttons/_button.scss
@@ -61,6 +61,16 @@
     }
 }
 
+// Severity for the basic enabled button
+.p-button.p-element:disabled:not(.p-splitbutton-defaultbutton, .p-splitbutton-menubutton),
+// Used for file upload button
+.p-button.p-element.p-fileupload-choose {
+    @extend #main-primary-severity;
+
+    &.p-button-secondary {
+        @extend #main-secondary-severity;
+    }
+}
 // Severity for outlined button
 .p-button-outlined:enabled:not(.p-splitbutton-defaultbutton, .p-splitbutton-menubutton) {
     @extend #outlined-primary-severity;


### PR DESCRIPTION
Update _button.scss disabled serverity state

While running the experiments locally I came across this issue. 

https://github.com/dotCMS/core/issues/25985

### Proposed Changes
* Update the severity state of the button in disabled state 


### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
