### PR TITLE
Fix #25995: Template Builder was emitting undefined value on save

### DIFF
--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -9,8 +9,7 @@
                 [icon]="rowIcon"
                 [gridstackOptions]="rowOptions"
                 data-widget-type="row"
-                data-testId="add-row"
-            ></dotcms-add-widget>
+                data-testId="add-row"></dotcms-add-widget>
             <dotcms-add-widget
                 id="box-picker"
                 #addBox
@@ -19,13 +18,12 @@
                 [attr.gs-w]="boxWidth"
                 [icon]="colIcon"
                 data-widget-type="col"
-                data-testId="add-box"
-            ></dotcms-add-widget>
+                data-testId="add-box"></dotcms-add-widget>
             <p-divider layout="vertical"></p-divider>
             <dotcms-template-builder-actions
                 [layoutProperties]="vm.layoutProperties"
                 (selectTheme)="openThemeSelectorDynamicDialog()"
-            ></dotcms-template-builder-actions>
+                data-testId="template-builder-actions"></dotcms-template-builder-actions>
             <ng-content select="[toolbar-actions-right]"></ng-content>
         </div>
     </p-toolbar>
@@ -33,8 +31,7 @@
         class="template-builder__main"
         #templateContainerRef
         (mousemove)="fixGridStackNodeOptions()"
-        data-testId="template-builder-main"
-    >
+        data-testId="template-builder-main">
         <dotcms-template-builder-section
             *ngIf="vm.layoutProperties.header"
             (deleteSection)="deleteSection('header')"
@@ -46,8 +43,7 @@
             [ngClass]="{
                 'template-builder__container--right':
                     vm.layoutProperties.sidebar.location == 'right'
-            }"
-        >
+            }">
             <dotcms-template-builder-sidebar
                 *ngIf="vm.layoutProperties.sidebar.location.length"
                 [ngClass]="{
@@ -56,8 +52,7 @@
                     'template-builder__sidebar--large': vm.layoutProperties.sidebar.width == 'large'
                 }"
                 [sidebarProperties]="vm.layoutProperties.sidebar"
-                [containerMap]="vm.containerMap"
-            />
+                [containerMap]="vm.containerMap" />
             <div class="grid-stack">
                 <dotcms-template-builder-row
                     class="grid-stack-item"
@@ -74,8 +69,7 @@
                         'template-builder-row--wont-fit': addBoxIsDragging && !row.willBoxFit
                     }"
                     [attr.data-wont-fit]="'dot.template.builder.row.box.wont.fit' | dm"
-                    data-testId="row"
-                >
+                    data-testId="row">
                     <div class="grid-stack-item-content grid-stack">
                         <div
                             class="grid-stack-item sub"
@@ -91,8 +85,7 @@
                             [attr.gs-y]="box.y"
                             [attr.gs-w]="box.w"
                             [attr.gs-h]="box.h"
-                            [attr.data-testId]="'box-' + i"
-                        >
+                            [attr.data-testId]="'box-' + i">
                             <dotcms-template-builder-box
                                 class="grid-stack-item-content"
                                 [attr.data-testId]="'builder-box-' + i"
@@ -102,8 +95,9 @@
                                 (deleteColumn)="removeColumn(box, boxElement, row.id)"
                                 (addContainer)="addContainer(box, row.id, $event)"
                                 (deleteContainer)="deleteContainer(box, row.id, $event)"
