### PR TITLE
fix(cli): Avoid running cli tests for frontend changes.

### DIFF
--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -49,6 +49,42 @@ jobs:
       - id: checkout-core
         name: Checkout core
         uses: actions/checkout@v3
+      -
+        id: meta
+        name: Docker meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            dotcms/dotcms
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha,enable=true,priority=100,prefix=master_,suffix=_SNAPSHOT,format=short
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: ${{ github.event.inputs.docker_build_push || 'false' }}
+          context: docker/dotcms
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          pull: true
+          no-cache: ${{ github.event.inputs.docker_build_cache || 'false' }}
+          build-args: |
+            BUILD_ID=${{ github.head_ref }}
+            BUILD_FROM=COMMIT 
             
       - id: prepare-license
         name: Prepare license

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -49,43 +49,6 @@ jobs:
       - id: checkout-core
         name: Checkout core
         uses: actions/checkout@v3
-
-      -
-        id: meta
-        name: Docker meta
-        uses: docker/metadata-action@v4
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            dotcms/dotcms
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=sha,enable=true,priority=100,prefix=master_,suffix=_SNAPSHOT,format=short
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v4
-        with:
-          push: ${{ github.event.inputs.docker_build_push || 'false' }}
-          context: docker/dotcms
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          pull: true
-          no-cache: ${{ github.event.inputs.docker_build_cache || 'false' }}
-          build-args: |
-            BUILD_ID=${{ github.head_ref }}
-            BUILD_FROM=COMMIT 
             
       - id: prepare-license
         name: Prepare license

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -23,6 +23,7 @@ on:
       - '*.adoc'
       - '*.txt'
       - '.github/ISSUE_TEMPLATE/**'
+      - 'core-web/**'
   pull_request:
     paths-ignore:
       - '.gitignore'
@@ -35,6 +36,7 @@ on:
       - '*.adoc'
       - '*.txt'
       - '.github/ISSUE_TEMPLATE/**'
+      - 'core-web/**'
 jobs:
   cli_tests:
     name: CLI tests


### PR DESCRIPTION
### Proposed Changes
Avoid running cli tests for frontend changes.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9c07d3</samp>

This pull request enhances the `cli-cicd-test` workflow to cover only backend code. It adds the `core-web` directory to the workflow configuration to ignore frontend changes and uses the dotCMS CLI to run tests and checks on it.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c9c07d3</samp>

* Add `core-web` directory to ignore rule of `cli-cicd-test` workflow ([link](https://github.com/dotCMS/core/pull/26098/files?diff=unified&w=0#diff-8d1d6a5b6e3ac11e5bae87e4a0670bf96a060d80ad414701b7e8b025a3b96a8eR26), [link](https://github.com/dotCMS/core/pull/26098/files?diff=unified&w=0#diff-8d1d6a5b6e3ac11e5bae87e4a0670bf96a060d80ad414701b7e8b025a3b96a8eR39))
