### PR TITLE
Remove 255 chars validation to text fields

### DIFF
--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -2759,4 +2759,29 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
         }
 
     }
+
+    /**
+     * Since we removed the validation of max length of 255 chars, we should be able to create content successfully, even
+     * thought we sent over 255 chars
+     */
+    @Test
+    public void createContentWhichTextFieldOver255Chars_success(){
+        final String textOver255Chars = "this-text-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-longer-than-two-hundred-fifty-five-characters-so-should-be-hitting-the-limit-for-the-fields-260-charsq";
+        final DefaultVanityUrl vanityURL = (DefaultVanityUrl) new VanityUrlDataGen()
+                .allSites()
+                .title(textOver255Chars)
+                .uri(textOver255Chars)
+                .action(HttpStatus.SC_MOVED_PERMANENTLY)
+                .forwardTo(textOver255Chars)
+                .nextPersisted();
+
+        ContentletDataGen.publish(vanityURL);
+
+        final Contentlet checkout = ContentletDataGen.checkout(vanityURL);
+        final VanityUrl vanityURLCheckout = APILocator.getVanityUrlAPI().fromContentlet(checkout);
+        assertEquals(textOver255Chars,vanityURLCheckout.getTitle());
+        assertEquals(textOver255Chars,vanityURLCheckout.getURI());
+        assertEquals(textOver255Chars,vanityURLCheckout.getForwardTo());
+
+    }
 }

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -2785,7 +2785,8 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
         assertEquals(textOver255Chars,vanityURLCheckout.getURI());
         assertEquals(textOver255Chars,vanityURLCheckout.getForwardTo());
     }
-  
+
+    /*
      * Method to test: {@link ESContentletAPIImpl#copyContentlet(Contentlet, User, boolean)}
      * Given Scenario:
      * Unable to copy a contentlet with Host/Folder field. Error is thrown when the field name is "Host"

--- a/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotCMS/src/integration-test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -2771,7 +2771,7 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
         final String textOver255Chars = "this-text-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-longer-than-two-hundred-fifty-five-characters-so-should-be-hitting-the-limit-for-the-fields-260-charsq";
         final DefaultVanityUrl vanityURL = (DefaultVanityUrl) new VanityUrlDataGen()
                 .allSites()
-                .title(textOver255Chars)
+                .title("Test VanityURL URI and Forward Over 255")
                 .uri(textOver255Chars)
                 .action(HttpStatus.SC_MOVED_PERMANENTLY)
                 .forwardTo(textOver255Chars)
@@ -2781,7 +2781,6 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
 
         final Contentlet checkout = ContentletDataGen.checkout(vanityURL);
         final VanityUrl vanityURLCheckout = APILocator.getVanityUrlAPI().fromContentlet(checkout);
-        assertEquals(textOver255Chars,vanityURLCheckout.getTitle());
         assertEquals(textOver255Chars,vanityURLCheckout.getURI());
         assertEquals(textOver255Chars,vanityURLCheckout.getForwardTo());
     }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -7896,14 +7896,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             "] in contentlet", e);
                     continue;
                 }
-                if (s.length() > 255) {
-                    hasError = true;
-                    cve.addMaxLengthField(field);
-                    Logger.warn(this, "Value of String field [" + field.getVelocityVarName()
-                            + "] is greater than 255" +
-                            " characters");
-                    continue;
-                }
             }
 
             // validate regex

--- a/dotCMS/src/main/java/com/dotcms/exception/ExceptionUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/exception/ExceptionUtil.java
@@ -54,7 +54,6 @@ import static com.dotmarketing.portlets.contentlet.business.DotContentletValidat
 import static com.dotmarketing.portlets.contentlet.business.DotContentletValidationException.VALIDATION_FAILED_BAD_CARDINALITY;
 import static com.dotmarketing.portlets.contentlet.business.DotContentletValidationException.VALIDATION_FAILED_BAD_REL;
 import static com.dotmarketing.portlets.contentlet.business.DotContentletValidationException.VALIDATION_FAILED_INVALID_REL_CONTENT;
-import static com.dotmarketing.portlets.contentlet.business.DotContentletValidationException.VALIDATION_FAILED_MAXLENGTH;
 import static com.dotmarketing.portlets.contentlet.business.DotContentletValidationException.VALIDATION_FAILED_PATTERN;
 import static com.dotmarketing.portlets.contentlet.business.DotContentletValidationException.VALIDATION_FAILED_REQUIRED;
 import static com.dotmarketing.portlets.contentlet.business.DotContentletValidationException.VALIDATION_FAILED_REQUIRED_REL;
@@ -284,19 +283,6 @@ public class ExceptionUtil {
                     errorString = errorString.replace("{0}", field.getFieldName());
                     contentValidationErrors
                             .computeIfAbsent(VALIDATION_FAILED_REQUIRED, k -> new ArrayList<>())
-                            .add(new ValidationError(field.getVelocityVarName(), errorString));
-                }
-
-            }
-
-            if (ve.hasLengthErrors()) {
-                final List<Field> reqs = ve.getNotValidFields().get(VALIDATION_FAILED_MAXLENGTH);
-                for (final Field field : reqs) {
-                    String errorString = LanguageUtil.get(user, "message.contentlet.maxlength");
-                    errorString = errorString.replace("{0}", field.getFieldName());
-                    errorString = errorString.replace("{1}", "255");
-                    contentValidationErrors
-                            .computeIfAbsent(VALIDATION_FAILED_MAXLENGTH, k -> new ArrayList<>())
                             .add(new ValidationError(field.getVelocityVarName(), errorString));
                 }
 

--- a/dotCMS/src/main/java/com/dotmarketing/business/DotValidationException.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/DotValidationException.java
@@ -19,7 +19,6 @@ public class DotValidationException extends DotStateException {
 	
 	public final static String VALIDATION_FAILED_BADTYPE = "badType";
 	public final static String VALIDATION_FAILED_REQUIRED = "required";
-	public final static String VALIDATION_FAILED_MAXLENGTH = "length";
 	public final static String VALIDATION_FAILED_PATTERN = "pattern";
 	
 	public final static String VALIDATION_FAILED_REQUIRED_REL = "reqRel";
@@ -114,18 +113,6 @@ public class DotValidationException extends DotStateException {
 	}
 	
 	/**
-	 * Use to add a field that failed length validation
-	 * @param field
-	 */
-	public void addMaxLengthField(Field field){
-		List<Field> fields = notValidFields.get(VALIDATION_FAILED_MAXLENGTH);
-		if(fields == null)
-			fields = new ArrayList<>();
-		fields.add(field);
-		notValidFields.put(VALIDATION_FAILED_MAXLENGTH, fields);
-	}
-	
-	/**
 	 * Use to add a field that failed because it has an unknown type
 	 * @param field
 	 */
