### PR TITLE
dotCMS/core#26399 Add timestamp to date pipe and improve date formatting

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/dot-container-list-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/dot-container-list-resolver.service.spec.ts
@@ -11,6 +11,7 @@ import {
     CoreWebService,
     DotcmsConfigService,
     LoggerService,
+    LoginService,
     StringUtils,
     UserModel
 } from '@dotcms/dotcms-js';
@@ -49,6 +50,10 @@ describe('DotContainerListResolverService', () => {
                                 offset: -21600000
                             })
                     }
+                },
+                {
+                    provide: LoginService,
+                    useValue: { currentUserLanguageId: 'en-US' }
                 }
             ]
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-listing-panel/dot-pages-listing-panel.component.spec.ts
@@ -16,7 +16,12 @@ import { TooltipModule } from 'primeng/tooltip';
 import { of } from 'rxjs/internal/observable/of';
 
 import { DotMessageService } from '@dotcms/data-access';
-import { CoreWebService, CoreWebServiceMock, DotcmsConfigService } from '@dotcms/dotcms-js';
+import {
+    CoreWebService,
+    CoreWebServiceMock,
+    DotcmsConfigService,
+    LoginService
+} from '@dotcms/dotcms-js';
 import { DotAutofocusDirective, DotMessagePipe, DotRelativeDatePipe } from '@dotcms/ui';
 import {
     DotcmsConfigServiceMock,
@@ -155,7 +160,11 @@ describe('DotPagesListingPanelComponent', () => {
                     { provide: DotcmsConfigService, useClass: DotcmsConfigServiceMock },
                     { provide: CoreWebService, useClass: CoreWebServiceMock },
                     { provide: DotPageStore, useClass: storeMock },
-                    { provide: DotMessageService, useValue: messageServiceMock }
+                    { provide: DotMessageService, useValue: messageServiceMock },
+                    {
+                        provide: LoginService,
+                        useValue: { currentUserLanguageId: 'en-US' }
+                    }
                 ]
             }).compileComponents();
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list-resolver.service.spec.ts
@@ -12,6 +12,7 @@ import {
     CoreWebService,
     DotcmsConfigService,
     LoggerService,
+    LoginService,
     StringUtils,
     UserModel
 } from '@dotcms/dotcms-js';
@@ -49,6 +50,10 @@ describe('DotTemplateListResolverService', () => {
                                 offset: -21600000
                             })
                     }
+                },
+                {
+                    provide: LoginService,
+                    useValue: { currentUserLanguageId: 'en-US' }
                 }
             ]
         });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.spec.ts
@@ -442,14 +442,17 @@ describe('DotTemplateListComponent', () => {
                 DotHttpErrorManagerService,
                 DotAlertConfirmService,
                 ConfirmationService,
-                LoginService,
                 DotcmsEventsService,
                 DotEventsSocket,
                 DotcmsConfigService,
                 DotMessageDisplayService,
                 DialogService,
                 DotSiteBrowserService,
-                { provide: DotFormatDateService, useClass: DotFormatDateServiceMock }
+                { provide: DotFormatDateService, useClass: DotFormatDateServiceMock },
+                {
+                    provide: LoginService,
+                    useValue: { currentUserLanguageId: 'en-US' }
+                }
             ],
             imports: [
                 DotListingDataTableModule,

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.spec.ts
@@ -14,7 +14,7 @@ import { TableModule } from 'primeng/table';
 import { DotContentComparePreviewFieldComponent } from '@components/dot-content-compare/components/fields/dot-content-compare-preview-field/dot-content-compare-preview-field.component';
 import { DotContentCompareTableData } from '@components/dot-content-compare/store/dot-content-compare.store';
 import { DotMessageService } from '@dotcms/data-access';
-import { DotcmsConfigService } from '@dotcms/dotcms-js';
+import { DotcmsConfigService, LoginService } from '@dotcms/dotcms-js';
 import { DotFormatDateService, DotMessagePipe, DotRelativeDatePipe } from '@dotcms/ui';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotDiffPipeModule } from '@pipes/dot-diff/dot-diff.pipe.module';
@@ -309,6 +309,10 @@ describe('DotContentCompareTableComponent', () => {
                                 offset: -21600000
                             })
                     }
