### PR TITLE
Incorrect Redirection from /c/containers to /starter URL

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.spec.ts
@@ -1,0 +1,195 @@
+import { HttpMethod, SpectatorHttp, createHttpFactory } from '@ngneat/spectator';
+import { of } from 'rxjs';
+
+import { DotMenu } from '@dotcms/app/shared/models/navigation';
+
+import { DotMenuService } from './dot-menu.service';
+
+const STATER_ANGULAR_ITEM_MOCK = {
+    ajax: false,
+    angular: true,
+    id: 'starter',
+    label: 'Welcome',
+    url: '/starter',
+    menuLink: '/starter',
+    active: false
+};
+
+const ACTIVITY_JSP_ITEM_MOCK = {
+    ajax: false,
+    angular: false,
+    id: 'c_Activities',
+    label: 'Activities',
+    url: '/c/portlet/c_Activities',
+    menuLink: '/c/c_Activities',
+    active: false
+};
+
+const ACTIVITY_MENU_ID = '71b8a1ca-37b6-4b6e-a43b-c7482f28db6c';
+
+const MENU_MOCK: DotMenu[] = [
+    {
+        id: '2df9f117-b140-44bf-93d7-5b10a36fb7f9',
+        menuItems: [STATER_ANGULAR_ITEM_MOCK],
+        name: 'Getting Started',
+        tabIcon: 'whatshot',
+        tabName: 'Getting Started',
+        url: '/starter',
+        active: false
+    } as DotMenu,
+    {
+        id: ACTIVITY_MENU_ID,
+        menuItems: [
+            ACTIVITY_JSP_ITEM_MOCK,
+            {
+                ajax: false,
+                angular: false,
+                id: 'c_Banners',
+                label: 'Banners',
+                url: '/c/portlet/c_Banners',
+                menuLink: '/c/c_Banners',
+                active: false
+            }
+        ],
+        name: 'Content',
+        tabIcon: 'format_align_left',
+        tabName: 'Content',
+        url: '/c/portal/layout?p_l_id=71b8a1ca-37b6-4b6e-a43b-c7482f28db6c&p_p_id=c_Activities&p_p_action=0&&dm_rlout=1&r=1698954909392',
+        active: false
+    } as DotMenu
+];
+
+describe('DotMenuService', () => {
+    let spectator: SpectatorHttp<DotMenuService>;
+    const createHttp = createHttpFactory(DotMenuService);
+
+    beforeEach(() => (spectator = createHttp()));
+
+    describe('loadMenu', () => {
+        it('should load menu', (done) => {
+            spectator.service.loadMenu().subscribe((menu) => {
+                expect(menu).toEqual(MENU_MOCK);
+                done();
+            });
+            spectator.expectOne('/api/v1/menu', HttpMethod.GET).flush({
+                entity: MENU_MOCK
+            });
+        });
+
+        it('should not load menu if already loaded', () => {
+            spectator.service.menu$ = of(MENU_MOCK);
+
+            spectator.service.loadMenu().subscribe(() => {
+                spectator.service.loadMenu().subscribe((menu) => {
+                    expect(menu).toEqual(MENU_MOCK);
+                });
+            });
+            spectator.controller.expectNone('/api/v1/menu');
+        });
+
+        it('should load menu if the param `force` is passed even if it is already loaded', () => {
+            spectator.service.menu$ = of([MENU_MOCK[0]]);
+
+            spectator.service.loadMenu(true).subscribe(() => {
+                spectator.service.loadMenu().subscribe((menu) => {
+                    expect(menu).toEqual(MENU_MOCK);
+                });
+            });
+            spectator.expectOne('/api/v1/menu', HttpMethod.GET).flush({
+                entity: MENU_MOCK
+            });
+        });
+    });
+
+    describe('getUrlById', () => {
+        it('should get URL of JSP menu item', (done) => {
+            spyOn(spectator.service, 'loadMenu').and.returnValue(of(MENU_MOCK));
+
+            spectator.service.getUrlById(ACTIVITY_JSP_ITEM_MOCK.id).subscribe((url) => {
+                expect(url).toEqual(ACTIVITY_JSP_ITEM_MOCK.url);
+                done();
+            });
+        });
+
+        it('should not return anything if the menu item is an Angular URL', (done) => {
+            spyOn(spectator.service, 'loadMenu').and.returnValue(of(MENU_MOCK));
+
+            spectator.service.getUrlById(STATER_ANGULAR_ITEM_MOCK.id).subscribe((url) => {
+                expect(url).toBe('');
+                done();
+            });
+        });
+    });
+
+    describe('isPortletInMenu', () => {
+        it('should return true if the menu item is in the menu', (done) => {
+            spyOn(spectator.service, 'loadMenu').and.returnValue(of(MENU_MOCK));
+
+            spectator.service.isPortletInMenu(ACTIVITY_JSP_ITEM_MOCK.id).subscribe((isInMenu) => {
+                expect(isInMenu).toBe(true);
+                done();
+            });
+        });
+
+        it('should return false if the menu item is not in the menu', (done) => {
+            spyOn(spectator.service, 'loadMenu').and.returnValue(of(MENU_MOCK));
+
+            spectator.service.isPortletInMenu(ACTIVITY_JSP_ITEM_MOCK.id).subscribe((isInMenu) => {
+                expect(isInMenu).toBe(true);
+                done();
+            });
+        });
+
+        describe('JSPPortlet', () => {
+            it('should return true if the menu item is in the menu and is a JSP Portlet', (done) => {
+                spyOn(spectator.service, 'loadMenu').and.returnValue(of(MENU_MOCK));
+
+                spectator.service
+                    .isPortletInMenu(ACTIVITY_JSP_ITEM_MOCK.id, true)
+                    .subscribe((isInMenu) => {
+                        expect(isInMenu).toBe(true);
+                        done();
+                    });
+            });
+
+            it('should return false if the menu item is not in the menu and is a JSP Portlet', (done) => {
+                spyOn(spectator.service, 'loadMenu').and.returnValue(of(MENU_MOCK));
+
+                spectator.service
+                    .isPortletInMenu(STATER_ANGULAR_ITEM_MOCK.id, true)
+                    .subscribe((isInMenu) => {
+                        expect(isInMenu).toBe(false);
+                        done();
+                    });
+            });
+        });
+    });
+
+    describe('reloadMenu', () => {
+        it('should set menu items to null and force reaload', (done) => {
+            spectator.service.menu$ = of([MENU_MOCK[0]]);
+
+            spectator.service.reloadMenu().subscribe((menu) => {
+                expect(menu).toEqual(MENU_MOCK);
+                done();
+            });
+
+            spectator.expectOne('/api/v1/menu', HttpMethod.GET).flush({
+                entity: MENU_MOCK
+            });
+        });
+    });
+
+    describe('getDotMenuId', () => {
+        it('should return the id of the menu', (done) => {
+            spyOn(spectator.service, 'loadMenu').and.returnValue(of(MENU_MOCK));
+
+            spectator.service.getDotMenuId(ACTIVITY_JSP_ITEM_MOCK.id).subscribe((id) => {
+                expect(id).toBe(ACTIVITY_MENU_ID);
+                done();
+            });
+        });
+    });
+
+    afterEach(() => spectator.controller.verify());
+});

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.ts
@@ -47,25 +47,17 @@ export class DotMenuService {
      * @returns Observable<boolean>
      * @memberof DotMenuService
      */
-    isPortletInMenu(menuId: string): Observable<boolean> {
+    isPortletInMenu(menuId: string, checkJSPPortlet: boolean = false): Observable<boolean> {
         return this.getMenuItems().pipe(
-            pluck('id'),
-            map((id: string) => menuId === id),
-            filter((val) => !!val),
-            defaultIfEmpty(false)
-        );
-    }
+            map(({ id, angular }) => {
+                const idMatch = id === menuId;
+                // Check if the JSP Portlet is in the menu and hasn't been migrated to Angular
+                if (checkJSPPortlet) {
+                    return idMatch && !angular;
+                }
 
-    /**
-     * Check if the JSP Portlet is in the menu and hasn't been migrated to Angular
-     *
-     * @param {string} menuId
-     * @return {*}  {Observable<boolean>}
-     * @memberof DotMenuService
-     */
-    isJSPPortletInMenu(menuId: string): Observable<boolean> {
-        return this.getMenuItems().pipe(
-            map(({ id, angular }) => id === menuId && !angular),
+                return idMatch;
+            }),
             filter((val) => !!val),
             defaultIfEmpty(false)
         );

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.ts
@@ -57,6 +57,21 @@ export class DotMenuService {
     }
 
     /**
+     * Check if the JSP Portlet is in the menu and hasn't been migrated to Angular
+     *
+     * @param {string} menuId
+     * @return {*}  {Observable<boolean>}
+     * @memberof DotMenuService
+     */
+    isJSPPortletInMenu(menuId: string): Observable<boolean> {
+        return this.getMenuItems().pipe(
+            map(({ id, angular }) => id === menuId && !angular),
+            filter((val) => !!val),
+            defaultIfEmpty(false)
+        );
+    }
+
+    /**
      * Load and set menu from endpoint
      * @param boolean force
      * @returns Observable<DotMenu[]>

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.ts
@@ -7,7 +7,6 @@ import {
     defaultIfEmpty,
     filter,
     find,
-    first,
     map,
     mergeMap,
     pluck,
@@ -35,8 +34,8 @@ export class DotMenuService {
     getUrlById(id: string): Observable<string> {
         return this.getMenuItems().pipe(
             filter((res: DotMenuItem) => !res.angular && res.id === id),
-            first(),
-            pluck('url')
+            pluck('url'),
+            defaultIfEmpty('')
         );
     }
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-menu.service.ts
@@ -1,6 +1,7 @@
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
 
 import {
     defaultIfEmpty,
@@ -14,16 +15,15 @@ import {
     refCount
 } from 'rxjs/operators';
 
-import { CoreWebService } from '@dotcms/dotcms-js';
+import { DotCMSResponse } from '@dotcms/dotcms-js';
 import { DotMenu, DotMenuItem } from '@models/navigation';
 
 @Injectable()
 export class DotMenuService {
     menu$: Observable<DotMenu[]>;
 
-    private urlMenus = 'v1/menu';
-
-    constructor(private coreWebService: CoreWebService) {}
+    private urlMenus = '/api/v1/menu';
+    private readonly http = inject(HttpClient);
 
     /**
      * Get the url for the iframe porlet from the menu object
@@ -71,10 +71,8 @@ export class DotMenuService {
      */
     loadMenu(force = false): Observable<DotMenu[]> {
         if (!this.menu$ || force) {
-            this.menu$ = this.coreWebService
-                .requestView({
-                    url: this.urlMenus
-                })
+            this.menu$ = this.http
+                .get<DotCMSResponse<DotMenu>>(this.urlMenus)
                 .pipe(publishLast(), refCount(), pluck('entity'));
         }
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-router/dot-router.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-router/dot-router.service.spec.ts
@@ -205,6 +205,14 @@ describe('DotRouterService', () => {
         expect(service.isJSPPortlet()).toBeTruthy();
     });
 
+    it('should return true if the URL is pointing to a portlet is jsp', () => {
+        expect(service.isJSPPortletURL('/c/test')).toBeTruthy();
+    });
+
+    it('should return false if the URL is not pointing to a portlet is jsp', () => {
+        expect(service.isJSPPortletURL('/test')).toBeFalsy();
+    });
+
     it('should return true if edit page url', () => {
         router.routerState.snapshot.url = 'edit-page';
         expect(service.isEditPage()).toBe(true);

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-router/dot-router.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-router/dot-router.service.ts
@@ -298,6 +298,15 @@ export class DotRouterService {
     }
 
     /**
+     * Check if a URL is pointing to a JSP/iframe page
+     * @returns boolean
+     * @memberof DotRouterService
+     */
+    isJSPPortletURL(url): boolean {
+        return url.startsWith('/c/');
+    }
+
+    /**
      * Check if the current route is an edit page
      *
      * @returns boolean

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/menu-guard.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/menu-guard.service.spec.ts
@@ -1,15 +1,16 @@
 import { of as observableOf } from 'rxjs';
 
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 
 import { DotNavigationService } from '@components/dot-navigation/services/dot-navigation.service';
-import { DOTTestBed } from '@dotcms/app/test/dot-test-bed';
 
 import { MenuGuardService } from './menu-guard.service';
 
 import { DotMenuService } from '../dot-menu.service';
+import { DotRouterService } from '../dot-router/dot-router.service';
 
 @Injectable()
 class MockDotMenuService {
@@ -27,13 +28,22 @@ describe('ValidMenuGuardService', () => {
     let menuGuardService: MenuGuardService;
     let dotMenuService: DotMenuService;
     let dotNavigationService: DotNavigationService;
+    let dotRouterService: DotRouterService;
     let mockRouterStateSnapshot: RouterStateSnapshot;
     let mockActivatedRouteSnapshot: ActivatedRouteSnapshot;
 
     beforeEach(() => {
-        DOTTestBed.configureTestingModule({
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
             providers: [
                 MenuGuardService,
+                {
+                    provide: DotRouterService,
+                    useValue: {
+                        getPortletId: () => 'test',
+                        isJSPPortletURL: () => false
+                    }
+                },
                 { provide: DotMenuService, useClass: MockDotMenuService },
                 {
                     provide: DotNavigationService,
@@ -42,9 +52,10 @@ describe('ValidMenuGuardService', () => {
             ]
         });
 
-        menuGuardService = TestBed.get(MenuGuardService);
-        dotMenuService = TestBed.get(DotMenuService);
-        dotNavigationService = TestBed.get(DotNavigationService);
+        menuGuardService = TestBed.inject(MenuGuardService);
+        dotMenuService = TestBed.inject(DotMenuService);
+        dotRouterService = TestBed.inject(DotRouterService);
+        dotNavigationService = TestBed.inject(DotNavigationService);
         mockRouterStateSnapshot = jasmine.createSpyObj<RouterStateSnapshot>('RouterStateSnapshot', [
             'toString'
         ]);
@@ -61,7 +72,7 @@ describe('ValidMenuGuardService', () => {
         menuGuardService
             .canActivate(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
             .subscribe((res) => (result = res));
-        expect(dotMenuService.isPortletInMenu).toHaveBeenCalledWith('test');
+        expect(dotMenuService.isPortletInMenu).toHaveBeenCalledWith('test', false);
         expect(result).toBe(true);
     });
 
@@ -72,7 +83,7 @@ describe('ValidMenuGuardService', () => {
         menuGuardService
             .canActivate(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
             .subscribe((res) => (result = res));
-        expect(dotMenuService.isPortletInMenu).toHaveBeenCalledWith('test');
+        expect(dotMenuService.isPortletInMenu).toHaveBeenCalledWith('test', false);
         expect(dotNavigationService.goToFirstPortlet).toHaveBeenCalled();
         expect(result).toBe(false);
     });
@@ -84,7 +95,7 @@ describe('ValidMenuGuardService', () => {
         menuGuardService
             .canActivateChild(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
             .subscribe((res) => (result = res));
-        expect(dotMenuService.isPortletInMenu).toHaveBeenCalledWith('test');
+        expect(dotMenuService.isPortletInMenu).toHaveBeenCalledWith('test', false);
         expect(result).toBe(true);
     });
 
@@ -95,8 +106,43 @@ describe('ValidMenuGuardService', () => {
         menuGuardService
             .canActivateChild(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
             .subscribe((res) => (result = res));
-        expect(dotMenuService.isPortletInMenu).toHaveBeenCalledWith('test');
+        expect(dotMenuService.isPortletInMenu).toHaveBeenCalledWith('test', false);
         expect(dotNavigationService.goToFirstPortlet).toHaveBeenCalled();
         expect(result).toBe(false);
+    });
+
+    describe('JSPPortlet', () => {
+        beforeEach(() => {
+            spyOn(dotRouterService, 'isJSPPortletURL').and.returnValue(true);
+            mockRouterStateSnapshot.url = '/c/test';
+        });
+
+        it('should allow children access to Menu Portlets if JSPPortlet is in menu', (done) => {
+            const spy = spyOn(dotMenuService, 'isPortletInMenu').and.returnValue(
+                observableOf(true)
+            );
+            menuGuardService
+                .canActivateChild(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
+                .subscribe((res) => {
+                    expect(res).toBe(true);
+                    done();
+                });
+            expect(spy).toHaveBeenCalledWith('test', true);
+            expect(dotNavigationService.goToFirstPortlet).not.toHaveBeenCalled();
+        });
+
+        it('should prevent children access to Menu Portlets if JSPPortlet is in menu', (done) => {
+            const spy = spyOn(dotMenuService, 'isPortletInMenu').and.returnValue(
+                observableOf(false)
+            );
+            menuGuardService
+                .canActivateChild(mockActivatedRouteSnapshot, mockRouterStateSnapshot)
+                .subscribe((res) => {
+                    expect(res).toBe(false);
+                    done();
+                });
+            expect(spy).toHaveBeenCalledWith('test', true);
+            expect(dotNavigationService.goToFirstPortlet).toHaveBeenCalled();
+        });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/menu-guard.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/menu-guard.service.ts
@@ -22,14 +22,14 @@ export class MenuGuardService implements CanActivate {
     ) {}
 
     canActivate(_route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
-        return this.canAccessPortlet(this.dotRouterService.getPortletId(state.url));
+        return this.canAccessPortlet(state.url);
     }
 
     canActivateChild(
         _route: ActivatedRouteSnapshot,
         state: RouterStateSnapshot
     ): Observable<boolean> {
-        return this.canAccessPortlet(this.dotRouterService.getPortletId(state.url));
+        return this.canAccessPortlet(state.url);
     }
 
     /**
@@ -39,7 +39,14 @@ export class MenuGuardService implements CanActivate {
      * @returns boolean
      */
     private canAccessPortlet(url: string): Observable<boolean> {
-        return this.dotMenuService.isPortletInMenu(url).pipe(
+        const id = this.dotRouterService.getPortletId(url);
+        const isJSPortlet = this.dotRouterService.isJSPPortletURL(url);
+
+        const obs$ = isJSPortlet
+            ? this.dotMenuService.isPortletInMenu(id)
+            : this.dotMenuService.isJSPPortletInMenu(id);
+
+        return obs$.pipe(
             map((isValidPortlet) => {
                 if (!isValidPortlet) {
                     this.dotNavigationService.goToFirstPortlet();

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/menu-guard.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/menu-guard.service.ts
@@ -40,13 +40,9 @@ export class MenuGuardService implements CanActivate {
      */
     private canAccessPortlet(url: string): Observable<boolean> {
         const id = this.dotRouterService.getPortletId(url);
-        const isJSPortlet = this.dotRouterService.isJSPPortletURL(url);
+        const checkJSPPortlet = this.dotRouterService.isJSPPortletURL(url);
 
-        const obs$ = isJSPortlet
-            ? this.dotMenuService.isPortletInMenu(id)
-            : this.dotMenuService.isJSPPortletInMenu(id);
-
-        return obs$.pipe(
+        return this.dotMenuService.isPortletInMenu(id, checkJSPPortlet).pipe(
             map((isValidPortlet) => {
                 if (!isValidPortlet) {
                     this.dotNavigationService.goToFirstPortlet();

--- a/core-web/apps/dotcms-ui/src/app/app-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/app-routing.module.ts
@@ -72,8 +72,6 @@ const PORTLETS_ANGULAR = [
             import('@portlets/dot-rules/dot-rules.module').then((m) => m.DotRulesModule)
     },
     {
-        // canActivate: [MenuGuardService],
-        // canActivateChild: [MenuGuardService],
         path: 'starter',
         loadChildren: () =>
             import('@portlets/dot-starter/dot-starter.module').then((m) => m.DotStarterModule)


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4bb6135</samp>

This pull request enhances the portlet access and navigation logic in the Angular UI. It adds methods to check and handle JSP portlets in the `DotMenuService` and `DotRouterService` classes, and removes redundant guards from the `app-routing.module.ts` file.

## Related Issue
Fixes #26591

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4bb6135</samp>

*  Add methods to check and handle JSP portlets in the Angular UI ([link](https://github.com/dotCMS/core/pull/26600/files?diff=unified&w=0#diff-6d1086b6ba6f8165deecbdc80ac9408a311b0b72781c89d3979b225a226f046aR60-R74), [link](https://github.com/dotCMS/core/pull/26600/files?diff=unified&w=0#diff-2432708add2f5b24358dc73b05b3ecef1ac4ee887a9b6fcceb921a78c4cdbb3fR301-R309))
*  Modify menu guard service to validate both JSP and Angular portlets based on the URL format ([link](https://github.com/dotCMS/core/pull/26600/files?diff=unified&w=0#diff-a07f00854e314aa8a377d9262fd3668528d42de2103fc6d6e2763c79045ded75L25-R25), [link](https://github.com/dotCMS/core/pull/26600/files?diff=unified&w=0#diff-a07f00854e314aa8a377d9262fd3668528d42de2103fc6d6e2763c79045ded75L32-R32), [link](https://github.com/dotCMS/core/pull/26600/files?diff=unified&w=0#diff-a07f00854e314aa8a377d9262fd3668528d42de2103fc6d6e2763c79045ded75L42-R49))
*  Simplify routing module by removing unnecessary guards from the Angular portlet routes ([link](https://github.com/dotCMS/core/pull/26600/files?diff=unified&w=0#diff-6c7f381c5033c96909090cb6d24c4507c999ed3ccec1ec3b74958152f21a572fL75-L76))

#### Video

https://github.com/dotCMS/core/assets/72418962/05cb2941-d711-4bd7-9ea1-ebe97ab0d224

