### PR TITLE
Fixing step output naming and run command args order.

### DIFF
--- a/tools/dotcms-cli/action/.github/workflows/main.yml
+++ b/tools/dotcms-cli/action/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Create workspace if not exists
         id: dot-workspace
-        run: |          
+        run: |
           if [ ${{ env.DOT_CREATE_WORKSPACE }} = true ]; then
             echo "Creating workspace ::: "             
             chmod +x ./.github/workflows/scripts/workspace.sh
@@ -102,6 +102,7 @@ jobs:
           PUSH_OPTIONS["removeFolders"] = os.getenv("DOT_CLI_REMOVE_FOLDERS")
           PUSH_OPTIONS["removeLanguages"] = os.getenv("DOT_CLI_REMOVE_LANGUAGES")
           PUSH_OPTIONS["removeSites"] = os.getenv("DOT_CLI_REMOVE_SITES")
+          PUSH_OPTIONS["errors"] = os.getenv("DOT_CLI_ERRORS")
 
           COMMAND_PUSH_OPTS = "";
 
@@ -110,8 +111,8 @@ jobs:
                   if value.lower() == "true":
                       COMMAND_PUSH_OPTS=f"{COMMAND_PUSH_OPTS} --{key}"
                   elif value.lower() != "false":
-                      COMMAND_PUSH_OPTS=f"{COMMAND_PUSH_OPTS} --{key}={value}"
-
+                      COMMAND_PUSH_OPTS=f"{COMMAND_PUSH_OPTS} --{key} {value}"
+          
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               print(f 'COMMAND_PUSH_OPTS={COMMAND_PUSH_OPTS}', file=f)
 
@@ -124,7 +125,7 @@ jobs:
             chmod +x ./.github/workflows/scripts/run-push.sh
             source ./.github/workflows/scripts/run-push.sh
             install_cli "${{env.DOT_CLI_JAR_DOWNLOAD_URL}}" "${{env.DOT_FORCE_DOWNLOAD}}" "${{env.DOT_API_URL}}"
-            run_cli_push "${{github.workspace}}${{env.DOT_REPO_BASE_PATH}}" "${{ steps.options.outputs.COMMAND_PUSH_OPTS }}" "${{ secrets.DOT_TOKEN }}"
+            run_cli_push "${{github.workspace}}${{env.DOT_REPO_BASE_PATH}}" "${{ secrets.DOT_TOKEN }}" "${{ steps.options.outputs.command_opts }}"
             echo "exit-code=$exit_code" >> "$GITHUB_OUTPUT"
             print_log
             if [ $exit_code -ne 0 ]; then

--- a/tools/dotcms-cli/action/.github/workflows/scripts/run-push.sh
+++ b/tools/dotcms-cli/action/.github/workflows/scripts/run-push.sh
@@ -85,8 +85,8 @@ print_log(){
 
 _run_cli_push(){
       workspace_path=$1
-      push_opts=$2
-      token=$3
+      token=$2
+      push_opts=$3
 
       #These environment vars are expected by the start-up script
       export JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
@@ -96,7 +96,7 @@ _run_cli_push(){
       export JAVA_APP_NAME="dotcms-cli"
       # Log file
       export QUARKUS_LOG_FILE_PATH="$DOT_CLI_HOME"dotcms-cli.log
-      bash /tmp/dot-cli/run-java.sh "push" "$workspace_path" "$push_opts" "--token" "$token" "--errors"
+      bash /tmp/dot-cli/run-java.sh push "$workspace_path" --token="$token" $push_opts
       export exit_code=$?
       echo $exit_code
 }
@@ -114,8 +114,8 @@ install_cli(){
 
 run_cli_push(){
     workspace_path=$1
-    opts=$2
-    token=$3
-    return_code=$(_run_cli_push "$workspace_path" "$opts" "$token")
+    token=$2
+    push_opts=$3
+    return_code=$(_run_cli_push "$workspace_path" "$token" "$push_opts")
     echo "$return_code"
 }


### PR DESCRIPTION
### Proposed Changes
* Fixing step output naming.
* Run command args order.

### Solves
#26534 

### Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c233e8e</samp>

This pull request enhances the dotCMS CLI action workflow and script by improving the code quality and adding a new error display option. It affects the files `main.yml` and `run-push.sh` in the `tools/dotcms-cli/action/.github/workflows` directory.

### Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c233e8e</samp>

*  Remove extra space and add newline in `main.yml` for formatting ([link](https://github.com/dotCMS/core/pull/26718/files?diff=unified&w=0#diff-d255805a0d45d4f3c63b1978a85a4145faa3f2af70f1fbb0e7ef32b2789549caL64-R64), [link](https://github.com/dotCMS/core/pull/26718/files?diff=unified&w=0#diff-d255805a0d45d4f3c63b1978a85a4145faa3f2af70f1fbb0e7ef32b2789549caL134-R135))
*  Add `DOT_CLI_ERRORS` environment variable to `main.yml` to allow user input for error handling in push command ([link](https://github.com/dotCMS/core/pull/26718/files?diff=unified&w=0#diff-d255805a0d45d4f3c63b1978a85a4145faa3f2af70f1fbb0e7ef32b2789549caR105))
*  Remove equal signs from push options in `main.yml` and `run-push.sh` to match dotCMS CLI syntax ([link](https://github.com/dotCMS/core/pull/26718/files?diff=unified&w=0#diff-d255805a0d45d4f3c63b1978a85a4145faa3f2af70f1fbb0e7ef32b2789549caL113-R115), [link](https://github.com/dotCMS/core/pull/26718/files?diff=unified&w=0#diff-1ac52cdb7bc4209ac7f350aa8f001662678cb257d5ee12aa5229f4c35d5d98f2L99-R99))
*  Change order and name of arguments for `run_cli_push` function in `main.yml` and `run-push.sh` to match dotCMS CLI and avoid confusion ([link](https://github.com/dotCMS/core/pull/26718/files?diff=unified&w=0#diff-d255805a0d45d4f3c63b1978a85a4145faa3f2af70f1fbb0e7ef32b2789549caL127-R128), [link](https://github.com/dotCMS/core/pull/26718/files?diff=unified&w=0#diff-1ac52cdb7bc4209ac7f350aa8f001662678cb257d5ee12aa5229f4c35d5d98f2L88-R89), [link](https://github.com/dotCMS/core/pull/26718/files?diff=unified&w=0#diff-1ac52cdb7bc4209ac7f350aa8f001662678cb257d5ee12aa5229f4c35d5d98f2L117-R118))