### PR TITLE
feat(EMA) #26892 : Add a depth parameter to the EMA App

### DIFF
--- a/dotCMS/src/main/resources/apps/dotema-config.yml
+++ b/dotCMS/src/main/resources/apps/dotema-config.yml
@@ -16,6 +16,7 @@ params:
               \"includeRendered\":false,
               \"headers\": {
                 \"authenticationToken\": \"123\",
+                \"depth\": 2,
                 \"X-CONTENT-APP\": \"dotCMS\"
               }
             },
@@ -25,6 +26,7 @@ params:
               \"includeRendered\":false,
               \"headers\": {
                 \"authenticationToken\": \"456\",
+                \"depth\": 2,
                 \"X-CONTENT-APP\": \"dotCMS\"
               }
             }


### PR DESCRIPTION
### Proposed Changes
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6ebaeee</samp>

This pull request improves the EMAWebInterceptor functionality and configuration by adding a `depth` parameter for the proxy server, refactoring the code for readability and consistency, and enhancing the error logging. The `depth` parameter is defined in the `dotema-config.yml` file and affects how much of the page tree is fetched from the proxy and local servers.