### PR TITLE
Respecting  the order of the provided filter

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/util/RelationshipUtilTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/util/RelationshipUtilTest.java
@@ -5,9 +5,18 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.dotcms.contenttype.business.ContentTypeAPI;
+import com.dotcms.contenttype.business.FieldAPI;
+import com.dotcms.contenttype.model.field.Field;
+import com.dotcms.contenttype.model.field.FieldBuilder;
+import com.dotcms.contenttype.model.field.RelationshipField;
+import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.model.type.ContentTypeBuilder;
+import com.dotcms.contenttype.model.type.SimpleContentType;
 import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.datagen.TestDataUtils;
+import com.dotcms.datagen.TestUserUtils;
+import com.dotcms.datagen.UserDataGen;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
@@ -15,7 +24,9 @@ import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
+import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
 import java.util.List;
 import org.junit.BeforeClass;
@@ -33,7 +44,8 @@ public class RelationshipUtilTest {
     private static HostAPI hostAPI;
     private static LanguageAPI languageAPI;
     private static long languageID;
-
+    private static FieldAPI contentTypeFieldAPI;
+    static long defaultLang;
     @BeforeClass
     public static void prepare() throws Exception {
         //Setting web app environment
@@ -45,6 +57,8 @@ public class RelationshipUtilTest {
         languageAPI    = APILocator.getLanguageAPI();
         languageID     = languageAPI.getDefaultLanguage().getId();
         host = hostAPI.findDefaultHost(user, false);
+        contentTypeFieldAPI = APILocator.getContentTypeFieldAPI();
+        defaultLang = APILocator.getLanguageAPI().getDefaultLanguage().getId();
     }
 
     @Test
@@ -117,5 +131,55 @@ public class RelationshipUtilTest {
             }
         }
     }
+    private ContentType createContentType(final String name) throws DotSecurityException, DotDataException {
+        return contentTypeAPI.save(ContentTypeBuilder.builder(SimpleContentType.class).folder(
+                        FolderAPI.SYSTEM_FOLDER).host(Host.SYSTEM_HOST).name(name)
+                .owner(user.getUserId()).build());
+    }
+
+
+    /**
+     * Method to test: {@link RelationshipUtil#filterContentlet(long, String, User, boolean)
+     * Given Scenario: ordering is consistently incorrect, in that it's not in the order received but always orders them the same way on every call.
+     * ExpectedResult: The order of the contentlets should be the same as the order they are received in the filter.
+     *
+     */
+    @Test
+    public void test_filterContentlet_shouldFollowTheFilterOrder(){
+
+        try{
+            //Create content type
+            final ContentType parentContentType = createContentType("ImageSim" + System.currentTimeMillis());
+
+            //Create Text Fields
+            final String titleFieldString = "title";
+            final Field field = FieldBuilder.builder(TextField.class)
+                    .name(titleFieldString)
+                    .contentTypeId(parentContentType.id())
+                    .build();
+
+            contentTypeFieldAPI.save(field, user);
+
+            final ContentletDataGen contentletDataGen = new ContentletDataGen(parentContentType.id());
+            final Contentlet child1 = contentletDataGen.languageId(defaultLang).nextPersisted();
+            final Contentlet child2 = contentletDataGen.languageId(defaultLang).nextPersisted();
+            final Contentlet child3 = contentletDataGen.languageId(defaultLang).nextPersisted();
+
+            final String filter = child1.getIdentifier()+","+child2.getIdentifier()+","+child3.getIdentifier();
+
+            final List<Contentlet> testResults = RelationshipUtil
+                    .filterContentlet(defaultLang,  filter, user, false);
+
+            assertNotNull(testResults);
+            assertEquals(testResults.get(0).getIdentifier(), child1.getIdentifier());
+            assertEquals(testResults.get(testResults.size()-1).getIdentifier(), child3.getIdentifier());
+
+        }catch(Exception e){
+            throw new RuntimeException(e);
+        }
+
+
+    }
+
 
 }

