### PR TITLE
Fix #26056: Autocomplete Styles were Off

### DIFF
--- a/core-web/libs/dotcms-scss/angular/_mixins.scss
+++ b/core-web/libs/dotcms-scss/angular/_mixins.scss
@@ -76,7 +76,7 @@
 
 @mixin dot-field-helper-on-input {
     position: absolute;
-    top: 1.8rem;
+    top: 1.96rem;
     right: $spacing-0;
     z-index: 1;
 }

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_autocomplete.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_autocomplete.scss
@@ -19,7 +19,9 @@
         color: $black;
         padding: 0;
         margin: 0;
-        height: 2.3125rem; // This input height is to match the 40px height, 37px + 3px of border
+        height: calc(
+            $field-height-md - (2 * $field-border-size)
+        ); // This input height is to match the 40px height, 40px - 3px of horizontal borders, because this input does not have borders
     }
 
     &.p-autocomplete-dd {

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_autocomplete.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_autocomplete.scss
@@ -13,7 +13,13 @@
 
     .p-autocomplete-input {
         all: unset;
+        border: none;
+        font-family: $font-default;
+        font-size: $font-size-md;
         color: $black;
+        padding: 0;
+        margin: 0;
+        height: 2.3125rem; // This input height is to match the 40px height, 37px + 3px of border
     }
 
     &.p-autocomplete-dd {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6a5318e</samp>

### Summary
🐛♻️🎨

<!--
1.  🐛 for the bug fix in the `dot-field-helper-on-input` mixin.
2.  ♻️ for the refactor of the `p-autocomplete-input` class.
3.  🎨 for the style improvement of the autocomplete component.
-->
Adjusted the styles of the helper icon and the autocomplete input field to fix a visual bug and improve consistency. Moved the `p-autocomplete-input` class to the `_mixins.scss` file to enhance reusability.

> _`dot-field-helper`_
> _Aligns the icon better_
> _A visual fix_

### Walkthrough
*  Align the helper icon with the input field in the `dot-field-helper-on-input` mixin ([link](https://github.com/dotCMS/core/pull/26369/files?diff=unified&w=0#diff-20d514eba468ae9cecdbff7c3c4cdde5863070d36273564e5ba60a75122467b6L79-R79))
*  Refactor the `p-autocomplete-input` class to a mixin and add styles to match other input fields ([link](https://github.com/dotCMS/core/pull/26369/files?diff=unified&w=0#diff-f9c2ffef72b1a8203e6a53c8a8e8110fce861367d47d87e12b09a16e201788d1L16-R22))

 

### Screenshots

<img width="725" alt="Screenshot 2023-10-05 at 1 10 20 PM" src="https://github.com/dotCMS/core/assets/63567962/e39c6b7e-ca39-4127-b585-c7b1c2443cae">
