### PR TITLE
Fixed Dropdown width on Containers

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-type-selector/dot-content-type-selector.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-type-selector/dot-content-type-selector.component.html
@@ -1,6 +1,6 @@
 <p-dropdown
     [options]="options$ | async"
-    [style]="{ 'min-width': '155px' }"
+    [style]="{ width: '215px' }"
     [filter]="true"
     [showClear]="true"
     [resetFilterOnHide]="true"

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-type-selector/dot-content-type-selector.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-type-selector/dot-content-type-selector.component.spec.ts
@@ -78,6 +78,6 @@ describe('DotContentTypeSelectorComponent', () => {
         expect(pDropDown.filterBy).toBeDefined();
         expect(pDropDown.showClear).toBeDefined();
         expect(pDropDown.resetFilterOnHide).toBeDefined();
-        expect(pDropDown.style).toEqual({ 'min-width': '155px' });
+        expect(pDropDown.style).toEqual({ width: '215px' });
     });
 });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7afc0f8</samp>

### Summary
:art::white_check_mark::zap:

<!--
1.  :art: - This emoji represents improvements to the UI or code style, such as layout, colors, typography, or formatting. The width change of the dropdown component falls under this category, as it enhances the visual appearance and readability of the UI.
2.  :white_check_mark: - This emoji represents adding or updating tests, such as unit tests, integration tests, or end-to-end tests. The unit test update for the dropdown component falls under this category, as it ensures that the test reflects the current UI state and passes successfully.
3.  :zap: - This emoji represents improving performance, such as optimizing code, caching, or reducing resource consumption. The width change of the dropdown component could also fall under this category, as it could potentially reduce the number of reflows or repaints caused by the dropdown resizing or truncating its content.
-->
Increased the width of the `dot-content-type-selector` dropdown component to display longer content type names. Updated the unit test accordingly.

> _Dropdown `width` grows_
> _Longer names fit in the box_
> _Winter of truncation_

### Walkthrough
*  Increased the width of the content type selector dropdown to avoid truncating long names ([link](https://github.com/dotCMS/core/pull/26169/files?diff=unified&w=0#diff-a5cd33958e34508a8793c208ff6c6b4d6a6692fe9b44b39d7ee6e102e1ae8cf3L3-R3))
*  Updated the unit test to match the new width value of the dropdown ([link](https://github.com/dotCMS/core/pull/26169/files?diff=unified&w=0#diff-38068862e5c2f1a1fe0fe50207d7606008661e6a96abff63153ed3cd1e25d045L81-R81))



### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
