### PR TITLE
Changed spacings, margins and gaps

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.scss
@@ -1,4 +1,5 @@
 :host {
     display: block;
     height: fit-content;
+    margin-bottom: 0;
 }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.scss
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.scss
@@ -18,13 +18,14 @@
     display: grid;
     grid-auto-flow: column;
     grid-auto-columns: minmax(0, 1fr);
-    gap: $spacing-2;
+    gap: $spacing-4;
+    margin-bottom: $spacing-4;
 }
 
 .column {
     display: flex;
     flex-direction: column;
-    gap: $spacing-3;
+    gap: $spacing-4;
 }
 
 code {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-checkbox-field/dot-edit-content-checkbox-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-checkbox-field/dot-edit-content-checkbox-field.component.scss
@@ -1,0 +1,3 @@
+p-checkbox:last-child {
+    margin-bottom: 0;
+}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-radio-field/dot-edit-content-radio-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-radio-field/dot-edit-content-radio-field.component.scss
@@ -1,0 +1,3 @@
+p-radiobutton:last-child {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2d22934</samp>

### Summary
🔲🔘📐

<!--
1.  🔲 - This emoji can represent the removal of the bottom margin of the dot-edit-content-field component, as it suggests a tighter alignment of the fields without extra space.
2.  🔘 - This emoji can represent the removal of the bottom margin of the last checkbox and radio button in their respective components, as it suggests a closer proximity of the options to the next field or the form actions.
3.  📐 - This emoji can represent the increased gaps between the columns and rows of the dot-edit-content-form component, as it suggests a more balanced and proportional layout of the content fields.
-->
Reduced the bottom margins of checkbox and radio fields and increased the gaps between the columns and rows of the content form. These changes improve the layout and appearance of the content fields in the `dot-edit-content-form` component.

> _Sing, O Muse, of the skillful web developers_
> _Who craft the forms and fields of content editing_
> _With keen-eyed care they trim the margins fine_
> _And make the columns and rows harmonious shine_

### Walkthrough
*  Remove extra bottom margins from checkbox and radio fields to improve spacing ([link](https://github.com/dotCMS/core/pull/26575/files?diff=unified&w=0#diff-397676076e6bdc846839e3e71bfda63bd8429f248fa3ec4b153b091b15355b51R1-R3), [link](https://github.com/dotCMS/core/pull/26575/files?diff=unified&w=0#diff-591b2fbc00bf731673e886b32e4cd846f5b6ec85171c04c80712de7b79e721c5R1-R3))
*  Increase column gap and add bottom margin to grid layout of content fields to improve alignment and separation ([link](https://github.com/dotCMS/core/pull/26575/files?diff=unified&w=0#diff-1a3e657016880498977ce74202425946ae817683630dd29a8b673b2dd4672e5aL21-R22))
*  Increase row gap of flex containers for field labels and inputs to improve readability ([link](https://github.com/dotCMS/core/pull/26575/files?diff=unified&w=0#diff-1a3e657016880498977ce74202425946ae817683630dd29a8b673b2dd4672e5aL27-R28))
*  Remove bottom margin from content field wrapper to avoid extra spacing ([link](https://github.com/dotCMS/core/pull/26575/files?diff=unified&w=0#diff-7d672c6a9147f1acf82f75314c98a7d6f0a4cc381ba30158ad4b8e1f62435a6aR4))


Original:
https://github.com/dotCMS/core/assets/751424/dae30098-fa89-43d7-a8b0-094557ab540e

Updated:
https://github.com/dotCMS/core/assets/144152756/160ea714-d049-46c3-ad26-d918a9b892ec


