### PR TITLE
fix(seo): Adding fix for tabs

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.scss
@@ -58,7 +58,7 @@ p-inputSwitch {
     }
 
     &.warn ::ng-deep .p-inputswitch-slider:after {
-        color: $orange;
+        color: $white;
     }
 }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
@@ -239,7 +239,7 @@ describe('DotEditPageStateControllerSeoComponent', () => {
                     'Page locked by Some One'
                 );
                 expect(lockerContainerDe.attributes['ng-reflect-tooltip-position']).toBe('bottom');
-                expect(locker.modelValue).toBe(false, 'checked');
+                expect(locker.modelValue).toBe(true, 'checked');
                 expect(locker.disabled).toBe(false, 'disabled');
             });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
@@ -358,7 +358,7 @@ export class DotEditPageStateControllerSeoComponent implements OnInit, OnChanges
     }
 
     private isLocked(pageState: DotPageRenderState): boolean {
-        return pageState.state.locked && !this.canTakeLock(pageState);
+        return pageState.state.locked || !this.canTakeLock(pageState);
     }
 
     private isPersonalized(): boolean {


### PR DESCRIPTION
Refs: #26193 

### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8c68dcd</samp>

### Summary
🎨🧪🔒

<!--
1.  🎨 for the color change of the text inside the input switch slider.
2.  🧪 for the unit test update for the SEO component.
3.  🔒 for the logic change for the input switch model value and the SEO component state.
-->
Changed the color and logic of the input switch in the SEO component of the edit page portlet. This improves the visibility and consistency of the SEO component state when the page is locked by different users.

> _`input switch` changes_
> _SEO logic and color_
> _autumn lock prevents_

### Walkthrough
*  Change the text color of the input switch slider to white when the SEO component is in a warning state ([link](https://github.com/dotCMS/core/pull/26499/files?diff=unified&w=0#diff-e027b3d5e93ddad386549fbdf5ff62a5447e81e4811783f03b17aa4a3ae92e62L61-R61))
*  Implement the new logic for the input switch model value and the SEO component state, based on the page lock status and the current user's permission to take the lock ([link](https://github.com/dotCMS/core/pull/26499/files?diff=unified&w=0#diff-525d72b2f066845092b3f8e47374c999304f59f8d049c44bb98ff91fddcac347L361-R361))
*  Update the unit test for the `dot-edit-page-state-controller-seo.component.ts` to reflect the new logic ([link](https://github.com/dotCMS/core/pull/26499/files?diff=unified&w=0#diff-1d2c7b1233cd3e09b6d3a05a5fd4905f512aa0256e44c8eb6316fc0a33a41c60L242-R242))



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
<img width="1547" alt="image" src="https://github.com/dotCMS/core/assets/3438705/3e4f632e-8159-4ba0-96c5-9dfd7c8454c1">
