### PR TITLE
dotCMS/core#25715 Handle ESC keydown to close a ConfirmPopup

### DIFF
--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/dot-experiments-configuration.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/dot-experiments-configuration.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="vm$ | async as vm">
     <dot-experiments-header
-        [isLoading]="vm.isLoading"
         [experiment]="vm.experiment"
+        [isLoading]="vm.isLoading"
         [title]="vm.experiment?.name"
         (goBack)="goToExperimentList(vm.experiment.pageId)">
         <div class="flex flex-grow-0 align-items-center justify-content-between">
@@ -49,4 +49,4 @@
 </ng-template>
 
 <p-confirmDialog [key]="confirmDialogKey" [style]="{ width: '30vw' }" />
-<p-confirmPopup></p-confirmPopup>
+<p-confirmPopup dotRemoveConfirmPopupWithEscape></p-confirmPopup>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/dot-experiments-configuration.component.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/dot-experiments-configuration.component.ts
@@ -19,6 +19,7 @@ import {
     DotExperiment,
     DotExperimentStatus
 } from '@dotcms/dotcms-models';
+import { DotRemoveConfirmPopupWithEscapeDirective } from '@dotcms/ui';
 
 import { DotExperimentsConfigurationGoalsComponent } from './components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component';
 import { DotExperimentsConfigurationSchedulingComponent } from './components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component';
@@ -48,6 +49,7 @@ import { DotExperimentsInlineEditTextComponent } from '../shared/ui/dot-experime
         DotExperimentsConfigurationSkeletonComponent,
         DotExperimentsInlineEditTextComponent,
         DotAddToBundleModule,
+        DotRemoveConfirmPopupWithEscapeDirective,
         CardModule,
         ButtonModule,
         InplaceModule,

--- a/core-web/libs/ui/src/index.ts
+++ b/core-web/libs/ui/src/index.ts
@@ -9,3 +9,4 @@ export * from './lib/dot-message/dot-message.pipe';
 export * from './lib/dot-site-selector/dot-site-selector.directive';
 export * from './lib/components/dot-empty-container/dot-empty-container.component';
 export * from './lib/dot-tab-buttons/dot-tab-buttons.component';
+export * from './lib/dot-remove-confirm-popup/dot-remove-confirm-popup.directive';

--- a/core-web/libs/ui/src/lib/dot-remove-confirm-popup/dot-remove-confirm-popup.directive.spec.ts
+++ b/core-web/libs/ui/src/lib/dot-remove-confirm-popup/dot-remove-confirm-popup.directive.spec.ts
@@ -1,0 +1,39 @@
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
+
+import { Component } from '@angular/core';
+
+import { ConfirmationService } from 'primeng/api';
+import { ConfirmPopupModule } from 'primeng/confirmpopup';
+
+import { DotRemoveConfirmPopupWithEscapeDirective } from '@dotcms/ui';
+
+@Component({
+    selector: 'dot-escape-confirm-popup-host',
+    template: `<p-confirmPopup dotRemoveConfirmPopupWithEscape></p-confirmPopup>`,
+    imports: [ConfirmPopupModule]
+})
+class CustomHostComponent {}
+
+describe('DotRemoveConfirmPopupWithEscape', () => {
+    let spectator: SpectatorHost<CustomHostComponent>;
+    let confirmationService: ConfirmationService;
+
+    const createHost = createHostFactory({
+        component: CustomHostComponent,
+        imports: [ConfirmPopupModule, DotRemoveConfirmPopupWithEscapeDirective],
+        providers: [ConfirmationService]
+    });
+
+    beforeEach(() => {
+        spectator = createHost(`<dot-escape-confirm-popup-host />`);
+        spectator.detectChanges();
+
+        confirmationService = spectator.inject(ConfirmationService);
+    });
+
+    it('should close the confirmPopup with escape', () => {
+        jest.spyOn(confirmationService, 'close');
+        spectator.dispatchKeyboardEvent(document, 'keydown', 'Escape');
+        expect(confirmationService.close).toHaveBeenCalledTimes(1);
+    });
+});

