### PR TITLE
Fix #26435: Design System Dojo Dropdown 

### DIFF
--- a/core-web/libs/dotcms-scss/jsp/scss/dijit/_menu.scss
+++ b/core-web/libs/dotcms-scss/jsp/scss/dijit/_menu.scss
@@ -80,6 +80,10 @@
         color: $black;
         height: $field-height-md;
 
+        .dijitComboBoxHighlightMatch {
+            font-weight: $font-weight-bold;
+        }
+
         &:has(small) {
             display: flex;
             align-items: start;

--- a/core-web/libs/dotcms-scss/jsp/scss/dijit/_menu.scss
+++ b/core-web/libs/dotcms-scss/jsp/scss/dijit/_menu.scss
@@ -76,13 +76,16 @@
     margin-top: $spacing-1;
 
     .dijitMenuItem {
-        display: flex;
-        align-items: start;
-        flex-direction: column;
-        justify-content: center;
         padding: 0 $spacing-2;
         color: $black;
         height: $field-height-md;
+
+        &:has(small) {
+            display: flex;
+            align-items: start;
+            flex-direction: column;
+            justify-content: center;
+        }
     }
 
     .dijitComboBoxMenu {

--- a/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
+++ b/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
@@ -5047,6 +5047,9 @@
   color: #14151a;
   height: 2.5rem;
 }
+.dijitComboBoxMenuPopup .dijitMenuItem .dijitComboBoxHighlightMatch {
+  font-weight: 700;
+}
 .dijitComboBoxMenuPopup .dijitMenuItem:has(small) {
   display: flex;
   align-items: start;

--- a/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
+++ b/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
@@ -5043,13 +5043,15 @@
   margin-top: 0.5rem;
 }
 .dijitComboBoxMenuPopup .dijitMenuItem {
+  padding: 0 0.75rem;
+  color: #14151a;
+  height: 2.5rem;
+}
+.dijitComboBoxMenuPopup .dijitMenuItem:has(small) {
   display: flex;
   align-items: start;
   flex-direction: column;
   justify-content: center;
-  padding: 0 0.75rem;
-  color: #14151a;
-  height: 2.5rem;
 }
 .dijitComboBoxMenuPopup .dijitComboBoxMenu {
   min-width: 200px;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 09a0bf0</samp>

### Summary
🎨♻️🐛

<!--
1.  🎨 - This emoji is often used for changes that improve the style or appearance of the code or UI, without affecting the functionality. It could be used for both of these changes, since they are mainly about adjusting the layout and theme of the dijit widgets.
2.  ♻️ - This emoji is often used for changes that refactor or improve the code quality, without changing the behavior. It could also be used for both of these changes, since they are part of a larger refactor to use SCSS variables and mixins, and they also move the style definition to a more appropriate file.
3.  🐛 - This emoji is often used for changes that fix bugs or errors in the code or UI. It could be used for the first change, if the gaps and misalignment of the menu items were considered a bug or a defect that needed to be fixed. However, it might not be the best choice for the second change, since it is more of a style improvement than a bug fix.
-->
Refactor the dijit menu and combo box styles to use SCSS variables and mixins, and fix the flexbox layout issues for menu items with text only. Move the combo box style from `dotcms.css` to `_menu.scss`.

> _`dijit` menu style_
> _flexbox only when needed_
> _autumn leaves no gaps_

### Walkthrough
* Refactor dijit menu and combo box styles to use SCSS variables and mixins ([link](https://github.com/dotCMS/core/pull/26436/files?diff=unified&w=0#diff-8ced0168f7b85d239121cce95e116f053fbd2c7c5194d010c428d27e5c4b0d39L79-R88), [link](https://github.com/dotCMS/core/pull/26436/files?diff=unified&w=0#diff-08d797a1a8ebab0a7a24680f4640b5434967d4e29c17783a873ad53dfefad1cdL5046-R5054))



### Screenshots

<img width="495" alt="Screenshot 2023-10-13 at 11 43 52 AM" src="https://github.com/dotCMS/core/assets/63567962/628040aa-6784-4f7f-ae99-b5d3acc0380e">
