### PR TITLE
#26643 Implement command execution ordering for push and pull

### DIFF
--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/DotPull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/DotPull.java
@@ -33,4 +33,13 @@ public interface DotPull {
         return Optional.empty();
     }
 
+    /**
+     * Returns the execution order of this pull command.
+     *
+     * @return the execution order of this pull command
+     */
+    default int getOrder() {
+        return Integer.MAX_VALUE;  // default to the highest possible value
+    }
+
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/DotPush.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/DotPush.java
@@ -32,4 +32,13 @@ public interface DotPush {
         return Optional.empty();
     }
 
+    /**
+     * Returns the execution order of this push command.
+     *
+     * @return the execution order of this push command
+     */
+    default int getOrder() {
+        return Integer.MAX_VALUE;  // default to the highest possible value
+    }
+
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/PullCommand.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/PullCommand.java
@@ -5,7 +5,9 @@ import com.dotcms.cli.common.FullPullOptionsMixin;
 import com.dotcms.cli.common.HelpOptionMixin;
 import com.dotcms.cli.common.OutputOptionMixin;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 import javax.enterprise.context.control.ActivateRequestContext;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -58,8 +60,13 @@ public class PullCommand implements Callable<Integer>, DotCommand {
         expandedArgs.add("--noValidateUnmatchedArguments");
         var args = expandedArgs.toArray(new String[0]);
 
+        // Sort the subcommands by order
+        final var pullCommandsSorted = pullCommands.stream()
+                .sorted(Comparator.comparingInt(DotPull::getOrder))
+                .collect(Collectors.toList());
+
         // Process each subcommand
-        for (var subCommand : pullCommands) {
+        for (var subCommand : pullCommandsSorted) {
 
             var cmdLine = createCommandLine(subCommand);
 

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/PushCommand.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/PushCommand.java
@@ -7,7 +7,9 @@ import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.common.WorkspaceManager;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 import javax.enterprise.context.control.ActivateRequestContext;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -67,8 +69,13 @@ public class PushCommand implements Callable<Integer>, DotCommand {
         expandedArgs.add("--noValidateUnmatchedArguments");
         var args = expandedArgs.toArray(new String[0]);
 
+        // Sort the subcommands by order
+        final var pushCommandsSorted = pushCommands.stream()
+                .sorted(Comparator.comparingInt(DotPush::getOrder))
+                .collect(Collectors.toList());
+
         // Process each subcommand
-        for (var subCommand : pushCommands) {
+        for (var subCommand : pushCommandsSorted) {
 
             var cmdLine = createCommandLine(subCommand);
 

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/contenttype/ContentTypePull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/contenttype/ContentTypePull.java
@@ -131,4 +131,9 @@ public class ContentTypePull extends AbstractContentTypeCommand implements Calla
         return Optional.empty();
     }
 
+    @Override
+    public int getOrder() {
+        return 2;
+    }
+
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/contenttype/ContentTypePull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/contenttype/ContentTypePull.java
@@ -5,6 +5,7 @@ import com.dotcms.api.client.pull.contenttype.ContentTypeFetcher;
 import com.dotcms.api.client.pull.contenttype.ContentTypePullHandler;
 import com.dotcms.cli.command.DotCommand;
 import com.dotcms.cli.command.DotPull;
+import com.dotcms.cli.common.ApplyCommandOrder;
 import com.dotcms.cli.common.FullPullOptionsMixin;
 import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.cli.common.PullMixin;
@@ -133,7 +134,7 @@ public class ContentTypePull extends AbstractContentTypeCommand implements Calla
 
     @Override
     public int getOrder() {
-        return 2;
+        return ApplyCommandOrder.CONTENT_TYPE.getOrder();
     }
 
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/contenttype/ContentTypePush.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/contenttype/ContentTypePush.java
@@ -138,4 +138,9 @@ public class ContentTypePush extends AbstractContentTypeCommand implements Calla
         return Optional.of(CONTENT_TYPE_PUSH_MIXIN);
     }
 
+    @Override
+    public int getOrder() {
+        return 2;
+    }
+
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/contenttype/ContentTypePush.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/contenttype/ContentTypePush.java
@@ -6,6 +6,7 @@ import com.dotcms.api.client.push.contenttype.ContentTypeFetcher;
 import com.dotcms.api.client.push.contenttype.ContentTypePushHandler;
 import com.dotcms.cli.command.DotCommand;
 import com.dotcms.cli.command.DotPush;
+import com.dotcms.cli.common.ApplyCommandOrder;
 import com.dotcms.cli.common.FullPushOptionsMixin;
 import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.cli.common.PushMixin;
@@ -140,7 +141,7 @@ public class ContentTypePush extends AbstractContentTypeCommand implements Calla
 
     @Override
     public int getOrder() {
-        return 2;
+        return ApplyCommandOrder.CONTENT_TYPE.getOrder();
     }
 
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/files/FilesPull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/files/FilesPull.java
@@ -155,4 +155,9 @@ public class FilesPull extends AbstractFilesCommand implements Callable<Integer>
         return Optional.empty();
     }
 
+    @Override
+    public int getOrder() {
+        return 3;
+    }
+
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/files/FilesPull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/files/FilesPull.java
@@ -13,6 +13,7 @@ import com.dotcms.api.client.pull.file.FileFetcher;
 import com.dotcms.api.client.pull.file.FilePullHandler;
 import com.dotcms.cli.command.DotCommand;
 import com.dotcms.cli.command.DotPull;
+import com.dotcms.cli.common.ApplyCommandOrder;
 import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.cli.common.PullMixin;
 import com.dotcms.common.WorkspaceManager;
@@ -157,7 +158,7 @@ public class FilesPull extends AbstractFilesCommand implements Callable<Integer>
 
     @Override
     public int getOrder() {
-        return 3;
+        return ApplyCommandOrder.FILES.getOrder();
     }
 
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/files/FilesPush.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/files/FilesPush.java
@@ -12,6 +12,7 @@ import com.dotcms.api.traversal.TreeNodePushInfo;
 import com.dotcms.cli.command.DotCommand;
 import com.dotcms.cli.command.DotPush;
 import com.dotcms.cli.command.PushContext;
+import com.dotcms.cli.common.ApplyCommandOrder;
 import com.dotcms.cli.common.ConsoleLoadingAnimation;
 import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.cli.common.PushMixin;
@@ -288,7 +289,7 @@ public class FilesPush extends AbstractFilesCommand implements Callable<Integer>
 
     @Override
     public int getOrder() {
-        return 3;
+        return ApplyCommandOrder.FILES.getOrder();
     }
 
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/files/FilesPush.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/files/FilesPush.java
@@ -286,4 +286,9 @@ public class FilesPush extends AbstractFilesCommand implements Callable<Integer>
         return Optional.of(FILES_PUSH_MIXIN);
     }
 
+    @Override
+    public int getOrder() {
+        return 3;
+    }
+
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePull.java
@@ -131,4 +131,9 @@ public class LanguagePull extends AbstractLanguageCommand implements Callable<In
         return Optional.empty();
     }
 
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+    
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePull.java
@@ -5,6 +5,7 @@ import com.dotcms.api.client.pull.language.LanguageFetcher;
 import com.dotcms.api.client.pull.language.LanguagePullHandler;
 import com.dotcms.cli.command.DotCommand;
 import com.dotcms.cli.command.DotPull;
+import com.dotcms.cli.common.ApplyCommandOrder;
 import com.dotcms.cli.common.FullPullOptionsMixin;
 import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.cli.common.PullMixin;
@@ -133,7 +134,7 @@ public class LanguagePull extends AbstractLanguageCommand implements Callable<In
 
     @Override
     public int getOrder() {
-        return 0;
+        return ApplyCommandOrder.LANGUAGE.getOrder();
     }
     
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePush.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePush.java
@@ -197,4 +197,9 @@ public class LanguagePush extends AbstractLanguageCommand implements Callable<In
         return Optional.of(LANGUAGE_PUSH_MIXIN);
     }
 
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+    
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePush.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/language/LanguagePush.java
@@ -8,6 +8,7 @@ import com.dotcms.api.client.push.language.LanguageFetcher;
 import com.dotcms.api.client.push.language.LanguagePushHandler;
 import com.dotcms.cli.command.DotCommand;
 import com.dotcms.cli.command.DotPush;
