### PR TITLE
dotCMS/core#26760 Remove variant session storage on server errors

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.spec.ts
@@ -53,6 +53,7 @@ describe('DotEditPageResolver', () => {
     let dotPageStateService: DotPageStateService;
     let dotPageStateServiceRequestPageSpy: jasmine.Spy;
     let dotRouterService: DotRouterService;
+    let dotSessionStorageService: DotSessionStorageService;
 
     let injector: TestBed;
     let dotEditPageResolver: DotEditPageResolver;
@@ -102,6 +103,7 @@ describe('DotEditPageResolver', () => {
         dotPageStateServiceRequestPageSpy = spyOn(dotPageStateService, 'requestPage');
         dotRouterService = injector.get(DotRouterService);
         siteService = injector.get(SiteService);
+        dotSessionStorageService = injector.get(DotSessionStorageService);
 
         spyOn(dotHttpErrorManagerService, 'handle').and.returnValue(of());
     });
@@ -239,6 +241,38 @@ describe('DotEditPageResolver', () => {
                 expect(state).toBeNull();
             });
             expect(dotRouterService.goToSiteBrowser).toHaveBeenCalled();
+            expect(dotHttpErrorManagerService.handle).toHaveBeenCalledWith(
+                new HttpErrorResponse(
+                    new HttpResponse({
+                        body: null,
+                        status: HttpCode.FORBIDDEN,
+                        headers: null,
+                        url: ''
+                    })
+                )
+            );
+        });
+
+        it('should call to `removeVariantId` when handle error and redirect to site-browser ', () => {
+            spyOn(dotSessionStorageService, 'removeVariantId');
+
+            const mock = new DotPageRenderState(
+                mockUser(),
+                new DotPageRender({
+                    ...mockDotRenderedPage(),
+                    page: {
+                        ...mockDotRenderedPage().page,
+                        canEdit: false
+                    }
+                })
+            );
+            dotPageStateServiceRequestPageSpy.and.returnValue(of(mock));
+
+            dotEditPageResolver.resolve(route).subscribe((state: DotPageRenderState) => {
+                expect(state).toBeNull();
+            });
+
+            expect(dotSessionStorageService.removeVariantId).toHaveBeenCalled();
             expect(dotHttpErrorManagerService.handle).toHaveBeenCalledWith(
                 new HttpErrorResponse(
                     new HttpResponse({

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/shared/services/dot-edit-page-resolver/dot-edit-page-resolver.service.ts
@@ -1,13 +1,14 @@
-import { Observable, forkJoin, of, throwError } from 'rxjs';
+import { forkJoin, Observable, of, throwError } from 'rxjs';
 
 import { HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 
 import { catchError, filter, map, switchMap } from 'rxjs/operators';
 
 import { DotHttpErrorManagerService } from '@dotcms/app/api/services/dot-http-error-manager/dot-http-error-manager.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
+import { DotSessionStorageService } from '@dotcms/data-access';
 import { DotCMSResponse, HttpCode, Site, SiteService } from '@dotcms/dotcms-js';
 import { DotPageRenderOptions, DotPageRenderState } from '@dotcms/dotcms-models';
 
@@ -22,6 +23,7 @@ import { DotPageStateService } from '../../../content/services/dot-page-state/do
  */
 @Injectable()
 export class DotEditPageResolver implements Resolve<DotPageRenderState> {
+    private dotSessionStorageService: DotSessionStorageService = inject(DotSessionStorageService);
     constructor(
         private dotPageStateService: DotPageStateService,
         private dotRouterService: DotRouterService,
@@ -119,6 +121,7 @@ export class DotEditPageResolver implements Resolve<DotPageRenderState> {
                     : of(dotRenderedPageState);
             }),
             catchError((err: HttpErrorResponse) => {
+                this.dotSessionStorageService.removeVariantId();
                 this.dotRouterService.goToSiteBrowser();
 
                 return this.dotHttpErrorManagerService.handle(err).pipe(map(() => null));

--- a/core-web/libs/data-access/src/lib/dot-session-storage/dot-session-storage.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-session-storage/dot-session-storage.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { SESSION_STORAGE_VARIATION_KEY } from '@dotcms/dotcms-models';
 
+//TODO: set a proper name for this
 @Injectable()
 export class DotSessionStorageService {
     /**


### PR DESCRIPTION
### Proposed Changes
* Remove variant session storage on server errors

## Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8e211b8</samp>

The pull request introduces a service to handle the session storage data of the page variants in the dot-edit-page module. It also adds a comment to rename the service later.

## Related Issue
Fixes #26760 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8e211b8</samp>

*  Clear the session storage data related to the page variant id when resolving the edit page ([link](https://github.com/dotCMS/core/pull/26779/files?diff=unified&w=0#diff-4fac9401f4a6c5cf837e65f987b43c3aa95d70cc7144e83484321e5068427546R124))
*  Inject the `DotSessionStorageService` as a dependency of the `DotEditPageResolver` service to access and manipulate the session storage data ([link](https://github.com/dotCMS/core/pull/26779/files?diff=unified&w=0#diff-4fac9401f4a6c5cf837e65f987b43c3aa95d70cc7144e83484321e5068427546L1-R4), [link](https://github.com/dotCMS/core/pull/26779/files?diff=unified&w=0#diff-4fac9401f4a6c5cf837e65f987b43c3aa95d70cc7144e83484321e5068427546R11), [link](https://github.com/dotCMS/core/pull/26779/files?diff=unified&w=0#diff-4fac9401f4a6c5cf837e65f987b43c3aa95d70cc7144e83484321e5068427546R26))
*  Add a comment to the `DotSessionStorageService` in `dot-session-storage.service.ts` to suggest renaming it to follow the naming convention ([link](https://github.com/dotCMS/core/pull/26779/files?diff=unified&w=0#diff-c9f03e6f7dcc444ec75e6ea9214ca67df28f79a444a9999c63d3f4e562e71a10R5))