-                                (editClasses)="editBoxStyleClasses(row.id, box)"
-                            ></dotcms-template-builder-box>
+                                (editClasses)="
+                                    editBoxStyleClasses(row.id, box)
+                                "></dotcms-template-builder-box>
                         </div>
                     </div>
                 </dotcms-template-builder-row>

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -310,7 +310,6 @@ describe('TemplateBuilderComponent', () => {
 
         templateBuilderThemeSelector.apply();
 
-        // expect(layoutChangeMock).toHaveBeenCalled();
         expect(layoutChangeMock).toHaveBeenCalledWith({
             layout: {
                 body: FULL_DATA_MOCK,

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -11,9 +11,16 @@ import { ToolbarModule } from 'primeng/toolbar';
 
 import { pluck, take } from 'rxjs/operators';
 
-import { DotContainersService, DotMessageService } from '@dotcms/data-access';
+import { DotContainersService, DotEventsService, DotMessageService } from '@dotcms/data-access';
+import { CoreWebService, LoginService, SiteService } from '@dotcms/dotcms-js';
 import { DotMessagePipe } from '@dotcms/ui';
-import { containersMock, DotContainersServiceMock } from '@dotcms/utils-testing';
+import {
+    containersMock,
+    CoreWebServiceMock,
+    DotContainersServiceMock,
+    LoginServiceMock,
+    SiteServiceMock
+} from '@dotcms/utils-testing';
 
 import { TemplateBuilderComponentsModule } from './components/template-builder-components.module';
 import { DotGridStackWidget, SCROLL_DIRECTION } from './models/models';
@@ -48,6 +55,7 @@ describe('TemplateBuilderComponent', () => {
     let store: DotTemplateBuilderStore;
     const mockContainer = containersMock[0];
     let dialog: DialogService;
+
     let openDialogMock: jest.SpyInstance;
 
     const createComponent = createComponentFactory({
@@ -77,7 +85,20 @@ describe('TemplateBuilderComponent', () => {
             {
                 provide: DotContainersService,
                 useValue: new DotContainersServiceMock()
-            }
+            },
+            {
+                provide: CoreWebService,
+                useClass: CoreWebServiceMock
+            },
+            {
+                provide: SiteService,
+                useClass: SiteServiceMock
+            },
+            {
+                provide: LoginService,
+                useClass: LoginServiceMock
+            },
+            DotEventsService
         ]
     });
 
@@ -99,6 +120,7 @@ describe('TemplateBuilderComponent', () => {
 
         store = spectator.inject(DotTemplateBuilderStore, true);
         dialog = spectator.inject(DialogService);
+
         openDialogMock = jest.spyOn(dialog, 'open');
         spectator.detectChanges();
     });
@@ -125,7 +147,7 @@ describe('TemplateBuilderComponent', () => {
         const totalBoxes = FULL_DATA_MOCK.rows.reduce((acc, row) => {
             return acc + row.columns.length;
         }, 0);
-        expect(spectator.queryAll(byTestId(/builder-box-\d+/g)).length).toBe(totalBoxes);
+        expect(spectator.queryAll(byTestId(/builder-box-\d+/)).length).toBe(totalBoxes);
     });
 
     it('should trigger removeColumn on store when triggering removeColumn', (done) => {
@@ -269,6 +291,37 @@ describe('TemplateBuilderComponent', () => {
         spectator.click(deleteSectionButton);
 
         expect(deleteSectionMock).toHaveBeenCalledWith('footer');
+    });
+
+    it("should emit changes with a not null layout when the theme is changed and layoutProperties or rows weren't touched", () => {
+        const templateBuilderActions = spectator.query(byTestId('template-builder-actions'));
+        const layoutChangeMock = jest.spyOn(spectator.component.templateChange, 'emit');
+
+        spectator.dispatchFakeEvent(templateBuilderActions, 'selectTheme');
+
+        // This queries from the body
+        const templateBuilderThemeSelector = spectator.fixture.debugElement.parent.query(
+            By.css('dotcms-template-builder-theme-selector')
+        ).componentInstance;
+
+        templateBuilderThemeSelector.currentTheme = {
+            identifier: 'test-123'
+        };
+
+        templateBuilderThemeSelector.apply();
+
+        // expect(layoutChangeMock).toHaveBeenCalled();
+        expect(layoutChangeMock).toHaveBeenCalledWith({
+            layout: {
+                body: FULL_DATA_MOCK,
+                header: true,
+                footer: true,
+                sidebar: null,
+                width: 'Mobile',
+                title: 'Test Title'
+            },
+            themeId: 'test-123'
+        });
     });
 
     describe('layoutChange', () => {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -213,6 +213,10 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
             resizingRowID: '',
             containerMap: this.containerMap
         });
+
+        this.dotLayout = {
+            ...this.layout
+        };
     }
 
     ngAfterViewInit() {
@@ -416,6 +420,7 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
             .subscribe(
                 (theme: DotTheme) => {
                     this.themeId = theme.identifier;
+
                     this.templateChange.emit({
                         themeId: this.themeId,
                         layout: { ...this.dotLayout }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -394,7 +394,7 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
     }
 
     /**
-     * @description This method opens the dialog to edit the row styleclasses
+     * @description This method opens the dialog to edit the themeID of the template
      *
      * @memberof TemplateBuilderComponent
      */


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at db4e503</samp>

### Summary
🛠️📝🎨

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the pull request improves the functionality or performance of the component.
2.  📝 - This emoji represents writing or editing, and can be used to indicate that the pull request modifies the code or the layout of the component.
3.  🎨 - This emoji represents art or design, and can be used to indicate that the pull request improves the style or appearance of the component.
-->
This pull request enhances the template builder component by using a copy of the layout object as its state, and fixes a minor code style issue. This avoids mutating the input layout and improves the template editing experience.

> _The template builder had a flaw_
> _It mutated the input layout raw_
> _So they made a copy_
> _And removed a sloppy_
> _Extra blank line that they saw_

### Walkthrough
*  Copy the input layout to an internal state object to avoid mutation ([link](https://github.com/dotCMS/core/pull/25996/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0R216-R219))
*  Remove an unnecessary empty line for code style ([link](https://github.com/dotCMS/core/pull/25996/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0R423))



### Screenshots
https://github.com/dotCMS/core/assets/63567962/431e96c1-903c-4097-8b39-5d60d78bbb88

