### PR TITLE
Edit Content: Implement Control Value Accessor in the Binary Field

### DIFF
--- a/core-web/libs/contenttype-fields/src/lib/fields/binary-field/binary-field.component.spec.ts
+++ b/core-web/libs/contenttype-fields/src/lib/fields/binary-field/binary-field.component.spec.ts
@@ -353,6 +353,11 @@ describe('DotBinaryFieldComponent', () => {
     });
 });
 
+/**
+ * TODO: Remove it and use `FormGroupMockDirective` when movving this component to `libs/edit-content` if needed.
+ *
+ * @class MockFormComponent
+ */
 @Component({
     selector: 'dot-app-mock-form',
     imports: [
@@ -384,10 +389,6 @@ describe('DotBinaryFieldComponent - ControlValueAccesor', () => {
 
     beforeEach(() => {
         spectator = createComponent();
-    });
-
-    it('should create', () => {
-        expect(spectator.component).toBeTruthy();
     });
 
     it('should set form value when binary file changes', () => {

--- a/core-web/libs/contenttype-fields/src/lib/fields/binary-field/binary-field.component.spec.ts
+++ b/core-web/libs/contenttype-fields/src/lib/fields/binary-field/binary-field.component.spec.ts
@@ -4,8 +4,9 @@ import { byTestId, createComponentFactory, Spectator } from '@ngneat/spectator';
 import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { NgZone } from '@angular/core';
+import { Component, NgZone } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -349,5 +350,56 @@ describe('DotBinaryFieldComponent', () => {
 
     afterEach(() => {
         jest.resetAllMocks();
+    });
+});
+
+@Component({
+    selector: 'dot-app-mock-form',
+    imports: [
+        ButtonModule,
+        DialogModule,
+        MonacoEditorModule,
+        ReactiveFormsModule,
+        DotBinaryFieldComponent
+    ],
+    standalone: true,
+    template: `
+        <form [formGroup]="form">
+            <dot-binary-field [field]="field" formControlName="binaryField"></dot-binary-field>
+        </form>
+    `
+})
+class MockFormComponent {
+    field = FIELD;
+    form = new FormGroup({
+        binaryField: new FormControl('')
+    });
+}
+
+describe('DotBinaryFieldComponent - ControlValueAccesor', () => {
+    let spectator: Spectator<MockFormComponent>;
+    const createComponent = createComponentFactory({
+        component: MockFormComponent
+    });
+
+    beforeEach(() => {
+        spectator = createComponent();
+    });
+
+    it('should create', () => {
+        expect(spectator.component).toBeTruthy();
+    });
+
+    it('should set form value when binary file changes', () => {
+        const binaryFieldComponent = spectator.query(DotBinaryFieldComponent);
+
+        // Call the writeValue method from ControlValueAccesor
+        binaryFieldComponent.setTempFile(TEMP_FILE_MOCK);
+
+        // Get the form value
+        const formValue = spectator.component.form.get('binaryField').value;
+
+        // Check if the form value was set
+        expect(formValue).toBe(TEMP_FILE_MOCK.id);
     });
 });

--- a/core-web/libs/contenttype-fields/src/lib/fields/binary-field/binary-field.component.ts
+++ b/core-web/libs/contenttype-fields/src/lib/fields/binary-field/binary-field.component.ts
@@ -13,8 +13,10 @@ import {
     OnDestroy,
     OnInit,
     Output,
-    ViewChild
+    ViewChild,
+    forwardRef
 } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
@@ -61,16 +63,30 @@ import { getUiMessage } from '../../utils/binary-field-utils';
         DotBinaryFieldUrlModeComponent,
         DotBinaryFieldPreviewComponent
     ],
-    providers: [DotBinaryFieldStore, DotLicenseService, DotBinaryFieldEditImageService],
+    providers: [
+        DotBinaryFieldStore,
+        DotLicenseService,
+        DotBinaryFieldEditImageService,
+        {
+            multi: true,
+            provide: NG_VALUE_ACCESSOR,
+            useExisting: forwardRef(() => DotBinaryFieldComponent)
+        }
+    ],
     templateUrl: './binary-field.component.html',
     styleUrls: ['./binary-field.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DotBinaryFieldComponent implements OnInit, AfterViewInit, OnDestroy {
+export class DotBinaryFieldComponent
+    implements OnInit, AfterViewInit, OnDestroy, ControlValueAccessor
+{
     @Input() field: DotCMSContentTypeField;
     @Input() contentlet: DotCMSContentlet;
     @Output() tempFile = new EventEmitter<DotCMSTempFile>();
     @ViewChild('inputFile') inputFile: ElementRef;
+
+    private onChange: (value: string) => void;
+    private onTouched: () => void;
 
     readonly dialogHeaderMap = {
         [BinaryFieldMode.URL]: 'dot.binary.field.dialog.import.from.url.header',
@@ -79,7 +95,6 @@ export class DotBinaryFieldComponent implements OnInit, AfterViewInit, OnDestroy
     readonly BinaryFieldStatus = BinaryFieldStatus;
     readonly BinaryFieldMode = BinaryFieldMode;
     readonly vm$ = this.dotBinaryFieldStore.vm$;
-
     private tempId = '';
     dialogOpen = false;
     accept: string[] = [];
@@ -97,8 +112,14 @@ export class DotBinaryFieldComponent implements OnInit, AfterViewInit, OnDestroy
 
     ngOnInit() {
         this.dotBinaryFieldStore.tempFile$.pipe(skip(1)).subscribe((tempFile) => {
-            this.tempId = tempFile?.id;
-            this.tempFile.emit(tempFile);
+            this.tempId = tempFile?.id || '';
+            this.tempFile.emit(tempFile); // We change value here
+
+            if (this.onChange) {
+                // If we have a change function we call it
+                this.onChange(this.tempId);
+                this.onTouched();
+            }
         });
 
         this.dotBinaryFieldEditImageService
@@ -120,6 +141,20 @@ export class DotBinaryFieldComponent implements OnInit, AfterViewInit, OnDestroy
         }
 
         this.cd.detectChanges();
+    }
+
+    writeValue(): void {
+        /*
+            We can set a value here but we use the fields and contentlet to set the value
+        */
+    }
+
+    registerOnChange(fn: (value: string) => void) {
+        this.onChange = fn;
+    }
+
+    registerOnTouched(fn: () => void) {
+        this.onTouched = fn;
     }
 
     ngOnDestroy() {
@@ -278,7 +313,7 @@ export class DotBinaryFieldComponent implements OnInit, AfterViewInit, OnDestroy
      * @memberof DotBinaryFieldComponent
      */
     private getFieldVariables(): Record<string, string> {
-        return this.field.fieldVariables.reduce(
+        return this.field?.fieldVariables.reduce(
             (prev, { key, value }) => ({
                 ...prev,
                 [key]: value

--- a/core-web/libs/contenttype-fields/src/lib/fields/binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.html
+++ b/core-web/libs/contenttype-fields/src/lib/fields/binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.html
@@ -63,7 +63,7 @@
 </div>
 
 <p-overlayPanel #op>
-    <div class="preview-metadata__container">
+    <div class="preview-metadata__responsive">
         <span class="preview-metadata_header">{{ file.name }}</span>
         <div *ngIf="file.width && file.height">
             {{ 'dot.binary.field.file.dimension' | dm }}:

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
@@ -20,6 +20,7 @@
         *ngSwitchCase="fieldTypes.TEXT"
         [field]="field"
         [attr.data-testId]="'field-' + field.variable" />
+
     <dot-edit-content-text-area
         *ngSwitchCase="fieldTypes.TEXTAREA"
         [field]="field"
@@ -43,6 +44,13 @@
 
     <dot-edit-content-tag-field
         *ngSwitchCase="fieldTypes.TAG"
+        [field]="field"
+        [attr.data-testId]="'field-' + field.variable" />
+
+    <dot-binary-field
+        *ngSwitchCase="fieldTypes.BINARY"
+        [formControlName]="field.variable"
+        [contentlet]="contentlet"
         [field]="field"
         [attr.data-testId]="'field-' + field.variable" />
 </ng-container>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
@@ -5,6 +5,8 @@ import { Type } from '@angular/core';
 import { ControlContainer, FormGroupDirective } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
+import { DotBinaryFieldComponent } from '@dotcms/contenttype-fields';
+
 import { DotEditContentFieldComponent } from './dot-edit-content-field.component';
 
 import { DotEditContentCalendarFieldComponent } from '../../fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component';
@@ -31,7 +33,8 @@ const FIELD_TYPES_COMPONENTS: Record<FIELD_TYPES, Type<unknown>> = {
     [FIELD_TYPES.TIME]: DotEditContentCalendarFieldComponent,
     [FIELD_TYPES.TAG]: DotEditContentTagFieldComponent,
     [FIELD_TYPES.CHECKBOX]: DotEditContentCheckboxFieldComponent,
-    [FIELD_TYPES.MULTI_SELECT]: DotEditContentMultiSelectFieldComponent
+    [FIELD_TYPES.MULTI_SELECT]: DotEditContentMultiSelectFieldComponent,
+    [FIELD_TYPES.BINARY]: DotBinaryFieldComponent
 };
 
 describe('FIELD_TYPES and FIELDS_MOCK', () => {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
@@ -2,7 +2,8 @@ import { NgIf, NgSwitch, NgSwitchCase } from '@angular/common';
 import { ChangeDetectionStrategy, Component, HostBinding, Input, inject } from '@angular/core';
 import { ControlContainer, ReactiveFormsModule } from '@angular/forms';
 
-import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
+import { DotBinaryFieldComponent } from '@dotcms/contenttype-fields';
+import { DotCMSContentTypeField, DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DotFieldRequiredDirective } from '@dotcms/ui';
 
 import { DotEditContentFieldsModule } from '../../fields/dot-edit-content-fields.module';
@@ -27,12 +28,14 @@ import { FIELD_TYPES } from '../../models/dot-edit-content-field.enum';
         NgIf,
         ReactiveFormsModule,
         DotEditContentFieldsModule,
-        DotFieldRequiredDirective
+        DotFieldRequiredDirective,
+        DotBinaryFieldComponent
     ]
 })
 export class DotEditContentFieldComponent {
     @HostBinding('class') class = 'field';
     @Input() field!: DotCMSContentTypeField;
+    @Input() contentlet!: DotCMSContentlet;
     readonly fieldTypes = FIELD_TYPES;
     readonly calendarTypes = CALENDAR_FIELD_TYPES as string[];
 }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/utils.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/utils.ts
@@ -4,5 +4,6 @@ export enum FIELD_TYPES {
     TEXTAREA = 'Textarea',
     SELECT = 'Select',
     RADIO = 'Radio',
-    CHECKBOX = 'Checkbox'
+    CHECKBOX = 'Checkbox',
+    BINARY = 'Binary'
 }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
@@ -5,6 +5,7 @@
                 <dot-edit-content-field
                     *ngFor="let field of column.fields"
                     [field]="field"
+                    [contentlet]="formData.contentlet"
                     data-testId="field" />
             </div>
         </div>

--- a/core-web/libs/edit-content/src/lib/models/dot-edit-content-field.enum.ts
+++ b/core-web/libs/edit-content/src/lib/models/dot-edit-content-field.enum.ts
@@ -18,5 +18,6 @@ export enum FIELD_TYPES {
     TIME = 'Time',
     TAG = 'Tag',
     CHECKBOX = 'Checkbox',
-    MULTI_SELECT = 'Multi-Select'
+    MULTI_SELECT = 'Multi-Select',
+    BINARY = 'Binary'
 }

--- a/core-web/libs/edit-content/src/lib/utils/mocks.ts
+++ b/core-web/libs/edit-content/src/lib/utils/mocks.ts
@@ -409,6 +409,30 @@ export const MULTI_SELECT_FIELD_MOCK: DotCMSContentTypeField = {
     variable: 'multiSelect'
 };
 
+export const BINARY_FIELD_MOCK: DotCMSContentTypeField = {
+    clazz: 'com.dotcms.contenttype.model.field.ImmutableBinaryField',
+    contentTypeId: '93ebaff75f3e3887bea73eca04588dc9',
+    dataType: 'BINARY',
+    fieldType: 'Binary',
+    fieldTypeLabel: 'Binary Field',
+    fieldVariables: [],
+    fixed: false,
+    hint: 'A hint text',
+    iDate: 1698264695000,
+    id: '535a6de288e3fe91fad2679e8d7d966b',
+    indexed: false,
+    listed: false,
+    modDate: 1698291913000,
+    name: 'Binary',
+    readOnly: false,
+    required: false,
+    searchable: false,
+    sortOrder: 3,
+    unique: false,
+    values: '/test.png',
+    variable: 'Binary'
+};
+
 export const FIELDS_MOCK: DotCMSContentTypeField[] = [
     TEXT_FIELD_MOCK,
     TEXT_AREA_FIELD_MOCK,
@@ -425,7 +449,8 @@ export const FIELDS_MOCK: DotCMSContentTypeField[] = [
     TIME_FIELD_MOCK,
     TAG_FIELD_MOCK,
     CHECKBOX_FIELD_MOCK,
-    MULTI_SELECT_FIELD_MOCK
+    MULTI_SELECT_FIELD_MOCK,
+    BINARY_FIELD_MOCK
 ];
 
 export const FIELD_MOCK: DotCMSContentTypeField = TEXT_FIELD_MOCK;

--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -265,7 +265,7 @@ dependencies {
 
     starter group: 'com.dotcms', name: 'starter', version: 'empty_20230710', ext: 'zip'
     //Uncomment this line if you want to download the starter that comes with data
-    starter group: 'com.dotcms', name: 'starter', version: '20230712', ext: 'zip'
+    //starter group: 'com.dotcms', name: 'starter', version: '20230712', ext: 'zip'
     testsStarter group: 'com.dotcms', name: 'starter', version: 'empty_20230710', ext: 'zip'
     
     profiler group: 'glowroot-custom', name: 'glowroot-agent', version: '0.13.1'

--- a/dotCMS/build.gradle
+++ b/dotCMS/build.gradle
@@ -265,7 +265,7 @@ dependencies {
 
     starter group: 'com.dotcms', name: 'starter', version: 'empty_20230710', ext: 'zip'
     //Uncomment this line if you want to download the starter that comes with data
-    //starter group: 'com.dotcms', name: 'starter', version: '20230712', ext: 'zip'
+    starter group: 'com.dotcms', name: 'starter', version: '20230712', ext: 'zip'
     testsStarter group: 'com.dotcms', name: 'starter', version: 'empty_20230710', ext: 'zip'
     
     profiler group: 'glowroot-custom', name: 'glowroot-agent', version: '0.13.1'


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 65827c9</samp>

Added support for binary fields in edit content mode. Refactored the `DotBinaryFieldComponent` to implement the `ControlValueAccessor` interface and communicate with the parent form. Updated the `DotEditContentFieldComponent` and the `DotEditContentFormComponent` to use the `DotBinaryFieldComponent` and pass the contentlet data to it. Added the `BINARY` value to the `FieldTypes` and `DotEditContentFieldTypes` enums and the field types components map. Added tests and mocks for the binary field type.

## Related Issue
Fixes #26579

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 65827c9</samp>

*  Implement the `ControlValueAccessor` interface for the `DotBinaryFieldComponent` to allow it to be used as a custom value accessor for the `FormControl` of the binary field ([link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-740e087d4ab3dc50c530488107c47d9fd0da08096e92f5459e56698387a23554L16-R19), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-740e087d4ab3dc50c530488107c47d9fd0da08096e92f5459e56698387a23554L64-R82), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-740e087d4ab3dc50c530488107c47d9fd0da08096e92f5459e56698387a23554R88-R90), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-740e087d4ab3dc50c530488107c47d9fd0da08096e92f5459e56698387a23554L82), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-740e087d4ab3dc50c530488107c47d9fd0da08096e92f5459e56698387a23554L100-R122), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-740e087d4ab3dc50c530488107c47d9fd0da08096e92f5459e56698387a23554R146-R159))
*  Remove the unused `tempFile` property from the `DotBinaryFieldComponent` class and use the `tempId` property instead to store and emit the temporary file id as the value of the binary field ([link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-740e087d4ab3dc50c530488107c47d9fd0da08096e92f5459e56698387a23554L82))
*  Add a null check for the `field` input in the `getFieldVariables` method of the `DotBinaryFieldComponent` class to prevent errors if the input is not defined or initialized ([link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-740e087d4ab3dc50c530488107c47d9fd0da08096e92f5459e56698387a23554L281-R316))
*  Make the overlay panel that shows the file metadata more responsive and adaptable to different screen sizes and orientations by replacing the `preview-metadata__container` class with the `preview-metadata__responsive` class in the `dot-binary-field-preview.component.html` template ([link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-1f4a9a7418368869300a97044d2d5333d4674f1b67425e31e58b98c8f8cd32e4L66-R66))
*  Add the `contentlet` input to the `DotEditContentFieldComponent` class and the `dot-edit-content-field.component.html` template to receive and pass the contentlet data to the child field components ([link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-f03434ad88316542a23c3fb0bf50b6650130632c3e7953d7ee3c882cb5950d06R38), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR23), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-e1699e9269f6da395f7be873c698dcd539479427c31b61e1a6ea3c15de73beb9R8))
*  Add the `dot-binary-field` component as a case for the `fieldTypes.BINARY` switch in the `dot-edit-content-field.component.html` template and bind the relevant inputs to the parent component properties ([link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR49-R55))
*  Add the `DotBinaryFieldComponent` to the testing module and the field types components map in the `dot-edit-content-field.component.ts` and `dot-edit-content-field.component.spec.ts` files ([link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-f03434ad88316542a23c3fb0bf50b6650130632c3e7953d7ee3c882cb5950d06L30-R32), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-23d2e2fd9b71e1819e10ae720cb79ecf5e4d75e51fee641b020017fe8186640fR8-R9), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-23d2e2fd9b71e1819e10ae720cb79ecf5e4d75e51fee641b020017fe8186640fL34-R37))
*  Add the `BINARY` value to the `FieldTypes` and `DotEditContentFieldTypes` enums in the `utils.ts` and `dot-edit-content-field.enum.ts` files to define the binary field type as a constant ([link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-72202882b348384879f6d696ea2c652a334c9cf4d2141b82ca531e37c8f3df2fL7-R8), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-aa72329fa1c18891b5d44042ac6ae09ff3d915621f16a084982f87d068c2453aL21-R22))
*  Add the `BINARY_FIELD_MOCK` object to the `mocks.ts` file and the `FIELDS_MOCK` array to create and include a mock binary field data for testing purposes ([link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-044e3c643ab55d05bd081afffe7251b7ebec1f4c383851aa1a219cdc626093f1R412-R435), [link](https://github.com/dotCMS/core/pull/26592/files?diff=unified&w=0#diff-044e3c643ab55d05bd081afffe7251b7ebec1f4c383851aa1a219cdc626093f1L428-R453))

#### Video

https://github.com/dotCMS/core/assets/72418962/0c7a1e4d-1548-44e6-95ac-5cca42a81f3d
