### PR TITLE
dotCMS/core#26738 Change from text button to link button in Scheduling and Traffic

### DIFF
--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.html
@@ -26,7 +26,7 @@
                     data-testId="tooltip-on-disabled"
                     tooltipPosition="bottom">
                     <button
-                        class="p-button-sm p-button-text"
+                        class="p-button-sm p-button-link"
                         [disabled]="vm.disabledTooltipLabel"
                         (click)="setupSchedule()"
                         data-testId="scheduling-setup-button"

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic/dot-experiments-configuration-traffic.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic/dot-experiments-configuration-traffic.component.html
@@ -25,7 +25,7 @@
                     data-testId="tooltip-on-disabled"
                     tooltipPosition="bottom">
                     <button
-                        class="p-button-sm p-button-text"
+                        class="p-button-sm p-button-link"
                         [disabled]="vm.disabledTooltipLabel"
                         (click)="changeTrafficAllocation()"
                         data-testId="traffic-allocation-button"


### PR DESCRIPTION
### Proposed Changes
* Change from text button to link button in Scheduling and Traffic

OLD
<img width="1612" alt="Screenshot 2023-11-22 at 9 37 58 AM" src="https://github.com/dotCMS/core/assets/1909643/ad3a2ab1-d164-4b84-a790-d98802327739">


NEW
<img width="1891" alt="Screenshot 2023-11-22 at 9 37 39 AM" src="https://github.com/dotCMS/core/assets/1909643/151d70c3-f4b8-4b52-b6db-57fa8f040038">
