### PR TITLE
Fix #25995: Template Builder Unknown Error in edit page (pre release)

### DIFF
--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-row/template-builder-row.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-row/template-builder-row.component.spec.ts
@@ -16,7 +16,7 @@ import { DotMessagePipe } from '@dotcms/ui';
 import { TemplateBuilderRowComponent } from './template-builder-row.component';
 
 import { DotTemplateBuilderStore } from '../../store/template-builder.store';
-import { DOT_MESSAGE_SERVICE_TB_MOCK } from '../../utils/mocks';
+import { DOT_MESSAGE_SERVICE_TB_MOCK, INITIAL_STATE_MOCK } from '../../utils/mocks';
 import { RemoveConfirmDialogComponent } from '../remove-confirm-dialog/remove-confirm-dialog.component';
 import { TemplateBuilderBackgroundColumnsComponent } from '../template-builder-background-columns/template-builder-background-columns.component';
 
@@ -71,14 +71,13 @@ describe('TemplateBuilderRowComponent', () => {
         store = TestBed.inject(DotTemplateBuilderStore);
 
         store.setState({
+            ...INITIAL_STATE_MOCK,
             rows: [],
             layoutProperties: {
                 header: false,
                 footer: false,
                 sidebar: null
-            },
-            resizingRowID: '',
-            containerMap: {}
+            }
         });
 
         fixture.detectChanges();

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-sidebar/template-builder-sidebar.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-sidebar/template-builder-sidebar.component.spec.ts
@@ -12,7 +12,11 @@ import { DotContainersServiceMock } from '@dotcms/utils-testing';
 import { TemplateBuilderSidebarComponent } from './template-builder-sidebar.component';
 
 import { DotTemplateBuilderStore } from '../../store/template-builder.store';
-import { DOT_MESSAGE_SERVICE_TB_MOCK, GRIDSTACK_DATA_MOCK } from '../../utils/mocks';
+import {
+    DOT_MESSAGE_SERVICE_TB_MOCK,
+    GRIDSTACK_DATA_MOCK,
+    INITIAL_STATE_MOCK
+} from '../../utils/mocks';
 import { TemplateBuilderBoxComponent } from '../template-builder-box/template-builder-box.component';
 
 describe('TemplateBuilderSidebarComponent', () => {
@@ -61,6 +65,7 @@ describe('TemplateBuilderSidebarComponent', () => {
         boxComponent = spectator.query(TemplateBuilderBoxComponent);
 
         store.setState({
+            ...INITIAL_STATE_MOCK,
             rows: GRIDSTACK_DATA_MOCK,
             layoutProperties: {
                 header: true,
@@ -70,9 +75,7 @@ describe('TemplateBuilderSidebarComponent', () => {
                     width: 'medium',
                     containers: []
                 }
-            },
-            resizingRowID: '',
-            containerMap: {}
+            }
         });
 
         spectator.detectChanges();

--- a/core-web/libs/template-builder/src/lib/components/template-builder/models/models.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/models/models.ts
@@ -69,6 +69,7 @@ export interface DotTemplateBuilderState {
     containerMap: DotContainerMap;
     layoutProperties: DotTemplateLayoutProperties;
     resizingRowID: string;
+    themeId: string;
 }
 
 export type WidgetType = 'col' | 'row';

--- a/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '../models/models';
 import {
     GRIDSTACK_DATA_MOCK,
+    INITIAL_STATE_MOCK,
     mockTemplateBuilderContainer,
     SIDEBAR_MOCK,
     STYLE_CLASS_MOCK
@@ -63,14 +64,13 @@ describe('DotTemplateBuilderStore', () => {
 
         // Reset the state because is manipulated by reference
         service.setState({
+            ...INITIAL_STATE_MOCK,
             rows: GRIDSTACK_DATA_MOCK,
             layoutProperties: {
                 header: true,
                 footer: true,
                 sidebar: SIDEBAR_MOCK
-            },
-            resizingRowID: '',
-            containerMap: {}
+            }
         });
 
         // Get the initial state
@@ -292,14 +292,13 @@ describe('DotTemplateBuilderStore', () => {
         ];
 
         service.setState({
+            ...INITIAL_STATE_MOCK,
             rows: GRIDSTACK_DATA_MOCK,
             layoutProperties: {
                 footer: false,
                 header: false,
                 sidebar: {}
-            },
-            resizingRowID: '',
-            containerMap: {}
+            }
         });
 
         const newWidth = 2;
@@ -344,14 +343,13 @@ describe('DotTemplateBuilderStore', () => {
         ];
 
         service.setState({
+            ...INITIAL_STATE_MOCK,
             rows: GRIDSTACK_DATA_MOCK,
             layoutProperties: {
                 footer: false,
                 header: false,
                 sidebar: {}
-            },
-            resizingRowID: '',
-            containerMap: {}
+            }
         });
 
         const affectedColumn: DotGridStackNode = {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/store/template-builder.store.ts
@@ -36,6 +36,7 @@ import {
 export class DotTemplateBuilderStore extends ComponentStore<DotTemplateBuilderState> {
     public rows$ = this.select((state) => state.rows);
     public layoutProperties$ = this.select((state) => state.layoutProperties);
+    public themeId$ = this.select((state) => state.themeId);
 
     public vm$ = this.select((state) => ({
         ...state,
@@ -466,6 +467,16 @@ export class DotTemplateBuilderStore extends ComponentStore<DotTemplateBuilderSt
             return { ...state, rows: updatedItems };
         }
     );
+
+    /**
+     * @description This method updates the themeId
+     *
+     * @memberof DotTemplateBuilderStore
+     */
+    readonly updateThemeId = this.updater((state, themeId: string) => ({
+        ...state,
+        themeId
+    }));
 
     // Utils methods
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -24,6 +24,7 @@ import {
     CONTAINER_MAP_MOCK,
     DOT_MESSAGE_SERVICE_TB_MOCK,
     FULL_DATA_MOCK,
+    INITIAL_STATE_MOCK,
     ROWS_MOCK
 } from './utils/mocks';
 
@@ -254,6 +255,7 @@ describe('TemplateBuilderComponent', () => {
             spectator.detectChanges();
 
             store.setState({
+                ...INITIAL_STATE_MOCK,
                 rows: parseFromDotObjectToGridStack(FULL_DATA_MOCK),
                 layoutProperties: {
                     header: true,
@@ -263,9 +265,7 @@ describe('TemplateBuilderComponent', () => {
                         location: 'left',
                         width: 'small'
                     }
-                },
-                resizingRowID: '',
-                containerMap: {}
+                }
             });
 
             store.vm$.pipe(pluck('items'), take(1)).subscribe(() => {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -79,7 +79,7 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
     layout!: DotLayout;
 
     @Input()
-    themeId!: string;
+    themeId!: string; // In the layout we have the themeId we can consider removing this.
 
     @Input()
     containerMap!: DotContainerMap;
@@ -108,6 +108,8 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
     private destroy$: Subject<boolean> = new Subject<boolean>();
     public rows$: Observable<DotLayoutBody>;
     public vm$: Observable<DotTemplateBuilderState> = this.store.vm$;
+
+    private themeId$ = this.store.themeId$;
 
     public readonly rowIcon = rowIcon;
     public readonly colIcon = colIcon;
@@ -183,13 +185,13 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
     ) {
         this.rows$ = this.store.rows$.pipe(map((rows) => parseFromGridStackToDotObject(rows)));
 
-        combineLatest([this.rows$, this.store.layoutProperties$])
+        combineLatest([this.rows$, this.store.layoutProperties$, this.themeId$])
             .pipe(
                 filter(([items, layoutProperties]) => !!items && !!layoutProperties),
                 skip(1),
                 takeUntil(this.destroy$)
             )
-            .subscribe(([rows, layoutProperties]) => {
+            .subscribe(([rows, layoutProperties, themeId]) => {
                 this.dotLayout = {
                     ...this.layout,
                     ...layoutProperties,
@@ -202,7 +204,7 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
                 };
 
                 this.templateChange.emit({
-                    themeId: this.themeId,
+                    themeId,
                     layout: { ...this.dotLayout }
                 });
             });
@@ -213,7 +215,8 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
             rows: parseFromDotObjectToGridStack(this.layout.body),
             layoutProperties: this.layoutProperties,
             resizingRowID: '',
-            containerMap: this.containerMap
+            containerMap: this.containerMap,
+            themeId: this.themeId
         });
     }
 
@@ -397,19 +400,19 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
      * @memberof TemplateBuilderComponent
      */
     openThemeSelectorDynamicDialog(): void {
-        const ref: DynamicDialogRef = this.dialogService.open(
-            TemplateBuilderThemeSelectorComponent,
-            {
+        let ref: DynamicDialogRef;
+
+        this.themeId$.pipe(take(1)).subscribe((themeId) => {
+            ref = this.dialogService.open(TemplateBuilderThemeSelectorComponent, {
                 header: this.dotMessage.get('dot.template.builder.theme.dialog.header.label'),
                 resizable: false,
                 width: '80%',
                 closeOnEscape: true,
                 data: {
-                    themeId: this.themeId
+                    themeId
                 }
-            }
-        );
-
+            });
+        });
         ref.onClose
             .pipe(
                 take(1),
@@ -417,11 +420,7 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
             )
             .subscribe(
                 (theme: DotTheme) => {
-                    this.themeId = theme.identifier;
-                    this.templateChange.emit({
-                        themeId: this.themeId,
-                        layout: { ...this.dotLayout }
-                    });
+                    this.store.updateThemeId(theme.identifier);
                 },
                 () => {
                     /* */

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
@@ -8,6 +8,7 @@ import { containersMapMock, MockDotMessageService } from '@dotcms/utils-testing'
 import {
     DotGridStackWidget,
     DotTemplateBuilderContainer,
+    DotTemplateBuilderState,
     SYSTEM_CONTAINER_IDENTIFIER
 } from '../models/models';
 
@@ -817,3 +818,20 @@ export class MockGridStackElementComponent {
         };
     }
 }
+
+// Mock used to maintain the state of the template builder
+export const INITIAL_STATE_MOCK: DotTemplateBuilderState = {
+    rows: [],
+    layoutProperties: {
+        header: true,
+        footer: true,
+        sidebar: {
+            containers: [],
+            location: 'left',
+            width: 'small'
+        }
+    },
+    resizingRowID: '',
+    containerMap: {},
+    themeId: '123'
+};


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f9861b5</samp>

### Summary
🎨🧪🛠️

<!--
1.  🎨 - This emoji represents the addition of the `themeId` property to the state interface, as it relates to the theme feature of the template builder.
2.  🧪 - This emoji represents the updates and refactors of the unit tests for the template builder components and the store, as they involve testing and improving the code quality.
3.  🛠️ - This emoji represents the new feature and the refactors of the template builder store and the component, as they involve adding and modifying functionality and logic.
-->
This pull request refactors the unit tests for the template builder components and the store to use a mock object for the initial state, reducing code duplication and improving readability. It also adds a new feature to the store that allows selecting and updating the theme ID of the template builder, which is needed for the theme selection functionality in the UI. It updates the `DotTemplateBuilderState` interface and the `TemplateBuilderComponent` class accordingly.

> _The template builder store got a new feature_
> _To select and update the theme ID_
> _The unit tests were refactored too_
> _To use a mock object for the state value_
> _And the `TemplateBuilderComponent` changed its input to use the store key_

### Walkthrough
*  Add `themeId` property to `DotTemplateBuilderState` interface and `themeId$` selector and `updateThemeId` updater to `DotTemplateBuilderStore` class ([link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-b93c6205d24c66efa12727a86a6616d0bd0fdcd030871cd4ead5d72a69792235R72), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-a32a0fcbcf1b026389eade1b0cd88e8838bbfacb92905fe9da2bea7f72b7c9abR39), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-a32a0fcbcf1b026389eade1b0cd88e8838bbfacb92905fe9da2bea7f72b7c9abR471-R480))
*  Use `INITIAL_STATE_MOCK` object to set default values for the state of the store in the unit tests for the template builder components and the store ([link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-0d94175e271fba9576c6032c57ca4c5641c0a80cb6bc9ebd8dfcc3a7f607e90aL19-R19), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-0d94175e271fba9576c6032c57ca4c5641c0a80cb6bc9ebd8dfcc3a7f607e90aR74), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-0d94175e271fba9576c6032c57ca4c5641c0a80cb6bc9ebd8dfcc3a7f607e90aL79-R80), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-364c0b4db4c53af7dfa24bb786ddc26cc452a1a7ccd2449db6a8ab6c4c370484L15-R19), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-364c0b4db4c53af7dfa24bb786ddc26cc452a1a7ccd2449db6a8ab6c4c370484R68), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-364c0b4db4c53af7dfa24bb786ddc26cc452a1a7ccd2449db6a8ab6c4c370484L73-R78), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24R22), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24R67), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24L71-R73), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24R295), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24L300-R301), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24R346), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24L352-R352), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-71156e8bc7aa2247cecab3f2627182871f930b385d4ff4de19df2f0951667597R27), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-71156e8bc7aa2247cecab3f2627182871f930b385d4ff4de19df2f0951667597R258), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-71156e8bc7aa2247cecab3f2627182871f930b385d4ff4de19df2f0951667597L266-R268))
*  Remove duplicated properties from `store.setState` calls in the unit tests for the template builder components and the store ([link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-0d94175e271fba9576c6032c57ca4c5641c0a80cb6bc9ebd8dfcc3a7f607e90aL79-R80), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-364c0b4db4c53af7dfa24bb786ddc26cc452a1a7ccd2449db6a8ab6c4c370484L73-R78), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24L71-R73), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24L300-R301), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-31b7a396b598816d0a94599edd0c1338d80f276fed9775642769710040776e24L352-R352), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-71156e8bc7aa2247cecab3f2627182871f930b385d4ff4de19df2f0951667597L266-R268))
*  Include `themeId$` in the observable stream and update `dotLayout` object and `templateChange` event emitter with the latest value of the theme ID in the `TemplateBuilderComponent` class ([link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0R112-R113), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L186-R188), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L192-R194), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L205-R207))
*  Set the theme ID in the state of the store when the input properties of the `TemplateBuilderComponent` class change ([link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L216-R219))
*  Get the current value of the theme ID from the store and pass it to the theme selector component in the `openThemeSelectorDynamicDialog` method of the `TemplateBuilderComponent` class ([link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L400-R406), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L408-R415))
*  Update the theme ID in the state of the store when the user selects a theme from the dialog in the `openThemeSelectorDynamicDialog` method of the `TemplateBuilderComponent` class ([link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L420-R423))
*  Add a comment to the `themeId` input property of the `TemplateBuilderComponent` class to suggest that it might be unnecessary ([link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-d12c3fc3a47505ab4b846cfc5090445b7597e2acd4c10382ff0dc22f8c0d9ff0L82-R82))
*  Define the type of the `INITIAL_STATE_MOCK` object using the `DotTemplateBuilderState` interface and create the mock object with default values for the state of the store in the `mocks.ts` file ([link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-98de89ac988dbfd17c912bb493096714d7c139835179a99162b4df2eb3c309e5R11), [link](https://github.com/dotCMS/core/pull/26011/files?diff=unified&w=0#diff-98de89ac988dbfd17c912bb493096714d7c139835179a99162b4df2eb3c309e5R821-R837))




## Notes

See the [PR](https://github.com/dotCMS/core/pull/26007) to master, we couldn't cherry pick the commit since this files are way ahead of pre-release 

### Screenshots
https://github.com/dotCMS/core/assets/63567962/df2c2ab9-7f10-4787-a5f0-6114232a318e