### PR TITLE
fix(core): Fixing default timestamp value to avoid cast exception

### DIFF
--- a/dotCMS/src/main/java/com/liferay/portal/util/ReleaseInfo.java
+++ b/dotCMS/src/main/java/com/liferay/portal/util/ReleaseInfo.java
@@ -19,8 +19,6 @@
 
 package com.liferay.portal.util;
 
-import com.dotcms.repackage.com.google.common.collect.ImmutableMap;
-
 import com.dotmarketing.util.Logger;
 
 import com.google.common.collect.Maps;
@@ -42,7 +40,7 @@ public final class ReleaseInfo {
 
 
 
-    private volatile Map<String, String> values = ImmutableMap.of("name", "dotCMS Platform", "version", "UNVERSIONED", "revision", "0", "timestamp", "1699480662");
+    private volatile Map<String, String> values = Map.of("name", "dotCMS Platform", "version", "UNVERSIONED", "revision", "0", "timestamp", "1699480662");
 
     protected ReleaseInfo() {
         load();

--- a/dotCMS/src/main/java/com/liferay/portal/util/ReleaseInfo.java
+++ b/dotCMS/src/main/java/com/liferay/portal/util/ReleaseInfo.java
@@ -38,9 +38,7 @@ import java.util.*;
 
 public final class ReleaseInfo {
 
-
-
-    private volatile Map<String, String> values = Map.of("name", "dotCMS Platform", "version", "UNVERSIONED", "revision", "0", "timestamp", "1699480662");
+    private Map<String, String> values = Map.of("name", "dotCMS Platform", "version", "UNVERSIONED", "revision", "0", "timestamp", "1699480662");
 
     protected ReleaseInfo() {
         load();
@@ -63,7 +61,7 @@ public final class ReleaseInfo {
         }
     }
 
-    private final static ReleaseInfo instance = new ReleaseInfo();
+    private static final ReleaseInfo instance = new ReleaseInfo();
 
     public static String getName() {
 

--- a/dotCMS/src/main/java/com/liferay/portal/util/ReleaseInfo.java
+++ b/dotCMS/src/main/java/com/liferay/portal/util/ReleaseInfo.java
@@ -42,7 +42,7 @@ public final class ReleaseInfo {
 
 
 
-    private volatile Map<String, String> values = ImmutableMap.of("name", "dotCMS Platform", "version", "UNVERSIONED", "revision", "0", "timestamp", "March 6 2009");
+    private volatile Map<String, String> values = ImmutableMap.of("name", "dotCMS Platform", "version", "UNVERSIONED", "revision", "0", "timestamp", "1699480662");
 
     protected ReleaseInfo() {
         load();


### PR DESCRIPTION
Refs: #25571 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cea541e</samp>

Updated the `ReleaseInfo` class and the `build.gradle` file to display the correct release info in the dotCMS UI based on the current build time.