### PR TITLE
Fix #26512: Edit Content Calendar Component add Icon

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.html
@@ -4,4 +4,6 @@
     [showTime]="calendarOptions[field.fieldType].showTime"
     [id]="field.variable"
     [inputId]="field.variable"
-    [attr.data-testId]="field.variable"></p-calendar>
+    [attr.data-testId]="field.variable"
+    [showIcon]="true"
+    [icon]="calendarOptions[field.fieldType].icon"></p-calendar>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.spec.ts
@@ -83,5 +83,9 @@ describe('DotEditContentCalendarFieldComponent', () => {
         it('should have the timeOnly as defined in the options', () => {
             expect(calendar.timeOnly).toBe(options.timeOnly);
         });
+
+        it('should have the icon as defined in the options', () => {
+            expect(calendar.icon).toBe(options.icon);
+        });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/utils.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/utils.ts
@@ -3,6 +3,7 @@ import { FIELD_TYPES } from '../../models/dot-edit-content-field.enum';
 export interface DateOptions {
     showTime?: boolean;
     timeOnly?: boolean;
+    icon?: string;
 }
 
 export type CalendarTypes = FIELD_TYPES.DATE_AND_TIME | FIELD_TYPES.DATE | FIELD_TYPES.TIME;
@@ -11,14 +12,17 @@ export type CalendarTypes = FIELD_TYPES.DATE_AND_TIME | FIELD_TYPES.DATE | FIELD
 export const CALENDAR_OPTIONS_PER_TYPE: Record<CalendarTypes, DateOptions> = {
     [FIELD_TYPES.DATE_AND_TIME]: {
         showTime: true,
-        timeOnly: false
+        timeOnly: false,
+        icon: 'pi pi-calendar'
     },
     [FIELD_TYPES.DATE]: {
         showTime: false,
-        timeOnly: false
+        timeOnly: false,
+        icon: 'pi pi-calendar'
     },
     [FIELD_TYPES.TIME]: {
         showTime: true,
-        timeOnly: true
+        timeOnly: true,
+        icon: 'pi pi-clock'
     }
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 06402ea</samp>

### Summary
🆕🧪🎨

<!--
1.  🆕 - This emoji represents the addition of a new feature or functionality, such as the new attributes for the `p-calendar` component and the new `icon` property for the options object.
2.  🧪 - This emoji represents the addition or improvement of tests, such as the new test case for the `icon` attribute of the `p-calendar` component.
3.  🎨 - This emoji represents the improvement of the user interface or design, such as the display of icons for the calendar fields.
-->
This pull request adds a new feature to show icons for different types of calendar fields in the edit content screen. It updates the `utils.ts` file to define the icon property, the `dot-edit-content-calendar-field.component.html` file to display the icon, and the `dot-edit-content-calendar-field.component.spec.ts` file to test the icon logic.

> _Sing, O Muse, of the skillful coder who enhanced the calendar fields_
> _With shining icons, showing the type of each content to be filled_
> _He added attributes to the `p-calendar` component with care_
> _And tested his work with a spec file, ensuring no errors were there_

### Walkthrough
*  Add icon attributes to `p-calendar` component in `dot-edit-content-calendar-field` template to improve UI ([link](https://github.com/dotCMS/core/pull/26527/files?diff=unified&w=0#diff-7b53b3487cc14a70194752d39ec752b0225874d182fc78b0f19e26b036dd7d48L7-R9))
*  Define `icon` property in `DateOptions` interface and `CALENDAR_OPTIONS_PER_TYPE` constant in `utils.ts` to map field types to icons ([link](https://github.com/dotCMS/core/pull/26527/files?diff=unified&w=0#diff-b83381c24842c1c58b78cd24259b3eb04632858f0ac2f4079d66a1dccf97a2edR6), [link](https://github.com/dotCMS/core/pull/26527/files?diff=unified&w=0#diff-b83381c24842c1c58b78cd24259b3eb04632858f0ac2f4079d66a1dccf97a2edL14-R26))
*  Test that `icon` attribute of `p-calendar` component matches expected icon from options object in `dot-edit-content-calendar-field` spec file ([link](https://github.com/dotCMS/core/pull/26527/files?diff=unified&w=0#diff-dea023ff30a75f2fb55992fbec1a4af0df8492e4ab8e1be25a5d6adb91e2ca62R86-R89))



### Screenshots
<img width="1128" alt="Screenshot 2023-10-26 at 11 32 46 AM" src="https://github.com/dotCMS/core/assets/63567962/b633b55d-26de-45bf-9012-98c45da8221a">
