### PR TITLE
feat(EMA) #26892 : Add a depth parameter to the EMA App

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
@@ -781,12 +781,15 @@ public class ContentUtils {
 		if (addRelationshipsOnPage &&
 				Objects.nonNull(response) &&
 				Objects.nonNull(request) &&
-				Objects.nonNull(user) &&
-				Objects.nonNull(request.getParameter(WebKeys.HTMLPAGE_DEPTH))
-			) {
-
-			final int depth = ConversionUtils.toInt(request.getParameter(WebKeys.HTMLPAGE_DEPTH), -1);
-			addRelationships(contentlet, user, mode, languageId, depth, request, response);
+				Objects.nonNull(user)) {
+			final String depthParam =
+					Objects.nonNull(request.getParameter(WebKeys.HTMLPAGE_DEPTH)) ?
+							request.getParameter(WebKeys.HTMLPAGE_DEPTH) :
+							(String) request.getAttribute(WebKeys.HTMLPAGE_DEPTH);
+			if (Objects.nonNull(depthParam)) {
+				final int depth = ConversionUtils.toInt(depthParam, -1);
+				addRelationships(contentlet, user, mode, languageId, depth, request, response);
+			}
 		}
 	}
 


### PR DESCRIPTION
### Proposed Changes
* **This is the correct fix for this ticket. Please ignore the following PR: https://github.com/dotCMS/core/pull/26924**

This pull request improves the EMAWebInterceptor functionality and configuration by adding a depth parameter for the proxy server, refactoring the code for readability and consistency, and enhancing the error logging. The depth parameter is defined in the dotema-config.yml file and affects how much of the page tree is fetched from the proxy and local servers.