@@ -151,13 +138,6 @@ public class DotValidationException extends DotStateException {
 	
 	public boolean hasRequiredErrors(){
 		List<Field> fields = notValidFields.get(VALIDATION_FAILED_REQUIRED);
-		if(fields == null || fields.isEmpty())
-			return false;
-		return true;
-	}
-	
-	public boolean hasLengthErrors(){
-		List<Field> fields = notValidFields.get(VALIDATION_FAILED_MAXLENGTH);
 		if(fields == null || fields.isEmpty())
 			return false;
 		return true;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/calendar/ajax/CalendarAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/calendar/ajax/CalendarAjax.java
@@ -777,16 +777,6 @@ public class CalendarAjax {
 				}
 			}
 			
-			if(ve.hasLengthErrors()){
-				List<Field> reqs = ve.getNotValidFields().get(DotContentletValidationException.VALIDATION_FAILED_MAXLENGTH);
-				for (Field field : reqs) {
-					String errorString = LanguageUtil.get(user,"message.contentlet.maxlength");
-					errorString = errorString.replace("{0}", field.getFieldName());
-					errorString = errorString.replace("{1}", "225");
-					saveContentErrors.add(errorString);
-				}
-			}
-			
 			if(ve.hasPatternErrors()){
 				List<Field> reqs = ve.getNotValidFields().get(DotContentletValidationException.VALIDATION_FAILED_PATTERN);
 				for (Field field : reqs) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/EditContentletAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/EditContentletAction.java
@@ -1499,12 +1499,6 @@ public class EditContentletAction extends DotPortletAction implements DotPortlet
 					ae.add(Globals.ERROR_KEY, new ActionMessage("message.contentlet.required", field.getFieldName()));
 				}
 			}