+                },
+                {
+                    provide: LoginService,
+                    useValue: { currentUserLanguageId: 'en-US' }
                 }
             ]
         });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/dot-content-compare.component.spec.ts
@@ -13,7 +13,7 @@ import { dotContentCompareTableDataMock } from '@components/dot-content-compare/
 import { DotContentCompareModule } from '@components/dot-content-compare/dot-content-compare.module';
 import { DotContentCompareStore } from '@components/dot-content-compare/store/dot-content-compare.store';
 import { DotAlertConfirmService, DotMessageService } from '@dotcms/data-access';
-import { DotcmsConfigService } from '@dotcms/dotcms-js';
+import { DotcmsConfigService, LoginService } from '@dotcms/dotcms-js';
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DotFormatDateService } from '@dotcms/ui';
 import { MockDotMessageService } from '@dotcms/utils-testing';
@@ -87,6 +87,10 @@ describe('DotContentCompareComponent', () => {
                                 offset: -21600000
                             })
                     }
+                },
+                {
+                    provide: LoginService,
+                    useValue: { currentUserLanguageId: 'en-US' }
                 }
             ]
         });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/store/dot-content-compare.store.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-content-compare/store/dot-content-compare.store.spec.ts
@@ -4,7 +4,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { DotContentCompareStore } from '@components/dot-content-compare/store/dot-content-compare.store';
 import { DotContentletService, DotContentTypeService } from '@dotcms/data-access';
-import { DotcmsConfigService } from '@dotcms/dotcms-js';
+import { DotcmsConfigService, LoginService } from '@dotcms/dotcms-js';
 import { DotFormatDateService } from '@dotcms/ui';
 
 const getContentTypeMOCKResponse = {
@@ -649,6 +649,10 @@ describe('DotContentCompareStore', () => {
                                 offset: -21600000
                             })
                     }
+                },
+                {
+                    provide: LoginService,
+                    useValue: { currentUserLanguageId: 'en-US' }
                 }
             ]
         });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.spec.ts
@@ -18,7 +18,13 @@ import { TableModule } from 'primeng/table';
 import { TooltipModule } from 'primeng/tooltip';
 
 import { DotAlertConfirmService, DotMessageService } from '@dotcms/data-access';
-import { CoreWebService, DotcmsConfigService, LoggerService, StringUtils } from '@dotcms/dotcms-js';
+import {
+    CoreWebService,
+    DotcmsConfigService,
+    LoggerService,
+    LoginService,
+    StringUtils
+} from '@dotcms/dotcms-js';
 import {
     DotIconModule,
     DotMessagePipe,
@@ -167,6 +173,10 @@ describe('DotListingDataTableComponent', () => {
                                 offset: -21600000
                             })
                     }
+                },
+                {
+                    provide: LoginService,
+                    useValue: { currentUserLanguageId: 'en-US' }
                 }
             ]
         });

--- a/core-web/libs/dotcms-js/src/lib/core/login.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/login.service.ts
@@ -25,8 +25,11 @@ export const LOGOUT_URL = '/dotAdmin/logout';
  * This Service get the server configuration to display in the login component
  * and execute the login and forgot password routines
  */
