### PR TITLE
Fix #26376: Design System Autocomplete had too weak css classes

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_autocomplete.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_autocomplete.scss
@@ -8,7 +8,7 @@ p-autocomplete.p-inputwrapper-focus {
 }
 
 .p-fluid .p-autocomplete.p-component, // To override the default behavior
-.p-autocomplete {
+.p-autocomplete.p-component {
     display: grid;
     align-items: center;
     grid-template-columns: auto repeat(3, max-content); // This will make the grid to remove the columns that are not in the grid


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 029f445</samp>

### Summary
🐛🎨🛠️

<!--
1.  🐛 - This emoji represents a bug fix, since the change was made to resolve an issue with the autocomplete component's layout and alignment.
2.  🎨 - This emoji represents an improvement to the UI or style of the component, since the change made the autocomplete input and dropdown panel more consistent and harmonious.
3.  🛠️ - This emoji represents a maintenance or refactoring change, since the change involved modifying an existing selector to make it more specific and avoid conflicts with other elements.
-->
Fixed autocomplete input alignment bug by adding `.p-component` class to `.p-autocomplete` selector in `_autocomplete.scss` file. This prevents style conflicts with other elements that share the same class name.

> _`.p-autocomplete`_
> _now has `.p-component` / to fix alignment_
> _a bug in autumn / leaves the input and panel / out of harmony_

### Walkthrough
* Fix autocomplete input alignment with dropdown panel by adding `.p-component` class to `.p-autocomplete` selector ([link](https://github.com/dotCMS/core/pull/26563/files?diff=unified&w=0#diff-f9c2ffef72b1a8203e6a53c8a8e8110fce861367d47d87e12b09a16e201788d1L11-R11))



### Screenshots
<img width="1284" alt="Screenshot 2023-10-30 at 11 38 11 AM" src="https://github.com/dotCMS/core/assets/63567962/ddb26acb-cfb6-4f57-a379-bd112d0f1a67">
