### PR TITLE
feat(chainable metadata provider) #24307 : Introducing the Storage Replication Job Storage Provider

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/storage/StorageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/storage/StorageResource.java
@@ -1,0 +1,126 @@
+package com.dotcms.rest.api.v1.system.storage;
+
+import com.dotcms.rest.InitDataObject;
+import com.dotcms.rest.ResponseEntityBooleanView;
+import com.dotcms.rest.ResponseEntityView;
+import com.dotcms.rest.WebResource;
+import com.dotcms.rest.annotation.NoCache;
+import com.dotcms.storage.StorageType;
+import com.dotmarketing.business.Role;
+import com.dotmarketing.quartz.job.StorageReplicationJob;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.PortletID;
+import com.dotmarketing.util.UtilMethods;
+import com.google.common.annotations.VisibleForTesting;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.PathSegment;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This REST Endpoint allows users to interact with dotCMS Storage Providers and perform operations
+ * such as data replication from one Provider to one or more Providers.
+ *
+ * @author jsanca
+ */
+@Path("/v1/storages")
+public class StorageResource {
+
+    private final WebResource webResource;
+
+    @VisibleForTesting
+    public StorageResource() {
+        this(new WebResource());
+    }
+
+    @VisibleForTesting
+    public StorageResource(final WebResource webResource) {
+        this.webResource = webResource;
+    }
+
+    /**
+     * This method is just a test method to check if the endpoint is up and running.
+     *
+     * @param request  The current instance of the {@link HttpServletRequest} object.
+     * @param response The current instance of the {@link HttpServletResponse} object.
+     *
+     * @return A {@link Response} object with dummy confirmation message.
+     */
+    @NoCache
+    @GET
+    @Path("/hello")
+    @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
+    public Response hello(@Context final HttpServletRequest request,
+                          @Context final HttpServletResponse response) {
+        new WebResource.InitBuilder(webResource)
+                .requestAndResponse(request, response)
+                .requiredBackendUser(true)
+                .requiredFrontendUser(false)
+                .requiredRoles(Role.CMS_ADMINISTRATOR_ROLE)
+                .requiredPortlet(PortletID.MAINTENANCE.toString().toLowerCase())
+                .rejectWhenNoUser(true).init();
+        return Response.ok(new ResponseEntityView<>("hello")).build();
+    }
+
+    /**
+     * Fires the data replication process from one Storage Provider to one or more Providers. Here's
+     * an example of what a GET request to replicate File System metadata to Redis would look like:
+     * <pre>
+     *   http://localhost:8080/api/v1/storages/chain/_replicate/FILE_SYSTEM/to/MEMORY
+     * </pre>
+     * If you want to replicate to the database as well, just add it to the path:
+     * <pre>
+     *   http://localhost:8080/api/v1/storages/chain/_replicate/FILE_SYSTEM/to/MEMORY/DB
+     * </pre>
+     *
+     * @param request                  The current instance of the {@link HttpServletRequest}.
+     * @param response                 The current instance of the  {@link HttpServletResponse}.
+     * @param fromStorageType          The source {@link StorageType} containing the metadata.
+     * @param pathSegmentsStorageTypes The {@link List} of {@link PathSegment} representing the
+     *                                 Storage Types that the metadata will be replicated to.
+     *
+     * @return Response The Status 200 response in case no errors were found.
+     */
+    @NoCache
+    @GET
+    @Path("/chain/_replicate/{from}/to/{to: .+}")
+    @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
+    public Response replicateStorages(@Context final HttpServletRequest request,
+                                      @Context final HttpServletResponse response,
+                                      @PathParam("from") final StorageType fromStorageType,
+                                      @PathParam("to") final List<PathSegment> pathSegmentsStorageTypes) {
+        final InitDataObject initDataObject = new WebResource.InitBuilder(webResource)
+                .requestAndResponse(request, response)
+                .requiredBackendUser(true)
+                .requiredFrontendUser(false)
+                .requiredRoles(Role.CMS_ADMINISTRATOR_ROLE)
+                .requiredPortlet(PortletID.MAINTENANCE.toString().toLowerCase())
+                .rejectWhenNoUser(true).init();
+
+        Logger.debug(this, "Scheduling Storage Provider replication from: " +
+                fromStorageType + ", to: " + pathSegmentsStorageTypes);
+
+        if (!UtilMethods.isSet(fromStorageType)) {
+            throw new IllegalArgumentException("The 'from' Storage Type is required");
+        }
+        if (UtilMethods.isNotSet(pathSegmentsStorageTypes)) {
+            throw new IllegalArgumentException("At least one 'to' Storage Type is required");
+        }
+
+        final List<StorageType> toStorageType = pathSegmentsStorageTypes.stream().
+                map(segment -> StorageType.valueOf(segment.getPath())).collect(Collectors.toList());
+
+        StorageReplicationJob.triggerReplicationStoragesJob(fromStorageType, toStorageType, initDataObject.getUser());
+        return Response.ok(new ResponseEntityBooleanView(true)).build();
+    }
+
+} // E:O:F:StorageResource.