+import com.dotcms.cli.common.ApplyCommandOrder;
 import com.dotcms.cli.common.FullPushOptionsMixin;
 import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.cli.common.PushMixin;
@@ -199,7 +200,7 @@ public class LanguagePush extends AbstractLanguageCommand implements Callable<In
 
     @Override
     public int getOrder() {
-        return 0;
+        return ApplyCommandOrder.LANGUAGE.getOrder();
     }
     
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/site/SitePull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/site/SitePull.java
@@ -134,4 +134,9 @@ public class SitePull extends AbstractSiteCommand implements Callable<Integer>, 
         return Optional.empty();
     }
 
+    @Override
+    public int getOrder() {
+        return 1;
+    }
+
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/site/SitePull.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/site/SitePull.java
@@ -5,6 +5,7 @@ import com.dotcms.api.client.pull.site.SiteFetcher;
 import com.dotcms.api.client.pull.site.SitePullHandler;
 import com.dotcms.cli.command.DotCommand;
 import com.dotcms.cli.command.DotPull;
+import com.dotcms.cli.common.ApplyCommandOrder;
 import com.dotcms.cli.common.FullPullOptionsMixin;
 import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.cli.common.PullMixin;
@@ -136,7 +137,7 @@ public class SitePull extends AbstractSiteCommand implements Callable<Integer>, 
 
     @Override
     public int getOrder() {
-        return 1;
+        return ApplyCommandOrder.SITE.getOrder();
     }
 
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/site/SitePush.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/site/SitePush.java
@@ -6,6 +6,7 @@ import com.dotcms.api.client.push.site.SiteFetcher;
 import com.dotcms.api.client.push.site.SitePushHandler;
 import com.dotcms.cli.command.DotCommand;
 import com.dotcms.cli.command.DotPush;
