### PR TITLE
test:  non null context breaking unit tests

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/util/ConfigTestHelper.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/util/ConfigTestHelper.java
@@ -82,7 +82,6 @@ public class ConfigTestHelper extends Config {
 
 
             Config.CONTEXT = context;
-            Config.CONTEXT_PATH = context.getRealPath("/");
 
         }
 

--- a/dotCMS/src/main/java/com/dotmarketing/listeners/ContextLifecycleListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/listeners/ContextLifecycleListener.java
@@ -66,7 +66,7 @@ public class ContextLifecycleListener implements ServletContextListener {
         String path = null;
 		try {
 
-            String contextPath = Config.CONTEXT_PATH;
+            String contextPath = Config.CONTEXT.getRealPath("/");
             if ( !contextPath.endsWith( File.separator ) ) {
                 contextPath += File.separator;
             }

--- a/dotCMS/src/main/java/com/dotmarketing/util/Config.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Config.java
@@ -80,7 +80,6 @@ public class Config {
 
     //Object Config properties      n
     public static javax.servlet.ServletContext CONTEXT = null;
-    public static String CONTEXT_PATH = null;
 
 
     //Config internal properties
@@ -748,7 +747,6 @@ public class Config {
      */
     public static void setMyApp(javax.servlet.ServletContext myApp) {
         CONTEXT = myApp;
-        CONTEXT_PATH = myApp.getRealPath("/");
     }
 
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/ResourceCollectorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ResourceCollectorUtil.java
@@ -186,7 +186,7 @@ public class ResourceCollectorUtil {
         boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
 
         //Getting the context path
-        String contextPath = Config.CONTEXT_PATH;
+        String contextPath = Config.CONTEXT.getRealPath("/");
         if ( !contextPath.endsWith( File.separator ) ) {
             contextPath += File.separator;
         }

--- a/dotCMS/src/main/java/com/liferay/util/FileUtil.java
+++ b/dotCMS/src/main/java/com/liferay/util/FileUtil.java
@@ -449,7 +449,7 @@ public class FileUtil {
 			return ret;
 		}
 
-		String base = Config.CONTEXT_PATH;
+		String base = Config.CONTEXT.getRealPath("/");
 		base = (base.lastIndexOf(File.separatorChar) == base.length()-1) ? base.substring(0, base.lastIndexOf(File.separatorChar)) : base;
 		relativePath = relativePath.replace('/', File.separatorChar);
 

--- a/dotCMS/src/test/java/com/dotcms/auth/providers/jwt/factories/SecretKeySpecFactoryTest.java
+++ b/dotCMS/src/test/java/com/dotcms/auth/providers/jwt/factories/SecretKeySpecFactoryTest.java
@@ -39,118 +39,121 @@ public class SecretKeySpecFactoryTest extends UnitTestBase {
         PowerMockito.mockStatic(ClusterFactory.class);
         PowerMockito.when(ClusterFactory.getClusterId()).thenReturn(clusterId);
         Config.CONTEXT = mock(ServletContext.class);
-        Config.CONTEXT_PATH = "/tmp";
-        final FileAssetAPI fileAssetAPI = mock(FileAssetAPI.class);
-        when(fileAssetAPI.getRealAssetsRootPath()).thenReturn("/tmp/assets");
+        try {
+            final FileAssetAPI fileAssetAPI = mock(FileAssetAPI.class);
+            when(fileAssetAPI.getRealAssetsRootPath()).thenReturn("/tmp/assets");
 
-        final KeyFactoryUtils keyFactoryUtils = KeyFactoryUtils.getInstance(fileAssetAPI);
+            final KeyFactoryUtils keyFactoryUtils = KeyFactoryUtils.getInstance(fileAssetAPI);
 
-        //First make sure to delete any existing secret file
-        cleanUp(keyFactoryUtils);
+            //First make sure to delete any existing secret file
+            cleanUp(keyFactoryUtils);
 
-        //----------------------------------
-        // 1) NO setting a json.web.token.hash.signing.key property
-        Assert.assertFalse(keyFactoryUtils.existSecretFile());
-        //Creating a new instance of our Key factory
-        new SecretKeySpecFactoryImpl().getKey();
-        Assert.assertTrue(keyFactoryUtils.existSecretFile());
-        final String secret1 = keyFactoryUtils.readSecretFromDisk();
-        Assert.assertNotNull(secret1);
-        System.out.println(secret1);
-        //Clean up
-        cleanUp(keyFactoryUtils);
+            //----------------------------------
+            // 1) NO setting a json.web.token.hash.signing.key property
+            Assert.assertFalse(keyFactoryUtils.existSecretFile());
+            //Creating a new instance of our Key factory
+            new SecretKeySpecFactoryImpl().getKey();
+            Assert.assertTrue(keyFactoryUtils.existSecretFile());
+            final String secret1 = keyFactoryUtils.readSecretFromDisk();
+            Assert.assertNotNull(secret1);
+            System.out.println(secret1);
+            //Clean up
+            cleanUp(keyFactoryUtils);
 
-        //----------------------------------
-        // 2) Setting a json.web.token.hash.signing.key property
-        Assert.assertFalse(keyFactoryUtils.existSecretFile());
-        final String mySecretKey2 = "MySecretKey2";
-        Config.setProperty("json.web.token.hash.signing.key", mySecretKey2);
-        //Creating a new instance of our Key factory
-        new SecretKeySpecFactoryImpl().getKey();
-        Assert.assertTrue(keyFactoryUtils.existSecretFile());
-        //Make sure we wrote properly the secret
-        final String secret2 = keyFactoryUtils.readSecretFromDisk();
-        Assert.assertNotNull(secret2);
-        System.out.println(secret2);
-        Assert.assertEquals(secret2, mySecretKey2);
+            //----------------------------------
+            // 2) Setting a json.web.token.hash.signing.key property
+            Assert.assertFalse(keyFactoryUtils.existSecretFile());
+            final String mySecretKey2 = "MySecretKey2";
+            Config.setProperty("json.web.token.hash.signing.key", mySecretKey2);
+            //Creating a new instance of our Key factory
+            new SecretKeySpecFactoryImpl().getKey();
+            Assert.assertTrue(keyFactoryUtils.existSecretFile());
+            //Make sure we wrote properly the secret
+            final String secret2 = keyFactoryUtils.readSecretFromDisk();
+            Assert.assertNotNull(secret2);
+            System.out.println(secret2);
+            Assert.assertEquals(secret2, mySecretKey2);
 
-        //----------------------------------
-        // 3) Setting a new json.web.token.hash.signing.key property with an existing secret file
-        Assert.assertTrue(keyFactoryUtils.existSecretFile());
-        String oldSecret = keyFactoryUtils.readSecretFromDisk();
-        Assert.assertEquals(mySecretKey2, oldSecret);
-        final String mySecretKey3 = "MySecretKey3";
-        Config.setProperty("json.web.token.hash.signing.key", mySecretKey3);
-        //Creating a new instance of our Key factory
-        new SecretKeySpecFactoryImpl().getKey();
-        Assert.assertTrue(keyFactoryUtils.existSecretFile());
-        //Make sure we wrote properly the secret
-        final String secret3 = keyFactoryUtils.readSecretFromDisk();
-        Assert.assertNotNull(secret3);
-        System.out.println(secret3);
-        Assert.assertEquals(secret3, mySecretKey3);
+            //----------------------------------
+            // 3) Setting a new json.web.token.hash.signing.key property with an existing secret file
+            Assert.assertTrue(keyFactoryUtils.existSecretFile());
+            String oldSecret = keyFactoryUtils.readSecretFromDisk();
+            Assert.assertEquals(mySecretKey2, oldSecret);
+            final String mySecretKey3 = "MySecretKey3";
+            Config.setProperty("json.web.token.hash.signing.key", mySecretKey3);
+            //Creating a new instance of our Key factory
+            new SecretKeySpecFactoryImpl().getKey();
+            Assert.assertTrue(keyFactoryUtils.existSecretFile());
+            //Make sure we wrote properly the secret
+            final String secret3 = keyFactoryUtils.readSecretFromDisk();
+            Assert.assertNotNull(secret3);
+            System.out.println(secret3);
+            Assert.assertEquals(secret3, mySecretKey3);
 
-        //----------------------------------
-        // 4) NO Setting a json.web.token.hash.signing.key property with an existing secret file
-        Assert.assertTrue(keyFactoryUtils.existSecretFile());
-        oldSecret = keyFactoryUtils.readSecretFromDisk();
-        Assert.assertEquals(mySecretKey3, oldSecret);
-        //Creating a new instance of our Key factory
-        new SecretKeySpecFactoryImpl().getKey();
-        Assert.assertTrue(keyFactoryUtils.existSecretFile());
-        //Make sure we wrote properly the secret
-        final String secret4 = keyFactoryUtils.readSecretFromDisk();
-        Assert.assertNotNull(secret4);
-        System.out.println(secret4);
-        Assert.assertEquals(secret4, mySecretKey3);
-        //Clean up
-        cleanUp(keyFactoryUtils);
+            //----------------------------------
+            // 4) NO Setting a json.web.token.hash.signing.key property with an existing secret file
+            Assert.assertTrue(keyFactoryUtils.existSecretFile());
+            oldSecret = keyFactoryUtils.readSecretFromDisk();
+            Assert.assertEquals(mySecretKey3, oldSecret);
+            //Creating a new instance of our Key factory
+            new SecretKeySpecFactoryImpl().getKey();
+            Assert.assertTrue(keyFactoryUtils.existSecretFile());
+            //Make sure we wrote properly the secret
+            final String secret4 = keyFactoryUtils.readSecretFromDisk();
+            Assert.assertNotNull(secret4);
+            System.out.println(secret4);
+            Assert.assertEquals(secret4, mySecretKey3);
+            //Clean up
+            cleanUp(keyFactoryUtils);
 
-        //----------------------------------
-        // 5) Again, NO property and NO file
-        Assert.assertFalse(keyFactoryUtils.existSecretFile());
-        //Creating a new instance of our Key factory
-        new SecretKeySpecFactoryImpl().getKey();
-        Assert.assertTrue(keyFactoryUtils.existSecretFile());
-        final String secret5 = keyFactoryUtils.readSecretFromDisk();
-        Assert.assertNotNull(secret5);
-        System.out.println(secret5);
-        Assert.assertNotEquals(secret5, mySecretKey3);
-        //Clean up
-        cleanUp(keyFactoryUtils);
+            //----------------------------------
+            // 5) Again, NO property and NO file
+            Assert.assertFalse(keyFactoryUtils.existSecretFile());
+            //Creating a new instance of our Key factory
+            new SecretKeySpecFactoryImpl().getKey();
+            Assert.assertTrue(keyFactoryUtils.existSecretFile());
+            final String secret5 = keyFactoryUtils.readSecretFromDisk();
+            Assert.assertNotNull(secret5);
+            System.out.println(secret5);
+            Assert.assertNotEquals(secret5, mySecretKey3);
+            //Clean up
+            cleanUp(keyFactoryUtils);
 
-        //----------------------------------
-        // 6) Setting the default value to the json.web.token.hash.signing.key property and NO file
-        Assert.assertFalse(keyFactoryUtils.existSecretFile());
-        final String mySecretKey6 = SecretKeySpecFactoryImpl.DEFAULT_SECRET;
-        Config.setProperty("json.web.token.hash.signing.key", mySecretKey6);
-        //Creating a new instance of our Key factory
-        new SecretKeySpecFactoryImpl().getKey();
-        Assert.assertTrue(keyFactoryUtils.existSecretFile());
-        //Make sure we wrote properly the secret
-        final String secret6 = keyFactoryUtils.readSecretFromDisk();
-        Assert.assertNotNull(secret6);
-        System.out.println(secret6);
-        Assert.assertNotEquals(secret6, mySecretKey6);
-        //Clean up
-        cleanUp(keyFactoryUtils);
+            //----------------------------------
+            // 6) Setting the default value to the json.web.token.hash.signing.key property and NO file
+            Assert.assertFalse(keyFactoryUtils.existSecretFile());
+            final String mySecretKey6 = SecretKeySpecFactoryImpl.DEFAULT_SECRET;
+            Config.setProperty("json.web.token.hash.signing.key", mySecretKey6);
+            //Creating a new instance of our Key factory
+            new SecretKeySpecFactoryImpl().getKey();
+            Assert.assertTrue(keyFactoryUtils.existSecretFile());
+            //Make sure we wrote properly the secret
+            final String secret6 = keyFactoryUtils.readSecretFromDisk();
+            Assert.assertNotNull(secret6);
+            System.out.println(secret6);
+            Assert.assertNotEquals(secret6, mySecretKey6);
+            //Clean up
+            cleanUp(keyFactoryUtils);
 
-        //----------------------------------
-        // 7) Setting the default value to the file
-        Assert.assertFalse(keyFactoryUtils.existSecretFile());
-        final String mySecretKey7 = SecretKeySpecFactoryImpl.DEFAULT_SECRET;
-        keyFactoryUtils.writeSecretToDisk(mySecretKey7);
-        //Creating a new instance of our Key factory
-        new SecretKeySpecFactoryImpl().getKey();
-        Assert.assertTrue(keyFactoryUtils.existSecretFile());
-        //Make sure we wrote properly the secret
-        final String secret7 = keyFactoryUtils.readSecretFromDisk();
-        Assert.assertNotNull(secret7);
-        System.out.println(secret7);
-        Assert.assertNotEquals(secret7, mySecretKey7);
+            //----------------------------------
+            // 7) Setting the default value to the file
+            Assert.assertFalse(keyFactoryUtils.existSecretFile());
+            final String mySecretKey7 = SecretKeySpecFactoryImpl.DEFAULT_SECRET;
+            keyFactoryUtils.writeSecretToDisk(mySecretKey7);
+            //Creating a new instance of our Key factory
+            new SecretKeySpecFactoryImpl().getKey();
+            Assert.assertTrue(keyFactoryUtils.existSecretFile());
+            //Make sure we wrote properly the secret
+            final String secret7 = keyFactoryUtils.readSecretFromDisk();
+            Assert.assertNotNull(secret7);
+            System.out.println(secret7);
+            Assert.assertNotEquals(secret7, mySecretKey7);
 
-        //Clean up
-        cleanUp(keyFactoryUtils);
+            //Clean up
+            cleanUp(keyFactoryUtils);
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     private void cleanUp(KeyFactoryUtils keyFactoryUtils) {

--- a/dotCMS/src/test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIHelperTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIHelperTest.java
@@ -37,32 +37,35 @@ public class ESContentletAPIHelperTest extends UnitTestBase {
 
         this.initMessages();
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            doAnswer(new Answer<Void>() { // if this method is called, should fail
 
-        doAnswer(new Answer<Void>() { // if this method is called, should fail
+                @Override
+                public Void answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
+                    testGenerateNotificationStartDeleting = true;
+                    return null;
+                }
+            }).when(notificationAPI).generateNotification(
+                    new I18NMessage("notification.escontentelet.cannotdelete.info.title"), //"Contentlet Notification"),
+                    new I18NMessage("notification.escontentelet.cannotdelete.info.message.", "iFieldNode1"),
+                    null,
+                    NotificationLevel.ERROR,
+                    NotificationType.GENERIC,
+                    "admin@dotcms.com",
+                    locale
+            );
 
-                testGenerateNotificationStartDeleting = true;
-                return null;
-            }
-        }).when(notificationAPI).generateNotification(
-                new I18NMessage("notification.escontentelet.cannotdelete.info.title"), //"Contentlet Notification"),
-                new I18NMessage("notification.escontentelet.cannotdelete.info.message.", "iFieldNode1"),
-                null,
-                NotificationLevel.ERROR,
-                NotificationType.GENERIC,
-                "admin@dotcms.com",
-                locale
-        );
-
-        esContentletAPIHelper.generateNotificationCanNotDelete
-                (notificationAPI, locale,
-                        "admin@dotcms.com", "iFieldNode1");
+            esContentletAPIHelper.generateNotificationCanNotDelete
+                    (notificationAPI, locale,
+                            "admin@dotcms.com", "iFieldNode1");
 
 
-        assertTrue(this.testGenerateNotificationStartDeleting);
+            assertTrue(this.testGenerateNotificationStartDeleting);
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/rest/RestUtilTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/RestUtilTest.java
@@ -77,13 +77,20 @@ public abstract class RestUtilTest extends UnitTestBase {
         };
 
         Config.CONTEXT=context;
+
         when(context.getInitParameter("company_id")).thenReturn(DEFAULT_COMPANY);
 
         LogMapper mockLogMapper = mock(LogMapper.class);
         when ( mockLogMapper.isLogEnabled( any() ) ).thenReturn( false );
 
         LogMapper.setLogMapper( mockLogMapper );
+
     }
+
+    public static void cleanupContext(){
+        Config.CONTEXT=null;
+    }
+
 
     public static WebResource getMockWebResource(final User user, final HttpServletRequest req) {
         WebResource webResource  = mock(WebResource.class);

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/authentication/AuthenticationResourceTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/authentication/AuthenticationResourceTest.java
@@ -105,41 +105,46 @@ public class AuthenticationResourceTest extends UnitTestBase {
         final ServletContext context = mock(ServletContext.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(
+                    userId,
+                    pass,
+                    false,
+                    request,
+                    response))
+                    .thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(
-                userId,
-                pass,
-                false,
-                request,
-                response))
-                .thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new NoSuchUserException();
-            }
-        });
+                    throw new NoSuchUserException();
+                }
+            });
 
 
-        final AuthenticationResource authenticationResource =
-                new AuthenticationResource(loginService, userLocalManager, responseUtil, authenticationHelper);
-        final AuthenticationForm authenticationForm =
-                new AuthenticationForm.Builder().userId(userId).password(pass).build();
+            final AuthenticationResource authenticationResource =
+                    new AuthenticationResource(loginService, userLocalManager, responseUtil, authenticationHelper);
+            final AuthenticationForm authenticationForm =
+                    new AuthenticationForm.Builder().userId(userId).password(pass).build();
 
-        final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
+            final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
+
 
     @Test
     public void testUserEmailAddressException() throws Exception {
@@ -157,34 +162,38 @@ public class AuthenticationResourceTest extends UnitTestBase {
         final ServletContext context = mock(ServletContext.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new UserEmailAddressException();
-            }
-        });
+                    throw new UserEmailAddressException();
+                }
+            });
 
 
-        final AuthenticationResource authenticationResource =
-                new AuthenticationResource(loginService, userLocalManager, responseUtil, authenticationHelper);
-        final AuthenticationForm authenticationForm =
-                new AuthenticationForm.Builder().userId(userId).password(pass).build();
+            final AuthenticationResource authenticationResource =
+                    new AuthenticationResource(loginService, userLocalManager, responseUtil, authenticationHelper);
+            final AuthenticationForm authenticationForm =
+                    new AuthenticationForm.Builder().userId(userId).password(pass).build();
 
