### PR TITLE
Adding missing Publish button in Advance template

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.html
@@ -1,18 +1,23 @@
 <dot-portlet-base>
-    <dot-portlet-toolbar *ngIf="actions" [actions]="actions">
-        <dot-global-message right></dot-global-message>
-    </dot-portlet-toolbar>
-
     <form [formGroup]="form">
+        <dot-portlet-toolbar
+            *ngIf="actions"
+            [actions]="actions"
+            [form]="form"
+            (saveAndPublish)="saveAndPublish.emit($event)"
+        >
+            <dot-global-message right></dot-global-message>
+        </dot-portlet-toolbar>
+
         <dot-container-selector (swap)="containerChange($event)"> </dot-container-selector>
         <dot-textarea-content
-            formControlName="body"
             #value
+            [show]="['code']"
+            (monacoInit)="initEditor($event)"
+            formControlName="body"
             height="100%"
             formControlName="body"
-            [show]="['code']"
             language="html"
-            (monacoInit)="initEditor($event)"
         ></dot-textarea-content>
     </form>
 </dot-portlet-base>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.html
@@ -1,4 +1,8 @@
 <dot-portlet-base>
+    <dot-portlet-toolbar *ngIf="actions" [actions]="actions">
+        <dot-global-message right></dot-global-message>
+    </dot-portlet-toolbar>
+
     <form [formGroup]="form">
         <dot-portlet-toolbar
             *ngIf="actions"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.spec.ts
