### PR TITLE
fix(experiments) fix proper style classes to buttons in variant list

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/buttons/_button.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/buttons/_button.scss
@@ -47,6 +47,10 @@
     &.p-button-outlined {
         @extend #button-disabled-outlined;
     }
+
+    &.p-button-text {
+        @extend #button-disabled-text;
+    }
 }
 
 // Severity for basic button

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/buttons/common.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/buttons/common.scss
@@ -223,3 +223,8 @@
 #button-disabled-outlined {
     border: $field-border-size solid $color-palette-gray-300;
 }
+
+#button-disabled-text {
+    border: none;
+    background-color: transparent;
+}

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -53,7 +53,7 @@
                         data-testId="tooltip-on-disabled"
                         tooltipPosition="bottom">
                         <button
-                            class="p-button-sm p-button-text"
+                            class="p-button-sm p-button-link"
                             [disabled]="!vm.isExperimentADraft || vm.disabledTooltipLabel"
                             (click)="changeTrafficProportion()"
                             data-testId="variant-weight"
@@ -87,7 +87,7 @@
                         data-testId="tooltip-on-disabled"
                         tooltipPosition="bottom">
                         <button
-                            class="p-button-sm p-button-danger p-button-text"
+                            class="p-button-sm p-button-text p-button-danger"
                             [disabled]="
                                 variant.name === defaultVariantName ||
                                 !vm.isExperimentADraft ||


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 553fb29</samp>

This pull request improves the appearance and functionality of text buttons in the dot-experiments-configuration-variants component. It updates the HTML template, the button styles, and the common mixin for disabled text buttons.

## Related Issue
Fixes #26738 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 553fb29</samp>

*  Make text buttons transparent when disabled ([link](https://github.com/dotCMS/core/pull/26761/files?diff=unified&w=0#diff-9cc81ddc4d2c27cb7a9e0c503c2b592abb371ed8dce7f55b34f0c9dd53aa46f4R50-R53), [link](https://github.com/dotCMS/core/pull/26761/files?diff=unified&w=0#diff-291473233533222487f2c2d6729e1c47bf788e43eeed2aab132f3123f71ce002R226-R230))
* Change text button to link button for traffic proportion ([link](https://github.com/dotCMS/core/pull/26761/files?diff=unified&w=0#diff-f87f95949e5719b6bc13b751f89074af7f822e136be08a5c84973e195ce9ecb1L56-R56))
* Reorder classes for delete variant button ([link](https://github.com/dotCMS/core/pull/26761/files?diff=unified&w=0#diff-f87f95949e5719b6bc13b751f89074af7f822e136be08a5c84973e195ce9ecb1L90-R90))

*** Screenshots
[OLD]
<img width="451" alt="Screenshot 2023-11-21 at 9 47 58 AM" src="https://github.com/dotCMS/core/assets/1909643/9342ce0b-1e24-4d67-b1af-d70052b35c17">

[CHANGES]
<img width="400" alt="Screenshot 2023-11-21 at 9 47 23 AM" src="https://github.com/dotCMS/core/assets/1909643/e407976d-a430-4d86-86e1-5e1b97f0654e">