-        final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
+            final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -202,34 +211,37 @@ public class AuthenticationResourceTest extends UnitTestBase {
         final ServletContext context = mock(ServletContext.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new AuthException();
-            }
-        });
+                    throw new AuthException();
+                }
+            });
 
 
-        final AuthenticationResource authenticationResource =
-                new AuthenticationResource(loginService, userLocalManager, ResponseUtil.INSTANCE,  authenticationHelper);
-        final AuthenticationForm authenticationForm =
-                new AuthenticationForm.Builder().userId(userId).password(pass).build();
+            final AuthenticationResource authenticationResource =
+                    new AuthenticationResource(loginService, userLocalManager, ResponseUtil.INSTANCE,  authenticationHelper);
+            final AuthenticationForm authenticationForm =
+                    new AuthenticationForm.Builder().userId(userId).password(pass).build();
 
-        final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
+            final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -247,34 +259,37 @@ public class AuthenticationResourceTest extends UnitTestBase {
         final ServletContext context = mock(ServletContext.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new UserPasswordException(UserPasswordException.PASSWORD_ALREADY_USED);
-            }
-        });
+                    throw new UserPasswordException(UserPasswordException.PASSWORD_ALREADY_USED);
+                }
+            });
 
 
-        final AuthenticationResource authenticationResource =
-                new AuthenticationResource(loginService, userLocalManager, ResponseUtil.INSTANCE,  authenticationHelper);
-        final AuthenticationForm authenticationForm =
-                new AuthenticationForm.Builder().userId(userId).password(pass).build();
+            final AuthenticationResource authenticationResource =
+                    new AuthenticationResource(loginService, userLocalManager, ResponseUtil.INSTANCE,  authenticationHelper);
+            final AuthenticationForm authenticationForm =
+                    new AuthenticationForm.Builder().userId(userId).password(pass).build();
 
