### PR TITLE
fix(build) " ( ) ' /  Fix special chars in pull request breaking workflow data

### DIFF
--- a/.github/workflows/maven-cicd-pipeline.yml
+++ b/.github/workflows/maven-cicd-pipeline.yml
@@ -312,7 +312,11 @@ jobs:
           path: /tmp/build-step-reports
 
       - name: Prepare workflow data
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+         
+          
           AGGREGATE_STATUS="SUCCESS"
           jobs_status="${{ toJson(needs) }}"
           echo "job status=${jobs_status}"
@@ -333,10 +337,30 @@ jobs:
                                           
                                           
                                           
-                                          FIRST_FAIL_STEP=""
+          FIRST_FAIL_STEP=""
           FIRST_FAIL_MODULE=""
           
+          
+          
+          
           echo '{' > workflow-data.json
+          
+          EVENT_TYPE="${{ github.event_name }}"
+          
+          if [[ "$EVENT_TYPE" == "pull_request" ]]; then
+            PR_TITLE_JQ=$(jq --arg title "$PR_TITLE" -n '$title') # result includes wrapping quotes
+            echo "Creating workflow data for pull request ${PR_TITLE_JQ}"
+          else
+              PR_TITLE="N/A"
+              BRANCH="${{ github.ref }}"
+              BRANCH="${BRANCH##*/}"
+              echo "Creating workflow data for branch ${BRANCH}"
+          fi
+        
+          PR_TITLE_JQ=$(jq --arg title "PR_TITLE" -n '$title')
+          
+  
+          
           
           echo '"branch": "'${{ github.head_ref }}'",' >> workflow-data.json
           echo '"run_id": "'${{ github.run_id }}'",' >> workflow-data.json
@@ -355,7 +379,7 @@ jobs:
           
           echo '"pr_id": "'${{ github.event.pull_request.id }}'",' >> workflow-data.json
           echo '"pr_number": "'${{ github.event.pull_request.number }}'",' >> workflow-data.json
-          echo '"pr_title": "'${{ github.event.pull_request.title }}'",' >> workflow-data.json
+          echo "\"pr_title\": $PR_TITLE_JQ," >> workflow-data.json
           echo '"pr_author": "'${{ github.event.pull_request.user.login }}'",' >> workflow-data.json
           echo '"pr_merge_state": "'${{ github.event.pull_request.mergeable_state }}'",' >> workflow-data.json
           


### PR DESCRIPTION
Some characters in pull requests on reports  are failing due to the way they are handled in the shell.  One step is to use and intermediate environment variable  https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable 
This till can cause issues when used in json.  jq is used to escape for json.  
#26214 