### PR TITLE
#26825 now the config reads first the env, system table and finally t…

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotmarketing/util/ITConfigTest.java
+++ b/dotCMS/src/integration-test/java/com/dotmarketing/util/ITConfigTest.java
@@ -88,4 +88,25 @@ public class ITConfigTest extends IntegrationTestBase {
         value = Config.getStringProperty("THIRD_PROPERTY", "DEFAULT_VALUE");
         Assert.assertEquals("Should return default value since the property has been removed", "DEFAULT_VALUE", value);
     }
+
+    /**
+     * Method to test: {@link Config#getStringProperty(String, String)}
+     * Given Scenario: This will add two properties, one is set only on the system table, the other is set on the system table and on the environment variables
+     * ExpectedResult: The one set on the environment variables should have priority over the one set on the system table
+     */
+    @Test
+    public void test_property_order_resolution () {
+
+        EnvironmentVariablesService.getInstance().put("DOT_ONLY_ENV_PROP", "ENV_VALUE");
+        APILocator.getSystemAPI().getSystemTable().set("DOT_ONLY_ENV_PROP", "NEW_VALUE_FROM_SYSTEM_TABLE");
+        APILocator.getSystemAPI().getSystemTable().set("DOT_ONLY_SYSTEM_TABLE", "NEW_VALUE_FROM_SYSTEM_TABLE");
+        Config.forceRefresh();
+        Config.refreshProperties();
+
+
+        String value = Config.getStringProperty("DOT_ONLY_ENV_PROP", "DEFAULT_VALUE");
+        Assert.assertEquals("Should return the value from the environment", "ENV_VALUE", value);
+        value = Config.getStringProperty("DOT_ONLY_SYSTEM_TABLE", "DEFAULT_VALUE");
+        Assert.assertEquals("Should return the value from the system table", "NEW_VALUE_FROM_SYSTEM_TABLE", value);
+    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/Config.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Config.java
@@ -52,7 +52,7 @@ public class Config {
 
     public static final Map<String, String> testOverrideTracker = new ConcurrentHashMap<>();
 
-    private static Set<String> environmentSetKeys = ConcurrentHashMap.newKeySet();
+    private static final Set<String> environmentSetKeys = ConcurrentHashMap.newKeySet();
 
     private static SystemTableConfigSource systemTableConfigSource = null;
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/Config.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Config.java
@@ -33,6 +33,11 @@ import java.util.stream.Collectors;
  * This class provides access to the system configuration parameters that are set through the
  * {@code dotmarketing-config.properties}, and the {@code dotcms-config-cluster.properties} files.
  *
+ * The order of the properties resolution is:
+ * 1) any property set by environmet variable
+ * 2) any property set by the system table (could be on runtime)
+ * 3) any property set by the property files
+ *
  * @author root
  * @version 1.0
  * @since Mar 22, 2012
@@ -326,6 +331,15 @@ public class Config {
             props.copy(configuration);
         }
 
+    }
+
+    /**
+     * Force the refresh properties, only for testing
+     */
+    @VisibleForTesting
+    protected static void refreshProperties() {
+
+       _loadProperties();
     }
 
     /**


### PR DESCRIPTION
We need to change the Config order from 
System table > Environment > Property Files 

To 

Environment > System table  > Property Files 

Environment will be the source of true

This means that even of the runtime nature of the system table, if the property is being overridden by env property, the system table won't have any effect overridden the property