-        final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
+            final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -292,35 +307,37 @@ public class AuthenticationResourceTest extends UnitTestBase {
         final ServletContext context = mock(ServletContext.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new RequiredLayoutException();
-            }
-        });
+                    throw new RequiredLayoutException();
+                }
+            });
 
 
-        final AuthenticationResource authenticationResource =
-                new AuthenticationResource(loginService, userLocalManager, ResponseUtil.INSTANCE,  authenticationHelper);
-        final AuthenticationForm authenticationForm =
-                new AuthenticationForm.Builder().userId(userId).password(pass).build();
+            final AuthenticationResource authenticationResource =
+                    new AuthenticationResource(loginService, userLocalManager, ResponseUtil.INSTANCE,  authenticationHelper);
+            final AuthenticationForm authenticationForm =
+                    new AuthenticationForm.Builder().userId(userId).password(pass).build();
 
-        final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
+            final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 500);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("user-without-portlet"));
-
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 500);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("user-without-portlet"));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -338,35 +355,38 @@ public class AuthenticationResourceTest extends UnitTestBase {
         final ServletContext context = mock(ServletContext.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new UserActiveException();
-            }
-        });
+                    throw new UserActiveException();
+                }
+            });
 
 
-        final AuthenticationResource authenticationResource =
-                new AuthenticationResource(loginService, userLocalManager, ResponseUtil.INSTANCE,  authenticationHelper);
-        final AuthenticationForm authenticationForm =
-                new AuthenticationForm.Builder().userId(userId).password(pass).language("en").country("US").build();
+            final AuthenticationResource authenticationResource =
+                    new AuthenticationResource(loginService, userLocalManager, ResponseUtil.INSTANCE,  authenticationHelper);
+            final AuthenticationForm authenticationForm =
+                    new AuthenticationForm.Builder().userId(userId).password(pass).language("en").country("US").build();
 
-        final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
+            final Response response1 = authenticationResource.authentication(request, response, authenticationForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("your-account-is-not-active"));
-        System.out.println(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("your-account-is-not-active"));
+            System.out.println(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/authentication/CreateJsonWebTokenResourceTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/authentication/CreateJsonWebTokenResourceTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.ejb.UserLocalManager;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.WebKeys;
 import com.liferay.util.LocaleUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -43,6 +44,11 @@ public class CreateJsonWebTokenResourceTest extends UnitTestBase {
     @Before
     public void initTest(){
         RestUtilTest.initMockContext();
+    }
+
+    @After
+    public void cleanupTest(){
+        RestUtilTest.cleanupContext();
     }
 
     public CreateJsonWebTokenResourceTest() {
@@ -109,40 +115,43 @@ public class CreateJsonWebTokenResourceTest extends UnitTestBase {
         final SecurityLoggerServiceAPI securityLoggerServiceAPI = mock(SecurityLoggerServiceAPI.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(
+                    userId,
+                    pass,
+                    false,
+                    request,
+                    response))
+                    .thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(
-                userId,
-                pass,
-                false,
-                request,
-                response))
-                .thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new NoSuchUserException();
-            }
-        });
+                    throw new NoSuchUserException();
+                }
+            });
 
 
-        final CreateJsonWebTokenResource createJsonWebTokenResource =
-                new CreateJsonWebTokenResource(loginService, userLocalManager, responseUtil, jsonWebTokenUtils, securityLoggerServiceAPI);
-        final CreateTokenForm createTokenForm =
-                new CreateTokenForm.Builder().user(userId).password(pass).build();
+            final CreateJsonWebTokenResource createJsonWebTokenResource =
+                    new CreateJsonWebTokenResource(loginService, userLocalManager, responseUtil, jsonWebTokenUtils, securityLoggerServiceAPI);
+            final CreateTokenForm createTokenForm =
+                    new CreateTokenForm.Builder().user(userId).password(pass).build();
 
-        final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
+            final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -161,34 +170,37 @@ public class CreateJsonWebTokenResourceTest extends UnitTestBase {
         final SecurityLoggerServiceAPI securityLoggerServiceAPI = mock(SecurityLoggerServiceAPI.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new UserEmailAddressException();
-            }
-        });
+                    throw new UserEmailAddressException();
+                }
+            });
 
 
-        final CreateJsonWebTokenResource createJsonWebTokenResource =
-                new CreateJsonWebTokenResource(loginService, userLocalManager, authenticationHelper, jsonWebTokenUtils, securityLoggerServiceAPI);
-        final CreateTokenForm createTokenForm =
-                new CreateTokenForm.Builder().user(userId).password(pass).build();
+            final CreateJsonWebTokenResource createJsonWebTokenResource =
+                    new CreateJsonWebTokenResource(loginService, userLocalManager, authenticationHelper, jsonWebTokenUtils, securityLoggerServiceAPI);
+            final CreateTokenForm createTokenForm =
+                    new CreateTokenForm.Builder().user(userId).password(pass).build();
 
-        final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
+            final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -206,34 +218,37 @@ public class CreateJsonWebTokenResourceTest extends UnitTestBase {
         final SecurityLoggerServiceAPI securityLoggerServiceAPI = mock(SecurityLoggerServiceAPI.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new AuthException();
-            }
-        });
+                    throw new AuthException();
+                }
+            });
 
 
-        final CreateJsonWebTokenResource createJsonWebTokenResource =
-                new CreateJsonWebTokenResource(loginService, userLocalManager, ResponseUtil.INSTANCE, jsonWebTokenUtils, securityLoggerServiceAPI);
-        final CreateTokenForm createTokenForm =
-                new CreateTokenForm.Builder().user(userId).password(pass).build();
+            final CreateJsonWebTokenResource createJsonWebTokenResource =
+                    new CreateJsonWebTokenResource(loginService, userLocalManager, ResponseUtil.INSTANCE, jsonWebTokenUtils, securityLoggerServiceAPI);
+            final CreateTokenForm createTokenForm =
+                    new CreateTokenForm.Builder().user(userId).password(pass).build();
 
-        final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
+            final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -251,34 +266,37 @@ public class CreateJsonWebTokenResourceTest extends UnitTestBase {
         final SecurityLoggerServiceAPI securityLoggerServiceAPI = mock(SecurityLoggerServiceAPI.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new UserPasswordException(UserPasswordException.PASSWORD_ALREADY_USED);
-            }
-        });
+                    throw new UserPasswordException(UserPasswordException.PASSWORD_ALREADY_USED);
+                }
+            });
 
 
-        final CreateJsonWebTokenResource createJsonWebTokenResource =
-                new CreateJsonWebTokenResource(loginService, userLocalManager, ResponseUtil.INSTANCE, jsonWebTokenUtils, securityLoggerServiceAPI);
-        final CreateTokenForm createTokenForm =
-                new CreateTokenForm.Builder().user(userId).password(pass).build();
+            final CreateJsonWebTokenResource createJsonWebTokenResource =
+                    new CreateJsonWebTokenResource(loginService, userLocalManager, ResponseUtil.INSTANCE, jsonWebTokenUtils, securityLoggerServiceAPI);
+            final CreateTokenForm createTokenForm =
+                    new CreateTokenForm.Builder().user(userId).password(pass).build();
 