+import com.dotcms.cli.common.ApplyCommandOrder;
 import com.dotcms.cli.common.FullPushOptionsMixin;
 import com.dotcms.cli.common.OutputOptionMixin;
 import com.dotcms.cli.common.PushMixin;
@@ -148,7 +149,7 @@ public class SitePush extends AbstractSiteCommand implements Callable<Integer>, 
 
     @Override
     public int getOrder() {
-        return 1;
+        return ApplyCommandOrder.SITE.getOrder();
     }
 
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/site/SitePush.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/command/site/SitePush.java
@@ -146,4 +146,9 @@ public class SitePush extends AbstractSiteCommand implements Callable<Integer>, 
         return Optional.of(SITE_PUSH_MIXIN);
     }
 
+    @Override
+    public int getOrder() {
+        return 1;
+    }
+
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/common/ApplyCommandOrder.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/common/ApplyCommandOrder.java
@@ -1,0 +1,24 @@
+package com.dotcms.cli.common;
+
+/**
+ * The ApplyCommandOrder enum represents the order of execution for the subcommands on the global
+ * push and pull commands.
+ */
+public enum ApplyCommandOrder {
+
+    LANGUAGE(0),
+    SITE(1),
+    CONTENT_TYPE(2),
+    FILES(3);
+
+    private final int order;
+
+    ApplyCommandOrder(int order) {
+        this.order = order;
+    }
+
+    public int getOrder() {
+        return this.order;
+    }
+
+}


### PR DESCRIPTION
The push and pull commands have been modified to allow subcommand execution in a custom order. A new method, `getOrder`, has been added in both `DotPush` and `DotPull` interfaces and implemented in all subclasses. Corresponding unit tests have also been updated to ensure that commands with lower `getOrder` values are executed first.