### PR TITLE
Fix #26422: Containers Add Content Type Menu Styles Were Off

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.html
@@ -20,7 +20,15 @@
                 <ng-template #contentTypesLoader>
                     <p-skeleton borderRadius="0px" width="4rem" height="3.9rem"></p-skeleton>
                 </ng-template>
-                <p-menu #actionsMenu [popup]="true" [model]="menuItems" appendTo="body"></p-menu>
+                <p-menu
+                    #actionsMenu
+                    [popup]="true"
+                    [model]="menuItems"
+                    [style]="{
+                        'max-height': '300px',
+                        overflow: 'auto'
+                    }"
+                    appendTo="body"></p-menu>
             </ng-template>
             <ng-template pTemplate="content">
                 <div

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.spec.ts
@@ -364,5 +364,10 @@ describe('DotContentEditorComponent', () => {
             const loader = de.query(By.css('p-skeleton'));
             expect(loader).toBeDefined();
         });
+
+        it('should have a menu with max height in 300px and overflow auto', () => {
+            expect(menu.style['max-height']).toBe('300px');
+            expect(menu.style.overflow).toBe('auto');
+        });
     });
 });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f5bf84f</samp>

### Summary
🎨🆕✅

<!--
1.  🎨 - This emoji is often used to indicate changes related to the UI, design, or style of a component. In this case, it represents the modification of the `p-menu` element's `style` attribute to improve the user experience.
2.  🆕 - This emoji is often used to indicate the addition of a new feature, functionality, or file. In this case, it represents the creation of a new test case to verify the `p-menu` element's `style` attribute.
3.  ✅ - This emoji is often used to indicate the completion of a task, the passing of a test, or the confirmation of a requirement. In this case, it represents the successful verification of the `p-menu` element's `style` attribute by the test case.
-->
Added a `style` attribute to the `p-menu` element in `dot-container-code.component.html` to limit its height and enable scrolling. Added a test case in `dot-container-code.component.spec.ts` to check the `style` attribute of the menu element. These changes improved the usability and quality of the container code editor.

> _`p-menu` styled_
> _to fit the screen and scroll_
> _autumn usability_

### Walkthrough
*  Set the `style` attribute of the `p-menu` element to limit its height and enable scrolling ([link](https://github.com/dotCMS/core/pull/26427/files?diff=unified&w=0#diff-5cb7e55e2f90c0d988faec0f7fa06c552e1d9a0a413fbfa1624edb532197456dL23-R31))
*  Add a test case to check the `style` attribute of the `p-menu` element in `dot-container-code.component.spec.ts` ([link](https://github.com/dotCMS/core/pull/26427/files?diff=unified&w=0#diff-1086a38776be3c3528883b1f6d665194c6b7e7bccd8e956cb320a52d842f1e53R367-R371))



### Screenshots

<img width="732" alt="Screenshot 2023-10-12 at 10 59 50 AM" src="https://github.com/dotCMS/core/assets/63567962/ee48233f-ddb1-406d-b321-bcb91e3853e2">
