### PR TITLE
dotCMS/core#26024 Persona Drop Down is Disabled inside Variant 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.spec.ts
@@ -585,7 +585,7 @@ describe('DotPageStateService', () => {
                 const subscribeCallback = jasmine.createSpy('spy');
                 service.haveContent$.subscribe(subscribeCallback);
 
-                expect(subscribeCallback).toHaveBeenCalledWith(false);
+                expect(subscribeCallback).toHaveBeenCalledWith(true);
 
                 service.updatePageStateHaveContent({
                     type: PageModelChangeEventType.REMOVE_CONTENT,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-page-state/dot-page-state.service.ts
@@ -359,10 +359,7 @@ export class DotPageStateService {
 
     private setCurrentState(newState: DotPageRenderState): void {
         this.currentState = newState;
-
-        if (!this.selectedIsDefaultPersona()) {
-            this.haveContent$.next(this.currentState.numberContents > 0);
-        }
+        this.haveContent$.next(this.currentState?.numberContents > 0);
     }
 
     private selectedIsDefaultPersona(): boolean {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selector/dot-persona-selector.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selector/dot-persona-selector.component.html
@@ -14,8 +14,7 @@
         (pageChange)="handlePageChange($event)"
         (switch)="personaChange($event)"
         labelPropertyName="name"
-        width="448px"
-    >
+        width="448px">
         <ng-template let-persona="item" pTemplate="select">
             <dot-persona-selected-item
                 [class.readonly]="readonly"
@@ -26,29 +25,26 @@
                 [readonly]="readonly"
                 (click)="!disabled && !readonly && searchableDropdown.toggleOverlayPanel($event)"
                 appendTo="target"
-                tooltipPosition="bottom"
-            ></dot-persona-selected-item>
+                tooltipPosition="bottom"></dot-persona-selected-item>
         </ng-template>
-        <ng-template
-            let-personaData="item"
-            let-selectedOptionValue="selectedOptionValue"
-            pTemplate="listItem"
-        >
+        <ng-template let-personaData="item" pTemplate="listItem">
             <dot-persona-selector-option
                 [canDespersonalize]="canDespersonalize"
-                [class.highlight]="personaData.name === selectedOptionValue"
-                [persona]="
-                    value && value.identifier === personaData.identifier ? value : personaData
+                [class.highlight]="
+                    value?.identifier === personaData.identifier ||
+                    (!value && personaData.identifier === defaultPersonaIdentifier)
                 "
-                [selected]="value && value.identifier === personaData.identifier"
+                [persona]="value?.identifier === personaData.identifier ? value : personaData"
+                [selected]="
+                    value?.identifier === personaData.identifier ||
+                    (!value && personaData.identifier === defaultPersonaIdentifier)
+                "
                 (delete)="delete.emit(personaData)"
-                (switch)="personaChange($event)"
-            ></dot-persona-selector-option>
+                (switch)="personaChange($event)"></dot-persona-selector-option>
         </ng-template>
     </dot-searchable-dropdown>
 </div>
 
 <dot-add-persona-dialog
     #personaDialog
-    (createdPersona)="handleNewPersona($event)"
-></dot-add-persona-dialog>
+    (createdPersona)="handleNewPersona($event)"></dot-add-persona-dialog>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selector/dot-persona-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selector/dot-persona-selector.component.spec.ts
@@ -3,11 +3,16 @@
 
 import { of } from 'rxjs';
 
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, Input } from '@angular/core';
-import { ComponentFixture, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
+import { ConfirmationService } from 'primeng/api';
+import { AvatarModule } from 'primeng/avatar';
+import { BadgeModule } from 'primeng/badge';
+import { ButtonModule } from 'primeng/button';
 import { TooltipModule } from 'primeng/tooltip';
 
 import { IframeOverlayService } from '@components/_common/iframe/service/iframe-overlay.service';
@@ -18,19 +23,27 @@ import { DotMessageDisplayServiceMock } from '@components/dot-message-display/do
 import { DotMessageDisplayService } from '@components/dot-message-display/services';
 import { DotPersonaSelectedItemModule } from '@components/dot-persona-selected-item/dot-persona-selected-item.module';
 import { DotPersonaSelectorOptionModule } from '@components/dot-persona-selector-option/dot-persona-selector-option.module';
-import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';
-import { DotMessageService, PaginatorService } from '@dotcms/data-access';
-import { LoginService, SiteService } from '@dotcms/dotcms-js';
+import { DotAvatarDirective } from '@directives/dot-avatar/dot-avatar.directive';
+import {
+    DotAlertConfirmService,
+    DotEventsService,
+    DotMessageService,
+    PaginatorService
+} from '@dotcms/data-access';
+import { CoreWebService, LoginService, SiteService } from '@dotcms/dotcms-js';
 import { DotPersona } from '@dotcms/dotcms-models';
 import { DotMessagePipe } from '@dotcms/ui';
 import {
     cleanUpDialog,
+    CoreWebServiceMock,
     LoginServiceMock,
     MockDotMessageService,
     mockDotPersona,
+    MockDotRouterService,
     SiteServiceMock
 } from '@dotcms/utils-testing';
-import { DotPipesModule } from '@pipes/dot-pipes.module';
+import { DotHttpErrorManagerService } from '@services/dot-http-error-manager/dot-http-error-manager.service';
+import { DotRouterService } from '@services/dot-router/dot-router.service';
 
 import { DotPersonaSelectorComponent } from './dot-persona-selector.component';
 
@@ -40,8 +53,7 @@ import { DotPersonaSelectorComponent } from './dot-persona-selector.component';
         <dot-persona-selector
             [disabled]="disabled"
             (selected)="selectedPersonaHandler($event)"
-            (delete)="deletePersonaHandler($event)"
-        ></dot-persona-selector>
+            (delete)="deletePersonaHandler($event)"></dot-persona-selector>
     `
 })
 class HostTestComponent {
@@ -90,7 +102,7 @@ describe('DotPersonaSelectorComponent', () => {
     const siteServiceMock = new SiteServiceMock();
 
     beforeEach(waitForAsync(() => {
-        DOTTestBed.configureTestingModule({
+        TestBed.configureTestingModule({
             declarations: [DotPersonaSelectorComponent, HostTestComponent],
             imports: [
                 BrowserAnimationsModule,
@@ -98,9 +110,13 @@ describe('DotPersonaSelectorComponent', () => {
                 DotPersonaSelectedItemModule,
                 DotPersonaSelectorOptionModule,
                 DotAddPersonaDialogModule,
-                TooltipModule,
-                DotPipesModule,
-                DotMessagePipe
+                DotMessagePipe,
+                HttpClientTestingModule,
+                DotAvatarDirective,
+                AvatarModule,
+                BadgeModule,
+                ButtonModule,
+                TooltipModule
             ],
             providers: [
                 IframeOverlayService,
@@ -111,13 +127,19 @@ describe('DotPersonaSelectorComponent', () => {
                 { provide: PaginatorService, useClass: TestPaginatorService },
                 { provide: DotMessageDisplayService, useClass: DotMessageDisplayServiceMock },
                 { provide: LoginService, useClass: LoginServiceMock },
-                { provide: SiteService, useValue: siteServiceMock }
+                { provide: SiteService, useValue: siteServiceMock },
+                { provide: CoreWebService, useClass: CoreWebServiceMock },
+                { provide: DotRouterService, useClass: MockDotRouterService },
+                DotHttpErrorManagerService,
+                ConfirmationService,
+                DotAlertConfirmService,
+                DotEventsService
             ]
         });
     }));
 
     beforeEach(() => {
-        hostFixture = DOTTestBed.createComponent(HostTestComponent);
+        hostFixture = TestBed.createComponent(HostTestComponent);
         de = hostFixture.debugElement.query(By.css('dot-persona-selector'));
         component = de.componentInstance;
         paginatorService = hostFixture.debugElement.injector.get(PaginatorService);

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selector/dot-persona-selector.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-persona-selector/dot-persona-selector.component.ts
@@ -11,6 +11,8 @@ import { DotAddPersonaDialogComponent } from '@components/dot-add-persona-dialog
 import { PaginatorService } from '@dotcms/data-access';
 import { DotPageMode, DotPageRenderState, DotPersona } from '@dotcms/dotcms-models';
 
+export const DEFAULT_PERSONA_IDENTIFIER_BY_BACKEND = 'modes.persona.no.persona';
+
 /**
  * It is dropdown of personas, it handle pagination and global search
  *
@@ -42,6 +44,7 @@ export class DotPersonaSelectorComponent implements OnInit {
     personas: DotPersona[] = [];
     totalRecords: number;
     value: DotPersona;
+    defaultPersonaIdentifier = DEFAULT_PERSONA_IDENTIFIER_BY_BACKEND;
     private personaSeachQuery: string;
 
     constructor(

--- a/core-web/libs/utils-testing/src/lib/dot-persona.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/dot-persona.mock.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PERSONA_IDENTIFIER_BY_BACKEND } from '@components/dot-persona-selector/dot-persona-selector.component';
 import { DotPersona } from '@dotcms/dotcms-models';
 
 export const mockDotPersona: DotPersona = {
@@ -9,7 +10,7 @@ export const mockDotPersona: DotPersona = {
     host: 'SYSTEM_HOST',
     hostFolder: 'SYSTEM_HOST',
     hostName: 'System Host',
-    identifier: '1c56ba62-1f41-4b81-bd62-b6eacff3ad23',
+    identifier: DEFAULT_PERSONA_IDENTIFIER_BY_BACKEND,
     inode: '',
     keyTag: 'dot:persona',
     languageId: 1,


### PR DESCRIPTION
### Proposed Changes
* Persona Selector should not be disabled after a refresh
* The `haveContent$` needs to be updated even when is not the default user. 
* Fix the selection in `dot-persona-selector`


### Screenshots


### Before 

<img width="338" alt="image" src="https://github.com/dotCMS/core/assets/31667212/81e06bb3-13b3-42f9-a904-bd5c79f19d4f">

<img width="344" alt="image" src="https://github.com/dotCMS/core/assets/31667212/89967368-4d29-4bbd-9922-7915c54ba526">


### After 

<img width="330" alt="image" src="https://github.com/dotCMS/core/assets/31667212/c010a434-d5f3-40df-91c3-ecdf90f8df24">

<img width="332" alt="image" src="https://github.com/dotCMS/core/assets/31667212/c689efb9-af0b-420f-ac76-2cdbb90d2e50">


