### PR TITLE
[Issue-25287]: Adding facebook og-tags

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
@@ -2,13 +2,11 @@
     <dot-form-selector
         [show]="editForm"
         (pick)="onFormSelected($event)"
-        (shutdown)="editForm = false"
-    ></dot-form-selector>
+        (shutdown)="editForm = false"></dot-form-selector>
     <dot-add-contentlet (custom)="onCustomEvent($event)"></dot-add-contentlet>
     <dot-create-contentlet
         (custom)="onCustomEvent($event)"
-        (shutdown)="handleCloseAction()"
-    ></dot-create-contentlet>
+        (shutdown)="handleCloseAction()"></dot-create-contentlet>
     <dot-edit-contentlet (custom)="onCustomEvent($event)"></dot-edit-contentlet>
     <dot-reorder-menu [url]="reorderMenuUrl" (shutdown)="onCloseReorderDialog()"></dot-reorder-menu>
 
@@ -22,8 +20,7 @@
             (backToExperiment)="backToExperiment()"
             (cancel)="onCancelToolbar()"
             (favoritePage)="showFavoritePageDialog($event)"
-            (whatschange)="showWhatsChanged = $event"
-        ></dot-edit-page-toolbar-seo>
+            (whatschange)="showWhatsChanged = $event"></dot-edit-page-toolbar-seo>
     </ng-template>
 
     <ng-template #disabledComponent>
@@ -36,14 +33,12 @@
             (backToExperiment)="backToExperiment()"
             (cancel)="onCancelToolbar()"
             (favoritePage)="showFavoritePageDialog($event)"
-            (whatschange)="showWhatsChanged = $event"
-        ></dot-edit-page-toolbar>
+            (whatschange)="showWhatsChanged = $event"></dot-edit-page-toolbar>
     </ng-template>
 
     <ng-container
         *dotShowHideFeature="featureFlagSeo; alternate: disabledComponent"
-        [ngTemplateOutlet]="enabledComponent"
-    ></ng-container>
+        [ngTemplateOutlet]="enabledComponent"></ng-container>
 
     <div class="dot-edit-content__wrapper">
         <dot-loading-indicator fullscreen="true"></dot-loading-indicator>
@@ -51,13 +46,12 @@
             *ngIf="pageState.seoMedia; else dotEditIframe"
             [seoOGTagsResults]="seoOGTagsResults"
             [seoOGTags]="seoOGTags"
-            [hostName]="pageState.page.title"
-        ></dot-results-seo-tool>
+            [hostName]="pageState.page.hostName"
+            [seoMedia]="pageState.seoMedia"></dot-results-seo-tool>
         <ng-template #dotEditIframe>
             <div
                 class="dot-edit__page-wrapper"
-                [class.dot-edit__page-wrapper--deviced]="pageState.viewAs.device"
-            >
+                [class.dot-edit__page-wrapper--deviced]="pageState.viewAs.device">
                 <div class="dot-edit__device-wrapper">
                     <div
                         class="dot-edit__iframe-wrapper"
@@ -68,17 +62,14 @@
                             height: pageState.viewAs.device
                                 ? pageState.viewAs.device.cssHeight + 'px'
                                 : '100%'
-                        }"
-                    >
+                        }">
                         <dot-overlay-mask
                             *ngIf="showOverlay"
-                            (click)="iframeOverlayService.hide()"
-                        ></dot-overlay-mask>
+                            (click)="iframeOverlayService.hide()"></dot-overlay-mask>
                         <dot-whats-changed
                             *ngIf="showWhatsChanged"
                             [languageId]="pageState.viewAs.language.id"
-                            [pageId]="pageState.page.identifier"
-                        ></dot-whats-changed>
+                            [pageId]="pageState.page.identifier"></dot-whats-changed>
                         <iframe
                             class="dot-edit__iframe"
                             #iframe
@@ -90,8 +81,7 @@
                             (load)="onLoad($event)"
                             frameborder="0"
                             height="100%"
-                            width="100%"
-                        ></iframe>
+                            width="100%"></iframe>
                     </div>
                 </div>
             </div>
@@ -101,22 +91,18 @@
             class="dot-edit-content__palette"
             *ngIf="(isEnterpriseLicense$ | async) && isEditMode && allowedContent"
             [class.collapsed]="paletteCollapsed"
-            [class.editMode]="isEditMode"
-        >
+            [class.editMode]="isEditMode">
             <dot-palette
                 [allowedContent]="allowedContent"
-                [languageId]="pageStateInternal.page?.languageId"
-            >
+                [languageId]="pageStateInternal.page?.languageId">
             </dot-palette>
             <div
                 class="dot-edit-content__palette-visibility"
                 (click)="paletteCollapsed = !paletteCollapsed"
-                data-testId="palette-visibility"
-            >
+                data-testId="palette-visibility">
                 <dot-icon
                     [name]="paletteCollapsed ? 'chevron_left' : 'chevron_right'"
-                    size="22"
-                ></dot-icon>
+                    size="22"></dot-icon>
             </div>
         </div>
     </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.ts