-@Injectable()
+@Injectable({
+    providedIn: 'root'
+})
 export class LoginService {
+    currentUserLanguageId: string = '';
     private country = '';
     private lang = '';
     private urls: Record<string, string>;
@@ -326,6 +329,8 @@ export class LoginService {
     setAuth(auth: Auth): void {
         this._auth = this.getFullAuth(auth);
         this._auth$.next(this.getFullAuth(auth));
+
+        this.currentUserLanguageId = auth.user.languageId;
 
         // When not logged user we need to fire the observable chain
         if (!auth.user) {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.html
@@ -19,26 +19,24 @@
                             {{ experiment.name }}
                         </td>
                         <td data-testId="experiment-row__createdDate">
-                            {{ experiment.creationDate | dotRelativeDate }}
+                            {{ experiment.creationDate | dotTimestampToDate }}
                         </td>
                         <td data-testId="experiment-row__modDate">
-                            {{ experiment.modDate | dotRelativeDate }}
+                            {{ experiment.modDate | dotTimestampToDate }}
                         </td>
                         <td class="text-right" data-testId="experiment-row__actions">
                             <p-menu
                                 #menu
                                 [model]="experiment.actionsItemsMenu"
                                 [popup]="true"
-                                appendTo="body"
-                            ></p-menu>
+                                appendTo="body"></p-menu>
                             <button
                                 class="p-button-rounded p-button-text"
                                 (click)="menu.toggle($event); $event.stopPropagation()"
                                 data-testId="experiment-row__action-button"
                                 icon="pi pi-ellipsis-v"
                                 pButton
-                                type="button"
-                            ></button>
+                                type="button"></button>
                         </td>
                     </tr>
                 </ng-template>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
@@ -10,7 +10,11 @@ import { Table } from 'primeng/table';
 import { DotMessageService } from '@dotcms/data-access';
 import { LoginService } from '@dotcms/dotcms-js';
 import { DotExperimentStatus, GroupedExperimentByStatus } from '@dotcms/dotcms-models';
-import { DotEmptyContainerComponent, DotFormatDateService } from '@dotcms/ui';
+import {
+    DotEmptyContainerComponent,
+    DotFormatDateService,
+    DotTimestampToDatePipe
+} from '@dotcms/ui';
 import {
     DotFormatDateServiceMock,
     getExperimentMock,
@@ -78,6 +82,7 @@ describe('DotExperimentsListTableComponent', () => {
 
     const createComponent = createComponentFactory({
         component: DotExperimentsListTableComponent,
+        imports: [DotTimestampToDatePipe],
         componentMocks: [ConfirmPopup],
         declarations: [MockDatePipe],
         providers: [
@@ -139,9 +144,11 @@ describe('DotExperimentsListTableComponent', () => {
                 DRAFT_EXPERIMENT_MOCK.name
             );
             expect(spectator.query(byTestId('experiment-row__createdDate'))).toHaveText(
-                '1 hour ago'
+                '10/10/2020 10:10 PM'
             );
-            expect(spectator.query(byTestId('experiment-row__modDate'))).toHaveText('1 hour ago');
+            expect(spectator.query(byTestId('experiment-row__modDate'))).toHaveText(
+                '10/10/2020 10:10 PM'
+            );
         });
 
         it('should emit action when a row is clicked', () => {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
@@ -8,6 +8,7 @@ import { Menu, MenuItemContent } from 'primeng/menu';
 import { Table } from 'primeng/table';
 
 import { DotMessageService } from '@dotcms/data-access';
+import { LoginService } from '@dotcms/dotcms-js';
 import { DotExperimentStatus, GroupedExperimentByStatus } from '@dotcms/dotcms-models';
 import { DotEmptyContainerComponent, DotFormatDateService } from '@dotcms/ui';
 import {
@@ -17,7 +18,6 @@ import {
 } from '@dotcms/utils-testing';
 
 import { DotExperimentsListTableComponent } from './dot-experiments-list-table.component';
-import { LoginService } from '@dotcms/dotcms-js';
 
 const MOCK_MENU_ITEMS: MenuItem[] = [
     // Delete Action

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '@dotcms/utils-testing';
 
 import { DotExperimentsListTableComponent } from './dot-experiments-list-table.component';
+import { LoginService } from '@dotcms/dotcms-js';
 
 const MOCK_MENU_ITEMS: MenuItem[] = [
     // Delete Action
@@ -86,7 +87,11 @@ describe('DotExperimentsListTableComponent', () => {
             },
             MessageService,
             ConfirmationService,
-            { provide: DotFormatDateService, useClass: DotFormatDateServiceMock }
+            { provide: DotFormatDateService, useClass: DotFormatDateServiceMock },
+            {
+                provide: LoginService,
+                useValue: { currentUserLanguageId: 'en-US' }
+            }
         ],
         schemas: [NO_ERRORS_SCHEMA]
     });

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-list/components/dot-experiments-list-table/dot-experiments-list-table.component.ts
@@ -21,6 +21,7 @@ import {
     DotEmptyContainerComponent,
     DotMessagePipe,
     DotRelativeDatePipe,
+    DotTimestampToDatePipe,
     PrincipalConfiguration
 } from '@dotcms/ui';
 
@@ -41,7 +42,8 @@ import {
         ButtonModule,
         TooltipModule,
         MenuModule,
-        DotEmptyContainerComponent
+        DotEmptyContainerComponent,
+        DotTimestampToDatePipe
     ],
     templateUrl: './dot-experiments-list-table.component.html',
     styleUrls: ['./dot-experiments-list-table.component.scss'],
@@ -50,8 +52,10 @@ import {
 })
 export class DotExperimentsListTableComponent {
     @Input() experimentGroupedByStatus: GroupedExperimentByStatus[] = [];
+
     @Output()
     goToContainer = new EventEmitter<DotExperiment>();
+
     private dotMessageService: DotMessageService = inject(DotMessageService);
     protected readonly emptyConfiguration: PrincipalConfiguration = {
         title: this.dotMessageService.get('experimentspage.not.experiments.found.filtered'),

--- a/core-web/libs/ui/src/index.ts
+++ b/core-web/libs/ui/src/index.ts
@@ -27,3 +27,4 @@ export * from './lib/services/clipboard/ClipboardUtil';
 export * from './lib/pipes/dot-relative-date/dot-relative-date.pipe';
 export * from './lib/dot-message/dot-message.pipe';
 export * from './lib/pipes/dot-string-format/dot-string-format.pipe';
+export * from './lib/pipes/dot-timestamp-to-date/dot-timestamp-to-date.pipe';

--- a/core-web/libs/ui/src/lib/pipes/dot-relative-date/dot-relative-date.pipe.spec.ts
+++ b/core-web/libs/ui/src/lib/pipes/dot-relative-date/dot-relative-date.pipe.spec.ts
@@ -1,6 +1,6 @@
-import { fakeAsync, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
-import { DotcmsConfigService } from '@dotcms/dotcms-js';
+import { DotcmsConfigService, LoginService } from '@dotcms/dotcms-js';
 import { DotFormatDateService, DotRelativeDatePipe } from '@dotcms/ui';
 import { DotcmsConfigServiceMock } from '@dotcms/utils-testing';
 
@@ -18,11 +18,23 @@ describe('DotRelativeDatePipe', () => {
     let pipe: DotRelativeDatePipe;
 
     beforeEach(() => {
-        formatDateService = new DotFormatDateService(
-            new DotcmsConfigServiceMock() as unknown as DotcmsConfigService
-        );
+        TestBed.configureTestingModule({
+            providers: [
+                {
+                    provide: LoginService,
+                    useValue: { currentUserLanguageId: 'en-US' }
+                },
+                {
+                    provide: DotcmsConfigService,
+                    useClass: DotcmsConfigServiceMock
+                },
+                DotFormatDateService,
+                DotRelativeDatePipe
+            ]
+        });
 
-        pipe = new DotRelativeDatePipe(formatDateService as unknown as DotFormatDateService);
+        formatDateService = TestBed.inject(DotFormatDateService);
+        pipe = TestBed.inject(DotRelativeDatePipe);
     });
 
     describe('relative', () => {

--- a/core-web/libs/ui/src/lib/pipes/dot-timestamp-to-date/dot-timestamp-to-date.pipe.spec.ts
+++ b/core-web/libs/ui/src/lib/pipes/dot-timestamp-to-date/dot-timestamp-to-date.pipe.spec.ts
@@ -1,0 +1,29 @@
+import { createPipeFactory, mockProvider, SpectatorPipe } from '@ngneat/spectator';
+
+import { DotFormatDateService } from '@dotcms/ui';
+
+import { DotTimestampToDatePipe } from './dot-timestamp-to-date.pipe';
+
+const TIMESTAMP_MOCK = 1698789866;
+const EXPECTED_DATE_MOCK = '10/29/2023, 12:43 PM';
+describe('DotTimestampPipe ', () => {
+    let spectator: SpectatorPipe<DotTimestampToDatePipe>;
+
+    const createPipe = createPipeFactory({
+        pipe: DotTimestampToDatePipe,
+        providers: [
+            DotFormatDateService,
+            mockProvider(DotFormatDateService, { getDateFromTimestamp: () => EXPECTED_DATE_MOCK })
+        ]
+    });
+
+    it('should transform the timestamp using getDateFromTimestamp to date format', () => {
+        spectator = createPipe(`<div>{{ timestamp |  dotTimestampToDate }}</div>`, {
+            hostProps: {
+                TIMESTAMP_MOCK
+            }
+        });
+
+        expect(spectator.element).toHaveText(EXPECTED_DATE_MOCK);
+    });
+});

--- a/core-web/libs/ui/src/lib/pipes/dot-timestamp-to-date/dot-timestamp-to-date.pipe.ts
+++ b/core-web/libs/ui/src/lib/pipes/dot-timestamp-to-date/dot-timestamp-to-date.pipe.ts
@@ -1,0 +1,30 @@
+import { inject, Pipe, PipeTransform } from '@angular/core';
+
+import { DotFormatDateService } from '@dotcms/ui';
+
+/**
+ * Transforms a timestamp into a formatted date string based on the user's selected language at login
+ *
+ * @remarks
+ * This pipe is a pure pipe, meaning it is only re-evaluated when the input value changes.
+ *
+ * @example
+ * ```html
+ * <p>{{ timestampValue | dotTimestampToDate }}</p>
+ * ```
+ *
+ * @param time - The timestamp to be transformed into a date string.
+ * @param userDateFormatOptions - Optional. The formatting options for the date string.
+ * @returns A formatted date string based on the provided timestamp and formatting options.
+ */
+@Pipe({
+    name: 'dotTimestampToDate',
+    standalone: true,
+    pure: true
+})
+export class DotTimestampToDatePipe implements PipeTransform {
+    private dotFormatDateService: DotFormatDateService = inject(DotFormatDateService);
+    transform(time: number, userDateFormatOptions?: Intl.DateTimeFormatOptions): string {
+        return this.dotFormatDateService.getDateFromTimestamp(time, userDateFormatOptions);
+    }
+}

--- a/core-web/libs/ui/src/lib/services/dot-format-date-service.spec.ts
+++ b/core-web/libs/ui/src/lib/services/dot-format-date-service.spec.ts
@@ -7,6 +7,15 @@ import { DotFormatDateService } from '@dotcms/ui';
 const INVALID_DATE_MSG = 'Invalid date';
 const VALID_TIMESTAMP = 1701189800000;
 const WRONG_TIMESTAMP = 1651337877000000;
+const DateFormatOptions: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'UTC'
+};
 
 describe('DotFormatDateService', () => {
     let spectator: SpectatorService<DotFormatDateService>;
@@ -35,15 +44,19 @@ describe('DotFormatDateService', () => {
         });
 
         it('should return a string date using timestamp using `currentUserLanguageId`with us-US', () => {
-            const EXPECTED_DATE = '11/28/2023, 11:43 AM';
-            expect(spectator.service.getDateFromTimestamp(VALID_TIMESTAMP)).toBe(EXPECTED_DATE);
+            const EXPECTED_DATE = '11/28/2023, 04:43 PM';
+            expect(spectator.service.getDateFromTimestamp(VALID_TIMESTAMP, DateFormatOptions)).toBe(
+                EXPECTED_DATE
+            );
         });
 
         it('should return a string with correct date format using timestamp using `currentUserLanguageId` with es-ES', () => {
-            const EXPECTED_DATE = '28/11/2023, 11:43 a. m.';
+            const EXPECTED_DATE = '28/11/2023, 04:43 p. m.';
 
             loginService.currentUserLanguageId = 'es-ES';
-            expect(spectator.service.getDateFromTimestamp(VALID_TIMESTAMP)).toBe(EXPECTED_DATE);
+            expect(spectator.service.getDateFromTimestamp(VALID_TIMESTAMP, DateFormatOptions)).toBe(
+                EXPECTED_DATE
+            );
         });
     });
 });

--- a/core-web/libs/ui/src/lib/services/dot-format-date-service.spec.ts
+++ b/core-web/libs/ui/src/lib/services/dot-format-date-service.spec.ts
@@ -1,0 +1,49 @@
+import { createServiceFactory, mockProvider, SpectatorService, SpyObject } from '@ngneat/spectator';
+import { of } from 'rxjs';
+
+import { DotcmsConfigService, LoginService } from '@dotcms/dotcms-js';
+import { DotFormatDateService } from '@dotcms/ui';
+
+const INVALID_DATE_MSG = 'Invalid date';
+const VALID_TIMESTAMP = 1701189800000;
+const WRONG_TIMESTAMP = 1651337877000000;
+
+describe('DotFormatDateService', () => {
+    let spectator: SpectatorService<DotFormatDateService>;
+    let loginService: SpyObject<LoginService>;
+    const createService = createServiceFactory({
+        service: DotFormatDateService,
+        providers: [
+            mockProvider(DotcmsConfigService, {
+                getSystemTimeZone: () => of('idk')
+            }),
+            mockProvider(LoginService)
+        ]
+    });
+
+    beforeEach(() => {
+        spectator = createService();
+        loginService = spectator.inject(LoginService);
+        loginService.currentUserLanguageId = 'en-US';
+    });
+
+    describe('getDateFromTimestamp', () => {
+        it('should return `Invalid date` when is not a timestamp', () => {
+            expect(spectator.service.getDateFromTimestamp(WRONG_TIMESTAMP)).toContain(
+                INVALID_DATE_MSG
+            );
+        });
+
+        it('should return a string date using timestamp using `currentUserLanguageId`with us-US', () => {
+            const EXPECTED_DATE = '11/28/2023, 11:43 AM';
+            expect(spectator.service.getDateFromTimestamp(VALID_TIMESTAMP)).toBe(EXPECTED_DATE);
+        });
+
+        it('should return a string with correct date format using timestamp using `currentUserLanguageId` with es-ES', () => {
+            const EXPECTED_DATE = '28/11/2023, 11:43 a. m.';
+
+            loginService.currentUserLanguageId = 'es-ES';
+            expect(spectator.service.getDateFromTimestamp(VALID_TIMESTAMP)).toBe(EXPECTED_DATE);
+        });
+    });
+});

--- a/core-web/libs/utils-testing/src/lib/format-date-service.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/format-date-service.mock.ts
@@ -37,4 +37,7 @@ export class DotFormatDateServiceMock {
     differenceInCalendarDays(_dateLeft: Date, _dateRight: Date): number {
         return 1;
     }
+    getDateFromTimestamp(_time: number, _userDateFormatOptions?: Intl.DateTimeFormatOptions) {
+        return '10/10/2020 10:10 PM';
+    }
 }


### PR DESCRIPTION
### Proposed Changes
* Add timestamp to date pipe and improve date formatting

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa9feb9</samp>

This pull request introduces a new pipe, `DotTimestampToDatePipe`, that formats date strings based on the user's language and the system time zone. It also updates the `DotFormatDateService` to use the native Intl.DateTimeFormat API instead of the date-fns library. It replaces the old `dotRelativeDate` pipe with the new pipe in several components and services, and adds tests for the new pipe and service. It also makes the `LoginService` a singleton service and stores the user's language id for date formatting.

## Related Issue
Fixes #26399 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa9feb9</samp>

*  Add a new pipe `DotTimestampToDatePipe` that formats the date strings based on the user's language and the system time zone, instead of the old pipe `dotRelativeDate` that only shows the relative time from the current date ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-99b8228870b42fa348fb5e31617353035c2b064ba3b7a0ad6c4d7356bf9e09f9R1-R30), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-ab89d36581ad170bfcdd0c21f82fcbfab07630f75dacd14c02528612824bd2f0R1-R29), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-bd390158a0315505d598e7ff896c73589c38f5263e0ff170662313807c45e15eR30), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-9c55858c58e4b1c77b3598923b9c6e6dcf5dc733db9390077691b89d2a86688aR24), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-9c55858c58e4b1c77b3598923b9c6e6dcf5dc733db9390077691b89d2a86688aL44-R46), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-47ff8e7da16ff598a09d04b521a054c50ccbca38ae913fec184a9440695f8b3fL22-R25))
*  Add a new service `DotFormatDateService` that provides methods to format and validate dates based on the user's language and the system time zone, and deprecate the old method `getLocaleOptions` that relies on the date-fns library ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-703c0e1152b258cf6f06ea90fa155f0f29fb93f92ab96ddebe61111459c300eeL4-R11), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-703c0e1152b258cf6f06ea90fa155f0f29fb93f92ab96ddebe61111459c300eeL18-R31), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-703c0e1152b258cf6f06ea90fa155f0f29fb93f92ab96ddebe61111459c300eeR40-R41), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-703c0e1152b258cf6f06ea90fa155f0f29fb93f92ab96ddebe61111459c300eeR50-R54), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-703c0e1152b258cf6f06ea90fa155f0f29fb93f92ab96ddebe61111459c300eeR76-R105), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-703c0e1152b258cf6f06ea90fa155f0f29fb93f92ab96ddebe61111459c300eeL130-R217), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-5b464f562f05d13c27163f1da9003d672a202104439d9a7b4b885430e6883191R1-R62))
*  Add a `currentUserLanguageId` property to the `LoginService` class that stores the user's language id obtained from the auth response, and make the `LoginService` a singleton service that can be injected anywhere in the application ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-70cf489f1df5bd22a9ddad9d7ef726363bd522b842a502c1b52e424f105f9138L28-R32), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-70cf489f1df5bd22a9ddad9d7ef726363bd522b842a502c1b52e424f105f9138R333-R334))
*  Replace the `dotRelativeDate` pipe with the `DotTimestampToDatePipe` in the `dot-experiments-list-table.component.html` file, and import and declare the new pipe in the `dot-experiments-list-table.component.ts` file ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-47ff8e7da16ff598a09d04b521a054c50ccbca38ae913fec184a9440695f8b3fL22-R25), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-9c55858c58e4b1c77b3598923b9c6e6dcf5dc733db9390077691b89d2a86688aR24), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-9c55858c58e4b1c77b3598923b9c6e6dcf5dc733db9390077691b89d2a86688aL44-R46))
*  Remove the `LoginService` from the test providers of the `dot-template-list.component.spec.ts` file, since it is already imported and provided by the dotcms-js library, and add a mock value for the `LoginService` with the `currentUserLanguageId` property set to 'en-US' ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-e16e5d71145ece8e7e3ac84c6efb9c108a31b1ccd8fee53dd7a309f71b295aa3L445), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-e16e5d71145ece8e7e3ac84c6efb9c108a31b1ccd8fee53dd7a309f71b295aa3L452-R455))
  - `dot-container-list-resolver.service.spec.ts` ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-c14cbac56c937927f1cc688ebc0878cd1aa838659f5f74c57d6047ff4b6663caR14), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-c14cbac56c937927f1cc688ebc0878cd1aa838659f5f74c57d6047ff4b6663caR53-R56))
  - `dot-pages-listing-panel.component.spec.ts` ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-b0f9020298ea1bc50a1a741ea744758d98df7f5a31173942b2bccb0a94c68028L19-R24), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-b0f9020298ea1bc50a1a741ea744758d98df7f5a31173942b2bccb0a94c68028L158-R167))
  - `dot-template-list-resolver.service.spec.ts` ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-6466489d2632628517ce14b4f1bd9892ee5b65c2b00bcf2041c4cb113e02325fR15), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-6466489d2632628517ce14b4f1bd9892ee5b65c2b00bcf2041c4cb113e02325fR53-R56))
  - `dot-content-compare-table.component.spec.ts` ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-c054e9d968f916ecce1d791591b6e50cf9cce1a53971879af4a3123cd0c52b3aL17-R17), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-c054e9d968f916ecce1d791591b6e50cf9cce1a53971879af4a3123cd0c52b3aR312-R315))
  - `dot-content-compare.component.spec.ts` ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-bd773809464ff5510bc642e0336b562b52fe2962608867498b1a4c5b2c2d7e45L16-R16), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-bd773809464ff5510bc642e0336b562b52fe2962608867498b1a4c5b2c2d7e45R90-R93))
  - `dot-content-compare.store.spec.ts` ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-361324cb094b117a50e85484e8fdf70b79ffe6b290107a7990efed6366693466L7-R7), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-361324cb094b117a50e85484e8fdf70b79ffe6b290107a7990efed6366693466R652-R655))
  - `dot-listing-data-table.component.spec.ts` ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-842c5b505f7d21a1407875034078cd665488338ebb6f6daea3279fc80c5eeff8L21-R28), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-842c5b505f7d21a1407875034078cd665488338ebb6f6daea3279fc80c5eeff8R176-R179))
  - `dot-experiments-list-table.component.spec.ts` ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-1f88958edd07bf54c9d3aab3eb150cb7f144525caed75a3e95708761aff5ccf9R11), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-1f88958edd07bf54c9d3aab3eb150cb7f144525caed75a3e95708761aff5ccf9L89-R94))
