### PR TITLE
fix(ui) Add taglink css fix to source scss

### DIFF
--- a/core-web/libs/dotcms-scss/jsp/scss/backend/dot-admin/forms/_fields.scss
+++ b/core-web/libs/dotcms-scss/jsp/scss/backend/dot-admin/forms/_fields.scss
@@ -268,6 +268,7 @@ $key-val-width: 500px;
     justify-content: center;
     gap: $spacing-0;
     text-decoration: none;
+    border: 1px solid rgba(0, 0, 0, 0.1);
 
     &.persona {
         &:before {

--- a/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
+++ b/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
@@ -8896,7 +8896,7 @@ Styles for commons fields along the backend
   justify-content: center;
   gap: 0.25rem;
   text-decoration: none;
-  border:1px solid rgba(0,0,0,0.1);
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 .tagLink.persona:before {
   content: "\f007";


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 229a2fe</samp>

### Summary
🖼️🏷️📁

<!--
1.  🖼️ - This emoji represents the border style that is added to the tags, as it suggests a frame or outline around an image or element.
2.  🏷️ - This emoji represents the tags themselves, as it is a common symbol for labeling or categorizing items.
3.  📁 - This emoji represents the file movement that is done to reorganize the SCSS code, as it suggests moving or sorting files into folders.
-->
This pull request updates the style of the tags in the content editing form by adding a border and moving the `.tagLink` class to the `_fields.scss` file. This improves the appearance and the code structure of the SCSS files.

> _`tagLink` gets border_
> _SCSS files reorganized_
> _Winter cleaning done_

### Walkthrough
*  Add a border style to the `.tagLink` class to improve the visibility of tags in the content editing form ([link](https://github.com/dotCMS/core/pull/26365/files?diff=unified&w=0#diff-61345e0d445d621388bbd8b79be5c30ecfa1c759dcde25c71598b2a29780321fR271))
*  Move the `.tagLink` class definition from the `dotcms.css` file to the `_fields.scss` file to organize the SCSS code better ([link](https://github.com/dotCMS/core/pull/26365/files?diff=unified&w=0#diff-08d797a1a8ebab0a7a24680f4640b5434967d4e29c17783a873ad53dfefad1cdL8899-R8899))



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