@@ -428,7 +428,7 @@ export class DotEditContentHtmlService {
      *
      * @returns SeoMetaTagsResult[]
      */
-    getMetaTagsResults(): SeoMetaTagsResult[] {
+    getMetaTagsResults(): Observable<SeoMetaTagsResult[]> {
         const pageDocument = this.getEditPageDocument();
 
         return this.dotSeoMetaTagsService.getMetaTagsResults(pageDocument);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/meta-tags-model.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/meta-tags-model.ts
@@ -1,3 +1,5 @@
+import { Observable } from 'rxjs';
+
 export enum SEO_OPTIONS {
     FAVICON = 'favicon',
     TITLE = 'title',
@@ -68,10 +70,26 @@ export const SeoMediaKeys = {
     facebook: [SEO_OPTIONS.DESCRIPTION, SEO_OPTIONS.OG_IMAGE, SEO_OPTIONS.OG_TITLE],
     google: [SEO_OPTIONS.DESCRIPTION, SEO_OPTIONS.FAVICON, SEO_OPTIONS.TITLE],
     linkedin: [],
-    twitter: []
+    twitter: [],
+    all: [
+        SEO_OPTIONS.DESCRIPTION,
+        SEO_OPTIONS.OG_IMAGE,
+        SEO_OPTIONS.OG_TITLE,
+        SEO_OPTIONS.FAVICON,
+        SEO_OPTIONS.TITLE,
+        SEO_OPTIONS.OG_DESCRIPTION
+    ]
 };
 
 export interface ImageMetaData {
     length: number;
     url: string;
+}
+
+export interface OpenGraphOptions {
+    [key: string]: {
+        getItems: (object: SeoMetaTags) => Observable<SeoRulesResult[]>;
+        sort: number;
+        info: string;
+    };
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/meta-tags-model.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/meta-tags-model.ts
@@ -2,7 +2,9 @@ export enum SEO_OPTIONS {
     FAVICON = 'favicon',
     TITLE = 'title',
     DESCRIPTION = 'description',
-    OG_DESCRIPTION = 'og:description'
+    OG_DESCRIPTION = 'og:description',
+    OG_TITLE = 'og:title',
+    OG_IMAGE = 'og:image'
 }
 
 export enum SEO_RULES_ICONS {
@@ -16,8 +18,11 @@ export enum SEO_RULES_ICONS {
 export enum SEO_LIMITS {
     MIN_TITLE_LENGTH = 30,
     MAX_TITLE_LENGTH = 60,
+    MIN_OG_TITLE_LENGTH = 30,
+    MAX_OG_TITLE_LENGTH = 160,
     MAX_FAVICONS = 1,
-    MAX_TITLES = 1
+    MAX_TITLES = 1,
+    MAX_IMAGE_BYTES = 8000000
 }
 
 export enum SEO_RULES_COLORS {
@@ -51,6 +56,22 @@ export interface SeoMetaTags {
     title?: string;
     faviconElements?: NodeListOf<Element>;
     titleElements?: NodeListOf<Element>;
+    titleOgElements?: NodeListOf<Element>;
+    imageOgElements?: NodeListOf<Element>;
     description?: string;
     'og:description'?: string;
+    'og:image'?: string;
+    'og:title'?: string;
+}
+
+export const SeoMediaKeys = {
+    facebook: [SEO_OPTIONS.DESCRIPTION, SEO_OPTIONS.OG_IMAGE, SEO_OPTIONS.OG_TITLE],
+    google: [SEO_OPTIONS.DESCRIPTION, SEO_OPTIONS.FAVICON, SEO_OPTIONS.TITLE],
+    linkedin: [],
+    twitter: []
+};
+
+export interface ImageMetaData {
+    length: number;
+    url: string;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/meta-tags-model.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/meta-tags-model.ts
@@ -87,9 +87,7 @@ export interface ImageMetaData {
 }
 
 export interface OpenGraphOptions {
-    [key: string]: {
-        getItems: (object: SeoMetaTags) => Observable<SeoRulesResult[]>;
-        sort: number;
-        info: string;
-    };
+    getItems: (object: SeoMetaTags) => Observable<SeoRulesResult[]>;
+    sort: number;
+    info: string;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-seo-meta-tags.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-seo-meta-tags.service.spec.ts
@@ -1,3 +1,5 @@
+import { of } from 'rxjs';
+
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
@@ -89,7 +91,10 @@ describe('DotSetMetaTagsService', () => {
 
         const ogMetaImage = document.createElement('meta');
         ogMetaImage.setAttribute('property', 'og:image');
-        ogMetaImage.setAttribute('content', 'image');
+        ogMetaImage.setAttribute(
+            'content',
+            'https://www.dotcms.com/dA/4e870b9fe0/1200w/jpeg/70/dotcms-defualt-og.jpg'
+        );
 
         const linkCanonical = document.createElement('link');
         linkCanonical.rel = 'icon';
@@ -120,11 +125,18 @@ describe('DotSetMetaTagsService', () => {
             titleOgElements: titleOgElements,
             imageOgElements: imagesOgElements,
             'og:title': 'Costa Rica Special Offer',
-            'og:image': 'image'
+            'og:image': 'https://www.dotcms.com/dA/4e870b9fe0/1200w/jpeg/70/dotcms-defualt-og.jpg'
         });
     });
 
-    it('should get the result found for ogTags', () => {
+    it('should get the result found for ogTags with the async call', () => {
+        spyOn(service, 'getImageFileSize').and.returnValue(
+            of({
+                length: 8000000,
+                url: 'https://www.dotcms.com/dA/4e870b9fe0/1200w/jpeg/70/dotcms-defualt-og.jpg'
+            })
+        );
+
         const result = service.getMetaTagsResults(testDoc);
 
         expect(result).toEqual(seoOGTagsResultOgMock);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-seo-meta-tags.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-seo-meta-tags.service.spec.ts
@@ -137,8 +137,9 @@ describe('DotSetMetaTagsService', () => {
             })
         );
 
-        const result = service.getMetaTagsResults(testDoc);
-
-        expect(result).toEqual(seoOGTagsResultOgMock);
+        service.getMetaTagsResults(testDoc).subscribe((value) => {
+            expect(value.length).toEqual(6);
+            expect(value).toEqual(seoOGTagsResultOgMock);
+        });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-seo-meta-tags.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-seo-meta-tags.service.spec.ts
@@ -1,9 +1,12 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { DotMessageService } from '@dotcms/data-access';
+import { DotMessageService, DotUploadService } from '@dotcms/data-access';
+import { MockDotMessageService } from '@dotcms/utils-testing';
 
 import { DotSeoMetaTagsService } from './dot-seo-meta-tags.service';
+
+import { seoOGTagsResultOgMock } from '../../../seo/components/dot-results-seo-tool/mocks';
 
 describe('DotSetMetaTagsService', () => {
     let service: DotSeoMetaTagsService;
@@ -13,7 +16,56 @@ describe('DotSetMetaTagsService', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
-            providers: [DotSeoMetaTagsService, DotMessageService]
+            providers: [
+                DotSeoMetaTagsService,
+                {
+                    provide: DotMessageService,
+                    useValue: new MockDotMessageService({
+                        'seo.rules.favicon.not.found': 'FavIcon not found!',
+                        'seo.rules.favicon.more.one.found': 'More than 1 FavIcon found!',
+                        'seo.rules.favicon.found': 'FavIcon found!',
+                        'seo.rules.description.not.found':
+                            'Meta Description not found! Showing Description instead.',
+                        'seo.rules.description.found.empty':
+                            'Meta Description found, but is empty!',
+                        'seo.rules.description.found': 'Meta Description found!',
+                        'seo.rules.title.not.found': 'HTML Title not found!',
+                        'seo.rules.title.more.one.found': 'More than 1 HTML Title found!',
+                        'seo.rules.title.greater':
+                            'HTML Title found, but has more than 60 characters.',
+                        'seo.rules.title.less':
+                            'HTML Title found, but has fewer than 30 characters of content.',
+                        'seo.rules.title.found':
+                            'HTML Title found, with an appropriate amount of content!',
+                        'seo.resuls.tool.read.more': 'Read More',
+                        'seo.resuls.tool.version': 'Version',
+                        'seo.rules.description.info':
+                            'The length of the description allowed will depend on the readers device size; on the smallest size only about 110 characters are allowed.',
+                        'seo.rules.title.info':
+                            'HTML Title content should be between 30 and 60 characters.',
+                        'seo.rules.og-title.not.found':
+                            'og:title metatag not found! Showing HTML Title instead.',
+                        'seo.rules.og-title.more.one.found': 'more than 1 og:title metatag found!',
+                        'seo.rules.og-title.more.one.found.empty':
+                            'og:title metatag found, but is empty!',
+                        'seo.rules.og-title.greater':
+                            'og:title metatag found, but has more than 160 characters.',
+                        'seo.rules.og-title.less:og':
+                            'title metatag found, but has fewer than 30 characters of content.',
+                        'seo.rules.og-title.found':
+                            'og:title metatag found, with an appropriate amount of content!',
+                        'seo.rules.og-image.not.found': 'og:image metatag not found!',
+                        'seo.rules.og-image.more.one.found': 'more than 1 og:image metatag found!',
+                        'seo.rules.og-image.more.one.found.empty':
+                            'og:image metatag found, but is empty!',
+                        'seo.rules.og-image.over':
+                            'og:image metatag found, but image is over 8 MB.',
+                        'seo.rules.og-image.found':
+                            'og:image metatag found, with an appropriate sized image!'
+                    })
+                },
+                DotUploadService
+            ]
         });
         service = TestBed.inject(DotSeoMetaTagsService);
 
@@ -31,6 +83,14 @@ describe('DotSetMetaTagsService', () => {
         metaDesc.content =
             'Get down to Costa Rica this winter for some of the best surfing int he world. Large winter swell is pushing across the Pacific.';
 
+        const ogMetaTitle = document.createElement('meta');
+        ogMetaTitle.setAttribute('property', 'og:title');
+        ogMetaTitle.setAttribute('content', 'Costa Rica Special Offer');
+
+        const ogMetaImage = document.createElement('meta');
+        ogMetaImage.setAttribute('property', 'og:image');
+        ogMetaImage.setAttribute('content', 'image');
+
         const linkCanonical = document.createElement('link');
         linkCanonical.rel = 'icon';
         linkCanonical.href = 'https://dotcms.com/img/favicon';
@@ -40,11 +100,15 @@ describe('DotSetMetaTagsService', () => {
         head.appendChild(linkCanonical);
         head.appendChild(metaDesc);
         head.appendChild(title);
+        head.appendChild(ogMetaImage);
+        head.appendChild(ogMetaTitle);
     });
 
     it('should returns the meta tags elements map in the object', () => {
         const titleList = testDoc.querySelectorAll('title');
         const faviconList = testDoc.querySelectorAll('link[rel="icon"]');
+        const titleOgElements = testDoc.querySelectorAll('meta[property="og:title"]');
+        const imagesOgElements = testDoc.querySelectorAll('meta[property="og:image"]');
 
         expect(service.getMetaTags(testDoc)).toEqual({
             title: 'Costa Rica Special Offer',
@@ -52,7 +116,17 @@ describe('DotSetMetaTagsService', () => {
                 'Get down to Costa Rica this winter for some of the best surfing int he world. Large winter swell is pushing across the Pacific.',
             favicon: 'https://dotcms.com/img/favicon',
             faviconElements: faviconList,
-            titleElements: titleList
+            titleElements: titleList,
+            titleOgElements: titleOgElements,
+            imageOgElements: imagesOgElements,
+            'og:title': 'Costa Rica Special Offer',
+            'og:image': 'image'
         });
+    });
+
+    it('should get the result found for ogTags', () => {
+        const result = service.getMetaTagsResults(testDoc);
+
+        expect(result).toEqual(seoOGTagsResultOgMock);
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.html
@@ -40,7 +40,7 @@
     </p-card>
 </div>
 
-<p-card class="results-seo-tool__result-card" *ngFor="let result of seoOGTagsResults | async">
+<p-card class="results-seo-tool__result-card" *ngFor="let result of currentResults | async">
     <ng-template class="results-seo-tool__result-card-header" pTemplate="header">
         <div class="results-seo-tool__result-card-title">
             <i

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.html
@@ -40,7 +40,7 @@
     </p-card>
 </div>
 
-<p-card class="results-seo-tool__result-card" *ngFor="let result of currentResults">
+<p-card class="results-seo-tool__result-card" *ngFor="let result of seoOGTagsResults | async">
     <ng-template class="results-seo-tool__result-card-header" pTemplate="header">
         <div class="results-seo-tool__result-card-title">
             <i

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.html
@@ -1,40 +1,51 @@
 <div class="results-seo-tool__main-card">
     <p-card>
         <div class="results-seo-tool__main-card-content">
-            <div *ngFor="let preview of mainPreview">
-                <span class="results-seo-tool__main-card-title">{{ preview.type }} Version</span>
-                <div
-                    class="results-seo-tool__card"
-                    [class.results-seo-tool__version--small]="preview.isMobile"
-                    data-testId="seo-preview"
-                >
-                    <div class="results-seo-tool__card-title">
-                        <img
-                            class="results-seo-tool__card-favicon"
-                            [src]="seoOGTags.favicon"
-                            alt="favicon"
-                        />
-                        <span>{{ preview.hostName }}</span>
+            <div [ngSwitch]="seoMedia">
+                <div *ngSwitchCase="'Facebook'">
+                    <img src="{{ mainPreview[0].image }}" width="100%" alt="preview image" />
+                    <div class="results-seo-tool__facebook">
+                        <span>{{ mainPreview[0].hostName }}</span>
+                        <h5>{{ mainPreview[0].title }}</h5>
+                        <p>{{ mainPreview[0].description }}</p>
                     </div>
-                    <a class="results-seo-tool__search-title" data-testId="page-title" href="#">
-                        {{ preview.title }}
-                    </a>
-                    <p class="results-seo-tool__search-description">
-                        {{ preview.description }}
-                    </p>
+                </div>
+                <div *ngSwitchDefault>
+                    <div *ngFor="let preview of mainPreview">
+                        <span class="results-seo-tool__main-card-title"
+                            >{{ preview.type }} Version</span
+                        >
+                        <div
+                            class="results-seo-tool__card"
+                            [class.results-seo-tool__version--small]="preview.isMobile"
+                            data-testId="seo-preview">
+                            <div class="results-seo-tool__card-title">
+                                <img
+                                    class="results-seo-tool__card-favicon"
+                                    [src]="seoOGTags.favicon"
+                                    alt="favicon" />
+                                <span>{{ preview.hostName }}</span>
+                            </div>
+                            <a class="results-seo-tool__search-title" data-testId="page-title">
+                                {{ preview.title }}
+                            </a>
+                            <p class="results-seo-tool__search-description">
+                                {{ preview.description }}
+                            </p>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
     </p-card>
 </div>
 
-<p-card class="results-seo-tool__result-card" *ngFor="let result of seoOGTagsResults">
+<p-card class="results-seo-tool__result-card" *ngFor="let result of currentResults">
     <ng-template class="results-seo-tool__result-card-header" pTemplate="header">
         <div class="results-seo-tool__result-card-title">
             <i
                 class="results-seo-tool__result-icon pi"
-                [ngClass]="[result.keyColor, result.keyIcon]"
-            ></i>
+                [ngClass]="[result.keyColor, result.keyIcon]"></i>
             <span data-testId="result-key"> {{ result.key | titlecase }}</span>
         </div>
     </ng-template>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.html
@@ -3,7 +3,7 @@
         <div class="results-seo-tool__main-card-content">
             <div [ngSwitch]="seoMedia">
                 <div *ngSwitchCase="'Facebook'">
-                    <img src="{{ mainPreview[0].image }}" width="100%" alt="preview image" />
+                    <img [src]="mainPreview[0].image" width="100%" alt="preview image" />
                     <div class="results-seo-tool__facebook">
                         <span>{{ mainPreview[0].hostName }}</span>
                         <h5>{{ mainPreview[0].title }}</h5>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.scss
@@ -173,6 +173,6 @@
     }
 
     .results-seo-tool__main-card .p-card .p-card-body {
-        padding: 1rem;
+        padding: $spacing-1;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.scss
@@ -128,6 +128,23 @@
     color: $color-alert-green;
 }
 
+.results-seo-tool__facebook {
+    margin-top: $spacing-1;
+
+    h5 {
+        padding: 0;
+        margin: $spacing-1 0;
+        font-size: $font-size-md;
+        font-weight: $font-weight-bold;
+        color: $black;
+    }
+
+    p {
+        padding: 0;
+        margin: 0;
+    }
+}
+
 :host ::ng-deep {
     .results-seo-tool__result-card .p-card {
         border: 1px solid $color-palette-gray-400;
@@ -153,5 +170,9 @@
 
     .results-seo-tool__result-card-list .pi-external-link {
         color: $color-palette-primary-500;
+    }
+
+    .results-seo-tool__main-card .p-card .p-card-body {
+        padding: 1rem;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.scss
@@ -173,6 +173,6 @@
     }
 
     .results-seo-tool__main-card .p-card .p-card-body {
-        padding: $spacing-1;
+        padding: $spacing-3;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.spec.ts
@@ -1,4 +1,5 @@
 import { Spectator, byTestId, createComponentFactory } from '@ngneat/spectator';
+import { of } from 'rxjs';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { MockDotMessageService } from '@dotcms/utils-testing';
@@ -66,7 +67,7 @@ describe('DotResultsSeoToolComponent', () => {
             props: {
                 hostName: 'A title',
                 seoOGTags: seoOGTagsMock,
-                seoOGTagsResults: seoOGTagsResultMock,
+                seoOGTagsResults: of(seoOGTagsResultMock),
                 seoMedia: 'google'
             }
         });
@@ -108,10 +109,11 @@ describe('DotResultsSeoToolComponent', () => {
     it('should filter seo results by seoMedia on changes', () => {
         spectator.fixture.componentInstance.seoMedia = 'facebook';
         spectator.component.ngOnChanges();
-
-        expect(spectator.component.currentResults.length).toEqual(3);
-        expect(spectator.component.currentResults[0].key).toEqual(seoOGTagsResultMock[1].key);
-        expect(spectator.component.currentResults[1].key).toEqual(seoOGTagsResultMock[3].key);
-        expect(spectator.component.currentResults[2].key).toEqual(seoOGTagsResultMock[4].key);
+        spectator.component.currentResults.subscribe((items) => {
+            expect(items.length).toEqual(3);
+            expect(items[0].key).toEqual(seoOGTagsResultMock[1].key);
+            expect(items[1].key).toEqual(seoOGTagsResultMock[3].key);
+            expect(items[2].key).toEqual(seoOGTagsResultMock[4].key);
+        });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.spec.ts
@@ -1,18 +1,73 @@
 import { Spectator, byTestId, createComponentFactory } from '@ngneat/spectator';
 
+import { DotMessageService } from '@dotcms/data-access';
+import { MockDotMessageService } from '@dotcms/utils-testing';
+
 import { DotResultsSeoToolComponent } from './dot-results-seo-tool.component';
 import { seoOGTagsMock, seoOGTagsResultMock } from './mocks';
 
+import { DotSeoMetaTagsService } from '../../../content/services/html/dot-seo-meta-tags.service';
+
 describe('DotResultsSeoToolComponent', () => {
     let spectator: Spectator<DotResultsSeoToolComponent>;
-    const createComponent = createComponentFactory(DotResultsSeoToolComponent);
+    const createComponent = createComponentFactory({
+        component: DotResultsSeoToolComponent,
+        providers: [
+            DotSeoMetaTagsService,
+
+            {
+                provide: DotMessageService,
+                useValue: new MockDotMessageService({
+                    'seo.rules.favicon.not.found': 'FavIcon not found!',
+                    'seo.rules.favicon.more.one.found': 'More than 1 FavIcon found!',
+                    'seo.rules.favicon.found': 'FavIcon found!',
+                    'seo.rules.description.not.found':
+                        'Meta Description not found! Showing Description instead.',
+                    'seo.rules.description.found.empty': 'Meta Description found, but is empty!',
+                    'seo.rules.description.found': 'Meta Description found!',
+                    'seo.rules.title.not.found': 'HTML Title not found!',
+                    'seo.rules.title.more.one.found': 'More than 1 HTML Title found!',
+                    'seo.rules.title.greater': 'HTML Title found, but has more than 60 characters.',
+                    'seo.rules.title.less':
+                        'HTML Title found, but has fewer than 30 characters of content.',
+                    'seo.rules.title.found':
+                        'HTML Title found, with an appropriate amount of content!',
+                    'seo.resuls.tool.read.more': 'Read More',
+                    'seo.resuls.tool.version': 'Version',
+                    'seo.rules.description.info':
+                        'The length of the description allowed will depend on the readers device size; on the smallest size only about 110 characters are allowed.',
+                    'seo.rules.title.info':
+                        'HTML Title content should be between 30 and 60 characters.',
+                    'seo.rules.og-title.not.found':
+                        'og:title metatag not found! Showing HTML Title instead.',
+                    'seo.rules.og-title.more.one.found': 'more than 1 og:title metatag found!',
+                    'seo.rules.og-title.more.one.found.empty':
+                        'og:title metatag found, but is empty!',
+                    'seo.rules.og-title.greater':
+                        'og:title metatag found, but has more than 160 characters.',
+                    'seo.rules.og-title.less:og':
+                        'title metatag found, but has fewer than 30 characters of content.',
+                    'seo.rules.og-title.found':
+                        'og:title metatag found, with an appropriate amount of content!',
+                    'seo.rules.og-image.not.found': 'og:image metatag not found!',
+                    'seo.rules.og-image.more.one.found': 'more than 1 og:image metatag found!',
+                    'seo.rules.og-image.more.one.found.empty':
+                        'og:image metatag found, but is empty!',
+                    'seo.rules.og-image.over': 'og:image metatag found, but image is over 8 MB.',
+                    'seo.rules.og-image.found':
+                        'og:image metatag found, with an appropriate sized image!'
+                })
+            }
+        ]
+    });
 
     beforeEach(() => {
         spectator = createComponent({
             props: {
                 hostName: 'A title',
                 seoOGTags: seoOGTagsMock,
-                seoOGTagsResults: seoOGTagsResultMock
+                seoOGTagsResults: seoOGTagsResultMock,
+                seoMedia: 'google'
             }
         });
     });
@@ -48,5 +103,15 @@ describe('DotResultsSeoToolComponent', () => {
     it('should display mobile size for the preview', () => {
         const previews = spectator.queryAll(byTestId('seo-preview'));
         expect(previews[1]).toHaveClass('results-seo-tool__version--small');
+    });
+
+    it('should filter seo results by seoMedia on changes', () => {
+        spectator.fixture.componentInstance.seoMedia = 'facebook';
+        spectator.component.ngOnChanges();
+
+        expect(spectator.component.currentResults.length).toEqual(3);
+        expect(spectator.component.currentResults[0].key).toEqual(seoOGTagsResultMock[1].key);
+        expect(spectator.component.currentResults[1].key).toEqual(seoOGTagsResultMock[3].key);
+        expect(spectator.component.currentResults[2].key).toEqual(seoOGTagsResultMock[4].key);
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.ts
@@ -11,7 +11,7 @@ import {
     NgSwitchDefault,
     TitleCasePipe
 } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit } from '@angular/core';
 
 import { CardModule } from 'primeng/card';
 
@@ -41,13 +41,12 @@ import { DotSeoMetaTagsService } from '../../../content/services/html/dot-seo-me
     styleUrls: ['./dot-results-seo-tool.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DotResultsSeoToolComponent implements OnInit {
+export class DotResultsSeoToolComponent implements OnInit, OnChanges {
     @Input() hostName: string;
     @Input() seoMedia: string;
     @Input() seoOGTags: SeoMetaTags;
     @Input() seoOGTagsResults: Observable<SeoMetaTagsResult[]>;
-
-    currentResults: SeoMetaTagsResult[];
+    currentResults: Observable<SeoMetaTagsResult[]>;
 
     constructor(private dotSeoMetaTagsService: DotSeoMetaTagsService) {}
 
@@ -81,12 +80,13 @@ export class DotResultsSeoToolComponent implements OnInit {
                 isMobile: true
             }
         ];
+        this.currentResults = this.seoOGTagsResults;
     }
 
-    /* ngOnChanges() {
-       this.currentResults = this.dotSeoMetaTagsService.getFilteredMetaTagsByMedia(
+    ngOnChanges() {
+        this.currentResults = this.dotSeoMetaTagsService.getFilteredMetaTagsByMedia(
             this.seoOGTagsResults,
             this.seoMedia
-        ); 
-    }*/
+        );
+    }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.ts
@@ -1,4 +1,7 @@
+import { Observable } from 'rxjs';
+
 import {
+    AsyncPipe,
     JsonPipe,
     NgClass,
     NgFor,
@@ -8,7 +11,7 @@ import {
     NgSwitchDefault,
     TitleCasePipe
 } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 
 import { CardModule } from 'primeng/card';
 
@@ -30,18 +33,19 @@ import { DotSeoMetaTagsService } from '../../../content/services/html/dot-seo-me
         JsonPipe,
         NgSwitch,
         NgSwitchCase,
-        NgSwitchDefault
+        NgSwitchDefault,
+        AsyncPipe
     ],
     providers: [DotSeoMetaTagsService],
     templateUrl: './dot-results-seo-tool.component.html',
     styleUrls: ['./dot-results-seo-tool.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DotResultsSeoToolComponent implements OnInit, OnChanges {
+export class DotResultsSeoToolComponent implements OnInit {
     @Input() hostName: string;
     @Input() seoMedia: string;
     @Input() seoOGTags: SeoMetaTags;
-    @Input() seoOGTagsResults: SeoMetaTagsResult[];
+    @Input() seoOGTagsResults: Observable<SeoMetaTagsResult[]>;
 
     currentResults: SeoMetaTagsResult[];
 
@@ -79,10 +83,10 @@ export class DotResultsSeoToolComponent implements OnInit, OnChanges {
         ];
     }
 
-    ngOnChanges() {
-        this.currentResults = this.dotSeoMetaTagsService.getFilteredMetaTagsByMedia(
+    /* ngOnChanges() {
+       this.currentResults = this.dotSeoMetaTagsService.getFilteredMetaTagsByMedia(
             this.seoOGTagsResults,
             this.seoMedia
-        );
-    }
+        ); 
+    }*/
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.ts
@@ -1,5 +1,14 @@
-import { NgClass, NgFor, NgIf, TitleCasePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import {
+    JsonPipe,
+    NgClass,
+    NgFor,
+    NgIf,
+    NgSwitch,
+    NgSwitchCase,
+    NgSwitchDefault,
+    TitleCasePipe
+} from '@angular/common';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit } from '@angular/core';
 
 import { CardModule } from 'primeng/card';
 
@@ -7,19 +16,36 @@ import {
     SeoMetaTags,
     SeoMetaTagsResult
 } from '../../../content/services/dot-edit-content-html/models/meta-tags-model';
+import { DotSeoMetaTagsService } from '../../../content/services/html/dot-seo-meta-tags.service';
 
 @Component({
     selector: 'dot-results-seo-tool',
     standalone: true,
-    imports: [NgClass, CardModule, NgFor, TitleCasePipe, NgIf],
+    imports: [
+        NgClass,
+        CardModule,
+        NgFor,
+        TitleCasePipe,
+        NgIf,
+        JsonPipe,
+        NgSwitch,
+        NgSwitchCase,
+        NgSwitchDefault
+    ],
+    providers: [DotSeoMetaTagsService],
     templateUrl: './dot-results-seo-tool.component.html',
     styleUrls: ['./dot-results-seo-tool.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DotResultsSeoToolComponent implements OnInit {
+export class DotResultsSeoToolComponent implements OnInit, OnChanges {
     @Input() hostName: string;
+    @Input() seoMedia: string;
     @Input() seoOGTags: SeoMetaTags;
     @Input() seoOGTagsResults: SeoMetaTagsResult[];
+
+    currentResults: SeoMetaTagsResult[];
+
+    constructor(private dotSeoMetaTagsService: DotSeoMetaTagsService) {}
 
     mainPreview = [];
     readMore = [
@@ -40,7 +66,8 @@ export class DotResultsSeoToolComponent implements OnInit {
                 title: this.seoOGTags['og:title'],
                 description: this.seoOGTags.description,
                 type: 'Desktop',
-                isMobile: false
+                isMobile: false,
+                image: this.seoOGTags['og:image']
             },
             {
                 hostName: this.hostName,
@@ -50,5 +77,12 @@ export class DotResultsSeoToolComponent implements OnInit {
                 isMobile: true
             }
         ];
+    }
+
+    ngOnChanges() {
+        this.currentResults = this.dotSeoMetaTagsService.getFilteredMetaTagsByMedia(
+            this.seoOGTagsResults,
+            this.seoMedia
+        );
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/mocks.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/mocks.ts
@@ -102,7 +102,13 @@ const seoOGTagsResultOgMock = [
         key: 'og:image',
         keyIcon: 'pi-check-circle',
         keyColor: 'results-seo-tool__result-icon--alert-green',
-        items: [],
+        items: [
+            {
+                message: 'og:image metatag found, with an appropriate sized image!',
+                color: 'results-seo-tool__result-icon--alert-green',
+                itemIcon: 'pi-check'
+            }
+        ],
         sort: 5,
         info: ''
     },

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/mocks.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/mocks.ts
@@ -52,7 +52,101 @@ const seoOGTagsResultMock = [
         ],
         sort: 3,
         info: 'HTML Title content should be between 30 and 60 characters.'
+    },
+    {
+        key: 'Og:title',
+        keyIcon: 'pi-check-circle',
+        keyColor: 'results-seo-tool__result-icon--alert-green',
+        items: [
+            {
+                message: 'og:title metatag found, with an appropriate amount of content!',
+                color: 'results-seo-tool__result-icon--alert-green',
+                itemIcon: 'pi-exclamation-circle'
+            }
+        ],
+        sort: 4,
+        info: 'HTML Title content should be between 30 and 60 characters.'
+    },
+    {
+        key: 'Og:image',
+        keyIcon: 'pi-check-circle',
+        keyColor: 'results-seo-tool__result-icon--alert-green',
+        items: [
+            {
+                message: 'og:image metatag found, with an appropriate sized image!',
+                color: 'results-seo-tool__result-icon--alert-green',
+                itemIcon: 'pi-exclamation-circle'
+            }
+        ],
+        sort: 5,
+        info: 'HTML Title content should be between 30 and 60 characters.'
     }
 ];
 
-export { seoOGTagsMock, seoOGTagsResultMock };
+const seoOGTagsResultOgMock = [
+    {
+        key: 'description',
+        keyIcon: 'pi-exclamation-triangle',
+        keyColor: 'results-seo-tool__result-icon--alert-red',
+        items: [
+            {
+                message: 'Meta Description not found! Showing Description instead.',
+                color: 'results-seo-tool__result-icon--alert-red',
+                itemIcon: 'pi-times'
+            }
+        ],
+        sort: 2,
+        info: 'The length of the description allowed will depend on the readers device size; on the smallest size only about 110 characters are allowed.'
+    },
+    {
+        key: 'og:image',
+        keyIcon: 'pi-check-circle',
+        keyColor: 'results-seo-tool__result-icon--alert-green',
+        items: [],
+        sort: 5,
+        info: ''
+    },
+    {
+        key: 'og:title',
+        keyIcon: 'pi-exclamation-triangle',
+        keyColor: 'results-seo-tool__result-icon--alert-yellow',
+        items: [
+            {
+                message: 'seo.rules.og-title.less',
+                color: 'results-seo-tool__result-icon--alert-yellow',
+                itemIcon: 'pi-exclamation-circle'
+            }
+        ],
+        sort: 4,
+        info: 'HTML Title content should be between 30 and 60 characters.'
+    },
+    {
+        key: 'favicon',
+        keyIcon: 'pi-check-circle',
+        keyColor: 'results-seo-tool__result-icon--alert-green',
+        items: [
+            {
+                message: 'FavIcon found!',
+                color: 'results-seo-tool__result-icon--alert-green',
+                itemIcon: 'pi-check'
+            }
+        ],
+        sort: 1
+    },
+    {
+        key: 'title',
+        keyIcon: 'pi-exclamation-triangle',
+        keyColor: 'results-seo-tool__result-icon--alert-yellow',
+        items: [
+            {
+                message: 'HTML Title found, but has fewer than 30 characters of content.',
+                color: 'results-seo-tool__result-icon--alert-yellow',
+                itemIcon: 'pi-exclamation-circle'
+            }
+        ],
+        sort: 3,
+        info: 'HTML Title content should be between 30 and 60 characters.'
+    }
+];
+
+export { seoOGTagsMock, seoOGTagsResultMock, seoOGTagsResultOgMock };

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/mocks.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/mocks.ts
@@ -109,7 +109,7 @@ const seoOGTagsResultOgMock = [
                 itemIcon: 'pi-check'
             }
         ],
-        sort: 5,
+        sort: 6,
         info: ''
     },
     {
@@ -123,7 +123,7 @@ const seoOGTagsResultOgMock = [
                 itemIcon: 'pi-exclamation-circle'
             }
         ],
-        sort: 4,
+        sort: 5,
         info: 'HTML Title content should be between 30 and 60 characters.'
     },
     {
@@ -137,7 +137,8 @@ const seoOGTagsResultOgMock = [
                 itemIcon: 'pi-check'
             }
         ],
-        sort: 1
+        sort: 1,
+        info: ''
     },
     {
         key: 'title',
@@ -150,8 +151,22 @@ const seoOGTagsResultOgMock = [
                 itemIcon: 'pi-exclamation-circle'
             }
         ],
-        sort: 3,
+        sort: 4,
         info: 'HTML Title content should be between 30 and 60 characters.'
+    },
+    {
+        key: 'og:description',
+        keyIcon: 'pi-exclamation-triangle',
+        keyColor: 'results-seo-tool__result-icon--alert-red',
+        items: [
+            {
+                message: 'Meta Description not found! Showing Description instead.',
+                color: 'results-seo-tool__result-icon--alert-red',
+                itemIcon: 'pi-times'
+            }
+        ],
+        sort: 3,
+        info: 'The length of the description allowed will depend on the readers device size; on the smallest size only about 110 characters are allowed.'
     }
 ];
 

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5423,3 +5423,20 @@ seo.resuls.tool.version=Version
 
 seo.rules.description.info=The length of the description allowed will depend on the reader's device size; on the smallest size only about 110 characters are allowed.
 seo.rules.title.info=HTML Title content should be between 30 and 60 characters.
+
+seo.rules.og-title.not.found=og:title metatag not found! Showing HTML Title instead.
+seo.rules.og-title.more.one.found=more than 1 og:title metatag found!
+seo.rules.og-title.more.one.found.empty=og:title metatag found, but is empty!
+
+seo.rules.og-title.greater=og:title metatag found, but has more than 160 characters.
+seo.rules.og-title.less=og:title metatag found, but has fewer than 30 characters of content.
+
+seo.rules.og-title.found=og:title metatag found, with an appropriate amount of content!
+
+seo.rules.og-image.not.found=og:image metatag not found!
+seo.rules.og-image.more.one.found=more than 1 og:image metatag found!
+seo.rules.og-image.more.one.found.empty=og:image metatag found, but is empty!
+
+seo.rules.og-image.over=og:image metatag found, but image is over 8 MB.
+
+seo.rules.og-image.found=og:image metatag found, with an appropriate sized image!


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f255678</samp>

### Summary
🌐🖼️📱

<!--
1.  🌐 - This emoji represents the addition of new messages and labels for different languages, which improves the internationalization of the dotCMS application.
2.  🖼️ - This emoji represents the support for the `og:image` meta tag, which improves the visual appearance of the social media sharing of pages.
3.  📱 - This emoji represents the feature of filtering and rendering the SEO results by media platform, which improves the user experience and the compatibility of the SEO preview.
-->
This pull request adds support for the `og:title` and `og:image` meta tags in the dotCMS SEO tool, which are used to improve the social media sharing of pages. It also fixes some minor HTML issues and adds a feature to filter the SEO results by media platform. It modifies several files in the `core-web` and `dotCMS` projects, including HTML templates, CSS styles, TypeScript models, services, and components, and language properties. It also adds unit tests and mock data for the new features and validations.

> _To improve social sharing of pages_
> _We added some new SEO stages_
> _We checked `og:title` and `og:image` too_
> _And filtered results by platform view_
> _And fixed some HTML and CSS rages_

### Walkthrough
*  Remove extra closing tags and line breaks in `dot-edit-content.component.html` to fix template rendering and layout issues ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-bdd3ad691984c6a98ed8584d09c67080428ce8738627187e6ab67504d175529fL5-R9), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-bdd3ad691984c6a98ed8584d09c67080428ce8738627187e6ab67504d175529fL25-R23), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-bdd3ad691984c6a98ed8584d09c67080428ce8738627187e6ab67504d175529fL39-R41), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-bdd3ad691984c6a98ed8584d09c67080428ce8738627187e6ab67504d175529fL71-R72), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-bdd3ad691984c6a98ed8584d09c67080428ce8738627187e6ab67504d175529fL93-R84), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-bdd3ad691984c6a98ed8584d09c67080428ce8738627187e6ab67504d175529fL104-R105))
* Add `hostName` and `seoMedia` inputs to `dot-results-seo-tool` component to display host name and filter SEO results by media platform ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-bdd3ad691984c6a98ed8584d09c67080428ce8738627187e6ab67504d175529fL54-R54))
* Add `OG_TITLE` and `OG_IMAGE` values to `SEO_OPTIONS` enum and `MIN_OG_TITLE_LENGTH`, `MAX_OG_TITLE_LENGTH`, and `MAX_IMAGE_BYTES` constants to `SEO_LIMITS` enum in `meta-tags-model.ts` to represent `og:title` and `og:image` meta tags and their validation limits ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-0b1cbca20fc4f4b1ccb288bb32c6dd4e26d1f4dc6d7647e530ca3c52dea1f1f5L5-R7), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-0b1cbca20fc4f4b1ccb288bb32c6dd4e26d1f4dc6d7647e530ca3c52dea1f1f5L19-R25))
* Add `titleOgElements`, `imageOgElements`, `og:title`, and `og:image` properties to `SeoMetaTags` interface in `meta-tags-model.ts` to store node list and content of `og:title` and `og:image` meta tags ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-0b1cbca20fc4f4b1ccb288bb32c6dd4e26d1f4dc6d7647e530ca3c52dea1f1f5L54-R77))
* Add mock provider for `DotMessageService` and imports for `DotMessageService` and `DotUploadService` in `dot-seo-meta-tags.service.spec.ts` to provide mock messages and upload service for `DotSeoMetaTagsService` unit tests ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-f58cdbe27f1c14d0eb0ce89dec3179e958e29561996358866889c3a1ce122185L4-R10), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-f58cdbe27f1c14d0eb0ce89dec3179e958e29561996358866889c3a1ce122185L16-R68))
* Add `ogMetaTitle` and `ogMetaImage` variables and append them to test document head in `dot-seo-meta-tags.service.spec.ts` to simulate `og:title` and `og:image` meta tags in test document ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-f58cdbe27f1c14d0eb0ce89dec3179e958e29561996358866889c3a1ce122185R86-R93), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-f58cdbe27f1c14d0eb0ce89dec3179e958e29561996358866889c3a1ce122185R103-R104))
* Add `titleOgElements` and `imagesOgElements` variables and properties to `dot-seo-meta-tags.service.spec.ts` to verify node list of `og:title` and `og:image` meta tags in SEO service output ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-f58cdbe27f1c14d0eb0ce89dec3179e958e29561996358866889c3a1ce122185R110-R111), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-f58cdbe27f1c14d0eb0ce89dec3179e958e29561996358866889c3a1ce122185L55-R131))
* Add imports for `Observable` and `from` in `dot-seo-meta-tags.service.ts` to create and return observable streams from promises for image size validation ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715L1-R9))
* Add provider for `DotUploadService` in `DotSeoMetaTagsService` class to upload `og:image` meta tag content to server if external and get file size information ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715L13-R28))
* Add `titleOgElements` and `imagesOgElements` variables and properties to `getMetaTagsObject` method in `DotSeoMetaTagsService` class to populate and store node list of `og:title` and `og:image` meta tags ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715R48-R49), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715R55-R56))
* Add conditional blocks to `getMetaTagsResults` method in `DotSeoMetaTagsService` class to handle SEO rules for `og:title` and `og:image` meta tags and call `getOgTitleItems` and `getOgImagesItems` methods to get SEO rules results ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715L93-R154))
* Fix logical error in `getTitleItems` method in `DotSeoMetaTagsService` class by using `||` operator instead of `&&` operator to check `title` length ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715L221-R279))
* Add `getOgTitleItems` and `getOgImagesItems` methods to `DotSeoMetaTagsService` class to return SEO rules results for `og:title` and `og:image` meta tags and check presence, length, and size of meta tags and generate messages, colors, and icons for SEO results ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715R290-R405))
* Add `ngSwitch` directive to `dot-results-seo-tool.component.html` template to render different SEO previews based on `seoMedia` input value and use `NgSwitchCase` and `NgSwitchDefault` directives to handle Facebook and default cases ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-89e37243c442c5e79f19f64f75095ce16f02aff9b8befc8f0af091039aabbff1L4-R37))
* Replace `seoOGTagsResults` input with `currentResults` property in `dot-results-seo-tool.component.html` template to use filtered SEO results by media platform ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-89e37243c442c5e79f19f64f75095ce16f02aff9b8befc8f0af091039aabbff1L31-R48))
* Add CSS rules to `dot-results-seo-tool.component.scss` file to style Facebook preview layout and override default padding for main card body in SEO preview ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-413673954769eefe0c51cf5d081b00d129a4bacea826b837e69b5d00f8a1168dR131-R147), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-413673954769eefe0c51cf5d081b00d129a4bacea826b837e69b5d00f8a1168dR174-R177))
* Add import for `DotSeoMetaTagsService` and input for `seoMedia` in `dot-results-seo-tool.component.spec.ts` to provide `DotSeoMetaTagsService` class and specify media platform for `DotResultsSeoToolComponent` unit tests ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-07d21ddb95ed132c23e64c908dea0c11193cf632cebf2359b2cc4ca67709429bL3-R63), [link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-07d21ddb95ed132c23e64c908dea0c11193cf632cebf2359b2cc4ca67709429bL15-R70))
* Add unit test to `dot-results-seo-tool.component.spec.ts` to check filtering of SEO results by media platform and expect `currentResults` property to have SEO results for `description`, `og:image`, and `og:title` meta tags for Facebook case ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-07d21ddb95ed132c23e64c908dea0c11193cf632cebf2359b2cc4ca67709429bR107-R116))
* Add imports for `JsonPipe`, `NgSwitch`, `NgSwitchCase`, `NgSwitchDefault`, and `OnChanges` in `dot-results-seo-tool.component.ts` to implement `ngSwitch` directive in template and `ngOnChanges` method in class ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-6084f02c375b9edee18f429040e76a983a8469637f28dd29a9c8fa330774fb88L1-R11))
* Add `currentResults`, `seoMedia`, `DotSeoMetaTagsService`, and `providers` properties and providers to `DotResultsSeoToolComponent` class to store filtered SEO results, specify media platform, inject `DotSeoMetaTagsService` class, and pass providers to component metadata ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-6084f02c375b9edee18f429040e76a983a8469637f28dd29a9c8fa330774fb88L10-R49))
* Add `image` property to `mainPreview` array in `DotResultsSeoToolComponent` class to store value of `og:image` meta tag and render image in Facebook preview layout ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-6084f02c375b9edee18f429040e76a983a8469637f28dd29a9c8fa330774fb88L43-R70))
* Add `ngOnChanges` method to `DotResultsSeoToolComponent` class to update SEO results based on media platform by calling `getFilteredMetaTagsByMedia` method from `DotSeoMetaTagsService` class and assigning result to `currentResults` property ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-6084f02c375b9edee18f429040e76a983a8469637f28dd29a9c8fa330774fb88R81-R87))
* Add values for SEO results for `og:title` and `og:image` meta tags to `seoOGTagsResultMock` object and add `seoOGTagsResultOgMock` object to `mocks.ts` file to use for `DotResultsSeoToolComponent` unit tests ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-d290baa51a6e580d34ffe887fb5755d18dde6ea3657af381622595ec0f751104L55-R152))
* Add properties for SEO rules messages for `og:title` and `og:image` meta tags to `Language.properties` file to display SEO results for these meta tags in different languages ([link](https://github.com/dotCMS/core/pull/26020/files?diff=unified&w=0#diff-21db9723fa4c52389731b7575f1e19bd364aa992b7e549e22c08a33456994e94L5426-R5441))



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
