### PR TITLE
feat(system table) #25184 : Fixing code to make POST method both save and update a key/value pair

### DIFF
--- a/dotCMS/src/curl-test/SystemTable.postman_collection.json
+++ b/dotCMS/src/curl-test/SystemTable.postman_collection.json
@@ -1,11 +1,11 @@
 {
 	"info": {
-		"_postman_id": "66446a0d-a484-449f-8b78-a69e14929ad1",
+		"_postman_id": "ce070bf0-e702-4ae1-a6e6-615cfe50ec8c",
 		"name": "SystemTable",
 		"description": "This Postman test verifies that CRUD operations executed on the System Table API work as expected. This API allows users and developers to store global properties in the application.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "5403727",
-		"_collection_link": "https://cloudy-robot-285072.postman.co/workspace/5bfa586e-54db-429b-b7d5-c4ff997e3a0d/collection/5403727-66446a0d-a484-449f-8b78-a69e14929ad1?action=share&source=collection_link&creator=5403727"
+		"_collection_link": "https://cloudy-robot-285072.postman.co/workspace/JCastro-Workspace~5bfa586e-54db-429b-b7d5-c4ff997e3a0d/collection/5403727-ce070bf0-e702-4ae1-a6e6-615cfe50ec8c?action=share&source=collection_link&creator=5403727"
 	},
 	"item": [
 		{
@@ -231,6 +231,122 @@
 			"response": []
 		},
 		{
+			"name": "Upserting a New Key",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Upserting a new key in the System Table\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin@dotcms.com",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"key\":\"MY_KEY2\",\n    \"value\":\"value1\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{serverURL}}/api/v1/system-table",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"system-table"
+					]
+				},
+				"description": "Adds a new key or updates an existing one. In this case, a new property is created."
+			},
+			"response": []
+		},
+		{
+			"name": "Upserting an Existing Key",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Upserting an existing key in the System Table\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "admin",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "admin@dotcms.com",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"key\":\"MY_KEY1\",\n    \"value\":\"upserted value3\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{serverURL}}/api/v1/system-table",
+					"host": [
+						"{{serverURL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"system-table"
+					]
+				},
+				"description": "Adds a new key or updates an existing one. In this case, the previously created `MY_KEY1` property is updated."
+			},
+			"response": []
+		},
+		{
 			"name": "Getting the Previously Updated Key",
 			"event": [
 				{
@@ -248,7 +364,7 @@
 							"",
 							"pm.test(\"Expecting the correct updated value of the key\", function () {",
 							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData.entity).to.eql(\"value2\");",
+							"    pm.expect(jsonData.entity).to.eql(\"upserted value3\");",
 							"});",
 							""
 						],

--- a/dotCMS/src/curl-test/SystemTable.postman_collection.json
+++ b/dotCMS/src/curl-test/SystemTable.postman_collection.json
@@ -5,7 +5,7 @@
 		"description": "This Postman test verifies that CRUD operations executed on the System Table API work as expected. This API allows users and developers to store global properties in the application.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "5403727",
-		"_collection_link": "https://cloudy-robot-285072.postman.co/workspace/JCastro-Workspace~5bfa586e-54db-429b-b7d5-c4ff997e3a0d/collection/5403727-ce070bf0-e702-4ae1-a6e6-615cfe50ec8c?action=share&source=collection_link&creator=5403727"
+		"_collection_link": "https://cloudy-robot-285072.postman.co/workspace/5bfa586e-54db-429b-b7d5-c4ff997e3a0d/collection/5403727-66446a0d-a484-449f-8b78-a69e14929ad1?action=share&source=collection_link&creator=5403727"
 	},
 	"item": [
 		{

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/SystemTableResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/SystemTableResource.java
@@ -6,7 +6,6 @@ import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource.InitBuilder;
 import com.dotcms.rest.annotation.NoCache;
 import com.dotcms.util.CollectionsUtils;
-import com.dotcms.util.DotPreconditions;
 import com.dotcms.util.WhiteBlackList;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Role;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/SystemTableResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/SystemTableResource.java
@@ -6,11 +6,11 @@ import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource.InitBuilder;
 import com.dotcms.rest.annotation.NoCache;
 import com.dotcms.util.CollectionsUtils;
+import com.dotcms.util.DotPreconditions;
 import com.dotcms.util.WhiteBlackList;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Role;
 import com.dotmarketing.exception.DoesNotExistException;
-import com.dotmarketing.exception.DotDuplicateDataException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.liferay.util.StringPool;
@@ -32,6 +32,9 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.dotcms.util.DotPreconditions.checkNotEmpty;
+import static com.dotcms.util.DotPreconditions.checkNotNull;
 
 /**
  * This Jersey end-point provides access to the system table.
@@ -96,7 +99,7 @@ public class SystemTableResource implements Serializable {
 											 @Context final HttpServletResponse response,
 											 @PathParam("key") final String key)
 			throws IllegalAccessException {
-
+		checkNotEmpty(key, IllegalArgumentException.class, "Key cannot be null or empty");
 		this.init(request, response);
 		this.checkBlackList(key);
 
@@ -143,7 +146,7 @@ public class SystemTableResource implements Serializable {
 	}
 
 	/**
-	 * Saves a value to the system table.
+	 * Saves or updates the value of a given key to the system table.
 	 *
 	 * @param request  The current instance of the {@link HttpServletRequest}.
 	 * @param response The current instance of the {@link HttpServletResponse}.
@@ -152,7 +155,6 @@ public class SystemTableResource implements Serializable {
 	 * @return The key that was saved.
 	 *
 	 * @throws IllegalArgumentException If the key is blacklisted.
-	 * @throws DotDuplicateDataException The key already exists.
 	 */
 	@POST
 	@JSONP
@@ -162,18 +164,13 @@ public class SystemTableResource implements Serializable {
 			@Context final HttpServletRequest request,
 			@Context final HttpServletResponse response,
 			final KeyValueForm form) throws IllegalAccessException {
-
+		checkNotNull(form, IllegalArgumentException.class, "KeyValueForm cannot be null");
 		this.init(request, response);
 		this.checkBlackList(form.getKey());
-
-		if (this.systemTable.get(form.getKey()).isPresent()) {
-			throw new DotDuplicateDataException("Key already exist: " + form.getKey());
-		}
-
-		Logger.debug(this, ()-> "Saving system table value for key: " + form.getKey());
+		Logger.debug(this, ()-> "Saving/updating system table value for key: " + form.getKey());
 		this.systemTable.set(form.getKey(), form.getValue());
 		
-		return new ResponseEntityStringView(form.getKey() + " Saved");
+		return new ResponseEntityStringView(form.getKey() + " saved/updated");
 	}
 
 	/**
@@ -194,7 +191,7 @@ public class SystemTableResource implements Serializable {
 			@Context final HttpServletRequest request,
 			@Context final HttpServletResponse response,
 			final KeyValueForm form) throws IllegalAccessException {
-
+		checkNotNull(form, IllegalArgumentException.class, "KeyValueForm cannot be null");
 		this.init(request, response);
 		this.checkBlackList(form.getKey());
 
@@ -228,7 +225,7 @@ public class SystemTableResource implements Serializable {
 			@Context final HttpServletRequest request,
 			@Context final HttpServletResponse response,
 			@PathParam("key") final String key) throws IllegalAccessException {
-
+		checkNotEmpty(key, IllegalArgumentException.class, "Key cannot be null or empty");
 		this.init(request, response);
 		this.checkBlackList(key);
 


### PR DESCRIPTION
### Proposed Changes
* The POST method must be able to handle upsert operations, not just save operations.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41cd299</samp>

This pull request enhances the `save` method of the `SystemTableResource` class, which handles key-value pairs in the system table. It adds better validation and documentation for the method arguments and simplifies the error handling.