-			if(ve.hasLengthErrors()){
-				List<Field> reqs = ve.getNotValidFields().get(DotContentletValidationException.VALIDATION_FAILED_MAXLENGTH);
-				for (Field field : reqs) {
-					ae.add(Globals.ERROR_KEY, new ActionMessage("message.contentlet.maxlength", field.getFieldName(),"255"));
-				}
-			}
 			if(ve.hasPatternErrors()){
 				List<Field> reqs = ve.getNotValidFields().get(DotContentletValidationException.VALIDATION_FAILED_PATTERN);
 				for (Field field : reqs) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
@@ -2254,18 +2254,6 @@ public class ContentletAjax {
 				clearBinary = false;
 			}
 
-			if (ve.hasLengthErrors()) {
-				final List<Field> reqs = ve.getNotValidFields()
-						.get(DotContentletValidationException.VALIDATION_FAILED_MAXLENGTH);
-				for (Field field : reqs) {
-					String errorString = LanguageUtil.get(user, "message.contentlet.maxlength");
-					errorString = errorString.replace("{0}", field.getFieldName());
-					errorString = errorString.replace("{1}", "255");
-					saveContentErrors.add(errorString);
-				}
-				clearBinary = false;
-			}
-
 			if (ve.hasPatternErrors()) {
 				List<Field> reqs = ve.getNotValidFields()
 						.get(DotContentletValidationException.VALIDATION_FAILED_PATTERN);
@@ -2490,16 +2478,6 @@ public class ContentletAjax {
 					for (Field field : reqs) {
 						String errorString = LanguageUtil.get(user,"message.contentlet.required");
 						errorString = errorString.replace("{0}", field.getFieldName());
-						saveContentErrors.add(errorString);
-					}
-				}
-
-				if(ve.hasLengthErrors()){
-					List<Field> reqs = ve.getNotValidFields().get(DotContentletValidationException.VALIDATION_FAILED_MAXLENGTH);
-					for (Field field : reqs) {
-						String errorString = LanguageUtil.get(user,"message.contentlet.maxlength");
-						errorString = errorString.replace("{0}", field.getFieldName());
-						errorString = errorString.replace("{1}", "255");
 						saveContentErrors.add(errorString);
 					}
 				}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/DotContentletValidationException.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/DotContentletValidationException.java
@@ -21,7 +21,6 @@ public class DotContentletValidationException extends DotContentletStateExceptio
 
 	public final static String VALIDATION_FAILED_BADTYPE = "badType";
 	public final static String VALIDATION_FAILED_REQUIRED = "required";
-	public final static String VALIDATION_FAILED_MAXLENGTH = "length";
 	public final static String VALIDATION_FAILED_PATTERN = "pattern";
 
 	public final static String VALIDATION_FAILED_REQUIRED_REL = "reqRel";
@@ -128,18 +127,6 @@ public class DotContentletValidationException extends DotContentletStateExceptio
 	}
 
 	/**
-	 * Use to add a field that failed length validation
-	 * @param field
-	 */
-	public void addMaxLengthField(Field field){
-		List<Field> fields = notValidFields.get(VALIDATION_FAILED_MAXLENGTH);
-		if(fields == null)
-			fields = new ArrayList<>();
-		fields.add(field);
-		notValidFields.put(VALIDATION_FAILED_MAXLENGTH, fields);
-	}
-
-	/**
 	 * Use to add a field that failed because it has an unknown type
 	 * @param field
 	 */
@@ -165,13 +152,6 @@ public class DotContentletValidationException extends DotContentletStateExceptio
 
 	public boolean hasRequiredErrors(){
 		List<Field> fields = notValidFields.get(VALIDATION_FAILED_REQUIRED);
-		if(fields == null || fields.isEmpty())
-			return false;
-		return true;
-	}
-
-	public boolean hasLengthErrors(){
-		List<Field> fields = notValidFields.get(VALIDATION_FAILED_MAXLENGTH);
 		if(fields == null || fields.isEmpty())
 			return false;
 		return true;


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 19e4ee4</samp>

This pull request removes the validation logic that checked if the value of a text field was greater than 255 characters and threw a validation exception. This logic was outdated and caused issues with content creation and editing. The pull request also removes the code blocks that handled the length errors in various classes and adds a new test case to verify the expected behavior of the contentlet API. The overall purpose of these changes is to simplify the code, fix a bug, and allow more flexibility for text fields.