### PR TITLE
fix(edit-content): Make Binary Field Preview Works with File ContentTypes

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -742,7 +742,7 @@
                     }
 
                     // Setting the value of the field
-                    field.value = "<%=binInode%>"
+                    field.value = "<%=value%>"
 
                     // Creating the binary field dynamically
                     // Help us to set inputs before the ngInit is executed.


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0496fff</samp>

Fixed a bug where the binary field displayed the wrong file name when editing a contentlet. Changed the field value to use the `value` variable instead of the `binInode` variable in `edit_field.jsp`.

## Related Issue
Fixes #26628

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0496fff</samp>

* Fix the binary field file name issue by setting the field value to the file name instead of the inode ([link](https://github.com/dotCMS/core/pull/26747/files?diff=unified&w=0#diff-56d86f13aa386cb1827964028808b975ede83f83670e89874ab7afa4207ed103L745-R745))

### Video

https://github.com/dotCMS/core/assets/72418962/44259f21-82f3-4889-a4f1-e29d40dd8392

