### PR TITLE
#26957: moving dotcms-webcompnents/dist contents to ROOT

### DIFF
--- a/dotCMS/src/assembly/descriptor.xml
+++ b/dotCMS/src/assembly/descriptor.xml
@@ -67,6 +67,20 @@
             <directory>${docs-directory}</directory>
             <outputDirectory>docs</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${exploded-webapp-dir}</directory>
+            <outputDirectory>dotserver/tomcat-${tomcat.version}/webapps/ROOT</outputDirectory>
+            <excludes>
+                <exclude>**/dotcms-webcomponents/dist/dotcms-webcomponents/**</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${exploded-webapp-dir}/dotcms-webcomponents/dist</directory>
+            <outputDirectory>dotserver/tomcat-${tomcat.version}/webapps/ROOT</outputDirectory>
+            <includes>
+                <include>**/dotcms-webcomponents/**</include>
+            </includes>
+        </fileSet>
     </fileSets>
     <!--
     <files>

--- a/dotCMS/src/main/docker/original/docker-descriptor.xml
+++ b/dotCMS/src/main/docker/original/docker-descriptor.xml
@@ -19,7 +19,6 @@
                 <exclude>**/logs/**</exclude>
             </excludes>
         </fileSet>
-
         <fileSet>
             <directory>${assembly-directory}/dotserver/tomcat-${tomcat.version}</directory>
             <outputDirectory>dotserver/tomcat-${tomcat.version}</outputDirectory>
@@ -36,9 +35,18 @@
         <fileSet>
             <directory>${exploded-webapp-dir}</directory>
             <outputDirectory>dotserver/tomcat-${tomcat.version}/webapps/ROOT</outputDirectory>
+            <excludes>
+                <exclude>**/dotcms-webcomponents/dist/dotcms-webcomponents/**</exclude>
+            </excludes>
         </fileSet>
+        <fileSet>
+            <directory>${exploded-webapp-dir}/dotcms-webcomponents/dist</directory>
+            <outputDirectory>dotserver/tomcat-${tomcat.version}/webapps/ROOT</outputDirectory>
+            <includes>
+                <include>**/dotcms-webcomponents/**</include>
+            </includes>
+        </fileSet>
+
     </fileSets>
-
-
 
 </assembly>


### PR DESCRIPTION
Moving `dotcms-webcompnents/dist` contents to `ROOT/dotcms-webcompnents` to fix frontend issue.