-        final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
+            final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -296,35 +314,37 @@ public class CreateJsonWebTokenResourceTest extends UnitTestBase {
         final SecurityLoggerServiceAPI securityLoggerServiceAPI = mock(SecurityLoggerServiceAPI.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
-
-                throw new RequiredLayoutException();
-            }
-        });
+                    throw new RequiredLayoutException();
+                }
+            });
 
 
-        final CreateJsonWebTokenResource createJsonWebTokenResource =
-                new CreateJsonWebTokenResource(loginService, userLocalManager, ResponseUtil.INSTANCE, jsonWebTokenUtils, securityLoggerServiceAPI);
-        final CreateTokenForm createTokenForm =
-                new CreateTokenForm.Builder().user(userId).password(pass).build();
+            final CreateJsonWebTokenResource createJsonWebTokenResource =
+                    new CreateJsonWebTokenResource(loginService, userLocalManager, ResponseUtil.INSTANCE, jsonWebTokenUtils, securityLoggerServiceAPI);
+            final CreateTokenForm createTokenForm =
+                    new CreateTokenForm.Builder().user(userId).password(pass).build();
 
-        final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
+            final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 500);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("user-without-portlet"));
-
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 500);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("user-without-portlet"));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -345,40 +365,43 @@ public class CreateJsonWebTokenResourceTest extends UnitTestBase {
 
         LocaleUtil.setUserWebAPI(userWebAPI);
         Config.CONTEXT = context;
+        try {
+            final Locale locale = new Locale.Builder().setLanguage("en").setRegion("CR").build();
+            user.setLocale(locale);
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getLocale()).thenReturn(locale); //
+            when(request.getSession(false)).thenReturn(session); //
+            when(session.getAttribute(WebKeys.USER_ID)).thenReturn(userId);
+            when(userLocalManager.getUserById(userId)).thenReturn(user);
+            when(userWebAPI.isLoggedToBackend(request)).thenReturn(false);
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
 
-        final Locale locale = new Locale.Builder().setLanguage("en").setRegion("CR").build();
-        user.setLocale(locale);
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getLocale()).thenReturn(locale); //
-        when(request.getSession(false)).thenReturn(session); //
-        when(session.getAttribute(WebKeys.USER_ID)).thenReturn(userId);
-        when(userLocalManager.getUserById(userId)).thenReturn(user);
-        when(userWebAPI.isLoggedToBackend(request)).thenReturn(false);
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenAnswer(new Answer<Boolean>() { // if this method is called, should fail
+                @Override
+                public Boolean answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                    throw new UserActiveException();
+                }
+            });
 
-                throw new UserActiveException();
-            }
-        });
+            final CreateJsonWebTokenResource createJsonWebTokenResource =
+                    new CreateJsonWebTokenResource(loginService, userLocalManager, ResponseUtil.INSTANCE, jsonWebTokenUtils, securityLoggerServiceAPI);
+            final CreateTokenForm createTokenForm =
+                    new CreateTokenForm.Builder().user(userId).password(pass).build();
 
-        final CreateJsonWebTokenResource createJsonWebTokenResource =
-                new CreateJsonWebTokenResource(loginService, userLocalManager, ResponseUtil.INSTANCE, jsonWebTokenUtils, securityLoggerServiceAPI);
-        final CreateTokenForm createTokenForm =
-                new CreateTokenForm.Builder().user(userId).password(pass).build();
+            final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
 
-        final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
-
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("your-account-is-not-active"));
-        System.out.println(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("your-account-is-not-active"));
+            System.out.println(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -399,34 +422,37 @@ public class CreateJsonWebTokenResourceTest extends UnitTestBase {
 
         LocaleUtil.setUserWebAPI(userWebAPI);
         Config.CONTEXT = context;
+        try {
+            final Locale locale = new Locale.Builder().setLanguage("en").setRegion("CR").build();
+            user.setLocale(locale);
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getLocale()).thenReturn(locale); //
+            when(request.getSession(false)).thenReturn(session); //
+            when(request.getSession()).thenReturn(session); //
+            when(session.getAttribute(WebKeys.USER_ID)).thenReturn(userId);
+            when(userLocalManager.getUserById(userId)).thenReturn(user);
+            when(loginService.doActionLogin(userId, pass, false, request, response)).thenReturn(false);
+            when(userWebAPI.isLoggedToBackend(request)).thenReturn(false);
 
-        final Locale locale = new Locale.Builder().setLanguage("en").setRegion("CR").build();
-        user.setLocale(locale);
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getLocale()).thenReturn(locale); //
-        when(request.getSession(false)).thenReturn(session); //
-        when(request.getSession()).thenReturn(session); //
-        when(session.getAttribute(WebKeys.USER_ID)).thenReturn(userId);
-        when(userLocalManager.getUserById(userId)).thenReturn(user);
-        when(loginService.doActionLogin(userId, pass, false, request, response)).thenReturn(false);
-        when(userWebAPI.isLoggedToBackend(request)).thenReturn(false);
+            final CreateJsonWebTokenResource createJsonWebTokenResource =
+                    new CreateJsonWebTokenResource(loginService, userLocalManager, ResponseUtil.INSTANCE, jsonWebTokenUtils, securityLoggerServiceAPI);
+            final CreateTokenForm createTokenForm =
+                    new CreateTokenForm.Builder().user(userId).password(pass).build();
 
-        final CreateJsonWebTokenResource createJsonWebTokenResource =
-                new CreateJsonWebTokenResource(loginService, userLocalManager, ResponseUtil.INSTANCE, jsonWebTokenUtils, securityLoggerServiceAPI);
-        final CreateTokenForm createTokenForm =
-                new CreateTokenForm.Builder().user(userId).password(pass).build();
+            final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
 
-        final Response response1 = createJsonWebTokenResource.getApiToken(request, response, createTokenForm);
-
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 401);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
-        assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
-        System.out.println(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 401);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() > 0);
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+            assertTrue(ErrorEntity.class.cast(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0)).getErrorCode().equals("authentication-failed"));
+            System.out.println(ResponseEntityView.class.cast(response1.getEntity()).getErrors().get(0));
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
 

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/authentication/LogoutResourceTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/authentication/LogoutResourceTest.java
@@ -38,28 +38,30 @@ public class LogoutResourceTest extends UnitTestBase {
         final ServletContext context = mock(ServletContext.class);
 
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session); //
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session); //
-
-        Mockito.doNothing().when(loginService).doActionLogout(
-                request,
-                response);
+            Mockito.doNothing().when(loginService).doActionLogout(
+                    request,
+                    response);
 
 
-        final LogoutResource logoutResource =
-                new LogoutResource(loginService, webResource);
+            final LogoutResource logoutResource =
+                    new LogoutResource(loginService, webResource);
 
-        final Response response1 = logoutResource.logout(request, response);
+            final Response response1 = logoutResource.logout(request, response);
 
