### PR TITLE
Fixed icon and columb title. Now icon is on the right and text is not…

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_datatable.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_datatable.scss
@@ -38,6 +38,7 @@
     padding: $spacing-2 $spacing-2;
     text-align: left;
     transition: none;
+    text-wrap: nowrap;
 
     &:first-child {
         padding-left: $spacing-5;
@@ -63,6 +64,7 @@
 }
 
 .p-datatable .p-sortable-column .p-sortable-column-icon {
+    display: inline-block;
     color: $color-palette-gray-700;
     margin-left: $spacing-1;
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 934d02a</samp>

### Summary
🎨🛠️📦

<!--
1.  🎨 - This emoji is often used for changes related to styling, layout, or appearance of the UI. In this case, the CSS properties are a form of styling that affect how the data table looks.
2.  🛠️ - This emoji is often used for changes related to fixing, improving, or tweaking existing features or components. In this case, the CSS properties are a form of improvement that enhance the usability and readability of the data table.
3.  📦 - This emoji is often used for changes related to adding, updating, or removing dependencies or packages. In this case, the CSS properties are a form of dependency that the data table component relies on to function properly.
-->
This pull request improves the appearance and usability of the data table component by applying some CSS styles to the header elements. It modifies the file `core-web/libs/dotcms-scss/angular/dotcms-theme/components/_datatable.scss` to achieve this.

> _Oh, we're the crew of the data table_
> _And we like to keep it neat_
> _We'll add some CSS to the header_
> _So the text won't wrap or fleet_

### Walkthrough
*  Prevent header text from wrapping and overflowing in data table component ([link](https://github.com/dotCMS/core/pull/26371/files?diff=unified&w=0#diff-ab3d63a930c48dfb3c34880fa930282b55a422891ad4cbc5b3ae208b858e9a8dR41))
*  Adjust header label width to match content in data table component ([link](https://github.com/dotCMS/core/pull/26371/files?diff=unified&w=0#diff-ab3d63a930c48dfb3c34880fa930282b55a422891ad4cbc5b3ae208b858e9a8dR67))


### Proposed Changes
* change 1
* change 2

### Checklist
### Problem Statement
The table header sort icons is currently misplaced, wrapping to the next line.

### Steps to Reproduce
1. Log into dotCMS
2. Navigate to the table view, for example Pages
3. Observe that the sort icons are misaligned with the header

<img width="897" alt="image" src="https://github.com/dotCMS/core/assets/751424/2ba0bb28-532e-4752-b867-8b50741245e2">


### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