*  Replace the manual instantiation of the `DotFormatDateService` and the `dotRelativeDate` pipe with the `TestBed` configuration and injection in the `dot-relative-date.pipe.spec.ts` file, and import the `TestBed` from the angular/core/testing library ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-c4b21f4f4b0cd2cdda92b0cc8157c82493d1c467ef437816ab0744e490bfb742L1-R3), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-c4b21f4f4b0cd2cdda92b0cc8157c82493d1c467ef437816ab0744e490bfb742L21-R37))
*  Remove some extra line breaks in the `dot-experiments-list-table.component.html` file to improve the code readability and consistency ([link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-47ff8e7da16ff598a09d04b521a054c50ccbca38ae913fec184a9440695f8b3fL32-R32), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-47ff8e7da16ff598a09d04b521a054c50ccbca38ae913fec184a9440695f8b3fL40-R39), [link](https://github.com/dotCMS/core/pull/26620/files?diff=unified&w=0#diff-9c55858c58e4b1c77b3598923b9c6e6dcf5dc733db9390077691b89d2a86688aL53-R58))

### en-EN selected at login
<img width="1817" alt="Screenshot 2023-11-07 at 4 23 03 PM" src="https://github.com/dotCMS/core/assets/1909643/73672e66-cff1-4551-9a8b-728e7b42e63e">

### es-ES selected at login
<img width="1824" alt="Screenshot 2023-11-07 at 4 22 33 PM" src="https://github.com/dotCMS/core/assets/1909643/0ff51bc1-5149-4833-9856-fdb410722077">
