### PR TITLE
Edit Content: Add JSON Field

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.spec.ts
@@ -64,6 +64,7 @@ describe('DotEditContentJsonFieldComponent', () => {
                 minimap: {
                     enabled: false
                 },
+                fixedOverflowWidgets: true,
                 cursorBlinking: 'solid',
                 overviewRulerBorder: false,
                 mouseWheelZoom: false,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.ts
@@ -42,6 +42,7 @@ export class DotEditContentJsonFieldComponent implements OnInit, OnDestroy {
         minimap: {
             enabled: false
         },
+        fixedOverflowWidgets: true,
         cursorBlinking: 'solid',
         overviewRulerBorder: false,
         mouseWheelZoom: false,


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a35125e</samp>

Added a new input `fixedOverflowWidgets` to the `DotEditContentJsonFieldComponent` to enable or disable the overflow of widgets in the edit content layout. Updated the test file to reflect the new input.

## Related Issue
Fixes #26797

# Explanation of Changes
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a35125e</samp>

*  Add a new input `fixedOverflowWidgets` to the `DotEditContentJsonFieldComponent` class to control the overflow of widgets in the edit content layout ([link](https://github.com/dotCMS/core/pull/26830/files?diff=unified&w=0#diff-cb3c5e92c52c399050b6321834f69fe6125ce05b964f3fdd5425d7ae0e623026R45))
*  Add a new property `fixedOverflowWidgets` to the `DotEditContentJsonFieldComponent` input in the test file to test the new feature ([link](https://github.com/dotCMS/core/pull/26830/files?diff=unified&w=0#diff-7de4eab63be6786869cc64142ef14ec11998fe5d7aa9bfd3c9a38979ebbd5216R67))

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
<img width="879" alt="JSON Field Warning - Original" src="https://github.com/dotCMS/core/assets/72418962/86228e6d-bed8-48fe-acf3-821e6e7873c2"> |  <img width="878" alt="JSON Field Warning - updated" src="https://github.com/dotCMS/core/assets/72418962/a16cb55f-6490-441c-acc1-b9b432fae786">

