### PR TITLE
fix(fix(tests)) this change fixes the fix of the unit tests here

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/Config.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Config.java
@@ -313,7 +313,15 @@ public class Config {
         final Configuration configuration = interpolator.interpolate(props);
 
         if(configuration instanceof PropertiesConfiguration){
-            props.append(configuration);
+            PropertiesConfiguration props2 = (PropertiesConfiguration)configuration;
+            props2.getKeys().forEachRemaining(k->{
+                if(props.containsKey(k)){
+                    props.clearProperty(k);
+                    props.setProperty(k,props2.getProperty(k));
+                }
+
+            });
+
         }
 
     }

--- a/dotCMS/src/main/java/com/dotmarketing/util/Config.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Config.java
@@ -313,15 +313,7 @@ public class Config {
         final Configuration configuration = interpolator.interpolate(props);
 
         if(configuration instanceof PropertiesConfiguration){
-            PropertiesConfiguration props2 = (PropertiesConfiguration)configuration;
-            props2.getKeys().forEachRemaining(k->{
-                if(props.containsKey(k)){
-                    props.clearProperty(k);
-                    props.setProperty(k,props2.getProperty(k));
-                }
-
-            });
-
+            props.copy(configuration);
         }
 
     }


### PR DESCRIPTION
#26123

When setting/reading keys, apache properties are additive.  Meaning if you add the same key twice, it adds the second value to the property value string separated by commas, rather than replacing the value.  Apache Properties do not work like maps, where you add a new property to a key and it takes the place of the existing value.  