### PR TITLE
Avoid overwriting the host, when copying a contentlet that contains a HostFolder field

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -2774,7 +2774,10 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
     public void test_copy_contentlet() throws DotDataException, DotSecurityException {
         final List<Field> fields = new ArrayList<>();
         fields.add(new FieldDataGen().name("Title").velocityVarName("title").next());
-        fields.add(new FieldDataGen().type(HostFolderField.class).name("Host").velocityVarName("Host").next());
+        fields.add(new FieldDataGen().type(HostFolderField.class)
+                .name(Host.HOST_VELOCITY_VAR_NAME)
+                .velocityVarName(Host.HOST_VELOCITY_VAR_NAME)
+                .next());
         final ContentType cType = new ContentTypeDataGen()
                 .host(APILocator.systemHost())
                 .fields(fields)

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -28,6 +29,7 @@ import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.FieldBuilder;
 import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.TextField;
+import com.dotcms.contenttype.model.field.HostFolderField;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ContentTypeBuilder;
 import com.dotcms.contenttype.model.type.SimpleContentType;
@@ -2757,6 +2759,33 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
         } finally {
             APILocator.getExperimentsAPI().end(experiment.id().orElseThrow(), APILocator.systemUser());
         }
+
+    }
+
+    /**
+     * Method to test: {@link ESContentletAPIImpl#copyContentlet(Contentlet, User, boolean)}
+     * Given Scenario:
+     * Unable to copy a contentlet with Host/Folder field. Error is thrown when the field name is "Host"
+     * ExpectedResult: Copy action should execute successfully without null-pointer error.
+     *
+     * @throws DotDataException
+     */
+    @Test
+    public void test_copy_contentlet() throws DotDataException, DotSecurityException {
+        final List<Field> fields = new ArrayList<>();
+        fields.add(new FieldDataGen().name("Title").velocityVarName("title").next());
+        fields.add(new FieldDataGen().type(HostFolderField.class).name("Host").velocityVarName("Host").next());
+        final ContentType cType = new ContentTypeDataGen()
+                .host(APILocator.systemHost())
+                .fields(fields)
+                .nextPersisted();
+        final Contentlet contentlet = new ContentletDataGen(cType.id())
+                .host(APILocator.systemHost())
+                .nextPersisted();
+        final Contentlet respCont =  contentletAPI.copyContentlet(contentlet, user, false);
+
+        assertNotEquals(respCont.getIdentifier(), contentlet.getIdentifier());
+        assertEquals(respCont.getHost(), APILocator.systemHost().getIdentifier());
 
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -9045,7 +9045,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
                 //verify if the velocity var name is not Host to avoid override the host
                 if (tempField.getFieldType().equals(Field.FieldType.HOST_OR_FOLDER.toString())
-                        && !"Host".equalsIgnoreCase(tempField.getVelocityVarName())) {
+                        && !Host.HOST_VELOCITY_VAR_NAME.equalsIgnoreCase(tempField.getVelocityVarName())) {
                     if (folder != null || host != null) {
                         newContentlet.setStringProperty(tempField.getVelocityVarName(),
                                 folder != null ? folder.getInode() : host.getIdentifier());

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -9043,8 +9043,9 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     }
                 }
 
+                //verify if the velocity var name is not Host to avoid override the host
                 if (tempField.getFieldType().equals(Field.FieldType.HOST_OR_FOLDER.toString())
-                        && !tempField.getVelocityVarName().equalsIgnoreCase("host") ) {
+                        && !"Host".equalsIgnoreCase(tempField.getVelocityVarName())) {
                     if (folder != null || host != null) {
                         newContentlet.setStringProperty(tempField.getVelocityVarName(),
                                 folder != null ? folder.getInode() : host.getIdentifier());

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -9043,7 +9043,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     }
                 }
 
-                if (tempField.getFieldType().equals(Field.FieldType.HOST_OR_FOLDER.toString())) {
+                if (tempField.getFieldType().equals(Field.FieldType.HOST_OR_FOLDER.toString())
+                        && !tempField.getVelocityVarName().equalsIgnoreCase("host") ) {
                     if (folder != null || host != null) {
                         newContentlet.setStringProperty(tempField.getVelocityVarName(),
                                 folder != null ? folder.getInode() : host.getIdentifier());


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b606792</samp>

### Summary
🐛🚨📝

<!--
1.  🐛 - This emoji represents a bug fix, since the change fixes the null-pointer error that occurred when copying contentlets with a host/folder field named "Host".
2.  🚨 - This emoji represents a test, since the change adds a new integration test for the `copyContentlet` method to verify its functionality and prevent future regressions.
3.  📝 - This emoji represents documentation, since the change adds some comments to explain the logic of the condition and the test.
-->
This pull request fixes a bug in the `copyContentlet` method of the `ESContentletAPIImpl` class, which caused a null-pointer error when copying contentlets with a host/folder field named "Host". It also adds a new integration test for this method to verify its functionality.

### Walkthrough
*  Fix the bug of copying contentlets with host/folder field named "Host" (#20477)
  - Add a condition to check the velocity variable name of the host/folder field in the `copyContentlet` method of the `ESContentletAPIImpl` class ([link](https://github.com/dotCMS/core/pull/26793/files?diff=unified&w=0#diff-fa1ceaa19618a6b2bbc30e24c6f930b4971f417db50babb748c2e2837ba9eb82L9046-R9048))
  - Import the `HostFolderField` class in the `ESContentletAPIImplTest` class ([link](https://github.com/dotCMS/core/pull/26793/files?diff=unified&w=0#diff-093de07a53a725b587963fd60c024f52e089c4f78e7ea88ba8e3a3a0cdaecab9R32))
  - Add a test method `test_copy_contentlet` to the `ESContentletAPIImplTest` class to verify the copy action and the host property of the copied contentlet ([link](https://github.com/dotCMS/core/pull/26793/files?diff=unified&w=0#diff-093de07a53a725b587963fd60c024f52e089c4f78e7ea88ba8e3a3a0cdaecab9R2764-R2790))
  - Import the `assertNotEquals` method in the `ESContentletAPIImplTest` class ([link](https://github.com/dotCMS/core/pull/26793/files?diff=unified&w=0#diff-093de07a53a725b587963fd60c024f52e089c4f78e7ea88ba8e3a3a0cdaecab9R14))

