### PR TITLE
dotCMS/core#26750 [UI] Experiments reports - JS error when bayesianResult is null 

### DIFF
--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/store/dot-experiments-reports-store.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/store/dot-experiments-reports-store.ts
@@ -95,9 +95,9 @@ export class DotExperimentsReportsStore extends ComponentStore<DotExperimentsRep
     );
 
     readonly getSuggestedWinner$: Observable<DotResultVariant | null> = this.select(({ results }) =>
-        BayesianNoWinnerStatus.includes(results?.bayesianResult.suggestedWinner)
+        BayesianNoWinnerStatus.includes(results?.bayesianResult?.suggestedWinner)
             ? null
-            : results?.goals.primary.variants[results?.bayesianResult.suggestedWinner]
+            : results?.goals.primary.variants[results?.bayesianResult?.suggestedWinner]
     );
 
     readonly getPromotedVariant$: Observable<Variant | null> = this.select(({ experiment }) =>
@@ -117,7 +117,7 @@ export class DotExperimentsReportsStore extends ComponentStore<DotExperimentsRep
                 const { datasets } = chartData;
 
                 return (
-                    results.bayesianResult.suggestedWinner != BayesianStatusResponse.NONE &&
+                    results.bayesianResult?.suggestedWinner != BayesianStatusResponse.NONE &&
                     datasets.every((dataset) => dataset.data.length > 0)
                 );
             }
@@ -163,7 +163,7 @@ export class DotExperimentsReportsStore extends ComponentStore<DotExperimentsRep
                 CONVERSION_RATE_RANGE_SEPARATOR_LABEL
             );
 
-            return results
+            return results && results.bayesianResult
                 ? Object.values(results.goals.primary.variants).map((variant) => {
                       return this.getDotExperimentVariantDetail(
                           experiment,

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
@@ -136,11 +136,15 @@ export const getSuggestedWinner = (
 ): SummaryLegend => {
     const { bayesianResult, sessions } = results;
 
+    if (!bayesianResult) {
+        return ReportSummaryLegendByBayesianStatus.NO_ENOUGH_SESSIONS;
+    }
+
     const hasSessions = sessions.total > 0;
     const isATieBayesianSuggestionWinner =
-        bayesianResult.suggestedWinner === BayesianStatusResponse.TIE;
+        bayesianResult?.suggestedWinner === BayesianStatusResponse.TIE;
     const isNoneBayesianSuggestionWinner =
-        bayesianResult.suggestedWinner === BayesianStatusResponse.NONE;
+        bayesianResult?.suggestedWinner === BayesianStatusResponse.NONE;
 
     if (!hasSessions || isNoneBayesianSuggestionWinner) {
         return experiment.status === DotExperimentStatus.ENDED
@@ -168,7 +172,7 @@ export const getBayesianDatasets = (
     const { sessions, bayesianResult } = results;
 
     // If we don't have a suggested winner, return an empty array
-    if (bayesianResult.suggestedWinner === BayesianStatusResponse.NONE) {
+    if (!bayesianResult || bayesianResult.suggestedWinner === BayesianStatusResponse.NONE) {
         return [];
     }
 


### PR DESCRIPTION
### Proposed Changes
* validate when `bayesianResult` is null to avoid js errors. 
