### PR TITLE
Apps : Fix Hidden Secrets Not Saving in Dot Velocity Secrets

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.spec.ts
@@ -140,12 +140,16 @@ describe('DotAppsConfigurationDetailFormComponent', () => {
             expect(de.query(By.css('dot-icon'))).toBeFalsy();
         });
 
-        it('should focus on first input when loaded', async () => {
-            const focusField = component.formContainer.nativeElement.querySelector('#name');
-            spyOn(focusField, 'focus');
+        it('should focus the first form field after view init', async () => {
             fixture.detectChanges();
             await fixture.whenStable();
-            expect(focusField.focus).toHaveBeenCalledTimes(1);
+            const firstFormField = fixture.nativeElement.querySelector(
+                `#${component.formFields[0].name}`
+            );
+            spyOn(firstFormField, 'focus');
+            component.ngAfterViewInit();
+            expect(firstFormField.focus).toHaveBeenCalled();
+            expect(document.activeElement).toEqual(firstFormField);
         });
 
         it('should load Label, Textarea & Hint with right attributes', () => {
@@ -225,7 +229,9 @@ describe('DotAppsConfigurationDetailFormComponent', () => {
             expect(openMock).toHaveBeenCalledWith(secrets[4].value, '_blank');
         });
 
-        it('should emit form state when loaded', () => {
+        it('should emit form state when loaded', async () => {
+            fixture.detectChanges();
+            await fixture.whenStable();
             expect(component.data.emit).toHaveBeenCalledWith(formState);
             expect(component.valid.emit).toHaveBeenCalledWith(true);
         });
@@ -234,8 +240,8 @@ describe('DotAppsConfigurationDetailFormComponent', () => {
             component.myFormGroup.get('name').setValue('Test2');
             component.myFormGroup.get('password').setValue('Password2');
             component.myFormGroup.get('enabled').setValue('false');
-            expect(component.data.emit).toHaveBeenCalledTimes(4);
-            expect(component.valid.emit).toHaveBeenCalledTimes(4);
+            expect(component.data.emit).toHaveBeenCalledTimes(3);
+            expect(component.valid.emit).toHaveBeenCalledTimes(3);
         });
 
         it('should emit form state disabled when required field empty', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.ts
@@ -1,4 +1,5 @@
 import {
+    AfterViewInit,
     Component,
     ElementRef,
     EventEmitter,
@@ -25,7 +26,7 @@ const getFieldValueFn = {
     templateUrl: './dot-apps-configuration-detail-form.component.html',
     styleUrls: ['./dot-apps-configuration-detail-form.component.scss']
 })
-export class DotAppsConfigurationDetailFormComponent implements OnInit {
+export class DotAppsConfigurationDetailFormComponent implements OnInit, AfterViewInit {
     @ViewChild('form', { static: true }) public form: NgForm;
     @ViewChild('formContainer', { static: true }) public formContainer: ElementRef;
 
@@ -49,10 +50,12 @@ export class DotAppsConfigurationDetailFormComponent implements OnInit {
             this.emitValues();
         });
 
-        setTimeout(() => {
-            this.emitValues();
-            this.formContainer.nativeElement.querySelector(`#${this.formFields[0].name}`).focus();
-        }, 0);
+        setTimeout(() => this.emitValues());
+    }
+
+    ngAfterViewInit() {
+        // Do it this way because the form is rendered dynamically
+        this.formContainer.nativeElement.querySelector(`#${this.formFields[0].name}`).focus();
     }
 
     /**

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.ts
@@ -49,9 +49,8 @@ export class DotAppsConfigurationDetailFormComponent implements OnInit {
             this.emitValues();
         });
 
-        this.emitValues();
-
         setTimeout(() => {
+            this.emitValues();
             this.formContainer.nativeElement.querySelector(`#${this.formFields[0].name}`).focus();
         }, 0);
     }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-ng.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-ng.component.spec.ts
@@ -25,7 +25,7 @@ export const mockKeyValue = [
     {
         key: 'password',
         hidden: true,
-        value: '*****'
+        value: '123456'
     }
 ];
 
@@ -34,8 +34,7 @@ export const mockKeyValue = [
     template: `
         <dot-key-value-ng
             [showHiddenField]="showHiddenField"
-            [variables]="value"
-        ></dot-key-value-ng>
+            [variables]="value"></dot-key-value-ng>
     `
 })
 class TestHostComponent {
@@ -176,6 +175,6 @@ describe('DotKeyValueComponent', () => {
         tableRow = de.query(By.css('dot-key-value-table-input-row')).componentInstance;
         tableRow.save.emit(mockKeyValue[1]);
         expect(component.save.emit).toHaveBeenCalledWith(mockKeyValue[1]);
-        expect(component.variables[1]).toEqual({ ...mockKeyValue[1], value: '********' });
+        expect(component.variables[1]).toEqual({ ...mockKeyValue[1], value: '123456' });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-ng.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-ng.component.ts
@@ -4,8 +4,6 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from
 
 import { DotKeyValue } from '@shared/models/dot-key-value-ng/dot-key-value-ng.model';
 
-import { DotKeyValueUtil } from './util/dot-key-value-util';
-
 @Component({
     selector: 'dot-key-value-ng',
     styleUrls: ['./dot-key-value-ng.component.scss'],
@@ -46,15 +44,6 @@ export class DotKeyValueComponent implements OnChanges {
      */
     saveVariable(variable: DotKeyValue): void {
         this.save.emit(variable);
-
-        variable = this.setHiddenValue(variable);
-        const indexChanged = DotKeyValueUtil.getVariableIndexChanged(variable, this.variables);
-        if (indexChanged !== null) {
-            this.variables[indexChanged] = _.cloneDeep(variable);
-        } else {
-            this.variables = [variable, ...this.variables];
-        }
-
         this.variablesBackup = [...this.variables];
     }
 
@@ -65,11 +54,5 @@ export class DotKeyValueComponent implements OnChanges {
      */
     onCancel(fieldIndex: number): void {
         this.variablesBackup[fieldIndex] = _.cloneDeep(this.variables[fieldIndex]);
-    }
-
-    private setHiddenValue(variable: DotKeyValue): DotKeyValue {
-        variable.value = variable.hidden ? '********' : variable.value;
-
-        return variable;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-ng.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-ng.component.ts
@@ -56,6 +56,7 @@ export class DotKeyValueComponent implements OnChanges {
 
         this.variablesBackup = [...this.variables];
     }
+
     /**
      * Handle Cancel event, restoring the original value of the variable
      * @param {number} fieldIndex

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-ng.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-ng.component.ts
@@ -4,6 +4,8 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from
 
 import { DotKeyValue } from '@shared/models/dot-key-value-ng/dot-key-value-ng.model';
 
+import { DotKeyValueUtil } from './util/dot-key-value-util';
+
 @Component({
     selector: 'dot-key-value-ng',
     styleUrls: ['./dot-key-value-ng.component.scss'],
@@ -44,9 +46,16 @@ export class DotKeyValueComponent implements OnChanges {
      */
     saveVariable(variable: DotKeyValue): void {
         this.save.emit(variable);
+
+        const indexChanged = DotKeyValueUtil.getVariableIndexChanged(variable, this.variables);
+        if (indexChanged !== null) {
+            this.variables[indexChanged] = _.cloneDeep(variable);
+        } else {
+            this.variables = [variable, ...this.variables];
+        }
+
         this.variablesBackup = [...this.variables];
     }
-
     /**
      * Handle Cancel event, restoring the original value of the variable
      * @param {number} fieldIndex

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.html
@@ -5,7 +5,7 @@
 
     <ng-template [ngIf]="isHiddenField" [ngIfElse]="editableValue">
         <td data-testId="dot-key-value-label">
-            {{ variableCopy.hidden ? passwordPlaceholder : variableCopy.value }}
+            {{ passwordPlaceholder }}
         </td>
     </ng-template>
     <ng-template #editableValue>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.html
@@ -1,14 +1,19 @@
 <tr class="dot-key-value-table-row">
-    <td>
+    <td data-testId="dot-key-value-key">
         {{ variableCopy.key }}
     </td>
+
     <ng-template [ngIf]="isHiddenField" [ngIfElse]="editableValue">
         <td data-testId="dot-key-value-label">
             {{ variableCopy.hidden ? passwordPlaceholder : variableCopy.value }}
         </td>
     </ng-template>
     <ng-template #editableValue>
-        <td #valueCell [pEditableColumn]="variableCopy.value" pEditableColumnField="value">
+        <td
+            #valueCell
+            [pEditableColumn]="variableCopy.value"
+            data-testId="dot-key-value-editable-column"
+            pEditableColumnField="value">
             <p-cellEditor>
                 <ng-template pTemplate="input">
                     <input
@@ -20,16 +25,22 @@
                         (keyup)="editFieldInit()"
                         (keydown.escape)="onCancel($event)"
                         (keydown.enter)="onPressEnter()"
+                        data-testId="dot-key-value-input"
                         pInputText
                         autocomplete="false" />
                 </ng-template>
                 <ng-template pTemplate="output">
                     <span
                         class="dot-key-value-table-row__value-label"
-                        *ngIf="variableCopy.value && !variableCopy.hidden">
+                        *ngIf="variableCopy.value && !variableCopy.hidden"
+                        data-testId="dot-editable-key-value">
                         {{ variableCopy.value }}
                     </span>
-                    <span *ngIf="variableCopy.hidden"> {{ passwordPlaceholder }} </span>
+                    <span
+                        *ngIf="variableCopy.hidden"
+                        data-testId="dot-key-editable-password-placeholder">
+                        {{ passwordPlaceholder }}
+                    </span>
                     <span class="empty-placeholder" *ngIf="!variableCopy.value">
                         {{ 'keyValue.value_input.placeholder' | dm }}
                     </span>
@@ -41,7 +52,8 @@
         <p-inputSwitch
             [(ngModel)]="variableCopy.hidden"
             [disabled]="isHiddenField"
-            (onChange)="showEditMenu = true"></p-inputSwitch>
+            (onChange)="showEditMenu = true"
+            data-testId="dot-key-value-hidden-switch"></p-inputSwitch>
     </td>
     <td class="dot-key-value-table-row__variables-actions">
         <ng-template [ngIf]="showEditMenu" [ngIfElse]="formButtons">
@@ -49,6 +61,7 @@
                 class="dot-key-value-table-row__variables-actions-edit-cancel p-button-outlined"
                 [label]="'Cancel' | dm"
                 (click)="onCancel($event)"
+                data-testId="dot-key-value-cancel-button"
                 pButton></button>
             <button
                 class="dot-key-value-table-row__variables-actions-edit-save"
@@ -56,16 +69,19 @@
                 [label]="'Save' | dm"
                 [disabled]="saveDisabled"
                 (click)="saveVariable()"
+                data-testId="dot-key-value-save-button"
                 pButton></button>
         </ng-template>
         <ng-template #formButtons>
             <p-button
                 (click)="delete.emit(variableCopy)"
+                data-testId="dot-key-value-delete-button"
                 icon="pi pi-trash"
                 styleClass="p-button-text p-button-danger p-button-rounded"></p-button>
             <p-button
                 [disabled]="isHiddenField || null"
                 (click)="focusKeyInput($event)"
+                data-testId="dot-key-value-edit-button"
                 icon="pi pi-pencil"
                 styleClass="p-button-text p-button-rounded"></p-button>
         </ng-template>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.html
@@ -3,8 +3,8 @@
         {{ variableCopy.key }}
     </td>
     <ng-template [ngIf]="isHiddenField" [ngIfElse]="editableValue">
-        <td>
-            {{ variableCopy.value }}
+        <td data-testId="dot-key-value-label">
+            {{ variableCopy.hidden ? passwordPlaceholder : variableCopy.value }}
         </td>
     </ng-template>
     <ng-template #editableValue>
@@ -21,17 +21,15 @@
                         (keydown.escape)="onCancel($event)"
                         (keydown.enter)="onPressEnter()"
                         pInputText
-                        autocomplete="false"
-                    />
+                        autocomplete="false" />
                 </ng-template>
                 <ng-template pTemplate="output">
                     <span
                         class="dot-key-value-table-row__value-label"
-                        *ngIf="variableCopy.value && !variableCopy.hidden"
-                    >
+                        *ngIf="variableCopy.value && !variableCopy.hidden">
                         {{ variableCopy.value }}
                     </span>
-                    <span *ngIf="variableCopy.hidden"> ******** </span>
+                    <span *ngIf="variableCopy.hidden"> {{ passwordPlaceholder }} </span>
                     <span class="empty-placeholder" *ngIf="!variableCopy.value">
                         {{ 'keyValue.value_input.placeholder' | dm }}
                     </span>
@@ -43,8 +41,7 @@
         <p-inputSwitch
             [(ngModel)]="variableCopy.hidden"
             [disabled]="isHiddenField"
-            (onChange)="showEditMenu = true"
-        ></p-inputSwitch>
+            (onChange)="showEditMenu = true"></p-inputSwitch>
     </td>
     <td class="dot-key-value-table-row__variables-actions">
         <ng-template [ngIf]="showEditMenu" [ngIfElse]="formButtons">
@@ -52,29 +49,25 @@
                 class="dot-key-value-table-row__variables-actions-edit-cancel p-button-outlined"
                 [label]="'Cancel' | dm"
                 (click)="onCancel($event)"
-                pButton
-            ></button>
+                pButton></button>
             <button
                 class="dot-key-value-table-row__variables-actions-edit-save"
                 #saveButton
                 [label]="'Save' | dm"
                 [disabled]="saveDisabled"
                 (click)="saveVariable()"
-                pButton
-            ></button>
+                pButton></button>
         </ng-template>
         <ng-template #formButtons>
             <p-button
                 (click)="delete.emit(variableCopy)"
                 icon="pi pi-trash"
-                styleClass="p-button-text p-button-danger p-button-rounded"
-            ></p-button>
+                styleClass="p-button-text p-button-danger p-button-rounded"></p-button>
             <p-button
                 [disabled]="isHiddenField || null"
                 (click)="focusKeyInput($event)"
                 icon="pi pi-pencil"
-                styleClass="p-button-text p-button-rounded"
-            ></p-button>
+                styleClass="p-button-text p-button-rounded"></p-button>
         </ng-template>
     </td>
 </tr>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.spec.ts
@@ -1,24 +1,18 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-import {
-    AfterContentInit,
-    Component,
-    ContentChildren,
-    DebugElement,
-    Directive,
-    Input,
-    QueryList,
-    TemplateRef
-} from '@angular/core';
-import { ComponentFixture } from '@angular/core/testing';
+import { CommonModule, NgIf } from '@angular/common';
+import { Component, DebugElement, Input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-import { PrimeTemplate } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { InputSwitchModule } from 'primeng/inputswitch';
+import { InputTextModule } from 'primeng/inputtext';
+import { TableModule } from 'primeng/table';
 
-import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';
+import { DotPipesModule } from '@dotcms/app/view/pipes/dot-pipes.module';
 import { DotMessageService } from '@dotcms/data-access';
+import { DotMessagePipe } from '@dotcms/ui';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotKeyValue } from '@shared/models/dot-key-value-ng/dot-key-value-ng.model';
 
@@ -27,247 +21,281 @@ import { DotKeyValueTableRowComponent } from './dot-key-value-table-row.componen
 import { mockKeyValue } from '../dot-key-value-ng.component.spec';
 
 const PASSWORD_PLACEHOLDER = '********';
+const VARIABLE_INDEX = 1;
+const MESSAGE_MOCK_SERVICE = new MockDotMessageService({
+    'keyValue.key_input.placeholder': 'Enter Key',
+    'keyValue.value_input.placeholder': 'Enter Value',
+    Save: 'Save',
+    Cancel: 'Cancel',
+    'keyValue.error.duplicated.variable': 'test {0}'
+});
+
+const triggerEditButtonClick = (de: DebugElement) => {
+    const button = de.query(By.css('[data-testId="dot-key-value-edit-button"]'));
+    button.triggerEventHandler('click', {
+        stopPropagation: () => {
+            //
+        }
+    });
+};
+
+const triggerEditableColumnClick = (de: DebugElement) => {
+    const editableColumn = de.query(By.css('[data-testId="dot-key-value-editable-column"]'));
+    editableColumn.nativeElement.click();
+};
 
 @Component({
     selector: 'dot-test-host-component',
     template: `
-        <dot-key-value-table-row
-            [showHiddenField]="showHiddenField"
-            [isHiddenField]="isHiddenField"
-            [variable]="variable"
-            [variableIndex]="variableIndex"
-            [variablesList]="variablesList">
-        </dot-key-value-table-row>
+        <p-table #table [value]="variablesList">
+            <ng-template pTemplate="body" let-variable let-rowIndex="rowIndex">
+                <dot-key-value-table-row
+                    [showHiddenField]="showHiddenField"
+                    [isHiddenField]="isHiddenField"
+                    [variable]="variable"
+                    [variableIndex]="variableIndex"
+                    [variablesList]="variablesList">
+                </dot-key-value-table-row>
+            </ng-template>
+        </p-table>
     `
 })
 class TestHostComponent {
     @Input() showHiddenField: boolean;
     @Input() isHiddenField: boolean;
     @Input() variable: DotKeyValue;
-    @Input() variableIndex: number;
+    @Input() variableIndex = VARIABLE_INDEX; // default value
     @Input() variablesList: DotKeyValue[];
 }
 
-@Directive({
-    // eslint-disable-next-line
-    selector: '[pEditableColumn]'
-})
-class MockEditableColumnDirective {
-    @Input()
-    public pEditableColumn: any;
-    @Input()
-    public pEditableColumnField: any;
-}
-
-@Component({
-    // eslint-disable-next-line
-    selector: 'p-cellEditor',
-    template: `
-        <ng-container>
-            <ng-container *ngTemplateOutlet="inputTemplate"></ng-container>
-        </ng-container>
-    `
-})
-class MockCellEditorComponent implements AfterContentInit {
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate>;
-    inputTemplate: TemplateRef<any>;
-    outputTemplate: TemplateRef<any>;
-
-    constructor(public tableRow: DotKeyValueTableRowComponent) {}
-
-    ngAfterContentInit() {
-        this.templates.forEach((item) => {
-            switch (item.getType()) {
-                case 'input':
-                    this.inputTemplate = item.template;
-                    break;
-
-                case 'output':
-                    this.outputTemplate = item.template;
-                    break;
-            }
-        });
-    }
-}
-
-xdescribe('DotKeyValueTableRowComponent', () => {
-    let comp: DotKeyValueTableRowComponent;
+describe('DotKeyValueTableRowComponent', () => {
     let hostComponent: TestHostComponent;
-    let hostComponentfixture: ComponentFixture<TestHostComponent>;
+    let hostComponentFixture: ComponentFixture<TestHostComponent>;
+    let component: DotKeyValueTableRowComponent;
     let de: DebugElement;
 
     beforeEach(() => {
-        const messageServiceMock = new MockDotMessageService({
-            'keyValue.key_input.placeholder': 'Enter Key',
-            'keyValue.value_input.placeholder': 'Enter Value',
-            Save: 'Save',
-            Cancel: 'Cancel',
-            'keyValue.error.duplicated.variable': 'test {0}'
-        });
-
-        DOTTestBed.configureTestingModule({
-            declarations: [
-                DotKeyValueTableRowComponent,
-                MockCellEditorComponent,
-                MockEditableColumnDirective,
-                TestHostComponent
+        TestBed.configureTestingModule({
+            declarations: [DotKeyValueTableRowComponent, TestHostComponent],
+            imports: [
+                NgIf,
+                CommonModule,
+                FormsModule,
+                ButtonModule,
+                InputSwitchModule,
+                ButtonModule,
+                TableModule,
+                InputSwitchModule,
+                InputTextModule,
+                TableModule,
+                DotPipesModule,
+                DotMessagePipe,
+                NoopAnimationsModule
             ],
-            imports: [ButtonModule, InputSwitchModule],
-            providers: [{ provide: DotMessageService, useValue: messageServiceMock }]
+            providers: [{ provide: DotMessageService, useValue: MESSAGE_MOCK_SERVICE }]
         });
 
-        hostComponentfixture = DOTTestBed.createComponent(TestHostComponent);
-        hostComponent = hostComponentfixture.componentInstance;
-        comp = hostComponentfixture.debugElement.query(
-            By.css('dot-key-value-table-row')
-        ).componentInstance;
-        de = hostComponentfixture.debugElement.query(By.css('dot-key-value-table-row'));
-
-        hostComponent.variableIndex = 0;
-        hostComponent.variablesList = mockKeyValue;
+        hostComponentFixture = TestBed.createComponent(TestHostComponent);
+        hostComponent = hostComponentFixture.componentInstance;
+        hostComponentFixture.detectChanges();
     });
 
-    describe('Without Hidden Fields', () => {
-        it('should load the component', () => {
-            hostComponent.variableIndex = 1;
+    describe('Editable variables', () => {
+        beforeEach(async () => {
+            hostComponent.isHiddenField = false;
             hostComponent.variable = mockKeyValue[0];
-            hostComponentfixture.detectChanges();
-            const inputs = de.queryAll(By.css('input'));
+            hostComponent.variablesList = [mockKeyValue[0]];
+            hostComponentFixture.detectChanges();
+            await hostComponentFixture.whenStable();
+            de = hostComponentFixture.debugElement.query(By.css('dot-key-value-table-row'));
+            component = de.componentInstance;
+        });
+
+        it('should load the component', () => {
             const btns = de.queryAll(By.css('button'));
-            expect(inputs[0].nativeElement.placeholder).toContain('Enter Value');
+            const cellEditor = de.query(By.css('p-cellEditor'));
+            const label = de.query(By.css('[data-testId="dot-editable-key-value"]'));
+
             expect(btns.length).toBe(2);
-            expect(comp.saveDisabled).toBe(false);
+            expect(label.nativeElement).toBeDefined();
+            expect(cellEditor.nativeElement).toBeDefined();
+            expect(component.saveDisabled).toBe(false);
         });
 
         it('should focus on "Value" input when "Edit" button clicked', () => {
-            hostComponent.variableIndex = 1;
-            hostComponent.variable = { key: 'TestKey', value: 'TestValue' };
-            hostComponentfixture.detectChanges();
-            spyOn(comp.valueCell.nativeElement, 'click');
-            const button = de.queryAll(
-                By.css('.dot-key-value-table-row__variables-actions p-button')
-            )[1];
-            button.triggerEventHandler('click', {
-                stopPropagation: () => {
-                    //
-                }
+            const valueCellSpy = spyOn(component.valueCell.nativeElement, 'click');
+            triggerEditButtonClick(de);
+
+            hostComponentFixture.detectChanges();
+            expect(valueCellSpy).toHaveBeenCalled();
+        });
+
+        it('should show edit menu when focus/key.up on a field', async () => {
+            // Initial state
+            expect(component.showEditMenu).toBe(false);
+            expect(component.saveDisabled).toBe(false);
+
+            // Click on edit button
+            triggerEditButtonClick(de);
+
+            // After click on edit button
+            hostComponentFixture.detectChanges();
+            await hostComponentFixture.whenStable();
+
+            // Focus on field
+            const field = de.query(By.css('[data-testId="dot-key-value-input"]'));
+            field.triggerEventHandler('keyup', { target: { value: 'a' } });
+
+            hostComponentFixture.detectChanges();
+
+            // After focus on field
+            expect(component.showEditMenu).toBe(true);
+            expect(component.saveDisabled).toBe(false);
+        });
+
+        describe('showHiddenField is true', () => {
+            beforeEach(async () => {
+                hostComponent.showHiddenField = true;
+                hostComponentFixture.detectChanges();
+                await hostComponentFixture.whenStable();
             });
-            hostComponentfixture.detectChanges();
-            expect(comp.valueCell.nativeElement.click).toHaveBeenCalled();
-        });
 
-        it('should show edit menu when focus/key.up on a field', () => {
-            hostComponent.variable = mockKeyValue[0];
-            hostComponentfixture.detectChanges();
-            expect(comp.showEditMenu).toBe(false);
-            expect(comp.saveDisabled).toBe(false);
-            de.query(By.css('.field-value-input')).triggerEventHandler('keyup', {
-                target: { value: 'a' }
+            it('should switch to hidden mode when clicked on the hidden switch button', async () => {
+                expect(component.variableCopy.hidden).toBeFalsy();
+
+                // Get the input switch element
+                const inputSwitch = de.query(By.css('[data-testId="dot-key-value-hidden-switch"]'));
+                const innerInputElement = inputSwitch.query(By.css('.p-inputswitch')).nativeElement;
+                innerInputElement.click();
+
+                hostComponentFixture.detectChanges();
+                await hostComponentFixture.whenStable();
+
+                // Click on edit button
+                triggerEditableColumnClick(de);
+
+                // After click on edit button
+                hostComponentFixture.detectChanges();
+                await hostComponentFixture.whenStable();
+
+                const inputElement = de.query(
+                    By.css('[data-testId="dot-key-value-input"]')
+                ).nativeElement;
+                expect(inputElement.type).toBe('password');
+                expect(component.showEditMenu).toBe(true);
             });
-            hostComponentfixture.detectChanges();
-            expect(comp.showEditMenu).toBe(true);
-            expect(comp.saveDisabled).toBe(false);
         });
 
-        it('should emit cancel event when press "Escape"', () => {
-            hostComponent.variable = mockKeyValue[0];
-            hostComponentfixture.detectChanges();
-            spyOn(comp.cancel, 'emit');
-            hostComponentfixture.detectChanges();
-            de.query(By.css('.field-value-input')).nativeElement.dispatchEvent(
-                new KeyboardEvent('keydown', { key: 'Escape' })
-            );
-            expect(comp.cancel.emit).toHaveBeenCalledWith(comp.variableIndex);
-            expect(comp.showEditMenu).toBe(false);
-        });
-
-        it('should emit save event when button clicked', async () => {
-            hostComponent.variable = { key: 'Key1', value: 'Value1' };
-            hostComponentfixture.detectChanges();
-            spyOn(comp.save, 'emit');
-            de.query(By.css('.field-value-input')).triggerEventHandler('focus', {});
-            hostComponentfixture.detectChanges();
-
-            await hostComponentfixture.whenStable();
-            de.query(
-                By.css('.dot-key-value-table-row__variables-actions-edit-save')
-            ).triggerEventHandler('click', {});
-            hostComponent.variablesList = [];
-            hostComponentfixture.detectChanges();
-            expect(comp.save.emit).toHaveBeenCalledWith(comp.variable);
-            expect(comp.showEditMenu).toBe(false);
-        });
-
-        it('should emit cancel event when button clicked', () => {
-            hostComponent.variable = { key: 'Key1', value: 'Value1' };
-            hostComponentfixture.detectChanges();
-            spyOn(comp.save, 'emit');
-            de.query(By.css('.field-value-input')).triggerEventHandler('focus', {});
-            spyOn(comp.cancel, 'emit');
-            hostComponentfixture.detectChanges();
-            de.query(
-                By.css('.dot-key-value-table-row__variables-actions-edit-cancel')
-            ).triggerEventHandler('click', {
-                stopPropagation: () => {
-                    //
-                }
+        describe('Edit Input field is visible', () => {
+            beforeEach(async () => {
+                triggerEditButtonClick(de);
+                hostComponentFixture.detectChanges();
+                await hostComponentFixture.whenStable();
             });
-            expect(comp.cancel.emit).toHaveBeenCalledWith(comp.variableIndex);
-            expect(comp.showEditMenu).toBe(false);
+
+            it('should emit cancel event when press "Escape"', () => {
+                const cancelSpy = spyOn(component.cancel, 'emit');
+                const inputElement = de.query(
+                    By.css('[data-testId="dot-key-value-input"]')
+                ).nativeElement;
+                inputElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+                hostComponentFixture.detectChanges();
+
+                expect(cancelSpy).toHaveBeenCalledWith(component.variableIndex);
+                expect(component.showEditMenu).toBe(false);
+            });
+
+            it('should emit save event when button clicked', () => {
+                const saveSpy = spyOn(component.save, 'emit');
+
+                // focus on field to show edit menu
+                const inputElement = de.query(By.css('[data-testId="dot-key-value-input"]'));
+                inputElement.triggerEventHandler('focus', {});
+
+                hostComponentFixture.detectChanges();
+
+                // click on save button
+                const saveButton = de.query(By.css('[data-testId="dot-key-value-save-button"]'));
+                saveButton.triggerEventHandler('click', {});
+
+                hostComponentFixture.detectChanges();
+
+                expect(saveSpy).toHaveBeenCalledWith(mockKeyValue[0]);
+                expect(component.showEditMenu).toBe(false);
+            });
+
+            it('should emit cancel event when button clicked', () => {
+                const cancelSpy = spyOn(component.cancel, 'emit');
+
+                // focus on field to show edit menu
+                const inputElement = de.query(By.css('[data-testId="dot-key-value-input"]'));
+                inputElement.triggerEventHandler('focus', {});
+
+                hostComponentFixture.detectChanges();
+
+                // click on save button
+                const cancelButton = de.query(
+                    By.css('[data-testId="dot-key-value-cancel-button"]')
+                );
+                cancelButton.triggerEventHandler('click', {
+                    stopPropagation: () => {
+                        //
+                    }
+                });
+
+                hostComponentFixture.detectChanges();
+
+                expect(cancelSpy).toHaveBeenCalledWith(VARIABLE_INDEX);
+                expect(component.showEditMenu).toBe(false);
+            });
+
+            it('should emit delete event when button clicked', () => {
+                const deleteSpy = spyOn(component.delete, 'emit');
+
+                // click on delete button
+                const deleteButton = de.query(
+                    By.css('[data-testId="dot-key-value-delete-button"]')
+                );
+                deleteButton.triggerEventHandler('click', {});
+
+                hostComponentFixture.detectChanges();
+
+                expect(deleteSpy).toHaveBeenCalledWith(component.variable);
+            });
         });
 
-        it('should emit delete event when button clicked', () => {
-            hostComponent.variable = { key: 'TestKey', value: 'TestValue' };
-            spyOn(comp.delete, 'emit');
-            hostComponentfixture.detectChanges();
-            de.queryAll(
-                By.css('.dot-key-value-table-row__variables-actions p-button')
-            )[0].triggerEventHandler('click', {});
-            expect(comp.delete.emit).toHaveBeenCalledWith(comp.variable);
-        });
-    });
+        describe('With Hidden Fields', () => {
+            beforeEach(async () => {
+                hostComponent.isHiddenField = true;
+                hostComponent.showHiddenField = true;
+                hostComponent.variable = mockKeyValue[1]; // Hidden Key Value
+                hostComponent.variablesList = [mockKeyValue[1]]; // Hidden Key Value
+                hostComponentFixture.detectChanges();
+                await hostComponentFixture.whenStable();
+                de = hostComponentFixture.debugElement.query(By.css('dot-key-value-table-row'));
+                component = de.componentInstance;
+            });
 
-    describe('With Hidden Fields', () => {
-        beforeEach(() => {
-            hostComponent.showHiddenField = true;
-            hostComponent.variableIndex = 1;
-            hostComponent.variable = mockKeyValue[1];
-        });
+            it('should show the password placeholder instead of the key value', () => {
+                const valueLabel = de.query(By.css('[data-testId="dot-key-value-label"]'));
+                const valueLabelHTML = valueLabel.nativeElement.innerHTML.trim();
+                expect(valueLabelHTML).toBe(PASSWORD_PLACEHOLDER);
+            });
 
-        it('should load the component with edit icon and switch button disabled', () => {
-            hostComponent.isHiddenField = true;
-            hostComponentfixture.detectChanges();
-            const switchButton = de.query(By.css('p-inputSwitch'));
-            const valueLabel = de.queryAll(By.css('.dot-key-value-table-row td'))[1];
-            const editIconButton = de.queryAll(
-                By.css('.dot-key-value-table-row__variables-actions p-button')
-            )[1];
-            expect(switchButton.componentInstance.disabled).toBe(true);
-            expect(editIconButton.attributes.disabled).toBe('true');
-            expect(valueLabel.nativeElement.innerText).toContain('*');
-        });
+            it('should load the component with edit icon and switch button disabled', () => {
+                const switchButton = de.query(
+                    By.css("[data-testId='dot-key-value-hidden-switch']")
+                );
+                const editIconButton = de.query(
+                    By.css("[data-testId='dot-key-value-edit-button']")
+                );
+                const valueLabel = de.query(By.css("[data-testId='dot-key-value-label']"));
+                const valueLabelHTML = valueLabel.nativeElement.innerHTML.trim();
 
-        it('should switch to hidden mode when clicked on the hidden switch button', async () => {
-            hostComponent.isHiddenField = false;
-            hostComponent.variable = { key: 'TestKey', hidden: true, value: 'TestValue' };
-            hostComponentfixture.detectChanges();
-            const valueInput = de.query(By.css('.field-value-input'));
-            const switchButton = de.query(By.css('p-inputSwitch')).nativeElement;
-            switchButton.dispatchEvent(new Event('onChange'));
-
-            hostComponentfixture.detectChanges();
-            await hostComponentfixture.whenStable();
-
-            expect(comp.showEditMenu).toBe(true);
-            expect(valueInput.nativeElement.type).toBe('password');
-        });
-
-        it('should show the password placeholder instead of the key value', () => {
-            hostComponent.isHiddenField = true;
-            hostComponent.variable = { key: 'TestKey', hidden: true, value: 'TestValue' };
-            hostComponentfixture.detectChanges();
-            const tableRow = de.query(By.css("[data-testId='dot-key-value-label']"));
-            expect(tableRow.nativeElement.innerHTML.trim()).toBe(PASSWORD_PLACEHOLDER);
+                expect(switchButton.componentInstance.disabled).toBe(true);
+                expect(editIconButton.componentInstance.disabled).toBe(true);
+                expect(valueLabelHTML).toBe(PASSWORD_PLACEHOLDER);
+            });
         });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.spec.ts
@@ -20,7 +20,7 @@ import { DotKeyValueTableRowComponent } from './dot-key-value-table-row.componen
 
 import { mockKeyValue } from '../dot-key-value-ng.component.spec';
 
-const PASSWORD_PLACEHOLDER = '********';
+const PASSWORD_PLACEHOLDER = '*****';
 const VARIABLE_INDEX = 1;
 const MESSAGE_MOCK_SERVICE = new MockDotMessageService({
     'keyValue.key_input.placeholder': 'Enter Key',

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.spec.ts
@@ -26,6 +26,8 @@ import { DotKeyValueTableRowComponent } from './dot-key-value-table-row.componen
 
 import { mockKeyValue } from '../dot-key-value-ng.component.spec';
 
+const PASSWORD_PLACEHOLDER = '********';
+
 @Component({
     selector: 'dot-test-host-component',
     template: `
@@ -34,8 +36,7 @@ import { mockKeyValue } from '../dot-key-value-ng.component.spec';
             [isHiddenField]="isHiddenField"
             [variable]="variable"
             [variableIndex]="variableIndex"
-            [variablesList]="variablesList"
-        >
+            [variablesList]="variablesList">
         </dot-key-value-table-row>
     `
 })
@@ -259,6 +260,14 @@ xdescribe('DotKeyValueTableRowComponent', () => {
 
             expect(comp.showEditMenu).toBe(true);
             expect(valueInput.nativeElement.type).toBe('password');
+        });
+
+        it('should show the password placeholder instead of the key value', () => {
+            hostComponent.isHiddenField = true;
+            hostComponent.variable = { key: 'TestKey', hidden: true, value: 'TestValue' };
+            hostComponentfixture.detectChanges();
+            const tableRow = de.query(By.css("[data-testId='dot-key-value-label']"));
+            expect(tableRow.nativeElement.innerHTML.trim()).toBe(PASSWORD_PLACEHOLDER);
         });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.ts
@@ -35,6 +35,7 @@ export class DotKeyValueTableRowComponent implements OnInit, OnChanges {
     @Output() cancel: EventEmitter<number> = new EventEmitter(false);
     @Output() delete: EventEmitter<DotKeyValue> = new EventEmitter(false);
 
+    passwordPlaceholder = '********';
     variableCopy: DotKeyValue;
     showEditMenu = false;
     saveDisabled = false;

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.ts
@@ -35,7 +35,7 @@ export class DotKeyValueTableRowComponent implements OnInit, OnChanges {
     @Output() cancel: EventEmitter<number> = new EventEmitter(false);
     @Output() delete: EventEmitter<DotKeyValue> = new EventEmitter(false);
 
-    readonly passwordPlaceholder = '********';
+    readonly passwordPlaceholder = '*****';
     variableCopy: DotKeyValue;
     showEditMenu = false;
     saveDisabled = false;

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-key-value-ng/dot-key-value-table-row/dot-key-value-table-row.component.ts
@@ -35,7 +35,7 @@ export class DotKeyValueTableRowComponent implements OnInit, OnChanges {
     @Output() cancel: EventEmitter<number> = new EventEmitter(false);
     @Output() delete: EventEmitter<DotKeyValue> = new EventEmitter(false);
 
-    passwordPlaceholder = '********';
+    readonly passwordPlaceholder = '********';
     variableCopy: DotKeyValue;
     showEditMenu = false;
     saveDisabled = false;


### PR DESCRIPTION
### Proposed Changes
* Fix hidden secrets not saving in dot velocity secrets

### Checklist
- [x] Tests

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d452604</samp>

This pull request improves the key-value component and its subcomponents by refactoring the code, adding test coverage, and enhancing security and testability. It changes the files `dot-key-value-ng.component.ts` and `dot-key-value-ng.component.spec.ts` to handle the `password` variable differently, and the files `dot-key-value-table-row.component.html`, `dot-key-value-table-row.component.ts`, and `dot-key-value-table-row.component.spec.ts` to add a password placeholder and a `data-testId` attribute.

## Related Issue
Fixes #25855

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d452604</samp>

*  Remove the logic of setting the hidden value of the variable to asterisks from the key-value component and move it to the key-value table row component, to simplify the code and avoid duplication ([link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-86b4c43a2626753069032d582c7d79ac4d6d3964a46a5c137edb7af3655a4be2L49-L57), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-86b4c43a2626753069032d582c7d79ac4d6d3964a46a5c137edb7af3655a4be2L69-L74), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-2610ac0d211d109fffa59c8ea3894a5575317a2819226334f138de3a324ec719L6-R7), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-2610ac0d211d109fffa59c8ea3894a5575317a2819226334f138de3a324ec719L24-R32))
*  Define a property and a constant for the password placeholder in the key-value table row component and its test, to avoid hard-coding the value and make it easier to change if needed ([link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-12d6f6b26442ea2a7a6a977e8407dcf66b456bb9bad8e41f64ee62eaa8f9f5dfR38), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-e26382376f0631375534fa80290146501db94b8751349124717ac0c0da85aef4R29-R30))
*  Add a data-testId attribute to the table cell that displays the value of the variable in the key-value table row component, to make it easier to query in the test ([link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-2610ac0d211d109fffa59c8ea3894a5575317a2819226334f138de3a324ec719L6-R7))
*  Update the key-value component test and add a new test case for the key-value table row component test, to check that the password placeholder is shown instead of the actual value if the variable is hidden ([link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-62c75db396c499f43b54eddb350886de53ad5aea490effcb15e07199d931884fL28-R28), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-62c75db396c499f43b54eddb350886de53ad5aea490effcb15e07199d931884fL179-R178), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-e26382376f0631375534fa80290146501db94b8751349124717ac0c0da85aef4R264-R271))
*  Remove the unused import of the DotKeyValueUtil class from the key-value component ([link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-86b4c43a2626753069032d582c7d79ac4d6d3964a46a5c137edb7af3655a4be2L7-L8))
*  Remove some unnecessary line breaks in the templates of the key-value component, the key-value table row component, and their test host components ([link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-62c75db396c499f43b54eddb350886de53ad5aea490effcb15e07199d931884fL37-R37), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-2610ac0d211d109fffa59c8ea3894a5575317a2819226334f138de3a324ec719L46-R44), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-2610ac0d211d109fffa59c8ea3894a5575317a2819226334f138de3a324ec719L55-R52), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-2610ac0d211d109fffa59c8ea3894a5575317a2819226334f138de3a324ec719L63-R59), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-2610ac0d211d109fffa59c8ea3894a5575317a2819226334f138de3a324ec719L70-R70), [link](https://github.com/dotCMS/core/pull/26023/files?diff=unified&w=0#diff-e26382376f0631375534fa80290146501db94b8751349124717ac0c0da85aef4L37-R39))

### Screenshots


https://github.com/dotCMS/core/assets/72418962/fcc390a9-959e-4708-8c1b-a4e3e86df341