@@ -171,9 +171,21 @@ describe('DotTemplateAdvancedComponent', () => {
     describe('events', () => {
         it('should emit updateTemplate event when the form changes', () => {
             const updateTemplate = spyOn(component.updateTemplate, 'emit');
-            component.form.get('body').setValue('<body></body>');
+            const body = '<body></body>';
+            const title = 'testTTl';
+            const image = 'testImg';
+            component.form.get('body').setValue(body);
+            component.form.get('title').setValue(title);
+            component.form.get('friendlyName').setValue(title + 'Fname');
+            component.form.get('image').setValue(image);
 
-            expect<any>(updateTemplate).toHaveBeenCalledWith({ body: '<body></body>' });
+            expect<any>(updateTemplate).toHaveBeenCalledWith({
+                title: title,
+                identifier: null,
+                body: '<body></body>',
+                friendlyName: title + 'Fname',
+                image: image
+            });
         });
 
         it('should have form and fields', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-advanced/dot-template-advanced.component.ts
@@ -41,12 +41,15 @@ interface MonacoEditor {
 })
 export class DotTemplateAdvancedComponent implements OnInit, OnDestroy, OnChanges {
     @Output() updateTemplate = new EventEmitter<DotTemplateItem>();
+    @Output() saveAndPublish = new EventEmitter<DotTemplateItem>();
     @Output() save = new EventEmitter<DotTemplateItem>();
     @Output() cancel = new EventEmitter();
-
+    @Input() title: string;
     @Input() body: string;
+    @Input() themeId: string;
+    @Input() image: string;
+    @Input() friendlyName: string;
     @Input() didTemplateChanged: boolean;
-
     // `any` because the type of the editor in the ngx-monaco-editor package is not typed
     editor: MonacoEditor;
     form: UntypedFormGroup;
@@ -56,7 +59,13 @@ export class DotTemplateAdvancedComponent implements OnInit, OnDestroy, OnChange
     constructor(private fb: UntypedFormBuilder, private dotMessageService: DotMessageService) {}
 
     ngOnInit(): void {
-        this.form = this.fb.group({ body: this.body });
+        this.form = this.fb.group({
+            title: this.title,
+            identifier: this.themeId,
+            body: this.body,
+            friendlyName: this.friendlyName,
+            image: this.image
+        });
 
         this.form.valueChanges
             .pipe(takeUntil(this.destroy$))

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.html
@@ -1,12 +1,17 @@
 <p-tabView>
     <p-tabPanel
-        data-testId="builder"
         [header]="item.type === 'advanced' ? ('code' | dm) : ('design' | dm)"
+        data-testId="builder"
     >
         <ng-container *ngIf="item.type === 'advanced'; else elseBlock">
             <dot-template-advanced
                 [didTemplateChanged]="didTemplateChanged"
+                [themeId]="item.identifier"
+                [title]="item.title"
                 [body]="item.body"
+                [image]="item.image"
+                [friendlyName]="item.friendlyName"
+                (saveAndPublish)="saveAndPublish.emit($event)"
                 (updateTemplate)="updateTemplate.emit($event)"
                 (save)="save.emit($event)"
                 (cancel)="cancel.emit()"
@@ -26,7 +31,7 @@
     <p-tabPanel [header]="'Permissions' | dm">
         <ng-template pTemplate="content">
             <dot-portlet-box>
-                <dot-iframe data-testId="permissionsIframe" [src]="permissionsUrl"></dot-iframe>
+                <dot-iframe [src]="permissionsUrl" data-testId="permissionsIframe"></dot-iframe>
             </dot-portlet-box>
         </ng-template>
     </p-tabPanel>
@@ -35,9 +40,9 @@
             <dot-portlet-box>
                 <dot-iframe
                     #historyIframe
+                    [src]="historyUrl"
                     (custom)="custom.emit($event)"
                     data-testId="historyIframe"
-                    [src]="historyUrl"
                 ></dot-iframe>
             </dot-portlet-box>
         </ng-template>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/components/dot-portlet-toolbar/dot-portlet-toolbar.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/components/dot-portlet-toolbar/dot-portlet-toolbar.component.html
@@ -1,6 +1,6 @@
 <p-toolbar>
     <div class="p-toolbar-group-left" data-testId="leftGroup">
-        <h3 data-testId="title" *ngIf="title">{{ title }}</h3>
+        <h3 *ngIf="title" data-testId="title">{{ title }}</h3>
         <div class="dot-portlet-toolbar__extra-left">
             <ng-content select="[left]"></ng-content>
         </div>
@@ -13,22 +13,33 @@
 
         <div class="dot-portlet-toolbar__actions" data-testId="actionsWrapper">
             <button
-                data-testId="actionsCancelButton"
-                *ngIf="actions?.cancel"
-                pButton
-                (click)="onCancelClick($event)"
-                [label]="cancelButtonLabel || ('cancel' | dm)"
                 class="p-button-secondary"
+                *ngIf="actions?.cancel"
+                [label]="cancelButtonLabel || ('cancel' | dm)"
+                (click)="onCancelClick($event)"
+                data-testId="actionsCancelButton"
+                pButton
             ></button>
 
             <ng-container *ngIf="actions?.primary?.length">
                 <button
                     *ngIf="actions?.primary?.length === 1; else elseBlock"
+                    [label]="actions?.primary[0]?.label || ('save' | dm)"
+                    [disabled]="actions?.primary[0]?.disabled"
+                    (click)="onPrimaryClick($event)"
                     data-testId="actionsPrimaryButton"
                     pButton
-                    [label]="actions?.primary[0]?.label || ('save' | dm)"
-                    (click)="onPrimaryClick($event)"
+                ></button>
+            </ng-container>
+            <ng-container *ngIf="form">
+                <button
+                    class="p-button-secondary"
                     [disabled]="actions?.primary[0]?.disabled"
+                    [label]="'Publish' | dm"
+                    (click)="onSaveAndPublish()"
+                    pButton
+                    data-testid="publishBtn"
+                    type="button"
                 ></button>
             </ng-container>
         </div>
@@ -37,12 +48,12 @@
 
 <ng-template #elseBlock>
     <button
+        [label]="actionsButtonLabel || ('actions' | dm)"
+        (click)="menu.toggle($event)"
         data-testId="actionsMenuButton"
         pButton
         icon="pi pi-chevron-down"
         iconPos="right"
-        [label]="actionsButtonLabel || ('actions' | dm)"
-        (click)="menu.toggle($event)"
     ></button>
     <p-menu #menu [popup]="true" [model]="actions?.primary" data-testId="actionsMenu"></p-menu>
 </ng-template>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/components/dot-portlet-toolbar/dot-portlet-toolbar.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/components/dot-portlet-toolbar/dot-portlet-toolbar.component.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { DotPortletToolbarActions } from '@shared/models/dot-portlet-toolbar.model/dot-portlet-toolbar-actions.model';
+import { UntypedFormGroup } from '@angular/forms';
 
 @Component({
     selector: 'dot-portlet-toolbar',
@@ -15,6 +16,11 @@ export class DotPortletToolbarComponent {
     @Input() actionsButtonLabel: string;
 
     @Input() actions: DotPortletToolbarActions;
+
+    @Input()
+    form: UntypedFormGroup;
+
+    @Output() saveAndPublish: EventEmitter<Event> = new EventEmitter();
 
     /**
      * Handle cancel button click
@@ -42,5 +48,9 @@ export class DotPortletToolbarComponent {
         } catch (error) {
             console.error(error);
         }
+    }
+
+    onSaveAndPublish(): void {
+        this.saveAndPublish.emit(this.form.value);
     }
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3900186</samp>

### Summary
📝🎨💾

<!--
1.  📝 - This emoji can be used to represent the changes related to the `<form>` element, the unit test, and the form group, as they all involve editing or updating some code or data.
2.  🎨 - This emoji can be used to represent the changes related to the layout and functionality of the dot-template-builder component, as they involve improving the appearance and usability of the UI.
3.  💾 - This emoji can be used to represent the changes related to the save and publish button and the communication between the toolbar and the parent component, as they involve adding a new feature and saving data.
-->
This pull request adds new features and improvements to the dot-template-create-edit component and its subcomponents. It allows users to edit advanced template properties, such as title, image, friendlyName, and identifier, and to publish the template from the toolbar. It also enhances the layout and readability of the dot-template-builder and dot-portlet-toolbar components.

### Walkthrough
*  Move the `<form>` element to wrap the `<dot-portlet-toolbar>` element in `dot-template-advanced.component.html` to enable the toolbar to access and emit the form values ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-fe382ee4382283c55d3fda6ebd517be2c263d6a13baffc0b3f3d02c5bd4fc19cL2-R20))
* Add new input properties to the advanced template component in `dot-template-advanced.component.ts` to receive the template data from the parent component, such as title, image, friendlyName, and themeId ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-6273c1cfdaefc103f45fc935c1074e1cd1c2c5c0136709aee2e3b53454989bfcL44-R52))
* Initialize the form group with the new input properties in `dot-template-advanced.component.ts` to track the changes and validations of the template fields ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-6273c1cfdaefc103f45fc935c1074e1cd1c2c5c0136709aee2e3b53454989bfcL59-R68))
* Update the tab panel header in `dot-template-builder.component.html` to use the item type as a condition instead of the item body, and pass the new input properties to the advanced template component ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-6892e6a6492cfd4e52aa7d4bea86bacc24f49f6cdf21f23f122407fe56f353e9L3-R14))
* Reorder the attributes of the dot-iframe elements for the permissions and history tabs in `dot-template-builder.component.html` to follow the convention of placing the input bindings before the output bindings and the data attributes ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-6892e6a6492cfd4e52aa7d4bea86bacc24f49f6cdf21f23f122407fe56f353e9L29-R34), [link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-6892e6a6492cfd4e52aa7d4bea86bacc24f49f6cdf21f23f122407fe56f353e9L38-R45))
* Reorder the attributes of the h3, button, and dot-action-button elements in `dot-portlet-toolbar.component.html` to follow the same convention as the previous changes ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-5320c170db0de7ed069782b7f23434de6bfc531142dec542275b8cbd5513aef2L3-R3), [link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-5320c170db0de7ed069782b7f23434de6bfc531142dec542275b8cbd5513aef2L16-R21), [link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-5320c170db0de7ed069782b7f23434de6bfc531142dec542275b8cbd5513aef2L27-R42), [link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-5320c170db0de7ed069782b7f23434de6bfc531142dec542275b8cbd5513aef2L40-R56))
* Add a new button element for the save and publish action in `dot-portlet-toolbar.component.html`, which is only visible when the form is present and calls the onSaveAndPublish method when clicked ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-5320c170db0de7ed069782b7f23434de6bfc531142dec542275b8cbd5513aef2L27-R42))
* Import the EventEmitter, Output, and UntypedFormGroup modules to the toolbar component in `dot-portlet-toolbar.component.ts` to enable the new functionality of emitting the form values and receiving the form reference as an input ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-8b12994e1467950aed0826dcab36996a58e2e6f72d0f24bba7286a1136b1921bL1-R3))
* Add the new input property form and the new output property saveAndPublish to the toolbar component in `dot-portlet-toolbar.component.ts` to bind the form values and the save and publish event with the parent component ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-8b12994e1467950aed0826dcab36996a58e2e6f72d0f24bba7286a1136b1921bR20-R24))
* Add the new method onSaveAndPublish to the toolbar component in `dot-portlet-toolbar.component.ts` to emit the form values when the user clicks on the save and publish button ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-8b12994e1467950aed0826dcab36996a58e2e6f72d0f24bba7286a1136b1921bR52-R55))
* Update the unit test for the updateTemplate event in `dot-template-advanced.component.spec.ts` to include the new form fields that are added to the advanced template component ([link](https://github.com/dotCMS/core/pull/26368/files?diff=unified&w=0#diff-1957d8c711508135fc4bbb2a43a65c57f830b0457cf08fd3bac13e8e42af472aL174-R188))