--- a/dotCMS/src/main/java/com/dotcms/util/RelationshipUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/RelationshipUtil.java
@@ -17,6 +17,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,8 +79,8 @@ public class RelationshipUtil {
             final String sortBy,
             final User user, final boolean respectFrontendRoles, final boolean isCheckout)
             throws DotDataException, DotSecurityException {
-
-        final Map<String, Contentlet> relatedContentlets = new HashMap<>();
+        //LinkedHashMap to preserve the order of the contentlets
+        final Map<String, Contentlet> relatedContentlets = new LinkedHashMap<>();
 
         //Filter can be an identifier or a lucene query (comma separated)
         for (final String elem : filter.split(StringPool.COMMA)) {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ef4d49c</samp>

### Summary
:white_check_mark::wrench::arrows_counterclockwise:

<!--
1.  :white_check_mark: - This emoji represents the addition of a new test case, which is a positive and successful outcome for the code quality and coverage.
2.  :wrench: - This emoji represents the refactoring of the `RelationshipUtilTest` class, which is a process of improving the code structure and readability without changing its functionality.
3.  :arrows_counterclockwise: - This emoji represents the modification of the `RelationshipUtil` class, which is a change that affects the logic and behavior of the code, but in a way that preserves or enhances its original purpose.
-->
Improved the `RelationshipUtil` class to respect the order of contentlets when filtering by relationship. Added a test case to verify the new behavior. Refactored the test class to use a helper method.


### Walkthrough
*  Add a new test method `test_filterContentlet_shouldFollowTheFilterOrder` to verify the order preservation of the `RelationshipUtil.filterContentlet` method ([link](https://github.com/dotCMS/core/pull/26651/files?diff=unified&w=0#diff-48fcaba0de5b6de4955bbece2048dc8cc2fe52ad24cc23bee3d1bb87c7d652c9L120-R184))
*  Change the `relatedContentlets` variable in the `RelationshipUtil.filterContentlet` method from a `HashMap` to a `LinkedHashMap` to preserve the insertion order of the contentlets ([link](https://github.com/dotCMS/core/pull/26651/files?diff=unified&w=0#diff-ff62a01d343da67457b543c859a6fa02114e20f07ec232e787aa58f55598209eL81-R84))
*  Initialize the `contentTypeFieldAPI` and the `defaultLang` variables in the `prepare` method of the `RelationshipUtilTest` class to create and save content types and fields, and to set the language for the contentlets ([link](https://github.com/dotCMS/core/pull/26651/files?diff=unified&w=0#diff-48fcaba0de5b6de4955bbece2048dc8cc2fe52ad24cc23bee3d1bb87c7d652c9R60-R61))
*  Add a new private method `createContentType` to the `RelationshipUtilTest` class to simplify the creation of a content type using the `ContentTypeAPI`, the `ContentTypeBuilder` and the `SimpleContentType` classes ([link](https://github.com/dotCMS/core/pull/26651/files?diff=unified&w=0#diff-48fcaba0de5b6de4955bbece2048dc8cc2fe52ad24cc23bee3d1bb87c7d652c9L120-R184))
*  Update the imports in the `RelationshipUtilTest` class to include the classes needed for the new test case, such as `FieldAPI`, `FieldBuilder`, `RelationshipField`, `TextField`, `ContentTypeBuilder`, `SimpleContentType`, `TestUserUtils`, `UserDataGen`, `FolderAPI` and `WebKeys` ([link](https://github.com/dotCMS/core/pull/26651/files?diff=unified&w=0#diff-48fcaba0de5b6de4955bbece2048dc8cc2fe52ad24cc23bee3d1bb87c7d652c9L8-R19), [link](https://github.com/dotCMS/core/pull/26651/files?diff=unified&w=0#diff-48fcaba0de5b6de4955bbece2048dc8cc2fe52ad24cc23bee3d1bb87c7d652c9L18-R29))
*  Update the fields in the `RelationshipUtilTest` class to include the `contentTypeFieldAPI` and the `defaultLang` variables ([link](https://github.com/dotCMS/core/pull/26651/files?diff=unified&w=0#diff-48fcaba0de5b6de4955bbece2048dc8cc2fe52ad24cc23bee3d1bb87c7d652c9L36-R48))
*  Add the import of the `LinkedHashMap` class to the `RelationshipUtil` class ([link](https://github.com/dotCMS/core/pull/26651/files?diff=unified&w=0#diff-ff62a01d343da67457b543c859a6fa02114e20f07ec232e787aa58f55598209eR20))

