### PR TITLE
Only show failed tests in report

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -38,6 +38,7 @@ jobs:
           path: '**/target/**/TEST-*.xml'                     # Path to test results (inside artifact .zip)
           reporter: java-junit            # Format of test results
           fail-on-error: true
+          list-tests: 'failed'
           
       - name: Get Workflow Data
         id: workflow-data


### PR DESCRIPTION
Fix to maven build test reports as there are too many passed tests to show in listing.

https://github.com/dorny/test-reporter
change to failed as 
# Limits which test cases are listed:
    #   all
    #   failed
    #   none
    list-tests: 'all'