--- a/core-web/libs/ui/src/lib/dot-remove-confirm-popup/dot-remove-confirm-popup.directive.ts
+++ b/core-web/libs/ui/src/lib/dot-remove-confirm-popup/dot-remove-confirm-popup.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, HostListener, inject } from '@angular/core';
+
+import { ConfirmationService } from 'primeng/api';
+
+/**
+ * Directive that adds to p-confirmPopup the escape functionality.
+ *
+ * The directive listens for the 'keydown' event on the document element.
+ * When the 'Escape' key is pressed, it closes it using the confirmation service.
+ */
+@Directive({
+    selector: 'p-confirmPopup[dotRemoveConfirmPopupWithEscape]',
+    standalone: true
+})
+export class DotRemoveConfirmPopupWithEscapeDirective {
+    private confirmationService: ConfirmationService = inject(ConfirmationService);
+
+    @HostListener('document:keydown.escape', ['$event'])
+    onPressEscape() {
+        this.confirmationService.close();
+    }
+}


### PR DESCRIPTION
### Proposed Changes
* Handle ESC key-down to close a ConfirmPopup

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 195faf8</samp>

Implemented and tested a new directive `DotRemoveConfirmPopupWithEscapeDirective` to close confirmation popups with the escape key. Refactored the dot-experiments portlet to use the directive and improve the user interface. Exported the directive from the `@dotcms/ui` library.

## Related Issue
Fixes #25715

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 195faf8</samp>

*  Refactor `dot-experiments-header` component to match property order in `DotExperimentsHeaderComponent` class ([link](https://github.com/dotCMS/core/pull/26012/files?diff=unified&w=0#diff-bfcee947310b87254d22a25f9d82ee34fe7cbc5c1d8b8b74c3724c4712d2e43dL3-R4))
*  Add `dotRemoveConfirmPopupWithEscape` directive to `p-confirmPopup` element in `dot-experiments-configuration.component.html` to enable closing the popup with escape key ([link](https://github.com/dotCMS/core/pull/26012/files?diff=unified&w=0#diff-bfcee947310b87254d22a25f9d82ee34fe7cbc5c1d8b8b74c3724c4712d2e43dL52-R52))
*  Import and declare `DotRemoveConfirmPopupWithEscapeDirective` in `dot-experiments-configuration.component.ts` to use the directive in the template ([link](https://github.com/dotCMS/core/pull/26012/files?diff=unified&w=0#diff-9dc2e8fba23c3c81c70ce66c8594ee74224013641319b260e3ae8f57a8420d14R22), [link](https://github.com/dotCMS/core/pull/26012/files?diff=unified&w=0#diff-9dc2e8fba23c3c81c70ce66c8594ee74224013641319b260e3ae8f57a8420d14R52))
*  Export `DotRemoveConfirmPopupWithEscapeDirective` from `@dotcms/ui` library to make it available to other modules ([link](https://github.com/dotCMS/core/pull/26012/files?diff=unified&w=0#diff-bd390158a0315505d598e7ff896c73589c38f5263e0ff170662313807c45e15eR12))
*  Implement `DotRemoveConfirmPopupWithEscapeDirective` using `ConfirmationService` and `keydown.escape` event listener in `dot-remove-confirm-popup.directive.ts` to close the popup programmatically ([link](https://github.com/dotCMS/core/pull/26012/files?diff=unified&w=0#diff-585a5a2231694fa41a1c6607fd0a073d73775069459c7206eb98d04ddc10df16R1-R22))
*  Test `DotRemoveConfirmPopupWithEscapeDirective` using `@ngneat/spectator` and a host component in `dot-remove-confirm-popup.directive.spec.ts` to verify the functionality of the directive ([link](https://github.com/dotCMS/core/pull/26012/files?diff=unified&w=0#diff-64e383e5ae3af36b55d431a4a3d514cbca89c84e0a4922d015c21651d57f51bdR1-R39))
