### PR TITLE
feat(cli): Create GHA workflow for creating CLI release.

### DIFF
--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -1,0 +1,28 @@
+name: dotCLI Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+      next:
+        description: 'Next version'
+        required: false
+
+defaults:
+  run:
+    shell: bash
+  
+jobs:
+  precheck:
+    name: Pre-check
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_VERSION: ${{ steps.vars.outputs.version }}
+      NEXT_VERSION: ${{ steps.vars.outputs.next }}
+    steps:
+      - name: Print inputs
+        run: |
+          echo "RELEASE_VERSION=$RELEASE_VERSION"
+          echo "NEXT_VERSION=$NEXT_VERSION"
+      


### PR DESCRIPTION
### Proposed Changes
It adds a new workflow for managing CLI release process. Basic workflow that gets input values and it prints them.


### Related to
#25951 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ab7f47</samp>

This pull request adds a new workflow file for dotCLI release process, which allows publishing a release version and setting the next development version with manual inputs. The file is named `.github/workflows/cli-release-process.yml`.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ab7f47</samp>

* Add a new workflow file for dotCLI release process ([link](https://github.com/dotCMS/core/pull/26096/files?diff=unified&w=0#diff-9fca42e4299dcaff9079b3f06f39dd3f23282f17d2baeaa3de86b001101b7b51R1-R28))
