### PR TITLE
fix(seo): preview button should always take user to default preview

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.spec.ts
@@ -191,17 +191,25 @@ describe('DotEditPageStateControllerComponent', () => {
                 expect(selectButton.options).toEqual([
                     {
                         label: 'Edit',
-                        value: { id: 'EDIT_MODE', showDropdownButton: false },
+                        value: { id: 'EDIT_MODE', showDropdownButton: false, shouldRefresh: false },
                         disabled: false
                     },
                     {
                         label: 'Preview',
-                        value: { id: 'PREVIEW_MODE', showDropdownButton: false },
+                        value: {
+                            id: 'PREVIEW_MODE',
+                            showDropdownButton: false,
+                            shouldRefresh: true
+                        },
                         disabled: false
                     },
                     {
                         label: 'Live',
-                        value: { id: 'ADMIN_MODE', showDropdownButton: false },
+                        value: {
+                            id: 'ADMIN_MODE',
+                            showDropdownButton: false,
+                            shouldRefresh: false
+                        },
                         disabled: false
                     }
                 ]);
@@ -250,7 +258,7 @@ describe('DotEditPageStateControllerComponent', () => {
                 await expect(selectButton).toBeDefined();
                 expect(selectButton.options[1]).toEqual({
                     label: 'Preview',
-                    value: { id: 'PREVIEW_MODE', showDropdownButton: false },
+                    value: { id: 'PREVIEW_MODE', showDropdownButton: false, shouldRefresh: true },
                     disabled: true
                 });
                 expect(selectButton.value).toBe(DotPageMode.PREVIEW);
@@ -270,7 +278,7 @@ describe('DotEditPageStateControllerComponent', () => {
                 expect(selectButton).toBeDefined();
                 expect(selectButton.options[0]).toEqual({
                     label: 'Edit',
-                    value: { id: 'EDIT_MODE', showDropdownButton: false },
+                    value: { id: 'EDIT_MODE', showDropdownButton: false, shouldRefresh: false },
                     disabled: true
                 });
                 expect(selectButton.value).toBe(DotPageMode.PREVIEW);
@@ -289,7 +297,7 @@ describe('DotEditPageStateControllerComponent', () => {
                 expect(selectButton).toBeDefined();
                 expect(selectButton.options[2]).toEqual({
                     label: 'Live',
-                    value: { id: 'ADMIN_MODE', showDropdownButton: false },
+                    value: { id: 'ADMIN_MODE', showDropdownButton: false, shouldRefresh: false },
                     disabled: true
                 });
                 expect(selectButton.value).toBe(DotPageMode.PREVIEW);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.ts
@@ -268,7 +268,8 @@ export class DotEditPageStateControllerComponent implements OnChanges, OnInit {
             label: this.dotMessageService.get(`editpage.toolbar.${mode}.page`),
             value: {
                 id: enumMode,
-                showDropdownButton: this.shouldShowDropdownButton(enumMode, pageState)
+                showDropdownButton: this.shouldShowDropdownButton(enumMode, pageState),
+                shouldRefresh: enumMode === DotPageMode.PREVIEW
             },
             disabled: disabled[mode]
         };

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.spec.ts
@@ -208,12 +208,16 @@ describe('DotEditPageStateControllerSeoComponent', () => {
                 expect(dotTabButtons.options).toEqual([
                     {
                         label: 'Edit',
-                        value: { id: 'EDIT_MODE', showDropdownButton: false },
+                        value: { id: 'EDIT_MODE', showDropdownButton: false, shouldRefresh: false },
                         disabled: false
                     },
                     {
                         label: 'Preview',
-                        value: { id: 'PREVIEW_MODE', showDropdownButton: true },
+                        value: {
+                            id: 'PREVIEW_MODE',
+                            showDropdownButton: true,
+                            shouldRefresh: true
+                        },
                         disabled: false
                     }
                 ]);
@@ -261,7 +265,7 @@ describe('DotEditPageStateControllerSeoComponent', () => {
                 await expect(dotTabButtons).toBeDefined();
                 expect(dotTabButtons.options[1]).toEqual({
                     label: 'Preview',
-                    value: { id: 'PREVIEW_MODE', showDropdownButton: true },
+                    value: { id: 'PREVIEW_MODE', showDropdownButton: true, shouldRefresh: true },
                     disabled: true
                 });
                 expect(dotTabButtons.activeId).toBe(DotPageMode.PREVIEW);
@@ -278,7 +282,7 @@ describe('DotEditPageStateControllerSeoComponent', () => {
                 expect(dotTabButtons).toBeDefined();
                 expect(dotTabButtons.options[0]).toEqual({
                     label: 'Edit',
-                    value: { id: 'EDIT_MODE', showDropdownButton: false },
+                    value: { id: 'EDIT_MODE', showDropdownButton: false, shouldRefresh: false },
                     disabled: true
                 });
                 expect(dotTabButtons.activeId).toBe(DotPageMode.PREVIEW);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
@@ -315,7 +315,8 @@ export class DotEditPageStateControllerSeoComponent implements OnInit, OnChanges
             label: this.dotMessageService.get(`editpage.toolbar.${mode}.page`),
             value: {
                 id: enumMode,
-                showDropdownButton: this.shouldShowDropdownButton(enumMode, pageState)
+                showDropdownButton: this.shouldShowDropdownButton(enumMode, pageState),
+                shouldRefresh: enumMode === DotPageMode.PREVIEW
             },
             disabled: disabled[mode]
         };

--- a/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.ts
+++ b/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.ts
@@ -7,11 +7,12 @@ import { TooltipModule } from 'primeng/tooltip';
 
 import { DotMessagePipe } from '../dot-message/dot-message.pipe';
 
-interface TabButtonOptions {
+export interface TabButtonOptions {
     id: string;
     toggle?: boolean;
     icon?: string;
     showDropdownButton: boolean;
+    shouldRefresh?: boolean;
 }
 
 /**
@@ -60,7 +61,7 @@ export class DotTabButtonsComponent implements OnChanges {
      * @param event
      */
     onClickOption(event: PointerEvent, optionId: string) {
-        if (optionId === this.activeId) {
+        if (optionId === this.activeId && !this.shouldRefresh(optionId)) {
             return;
         }
 
@@ -132,6 +133,20 @@ export class DotTabButtonsComponent implements OnChanges {
             this._options.find(
                 (option) => option.value.id === menuId && option.value.showDropdownButton
             )
+        );
+    }
+
+    /**
+     * Checks if the option you clicked should refresh the page
+     *
+     * @private
+     * @param {string} menuId
+     * @return {*}  {boolean}
+     * @memberof DotTabButtonsComponent
+     */
+    private shouldRefresh(menuId: string): boolean {
+        return Boolean(
+            this._options.find((option) => option.value.id === menuId && option.value.shouldRefresh)
         );
     }
 }

--- a/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.ts
+++ b/core-web/libs/ui/src/lib/dot-tab-buttons/dot-tab-buttons.component.ts
@@ -7,7 +7,7 @@ import { TooltipModule } from 'primeng/tooltip';
 
 import { DotMessagePipe } from '../dot-message/dot-message.pipe';
 
-export interface TabButtonOptions {
+interface TabButtonOptions {
     id: string;
     toggle?: boolean;
     icon?: string;


### PR DESCRIPTION
Refs: #26419

### Proposed Changes
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c152f79</samp>

### Summary
🔄🛠️📑

<!--
1.  🔄 This emoji represents the idea of refreshing or reloading something, which is the main feature of the `shouldRefresh` property.
2.  🛠️ This emoji represents the idea of fixing or improving something, which is the general purpose of this pull request.
3.  📑 This emoji represents the idea of tabs or documents, which is the context of the `dotTabButtons` component.
-->
This pull request adds a new feature to the `dotTabButtons` component and its usage in the edit page and SEO tabs. The feature allows some options to refresh the page and some not, depending on a new `shouldRefresh` property. This improves the user experience and performance of the edit page and SEO tabs.

> _We are the masters of the tabs_
> _We control the page reloads_
> _With the `shouldRefresh` property_
> _We unleash the SEO beast_

### Walkthrough
*  Add `shouldRefresh` property to each option in `selectButton` and `dotTabButtons` components to indicate whether the page should reload when the user selects that option ([link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-f775ff5f5eccde913b08700abaf446f61e4a1d87e6ef270b0e9ef0400db7e207L194-R212), [link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-84234dcd86607cc47cde97f03efe38b8a51c51066cbb4e8143994838065911e8L271-R272), [link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-525d72b2f066845092b3f8e47374c999304f59f8d049c44bb98ff91fddcac347L318-R319), [link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-bf8bca39c1833ed819e57a1eb3902053bef01922de6f904b73c5a7e4ad6a5e53R15))
*  Update test cases for `selectButton` and `dotTabButtons` components to include the `shouldRefresh` property and the expected values for each option ([link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-f775ff5f5eccde913b08700abaf446f61e4a1d87e6ef270b0e9ef0400db7e207L253-R261), [link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-f775ff5f5eccde913b08700abaf446f61e4a1d87e6ef270b0e9ef0400db7e207L273-R281), [link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-f775ff5f5eccde913b08700abaf446f61e4a1d87e6ef270b0e9ef0400db7e207L292-R300), [link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-1d2c7b1233cd3e09b6d3a05a5fd4905f512aa0256e44c8eb6316fc0a33a41c60L211-R220), [link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-1d2c7b1233cd3e09b6d3a05a5fd4905f512aa0256e44c8eb6316fc0a33a41c60L264-R268), [link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-1d2c7b1233cd3e09b6d3a05a5fd4905f512aa0256e44c8eb6316fc0a33a41c60L281-R285))
*  Add condition to `onClickOption` method in `dotTabButtons` component to return early if the option should not refresh the page ([link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-bf8bca39c1833ed819e57a1eb3902053bef01922de6f904b73c5a7e4ad6a5e53L63-R64))
*  Add `shouldRefresh` method in `dotTabButtons` component to find the option that matches the menuId and check its `shouldRefresh` property ([link](https://github.com/dotCMS/core/pull/26517/files?diff=unified&w=0#diff-bf8bca39c1833ed819e57a1eb3902053bef01922de6f904b73c5a7e4ad6a5e53R138-R151))



### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Screenshots


https://github.com/dotCMS/core/assets/3438705/bd107171-d749-4359-adfd-5b44258a6e54


