### PR TITLE
dotCMS/core#26271 [UI] Text in experiment data results needs be aligned

### DIFF
--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/components/dot-experiments-reports-chart/chartjs/options/dotExperiments-chartjs.options.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/components/dot-experiments-reports-chart/chartjs/options/dotExperiments-chartjs.options.ts
@@ -135,7 +135,7 @@ export const generateDotExperimentLineChartJsOptions = ({
             tooltip: {
                 callbacks: {
                     title: function (context) {
-                        return Number(context[0].label) * 100 + '%';
+                        return Math.round(context[0].label * 100) + '%';
                     },
                     label: function (context) {
                         const label = context.dataset.label || '';

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/store/dot-experiments-reports-store.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/store/dot-experiments-reports-store.spec.ts
@@ -485,8 +485,8 @@ describe('DotExperimentsReportsStore', () => {
         it('should has a label and data properly parsed for each dataset', (done) => {
             // First data is added manually when we parse the data
             const expectedDataByDataset = [
-                [0, 90.555, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15.25],
-                [0, 15.25, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 90.555]
+                [0, 90.56, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15.25],
+                [0, 15.25, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 90.56]
             ];
             const expectedLabel = [
                 EXPERIMENT_MOCK_RESULTS.goals.primary.variants.DEFAULT.variantDescription,

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
@@ -212,9 +212,9 @@ const generateProbabilityDensityData = (
     // Loop through the x values from 0 to 1.
     for (let i = 0; i <= 1; i += step) {
         // Set the x value to the current value of i.
-        const x = Number(i.toFixed(3));
+        const x = Number(i.toFixed(2));
         // Set the y value to the value of the pdf at the current value of i.
-        const y = Number(betaDist.pdf(x).toFixed(3));
+        const y = Number(betaDist.pdf(x).toFixed(2));
 
         if (!isFinite(y)) {
             continue;

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
@@ -42,7 +42,7 @@ export const orderVariants = (arrayToOrder: Array<string>): Array<string> => {
  * @return {number[]} - An array of conversion Rate values.
  */
 export const getParsedChartData = (data: Record<string, DotResultDate>): number[] => {
-    return [0, ...Object.values(data).map((day) => day.conversionRate)];
+    return [0, ...Object.values(data).map((day) => Math.round(day.conversionRate * 100) / 100)];
 };
 
 export const getPropertyColors = (index: number): LineChartColorsProperties => {
@@ -212,9 +212,9 @@ const generateProbabilityDensityData = (
     // Loop through the x values from 0 to 1.
     for (let i = 0; i <= 1; i += step) {
         // Set the x value to the current value of i.
-        const x = i;
+        const x = Number(i.toFixed(3));
         // Set the y value to the value of the pdf at the current value of i.
-        const y = betaDist.pdf(x);
+        const y = Number(betaDist.pdf(x).toFixed(3));
 
         if (!isFinite(y)) {
             continue;


### PR DESCRIPTION
### Proposed Changes
Reduce the amount of decimals in the charts. 

### Screenshots
Before
<img width="217" alt="Original 18 181818" src="https://github.com/dotCMS/core/assets/31667212/bea3f8ee-c5e7-4452-b140-c5697cc7367c">

<img width="278" alt="Pasted Graphic 4" src="https://github.com/dotCMS/core/assets/31667212/95018793-2370-4d25-a8c8-732ff76e2f96">

<img width="304" alt="14 000000000000002" src="https://github.com/dotCMS/core/assets/31667212/77466ea9-b2e9-44e8-b83e-12cc359bd57c">


After 

<img width="242" alt="Original 18 18" src="https://github.com/dotCMS/core/assets/31667212/463a9d9e-cfa0-4dde-8c4b-6d20fccd2213">

<img width="224" alt="image" src="https://github.com/dotCMS/core/assets/31667212/50d4ecf9-a4b6-42ae-8b86-7885f26caa56">

<img width="235" alt="Pasted Graphic 3" src="https://github.com/dotCMS/core/assets/31667212/0b5300d1-9d08-48e7-9066-7bdcb1550c23">



