### PR TITLE
fix: folder no longer inherit from inode and also was removed from hbm

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/factories/InodeFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/InodeFactory.java
@@ -58,6 +58,9 @@ public class InodeFactory {
 		if(c.equals(Category.class)){
 			throw new DotStateException("Category mapping was deleted from hibernate files");
 		}
+		if(c.equals(Folder.class)){
+			throw new DotStateException("Folder mapping was deleted from hibernate files");
+		}
 
 		try {
 			final String tableName = c.getDeclaredConstructor().newInstance().getType();
@@ -139,7 +142,10 @@ public class InodeFactory {
 			throw new DotStateException("Relationship mapping was deleted from hibernate files");
 		}
 		if(c.equals(Template.class)){
-			throw new DotStateException("Relationship mapping was deleted from hibernate files");
+			throw new DotStateException("Template mapping was deleted from hibernate files");
+		}
+		if(c.equals(Folder.class)){
+			throw new DotStateException("Folder mapping was deleted from hibernate files");
 		}
 		
 		

--- a/dotCMS/src/main/java/com/dotmarketing/util/InodeUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/InodeUtils.java
@@ -195,7 +195,10 @@ public class InodeUtils {
                 //Transform the found content type to a Structure
                 inodeObj = new StructureTransformer(foundContentType).asStructure();
             }
-        } else {
+		}else if ( shortOpt.isPresent() && ShortType.FOLDER == shortOpt.get().subType ) {
+			//Folder no longer inherit from inode, returning an empty inode
+			inodeObj = new Inode();
+		} else {
             inodeObj = InodeFactory.getInode(inode, Inode.class);
         }
         return inodeObj;


### PR DESCRIPTION
Ref: #26693 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afe2ab1</samp>

This pull request refactors the code to separate folders from inodes in dotCMS. It adds checks for the `Folder` class and the `ShortType.FOLDER` enum value in the `InodeFactory` and `InodeUtils` classes, respectively, to avoid unnecessary database queries and errors.