### PR TITLE
#26508 handle rename

### DIFF
--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/files/traversal/task/LocalFolderTraversalTask.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/files/traversal/task/LocalFolderTraversalTask.java
@@ -590,7 +590,7 @@ public class LocalFolderTraversalTask extends RecursiveTask<Pair<List<Exception>
         if (!Strings.isNullOrEmpty(remoteFileHash)) { // We found the file in the remote server
 
             // Local SHA-256
-            final String localFileHash = Utils.Sha256toUnixHash(file.toPath());
+            final String localFileHash = Utils.sha256ToUnixHash(file.toPath());
 
             // Verify if we need to push the file
             if (localFileHash.equals(remoteFileHash)) {

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/files/traversal/task/PullTreeNodeTask.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/files/traversal/task/PullTreeNodeTask.java
@@ -245,9 +245,9 @@ public class PullTreeNodeTask extends RecursiveTask<List<Exception>> {
         if (remoteUnderlyingName != null && !remoteUnderlyingName.equals(asset.name())) {
             //First if the logical name and the underlying name are different, we check if there is a file with the underlying name in the file system
             var unnderlyingFilePath = Paths.get(destination, folder.path(), remoteUnderlyingName);
-            localFileHash = hashFunction.apply(localFileHash, unnderlyingFilePath);
+            var assetFilePath = Paths.get(destination, folder.path(), asset.name());
             if (Files.exists(unnderlyingFilePath) //if the file exists
-                    && Utils.sha256ToUnixHash(unnderlyingFilePath).equals(localFileHash)) { //and the hash is the same
+                && Utils.sha256ToUnixHash(unnderlyingFilePath).equals(hashFunction.apply(localFileHash, assetFilePath))) { //and the hash is the same
                 //it means that the file was logically renamed via change title
                 logger.info(String.format("Deleting old file [%s] because it was renamed to [%s]", unnderlyingFilePath, asset.name()));
                 //Therefore we delete the old file

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/security/Utils.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/security/Utils.java
@@ -21,7 +21,7 @@ public class Utils {
      * @throws NoSuchAlgorithmException
      * @throws IOException
      */
-    public static String Sha256toUnixHash(final Path path) {
+    public static String sha256ToUnixHash(final Path path) {
 
         try {
             final HashBuilder sha256Builder = Encryptor.Hashing.sha256();

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/security/UtilsTest.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/security/UtilsTest.java
@@ -23,7 +23,7 @@ class UtilsTest {
             Files.write(path, "Hello, world!".getBytes());
 
             String expectedHash = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3";
-            String actualHash = Utils.Sha256toUnixHash(path);
+            String actualHash = Utils.sha256ToUnixHash(path);
 
             Assertions.assertEquals(expectedHash, actualHash);
         } finally {
@@ -43,13 +43,13 @@ class UtilsTest {
             originalPath = Files.createTempFile("test", ".txt");
             Files.write(originalPath, "Hello, world!".getBytes());
 
-            var originalHash = Utils.Sha256toUnixHash(originalPath);
+            var originalHash = Utils.sha256ToUnixHash(originalPath);
             Assertions.assertNotNull(originalHash);
 
             renamePath = Files.createTempFile("new-test", ".txt");
             Files.move(originalPath, renamePath, StandardCopyOption.REPLACE_EXISTING);
 
-            var newHash = Utils.Sha256toUnixHash(renamePath);
+            var newHash = Utils.sha256ToUnixHash(renamePath);
             Assertions.assertNotNull(newHash);
 
             Assertions.assertEquals(originalHash, newHash);
@@ -69,7 +69,7 @@ class UtilsTest {
         Path path = Path.of("nonexistent.txt");
 
         try {
-            Utils.Sha256toUnixHash(path);
+            Utils.sha256ToUnixHash(path);
             Assertions.fail("Expected NoSuchFileException to be thrown");
         } catch (Exception e) {
             Assertions.assertTrue(e.getCause() instanceof NoSuchFileException);
@@ -78,7 +78,7 @@ class UtilsTest {
 
     @Test
     void testSha256toUnixHash_withNullPath_throwsNullPointerException() {
-        Assertions.assertThrows(NullPointerException.class, () -> Utils.Sha256toUnixHash(null));
+        Assertions.assertThrows(NullPointerException.class, () -> Utils.sha256ToUnixHash(null));
     }
 
 }


### PR DESCRIPTION
### Proposed Changes
* If a file gets renamed e.g. by creating a version in a different langauge using a different binary we need to handle to synchronize case 
* When a different binary gets uploaded to create a new version in lets say a differen language the title of the contentlet chages to reflect the new file uploaded. thereofre any prior version of that file asset that had been already downloaded needs to be updated 
* When we pull down the contents the file with the old name needs to be removed and the same file with the updated logical name should replace it

