### PR TITLE
fix(core): Restoring Reorder Rows Functionality in Content Type Editing #26680

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.html
@@ -1,5 +1,5 @@
 <div class="row-header">
-    <span class="row-header__drag"></span>
+    <dot-icon class="row-header__drag" name="drag_handle"></dot-icon>
 </div>
 <div class="row-columns">
     <div
@@ -8,24 +8,21 @@
         [(dragulaModel)]="column.fields"
         [class.empty]="!column.fields.length"
         data-drag-type="target"
-        dragula="fields-bag"
-    >
+        dragula="fields-bag">
         <p-button
             class="row-header__remove"
             *ngIf="!column.fields.length"
             [pTooltip]="'contenttypes.action.delete' | dm"
             (click)="remove(i)"
             icon="pi pi-trash"
-            styleClass="p-button-rounded p-button-text p-button-sm p-button-danger"
-        ></p-button>
+            styleClass="p-button-rounded p-button-text p-button-sm p-button-danger"></p-button>
 
         <dot-content-type-field-dragabble-item
             *ngFor="let field of column.fields"
             [field]="field"
             [isSmall]="fieldRow.columns.length > 1"
             (remove)="onRemoveField($event)"
-            (edit)="this.editField.emit(field)"
-        >
+            (edit)="this.editField.emit(field)">
         </dot-content-type-field-dragabble-item>
     </div>
 </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.scss
@@ -15,7 +15,7 @@
     display: flex;
     background: $white;
     padding: $spacing-1;
-    border-radius: $border-radius-xl;
+    border-radius: 0 0 $border-radius-xl $border-radius-xl;
 }
 
 .row-columns__item {
@@ -83,16 +83,16 @@
 }
 
 .row-header {
-    opacity: 0.25;
-    text-align: center;
-    transition: opacity $basic-speed;
-    margin: 0 -#{$spacing-3};
+    background: #ffffff;
+    border-radius: $border-radius-xl $border-radius-xl 0 0;
+    display: flex;
+    justify-content: center;
 }
 
 .row-header__drag {
     cursor: move;
     display: block;
-    width: 100%;
+    color: $color-palette-gray-400;
 }
 
 .row-header__remove {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-drag-drop.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-drag-drop.service.ts
@@ -198,7 +198,9 @@ export class FieldDragDropService {
         if (!fieldRowBagOpts) {
             this.dragulaService.createGroup(FieldDragDropService.FIELD_ROW_BAG_NAME, {
                 copy: this.shouldCopy.bind(this),
-                moves: this.shouldMoveRow.bind(this)
+                accepts: this.shouldAccepts.bind(this),
+                moves: this.shouldMoveRow.bind(this),
+                copyItem: (item) => _.cloneDeep(item)
             });
         }
     }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d65abee</samp>

### Summary
🛠️🖱️🎨

<!--
1.  🛠️ - This emoji represents the modification of the dragulaService.createGroup method to add new options and functionality. It conveys the idea of fixing or improving something.
2. 🖱️ - This emoji represents the replacement of the drag handle icon with a dot-icon component and the HTML formatting fixes. It conveys the idea of changing the user interface or interaction.
3. 🎨 - This emoji represents the style updates of the row header and the row columns in the content type fields component. It conveys the idea of enhancing the appearance or design of something.
-->
Updated the UI and functionality of the content type fields component. Used dot-icon for the drag handle, improved the style of the rows and columns, and added validation and cloning logic for the drag and drop feature.

> _To drag and drop rows with more ease_
> _We added some options to `dragulaService`_
> _The style of the row_
> _Got a makeover, you know_
> _With a dot-icon and some CSS keys_

### Walkthrough
* Replace the span element with a dot-icon component for the drag handle of the row ([link](https://github.com/dotCMS/core/pull/26724/files?diff=unified&w=0#diff-795baef2a96a3e7833131fe3b8c29e76f6ed10afd567c8dc7a4b944efc497406L2-R2))
* Modify the border-radius property of the row-columns class to have rounded corners only at the bottom ([link](https://github.com/dotCMS/core/pull/26724/files?diff=unified&w=0#diff-74be00eed30ccd8f6375f60a1b93bf58b744d06693aba43311190d8bb025cecfL18-R18))
* Change the row-header class to have a white background, a border-radius at the top, and a flex display with center alignment ([link](https://github.com/dotCMS/core/pull/26724/files?diff=unified&w=0#diff-74be00eed30ccd8f6375f60a1b93bf58b744d06693aba43311190d8bb025cecfL86-R89))
* Change the color property of the row-header__drag class to use a gray color from the color palette ([link](https://github.com/dotCMS/core/pull/26724/files?diff=unified&w=0#diff-74be00eed30ccd8f6375f60a1b93bf58b744d06693aba43311190d8bb025cecfL95-R95))
* Move the closing tags of some elements to the same line as the opening tags to follow the HTML style guide and avoid unnecessary whitespace ([link](https://github.com/dotCMS/core/pull/26724/files?diff=unified&w=0#diff-795baef2a96a3e7833131fe3b8c29e76f6ed10afd567c8dc7a4b944efc497406L11-R11), [link](https://github.com/dotCMS/core/pull/26724/files?diff=unified&w=0#diff-795baef2a96a3e7833131fe3b8c29e76f6ed10afd567c8dc7a4b944efc497406L19-R18), [link](https://github.com/dotCMS/core/pull/26724/files?diff=unified&w=0#diff-795baef2a96a3e7833131fe3b8c29e76f6ed10afd567c8dc7a4b944efc497406L27-R25))
* Add an accepts option and a copyItem option to the dragulaService.createGroup method in `field-drag-drop.service.ts` to prevent dropping rows into rows with different columns and to avoid mutating the original row object when copying it ([link](https://github.com/dotCMS/core/pull/26724/files?diff=unified&w=0#diff-613673a154d00a52abad3ef967e298ddb3fb36304a5e1c0537cb2a0b14445950L201-R203))



### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
