### PR TITLE
#26616 better handling of archived pieces + none existing inode from checkout when publishing

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/asset/WebAssetHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/asset/WebAssetHelper.java
@@ -568,18 +568,23 @@ public class WebAssetHelper {
      */
     Contentlet checkinOrPublish(final Contentlet checkout, User user, final boolean live) throws DotDataException, DotSecurityException {
         if(live){
+            //if the desired state is live, and we need to publish the contentlet
+            //But checkout forces creation of a new version, so we need to check in first
             if(isNotSet(checkout.getInode())){
               Contentlet checkin = contentletAPI.checkin(checkout, user, false);
               contentletAPI.publish(checkin, user, false);
               return checkin;
             }
+            //Live means publish, so we need to publish the contentlet
             contentletAPI.publish(checkout, user, false);
             return checkout;
         } else {
+            //if the desired state is working we need to unpublish the contentlet
             if(checkout.isLive()){
                 contentletAPI.unpublish(checkout, user, false);
             }
         }
+        //and finally checkin the contentlet to persist the changes
         return contentletAPI.checkin(checkout, user, false);
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/asset/WebAssetHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/asset/WebAssetHelper.java
@@ -1,5 +1,7 @@
 package com.dotcms.rest.api.v1.asset;
 
+import static com.dotmarketing.util.UtilMethods.isNotSet;
+
 import com.dotcms.browser.BrowserAPI;
 import com.dotcms.browser.BrowserQuery;
 import com.dotcms.browser.BrowserQuery.Builder;
@@ -12,6 +14,7 @@ import com.dotcms.rest.api.v1.asset.view.WebAssetView;
 import com.dotcms.rest.api.v1.temp.DotTempFile;
 import com.dotcms.rest.api.v1.temp.TempFileAPI;
 import com.dotmarketing.beans.Host;
+import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Treeable;
 import com.dotmarketing.exception.DotDataException;
@@ -483,10 +486,7 @@ public class WebAssetHelper {
                 // We trust that the asset we're getting here is working and or live which is the inode we need to do the checkout
                 final AssetView asset = versions.get(0);
 
-                if(versionsView.archived()){
-                    contentletAPI.findLiveOrWorkingVersions(Set.of(asset.identifier()), user, false)
-                            .forEach(contentlet -> handleArchivedContent(contentlet, user));
-                }
+                handleArchivedVersions(user, asset, lang.get());
 
                 //now checkout and create a new version of the asset in the given language
                 final Contentlet checkout = contentletAPI.checkout(asset.inode(), user, false);
@@ -504,6 +504,22 @@ public class WebAssetHelper {
         } finally {
             disposeTempFile(tempFile);
         }
+    }
+
+    /**
+     * If we want to be successful publishing content that has been archived we need to get rid of any archived version
+     * @param user the user performing the action
+     * @param asset the asset to check
+     * @param language the language to check
+     * @throws DotSecurityException
+     * @throws DotDataException
+     */
+    private void handleArchivedVersions(User user, AssetView asset, Language language)
+            throws DotSecurityException, DotDataException {
+        //Always verify if any prior version remains archived for the give language, if so get rid of the problem
+        contentletAPI.findAllVersions( new Identifier(asset.identifier()), user, false)
+                .stream().filter(contentlet -> language.getId() == contentlet.getLanguageId())
+                .forEach(contentlet -> handleArchivedContent(contentlet, user));
     }
 
     /**
@@ -552,6 +568,11 @@ public class WebAssetHelper {
      */
     Contentlet checkinOrPublish(final Contentlet checkout, User user, final boolean live) throws DotDataException, DotSecurityException {
         if(live){
+            if(isNotSet(checkout.getInode())){
+              Contentlet checkin = contentletAPI.checkin(checkout, user, false);
+              contentletAPI.publish(checkin, user, false);
+              return checkin;
+            }
             contentletAPI.publish(checkout, user, false);
             return checkout;
         } else {


### PR DESCRIPTION
### Proposed Changes
* correcting flawed logic that handled archived pieces scenario was failing when there were several versions
* correcting flawed logic when publishing content with target state live

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ae5907a</samp>

### Summary
🌐📁🐛

<!--
1.  🌐 - This emoji represents the multilingual aspect of the changes, as they involve working with files in different languages.
2.  📁 - This emoji represents the file uploading and archiving functionality that is affected by the changes, as they involve manipulating files and their versions on the server.
3.  🐛 - This emoji represents the bug fixing and refactoring aspect of the changes, as they involve fixing a logic error and improving the code quality and readability.
-->
This pull request enhances the integration tests and the logic for uploading multilingual files. It adds a new parameter and a new test method to `WebAssetHelperIntegrationTest.java` to cover different scenarios of publishing and archiving files for different languages. It also refactors and fixes some issues in `WebAssetHelper.java` to handle archived versions correctly and import some useful classes.

> _To upload files for languages galore_
> _We added a `live` param and more_
> _We imported some utils_
> _Refactored and fixed bugs_
> _And tested the archiving and restore_

### Walkthrough
*  Add `live` parameter to `pushFileForLanguageThenValidate` method and test cases to handle publishing logic for files ([link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-6d4b2ec9f16ebe307a29cd7e4212e691b95d1c775de769090c436bed73764aadL338-R343), [link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-6d4b2ec9f16ebe307a29cd7e4212e691b95d1c775de769090c436bed73764aadL356-R361), [link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-6d4b2ec9f16ebe307a29cd7e4212e691b95d1c775de769090c436bed73764aadL372-R376), [link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-6d4b2ec9f16ebe307a29cd7e4212e691b95d1c775de769090c436bed73764aadR385-R431), [link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-6d4b2ec9f16ebe307a29cd7e4212e691b95d1c775de769090c436bed73764aadL389-R440), [link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-6d4b2ec9f16ebe307a29cd7e4212e691b95d1c775de769090c436bed73764aadL398-R449), [link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-6d4b2ec9f16ebe307a29cd7e4212e691b95d1c775de769090c436bed73764aadL404-R455))
*  Fix bug where new version of asset was not published when uploading file for different language by checking inode of checkout contentlet ([link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-bc183f5f0bbfa16e0f5ca9296cfb9f912f3a831d598a9ee68bed1b745d13cefbR571-R575))
*  Refactor logic to handle archived versions of asset by language into a private method `handleArchivedVersions` ([link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-bc183f5f0bbfa16e0f5ca9296cfb9f912f3a831d598a9ee68bed1b745d13cefbL486-R489), [link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-bc183f5f0bbfa16e0f5ca9296cfb9f912f3a831d598a9ee68bed1b745d13cefbR510-R525))
*  Import `Identifier` class to use in test cases and asset handling ([link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-6d4b2ec9f16ebe307a29cd7e4212e691b95d1c775de769090c436bed73764aadR23), [link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-bc183f5f0bbfa16e0f5ca9296cfb9f912f3a831d598a9ee68bed1b745d13cefbR17))
*  Import `Try` class to use in test cases for functional error handling ([link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-6d4b2ec9f16ebe307a29cd7e4212e691b95d1c775de769090c436bed73764aadR41))
*  Import `isNotSet` method to use in asset handling for string validation ([link](https://github.com/dotCMS/core/pull/26623/files?diff=unified&w=0#diff-bc183f5f0bbfa16e0f5ca9296cfb9f912f3a831d598a9ee68bed1b745d13cefbR3-R4))


