### PR TITLE
chore: write stdout to catalina.out ref: #26934

### DIFF
--- a/docker/dotcms/ROOT/srv/OVERRIDE/tomcat/conf/logging.properties
+++ b/docker/dotcms/ROOT/srv/OVERRIDE/tomcat/conf/logging.properties
@@ -1,8 +1,14 @@
-handlers =  java.util.logging.ConsoleHandler
-.handlers = java.util.logging.ConsoleHandler
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
 
-java.util.logging.ConsoleHandler.level = INFO
-java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
 
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = java.util.logging.ConsoleHandler
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.AsyncFileHandler.level = INFO
+1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
+1catalina.org.apache.juli.AsyncFileHandler.maxDays = 2
+1catalina.org.apache.juli.AsyncFileHandler.encoding = UTF-8

--- a/dotCMS/src/main/docker/original/ROOT/srv/OVERRIDE/tomcat/conf/logging.properties
+++ b/dotCMS/src/main/docker/original/ROOT/srv/OVERRIDE/tomcat/conf/logging.properties
@@ -1,8 +1,14 @@
-handlers =  java.util.logging.ConsoleHandler
-.handlers = java.util.logging.ConsoleHandler
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
 
-java.util.logging.ConsoleHandler.level = INFO
-java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
 
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = java.util.logging.ConsoleHandler
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.AsyncFileHandler.level = INFO
+1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
+1catalina.org.apache.juli.AsyncFileHandler.maxDays = 2
+1catalina.org.apache.juli.AsyncFileHandler.encoding = UTF-8


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 05a1282</samp>

This pull request adds a file handler to the logging configuration for the dotCMS docker image, which enables log persistence and rotation. It does so by creating a new file `docker/dotcms/ROOT/srv/OVERRIDE/tomcat/conf/logging.properties` and copying and modifying the original file `dotCMS/src/main/docker/original/ROOT/srv/OVERRIDE/tomcat/conf/logging.properties`.