### PR TITLE
Fix/25808 containers portlet dropdown

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-seo-meta-tags.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-seo-meta-tags.service.ts
@@ -134,12 +134,11 @@ export class DotSeoMetaTagsService {
     }
 
     /**
-     * Filter
+     * Filter the results by the seoMedia
      * @param results
      * @param seoMedia
      * @returns
      */
-
     getFilteredMetaTagsByMedia(
         results: Observable<SeoMetaTagsResult[]>,
         seoMedia: string
@@ -221,7 +220,7 @@ export class DotSeoMetaTagsService {
             });
         }
 
-        if (ogDescription && ogDescription.length === 0) {
+        if (ogDescription?.length === 0) {
             result.push({
                 message: this.dotMessageService.get('seo.rules.description.found.empty'),
                 color: SEO_RULES_COLORS.ERROR,
@@ -229,7 +228,7 @@ export class DotSeoMetaTagsService {
             });
         }
 
-        if (ogDescription && ogDescription.length > 0) {
+        if (ogDescription && ogDescription?.length > 0) {
             result.push({
                 message: this.dotMessageService.get('seo.rules.description.found'),
                 color: SEO_RULES_COLORS.DONE,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.html
@@ -1,5 +1,6 @@
 <p-overlayPanel
     #deviceSelector
+    (onHide)="onHideDeviceSelector()"
     data-testId="p-overlaypanel-selector"
     styleClass="dot-device-selector__overlayPanel">
     <div class="dot-device-selector__column" data-testId="dot-devices-selector">

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.spec.ts
@@ -206,4 +206,10 @@ describe('DotDeviceSelectorSeoComponent', () => {
 
         expect(component.changeSeoMediaEvent).toHaveBeenCalled();
     });
+
+    it('should emit hideOverlayPanel event when onHideDeviceSelector is called', () => {
+        spyOn(component.hideOverlayPanel, 'emit');
+        component.onHideDeviceSelector();
+        expect(component.hideOverlayPanel.emit).toHaveBeenCalled();
+    });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.ts
@@ -50,6 +50,7 @@ export class DotDeviceSelectorSeoComponent implements OnInit {
     @Input() value: DotDevice;
     @Output() selected = new EventEmitter<DotDevice>();
     @Output() changeSeoMedia = new EventEmitter<string>();
+    @Output() hideOverlayPanel = new EventEmitter<string>();
     @ViewChild('deviceSelector') overlayPanel: OverlayPanel;
     previewUrl: string;
 
@@ -170,12 +171,23 @@ export class DotDeviceSelectorSeoComponent implements OnInit {
         );
     }
 
+    /**
+     * Check if current user is CMS Admin
+     * @returns Observable<boolean>
+     */
     checkIfCMSAdmin(): Observable<boolean> {
         return this.dotCurrentUser.getCurrentUser().pipe(
             map((user: DotCurrentUser) => {
                 return user.admin;
             })
         );
+    }
+
+    /**
+     * Hide the overlay panel
+     */
+    onHideDeviceSelector() {
+        this.hideOverlayPanel.emit();
     }
 
     @Input()

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.html
@@ -4,6 +4,7 @@
     [apiLink]="apiLink"
     (selected)="changeDeviceHandler($event)"
     (changeSeoMedia)="changeSeoMedia($event)"
+    (hideOverlayPanel)="onHideDeviceSelector()"
     appendTo="body"
     tooltipPosition="bottom"
     tooltipStyleClass="dot-device-selector__dialog"
@@ -11,7 +12,8 @@
 <dot-tab-buttons
     [mode]="mode"
     [options]="options"
-    (openMenu)="deviceSelector.openMenu($event)"
+    [icon]="dotTabsIcon"
+    (dropdownClick)="openDeviceSelector($event)"
     (clickOption)="stateSelectorHandler($event.target.value)"
     data-testId="dot-tabs-buttons"></dot-tab-buttons>
 <ng-container *ngIf="!variant">

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
@@ -340,7 +340,7 @@ describe('DotEditPageStateControllerSeoComponent', () => {
         it('should without confirmation dialog emit modeChange and update pageState service', async () => {
             fixtureHost.detectChanges();
 
-            const dotTabButtons = de.query(By.css('[data-testId="dot-tab-container"]'));
+            const dotTabButtons = de.query(By.css('[data-testId="dot-tab-button"]'));
             dotTabButtons.triggerEventHandler('click', {
                 target: { value: 'EDIT_MODE' },
                 value: DotPageMode.EDIT
@@ -375,7 +375,7 @@ describe('DotEditPageStateControllerSeoComponent', () => {
 
             fixtureHost.detectChanges();
 
-            const dotTabButtons = de.query(By.css('[data-testId="dot-tab-container"]'));
+            const dotTabButtons = de.query(By.css('[data-testId="dot-tab-button"]'));
             dotTabButtons.triggerEventHandler('click', {
                 target: { value: 'EDIT_MODE' },
                 value: DotPageMode.EDIT
@@ -398,7 +398,7 @@ describe('DotEditPageStateControllerSeoComponent', () => {
 
             fixtureHost.detectChanges();
 
-            const dotTabButtons = de.query(By.css('[data-testId="dot-tab-container"]'));
+            const dotTabButtons = de.query(By.css('[data-testId="dot-tab-button"]'));
             dotTabButtons.triggerEventHandler('click', {
                 target: { value: 'EDIT_MODE' },
                 value: DotPageMode.EDIT
@@ -438,7 +438,7 @@ describe('DotEditPageStateControllerSeoComponent', () => {
 
             fixtureHost.detectChanges();
 
-            const dotTabButtons = de.query(By.css('[data-testId="dot-tab-container"]'));
+            const dotTabButtons = de.query(By.css('[data-testId="dot-tab-button"]'));
             dotTabButtons.triggerEventHandler('click', {
                 target: { value: 'EDIT_MODE' },
                 value: DotPageMode.EDIT
@@ -476,7 +476,7 @@ describe('DotEditPageStateControllerSeoComponent', () => {
             });
             fixtureHost.detectChanges();
 
-            const dotTabButtons = de.query(By.css('[data-testId="dot-tab-container"]'));
+            const dotTabButtons = de.query(By.css('[data-testId="dot-tab-button"]'));
             dotTabButtons.triggerEventHandler('click', {
                 target: { value: 'EDIT_MODE' },
                 value: DotPageMode.EDIT

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
@@ -73,11 +73,13 @@ export class DotEditPageStateControllerSeoComponent implements OnChanges {
     @Output() modeChange = new EventEmitter<DotPageMode>();
     @Input() variant: DotVariantData | null = null;
     @Input() apiLink: string;
+    @ViewChild('deviceSelector') deviceSelector: DotDeviceSelectorSeoComponent;
 
     lock: boolean;
     lockWarn = false;
     mode: DotPageMode;
     options: SelectItem[] = [];
+    dotTabsIcon = 'pi-angle-down';
 
     constructor(
         private dotAlertConfirmService: DotAlertConfirmService,
@@ -193,6 +195,24 @@ export class DotEditPageStateControllerSeoComponent implements OnChanges {
      */
     changeSeoMedia(seoMedia: string): void {
         this.dotPageStateService.setSeoMedia(seoMedia);
+    }
+
+    /**
+     * OnChange Device Selector
+     * @param pageState
+     * @returns
+     */
+    onHideDeviceSelector(): void {
+        this.dotTabsIcon = 'pi-angle-down';
+    }
+
+    /**
+     * Open Device Selector
+     * @param event
+     */
+    openDeviceSelector(event): void {
+        this.deviceSelector.openMenu(event);
+        this.dotTabsIcon = 'pi-angle-up';
     }
 
     private canTakeLock(pageState: DotPageRenderState): boolean {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.ts
@@ -80,7 +80,6 @@ export class DotResultsSeoToolComponent implements OnInit, OnChanges {
                 isMobile: true
             }
         ];
-        this.currentResults = this.seoOGTagsResults;
     }
 
     ngOnChanges() {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-type-selector/dot-content-type-selector.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-type-selector/dot-content-type-selector.component.html
@@ -1,6 +1,6 @@
 <p-dropdown
     [options]="options$ | async"
-    [style]="{ width: '185px' }"
+    [style]="{ width: '215px' }"
     [filter]="true"
     [showClear]="true"
     [resetFilterOnHide]="true"

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-type-selector/dot-content-type-selector.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-type-selector/dot-content-type-selector.component.html
@@ -1,11 +1,10 @@
 <p-dropdown
     [options]="options$ | async"
-    [style]="{ width: '155px' }"
+    [style]="{ width: '185px' }"
     [filter]="true"
     [showClear]="true"
     [resetFilterOnHide]="true"
     (onChange)="change($event)"
     appendTo="body"
-    filterBy="label"
->
+    filterBy="label">
 </p-dropdown>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-type-selector/dot-content-type-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-type-selector/dot-content-type-selector.component.spec.ts
@@ -78,6 +78,6 @@ describe('DotContentTypeSelectorComponent', () => {
         expect(pDropDown.filterBy).toBeDefined();
         expect(pDropDown.showClear).toBeDefined();
         expect(pDropDown.resetFilterOnHide).toBeDefined();
-        expect(pDropDown.style).toEqual({ 'min-width': '155px' });
+        expect(pDropDown.style).toEqual({ width: '215px' });
     });
 });

--- a/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.html
+++ b/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.html
@@ -1,6 +1,6 @@
 <div class="dot-tab-buttons">
     <div class="dot-tab-buttons__container" *ngFor="let item of options">
-        <div class="dot-tab" (click)="onClickOption($event)" data-testId="dot-tab-container">
+        <div class="dot-tab">
             <button
                 class="dot-tab__button"
                 [ngClass]="{
@@ -10,6 +10,8 @@
                 [value]="item.value"
                 [disabled]="item.disabled"
                 [pTooltip]="'editpage.toolbar.' + item.label.toLowerCase() + '.page.clipboard' | dm"
+                (click)="onClickOption($event)"
+                data-testId="dot-tab-button"
                 data-testId="dot-tab-button-text"
                 tooltipPosition="bottom">
                 {{ item.label }}
@@ -19,8 +21,14 @@
                 class="dot-tab__dropdow"
                 *ngIf="item.value === pageMode.PREVIEW"
                 [ngClass]="{ 'dot-tab-dropdown--active': mode === pageMode.PREVIEW }"
+                (click)="onClickOption($event)"
+                data-testId="dot-tab-button"
                 value="openMenu">
-                <i class="dot-tab-dropdown__icon" [value]="'openMenu'" [class]="icon"></i>
+                <i
+                    class="dot-tab-dropdown__icon pi"
+                    [value]="'openMenu'"
+                    [class]="icon"
+                    data-testId="dot-tab-icon"></i>
             </button>
         </div>
         <div

--- a/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.spec.ts
+++ b/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.spec.ts
@@ -34,7 +34,8 @@ describe('DotTabButtonsComponent', () => {
         spectator = createComponent({
             props: {
                 options: optionsMock,
-                mode: DotPageMode.PREVIEW
+                mode: DotPageMode.PREVIEW,
+                icon: 'pi-angle-down'
             }
         });
     });
@@ -49,7 +50,7 @@ describe('DotTabButtonsComponent', () => {
     });
 
     it('should emit openMenu event when showMenu is called', () => {
-        const openMenuSpy = spyOn(spectator.component.openMenu, 'emit');
+        const openMenuSpy = spyOn(spectator.component.dropdownClick, 'emit');
         spectator.component.showMenu(null);
         expect(openMenuSpy).toHaveBeenCalled();
     });
@@ -90,14 +91,20 @@ describe('DotTabButtonsComponent', () => {
     });
 
     it('should toggle icon', () => {
-        expect(spectator.component.icon).toEqual('pi pi-angle-down');
+        const dotTabsIcon = spectator.queryAll(byTestId('dot-tab-icon'));
 
-        spectator.component.toggle = true;
-        spectator.component.toggleIcon();
-        expect(spectator.component.icon).toEqual('pi pi-angle-up');
+        spectator.setInput({
+            icon: 'pi-angle-up'
+        });
+        spectator.detectChanges();
+        expect(dotTabsIcon).toHaveClass('dot-tab-dropdown__icon pi pi-angle-up');
 
-        spectator.component.toggle = false;
-        spectator.component.toggleIcon();
-        expect(spectator.component.icon).toEqual('pi pi-angle-down');
+        spectator.setInput({
+            icon: 'pi-angle-down'
+        });
+
+        spectator.fixture.detectChanges();
+
+        expect(dotTabsIcon).toHaveClass('pi-angle-down');
     });
 });

--- a/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.ts
+++ b/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.ts
@@ -23,16 +23,15 @@ import { DotMessagePipe } from '@dotcms/ui';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotTabButtonsComponent {
-    @Output() openMenu = new EventEmitter();
+    @Output() dropdownClick = new EventEmitter();
     @Output() clickOption = new EventEmitter();
     @Input() mode: DotPageMode;
     @Input() options: SelectItem[];
+    @Input() icon: string;
+
     protected readonly pageMode = DotPageMode;
-    protected readonly dropDownOpenIcon = 'pi pi-angle-up';
-    protected readonly dropDownCloseIcon = 'pi pi-angle-down';
     readonly OPEN_MENU = 'openMenu';
     toggle = false;
-    icon = this.dropDownCloseIcon;
 
     /**
      * Handles the click event on the tab buttons.
@@ -52,11 +51,6 @@ export class DotTabButtonsComponent {
      */
     showMenu(event) {
         this.toggle = !this.toggle;
-        this.toggleIcon();
-        this.openMenu.emit(event);
-    }
-
-    toggleIcon() {
-        this.icon = this.toggle ? this.dropDownOpenIcon : this.dropDownCloseIcon;
+        this.dropdownClick.emit(event);
     }
 }

--- a/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjaxTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjaxTest.java
@@ -5,15 +5,12 @@ import static com.dotcms.integrationtestutil.content.ContentUtils.deleteContentl
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.FieldAPI;
-import com.dotcms.contenttype.model.field.DateTimeField;
-import com.dotcms.contenttype.model.field.Field;
-import com.dotcms.contenttype.model.field.FieldBuilder;
-import com.dotcms.contenttype.model.field.HostFolderField;
-import com.dotcms.contenttype.model.field.RelationshipField;
-import com.dotcms.contenttype.model.field.TextField;
+import com.dotcms.contenttype.model.field.*;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ContentTypeBuilder;
@@ -24,6 +21,8 @@ import com.dotcms.datagen.FieldDataGen;
 import com.dotcms.datagen.LanguageDataGen;
 import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.languagevariable.business.LanguageVariableAPI;
+import com.dotcms.repackage.org.directwebremoting.WebContext;
+import com.dotcms.repackage.org.directwebremoting.WebContextFactory;
 import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
@@ -44,16 +43,15 @@ import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
 import com.google.common.collect.ImmutableList;
 import com.liferay.portal.model.User;
+import com.liferay.portal.util.WebKeys;
 import com.liferay.util.StringPool;
+import com.liferay.util.servlet.SessionMessages;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import io.vavr.control.Try;
@@ -61,6 +59,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 /**
  *
@@ -69,7 +68,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(DataProviderRunner.class)
 public class ContentletAjaxTest {
-	
+
 	private Language language;
 	private Contentlet contentlet;
 	private static User systemUser;
@@ -97,10 +96,10 @@ public class ContentletAjaxTest {
     }
 
 	/**
-	 * Test problem on "Content Search" when switching on one language 
-	 * show all the contentlets 
-	 * @throws DotDataException 
-	 * @throws DotSecurityException 
+	 * Test problem on "Content Search" when switching on one language
+	 * show all the contentlets
+	 * @throws DotDataException
+	 * @throws DotSecurityException
 	 */
 	@Test
 	public void issue5330() throws DotDataException, DotSecurityException{
@@ -131,7 +130,7 @@ public class ContentletAjaxTest {
         contentlet.setIndexPolicyDependencies(IndexPolicy.FORCE);
 		APILocator.getVersionableAPI().setLive(contentlet);
 		contentletAPI.isInodeIndexed(contentlet.getInode(),true);
-		
+
 		String ident = contentlet.getIdentifier();
 		contentlet = contentletAPI.findContentletByIdentifier(ident, true, defaultLang.getId(), systemUser, false);
 		contentlet = contentletAPI.checkout(contentlet.getInode(), systemUser, false);
@@ -162,7 +161,7 @@ public class ContentletAjaxTest {
 		fieldsValues.add("languageId");
 		fieldsValues.add(String.valueOf(defaultLang.getId()));
 		List<String> categories = new ArrayList<>();
-		
+
 		List<Object> results=new ContentletAjax().searchContentletsByUser(structure.getInode(), fieldsValues, categories, false, false, false, false,1, "modDate Desc", 10,systemUser, null, null, null);
 		Map<String,Object> result = (Map<String,Object>)results.get(0);
 		Assert.assertEquals((Long)result.get("total"), Long.valueOf(1));
@@ -195,7 +194,7 @@ public class ContentletAjaxTest {
 	@Test
 	public void test_doSearchGlossaryTerm_ReturnsListLanguageVariables()
 			throws Exception {
-	    language = new LanguageDataGen().nextPersisted();
+		language = new LanguageDataGen().nextPersisted();
 		Contentlet languageVariable1 = null;
 		Contentlet languageVariable2 = null;
 		Contentlet languageVariable3 = null;
@@ -406,6 +405,56 @@ public class ContentletAjaxTest {
 		}finally {
 			contentTypeAPI.delete(eventContentType);
 		}
+	}
+
+	private static void setUpContext() {
+		final HttpSession session = mock(HttpSession.class);
+		Mockito.when(session.getAttribute(SessionMessages.KEY)).thenReturn(new LinkedHashMap());
+
+		final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+		Mockito.when(httpServletRequest.getSession()).thenReturn(session);
+		Mockito.when(httpServletRequest.getAttribute(WebKeys.USER)).thenReturn(APILocator.systemUser());
+
+		final WebContext webContext = mock(WebContext.class);
+		Mockito.when(webContext.getHttpServletRequest()).thenReturn(httpServletRequest);
+
+		final WebContextFactory.WebContextBuilder webContextBuilderMock =
+				mock(WebContextFactory.WebContextBuilder.class);
+		Mockito.when(webContextBuilderMock.get()).thenReturn(webContext);
+
+		final com.dotcms.repackage.org.directwebremoting.Container containerMock =
+				mock(com.dotcms.repackage.org.directwebremoting.Container.class);
+		Mockito.when(containerMock.getBean(WebContextFactory.WebContextBuilder.class)).thenReturn(webContextBuilderMock);
+
+		WebContextFactory.attach(containerMock);
+	}
+
+
+	/**
+	 * <b>Method to Test:</b> {@link ContentletAjax#getContentletData(String)}<p>
+	 * <b>When:</b> getting the data of the contentlet <p>
+	 * <b>Should:</b> Return if the field contains an image field
+	 */
+	@Test
+	public void test_getContentletData_addingHasImageField(){
+		setUpContext();
+
+		final ContentType contentType = new ContentTypeDataGen().nextPersisted();
+		ContentTypeDataGen.addField(new FieldDataGen()
+				.velocityVarName("title")
+				.contentTypeId(contentType.id())
+				.type(TextField.class)
+				.nextPersisted());
+		ContentTypeDataGen.addField(new FieldDataGen()
+				.velocityVarName("constImage")
+				.contentTypeId(contentType.id())
+				.type(ImageField.class)
+				.nextPersisted());
+		final Contentlet contentlet = new ContentletDataGen(contentType.id()).nextPersisted();
+		final ContentletAjax contentletAjax = new ContentletAjax();
+		final Map<String, Object> contentletData = contentletAjax.getContentletData(contentlet.getInode());
+		assertNotNull(contentletData);
+		assertTrue(contentletData.get("hasImageFields").equals("true"));
 	}
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
@@ -207,6 +207,7 @@ public class ContentletAjax {
 			result.put("langName", languageName);
 			result.put("langId", language.getId()+"");
 			result.put("siblings", getContentSiblingsData(inode));
+			result.put("hasImageFields",String.valueOf(hasImageFields(inode)));
 
 		} catch (DotDataException e) {
 			Logger.error(this, "Error trying to obtain the contentlets from the relationship.", e);
@@ -244,6 +245,24 @@ public class ContentletAjax {
                 result.put(field.variable(), fieldValue);
             }
         }
+	}
+
+	private boolean hasImageFields(String inode) throws DotDataException, DotSecurityException {
+
+		final HttpServletRequest req = WebContextFactory.get().getHttpServletRequest();
+		final User currentUser = com.liferay.portal.util.PortalUtil.getUser(req);
+		final Contentlet firstContentlet = conAPI.find(inode, currentUser, true);
+		final Structure targetStructure = firstContentlet.getStructure();
+		final List<Field> targetFields = FieldsCache.getFieldsByStructureInode(targetStructure.getInode());
+
+		//use a for each to iterate targetFields and validate if fieldType contains image
+		for(final Field field : targetFields){
+			if(field.getFieldType().equals(FieldType.IMAGE.toString()) ){
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private List<Map<String, String>> getContentSiblingsData(String inode) {//GIT-1057

--- a/dotCMS/src/main/java/com/dotmarketing/util/Config.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Config.java
@@ -313,7 +313,7 @@ public class Config {
         final Configuration configuration = interpolator.interpolate(props);
 
         if(configuration instanceof PropertiesConfiguration){
-            props.append(configuration);
+            props.copy(configuration);
         }
 
     }

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/relationship_field.jsp
@@ -26,6 +26,8 @@
 <%@page import="java.util.Objects" %>
 <%@page import="com.google.common.collect.ImmutableMap" %>
 <%@page import="io.vavr.Tuple2" %>
+<%@ page import="com.dotmarketing.exception.DotDataException" %>
+<%@ page import="com.dotmarketing.exception.DotSecurityException" %>
 <%
 	LanguageAPI langAPI = APILocator.getLanguageAPI();
 	PermissionAPI conPerAPI = APILocator.getPermissionAPI();
@@ -421,8 +423,6 @@
 
 		//Invoked when a contentlet is selected to fill the contentlet data in the table
 		function <%= relationJsName %>_addRelationshipCallback(selectedData){
-			console.log("selectedData");
-			console.log(selectedData);
 
 			//A new list will be created with all the relationships but will remove multilingual ones, and in that
 			//case will add the one of the selected language.
@@ -676,13 +676,16 @@
                     var fieldValue = '';
                     if (fieldName === 'languageId') {
                         createLangTd(row, item, '<%= relationJsName %>');
-                    } else if (fieldName === 'titleImage') {
+
+                    } else if ((item[fieldName] && (fieldName === 'titleImage' || item[fieldName].includes("assets")))
+							|| (!item[fieldName] && item['hasImageFields'] === 'true') ) {
                         createImageCell(row, item);
-                    } else {
-                        var fieldCell = row.insertCell(row.cells.length);
-                        fieldCell.innerHTML = <%= relationJsName%>EditRelatedContentWrap(
-                            item,
-                            item[fieldName] || "");
+                    } else{
+							var fieldCell = row.insertCell(row.cells.length);
+							fieldCell.innerHTML = <%= relationJsName%>EditRelatedContentWrap(
+									item,
+									item[fieldName] || "");
+
                     }
                 });
             }


### PR DESCRIPTION

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0a5ddb9</samp>

### Summary
:sparkles::bug::lipstick:

<!--
1.  :sparkles: - This emoji represents a new feature or enhancement, and can be used to indicate that the width of the dropdown component was increased as an improvement to the UI.
2.  :bug: - This emoji represents a bug fix or a patch, and can be used to indicate that the content type names were truncated in the dropdown and that this issue was resolved by the width adjustment.
3.  :lipstick: - This emoji represents a cosmetic or UI change, and can be used to indicate that the appearance of the dropdown component was modified to better display the content type names.
-->
Increased the width of the `dot-content-type-selector` component to display longer content type names. This was a UI fix for the `dotcms-ui` app.

> _Dropdown `width` grows_
> _Longer content type names fit_
> _Autumn of truncation_

### Walkthrough
*  Increased the width of the content type selector dropdown to prevent truncation of long names ([link](https://github.com/dotCMS/core/pull/26165/files?diff=unified&w=0#diff-a5cd33958e34508a8793c208ff6c6b4d6a6692fe9b44b39d7ee6e102e1ae8cf3L3-R3))



### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
