### PR TITLE
[#26261]: use copy from designs

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/meta-tags-model.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/models/meta-tags-model.ts
@@ -54,6 +54,7 @@ export interface SeoKeyResult {
 
 export interface SeoMetaTagsResult {
     key: string;
+    title: string;
     keyIcon: string;
     keyColor: string;
     items: SeoRulesResult[];

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-seo-meta-tags.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-seo-meta-tags.service.ts
@@ -98,6 +98,7 @@ export class DotSeoMetaTagsService {
 
                     return {
                         key,
+                        title: key.replace('og:', '').replace('twitter:', ''),
                         keyIcon: keysValues.keyIcon,
                         keyColor: keysValues.keyColor,
                         items: items,
@@ -121,23 +122,23 @@ export class DotSeoMetaTagsService {
             [SEO_OPTIONS.DESCRIPTION]: {
                 getItems: (metaTagsObject: SeoMetaTags) =>
                     of(this.getDescriptionItems(metaTagsObject)),
-                sort: 2,
+                sort: 3,
                 info: this.dotMessageService.get('seo.rules.description.info')
             },
             [SEO_OPTIONS.OG_DESCRIPTION]: {
                 getItems: (metaTagsObject: SeoMetaTags) =>
                     of(this.getDescriptionItems(metaTagsObject)),
-                sort: 3,
+                sort: 4,
                 info: this.dotMessageService.get('seo.rules.description.info')
             },
             [SEO_OPTIONS.TITLE]: {
                 getItems: (metaTagsObject: SeoMetaTags) => of(this.getTitleItems(metaTagsObject)),
-                sort: 4,
+                sort: 2,
                 info: this.dotMessageService.get('seo.rules.title.info')
             },
             [SEO_OPTIONS.OG_TITLE]: {
                 getItems: (metaTagsObject: SeoMetaTags) => of(this.getOgTitleItems(metaTagsObject)),
-                sort: 5,
+                sort: 2,
                 info: this.dotMessageService.get('seo.rules.title.info')
             },
             [SEO_OPTIONS.OG_IMAGE]: {
@@ -148,13 +149,13 @@ export class DotSeoMetaTagsService {
             [SEO_OPTIONS.TWITTER_CARD]: {
                 getItems: (metaTagsObject: SeoMetaTags) =>
                     of(this.getTwitterCardItems(metaTagsObject)),
-                sort: 1,
+                sort: 2,
                 info: ''
             },
             [SEO_OPTIONS.TWITTER_TITLE]: {
                 getItems: (metaTagsObject: SeoMetaTags) =>
                     of(this.getTwitterTitleItems(metaTagsObject)),
-                sort: 2,
+                sort: 1,
                 info: ''
             },
             [SEO_OPTIONS.TWITTER_DESCRIPTION]: {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.html
@@ -57,7 +57,7 @@
 <p-card class="results-seo-tool__result-card" *ngFor="let result of currentResults$ | async">
     <ng-template pTemplate="header">
         <div class="results-seo-tool__result-card-title">
-            <span data-testId="result-key"> {{ result.key | titlecase }}</span>
+            <span data-testId="result-key"> {{ result.title | titlecase }}</span>
         </div>
     </ng-template>
     <ul class="results-seo-tool__result-card-list">

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/dot-results-seo-tool.component.spec.ts
@@ -150,4 +150,17 @@ describe('DotResultsSeoToolComponent', () => {
             done();
         });
     });
+
+    it('should render the result card title with title case', () => {
+        const expectedTitle = 'Title';
+        const expectedDescription = 'Description';
+
+        const resultKeyTitle = spectator.queryAll(byTestId('result-key'))[2];
+        const resultKeyDescription = spectator.queryAll(byTestId('result-key'))[1];
+
+        expect(resultKeyTitle).toExist();
+        expect(resultKeyDescription).toExist();
+        expect(resultKeyTitle).toContainText(expectedTitle);
+        expect(resultKeyDescription).toContainText(expectedDescription);
+    });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/mocks.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-results-seo-tool/mocks.ts
@@ -14,6 +14,7 @@ const seoOGTagsMock = {
 const seoOGTagsResultOgMockTwitter = [
     {
         key: 'twitter:card',
+        title: 'card',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [
@@ -28,6 +29,7 @@ const seoOGTagsResultOgMockTwitter = [
     },
     {
         key: 'twitter:title',
+        title: 'title',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [
@@ -43,6 +45,7 @@ const seoOGTagsResultOgMockTwitter = [
     },
     {
         key: 'twitter:description',
+        title: 'description',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [
@@ -58,6 +61,7 @@ const seoOGTagsResultOgMockTwitter = [
     },
     {
         key: 'twitter:image',
+        title: 'image',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [
@@ -75,6 +79,7 @@ const seoOGTagsResultOgMockTwitter = [
 const seoOGTagsResultMock = [
     {
         key: 'Favicon',
+        title: 'favicon',
         keyIcon: 'pi-check-circle',
         keyColor: 'results-seo-tool__result-icon--alert-green',
         items: [
@@ -88,6 +93,7 @@ const seoOGTagsResultMock = [
     },
     {
         key: 'Description',
+        title: 'Description',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [
@@ -102,6 +108,7 @@ const seoOGTagsResultMock = [
     },
     {
         key: 'Title',
+        title: 'Title',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-yellow',
         items: [
@@ -116,6 +123,7 @@ const seoOGTagsResultMock = [
     },
     {
         key: 'Og:title',
+        title: 'title',
         keyIcon: 'pi-check-circle',
         keyColor: 'results-seo-tool__result-icon--alert-green',
         items: [
@@ -131,6 +139,7 @@ const seoOGTagsResultMock = [
     },
     {
         key: 'Og:image',
+        title: 'image',
         keyIcon: 'pi-check-circle',
         keyColor: 'results-seo-tool__result-icon--alert-green',
         items: [
@@ -145,6 +154,7 @@ const seoOGTagsResultMock = [
     },
     {
         key: 'Og:description',
+        title: 'Description',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [
@@ -163,77 +173,7 @@ const seoOGTagsResultMock = [
 const seoOGTagsResultOgMock = [
     {
         key: 'description',
-        keyIcon: 'pi-exclamation-triangle',
-        keyColor: 'results-seo-tool__result-icon--alert-red',
-        items: [
-            {
-                message:
-                    '<code>og:description</code> meta tag not found! Showing Meta Description instead.',
-                color: 'results-seo-tool__result-icon--alert-red',
-                itemIcon: 'pi-times'
-            }
-        ],
-        sort: 2,
-        info: "The length of the description allowed will depend on the reader's device size; on the smallest size only about 110 characters are allowed."
-    },
-    {
-        key: 'og:image',
-        keyIcon: 'pi-check-circle',
-        keyColor: 'results-seo-tool__result-icon--alert-green',
-        items: [
-            {
-                message: '<code>og:image</code> metatag found, with an appropriate sized image!',
-                color: 'results-seo-tool__result-icon--alert-green',
-                itemIcon: 'pi-check'
-            }
-        ],
-        sort: 6,
-        info: ''
-    },
-    {
-        key: 'og:title',
-        keyIcon: 'pi-exclamation-triangle',
-        keyColor: 'results-seo-tool__result-icon--alert-yellow',
-        items: [
-            {
-                message: 'title metatag found, but has fewer than 30 characters of content.',
-                color: 'results-seo-tool__result-icon--alert-yellow',
-                itemIcon: 'pi-exclamation-circle'
-            }
-        ],
-        sort: 5,
-        info: 'HTML Title content should be between 30 and 60 characters.'
-    },
-    {
-        key: 'favicon',
-        keyIcon: 'pi-check-circle',
-        keyColor: 'results-seo-tool__result-icon--alert-green',
-        items: [
-            {
-                message: 'Favicon found!',
-                color: 'results-seo-tool__result-icon--alert-green',
-                itemIcon: 'pi-check'
-            }
-        ],
-        sort: 1,
-        info: ''
-    },
-    {
-        key: 'title',
-        keyIcon: 'pi-exclamation-triangle',
-        keyColor: 'results-seo-tool__result-icon--alert-yellow',
-        items: [
-            {
-                message: 'HTML Title found, but has fewer than 30 characters of content.',
-                color: 'results-seo-tool__result-icon--alert-yellow',
-                itemIcon: 'pi-exclamation-circle'
-            }
-        ],
-        sort: 4,
-        info: 'HTML Title content should be between 30 and 60 characters.'
-    },
-    {
-        key: 'og:description',
+        title: 'description',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [
@@ -248,7 +188,84 @@ const seoOGTagsResultOgMock = [
         info: "The length of the description allowed will depend on the reader's device size; on the smallest size only about 110 characters are allowed."
     },
     {
+        key: 'og:image',
+        title: 'image',
+        keyIcon: 'pi-check-circle',
+        keyColor: 'results-seo-tool__result-icon--alert-green',
+        items: [
+            {
+                message: '<code>og:image</code> metatag found, with an appropriate sized image!',
+                color: 'results-seo-tool__result-icon--alert-green',
+                itemIcon: 'pi-check'
+            }
+        ],
+        sort: 6,
+        info: ''
+    },
+    {
+        key: 'og:title',
+        title: 'title',
+        keyIcon: 'pi-exclamation-triangle',
+        keyColor: 'results-seo-tool__result-icon--alert-yellow',
+        items: [
+            {
+                message: 'title metatag found, but has fewer than 30 characters of content.',
+                color: 'results-seo-tool__result-icon--alert-yellow',
+                itemIcon: 'pi-exclamation-circle'
+            }
+        ],
+        sort: 2,
+        info: 'HTML Title content should be between 30 and 60 characters.'
+    },
+    {
+        key: 'favicon',
+        title: 'favicon',
+        keyIcon: 'pi-check-circle',
+        keyColor: 'results-seo-tool__result-icon--alert-green',
+        items: [
+            {
+                message: 'Favicon found!',
+                color: 'results-seo-tool__result-icon--alert-green',
+                itemIcon: 'pi-check'
+            }
+        ],
+        sort: 1,
+        info: ''
+    },
+    {
+        key: 'title',
+        title: 'title',
+        keyIcon: 'pi-exclamation-triangle',
+        keyColor: 'results-seo-tool__result-icon--alert-yellow',
+        items: [
+            {
+                message: 'HTML Title found, but has fewer than 30 characters of content.',
+                color: 'results-seo-tool__result-icon--alert-yellow',
+                itemIcon: 'pi-exclamation-circle'
+            }
+        ],
+        sort: 2,
+        info: 'HTML Title content should be between 30 and 60 characters.'
+    },
+    {
+        key: 'og:description',
+        title: 'description',
+        keyIcon: 'pi-exclamation-triangle',
+        keyColor: 'results-seo-tool__result-icon--alert-red',
+        items: [
+            {
+                message:
+                    '<code>og:description</code> meta tag not found! Showing Meta Description instead.',
+                color: 'results-seo-tool__result-icon--alert-red',
+                itemIcon: 'pi-times'
+            }
+        ],
+        sort: 4,
+        info: "The length of the description allowed will depend on the reader's device size; on the smallest size only about 110 characters are allowed."
+    },
+    {
         key: 'twitter:card',
+        title: 'card',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [
@@ -258,11 +275,12 @@ const seoOGTagsResultOgMock = [
                 itemIcon: 'pi-times'
             }
         ],
-        sort: 1,
+        sort: 2,
         info: ''
     },
     {
         key: 'twitter:title',
+        title: 'title',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [
@@ -273,11 +291,12 @@ const seoOGTagsResultOgMock = [
                 itemIcon: 'pi-times'
             }
         ],
-        sort: 2,
+        sort: 1,
         info: ''
     },
     {
         key: 'twitter:description',
+        title: 'description',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [
@@ -293,6 +312,7 @@ const seoOGTagsResultOgMock = [
     },
     {
         key: 'twitter:image',
+        title: 'image',
         keyIcon: 'pi-exclamation-triangle',
         keyColor: 'results-seo-tool__result-icon--alert-red',
         items: [


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8aaf0ee</samp>

### Summary
:sparkles::recycle::art:

<!--
1.  :sparkles: - This emoji is often used to indicate the addition of a new feature or enhancement, and in this case it could represent the addition of the `title` property to the interface `SeoMetaTagsResult`.
2. :recycle: - This emoji is often used to indicate the refactoring or improvement of existing code, and in this case it could represent the replacement of the `result.key` property with the `result.title` property in the template of the `dot-results-seo-tool` component.
3. :art: - This emoji is often used to indicate the improvement of the UI or layout, and in this case it could represent the update of the `sort` properties and the simplification of the meta tag keys for the `title` category.
-->
This pull request reorders and simplifies the meta tag categories in the dot-edit-page UI, using a new `title` property for each category. It affects the files `dot-seo-meta-tags.service.ts`, `meta-tags-model.ts`, and `dot-results-seo-tool.component.html`.

> _Sing, O Muse, of the skillful coder who devised_
> _A new property `title` for the meta tags of the web,_
> _And thus made clear the names of each category wise,_
> _Without the prefixes that confused the mortal's head._

### Walkthrough
*  Add `title` property to `SeoMetaTagsResult` interface to store the name of the meta tag category ([link](https://github.com/dotCMS/core/pull/26274/files?diff=unified&w=0#diff-0b1cbca20fc4f4b1ccb288bb32c6dd4e26d1f4dc6d7647e530ca3c52dea1f1f5R57))
*  Assign `title` property to the meta tag key without the `og:` or `twitter:` prefixes using string replacement in `dot-seo-meta-tags.service.ts` ([link](https://github.com/dotCMS/core/pull/26274/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715R101))
*  Change the `sort` property of the meta tag categories in `dot-seo-meta-tags.service.ts` to modify the order of the results in the UI ([link](https://github.com/dotCMS/core/pull/26274/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715L124-R125), [link](https://github.com/dotCMS/core/pull/26274/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715L130-R141), [link](https://github.com/dotCMS/core/pull/26274/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715L151-R152), [link](https://github.com/dotCMS/core/pull/26274/files?diff=unified&w=0#diff-e2c6edc96a3d4a7581030dec6768557e11cfc76d6863da2ff346f2cb3efbc715L157-R158))
*  Use `title` property instead of `key` property to display the meta tag categories in the template of `dot-results-seo-tool` component ([link](https://github.com/dotCMS/core/pull/26274/files?diff=unified&w=0#diff-89e37243c442c5e79f19f64f75095ce16f02aff9b8befc8f0af091039aabbff1L60-R60))



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
