### PR TITLE
Fix #25995: Template Builder Unknown Error in edit page 

### DIFF
--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-row/template-builder-row.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-row/template-builder-row.component.spec.ts
@@ -16,7 +16,7 @@ import { DotMessagePipe } from '@dotcms/ui';
 import { TemplateBuilderRowComponent } from './template-builder-row.component';
 
 import { DotTemplateBuilderStore } from '../../store/template-builder.store';
-import { DOT_MESSAGE_SERVICE_TB_MOCK } from '../../utils/mocks';
+import { DOT_MESSAGE_SERVICE_TB_MOCK, INITIAL_STATE_MOCK } from '../../utils/mocks';
 import { RemoveConfirmDialogComponent } from '../remove-confirm-dialog/remove-confirm-dialog.component';
 import { TemplateBuilderBackgroundColumnsComponent } from '../template-builder-background-columns/template-builder-background-columns.component';
 
@@ -71,14 +71,12 @@ describe('TemplateBuilderRowComponent', () => {
         store = TestBed.inject(DotTemplateBuilderStore);
 
         store.setState({
-            rows: [],
+            ...INITIAL_STATE_MOCK,
             layoutProperties: {
                 header: false,
                 footer: false,
                 sidebar: null
-            },
-            resizingRowID: '',
-            containerMap: {}
+            }
         });
 
         fixture.detectChanges();

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-sidebar/template-builder-sidebar.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-sidebar/template-builder-sidebar.component.spec.ts
@@ -12,7 +12,11 @@ import { DotContainersServiceMock } from '@dotcms/utils-testing';
 import { TemplateBuilderSidebarComponent } from './template-builder-sidebar.component';
 
 import { DotTemplateBuilderStore } from '../../store/template-builder.store';
-import { DOT_MESSAGE_SERVICE_TB_MOCK, GRIDSTACK_DATA_MOCK } from '../../utils/mocks';
+import {
+    DOT_MESSAGE_SERVICE_TB_MOCK,
+    GRIDSTACK_DATA_MOCK,
+    INITIAL_STATE_MOCK
+} from '../../utils/mocks';
 import { TemplateBuilderBoxComponent } from '../template-builder-box/template-builder-box.component';
 
 describe('TemplateBuilderSidebarComponent', () => {
@@ -61,6 +65,7 @@ describe('TemplateBuilderSidebarComponent', () => {
         boxComponent = spectator.query(TemplateBuilderBoxComponent);
 
         store.setState({
+            ...INITIAL_STATE_MOCK,
             rows: GRIDSTACK_DATA_MOCK,
             layoutProperties: {
                 header: true,
@@ -70,9 +75,7 @@ describe('TemplateBuilderSidebarComponent', () => {
                     width: 'medium',
                     containers: []
                 }
-            },
-            resizingRowID: '',
-            containerMap: {}
+            }
         });
 
         spectator.detectChanges();

--- a/core-web/libs/template-builder/src/lib/components/template-builder/models/models.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/models/models.ts
@@ -69,6 +69,7 @@ export interface DotTemplateBuilderState {
     containerMap: DotContainerMap;
     layoutProperties: DotTemplateLayoutProperties;
     resizingRowID: string;
+    themeId: string;
 }
 
 export type WidgetType = 'col' | 'row';

--- a/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '../models/models';
 import {
     GRIDSTACK_DATA_MOCK,
+    INITIAL_STATE_MOCK,
     mockTemplateBuilderContainer,
     SIDEBAR_MOCK,
     STYLE_CLASS_MOCK
@@ -63,14 +64,13 @@ describe('DotTemplateBuilderStore', () => {
 
         // Reset the state because is manipulated by reference
         service.setState({
+            ...INITIAL_STATE_MOCK,
             rows: GRIDSTACK_DATA_MOCK,
             layoutProperties: {
                 header: true,
                 footer: true,
                 sidebar: SIDEBAR_MOCK
-            },
-            resizingRowID: '',
-            containerMap: {}
+            }
         });
 
         // Get the initial state
@@ -292,14 +292,13 @@ describe('DotTemplateBuilderStore', () => {
         ];
 
         service.setState({
+            ...INITIAL_STATE_MOCK,
             rows: GRIDSTACK_DATA_MOCK,
             layoutProperties: {
                 footer: false,
                 header: false,
                 sidebar: {}
-            },
-            resizingRowID: '',
-            containerMap: {}
+            }
         });
 
         const newWidth = 2;
@@ -344,14 +343,13 @@ describe('DotTemplateBuilderStore', () => {
         ];
 
         service.setState({
+            ...INITIAL_STATE_MOCK,
             rows: GRIDSTACK_DATA_MOCK,
             layoutProperties: {
                 footer: false,
                 header: false,
                 sidebar: {}
-            },
-            resizingRowID: '',
-            containerMap: {}
+            }
         });
 
         const affectedColumn: DotGridStackNode = {
@@ -494,6 +492,16 @@ describe('DotTemplateBuilderStore', () => {
             expect(row?.subGridOpts?.children[0].containers).not.toContain(
                 mockTemplateBuilderContainer
             );
+            done();
+        });
+    });
+
+    it('should update the theme id', (done) => {
+        expect.assertions(1);
+        service.updateThemeId('test-1234');
+
+        service.themeId$.subscribe((themeId) => {
+            expect(themeId).toBe('test-1234');
             done();
         });
     });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.ts
@@ -36,6 +36,7 @@ import {
 export class DotTemplateBuilderStore extends ComponentStore<DotTemplateBuilderState> {
     public rows$ = this.select((state) => state.rows);
     public layoutProperties$ = this.select((state) => state.layoutProperties);
+    public themeId$ = this.select((state) => state.themeId);
 
     public vm$ = this.select((state) => ({
         ...state,
@@ -468,6 +469,16 @@ export class DotTemplateBuilderStore extends ComponentStore<DotTemplateBuilderSt
             return { ...state, rows: updatedItems };
         }
     );
+
+    /**
+     * @description This method updates the themeId
+     *
+     * @memberof DotTemplateBuilderStore
+     */
+    readonly updateThemeId = this.updater((state, themeId: string) => ({
+        ...state,
+        themeId
+    }));
 
     // Utils methods
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -31,6 +31,7 @@ import {
     CONTAINER_MAP_MOCK,
     DOT_MESSAGE_SERVICE_TB_MOCK,
     FULL_DATA_MOCK,
+    INITIAL_STATE_MOCK,
     ROWS_MOCK
 } from './utils/mocks';
 
@@ -330,6 +331,7 @@ describe('TemplateBuilderComponent', () => {
             spectator.detectChanges();
 
             store.setState({
+                ...INITIAL_STATE_MOCK,
                 rows: parseFromDotObjectToGridStack(FULL_DATA_MOCK),
                 layoutProperties: {
                     header: true,
@@ -339,9 +341,7 @@ describe('TemplateBuilderComponent', () => {
                         location: 'left',
                         width: 'small'
                     }
-                },
-                resizingRowID: '',
-                containerMap: {}
+                }
             });
 
             store.vm$.pipe(pluck('items'), take(1)).subscribe(() => {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -108,7 +108,7 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
     public rows$: Observable<DotLayoutBody>;
     public vm$: Observable<DotTemplateBuilderState> = this.store.vm$;
 
-    private themeId$ = new BehaviorSubject<string | undefined>(undefined); // at this point this.themeId is undefined
+    private themeId$ = new BehaviorSubject<string>(null); // at this point this.themeId is undefined
 
     public readonly rowIcon = rowIcon;
     public readonly colIcon = colIcon;

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
@@ -8,6 +8,7 @@ import { containersMapMock, MockDotMessageService } from '@dotcms/utils-testing'
 import {
     DotGridStackWidget,
     DotTemplateBuilderContainer,
+    DotTemplateBuilderState,
     SYSTEM_CONTAINER_IDENTIFIER
 } from '../models/models';
 
@@ -817,3 +818,20 @@ export class MockGridStackElementComponent {
         };
     }
 }
+
+// Mock used to maintain the state of the template builder
+export const INITIAL_STATE_MOCK: DotTemplateBuilderState = {
+    rows: [],
+    layoutProperties: {
+        header: true,
+        footer: true,
+        sidebar: {
+            containers: [],
+            location: 'left',
+            width: 'small'
+        }
+    },
+    resizingRowID: '',
+    containerMap: {},
+    themeId: '123'
+};


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c59fb0d</samp>

### Summary
🎨🔧🚀

<!--
1.  🎨 - This emoji represents the addition of the `themeId$` property, which is related to the theme or appearance of the template.
2.  🔧 - This emoji represents the refactoring of the template change event emission, which is a technical improvement or adjustment of the code.
3.  🚀 - This emoji represents the use of the `combineLatest` operator, which is a performance enhancement or optimization of the code.
-->
Added theme id handling and refactored template change emission in template builder component. This improves the responsiveness and consistency of the template builder UI and logic.

> _To handle the theme id with ease_
> _They added a new `themeId$`_
> _They used `combineLatest` to emit_
> _The template change with rows and layout_
> _And refactored the component a bit_

### Walkthrough
* Create a new observable property `themeId$` that emits the current theme id of the template builder component ([link](https://github.com/dotCMS/core/pull/26007/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L10-R10), [link](https://github.com/dotCMS/core/pull/26007/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0R111-R112))
* Add the `themeId$` observable to the `combineLatest` operator that combines the layout properties and rows observables, and pass the theme id parameter to the subscribe callback ([link](https://github.com/dotCMS/core/pull/26007/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L184-R186), [link](https://github.com/dotCMS/core/pull/26007/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L190-R194))
* Use a variable `cleanThemeId` to assign either the theme id parameter or the property, depending on which one is defined, and use it to emit the template change event ([link](https://github.com/dotCMS/core/pull/26007/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L190-R194), [link](https://github.com/dotCMS/core/pull/26007/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L203-R207))
* Remove the redundant assignment of the `dotLayout` property, since it is already done in the subscribe callback of the `combineLatest` operator ([link](https://github.com/dotCMS/core/pull/26007/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L216-L219))
* Add a comment to explain why the `this.themeId` property is passed in the data of the dynamic dialog that opens the theme selector component ([link](https://github.com/dotCMS/core/pull/26007/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L410-R410))
* Update the `themeId$` observable with the new theme id value from the dynamic dialog, instead of emitting the template change event directly, to trigger the `combineLatest` operator to emit a new value with the updated theme id, layout properties and rows ([link](https://github.com/dotCMS/core/pull/26007/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L422-R425))



### Screenshots

https://github.com/dotCMS/core/assets/63567962/df2c2ab9-7f10-4787-a5f0-6114232a318e