### PR TITLE
fix(seo): Adding a mask to close when clicking outside of the modal

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.html
@@ -1,4 +1,7 @@
-<div class="dot-device-selector-mask" *ngIf="deviceSelector.overlayVisible"></div>
+<div
+    class="dot-device-selector-mask"
+    *ngIf="deviceSelector.overlayVisible"
+    data-testId="selector-mask"></div>
 
 <p-overlayPanel
     #deviceSelector

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.html
@@ -1,3 +1,5 @@
+<div class="dot-device-selector-mask" *ngIf="deviceSelector.overlayVisible"></div>
+
 <p-overlayPanel
     #deviceSelector
     (onHide)="onHideDeviceSelector()"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.scss
@@ -136,3 +136,16 @@ $device-selector-name-margin: 0.375rem;
         }
     }
 }
+
+.dot-device-selector-mask {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2;
+    background-color: transparent;
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-device-selector-seo/dot-device-selector-seo.component.spec.ts
@@ -212,4 +212,12 @@ describe('DotDeviceSelectorSeoComponent', () => {
         component.onHideDeviceSelector();
         expect(component.hideOverlayPanel.emit).toHaveBeenCalled();
     });
+
+    it('should have the mask to being able to close when the user click outside', () => {
+        fixtureHost.detectChanges();
+
+        const selectorMask: DebugElement = de.query(By.css('[data-testId="selector-mask"]'));
+
+        expect(selectorMask).toBeDefined();
+    });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.html
@@ -1,13 +1,10 @@
 <dot-device-selector-seo
     #deviceSelector
-    [pTooltip]="pageState.viewAs.device?.name || ('editpage.viewas.default.device' | dm)"
     [apiLink]="apiLink"
     (selected)="changeDeviceHandler($event)"
     (changeSeoMedia)="changeSeoMedia($event)"
     (hideOverlayPanel)="tabButtons.resetDropdownById(dotPageMode.PREVIEW)"
     appendTo="body"
-    tooltipPosition="bottom"
-    tooltipStyleClass="dot-device-selector__dialog"
     data-testId="dot-device-selector"></dot-device-selector-seo>
 <p-menu
     #menu


### PR DESCRIPTION
Refs: #26089

### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 030f8b0</samp>

### Summary
🎭🎨🗑️

<!--
1.  🎭 - This emoji can be used to represent the mask element that covers the page and creates a modal-like effect for the device selector dialog. It also conveys the idea of changing the appearance or perspective of the page according to the selected device.
2. 🎨 - This emoji can be used to represent the CSS styles that are applied to the mask element and the device selector dialog. It suggests the notion of design, aesthetics, and customization.
3. 🗑️ - This emoji can be used to represent the removal of the tooltip functionality from the device selector button. It implies the idea of deleting, simplifying, or cleaning up the user interface.
-->
This pull request improves the user interface of the edit page SEO portlet by removing the tooltip from the `device selector button` and adding a transparent mask that centers the device selector dialog. The changes affect the `dot-edit-page-state-controller-seo` and the `dot-device-selector-seo` components and their respective HTML and SCSS files.

> _`device selector`_
> _overlay and mask added_
> _winter UI change_

### Walkthrough
*  Add a mask element to cover the page and center the device selector dialog when the overlay is visible ([link](https://github.com/dotCMS/core/pull/26513/files?diff=unified&w=0#diff-20ee3da83820dff9c0690885a51f7e6740749b9a33bcf6469f67dfaa43463672R1-R2), [link](https://github.com/dotCMS/core/pull/26513/files?diff=unified&w=0#diff-cc5ff195d203c6abaf424de61ea85a5a5e8237fc6f9d5774ef23a838447a0538R139-R151))
*  Remove the tooltip from the device selector button in the edit page state controller component to simplify the user interface ([link](https://github.com/dotCMS/core/pull/26513/files?diff=unified&w=0#diff-c33fbce2e3590bf75f68ecc21dbdd226cf8301b16259e8029d4d6f426f9e75d4L3), [link](https://github.com/dotCMS/core/pull/26513/files?diff=unified&w=0#diff-c33fbce2e3590bf75f68ecc21dbdd226cf8301b16259e8029d4d6f426f9e75d4L9-L10))



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots

https://github.com/dotCMS/core/assets/3438705/bd7c92c8-9c5e-4815-a763-de7e7896ed99





