### PR TITLE
fix(cli):  Setting SNAPSHOT label on the version tag.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
         <module>dotcms-integration</module>
         <module>plugins-core</module>
         <module>reports</module>
-        <module>tools/dotcms-cli</module>
     </modules>
     <distributionManagement>
         <repository>

--- a/tools/dotcms-cli/api-data-model/pom.xml
+++ b/tools/dotcms-cli/api-data-model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dotCMS-cli</artifactId>
         <groupId>com.dotcms</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tools/dotcms-cli/cli/pom.xml
+++ b/tools/dotcms-cli/cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dotCMS-cli</artifactId>
         <groupId>com.dotcms</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tools/dotcms-cli/pom.xml
+++ b/tools/dotcms-cli/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.dotcms</groupId>
   <artifactId>dotCMS-cli</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
   <modules>
     <module>api-data-model</module>
     <module>cli</module>


### PR DESCRIPTION
### Proposed Changes

Fixing dotCMS-cli version.
Setting SNAPSHOT label on the version tag.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e063bf</samp>

Updated the dotCMS-cli tool to support the latest dotCMS API changes by changing the version of the `dotCMS-cli` parent pom and its sub-modules from `1.0.0` to `1.0.0-SNAPSHOT`.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e063bf</samp>

*  Update the dotCMS-cli tool to support the latest dotCMS API changes ([link](https://github.com/dotCMS/core/pull/26097/files?diff=unified&w=0#diff-5dfff11042c513b18898055e9b67ae650016aaaf2a1645804ba3323401ad48ebL8-R8), [link](https://github.com/dotCMS/core/pull/26097/files?diff=unified&w=0#diff-73a27979af1cf948c5e900d405672ffdfa8373a0fbc85aa73e2c256356a2c65cL8-R8), [link](https://github.com/dotCMS/core/pull/26097/files?diff=unified&w=0#diff-23556d6da3b41fa23f4588dc74d5c4ea92a229304da7379d5119caf1c33e4417L8-R8))
