### PR TITLE
#26386 Reordering args on the push script calling.

### DIFF
--- a/tools/dotcms-cli/action/.github/workflows/scripts/run-push.sh
+++ b/tools/dotcms-cli/action/.github/workflows/scripts/run-push.sh
@@ -96,7 +96,7 @@ _run_cli_push(){
       export JAVA_APP_NAME="dotcms-cli"
       # Log file
       export QUARKUS_LOG_FILE_PATH="$DOT_CLI_HOME"dotcms-cli.log
-      cmd="bash /tmp/dot-cli/run-java.sh push $workspace_path --token $token $push_opts"
+      cmd="bash /tmp/dot-cli/run-java.sh push $workspace_path $push_opts --token=$token"
       eval "$cmd"
       export exit_code=$?
       echo $exit_code


### PR DESCRIPTION
### Proposed Changes
- Fixing NPE when push script is called on GHA workflow.

### Solves
#26386 

### Summary
Fixed a bug in the `push` command of the dotCMS CLI when used with GitHub Actions. Changed the order and format of the command arguments in `run-push.sh`.