-        assertNotNull(response1);
-        assertEquals(response1.getStatus(), 200);
-        assertNotNull(response1.getEntity());
-        assertTrue(response1.getEntity() instanceof ResponseEntityView);
-        assertTrue("Logout successfully".equals(ResponseEntityView.class.cast(response1.getEntity()).getEntity()));
-        assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
-        assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() == 0);
-
+            assertNotNull(response1);
+            assertEquals(response1.getStatus(), 200);
+            assertNotNull(response1.getEntity());
+            assertTrue(response1.getEntity() instanceof ResponseEntityView);
+            assertTrue("Logout successfully".equals(ResponseEntityView.class.cast(response1.getEntity()).getEntity()));
+            assertNotNull(ResponseEntityView.class.cast(response1.getEntity()).getErrors());
+            assertTrue(ResponseEntityView.class.cast(response1.getEntity()).getErrors().size() == 0);
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
 }

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/user/UserResourceTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/user/UserResourceTest.java
@@ -75,58 +75,60 @@ public class UserResourceTest extends UnitTestBase {
         final ErrorResponseHelper errorHelper  = mock(ErrorResponseHelper.class);
 
         Config.CONTEXT = context;
-
-        when(initDataObject.getUser()).thenReturn(user);
-        when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
-        when(webResource.init(null, request, response, true, null)).thenReturn(initDataObject);
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
-        when(request.getSession()).thenReturn(session);
-        when(request.getSession(false)).thenReturn(session);
-        when(session.getAttribute(Globals.LOCALE_KEY)).thenReturn(new Locale.Builder().setLanguage("en").setRegion("US").build());
-
-        String filter = "filter";
-        int page = 3;
-        int perPage = 4;
-        final List<User> users = new ArrayList<>();
-        Response responseExpected = Response.ok(new ResponseEntityView<>(users)).build();
-        final PaginationUtil paginationUtil = mock(PaginationUtil.class);
-        when(paginationUtil.getPage(request, user, filter, page, perPage )).thenReturn(responseExpected);
-
-        final DotRestInstanceProvider instanceProvider = new DotRestInstanceProvider()
-                                                                 .setUserAPI(userAPI)
-                                                                 .setHostAPI(siteAPI)
-                                                                 .setRoleAPI(roleAPI)
-                                                                 .setErrorHelper(errorHelper);
-        UserResource userResource =
-                new UserResource(webResource, userHelper, paginationUtil, instanceProvider);
-
         try {
+            when(initDataObject.getUser()).thenReturn(user);
+            when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
+            when(webResource.init(null, request, response, true, null)).thenReturn(initDataObject);
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            when(request.getSession()).thenReturn(session);
+            when(request.getSession(false)).thenReturn(session);
+            when(session.getAttribute(Globals.LOCALE_KEY)).thenReturn(new Locale.Builder().setLanguage("en").setRegion("US").build());
 
-            UpdateUserForm updateUserForm = new UpdateUserForm.Builder()/*.userId("dotcms.org.1")*/.givenName("Admin").surname("User Admin").email("admin@dotcms.com").build();
-            userResource.update(request, response, updateUserForm);
-            fail ("Should throw a ValidationException");
-        } catch (Exception e) {
-            e.printStackTrace();
+            String filter = "filter";
+            int page = 3;
+            int perPage = 4;
+            final List<User> users = new ArrayList<>();
+            Response responseExpected = Response.ok(new ResponseEntityView<>(users)).build();
+            final PaginationUtil paginationUtil = mock(PaginationUtil.class);
+            when(paginationUtil.getPage(request, user, filter, page, perPage )).thenReturn(responseExpected);
+
+            final DotRestInstanceProvider instanceProvider = new DotRestInstanceProvider()
+                                                                     .setUserAPI(userAPI)
+                                                                     .setHostAPI(siteAPI)
+                                                                     .setRoleAPI(roleAPI)
+                                                                     .setErrorHelper(errorHelper);
+            UserResource userResource =
+                    new UserResource(webResource, userHelper, paginationUtil, instanceProvider);
+
+            try {
+
+                UpdateUserForm updateUserForm = new UpdateUserForm.Builder()/*.userId("dotcms.org.1")*/.givenName("Admin").surname("User Admin").email("admin@dotcms.com").build();
+                userResource.update(request, response, updateUserForm);
+                fail ("Should throw a ValidationException");
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
+            try {
+
+                UpdateUserForm updateUserForm = new UpdateUserForm.Builder().userId("dotcms.org.1")/*.givenName("Admin")*/.surname("User Admin").email("admin@dotcms.com").build();
+                userResource.update(request, response, updateUserForm);
+                fail ("Should throw a ValidationException");
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
+            try {
+
+                UpdateUserForm updateUserForm = new UpdateUserForm.Builder()/*.userId("dotcms.org.1")*/.givenName("Admin")/*.surname("User Admin")*/.email("admin@dotcms.com").build();
+                userResource.update(request, response, updateUserForm);
+                fail ("Should throw a ValidationException");
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        } finally {
+            Config.CONTEXT = null;
         }
-
-        try {
-
-            UpdateUserForm updateUserForm = new UpdateUserForm.Builder().userId("dotcms.org.1")/*.givenName("Admin")*/.surname("User Admin").email("admin@dotcms.com").build();
-            userResource.update(request, response, updateUserForm);
-            fail ("Should throw a ValidationException");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        try {
-
-            UpdateUserForm updateUserForm = new UpdateUserForm.Builder()/*.userId("dotcms.org.1")*/.givenName("Admin")/*.surname("User Admin")*/.email("admin@dotcms.com").build();
-            userResource.update(request, response, updateUserForm);
-            fail ("Should throw a ValidationException");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
 
     }
 
@@ -149,76 +151,83 @@ public class UserResourceTest extends UnitTestBase {
         final InitDataObject initDataObject = mock(InitDataObject.class);
 
         RestUtilTest.initMockContext();
+        try {
+            User user = Mockito.mock(User.class);
+            UserUtilTest.set(user);
+            user.setCompanyId(User.DEFAULT + "NO");
+            user.setUserId("dotcms.org.1");
 
-        User user = Mockito.mock(User.class);
-        UserUtilTest.set(user);
-        user.setCompanyId(User.DEFAULT + "NO");
-        user.setUserId("dotcms.org.1");
+            final User systemUser = new User();
 
-        final User systemUser = new User();
+            when(user.clone()).thenReturn(user);
+            when(user.getUserId()).thenReturn("dotcms.org.1");
+            when(initDataObject.getUser()).thenReturn(user);
+            when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
+            when(userAPI.getSystemUser()).thenReturn(systemUser);
+            when(userAPI
+                    .loadUserById(Mockito.anyString(), Mockito.any(User.class),
+                            Mockito.anyBoolean()))
+                    .thenReturn(user);
+            when(webResource.init(request, httpServletResponse, true)).thenReturn(initDataObject);
+            when(request.getSession()).thenReturn(session);
+            when(request.getSession(false)).thenReturn(session);
+            when(session.getAttribute(Globals.LOCALE_KEY)).thenReturn(
+                    new Locale.Builder().setLanguage("en").setRegion("US").build());
+            when(loginService.passwordMatch("password", user)).thenReturn(true);
 
-        when(user.clone()).thenReturn(user);
-        when(user.getUserId()).thenReturn("dotcms.org.1");
-        when(initDataObject.getUser()).thenReturn(user);
-        when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
-        when(userAPI.getSystemUser()).thenReturn(systemUser);
-        when(userAPI
-                .loadUserById(Mockito.anyString(), Mockito.any(User.class), Mockito.anyBoolean()))
-                .thenReturn(user);
-        when(webResource.init(request, httpServletResponse, true)).thenReturn(initDataObject);
-        when(request.getSession()).thenReturn(session);
-        when(request.getSession(false)).thenReturn(session);
-        when(session.getAttribute(Globals.LOCALE_KEY)).thenReturn(new Locale.Builder().setLanguage("en").setRegion("US").build());
-        when(loginService.passwordMatch("password", user)).thenReturn(true);
+            final DotRestInstanceProvider helperInstanceProvider = new DotRestInstanceProvider()
+                    .setRoleAPI(roleAPI)
+                    .setUserAPI(userAPI)
+                    .setLayoutAPI(layoutAPI)
+                    .setHostWebAPI(hostWebAPI)
+                    .setUserWebAPI(userWebAPI)
+                    .setPermissionAPI(permissionAPI)
+                    .setUserProxyAPI(userProxyAPI)
+                    .setLoginService(loginService);
+            final UserResourceHelper userHelper = new UserResourceHelper(helperInstanceProvider);
 
-        final DotRestInstanceProvider helperInstanceProvider = new DotRestInstanceProvider()
-                                                                       .setRoleAPI(roleAPI)
-                                                                       .setUserAPI(userAPI)
-                                                                       .setLayoutAPI(layoutAPI)
-                                                                       .setHostWebAPI(hostWebAPI)
-                                                                       .setUserWebAPI(userWebAPI)
-                                                                       .setPermissionAPI(permissionAPI)
-                                                                       .setUserProxyAPI(userProxyAPI)
-                                                                       .setLoginService(loginService);
-        final UserResourceHelper userHelper = new UserResourceHelper(helperInstanceProvider);
+            String filter = "filter";
+            int page = 3;
+            int perPage = 4;
+            final List<User> users = new ArrayList<>();
+            Response responseExpected = Response.ok(new ResponseEntityView<>(users)).build();
+            final PaginationUtil paginationUtil = mock(PaginationUtil.class);
+            when(paginationUtil.getPage(request, user, filter, page, perPage)).thenReturn(
+                    responseExpected);
 
-        String filter = "filter";
-        int page = 3;
-        int perPage = 4;
-        final List<User> users = new ArrayList<>();
-        Response responseExpected = Response.ok(new ResponseEntityView<>(users)).build();
-        final PaginationUtil paginationUtil = mock(PaginationUtil.class);
-        when(paginationUtil.getPage(request, user, filter, page, perPage )).thenReturn(responseExpected);
+            final DotRestInstanceProvider instanceProvider = new DotRestInstanceProvider()
+                    .setUserAPI(userAPI)
+                    .setHostAPI(siteAPI)
+                    .setRoleAPI(roleAPI)
+                    .setErrorHelper(errorHelper);
+            UserResource userResource =
+                    new UserResource(webResource, userHelper, paginationUtil, instanceProvider);
 
-        final DotRestInstanceProvider instanceProvider = new DotRestInstanceProvider()
-                                                                 .setUserAPI(userAPI)
-                                                                 .setHostAPI(siteAPI)
-                                                                 .setRoleAPI(roleAPI)
-                                                                 .setErrorHelper(errorHelper);
-        UserResource userResource =
-                new UserResource(webResource, userHelper, paginationUtil, instanceProvider);
+            UpdateUserForm updateUserForm = new UpdateUserForm.Builder()
+                    .userId("dotcms.org.1")
+                    .givenName("Admin")
+                    .surname("User Admin")
+                    .email("admin@dotcms.com")
+                    .currentPassword("password")
+                    .build();
 
-        UpdateUserForm updateUserForm = new UpdateUserForm.Builder()
-                .userId("dotcms.org.1")
-                .givenName("Admin")
-                .surname("User Admin")
-                .email("admin@dotcms.com")
-                .currentPassword("password")
-                .build();
+            Response response = userResource.update(request, httpServletResponse, updateUserForm);
+            RestUtilTest.verifySuccessResponse(response);
 
-        Response response = userResource.update(request, httpServletResponse, updateUserForm);
-        RestUtilTest.verifySuccessResponse(response);
+            Map userMap = Map.class.cast(
+                    ResponseEntityView.class.cast(response.getEntity()).getEntity());
 
-        Map userMap = Map.class.cast(ResponseEntityView.class.cast(response.getEntity()).getEntity());
+            assertTrue(!userMap.isEmpty());
+            assertTrue(userMap.containsKey("reauthenticate"));
+            assertTrue(userMap.get("reauthenticate").equals(false));
+            assertTrue(userMap.containsKey("userID"));
+            assertTrue(userMap.get("userID").equals("dotcms.org.1"));
+            assertTrue(userMap.containsKey("user"));
 
-        assertTrue(!userMap.isEmpty());
-        assertTrue(userMap.containsKey("reauthenticate"));
-        assertTrue(userMap.get("reauthenticate").equals(false));
-        assertTrue(userMap.containsKey("userID"));
-        assertTrue(userMap.get("userID").equals("dotcms.org.1"));
-        assertTrue(userMap.containsKey("user"));
-
-        verify(userAPI).save(user, systemUser, false, false);
+            verify(userAPI).save(user, systemUser, false, false);
+        } finally {
+            RestUtilTest.cleanupContext();
+        }
     }
 
     @Test
@@ -240,72 +249,78 @@ public class UserResourceTest extends UnitTestBase {
         final InitDataObject initDataObject = mock(InitDataObject.class);
 
         RestUtilTest.initMockContext();
+        try {
+            final User user = new User();
+            user.setCompanyId(User.DEFAULT + "NO");
+            user.setUserId("dotcms.org.1");
 
-        final User user = new User();
-        user.setCompanyId(User.DEFAULT + "NO");
-        user.setUserId("dotcms.org.1");
+            final User systemUser = new User();
 
-        final User systemUser = new User();
+            when(initDataObject.getUser()).thenReturn(user);
+            when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
+            when(userAPI.getSystemUser()).thenReturn(systemUser);
+            when(userAPI.loadUserById("dotcms.org.1", systemUser, false)).thenReturn(user);
+            when(webResource.init(request, httpServletResponse, true)).thenReturn(initDataObject);
+            when(request.getSession()).thenReturn(session);
+            when(request.getSession(false)).thenReturn(session);
+            when(session.getAttribute(Globals.LOCALE_KEY)).thenReturn(
+                    new Locale.Builder().setLanguage("en").setRegion("US").build());
+            when(loginService.passwordMatch("password", user)).thenReturn(true);
 
-        when(initDataObject.getUser()).thenReturn(user);
-        when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
-        when(userAPI.getSystemUser()).thenReturn(systemUser);
-        when(userAPI.loadUserById("dotcms.org.1", systemUser, false)).thenReturn(user);
-        when(webResource.init(request, httpServletResponse, true)).thenReturn(initDataObject);
-        when(request.getSession()).thenReturn(session);
-        when(request.getSession(false)).thenReturn(session);
-        when(session.getAttribute(Globals.LOCALE_KEY)).thenReturn(new Locale.Builder().setLanguage("en").setRegion("US").build());
-        when(loginService.passwordMatch("password", user)).thenReturn(true);
+            final DotRestInstanceProvider helperInstanceProvider = new DotRestInstanceProvider()
+                    .setRoleAPI(roleAPI)
+                    .setUserAPI(userAPI)
+                    .setLayoutAPI(layoutAPI)
+                    .setHostWebAPI(hostWebAPI)
+                    .setUserWebAPI(userWebAPI)
+                    .setPermissionAPI(permissionAPI)
+                    .setUserProxyAPI(userProxyAPI)
+                    .setLoginService(loginService);
+            final UserResourceHelper userHelper = new UserResourceHelper(helperInstanceProvider);
+            String filter = "filter";
+            int page = 3;
+            int perPage = 4;
+            final List<User> users = new ArrayList<>();
+            Response responseExpected = Response.ok(new ResponseEntityView<>(users)).build();
+            final PaginationUtil paginationUtil = mock(PaginationUtil.class);
+            when(paginationUtil.getPage(request, user, filter, page, perPage)).thenReturn(
+                    responseExpected);
+            final DotRestInstanceProvider instanceProvider = new DotRestInstanceProvider()
+                    .setUserAPI(userAPI)
+                    .setHostAPI(siteAPI)
+                    .setRoleAPI(roleAPI)
+                    .setErrorHelper(errorHelper);
+            UserResource userResource =
+                    new UserResource(webResource, userHelper, paginationUtil, instanceProvider);
 
-        final DotRestInstanceProvider helperInstanceProvider = new DotRestInstanceProvider()
-                                                                       .setRoleAPI(roleAPI)
-                                                                       .setUserAPI(userAPI)
-                                                                       .setLayoutAPI(layoutAPI)
-                                                                       .setHostWebAPI(hostWebAPI)
-                                                                       .setUserWebAPI(userWebAPI)
-                                                                       .setPermissionAPI(permissionAPI)
-                                                                       .setUserProxyAPI(userProxyAPI)
-                                                                       .setLoginService(loginService);
-        final UserResourceHelper userHelper  = new UserResourceHelper(helperInstanceProvider);
-        String filter = "filter";
-        int page = 3;
-        int perPage = 4;
-        final List<User> users = new ArrayList<>();
-        Response responseExpected = Response.ok(new ResponseEntityView<>(users)).build();
-        final PaginationUtil paginationUtil = mock(PaginationUtil.class);
-        when(paginationUtil.getPage(request, user, filter, page, perPage )).thenReturn(responseExpected);
-        final DotRestInstanceProvider instanceProvider = new DotRestInstanceProvider()
-                                                                 .setUserAPI(userAPI)
-                                                                 .setHostAPI(siteAPI)
-                                                                 .setRoleAPI(roleAPI)
-                                                                 .setErrorHelper(errorHelper);
-        UserResource userResource =
-                new UserResource(webResource, userHelper, paginationUtil, instanceProvider);
+            UpdateUserForm updateUserForm = new UpdateUserForm.Builder()
+                    .userId("dotcms.org.1")
+                    .givenName("Admin")
+                    .surname("User Admin")
+                    .email("admin@dotcms.com")
+                    .currentPassword("password")
+                    .newPassword("new password")
+                    .build();
 
-        UpdateUserForm updateUserForm = new UpdateUserForm.Builder()
-                .userId("dotcms.org.1")
-                .givenName("Admin")
-                .surname("User Admin")
-                .email("admin@dotcms.com")
-                .currentPassword("password")
-                .newPassword("new password")
-                .build();
+            Response response = userResource.update(request, httpServletResponse, updateUserForm);
+            RestUtilTest.verifySuccessResponse(response);
 
-        Response response = userResource.update(request, httpServletResponse, updateUserForm);
-        RestUtilTest.verifySuccessResponse(response);
+            Map userMap = Map.class.cast(
+                    ResponseEntityView.class.cast(response.getEntity()).getEntity());
 
-        Map userMap = Map.class.cast(ResponseEntityView.class.cast(response.getEntity()).getEntity());
+            assertTrue(!userMap.isEmpty());
+            assertTrue(userMap.containsKey("reauthenticate"));
+            assertTrue(userMap.get("reauthenticate").equals(true));
+            assertTrue(userMap.containsKey("userID"));
+            assertTrue(userMap.get("userID").equals("dotcms.org.1"));
+            assertTrue(userMap.containsKey("user"));
+            assertTrue(userMap.containsKey("user"));
+            assertTrue(((Map) userMap.get("user")).isEmpty());
 
-        assertTrue(!userMap.isEmpty());
-        assertTrue(userMap.containsKey("reauthenticate"));
-        assertTrue(userMap.get("reauthenticate").equals(true));
-        assertTrue(userMap.containsKey("userID"));
-        assertTrue(userMap.get("userID").equals("dotcms.org.1"));
-        assertTrue(userMap.containsKey("user"));
-        assertTrue(userMap.containsKey("user"));
-        assertTrue(((Map) userMap.get("user")).isEmpty());
-
-        verify(userAPI).save(user, systemUser, true, false);
+            verify(userAPI).save(user, systemUser, true, false);
+        } finally {
+            RestUtilTest.cleanupContext();
+        }
     }
 
     @Test
@@ -327,64 +342,70 @@ public class UserResourceTest extends UnitTestBase {
         final InitDataObject initDataObject = mock(InitDataObject.class);
 
         RestUtilTest.initMockContext();
+        try {
+            final User user = new User();
+            user.setCompanyId(User.DEFAULT + "NO");
+            user.setUserId("dotcms.org.1");
 
-        final User user = new User();
-        user.setCompanyId(User.DEFAULT + "NO");
-        user.setUserId("dotcms.org.1");
+            final User systemUser = new User();
+            final Locale enUsLocale = new Locale.Builder().setLanguage("en").setRegion("US")
+                    .build();
+            systemUser.setLocale(enUsLocale);
+            when(initDataObject.getUser()).thenReturn(user);
+            when(userAPI.getSystemUser()).thenReturn(systemUser);
+            when(userAPI.loadUserById("dotcms.org.1", systemUser, false)).thenReturn(user);
+            when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
+            when(request.getSession()).thenReturn(session);
+            when(request.getSession(false)).thenReturn(session);
+            when(session.getAttribute(Globals.LOCALE_KEY)).thenReturn(enUsLocale);
+            when(loginService.passwordMatch("password", user)).thenReturn(false);
+            when(errorHelper
+                    .getErrorResponse(Response.Status.BAD_REQUEST, enUsLocale,
+                            "current.usermanager.password.incorrect"))
+                    .thenReturn(Response.status(Response.Status.BAD_REQUEST).build());
 
-        final User systemUser = new User();
-        final Locale enUsLocale = new Locale.Builder().setLanguage("en").setRegion("US").build();
-        systemUser.setLocale(enUsLocale);
-        when(initDataObject.getUser()).thenReturn(user);
-        when(userAPI.getSystemUser()).thenReturn(systemUser);
-        when(userAPI.loadUserById("dotcms.org.1", systemUser, false)).thenReturn(user);
-        when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
-        when(request.getSession()).thenReturn(session);
-        when(request.getSession(false)).thenReturn(session);
-        when(session.getAttribute(Globals.LOCALE_KEY)).thenReturn(enUsLocale);
-        when(loginService.passwordMatch("password", user)).thenReturn(false);
-        when(errorHelper
-                     .getErrorResponse(Response.Status.BAD_REQUEST, enUsLocale, "current.usermanager.password.incorrect"))
-                .thenReturn(Response.status(Response.Status.BAD_REQUEST).build());
+            final DotRestInstanceProvider helperInstanceProvider = new DotRestInstanceProvider()
+                    .setRoleAPI(roleAPI)
+                    .setUserAPI(userAPI)
+                    .setLayoutAPI(layoutAPI)
+                    .setHostWebAPI(hostWebAPI)
+                    .setUserWebAPI(userWebAPI)
+                    .setPermissionAPI(permissionAPI)
+                    .setUserProxyAPI(userProxyAPI)
+                    .setLoginService(loginService);
+            final UserResourceHelper userHelper = new UserResourceHelper(helperInstanceProvider);
 
-        final DotRestInstanceProvider helperInstanceProvider = new DotRestInstanceProvider()
-                                                                       .setRoleAPI(roleAPI)
-                                                                       .setUserAPI(userAPI)
-                                                                       .setLayoutAPI(layoutAPI)
-                                                                       .setHostWebAPI(hostWebAPI)
-                                                                       .setUserWebAPI(userWebAPI)
-                                                                       .setPermissionAPI(permissionAPI)
-                                                                       .setUserProxyAPI(userProxyAPI)
-                                                                       .setLoginService(loginService);
-        final UserResourceHelper userHelper  = new UserResourceHelper(helperInstanceProvider);
+            String filter = "filter";
+            int page = 3;
+            int perPage = 4;
+            final List<User> users = new ArrayList<>();
+            Response responseExpected = Response.ok(new ResponseEntityView<>(users)).build();
+            final PaginationUtil paginationUtil = mock(PaginationUtil.class);
+            when(paginationUtil.getPage(request, user, filter, page, perPage)).thenReturn(
+                    responseExpected);
 
-        String filter = "filter";
-        int page = 3;
-        int perPage = 4;
-        final List<User> users = new ArrayList<>();
-        Response responseExpected = Response.ok(new ResponseEntityView<>(users)).build();
-        final PaginationUtil paginationUtil = mock(PaginationUtil.class);
-        when(paginationUtil.getPage(request, user, filter, page, perPage )).thenReturn(responseExpected);
+            final DotRestInstanceProvider instanceProvider = new DotRestInstanceProvider()
+                    .setUserAPI(userAPI)
+                    .setHostAPI(siteAPI)
+                    .setRoleAPI(roleAPI)
+                    .setErrorHelper(errorHelper);
+            UserResource userResource =
+                    new UserResource(webResource, userHelper, paginationUtil, instanceProvider);
 
-        final DotRestInstanceProvider instanceProvider = new DotRestInstanceProvider()
-                                                                 .setUserAPI(userAPI)
-                                                                 .setHostAPI(siteAPI)
-                                                                 .setRoleAPI(roleAPI)
-                                                                 .setErrorHelper(errorHelper);
-        UserResource userResource =
-                new UserResource(webResource, userHelper, paginationUtil, instanceProvider);
+            UpdateUserForm updateUserForm = new UpdateUserForm.Builder()
+                    .userId("dotcms.org.1")
+                    .givenName("Admin")
+                    .surname("User Admin")
+                    .email("admin@dotcms.com")
+                    .currentPassword("password")
+                    .newPassword("new password")
+                    .build();
 
-        UpdateUserForm updateUserForm = new UpdateUserForm.Builder()
-                .userId("dotcms.org.1")
-                .givenName("Admin")
-                .surname("User Admin")
-                .email("admin@dotcms.com")
-                .currentPassword("password")
-                .newPassword("new password")
-                .build();
-
-        Response response = userResource.update(request, httpServletResponse, updateUserForm);
-        assertEquals(response.getStatus(), 400);
+            Response response = userResource.update(request, httpServletResponse, updateUserForm);
+            assertEquals(response.getStatus(), 400);
+        } finally {
+            RestUtilTest.cleanupContext();
+        }
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotcms/timemachine/ajax/TimeMachineAjaxActionTest.java
+++ b/dotCMS/src/test/java/com/dotcms/timemachine/ajax/TimeMachineAjaxActionTest.java
@@ -44,32 +44,35 @@ public class TimeMachineAjaxActionTest extends UnitTestBase {
 
         this.initMessages();
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            doAnswer(new Answer<Void>() { // if this method is called, should fail
 
-        doAnswer(new Answer<Void>() { // if this method is called, should fail
+                @Override
+                public Void answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
+                    testGenerateNotification = true;
+                    return null;
+                }
+            }).when(notificationAPI).generateNotification(
+                    new I18NMessage("notification.timemachine.created.info.title"),
+                    new I18NMessage("TIMEMACHINE-SNAPSHOT-CREATED"),
+                    null,
+                    NotificationLevel.INFO,
+                    NotificationType.GENERIC,
+                    "admin@dotcms.com",
+                    locale
+            );
 
-                testGenerateNotification = true;
-                return null;
-            }
-        }).when(notificationAPI).generateNotification(
-                new I18NMessage("notification.timemachine.created.info.title"),
-                new I18NMessage("TIMEMACHINE-SNAPSHOT-CREATED"),
-                null,
-                NotificationLevel.INFO,
-                NotificationType.GENERIC,
-                "admin@dotcms.com",
-                locale
-        );
-
-        machineAjaxAction.generateNotification
-                (locale,
-                        "admin@dotcms.com");
+            machineAjaxAction.generateNotification
+                    (locale,
+                            "admin@dotcms.com");
 
 
-        assertTrue(this.testGenerateNotification);
+            assertTrue(this.testGenerateNotification);
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 }

--- a/dotCMS/src/test/java/com/dotmarketing/common/reindex/ReindexThreadUnitTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/common/reindex/ReindexThreadUnitTest.java
@@ -82,36 +82,39 @@ public class ReindexThreadUnitTest extends UnitTestBase {
 
         this.initMessages();
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter(WebKeys.COMPANY_ID)).thenReturn(RestUtilTest.DEFAULT_COMPANY);
 
-        when(context.getInitParameter(WebKeys.COMPANY_ID)).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            doAnswer(new Answer<Void>() { // if this method is called, should fail
 
-        doAnswer(new Answer<Void>() { // if this method is called, should fail
+                @Override
+                public Void answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
+                    testGenerateNotification = true;
+                    return null;
+                }
+            }).when(notificationAPI).generateNotification(
+                    new I18NMessage("notification.reindex.error.title"),
+                    new I18NMessage("notification.reindexing.error.processrecord", msg, identToIndex),
+                    null,
+                    NotificationLevel.INFO,
+                    NotificationType.GENERIC,
+                    Visibility.ROLE,
+                    cmsAdminRoleId,
+                    user.getUserId(),
+                    locale
+            );
 
-                testGenerateNotification = true;
-                return null;
-            }
-        }).when(notificationAPI).generateNotification(
-                new I18NMessage("notification.reindex.error.title"),
-                new I18NMessage("notification.reindexing.error.processrecord", msg, identToIndex),
-                null,
-                NotificationLevel.INFO,
-                NotificationType.GENERIC,
-                Visibility.ROLE,
-                cmsAdminRoleId,
-                user.getUserId(),
-                locale
-        );
+            //Execute the notification call
+            reindexThread.sendNotification
+                    ("notification.reindexing.error.processrecord",
+                            new Object[] {identToIndex}, msg, false);
 
-        //Execute the notification call
-        reindexThread.sendNotification
-                ("notification.reindexing.error.processrecord",
-                        new Object[] {identToIndex}, msg, false);
-
-        //Validate
-        assertTrue(this.testGenerateNotification);
+            //Validate
+            assertTrue(this.testGenerateNotification);
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @After

--- a/dotCMS/src/test/java/com/dotmarketing/quartz/DeleteFieldJobHelperTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/quartz/DeleteFieldJobHelperTest.java
@@ -38,35 +38,38 @@ public class DeleteFieldJobHelperTest extends UnitTestBase {
 
         this.initMessages();
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            doAnswer(new Answer<Void>() { // if this method is called, should fail
 
-        doAnswer(new Answer<Void>() { // if this method is called, should fail
+                @Override
+                public Void answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
+                    testGenerateNotificationStartDeleting = true;
+                    return null;
+                }
+            }).when(notificationAPI).generateNotification(
+                    new I18NMessage("notification.deletefieldjob.delete.info.title"),
+                    new I18NMessage(
+                            "notification.deletefieldjob.startdelete.info.message", null,
+                            "velocityVar", "iFieldNode1", "iStructureNode1"),
+                    null,
+                    NotificationLevel.INFO,
+                    NotificationType.GENERIC,
+                    "admin@dotcms.com",
+                    Locale.US
+                    );
 
-                testGenerateNotificationStartDeleting = true;
-                return null;
-            }
-        }).when(notificationAPI).generateNotification(
-                new I18NMessage("notification.deletefieldjob.delete.info.title"),
-                new I18NMessage(
-                        "notification.deletefieldjob.startdelete.info.message", null,
-                        "velocityVar", "iFieldNode1", "iStructureNode1"),
-                null,
-                NotificationLevel.INFO,
-                NotificationType.GENERIC,
-                "admin@dotcms.com",
-                Locale.US
-                );
-
-        deleteFieldJobHelper.generateNotificationStartDeleting
-                (notificationAPI, new Locale.Builder().setLanguage("en").setRegion("US").build(),
-                        "admin@dotcms.com", "velocityVar", "iFieldNode1", "iStructureNode1");
+            deleteFieldJobHelper.generateNotificationStartDeleting
+                    (notificationAPI, new Locale.Builder().setLanguage("en").setRegion("US").build(),
+                            "admin@dotcms.com", "velocityVar", "iFieldNode1", "iStructureNode1");
 
 
-        assertTrue(this.testGenerateNotificationStartDeleting);
+            assertTrue(this.testGenerateNotificationStartDeleting);
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -79,35 +82,38 @@ public class DeleteFieldJobHelperTest extends UnitTestBase {
 
         this.initMessages();
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            doAnswer(new Answer<Void>() { // if this method is called, should fail
 
-        doAnswer(new Answer<Void>() { // if this method is called, should fail
+                @Override
+                public Void answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
+                    testGenerateNotificationEndDeleting = true;
+                    return null;
+                }
+            }).when(notificationAPI).generateNotification(
+                    new I18NMessage("notification.deletefieldjob.delete.info.title"),
+                    new I18NMessage(
+                            "notification.deletefieldjob.enddelete.info.message", null,
+                            "velocityVar", "iFieldNode1", "iStructureNode1"),
+                    null,
+                    NotificationLevel.INFO,
+                    NotificationType.GENERIC,
+                    "admin@dotcms.com",
+                    Locale.US
+            );
 
-                testGenerateNotificationEndDeleting = true;
-                return null;
-            }
-        }).when(notificationAPI).generateNotification(
-                new I18NMessage("notification.deletefieldjob.delete.info.title"),
-                new I18NMessage(
-                        "notification.deletefieldjob.enddelete.info.message", null,
-                        "velocityVar", "iFieldNode1", "iStructureNode1"),
-                null,
-                NotificationLevel.INFO,
-                NotificationType.GENERIC,
-                "admin@dotcms.com",
-                Locale.US
-        );
-
-        deleteFieldJobHelper.generateNotificationEndDeleting
-                (notificationAPI, new Locale.Builder().setLanguage("en").setRegion("US").build(),
-                        "admin@dotcms.com", "velocityVar", "iFieldNode1", "iStructureNode1");
+            deleteFieldJobHelper.generateNotificationEndDeleting
+                    (notificationAPI, new Locale.Builder().setLanguage("en").setRegion("US").build(),
+                            "admin@dotcms.com", "velocityVar", "iFieldNode1", "iStructureNode1");
 
 
-        assertTrue(this.testGenerateNotificationEndDeleting);
+            assertTrue(this.testGenerateNotificationEndDeleting);
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 
     @Test
