### PR TITLE
fix(core): Current device is removed from session when the deviceInode is null or empty

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
@@ -1146,4 +1146,32 @@ public class PageResourceTest {
         // Assertions
         assertTrue(containerRaw.toString().contains("data-dot-on-number-of-pages="));
     }
+
+    /**
+     * <ul>
+     *     <li><b>Method to Test:</b> {@link PageResource#render(HttpServletRequest, HttpServletResponse, String, String, String, String, String)}</li>
+     *     <li><b>Given Scenario:</b> The deviceInode is not set as part of the request</li>
+     *     <li><b>Expected Result:</b> The {@link WebKeys#CURRENT_DEVICE} is removed from session</li>
+     * </ul>
+     */
+    @Test
+    public void testCleanUpSessionWhenDeviceInodeIsNull() throws DotDataException, DotSecurityException {
+        pageResource.render(request, response, pagePath, null, null, APILocator.getLanguageAPI().getDefaultLanguage().getLanguage(), null);
+
+        verify(session).removeAttribute(WebKeys.CURRENT_DEVICE);
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to Test:</b> {@link PageResource#render(HttpServletRequest, HttpServletResponse, String, String, String, String, String)}</li>
+     *     <li><b>Given Scenario:</b> The deviceInode in the request is blank</li>
+     *     <li><b>Expected Result:</b> The {@link WebKeys#CURRENT_DEVICE} is removed from session</li>
+     * </ul>
+     */
+    @Test
+    public void testCleanUpSessionWhenDeviceInodeIsNull() throws DotDataException, DotSecurityException {
+        pageResource.render(request, response, pagePath, null, null, APILocator.getLanguageAPI().getDefaultLanguage().getLanguage(), "");
+
+        verify(session).removeAttribute(WebKeys.CURRENT_DEVICE);
+    }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
@@ -108,7 +108,6 @@ import static org.mockito.Mockito.when;
 public class PageResourceTest {
     private ContentletAPI esapi;
     private PageResource pageResource;
-    private PageResource pageResourceWithHelper;
     private User user;
     private HttpServletRequest request;
     private HttpServletResponse response;
@@ -1169,7 +1168,7 @@ public class PageResourceTest {
      * </ul>
      */
     @Test
-    public void testCleanUpSessionWhenDeviceInodeIsNull() throws DotDataException, DotSecurityException {
+    public void testCleanUpSessionWhenDeviceInodeIsBlank() throws DotDataException, DotSecurityException {
         pageResource.render(request, response, pagePath, null, null, APILocator.getLanguageAPI().getDefaultLanguage().getLanguage(), "");
 
         verify(session).removeAttribute(WebKeys.CURRENT_DEVICE);

--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
@@ -108,6 +108,7 @@ import static org.mockito.Mockito.when;
 public class PageResourceTest {
     private ContentletAPI esapi;
     private PageResource pageResource;
+    private PageResource pageResourceWithHelper;
     private User user;
     private HttpServletRequest request;
     private HttpServletResponse response;

--- a/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
@@ -100,6 +100,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.nullable;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -1155,7 +1156,7 @@ public class PageResourceTest {
      * </ul>
      */
     @Test
-    public void testCleanUpSessionWhenDeviceInodeIsNull() throws DotDataException, DotSecurityException {
+    public void testCleanUpSessionWhenDeviceInodeIsNull() throws Exception {
         pageResource.render(request, response, pagePath, null, null, APILocator.getLanguageAPI().getDefaultLanguage().getLanguage(), null);
 
         verify(session).removeAttribute(WebKeys.CURRENT_DEVICE);
@@ -1169,7 +1170,7 @@ public class PageResourceTest {
      * </ul>
      */
     @Test
-    public void testCleanUpSessionWhenDeviceInodeIsBlank() throws DotDataException, DotSecurityException {
+    public void testCleanUpSessionWhenDeviceInodeIsBlank() throws Exception {
         pageResource.render(request, response, pagePath, null, null, APILocator.getLanguageAPI().getDefaultLanguage().getLanguage(), "");
 
         verify(session).removeAttribute(WebKeys.CURRENT_DEVICE);

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -54,6 +54,7 @@ import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.portlets.workflows.model.WorkflowAction;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
+import com.dotmarketing.util.StringUtils;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.google.common.annotations.VisibleForTesting;
@@ -281,8 +282,10 @@ public class PageResource {
 
         PageMode.setPageMode(request, mode);
 
-        if (deviceInode != null) {
+        if (StringUtils.isSet(deviceInode)) {
             request.getSession().setAttribute(WebKeys.CURRENT_DEVICE, deviceInode);
+        } else {
+            request.getSession().removeAttribute(WebKeys.CURRENT_DEVICE);
         }
 
         final HttpSession session = request.getSession(false);


### PR DESCRIPTION
Refs: #25278

### Proposed Changes
* The `CURRENT_DEVICE` is removed from session when the `deviceInode` is null or empty
* ITs implemented