### PR TITLE
ci:  fix duplicate id for slack

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -130,7 +130,7 @@ jobs:
           
       - name: Post to a Slack channel
         if: steps.workflow-data.outputs.has-json == 'true' && steps.workflow-data.outputs.report_type == 'PR'
-        id: slack
+        id: slack-pr
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ vars.SLACK_REPORT_CHANNEL }}
@@ -211,7 +211,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       - name: Post to a Slack channel non PR
         if: steps.workflow-data.outputs.has-json == 'true' && steps.workflow-data.outputs.report_type != 'PR'
-        id: slack
+        id: slack-non-pr
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ vars.SLACK_REPORT_CHANNEL }}


### PR DESCRIPTION
fix of Duplicate id for slack step.  This file build-report.yml only runs from master so required an override to merge. 