### PR TITLE
Change to use VelocityUtil.getVelocityRootPath

### DIFF
--- a/dotCMS/dependencies.gradle
+++ b/dotCMS/dependencies.gradle
@@ -152,12 +152,12 @@ dependencies {
     implementation (group: 'com.squareup.okio', name: 'okio', version: '1.6.0'){}
     implementation (group: 'com.sun.activation', name: 'jakarta.activation', version: '1.2.1'){}
     implementation (group: 'com.sun.activation', name: 'javax.activation', version: '1.2.0'){}
-    compileOnly (group: 'com.sun.istack', name: 'istack-commons-runtime', version: '3.0.12'){}
+    implementation (group: 'com.sun.istack', name: 'istack-commons-runtime', version: '3.0.12'){}
     implementation (group: 'com.sun.mail', name: 'jakarta.mail', version: '1.6.7'){}
     implementation (group: 'com.tdunning', name: 't-digest', version: '3.2') {
         transitive=false
     }
-    implementation (group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.8') {
+    implementation (group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.17') {
         exclude group: 'xpp3', module: 'xpp3_min'
     }
     testImplementation (group: 'com.tngtech.junit.dataprovider', name: 'junit-dataprovider-core', version: '2.6'){}
@@ -204,6 +204,7 @@ dependencies {
     }
     implementation (group: 'fop', name: 'fop', version: '0.20.3'){}
     implementation (group: 'io.github.classgraph', name: 'classgraph', version: '4.8.138'){}
+    implementation (group: 'io.github.x-stream', name: 'mxparser', version: '1.2.1'){}
     implementation (group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'){}
     implementation (group: 'io.lettuce', name: 'lettuce-core', version: '6.1.1.RELEASE'){}
     implementation (group: 'io.netty', name: 'netty-buffer', version: '4.1.63.Final'){}
@@ -395,8 +396,8 @@ dependencies {
     implementation (group: 'org.glassfish.hk2', name: 'hk2-locator', version: '2.4.0-b31'){}
     implementation (group: 'org.glassfish.hk2', name: 'hk2-utils', version: '2.4.0-b31'){}
     implementation (group: 'org.glassfish.hk2', name: 'osgi-resource-locator', version: '1.0.1'){}
-    compileOnly (group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '2.3.8'){}
-    compileOnly (group: 'org.glassfish.jaxb', name: 'txw2', version: '2.3.8'){}
+    implementation (group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '2.3.8'){}
+    implementation (group: 'org.glassfish.jaxb', name: 'txw2', version: '2.3.8'){}
     implementation (group: 'org.glassfish.jersey.bundles.repackaged', name: 'jersey-guava', version: '2.22.1'){}
     implementation (group: 'org.glassfish.jersey.connectors', name: 'jersey-apache-connector', version: '2.22.1'){}
     implementation (group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet-core', version: '2.22.1'){}

--- a/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMapTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMapTest.java
@@ -154,7 +154,7 @@ public class StoryBlockMapTest extends IntegrationTestBase {
     @Test
     public void test_default_olist_render_to_html() throws  JSONException {
 
-        final String velocityRoot   = Config.getStringProperty("VELOCITY_ROOT", "/WEB-INF/velocity");
+        final String velocityRoot   = VelocityUtil.getVelocityRootPath();
         final File velocityRootFile = new File(velocityRoot);
 
         Assert.assertTrue("the " + velocityRoot + "/static/storyblock/bulletList.vtl" + " should exists",
@@ -178,7 +178,7 @@ public class StoryBlockMapTest extends IntegrationTestBase {
     @Test
     public void test_default_ulist_render_to_html() throws  JSONException {
 
-        final String velocityRoot   = Config.getStringProperty("VELOCITY_ROOT", "/WEB-INF/velocity");
+        final String velocityRoot   = VelocityUtil.getVelocityRootPath();
         final File velocityRootFile = new File(velocityRoot);
 
         Assert.assertTrue("the " + velocityRoot + "/static/storyblock/orderedList.vtl" + " should exists",
@@ -204,7 +204,7 @@ public class StoryBlockMapTest extends IntegrationTestBase {
     @Test
     public void test_default_paragraph_render_to_html() throws  JSONException {
 
-        final String velocityRoot   = Config.getStringProperty("VELOCITY_ROOT", "/WEB-INF/velocity");
+        final String velocityRoot   = VelocityUtil.getVelocityRootPath();
         final File velocityRootFile = new File(velocityRoot);
 
         Assert.assertTrue("the " + velocityRoot + "/static/storyblock/paragraph.vtl" + " should exists",
@@ -240,7 +240,7 @@ public class StoryBlockMapTest extends IntegrationTestBase {
     @Test
     public void test_default_render_to_html() throws  JSONException {
 
-        final String velocityRoot   = Config.getStringProperty("VELOCITY_ROOT", "/WEB-INF/velocity");
+        final String velocityRoot   = VelocityUtil.getVelocityRootPath();;
         final File velocityRootFile = new File(velocityRoot);
 
         Assert.assertTrue("the " + velocityRoot + "/static/storyblock/default.vtl" + " should exists",

--- a/dotCMS/src/integration-test/java/com/dotcms/util/ConfigTestHelper.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/util/ConfigTestHelper.java
@@ -2,6 +2,7 @@ package com.dotcms.util;
 
 import com.dotcms.repackage.org.apache.struts.Globals;
 import com.dotcms.repackage.org.apache.struts.config.ModuleConfig;
+import com.dotmarketing.util.VelocityUtil;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -51,7 +52,7 @@ public class ConfigTestHelper extends Config {
 
             final String topPath = Files.createTempDirectory("config_test_helper").toAbsolutePath().toString();
 
-            final String velocityPath = Config.getStringProperty("VELOCITY_ROOT", "/WEB-INF/velocity");
+            final String velocityPath = VelocityUtil.getVelocityRootPath();
             copyVelocityFolder(topPath, velocityPath);
 
             Path testRoot = Paths.get(Config.getStringProperty("TEST_WEBAPP_ROOT","src/main/webapp")).normalize().toAbsolutePath();
@@ -79,8 +80,8 @@ public class ConfigTestHelper extends Config {
                         return null;
                 }
             });
-            
-           
+
+
             Config.CONTEXT = context;
             Config.CONTEXT_PATH = context.getRealPath("/");
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/VTLLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/VTLLoader.java
@@ -8,6 +8,7 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
 
+import com.dotmarketing.util.VelocityUtil;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -41,12 +42,7 @@ public class VTLLoader implements DotLoader {
     }
 
     private void init() {
-        String velocityRootPath = Config.getStringProperty("VELOCITY_ROOT", "/WEB-INF/velocity");
-        if (velocityRootPath.startsWith("/WEB-INF")) {
-            String startPath = velocityRootPath.substring(0, 8);
-            String endPath = velocityRootPath.substring(9, velocityRootPath.length());
-            velocityRootPath = FileUtil.getRealPath(startPath) + File.separator + endPath;
-        } 
+        String velocityRootPath = VelocityUtil.getVelocityRootPath();
 
         VELOCITY_ROOT = velocityRootPath + File.separator;
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/GenericRenderableImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/GenericRenderableImpl.java
@@ -19,6 +19,8 @@ import com.liferay.util.StringPool;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.control.Try;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.apache.velocity.context.Context;
 
 import javax.servlet.http.HttpServletRequest;
@@ -81,16 +83,7 @@ class GenericRenderableImpl implements Renderable {
     }
 
     private boolean existsInFileSystem(final String filePath) {
-
-        final String velocityRoot   = Config.getStringProperty("VELOCITY_ROOT", "/WEB-INF/velocity");
-        final File velocityRootFile = new File(velocityRoot);
-        if (!velocityRootFile.exists()) {
-            final File velocityRootPath = new File(Config.CONTEXT.getRealPath(Config.getStringProperty("VELOCITY_ROOT", "/WEB-INF/velocity")));
-            final File vtlFile = new File(velocityRootPath, filePath);
-            return vtlFile.exists();
-        }
-
-        return new File(velocityRootFile, filePath).exists();
+        return Files.exists(Paths.get(VelocityUtil.getVelocityRootPath(),filePath));
     }
 
     private Tuple2<Boolean, String> existsFile (final String path, final Host host, final User user)  {


### PR DESCRIPTION
fixes #26185 to consistently handle VELOCITY_ROOT configuration  as either an absolute path or a webapp path