@@ -120,34 +126,37 @@ public class DeleteFieldJobHelperTest extends UnitTestBase {
 
         this.initMessages();
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            doAnswer(new Answer<Void>() { // if this method is called, should fail
 
-        doAnswer(new Answer<Void>() { // if this method is called, should fail
+                @Override
+                public Void answer(InvocationOnMock invocation) throws Throwable {
 
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
+                    testGenerateNotificationUnableDeleting = true;
+                    return null;
+                }
+            }).when(notificationAPI).generateNotification(
+                    new I18NMessage("notification.deletefieldjob.delete.info.title"),
+                    new I18NMessage(
+                            "notification.deletefieldjob.unabledelete.info.message", null,
+                            "velocityVar", "iFieldNode1", "iStructureNode1"),
+                    null,
+                    NotificationLevel.ERROR,
+                    NotificationType.GENERIC,
+                    "admin@dotcms.com",
+                    Locale.US
+            );
 
-                testGenerateNotificationUnableDeleting = true;
-                return null;
-            }
-        }).when(notificationAPI).generateNotification(
-                new I18NMessage("notification.deletefieldjob.delete.info.title"),
-                new I18NMessage(
-                        "notification.deletefieldjob.unabledelete.info.message", null,
-                        "velocityVar", "iFieldNode1", "iStructureNode1"),
-                null,
-                NotificationLevel.ERROR,
-                NotificationType.GENERIC,
-                "admin@dotcms.com",
-                Locale.US
-        );
-
-        deleteFieldJobHelper.generateNotificationUnableDelete
-                (notificationAPI, new Locale.Builder().setLanguage("en").setRegion("US").build(),
-                        "admin@dotcms.com", "velocityVar", "iFieldNode1", "iStructureNode1");
+            deleteFieldJobHelper.generateNotificationUnableDelete
+                    (notificationAPI, new Locale.Builder().setLanguage("en").setRegion("US").build(),
+                            "admin@dotcms.com", "velocityVar", "iFieldNode1", "iStructureNode1");
 
 
-        assertTrue(this.testGenerateNotificationUnableDeleting);
+            assertTrue(this.testGenerateNotificationUnableDeleting);
+        } finally {
+            Config.CONTEXT = null;
+        }
     }
 }

