### PR TITLE
feat(edit-content) Add event to signal form load inside the custom field

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.spec.ts
@@ -93,4 +93,15 @@ describe('DotEditContentCustomFieldComponent', () => {
 
         expect(spectator.component.form.get('custom').value).toBe('Other text');
     });
+
+    it('should the custom field component sent a onFormLoad event to iframe', () => {
+        spectator.setInput('field', CUSTOM_FIELD_MOCK);
+        spectator.detectChanges();
+
+        const iframe = spectator.debugElement.query(By.css('[data-testId="iframe"]'));
+        const postMessageSpy = jest.spyOn(iframe.nativeElement.contentWindow, 'postMessage');
+        spectator.component.onIframeLoad();
+
+        expect(postMessageSpy).toHaveBeenCalled();
+    });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.ts
@@ -4,6 +4,7 @@ import {
     Component,
     ElementRef,
     HostListener,
+    Inject,
     Input,
     NgZone,
     OnInit,
@@ -16,6 +17,7 @@ import { ButtonModule } from 'primeng/button';
 
 import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
 import { DotIconModule, SafeUrlPipe } from '@dotcms/ui';
+import { WINDOW } from '@dotcms/utils';
 
 import { DotEditContentService } from '../../services/dot-edit-content.service';
 
@@ -25,7 +27,13 @@ import { DotEditContentService } from '../../services/dot-edit-content.service';
     imports: [SafeUrlPipe, NgStyle, NgClass, DotIconModule, NgIf, ButtonModule],
     templateUrl: './dot-edit-content-custom-field.component.html',
     styleUrls: ['./dot-edit-content-custom-field.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [
+        {
+            provide: WINDOW,
+            useValue: window
+        }
+    ]
 })
 export class DotEditContentCustomFieldComponent implements OnInit {
     @Input() field!: DotCMSContentTypeField;
@@ -40,6 +48,8 @@ export class DotEditContentCustomFieldComponent implements OnInit {
     variables!: { [key: string]: string };
     isFullscreen = false;
     src!: string;
+
+    constructor(@Inject(WINDOW) private window: Window) {}
 
     ngOnInit() {
         this.src = `/html/legacy_custom_field/legacy-custom-field.jsp?variable=${this.contentType}&field=${this.field.variable}`;
@@ -68,7 +78,7 @@ export class DotEditContentCustomFieldComponent implements OnInit {
     onIframeLoad() {
         const iframeWindow = this.iframe.nativeElement.contentWindow as Window;
         iframeWindow['form'] = this.zone.run(() => this.form);
-        iframeWindow.postMessage({ type: 'dotcms:form:loaded' }, '*');
+        iframeWindow.postMessage({ type: 'dotcms:form:loaded' }, this.window.parent.origin);
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.ts
@@ -68,6 +68,7 @@ export class DotEditContentCustomFieldComponent implements OnInit {
     onIframeLoad() {
         const iframeWindow = this.iframe.nativeElement.contentWindow as Window;
         iframeWindow['form'] = this.zone.run(() => this.form);
+        iframeWindow.postMessage({ type: 'dotcms:form:loaded' }, '*');
     }
 
     /**

--- a/core-web/libs/utils/src/index.ts
+++ b/core-web/libs/utils/src/index.ts
@@ -1,3 +1,5 @@
 export * from './lib/services/dot-asset.service';
 export * from './lib/dot-utils';
 export * from './lib/services/dot-loading-indicator.service';
+
+export * from './lib/shared/const';

--- a/core-web/libs/utils/src/lib/shared/const.ts
+++ b/core-web/libs/utils/src/lib/shared/const.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const WINDOW = new InjectionToken<Window>('WindowToken');


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4ebcb99</samp>

### Summary
🧪📨🖼️

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate that the change adds a unit test for the component.
2.  📨 - This emoji represents sending or receiving mail, messages, or communication, and can be used to indicate that the change implements the logic for sending the event to the iframe window.
3.  🖼️ - This emoji represents a picture frame, an image, or a display, and can be used to indicate that the change is related to rendering custom fields inside an iframe.
-->
This pull request adds a feature that allows custom fields to be rendered inside an iframe in the edit content form. It implements the communication between the parent window and the iframe window using the `postMessage` method and the `dotcms:form:loaded` event.

> _`postMessage` sends_
> _event to iframe window_
> _autumn leaves falling_

### Walkthrough
*  Send `dotcms:form:loaded` event to iframe window when iframe is loaded ([link](https://github.com/dotCMS/core/pull/27004/files?diff=unified&w=0#diff-a3bf0b4662398fd287c4992a12e5189f36e79545ab0f72df7a6c0d1d30352717R71), [link](https://github.com/dotCMS/core/pull/27004/files?diff=unified&w=0#diff-04465fbcea9c39bc66d73064e129700c837b5f08317a4fcab62e054b42d15665R96-R106))



### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
