### PR TITLE
dotCMS/core#27063 Experiments result dates in chart dates are incorrect by one day. 

### DIFF
--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/store/dot-experiments-reports-store.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/store/dot-experiments-reports-store.ts
@@ -349,14 +349,12 @@ export class DotExperimentsReportsStore extends ComponentStore<DotExperimentsRep
     }
 
     private parseDaysLabels(labels: Array<string>): string[] {
-        const data = [getPreviousDay(labels[0]), ...labels].map((item) => {
+        return [getPreviousDay(labels[0]), ...labels].map((item) => {
             const [, month, day] = item.split('-').map(Number);
             const monthTranslated = this.dotMessageService.get(MonthsOfTheYear[month - 1]);
 
             return `${monthTranslated}-${day}`;
         });
-
-        return data;
     }
 
     private getDotExperimentVariantDetail(

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/store/dot-experiments-reports-store.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/store/dot-experiments-reports-store.ts
@@ -349,13 +349,14 @@ export class DotExperimentsReportsStore extends ComponentStore<DotExperimentsRep
     }
 
     private parseDaysLabels(labels: Array<string>): string[] {
-        return [getPreviousDay(labels[0]), ...labels].map((item) => {
-            const date = new Date(item);
-            const day = date.getDate();
-            const monthTranslated = this.dotMessageService.get(MonthsOfTheYear[date.getMonth()]);
+        const data = [getPreviousDay(labels[0]), ...labels].map((item) => {
+            const [, month, day] = item.split('-').map(Number);
+            const monthTranslated = this.dotMessageService.get(MonthsOfTheYear[month - 1]);
 
             return `${monthTranslated}-${day}`;
         });
+
+        return data;
     }
 
     private getDotExperimentVariantDetail(

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
@@ -24,6 +24,8 @@ import {
     TIME_90_DAYS
 } from '@dotcms/dotcms-models';
 
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
 export const orderVariants = (arrayToOrder: Array<string>): Array<string> => {
     const index = arrayToOrder.indexOf(DEFAULT_VARIANT_ID);
     if (index > -1) {
@@ -74,7 +76,7 @@ export const processExperimentConfigProps = (
 };
 
 export const daysToMilliseconds = (days: number): number => {
-    return days * 24 * 60 * 60 * 1000;
+    return days * ONE_DAY;
 };
 
 export const checkIfExperimentDescriptionIsSaving = (stepStatusSidebar) =>
@@ -123,8 +125,8 @@ export const getPreviousDay = (givenDate: string) => {
     // Create a Date object in UTC | - 1 - Months are zero-based in JavaScript
     const inputDateUTC = new Date(Date.UTC(year, month - 1, day));
 
-    // Subtract one day from the timestamp (in milliseconds) to avoid TIMEZONE issues & month change.
-    inputDateUTC.setTime(inputDateUTC.getTime() - 24 * 60 * 60 * 1000);
+    // in milliseconds to avoid TIMEZONE issues & month change.
+    inputDateUTC.setTime(inputDateUTC.getTime() - ONE_DAY);
 
     // Format the date as "YYYY-MM-dd"
     return inputDateUTC.toISOString().split('T')[0];

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
@@ -118,14 +118,16 @@ export const isPromotedVariant = (experiment: DotExperiment, variantName: string
 };
 
 export const getPreviousDay = (givenDate: string) => {
-    const date = new Date(givenDate);
-    date.setDate(date.getDate() - 1);
+    const [year, month, day] = givenDate.split('-').map(Number);
 
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    const year = date.getFullYear();
+    // Create a Date object in UTC | - 1 - Months are zero-based in JavaScript
+    const inputDateUTC = new Date(Date.UTC(year, month - 1, day));
 
-    return `${month}/${day}/${year}`;
+    // Subtract one day from the timestamp (in milliseconds) to avoid TIMEZONE issues & month change.
+    inputDateUTC.setTime(inputDateUTC.getTime() - 24 * 60 * 60 * 1000);
+
+    // Format the date as "YYYY-MM-dd"
+    return inputDateUTC.toISOString().split('T')[0];
 };
 
 export const getRandomUUID = () => self.crypto.randomUUID();

--- a/core-web/libs/utils-testing/src/lib/dot-experiments.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/dot-experiments.mock.ts
@@ -180,77 +180,77 @@ export const ExperimentResultsMocks: Array<DotExperimentResults> = [
                 variants: {
                     [DEFAULT_VARIANT_ID]: {
                         details: {
-                            '04/01/2023': {
+                            '2023-04-01': {
                                 multiBySession: 1,
                                 uniqueBySession: 1,
                                 conversionRate: 90.555
                             },
-                            '04/02/2023': {
+                            '2023-04-02': {
                                 multiBySession: 2,
                                 uniqueBySession: 2,
                                 conversionRate: 2
                             },
-                            '04/03/2023': {
+                            '2023-04-03': {
                                 multiBySession: 3,
                                 uniqueBySession: 3,
                                 conversionRate: 3
                             },
-                            '04/04/2023': {
+                            '2023-04-04': {
                                 multiBySession: 4,
                                 uniqueBySession: 4,
                                 conversionRate: 4
                             },
-                            '04/05/2023': {
+                            '2023-04-05': {
                                 multiBySession: 5,
                                 uniqueBySession: 5,
                                 conversionRate: 5
                             },
-                            '04/06/2023': {
+                            '2023-04-06': {
                                 multiBySession: 6,
                                 uniqueBySession: 6,
                                 conversionRate: 6
                             },
-                            '04/07/2023': {
+                            '2023-04-07': {
                                 multiBySession: 7,
                                 uniqueBySession: 7,
                                 conversionRate: 7
                             },
-                            '04/08/2023': {
+                            '2023-04-08': {
                                 multiBySession: 8,
                                 uniqueBySession: 8,
                                 conversionRate: 8
                             },
-                            '04/09/2023': {
+                            '2023-04-09': {
                                 multiBySession: 9,
                                 uniqueBySession: 9,
                                 conversionRate: 9
                             },
-                            '04/10/2023': {
+                            '2023-04-10': {
                                 multiBySession: 10,
                                 uniqueBySession: 10,
                                 conversionRate: 10
                             },
-                            '04/11/2023': {
+                            '2023-04-11': {
                                 multiBySession: 11,
                                 uniqueBySession: 11,
                                 conversionRate: 11
                             },
-                            '04/12/2023': {
+                            '2023-04-12': {
                                 multiBySession: 12,
                                 uniqueBySession: 12,
                                 conversionRate: 12
                             },
-                            '04/13/2023': {
+                            '2023-04-13': {
                                 multiBySession: 13,
                                 uniqueBySession: 13,
                                 conversionRate: 13
                             },
-                            '04/14/2023': {
+                            '2023-04-14': {
                                 multiBySession: 14,
                                 uniqueBySession: 14,
                                 conversionRate: 14
                             },
-                            '04/15/2023': {
+                            '2023-04-15': {
                                 multiBySession: 15,
                                 uniqueBySession: 15,
                                 conversionRate: 15.25
@@ -268,77 +268,77 @@ export const ExperimentResultsMocks: Array<DotExperimentResults> = [
                     },
                     '111': {
                         details: {
-                            '04/01/2023': {
+                            '2023-04-01': {
                                 multiBySession: 15,
                                 uniqueBySession: 15,
                                 conversionRate: 15.25
                             },
-                            '04/02/2023': {
+                            '2023-04-02': {
                                 multiBySession: 14,
                                 uniqueBySession: 14,
                                 conversionRate: 14
                             },
-                            '04/03/2023': {
+                            '2023-04-03': {
                                 multiBySession: 13,
                                 uniqueBySession: 13,
                                 conversionRate: 13
                             },
-                            '04/04/2023': {
+                            '2023-04-04': {
                                 multiBySession: 12,
                                 uniqueBySession: 12,
                                 conversionRate: 12
                             },
-                            '04/05/2023': {
+                            '2023-04-05': {
                                 multiBySession: 11,
                                 uniqueBySession: 11,
                                 conversionRate: 11
                             },
-                            '04/06/2023': {
+                            '2023-04-06': {
                                 multiBySession: 10,
                                 uniqueBySession: 10,
                                 conversionRate: 10
                             },
-                            '04/07/2023': {
+                            '2023-04-07': {
                                 multiBySession: 9,
                                 uniqueBySession: 9,
                                 conversionRate: 9
                             },
-                            '04/08/2023': {
+                            '2023-04-08': {
                                 multiBySession: 8,
                                 uniqueBySession: 8,
                                 conversionRate: 8
                             },
-                            '04/09/2023': {
+                            '2023-04-09': {
                                 multiBySession: 7,
                                 uniqueBySession: 7,
                                 conversionRate: 7
                             },
-                            '04/10/2023': {
+                            '2023-04-10': {
                                 multiBySession: 6,
                                 uniqueBySession: 6,
                                 conversionRate: 6
                             },
-                            '04/11/2023': {
+                            '2023-04-11': {
                                 multiBySession: 5,
                                 uniqueBySession: 5,
                                 conversionRate: 5
                             },
-                            '04/12/2023': {
+                            '2023-04-12': {
                                 multiBySession: 4,
                                 uniqueBySession: 4,
                                 conversionRate: 4
                             },
-                            '04/13/2023': {
+                            '2023-04-13': {
                                 multiBySession: 3,
                                 uniqueBySession: 3,
                                 conversionRate: 3
                             },
-                            '04/14/2023': {
+                            '2023-04-14': {
                                 multiBySession: 2,
                                 uniqueBySession: 2,
                                 conversionRate: 2
                             },
-                            '04/15/2023': {
+                            '2023-04-15': {
                                 multiBySession: 1,
                                 uniqueBySession: 1,
                                 conversionRate: 90.555


### PR DESCRIPTION
### Proposed Changes
* Change how we subtract one day to the given date to avoid time zone issues and month change issues. 


### Screenshots

Given value: 

`{
  "DEFAULT": {
    "details": {
      "2023-12-19": {
        "conversionRate": 66.67,
        "totalSessions": 6,
        "uniqueBySession": 4
      }
    },
    "uniqueBySession": {
      "conversionRate": 66.67,
      "count": 4
    },
    "variantDescription": "Original",
    "variantName": "DEFAULT",
    "weight": 50
  },
  "dotexperiment-3a076f427a-variant-1": {
    "details": {
      "2023-12-19": {
        "conversionRate": 25,
        "totalSessions": 4,
        "uniqueBySession": 1
      }
    },
    "uniqueBySession": {
      "conversionRate": 25,
      "count": 1
    },
    "variantDescription": "v1",
    "variantName": "dotexperiment-3a076f427a-variant-1",
    "weight": 50
  }`


#### Before 

<img width="1172" alt="image" src="https://github.com/dotCMS/core/assets/31667212/95bda736-342a-4f41-9ce8-7d8dd455f7f5">


#### After 

<img width="1140" alt="image" src="https://github.com/dotCMS/core/assets/31667212/343ab8e6-68e8-447c-adc7-8e4169af2651">