--- a/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
@@ -241,68 +241,71 @@ public class DateUtilTest extends UnitTestBase {
 
         this.initMessages();
         Config.CONTEXT = context;
+        try {
+            when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
 
-        when(context.getInitParameter("company_id")).thenReturn(RestUtilTest.DEFAULT_COMPANY);
+            final SimpleDateFormat format = new SimpleDateFormat("yyyy/MMM/dd");
 
-        final SimpleDateFormat format = new SimpleDateFormat("yyyy/MMM/dd");
+            format.setLenient(true);
 
-        format.setLenient(true);
+            final Date toDate    = format.parse("2016/Apr/01");
+            Date date    = format.parse("2015/Mar/01");
 
-        final Date toDate    = format.parse("2016/Apr/01");
-        Date date    = format.parse("2015/Mar/01");
+            String prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
 
-        String prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
+            assertNotNull(prettyDate);
+            assertEquals("more-than-a-year-ago", prettyDate);
 
-        assertNotNull(prettyDate);
-        assertEquals("more-than-a-year-ago", prettyDate);
+            //////////******************
+            date    = format.parse("2016/Feb/25");
+            prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
 
-        //////////******************
-        date    = format.parse("2016/Feb/25");
-        prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
+            System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
+            assertNotNull(prettyDate);
+            assertEquals("last-month", prettyDate);
 
-        System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
-        assertNotNull(prettyDate);
-        assertEquals("last-month", prettyDate);
+            //////////******************
+            date    = format.parse("2016/Mar/04");
+            prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
 
-        //////////******************
-        date    = format.parse("2016/Mar/04");
-        prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
+            System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
+            assertNotNull(prettyDate);
+            assertEquals("x-weeks-ago", prettyDate);
 
-        System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
-        assertNotNull(prettyDate);
-        assertEquals("x-weeks-ago", prettyDate);
+            //////////******************
+            date    = format.parse("2016/Jan/04");
+            prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
 
-        //////////******************
-        date    = format.parse("2016/Jan/04");
-        prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
+            System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
+            assertNotNull(prettyDate);
+            assertEquals("x-months-ago", prettyDate);
 
-        System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
-        assertNotNull(prettyDate);
-        assertEquals("x-months-ago", prettyDate);
+            //////////******************
+            date    = format.parse("2016/Mar/20");
+            prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
 
-        //////////******************
-        date    = format.parse("2016/Mar/20");
-        prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
+            System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
+            assertNotNull(prettyDate);
+            assertEquals("last-week", prettyDate);
 
-        System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
-        assertNotNull(prettyDate);
-        assertEquals("last-week", prettyDate);
+            //////////******************
+            date    = format.parse("2016/Mar/27");
+            prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
 
-        //////////******************
-        date    = format.parse("2016/Mar/27");
-        prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
+            System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
+            assertNotNull(prettyDate);
+            assertEquals("x-days-ago", prettyDate);
 
-        System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
-        assertNotNull(prettyDate);
-        assertEquals("x-days-ago", prettyDate);
+            //////////******************
+            date    = format.parse("2016/Mar/31");
+            prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
 
-        //////////******************
-        date    = format.parse("2016/Mar/31");
-        prettyDate = DateUtil.prettyDateSince(date, new Locale.Builder().setLanguage("en").setRegion("US").build(), toDate);
-
-        System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
-        assertNotNull(prettyDate);
-        assertEquals("yesterday", prettyDate);
+            System.out.println(MessageFormat.format("Pretty Date: {0}, from {1} to {2}", prettyDate, date, toDate));
+            assertNotNull(prettyDate);
+            assertEquals("yesterday", prettyDate);
+        } finally {
+            Config.CONTEXT = null;
+        }
 
     }
 


### PR DESCRIPTION
Some unit tests are setting Config.CONTEXT to a mock context.  This value is static and does not automatically get cleared for following tests.   If a service is started that requires FileUtils.getRealPath it will see this non null value but if this mock context .getRealPath returns a null value then the FileUtile method falls through to looking for Config.CONTEXT_PATH which is not consistently set causing a null pointer exception.    Tests should not rely upon or be impacted by a mock set by a previous test. 

Removed Config.CONTEXT_PATH that is just a proxy for Config.CONTEXT.getRealPath("/") This was used only in a couple of places and added complexity. 