--- a/dotCMS/src/main/java/com/dotcms/rest/config/DotRestApplication.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/config/DotRestApplication.java
@@ -78,6 +78,7 @@ import com.dotcms.rest.api.v1.system.permission.PermissionResource;
 import com.dotcms.rest.api.v1.system.role.RoleResource;
 import com.dotcms.rest.api.v1.system.ruleengine.actionlets.ActionletsResource;
 import com.dotcms.rest.api.v1.system.ruleengine.conditionlets.ConditionletsResource;
+import com.dotcms.rest.api.v1.system.storage.StorageResource;
 import com.dotcms.rest.api.v1.taillog.TailLogResource;
 import com.dotcms.rest.api.v1.temp.TempFileResource;
 import com.dotcms.rest.api.v1.template.TemplateResource;
@@ -110,7 +111,6 @@ import com.dotcms.rest.personas.PersonasResourcePortlet;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.exception.AlreadyExistException;
 import com.dotmarketing.portlets.folders.exception.InvalidFolderNameException;
-import com.dotmarketing.portlets.templates.model.SystemTemplate;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import com.google.common.collect.ImmutableSet;
@@ -120,11 +120,12 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+
+import javax.ws.rs.core.Application;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.ws.rs.core.Application;
-import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
 /**
  * This class provides the list of all the REST end-points in dotCMS. Every new
@@ -153,7 +154,6 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 				@Tag(name = "Experiment")
 		}
 )
-
 public class DotRestApplication extends Application {
 
 	/**
@@ -254,6 +254,7 @@ public class DotRestApplication extends Application {
 			.add(VariantResource.class)
 			.add(WebAssetResource.class)
 			.add(SystemTableResource.class)
+			.add(StorageResource.class)
 			.build();
 
 	private static final Set<Class<?>> PROVIDER_CLASSES = ImmutableSet.<Class<?>>builder()
@@ -287,7 +288,6 @@ public class DotRestApplication extends Application {
 			.add(NotAllowedExceptionMapper.class)
 			.add(RuntimeExceptionMapper.class)
 			.build();
-
 
 	/**
 	 * This is the cheap way to create a concurrent set of user provided classes

--- a/dotCMS/src/main/java/com/dotcms/storage/FileStorageAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileStorageAPI.java
@@ -16,6 +16,10 @@ public interface FileStorageAPI {
     int SIZE                       = 1024;
     int DEFAULT_META_DATA_MAX_SIZE = 5;
 
+    ObjectReaderDelegate DEFAULT_OBJECT_READER_DELEGATE = new JsonReaderDelegate<>(Map.class);
+    ObjectWriterDelegate DEFAULT_OBJECT_WRITER_DELEGATE = new JsonWriterDelegate();
+    MetadataGenerator DEFAULT_METADATA_GENERATOR = new MetadataGeneratorImpl();
+
     /**
      * Returns the default configured max length
      * @return int

--- a/dotCMS/src/main/java/com/dotcms/storage/FileStorageAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileStorageAPIImpl.java
@@ -1,27 +1,17 @@
 package com.dotcms.storage;
 
-import static com.dotcms.storage.StoragePersistenceAPI.HASH_OBJECT;
-import static com.dotcms.storage.model.BasicMetadataFields.*;
-import static com.dotmarketing.util.UtilMethods.isSet;
-
 import com.dotcms.storage.model.BasicMetadataFields;
 import com.dotcms.storage.model.Metadata;
-import com.dotcms.util.MimeTypeUtils;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.contentlet.business.MetadataCache;
-import com.dotmarketing.util.Config;
-import com.dotmarketing.util.ConfigUtils;
-import com.dotmarketing.util.FileUtil;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
-import com.liferay.util.StringPool;
 import io.vavr.control.Try;
-import java.awt.Dimension;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.Collections;
@@ -34,26 +24,26 @@ import java.util.TreeMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static com.dotcms.storage.StoragePersistenceAPI.HASH_OBJECT;
+import static com.dotcms.storage.model.BasicMetadataFields.CONTENT_TYPE_META_KEY;
+import static com.dotcms.storage.model.BasicMetadataFields.LENGTH_META_KEY;
+import static com.dotcms.storage.model.BasicMetadataFields.SIZE_META_KEY;
+import static com.dotcms.storage.model.BasicMetadataFields.VERSION_KEY;
+import static com.dotmarketing.util.UtilMethods.isSet;
+
 /**
- * Default implementation
+ * This is the default implementation of the {@link FileStorageAPI} class.
  *
  * @author jsanca
  */
 public class FileStorageAPIImpl implements FileStorageAPI {
 
-    private volatile ObjectReaderDelegate objectReaderDelegate;
-    private volatile ObjectWriterDelegate objectWriterDelegate;
-    private volatile MetadataGenerator metadataGenerator;
+    private final ObjectReaderDelegate objectReaderDelegate;
+    private final ObjectWriterDelegate objectWriterDelegate;
+    private final MetadataGenerator metadataGenerator;
     private final StoragePersistenceProvider persistenceProvider;
     private final MetadataCache metadataCache;
 
-    /**
-     * Testing constructor
-     * @param objectReaderDelegate
-     * @param objectWriterDelegate
-     * @param metadataGenerator
-     * @param persistenceProvider
-     */
     @VisibleForTesting
     FileStorageAPIImpl(final ObjectReaderDelegate objectReaderDelegate,
             final ObjectWriterDelegate objectWriterDelegate,
@@ -70,8 +60,9 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      * Default constructor
      */
     public FileStorageAPIImpl() {
-        this(new JsonReaderDelegate<>(Map.class), new JsonWriterDelegate(),
-                new MetadataGeneratorImpl(), StoragePersistenceProvider.INSTANCE.get(), CacheLocator.getMetadataCache());
+        this(DEFAULT_OBJECT_READER_DELEGATE, DEFAULT_OBJECT_WRITER_DELEGATE,
+                DEFAULT_METADATA_GENERATOR, StoragePersistenceProvider.INSTANCE.get(),
+                CacheLocator.getMetadataCache());
     }
 
     /**
@@ -81,7 +72,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      */
     @Override
     public Map<String, Serializable> generateRawBasicMetaData(final File binary) {
-
         return this.generateBasicMetaData(binary, s -> true); // raw = no filter
     }
 
@@ -93,7 +83,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      */
     @Override
     public Map<String, Serializable> generateRawFullMetaData(final File binary, long maxLength) {
-
         return this.generateFullMetaData(binary, s -> true, maxLength); // raw = no filter
     }
 
@@ -107,7 +96,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      */
     private Map<String, Serializable> generateBasicMetaData(final File binary,
             final Predicate<String> metaDataKeyFilter) {
-
         if (this.validBinary(binary)) {
 
             final TreeMap<String, Serializable> standAloneMetadata = metadataGenerator.standAloneMetadata(binary);
@@ -132,8 +120,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
         return ImmutableMap.of();
     }
 
-
-
     /**
      * Gets the full metadata from the binary, this could involved a more expensive process such as Tika, this method does not any stores but could do a filter anything
      * @param binary  {@link File} file to get the information
@@ -144,7 +130,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
     private Map<String, Serializable> generateFullMetaData(final File binary,
             final Predicate<String> metaDataKeyFilter,
             final long maxLength) {
-
         TreeMap<String, Serializable> metadataMap = new TreeMap<>(Comparator.naturalOrder());
 
         try {
@@ -178,7 +163,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      * @return
      */
     private TreeMap<String, Serializable> ensureTypes(TreeMap<String, Serializable> metadataMap){
-
         final Map<String, BasicMetadataFields> metadataFieldsMap = BasicMetadataFields.keyMap();
         final Iterator<Entry<String, Serializable>> iterator = metadataMap.entrySet().iterator();
         while(iterator.hasNext()){
@@ -210,7 +194,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
     @Override
     public Map<String, Serializable> generateMetaData(final File binary,
             final GenerateMetadataConfig configuration) throws DotDataException {
-
         final StorageKey storageKey = configuration.getStorageKey();
         final StoragePersistenceAPI storage = persistenceProvider.getStorage(storageKey.getStorage());
         if(configuration.isStore()) {
@@ -313,7 +296,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
     @SuppressWarnings("unchecked")
     private Map<String, Serializable> retrieveMetadata(final StorageKey storageKey,
             final StoragePersistenceAPI storage) throws DotDataException {
-
         final Map<String, Serializable> objectMap = (Map<String, Serializable>) storage
                 .pullObject(storageKey.getGroup(), storageKey.getPath(), this.objectReaderDelegate);
         Logger.debug(this, "Metadata read from path: " + storageKey.getPath());
@@ -329,7 +311,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      */
     private void storeMetadata(final StorageKey storageKey, final StoragePersistenceAPI storage,
             final Map<String, Serializable> metadataMap) throws DotDataException {
-
         final Map<String, Serializable> paramsMap = new HashMap<>(metadataMap);
         paramsMap.put(HASH_OBJECT, true);
 
@@ -345,7 +326,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      * @return
      */
     private boolean validBinary(final File binary) {
-
         return null != binary && binary.exists() && binary.canRead();
     }
 
@@ -356,7 +336,7 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      */
     private void checkOverride(final StoragePersistenceAPI storage,
             final GenerateMetadataConfig generateMetaDataConfiguration) throws DotDataException {
-            checkOverride(storage, generateMetaDataConfiguration.getStorageKey(), generateMetaDataConfiguration.isOverride());
+        checkOverride(storage, generateMetaDataConfiguration.getStorageKey(), generateMetaDataConfiguration.isOverride());
     }
 
     /**
@@ -366,15 +346,10 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      * @param override
      */
     private void checkOverride(final StoragePersistenceAPI storage, final StorageKey storageKey, final boolean override) throws DotDataException {
-
-        if (override && storage
-                .existsObject(storageKey.getGroup(), storageKey.getPath())) {
-
+        if (override && storage.existsObject(storageKey.getGroup(), storageKey.getPath())) {
             try {
-
                 storage.deleteObjectAndReferences(storageKey.getGroup(), storageKey.getPath());
-            } catch (Exception e) {
-
+            } catch (final Exception e) {
                 Logger.error(this.getClass(),
                         String.format("Unable to delete existing metadata file [%s] [%s]",
                                 storageKey.getPath(), e.getMessage()), e);
@@ -390,7 +365,6 @@ public class FileStorageAPIImpl implements FileStorageAPI {
     @Override
     public Map<String, Serializable> retrieveMetaData(final FetchMetadataParams requestMetaData)
             throws DotDataException {
-
         if (requestMetaData.isCache()) {
             final Map<String, Serializable> metadataMap = metadataCache
                     .getMetadataMap(requestMetaData.getCacheKeySupplier().get());

--- a/dotCMS/src/main/java/com/dotcms/storage/FileSystemStoragePersistenceAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileSystemStoragePersistenceAPIImpl.java
@@ -1,6 +1,7 @@
 package com.dotcms.storage;
 
 import com.dotcms.concurrent.DotConcurrentFactory;
+import com.dotcms.enterprise.achecker.parsing.EmptyIterable;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
@@ -9,19 +10,25 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.liferay.util.FileUtil;
 import io.vavr.Lazy;
+import io.vavr.control.Try;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
+import java.util.stream.Stream;
 
 /**
  * Represents a Storage Provider base on the File System. The groups used by this implementation are
@@ -473,4 +480,96 @@ public class FileSystemStoragePersistenceAPIImpl implements StoragePersistenceAP
             }
         }
     }
+
+    @Override
+    public Iterable<? extends ObjectPath> toIterable(final String group) {
+
+        final File destBucketFile = this.groups.get(group.toLowerCase());
+        if (destBucketFile.exists() && destBucketFile.isDirectory()) {
+
+            final Iterable<? extends ObjectPath> ite = Try.of(()->new FilesIterable(destBucketFile, group)).getOrNull();
+            return ite != null ? ite : new EmptyIterable<>();
+        }
+
+        return new EmptyIterable<>();
+    }
+
+    public class FilesIterable implements Iterable<ObjectPath> {
+
+        private final Stream<Path> stream;
+        private final File destBucketFile;
+
+        private final String groupName;
+
+        public FilesIterable(final File destBucketFile, final String groupName) throws IOException {
+            this.groupName      = groupName;
+            this.destBucketFile = destBucketFile;
+            this.stream = Files.walk(destBucketFile.toPath());
+        }
+
+        @NotNull
+        @Override
+        public Iterator<ObjectPath> iterator() {
+
+            return new ObjectPathIterator(stream.iterator(), destBucketFile, groupName);
+        }
+    } // FilesIterable.
+
+    class ObjectPathIterator implements Iterator<ObjectPath> {
+
+        private final File destBucketFile;
+        private final String groupName;
+        private Path currentElement = null;
+        private final Iterator<Path> iterator;
+
+        public ObjectPathIterator(final Iterator<Path> iterator, final File destBucketFile, final String groupName) {
+            this.groupName      = groupName;
+            this.destBucketFile = destBucketFile;
+            this.iterator       = iterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return null != nextFile();
+}
+
+        @Override
+        public ObjectPath next() {
+
+            ObjectPath objectPath = null;
+
+            if (null == currentElement) {
+                nextFile();
+            }
+
+            if (null != currentElement) {
+
+                final Path path = this.currentElement;
+                final String absolutePath = path.toFile().getAbsolutePath();
+                final String relativePath = absolutePath.substring(this.destBucketFile.getAbsolutePath().length() + 1);
+                objectPath = Try.of(()->new ObjectPath(relativePath,
+                        FileSystemStoragePersistenceAPIImpl.this.pullFile(groupName, relativePath))).getOrNull();
+            }
+
+            return objectPath;
+        }
+
+        private Path nextFile() {
+            if (this.iterator.hasNext()) {
+
+                Path path = iterator.next();
+                // if we have to find the fist file
+                while(path.toFile().isDirectory() && this.iterator.hasNext()) {
+                    path = iterator.next();
+                }
+                currentElement = path.toFile().isFile()?path: null;
+                return currentElement;
+            }
+
+            currentElement = null;
+            return null;
+        }
+
+    } // ObjectPathIterator.
+
 }

--- a/dotCMS/src/main/java/com/dotcms/storage/ObjectPath.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/ObjectPath.java
@@ -1,0 +1,30 @@
+package com.dotcms.storage;
+
+import java.io.Serializable;
+
+/**
+ * Represents an object returned by a Storage Provider. It contains the path to a given object and
+ * the object itself. This data structure allows the Storage Replication Job to keep track of all
+ * objects in the origin Storage Type and replicate them to one or more Storage Types.
+ *
+ * @author jsanca
+ */
+public class ObjectPath implements Serializable {
+
+    private final String path;
+    private final Object object;
+
+    public ObjectPath(final String path, final Object object) {
+        this.path = path;
+        this.object = object;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public Object getObject() {
+        return object;
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/storage/StoragePersistenceAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/StoragePersistenceAPI.java
@@ -1,6 +1,8 @@
 package com.dotcms.storage;
 
+import com.dotcms.enterprise.achecker.parsing.EmptyIterable;
 import com.dotmarketing.exception.DotDataException;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.List;
@@ -166,5 +168,19 @@ public interface StoragePersistenceAPI {
      * @return Future File, the future will return the file when done
      */
     Future<Object> pullObjectAsync (final String groupName, final String path, final ObjectReaderDelegate readerDelegate);
+
+    /**
+     * Returns an iterable object with all the paths and objects from the specified group. This is
+     * completely specific to the implementation of the Storage Provider, so it needs to be
+     * developed as required. If your Provider doesn't implement it, an empty Iterable will be
+     * returned.
+     *
+     * @param group The group name.
+     *
+     * @return The {@link Iterable} with the group objects.
+     */
+    default Iterable<? extends ObjectPath> toIterable(String group) {
+        return new EmptyIterable<>();
+    }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/StorageReplicationJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/StorageReplicationJob.java
@@ -1,0 +1,227 @@
+package com.dotmarketing.quartz.job;
+
+import com.dotcms.exception.ExceptionUtil;
+import com.dotcms.storage.FileStorageAPI;
+import com.dotcms.storage.ObjectPath;
+import com.dotcms.storage.StoragePersistenceAPI;
+import com.dotcms.storage.StoragePersistenceProvider;
+import com.dotcms.storage.StorageType;
+import com.dotcms.util.LogTime;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.quartz.DotStatefulJob;
+import com.dotmarketing.util.AdminLogger;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.DateUtil;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.liferay.portal.model.User;
+import io.vavr.Lazy;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+
+import java.io.File;
+import java.io.Serializable;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Performs the data replication from one Storage Provider to one or more Providers.
+ * <p>Depending on the amount of data to be transferred and the number of destination Storage
+ * Providers, this may be a heavy process. In order to overcome this situation, the Job replicates
+ * small batches of data at a time and sleeps the process for a given amount of time before
+ * proceeding with the next batch.</p>
+ *
+ * @author jsanca
+ */
+public class StorageReplicationJob extends DotStatefulJob {
+
+    public static final String BATCH_SIZE_PROP = "storage.replication.batch-size";
+    public static final String SLEEP_FOR_PROP = "storage.replication.sleep-for";
+
+    private static final int BATCH_SIZE_DEFAULT = 100;
+    private static final long SLEEP_FOR_DEFAULT = DateUtil.SECOND_MILLIS;
+
+    private static final Lazy<Integer> BATCH_SIZE =
+            Lazy.of(() -> Config.getIntProperty(BATCH_SIZE_PROP, BATCH_SIZE_DEFAULT));
+    private static final Lazy<Long> SLEEP_FOR =
+            Lazy.of(() -> Config.getLongProperty(SLEEP_FOR_PROP, SLEEP_FOR_DEFAULT));
+
+    /**
+     * Schedules the Storage Replication Quartz Job to be executed immediately.
+     *
+     * @param fromStorageType The storage type to replicate from.
+     * @param storageTypes    The storage types to replicate to.
+     * @param user            The {@link User} who triggered this job.
+     */
+    public static void triggerReplicationStoragesJob(final StorageType fromStorageType,
+                                                     final List<StorageType> storageTypes,
+                                                     final User user) {
+        final Map<String, Serializable> nextExecutionData = ImmutableMap
+                .of("fromStorageType", fromStorageType,
+                        "toStorageTypes", storageTypes instanceof Serializable ?
+                                (Serializable) storageTypes : new ArrayList<>(storageTypes),
+                        "user", user);
+        try {
+            DotStatefulJob.enqueueTrigger(nextExecutionData, StorageReplicationJob.class);
+            AdminLogger.log(StorageReplicationJob.class, "triggerJobImmediately",
+                    String.format("Replication Storage '%s'", fromStorageType.name()));
+        } catch (final ParseException | SchedulerException | ClassNotFoundException e) {
+            final String errorMsg = String.format("Failed to schedule the ReplicateStoragesJob " +
+                    "replicating from Storage Type '%s' to Types '%s': %s",
+                    fromStorageType.name(), storageTypes, ExceptionUtil.getErrorMessage(e));
+            Logger.error(StorageReplicationJob.class, errorMsg, e);
+            throw new DotRuntimeException(errorMsg, e);
+        }
+    }
+
+    /**
+     * Makes sure that the specified group exists in all the given {@link StoragePersistenceAPI}
+     * providers.
+     *
+     * @param toStoragePersistenceAPIs The list of {@link StoragePersistenceAPI} providers.
+     * @param group                    The group name that must exist.
+     *
+     * @throws DotDataException An error occurred when checking or creating the group.
+     */
+    private static void forceGroupCreation(final List<StoragePersistenceAPI> toStoragePersistenceAPIs,
+                                           final String group) throws DotDataException {
+        for (final StoragePersistenceAPI toStoragePersistenceAPI : toStoragePersistenceAPIs) {
+            if (!toStoragePersistenceAPI.existsGroup(group)) {
+                toStoragePersistenceAPI.createGroup(group);
+            }
+        }
+    } // ensureGroup.
+
+    @Override
+    @LogTime
+    public void run(final JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        final Trigger trigger = jobExecutionContext.getTrigger();
+        final Map<String, Serializable> map = getExecutionData(trigger, StorageReplicationJob.class);
+        final StorageType fromStorageType = (StorageType) map.get("fromStorageType");
+        final List<StorageType> toStorageTypes = (List<StorageType>) map.get("toStorageTypes");
+        final User user = (User) map.get("user");
+        Logger.info(this, "--------------------------------------");
+        Logger.info(this, "ReplicateStoragesJob has started");
+        Logger.info(this, String.format("-> Initiated by User: %s", user.getUserId()));
+        Logger.info(this, String.format("-> From Storage Type: %s", fromStorageType.name()));
+        Logger.info(this, String.format("-> To Storage Type(s): %s", toStorageTypes.toString()));
+        Logger.info(this, String.format("-> Batch Size: %d", BATCH_SIZE.get()));
+        Logger.info(this, String.format("-> Sleep For: %d millis", SLEEP_FOR.get()));
+        Logger.info(this, "This process runs in the background and may take a long time. " +
+                "Please wait...");
+        replicate(fromStorageType, toStorageTypes);
+        Logger.info(this.getClass(), String.format("ReplicateStoragesJob initiated by '%s' from " +
+                "type '%s' to type(s) '%s' has finished!", user.getUserId(),
+                fromStorageType.name(), toStorageTypes));
+    } // run
+
+    /**
+     * Replicates the data from the specified {@link StorageType} to the given list of destination
+     * Storage Types. The data to be replicated will be provided in batches, and a specific amount
+     * of time will be given in order to start with the next batch.
+     *
+     * @param fromStorageType The source {@link StorageType}.
+     * @param toStorageTypes  The list of destination {@link StorageType} inatances.
+     */
+    @VisibleForTesting
+    public void replicate(final StorageType fromStorageType,
+                          final List<StorageType> toStorageTypes) {
+        try {
+            final StoragePersistenceAPI storagePersistenceAPI =
+                    StoragePersistenceProvider.INSTANCE.get().getStorage(fromStorageType);
+            final List<StoragePersistenceAPI> toStoragePersistenceAPIs = toStorageTypes.stream()
+                    .map(type -> StoragePersistenceProvider.INSTANCE.get().getStorage(type))
+                    .filter(Objects::nonNull).collect(Collectors.toList());
+            if (null == storagePersistenceAPI) {
+                Logger.error(this, String.format("Source Storage Type '%s' was not found",
+                        fromStorageType));
+                return;
+            }
+            if (toStoragePersistenceAPIs.isEmpty()) {
+                Logger.error(this, String.format("None of the destination Storage Types '%s' were" +
+                        " found", toStorageTypes));
+                return;
+            }
+            if (toStoragePersistenceAPIs.size() != toStorageTypes.size()) {
+                Logger.warn(this, String.format("Only %d out of %d Storage Types were found: %s",
+                        toStoragePersistenceAPIs.size(), toStorageTypes.size(),
+                        toStoragePersistenceAPIs.stream().map(storage
+                                -> storage.getClass().getSimpleName()).collect(Collectors.joining(", "))));
+                return;
+            }
+            final int batch = BATCH_SIZE.get();
+            if (UtilMethods.isSet(storagePersistenceAPI.listGroups())) {
+                for (final String group : storagePersistenceAPI.listGroups()) {
+                    forceGroupCreation(toStoragePersistenceAPIs, group);
+                    int count = 0;
+                    for (final ObjectPath objectPath : storagePersistenceAPI.toIterable(group)) {
+                        if (null != objectPath) {
+                            this.replicateToStorages(toStoragePersistenceAPIs, group, objectPath);
+                            if (count++ % batch == 0) {
+                                DateUtil.sleep(SLEEP_FOR.get());
+                            }
+                        }
+                    }
+                }
+            } else {
+                Logger.warn(this, String.format("Group list for Storage Provider '%s' is empty",
+                        storagePersistenceAPI.getClass().getSimpleName()));
+            }
+        } catch (final Throwable e) {
+            Logger.error(this, String.format("Failed to replicate Storage Type '%s': %s",
+                    fromStorageType, ExceptionUtil.getErrorMessage(e)), e);
+        }
+    }
+
+    /**
+     * Replicates the data of the specified {@link ObjectPath} to the given list of
+     * {@link StoragePersistenceAPI} providers. The replication will take place even if such an
+     * object already exists in the destination provider. This is intentional because we want to
+     * make sure both source and destination storages are synchronized.
+     *
+     * @param toStoragePersistenceAPIs The list of {@link StoragePersistenceAPI} providers that will
+     *                                 contain the replicated data.
+     * @param group                    The group name that the {@link ObjectPath} belongs to.
+     * @param objectPath               The {@link ObjectPath} containing the data to be replicated.
+     */
+    private void replicateToStorages(final List<StoragePersistenceAPI> toStoragePersistenceAPIs,
+                                     final String group, final ObjectPath objectPath) {
+        for (final StoragePersistenceAPI toStoragePersistenceAPI : toStoragePersistenceAPIs) {
+            try {
+                if (null != objectPath.getObject()) {
+                    Logger.debug(this, String.format("-> Replicating object in path: '%s'",
+                            objectPath.getPath()));
+                    if (objectPath.getObject() instanceof File) {
+                        toStoragePersistenceAPI.pushFile(group, objectPath.getPath(),
+                                (File) objectPath.getObject(), null);
+                    } else if (objectPath.getObject() instanceof Serializable) {
+                        toStoragePersistenceAPI.pushObject(group, objectPath.getPath(),
+                                FileStorageAPI.DEFAULT_OBJECT_WRITER_DELEGATE,
+                                (Serializable) objectPath.getObject(), null);
+                    } else {
+                        Logger.warn(this, String.format("Object '%s' under group '%s' and path " +
+                                "'%s' is NOT serializable", objectPath.getObject(), group,
+                                objectPath.getPath()));
+                    }
+                } else {
+                    Logger.warn(this, String.format("Object in path '%s' is null. It will NOT be " +
+                            "replicated", objectPath.getPath()));
+                }
+            } catch (final Exception e) {
+                Logger.error(this, String.format("Error replicating to Storage Provider '%s': %s"
+                        , toStoragePersistenceAPI.getClass().getSimpleName(),
+                        ExceptionUtil.getErrorMessage(e)), e);
+            }
+        }
+    } // replicateToStorages.
+
+}


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 05bdb8c</samp>

This pull request adds a new feature to dotCMS that allows users to configure and manage different Storage Providers for storing files and metadata. It introduces a new REST endpoint, `StorageResource`, to access and manipulate the storage content. It also adds new classes and interfaces, such as `FileStorageAPI`, `StoragePersistenceAPI`, `ObjectPath`, and `StorageReplicationJob`, to support the feature. It also contains minor code refactors and style improvements in some existing classes.