### PR TITLE
fix(edit-page): clear session Storage when the component is destroyed

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { mockProvider } from '@ngneat/spectator';
 import { of, Subject } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -64,7 +65,6 @@ import { DotEditPageMainComponent } from './dot-edit-page-main.component';
 import { DotPageStateService } from '../../content/services/dot-page-state/dot-page-state.service';
 import { DotEditPageNavComponent } from '../dot-edit-page-nav/dot-edit-page-nav.component';
 import { DotEditPageNavModule } from '../dot-edit-page-nav/dot-edit-page-nav.module';
-import { mockProvider } from '@ngneat/spectator';
 
 @Injectable()
 class MockDotContentletEditorService {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.spec.ts
@@ -31,6 +31,7 @@ import {
     DotGenerateSecurePasswordService,
     DotLicenseService,
     DotMessageService,
+    DotSessionStorageService,
     DotWorkflowActionsFireService
 } from '@dotcms/data-access';
 import {
@@ -63,6 +64,7 @@ import { DotEditPageMainComponent } from './dot-edit-page-main.component';
 import { DotPageStateService } from '../../content/services/dot-page-state/dot-page-state.service';
 import { DotEditPageNavComponent } from '../dot-edit-page-nav/dot-edit-page-nav.component';
 import { DotEditPageNavModule } from '../dot-edit-page-nav/dot-edit-page-nav.module';
+import { mockProvider } from '@ngneat/spectator';
 
 @Injectable()
 class MockDotContentletEditorService {
@@ -186,7 +188,8 @@ describe('DotEditPageMainComponent', () => {
                 DotIframeService,
                 LoginService,
                 DotLicenseService,
-                Title
+                Title,
+                mockProvider(DotSessionStorageService)
             ]
         });
     }));

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-main/dot-edit-page-main.component.ts
@@ -1,6 +1,6 @@
 import { merge, Observable, Subject } from 'rxjs';
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 
@@ -9,6 +9,7 @@ import { pluck, takeUntil, tap } from 'rxjs/operators';
 import { DotContentletEditorService } from '@components/dot-contentlet-editor/services/dot-contentlet-editor.service';
 import { DotCustomEventHandlerService } from '@dotcms/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service';
 import { DotRouterService } from '@dotcms/app/api/services/dot-router/dot-router.service';
+import { DotSessionStorageService } from '@dotcms/data-access';
 import { DotPageRenderState } from '@dotcms/dotcms-models';
 
 import { DotPageStateService } from '../../content/services/dot-page-state/dot-page-state.service';
@@ -20,6 +21,7 @@ import { DotPageStateService } from '../../content/services/dot-page-state/dot-p
 })
 export class DotEditPageMainComponent implements OnInit, OnDestroy {
     pageState$: Observable<DotPageRenderState>;
+    private dotSessionStorageService: DotSessionStorageService = inject(DotSessionStorageService);
     private pageUrl: string;
     private languageId: string;
     private pageIsSaved = false;
@@ -66,9 +68,12 @@ export class DotEditPageMainComponent implements OnInit, OnDestroy {
         );
 
         this.subscribeIframeCloseAction();
+
+        this.dotSessionStorageService.removeVariantId();
     }
 
     ngOnDestroy(): void {
+        this.dotSessionStorageService.removeVariantId();
         this.destroy$.next(true);
         this.destroy$.complete();
     }


### PR DESCRIPTION
### Proposed Changes
* Add clear session Storage when the component is destroyed.

## Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a92c52c</samp>

Use session storage to persist page variant id in edit mode. This allows the user to keep the same variant when switching tabs or reloading the page. The variant id is stored by the `DotEditPageMainComponent` and cleared when the component or the iframe is destroyed.

## Related Issue
Fixes #26760 

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a92c52c</samp>

*  Import and inject `DotSessionStorageService` to access session storage ([link](https://github.com/dotCMS/core/pull/26810/files?diff=unified&w=0#diff-2da1116f4e48dec7a903bfdfa74bbc2495c9fc9e3f10bf98882d0d1f8ebec4adL3-R3), [link](https://github.com/dotCMS/core/pull/26810/files?diff=unified&w=0#diff-2da1116f4e48dec7a903bfdfa74bbc2495c9fc9e3f10bf98882d0d1f8ebec4adR12), [link](https://github.com/dotCMS/core/pull/26810/files?diff=unified&w=0#diff-2da1116f4e48dec7a903bfdfa74bbc2495c9fc9e3f10bf98882d0d1f8ebec4adR24))
*  Clear variant id from session storage when leaving edit page mode ([link](https://github.com/dotCMS/core/pull/26810/files?diff=unified&w=0#diff-2da1116f4e48dec7a903bfdfa74bbc2495c9fc9e3f10bf98882d0d1f8ebec4adL69-R76))