### PR TITLE
fix(cli-workflow): Avoid triggering cli tests for frontend changes.

### DIFF
--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -15,7 +15,7 @@ on:
     paths-ignore:
       - '.gitignore'
       - '.dockerignore'
-      - 'dotCMS/src/main/webapp/html'
+      - '!dotCMS/src/main/webapp/html'
       - '!docker/**'
       - 'cicd/**'
       - '.cicd/**'
@@ -23,12 +23,12 @@ on:
       - '*.adoc'
       - '*.txt'
       - '.github/ISSUE_TEMPLATE/**'
-      - 'core-web/**'
+      - '!core-web/**'
   pull_request:
     paths-ignore:
       - '.gitignore'
       - '.dockerignore'
-      - 'dotCMS/src/main/webapp/html'
+      - '!dotCMS/src/main/webapp/html'
       - '!docker/**'
       - 'cicd/**'
       - '.cicd/**'
@@ -36,7 +36,7 @@ on:
       - '*.adoc'
       - '*.txt'
       - '.github/ISSUE_TEMPLATE/**'
-      - 'core-web/**'
+      - '!core-web/**'
 jobs:
   cli_tests:
     name: CLI tests

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -22,7 +22,7 @@ on:
       - '!dotCMS/src/main/webapp/html'
       - 'pom.xml'
       - 'tools/**'
-      - '!core-web'
+
   pull_request:
     paths:
       - '.cicd/**'
@@ -34,7 +34,7 @@ on:
       - '!dotCMS/src/main/webapp/html'
       - 'pom.xml'
       - 'tools/**'
-      - '!core-web'
+
 jobs:
   cli_tests:
     name: CLI tests

--- a/.github/workflows/cli-cicd-test.yml
+++ b/.github/workflows/cli-cicd-test.yml
@@ -12,31 +12,29 @@ on:
     branches:
       - master
       - release-*
-    paths-ignore:
-      - '.gitignore'
-      - '.dockerignore'
-      - '!dotCMS/src/main/webapp/html'
-      - '!docker/**'
-      - 'cicd/**'
+    paths:
       - '.cicd/**'
-      - '*.md'
-      - '*.adoc'
-      - '*.txt'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '!core-web/**'
+      - '.github/**'
+      - 'cicd/**'
+      - 'docker/**'
+      - '!docker/dotcms-compose-examples/**'
+      - 'dotCMS/**'
+      - '!dotCMS/src/main/webapp/html'
+      - 'pom.xml'
+      - 'tools/**'
+      - '!core-web'
   pull_request:
-    paths-ignore:
-      - '.gitignore'
-      - '.dockerignore'
-      - '!dotCMS/src/main/webapp/html'
-      - '!docker/**'
-      - 'cicd/**'
+    paths:
       - '.cicd/**'
-      - '*.md'
-      - '*.adoc'
-      - '*.txt'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '!core-web/**'
+      - '.github/**'
+      - 'cicd/**'
+      - 'docker/**'
+      - '!docker/dotcms-compose-examples/**'
+      - 'dotCMS/**'
+      - '!dotCMS/src/main/webapp/html'
+      - 'pom.xml'
+      - 'tools/**'
+      - '!core-web'
 jobs:
   cli_tests:
     name: CLI tests

--- a/core-web/README.MD
+++ b/core-web/README.MD
@@ -102,4 +102,3 @@ Run `nx dep-graph` to see a diagram of the dependencies of your projects.
 ### Further help
 
 Visit the [Nx Documentation](https://nx.dev/angular) to learn more.
-

--- a/core-web/README.MD
+++ b/core-web/README.MD
@@ -102,3 +102,5 @@ Run `nx dep-graph` to see a diagram of the dependencies of your projects.
 ### Further help
 
 Visit the [Nx Documentation](https://nx.dev/angular) to learn more.
+
+

--- a/core-web/README.MD
+++ b/core-web/README.MD
@@ -103,4 +103,3 @@ Run `nx dep-graph` to see a diagram of the dependencies of your projects.
 
 Visit the [Nx Documentation](https://nx.dev/angular) to learn more.
 
-


### PR DESCRIPTION
### Proposed Changes
Avoid to trigger CLI tests workflow for frontend changes.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf7db42</samp>

Updated the CLI tests workflow to optimize the trigger conditions. Fine-tuned the `paths-ignore` filters for different events to match the directories that affect the CLI tests.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf7db42</samp>

*  Exclude `dotCMS/src/main/webapp/html` directory from triggering CLI tests workflow on `push` and `pull_request` events ([link](https://github.com/dotCMS/core/pull/26247/files?diff=unified&w=0#diff-8d1d6a5b6e3ac11e5bae87e4a0670bf96a060d80ad414701b7e8b025a3b96a8eL18-R18), [link](https://github.com/dotCMS/core/pull/26247/files?diff=unified&w=0#diff-8d1d6a5b6e3ac11e5bae87e4a0670bf96a060d80ad414701b7e8b025a3b96a8eL26-R31))
* Include `core-web` directory in CLI tests workflow for all events (`push`, `pull_request`, and `schedule`) to cover Angular UI code changes ([link](https://github.com/dotCMS/core/pull/26247/files?diff=unified&w=0#diff-8d1d6a5b6e3ac11e5bae87e4a0670bf96a060d80ad414701b7e8b025a3b96a8eL26-R31), [link](https://github.com/dotCMS/core/pull/26247/files?diff=unified&w=0#diff-8d1d6a5b6e3ac11e5bae87e4a0670bf96a060d80ad414701b7e8b025a3b96a8eL39-R39))