### PR TITLE
feat(edit-ema): Sync client and editor routing

### DIFF
--- a/core-web/libs/portlets/dot-ema/src/lib/feature/dot-ema.component.spec.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/feature/dot-ema.component.spec.ts
@@ -137,6 +137,30 @@ describe('DotEmaComponent', () => {
             expect(dialog.getAttribute('ng-reflect-visible')).toBe('false');
         });
 
+        it('should navigate to new url when postMessage SET_URL', () => {
+            const router = spectator.inject(Router);
+            jest.spyOn(router, 'navigate');
+
+            spectator.detectChanges();
+
+            window.dispatchEvent(
+                new MessageEvent('message', {
+                    origin: 'http://localhost:3000',
+                    data: {
+                        action: 'set-url',
+                        payload: {
+                            url: '/some'
+                        }
+                    }
+                })
+            );
+
+            expect(router.navigate).toHaveBeenCalledWith([], {
+                queryParams: { url: '/some' },
+                queryParamsHandling: 'merge'
+            });
+        });
+
         it('should trigger onIframeLoad when the dialog is opened', (done) => {
             spectator.detectChanges();
 

--- a/core-web/libs/portlets/dot-ema/src/lib/feature/dot-ema.component.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/feature/dot-ema.component.ts
@@ -26,7 +26,7 @@ import { EditEmaStore } from './store/dot-ema.store';
 import { DotPageApiService } from '../services/dot-page-api.service';
 import { WINDOW } from '../shared/consts';
 import { CUSTOMER_ACTIONS, NG_CUSTOM_EVENTS, NOTIFY_CUSTOMER } from '../shared/enums';
-import { AddContentletPayload } from '../shared/models';
+import { AddContentletPayload, SetUrlPayload } from '../shared/models';
 
 @Component({
     selector: 'dot-ema',
@@ -227,6 +227,18 @@ export class DotEmaComponent implements OnInit, OnDestroy {
                 });
 
                 this.savePayload = payload;
+            },
+            [CUSTOMER_ACTIONS.SET_URL]: () => {
+                const payload = <SetUrlPayload>data.payload;
+
+                this.router.navigate([], {
+                    queryParams: {
+                        url: payload.url
+                    },
+                    queryParamsHandling: 'merge',
+                    skipLocationChange: true,
+                    onSameUrlNavigation: 'reload'
+                });
             },
             [CUSTOMER_ACTIONS.NOOP]: () => {
                 /* Do Nothing because is not the origin we are expecting */

--- a/core-web/libs/portlets/dot-ema/src/lib/feature/dot-ema.component.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/feature/dot-ema.component.ts
@@ -235,9 +235,7 @@ export class DotEmaComponent implements OnInit, OnDestroy {
                     queryParams: {
                         url: payload.url
                     },
-                    queryParamsHandling: 'merge',
-                    skipLocationChange: true,
-                    onSameUrlNavigation: 'reload'
+                    queryParamsHandling: 'merge'
                 });
             },
             [CUSTOMER_ACTIONS.NOOP]: () => {

--- a/core-web/libs/portlets/dot-ema/src/lib/shared/enums.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/shared/enums.ts
@@ -1,6 +1,7 @@
 export enum CUSTOMER_ACTIONS {
     EDIT_CONTENTLET = 'edit-contentlet', // The customer hit edit button
     ADD_CONTENTLET = 'add-contentlet', // The customer hit add button
+    SET_URL = 'set-url', // The customer hit add button
     NOOP = 'noop'
 }
 

--- a/core-web/libs/portlets/dot-ema/src/lib/shared/enums.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/shared/enums.ts
@@ -1,7 +1,7 @@
 export enum CUSTOMER_ACTIONS {
     EDIT_CONTENTLET = 'edit-contentlet', // The customer hit edit button
     ADD_CONTENTLET = 'add-contentlet', // The customer hit add button
-    SET_URL = 'set-url', // The customer hit add button
+    SET_URL = 'set-url', // User navigate internally within the ema
     NOOP = 'noop'
 }
 

--- a/core-web/libs/portlets/dot-ema/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/shared/models.ts
@@ -4,6 +4,10 @@ export interface AddContentletPayload {
     pageID: string;
 }
 
+export interface SetUrlPayload {
+    url: string;
+}
+
 export interface Container {
     acceptTypes: string;
     identifier: string;

--- a/ema/nextjs/src/components/dotcms-page.js
+++ b/ema/nextjs/src/components/dotcms-page.js
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useContext } from 'react';
 import { GlobalContext } from '../providers/global';
 import Image from 'next/image';
 import Link from 'next/link';
 import { getPageContainers } from '@/utils';
+import { usePathname } from 'next/navigation';
 
 // Provide a component for each content type
 const contentComponents = {
@@ -375,8 +376,21 @@ function reloadWindow(event) {
 
 // Main layout component
 export const DotcmsPage = () => {
+    const pathname = usePathname();
     // Get the page layout from the global context
     const { layout, page } = useContext(GlobalContext);
+
+    useEffect(() => {
+        window.parent.postMessage(
+            {
+                action: 'set-url',
+                payload: {
+                    url: url === '/' ? 'index' : pathname.split('/').pop()
+                }
+            },
+            '*'
+        );
+    }, [pathname]);
 
     useEffect(() => {
         window.addEventListener('message', reloadWindow);


### PR DESCRIPTION
### Proposed Changes
* Emit event from customer
* Catch event in Angular and update the routing
* There is a reload of the iframe, not sure how can avoid it.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
