### PR TITLE
feat(edit-ema): #26997 Add page properties functionality

### DIFF
--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.html
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.html
@@ -1,9 +1,16 @@
 <nav class="edit-ema-nav-bar">
+    <ng-container *ngFor="let item of items">
+        <ng-container
+            [ngTemplateOutlet]="item.action ? button : anchor"
+            [ngTemplateOutletContext]="{ item: item }">
+        </ng-container>
+    </ng-container>
+</nav>
+
+<ng-template #anchor let-item="item">
     <a
         class="edit-ema-nav-bar__item"
-        *ngFor="let item of items"
         [routerLink]="item.href"
-        (click)="item?.action()"
         data-testId="nav-bar-item"
         routerLinkActive="edit-ema-nav-bar__item--active"
         queryParamsHandling="merge"
@@ -16,7 +23,22 @@
             {{ item.label }}
         </span>
     </a>
-</nav>
+</ng-template>
+
+<ng-template #button let-item="item">
+    <button
+        class="edit-ema-nav-bar__item edit-ema-nav-bar__item--button"
+        (click)="item?.action()"
+        data-testId="nav-bar-item">
+        <ng-container
+            [ngTemplateOutlet]="item.icon ? icon : iconURL"
+            [ngTemplateOutletContext]="{ item: item }">
+        </ng-container>
+        <span class="item__label" data-testId="nav-bar-item-label">
+            {{ item.label }}
+        </span>
+    </button>
+</ng-template>
 
 <ng-template #icon let-item="item">
     <i [class]="'pi ' + item.icon" data-testId="nav-bar-item-icon"></i>

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.scss
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.scss
@@ -33,6 +33,11 @@
     }
 }
 
+.edit-ema-nav-bar__item--button {
+    background-color: transparent;
+    border: none;
+}
+
 .item__image,
 use {
     user-select: none;

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.spec.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.spec.ts
@@ -69,7 +69,7 @@ describe('EditEmaNavigationBarComponent', () => {
     describe('DOM', () => {
         describe('Nav Bar', () => {
             it('should have 5 items', () => {
-                const links = spectator.queryAll('a');
+                const links = spectator.queryAll(byTestId('nav-bar-item'));
 
                 expect(links.length).toBe(5);
                 expect(links[0].textContent.trim()).toBe('Content');
@@ -83,6 +83,12 @@ describe('EditEmaNavigationBarComponent', () => {
                 expect(links[2].getAttribute('ng-reflect-router-link')).toBe('rules');
                 expect(links[3].getAttribute('ng-reflect-router-link')).toBe('experiments');
                 expect(links[4].getAttribute('ng-reflect-router-link')).toBeNull();
+            });
+
+            it("should be a button if action is defined on last item 'Action'", () => {
+                const actionLink = spectator.query('button[data-testId="nav-bar-item"]');
+
+                expect(actionLink).not.toBeNull();
             });
 
             it("should trigger mockedAction on clicking last item 'Action'", () => {

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.html
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.html
@@ -6,3 +6,29 @@
         [visible]="pageToolsVisible"
         [currentPageUrlParams]="sp.seoProperties"></dot-page-tools-seo>
 </ng-container>
+<p-dialog
+    #dialog
+    *ngIf="dialogState$ | async as ds"
+    [visible]="ds.context === 'shell'"
+    [style]="{ height: '90vh', width: '90vw' }"
+    [header]="ds.header"
+    [draggable]="false"
+    [resizable]="false"
+    [maximizable]="true"
+    [modal]="true"
+    (visibleChange)="resetDialogIframeData()"
+    data-testId="dialog">
+    <iframe
+        #dialogIframe
+        [style]="{ border: 'none', display: ds.iframeLoading ? 'none' : 'block' }"
+        [src]="ds.iframeURL | safeUrl"
+        (load)="onIframeLoad()"
+        title="dialog"
+        data-testId="dialog-iframe"
+        width="100%"
+        height="100%"></iframe>
+    <dot-spinner
+        *ngIf="ds.iframeLoading"
+        [ngStyle]="{ position: 'absolute', top: '50%' }"
+        data-testId="spinner"></dot-spinner>
+</p-dialog>

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.html
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.html
@@ -9,14 +9,14 @@
 <p-dialog
     #dialog
     *ngIf="dialogState$ | async as ds"
-    [visible]="ds.context === 'shell'"
+    [visible]="ds.type === 'shell'"
     [style]="{ height: '90vh', width: '90vw' }"
     [header]="ds.header"
     [draggable]="false"
     [resizable]="false"
     [maximizable]="true"
     [modal]="true"
-    (visibleChange)="resetDialogIframeData()"
+    (visibleChange)="store.resetDialog()"
     data-testId="dialog">
     <iframe
         #dialogIframe

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1,8 +1,9 @@
 import { describe, expect } from '@jest/globals';
-import { SpectatorRouting, createRoutingFactory } from '@ngneat/spectator/jest';
+import { SpectatorRouting, byTestId, createRoutingFactory } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -22,6 +23,7 @@ import { EditEmaStore } from './store/dot-ema.store';
 import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.service';
 import { DotPageApiService } from '../services/dot-page-api.service';
 import { DEFAULT_PERSONA, WINDOW } from '../shared/consts';
+import { NG_CUSTOM_EVENTS } from '../shared/enums';
 
 describe('DotEmaShellComponent', () => {
     let spectator: SpectatorRouting<DotEmaShellComponent>;
@@ -48,7 +50,8 @@ describe('DotEmaShellComponent', () => {
                         return of({
                             page: {
                                 title: 'hello world',
-                                identifier: '123'
+                                identifier: '123',
+                                inode: '123'
                             },
                             viewAs: {
                                 language: {
@@ -145,6 +148,93 @@ describe('DotEmaShellComponent', () => {
             spectator.detectChanges();
 
             expect(navigate).toHaveBeenCalledWith(['/pages']);
+        });
+    });
+
+    describe('dialog', () => {
+        it('should open the dialog when triggering store.initEditAction with shell as context', () => {
+            spectator.detectChanges();
+            store.initActionEdit({
+                inode: '123',
+                title: 'hello world',
+                context: 'shell'
+            });
+            spectator.detectChanges();
+
+            expect(spectator.query(byTestId('dialog-iframe'))).not.toBeNull();
+        });
+
+        it('should trigger a navigate when saving and the url changed', () => {
+            const navigate = jest.spyOn(router, 'navigate');
+
+            spectator.detectChanges();
+            store.initActionEdit({
+                inode: '123',
+                title: 'hello world',
+                context: 'shell'
+            });
+            spectator.detectChanges();
+
+            const dialogIframe = spectator.debugElement.query(
+                By.css('[data-testId="dialog-iframe"]')
+            );
+
+            spectator.triggerEventHandler(dialogIframe, 'load', {}); // There's no way we can load the iframe, because we are setting a real src and will not load
+
+            dialogIframe.nativeElement.contentWindow.document.dispatchEvent(
+                new CustomEvent('ng-event', {
+                    detail: {
+                        name: NG_CUSTOM_EVENTS.SAVE_CONTENTLET,
+                        payload: {
+                            htmlPageReferer: '/my-awesome-page'
+                        }
+                    }
+                })
+            );
+            spectator.detectChanges();
+
+            expect(navigate).toHaveBeenCalledWith([], {
+                queryParams: {
+                    url: 'my-awesome-page'
+                },
+                queryParamsHandling: 'merge'
+            });
+        });
+
+        it('should trigger a store load if the url is the same', () => {
+            const loadMock = jest.spyOn(store, 'load');
+
+            spectator.detectChanges();
+            store.initActionEdit({
+                inode: '123',
+                title: 'hello world',
+                context: 'shell'
+            });
+            spectator.detectChanges();
+
+            const dialogIframe = spectator.debugElement.query(
+                By.css('[data-testId="dialog-iframe"]')
+            );
+
+            spectator.triggerEventHandler(dialogIframe, 'load', {}); // There's no way we can load the iframe, because we are setting a real src and will not load
+
+            dialogIframe.nativeElement.contentWindow.document.dispatchEvent(
+                new CustomEvent('ng-event', {
+                    detail: {
+                        name: NG_CUSTOM_EVENTS.SAVE_CONTENTLET,
+                        payload: {
+                            htmlPageReferer: '/index'
+                        }
+                    }
+                })
+            );
+            spectator.detectChanges();
+
+            expect(loadMock).toHaveBeenCalledWith({
+                language_id: 1,
+                url: 'index',
+                persona_id: DEFAULT_PERSONA.identifier
+            });
         });
     });
 });

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -151,13 +151,13 @@ describe('DotEmaShellComponent', () => {
         });
     });
 
-    describe('dialog', () => {
+    describe('page properties', () => {
         it('should open the dialog when triggering store.initEditAction with shell as context', () => {
             spectator.detectChanges();
             store.initActionEdit({
                 inode: '123',
                 title: 'hello world',
-                context: 'shell'
+                type: 'shell'
             });
             spectator.detectChanges();
 
@@ -171,7 +171,7 @@ describe('DotEmaShellComponent', () => {
             store.initActionEdit({
                 inode: '123',
                 title: 'hello world',
-                context: 'shell'
+                type: 'shell'
             });
             spectator.detectChanges();
 
@@ -208,7 +208,7 @@ describe('DotEmaShellComponent', () => {
             store.initActionEdit({
                 inode: '123',
                 title: 'hello world',
-                context: 'shell'
+                type: 'shell'
             });
             spectator.detectChanges();
 

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -63,8 +63,8 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
     @ViewChild('dialogIframe') dialogIframe!: ElementRef<HTMLIFrameElement>;
     private readonly route = inject(ActivatedRoute);
     private readonly router = inject(Router);
-    private readonly store = inject(EditEmaStore);
     private readonly siteService = inject(SiteService);
+    readonly store = inject(EditEmaStore);
 
     private readonly destroy$ = new Subject<boolean>();
     private queryParams: DotPageApiParams;
@@ -114,7 +114,7 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
                         this.store.initActionEdit({
                             inode: page.inode,
                             title: page.title,
-                            context: 'shell'
+                            type: 'shell'
                         });
                     }
                 }
@@ -148,10 +148,6 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
     ngOnDestroy(): void {
         this.destroy$.next(true);
         this.destroy$.complete();
-    }
-
-    resetDialogIframeData() {
-        this.store.resetDialog();
     }
 
     onIframeLoad() {

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -1,11 +1,12 @@
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, fromEvent } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
-import { Component, OnInit, inject, OnDestroy } from '@angular/core';
+import { Component, OnInit, inject, OnDestroy, ViewChild, ElementRef } from '@angular/core';
 import { ActivatedRoute, Params, Router, RouterModule } from '@angular/router';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { DialogModule } from 'primeng/dialog';
 import { ToastModule } from 'primeng/toast';
 
 import { map, skip, takeUntil } from 'rxjs/operators';
@@ -17,13 +18,14 @@ import {
 } from '@dotcms/data-access';
 import { SiteService } from '@dotcms/dotcms-js';
 import { DotPageToolUrlParams } from '@dotcms/dotcms-models';
+import { SafeUrlPipe } from '@dotcms/ui';
 
 import { EditEmaNavigationBarComponent } from './components/edit-ema-navigation-bar/edit-ema-navigation-bar.component';
 import { EditEmaStore } from './store/dot-ema.store';
 
 import { DotPageToolsSeoComponent } from '../dot-page-tools-seo/dot-page-tools-seo.component';
 import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.service';
-import { DotPageApiService } from '../services/dot-page-api.service';
+import { DotPageApiParams, DotPageApiService } from '../services/dot-page-api.service';
 import { DEFAULT_LANGUAGE_ID, DEFAULT_PERSONA, DEFAULT_URL, WINDOW } from '../shared/consts';
 import { NavigationBarItem } from '../shared/models';
 
@@ -36,7 +38,9 @@ import { NavigationBarItem } from '../shared/models';
         ToastModule,
         EditEmaNavigationBarComponent,
         RouterModule,
-        DotPageToolsSeoComponent
+        DotPageToolsSeoComponent,
+        DialogModule,
+        SafeUrlPipe
     ],
     providers: [
         EditEmaStore,
@@ -56,13 +60,17 @@ import { NavigationBarItem } from '../shared/models';
     styleUrls: ['./dot-ema-shell.component.scss']
 })
 export class DotEmaShellComponent implements OnInit, OnDestroy {
+    @ViewChild('dialogIframe') dialogIframe!: ElementRef<HTMLIFrameElement>;
     private readonly route = inject(ActivatedRoute);
     private readonly router = inject(Router);
     private readonly store = inject(EditEmaStore);
     private readonly siteService = inject(SiteService);
 
     private readonly destroy$ = new Subject<boolean>();
+    private queryParams: DotPageApiParams;
     pageToolsVisible = false;
+
+    dialogState$ = this.store.dialogState$;
 
     // We can internally navigate, so the PageID can change
     // We need to move the logic to a function, we still need to add enterprise logic
@@ -70,7 +78,7 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
         items: NavigationBarItem[];
         seoProperties: DotPageToolUrlParams;
     }> = this.store.shellProperties$.pipe(
-        map(({ currentUrl, pageId, host, languageId, siteId }) => ({
+        map(({ currentUrl, page, host, languageId, siteId }) => ({
             items: [
                 {
                     icon: 'pi-file',
@@ -85,7 +93,7 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
                 {
                     icon: 'pi-sliders-h',
                     label: 'Rules',
-                    href: `rules/${pageId}`
+                    href: `rules/${page.identifier}`
                 },
                 {
                     iconURL: 'experiments',
@@ -102,7 +110,13 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
                 {
                     icon: 'pi-ellipsis-v',
                     label: 'Properties',
-                    href: 'edit-content'
+                    action: () => {
+                        this.store.initActionEdit({
+                            inode: page.inode,
+                            title: page.title,
+                            context: 'shell'
+                        });
+                    }
                 }
             ],
             seoProperties: {
@@ -116,11 +130,13 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((queryParams: Params) => {
-            this.store.load({
+            this.queryParams = {
                 language_id: queryParams['language_id'] ?? DEFAULT_LANGUAGE_ID,
                 url: queryParams['url'] ?? DEFAULT_URL,
                 persona_id: queryParams['com.dotmarketing.persona.id'] ?? DEFAULT_PERSONA.identifier
-            });
+            };
+
+            this.store.load(this.queryParams);
         });
 
         // We need to skip one because it's the initial value
@@ -132,5 +148,35 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
     ngOnDestroy(): void {
         this.destroy$.next(true);
         this.destroy$.complete();
+    }
+
+    resetDialogIframeData() {
+        this.store.resetDialog();
+    }
+
+    onIframeLoad() {
+        this.store.setDialogIframeLoading(false);
+
+        fromEvent(
+            // The events are getting sended to the document
+            this.dialogIframe.nativeElement.contentWindow.document,
+            'ng-event'
+        )
+            .pipe(takeUntil(this.destroy$))
+            .subscribe((event: CustomEvent) => {
+                if (event.detail.name === 'save-page') {
+                    const url = event.detail.payload.htmlPageReferer.split('?')[0].replace('/', '');
+
+                    this.queryParams.url !== url
+                        ? // If the url is different we need to navigate
+                          this.router.navigate([], {
+                              queryParams: {
+                                  url
+                              },
+                              queryParamsHandling: 'merge'
+                          })
+                        : this.store.load(this.queryParams); // If the url is the same we need to fetch the page
+                }
+            });
     }
 }

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/store/dot-ema.store.spec.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/store/dot-ema.store.spec.ts
@@ -85,7 +85,7 @@ describe('EditEmaStore', () => {
                     dialogIframeURL: '',
                     dialogIframeLoading: true,
                     dialogHeader: '',
-                    dialogContext: null,
+
                     dialogType: null
                 });
                 done();
@@ -104,7 +104,7 @@ describe('EditEmaStore', () => {
                     dialogIframeURL: '',
                     dialogIframeLoading: false,
                     dialogHeader: '',
-                    dialogContext: null,
+
                     dialogType: null
                 });
                 done();
@@ -115,7 +115,7 @@ describe('EditEmaStore', () => {
             spectator.service.initActionEdit({
                 inode: '123',
                 title: 'test',
-                context: 'editor'
+                type: 'content'
             });
 
             spectator.service.state$.subscribe((state) => {
@@ -125,7 +125,6 @@ describe('EditEmaStore', () => {
                     dialogIframeURL: EDIT_CONTENTLET_URL + '123',
                     dialogIframeLoading: true,
                     dialogHeader: 'test',
-                    dialogContext: 'editor',
                     dialogType: 'content'
                 });
                 done();
@@ -136,8 +135,7 @@ describe('EditEmaStore', () => {
             spectator.service.initActionAdd({
                 containerId: '1234',
                 acceptTypes: 'test',
-                language_id: '1',
-                context: 'editor'
+                language_id: '1'
             });
 
             spectator.service.state$.subscribe((state) => {
@@ -148,7 +146,6 @@ describe('EditEmaStore', () => {
                         '/html/ng-contentlet-selector.jsp?ng=true&container_id=1234&add=test&language_id=1',
                     dialogIframeLoading: true,
                     dialogHeader: 'Search Content',
-                    dialogContext: 'editor',
                     dialogType: 'content'
                 });
                 done();
@@ -158,8 +155,7 @@ describe('EditEmaStore', () => {
         it('should initialize createAction properties', (done) => {
             spectator.service.initActionCreate({
                 contentType: 'test',
-                url: 'some/really/long/url',
-                context: 'editor'
+                url: 'some/really/long/url'
             });
 
             spectator.service.state$.subscribe((state) => {
@@ -169,7 +165,6 @@ describe('EditEmaStore', () => {
                     dialogIframeURL: 'some/really/long/url',
                     dialogIframeLoading: true,
                     dialogHeader: 'test',
-                    dialogContext: 'editor',
                     dialogType: 'content'
                 });
                 done();
@@ -186,7 +181,6 @@ describe('EditEmaStore', () => {
                 expect(state.dialogHeader).toBe('Create Blog Posts');
                 expect(state.dialogIframeLoading).toBe(true);
                 expect(state.dialogIframeURL).toBe('some/really/long/url');
-                expect(state.dialogContext).toBe('editor');
                 expect(state.dialogType).toBe('content');
                 done();
             });
@@ -230,7 +224,7 @@ describe('EditEmaStore', () => {
                 expect(state.dialogHeader).toBe('Create Blog');
                 expect(state.dialogIframeLoading).toBe(true);
                 expect(state.dialogIframeURL).toBe('https://demo.dotcms.com/jsp.jsp');
-                expect(state.dialogContext).toBe('editor');
+                expect(state.dialogType).toBe('content');
                 done();
             });
 
@@ -251,7 +245,6 @@ describe('EditEmaStore', () => {
                     dialogIframeURL: '',
                     dialogIframeLoading: false,
                     dialogHeader: '',
-                    dialogContext: null,
                     dialogType: null
                 });
                 done();

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/store/dot-ema.store.spec.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/store/dot-ema.store.spec.ts
@@ -19,7 +19,8 @@ import { ActionPayload } from '../../shared/models';
 const mockResponse: DotPageApiResponse = {
     page: {
         title: 'Test Page',
-        identifier: '123'
+        identifier: '123',
+        inode: '123-i'
     },
     viewAs: {
         language: {
@@ -43,6 +44,7 @@ const mockResponse: DotPageApiResponse = {
 describe('EditEmaStore', () => {
     let spectator: SpectatorService<EditEmaStore>;
     let dotPageApiService: SpyObject<DotPageApiService>;
+    const now = Date.now();
     const createService = createServiceFactory({
         service: EditEmaStore,
         mocks: [DotPageApiService, DotActionUrlService]
@@ -50,7 +52,7 @@ describe('EditEmaStore', () => {
 
     beforeEach(() => {
         spectator = createService();
-        mockResponse;
+
         dotPageApiService = spectator.inject(DotPageApiService);
         dotPageApiService.get.andReturn(of(mockResponse));
 
@@ -59,14 +61,15 @@ describe('EditEmaStore', () => {
 
     describe('selectors', () => {
         it('should return editorState', (done) => {
+            jest.useFakeTimers().setSystemTime(now);
             spectator.service.editorState$.subscribe((state) => {
                 expect(state).toEqual({
                     editor: mockResponse,
                     apiURL: 'http://localhost/api/v1/page/json/test-url?language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona',
-                    iframeURL:
-                        'http://localhost:3000/test-url?language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona'
+                    iframeURL: `http://localhost:3000/test-url?language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&t=${now}`
                 });
                 done();
+                jest.useRealTimers();
             });
         });
     });
@@ -82,7 +85,7 @@ describe('EditEmaStore', () => {
                     dialogIframeURL: '',
                     dialogIframeLoading: true,
                     dialogHeader: '',
-                    dialogVisible: false,
+                    dialogContext: null,
                     dialogType: null
                 });
                 done();
@@ -101,7 +104,7 @@ describe('EditEmaStore', () => {
                     dialogIframeURL: '',
                     dialogIframeLoading: false,
                     dialogHeader: '',
-                    dialogVisible: false,
+                    dialogContext: null,
                     dialogType: null
                 });
                 done();
@@ -111,7 +114,8 @@ describe('EditEmaStore', () => {
         it('should initialize editAction properties', (done) => {
             spectator.service.initActionEdit({
                 inode: '123',
-                title: 'test'
+                title: 'test',
+                context: 'editor'
             });
 
             spectator.service.state$.subscribe((state) => {
@@ -121,7 +125,7 @@ describe('EditEmaStore', () => {
                     dialogIframeURL: EDIT_CONTENTLET_URL + '123',
                     dialogIframeLoading: true,
                     dialogHeader: 'test',
-                    dialogVisible: true,
+                    dialogContext: 'editor',
                     dialogType: 'content'
                 });
                 done();
@@ -130,9 +134,10 @@ describe('EditEmaStore', () => {
 
         it('should initialize addAction properties', (done) => {
             spectator.service.initActionAdd({
-                containerId: '123',
+                containerId: '1234',
                 acceptTypes: 'test',
-                language_id: '1'
+                language_id: '1',
+                context: 'editor'
             });
 
             spectator.service.state$.subscribe((state) => {
@@ -140,10 +145,10 @@ describe('EditEmaStore', () => {
                     editor: mockResponse,
                     url: 'test-url',
                     dialogIframeURL:
-                        '/html/ng-contentlet-selector.jsp?ng=true&container_id=123&add=test&language_id=1',
+                        '/html/ng-contentlet-selector.jsp?ng=true&container_id=1234&add=test&language_id=1',
                     dialogIframeLoading: true,
                     dialogHeader: 'Search Content',
-                    dialogVisible: true,
+                    dialogContext: 'editor',
                     dialogType: 'content'
                 });
                 done();
@@ -153,7 +158,8 @@ describe('EditEmaStore', () => {
         it('should initialize createAction properties', (done) => {
             spectator.service.initActionCreate({
                 contentType: 'test',
-                url: 'some/really/long/url'
+                url: 'some/really/long/url',
+                context: 'editor'
             });
 
             spectator.service.state$.subscribe((state) => {
@@ -163,7 +169,7 @@ describe('EditEmaStore', () => {
                     dialogIframeURL: 'some/really/long/url',
                     dialogIframeLoading: true,
                     dialogHeader: 'test',
-                    dialogVisible: true,
+                    dialogContext: 'editor',
                     dialogType: 'content'
                 });
                 done();
@@ -180,7 +186,7 @@ describe('EditEmaStore', () => {
                 expect(state.dialogHeader).toBe('Create Blog Posts');
                 expect(state.dialogIframeLoading).toBe(true);
                 expect(state.dialogIframeURL).toBe('some/really/long/url');
-                expect(state.dialogVisible).toBe(true);
+                expect(state.dialogContext).toBe('editor');
                 expect(state.dialogType).toBe('content');
                 done();
             });
@@ -224,7 +230,7 @@ describe('EditEmaStore', () => {
                 expect(state.dialogHeader).toBe('Create Blog');
                 expect(state.dialogIframeLoading).toBe(true);
                 expect(state.dialogIframeURL).toBe('https://demo.dotcms.com/jsp.jsp');
-                expect(state.dialogVisible).toBe(true);
+                expect(state.dialogContext).toBe('editor');
                 done();
             });
 
@@ -245,7 +251,7 @@ describe('EditEmaStore', () => {
                     dialogIframeURL: '',
                     dialogIframeLoading: false,
                     dialogHeader: '',
-                    dialogVisible: false,
+                    dialogContext: null,
                     dialogType: null
                 });
                 done();

--- a/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/store/dot-ema.store.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/dot-ema-shell/store/dot-ema.store.ts
@@ -22,15 +22,12 @@ import {
 import { ActionPayload, SavePagePayload } from '../../shared/models';
 import { insertContentletInContainer } from '../../utils';
 
-type DialogType = 'content' | 'form' | 'widget' | null;
-
-type DialogContext = 'editor' | 'shell' | null;
+type DialogType = 'content' | 'form' | 'widget' | 'shell' | null;
 
 export interface EditEmaState {
     editor: DotPageApiResponse;
     url: string;
     dialogIframeURL: string;
-    dialogContext: DialogContext;
     dialogHeader: string;
     dialogIframeLoading: boolean;
     dialogType: DialogType;
@@ -88,7 +85,6 @@ export class EditEmaStore extends ComponentStore<EditEmaState> {
 
     readonly dialogState$ = this.select((state) => ({
         iframeURL: state.dialogIframeURL,
-        context: state.dialogContext,
         header: state.dialogHeader,
         iframeLoading: state.dialogIframeLoading,
         type: state.dialogType
@@ -124,7 +120,6 @@ export class EditEmaStore extends ComponentStore<EditEmaState> {
                                 editor,
                                 url,
                                 dialogIframeURL: '',
-                                dialogContext: null,
                                 dialogHeader: '',
                                 dialogIframeLoading: false,
                                 dialogType: null
@@ -227,7 +222,6 @@ export class EditEmaStore extends ComponentStore<EditEmaState> {
             return {
                 ...state,
                 dialogIframeURL: url,
-                dialogContext: 'editor',
                 dialogHeader: `Create ${name}`,
                 dialogIframeLoading: true,
                 dialogType: 'content'
@@ -245,7 +239,6 @@ export class EditEmaStore extends ComponentStore<EditEmaState> {
         return {
             ...state,
             dialogIframeURL: '',
-            dialogContext: null,
             dialogHeader: '',
             dialogIframeLoading: false,
             dialogType: null
@@ -254,14 +247,13 @@ export class EditEmaStore extends ComponentStore<EditEmaState> {
 
     // This method is called when the user clicks on the edit button
     readonly initActionEdit = this.updater(
-        (state, payload: { inode: string; title: string; context: DialogContext }) => {
+        (state, payload: { inode: string; title: string; type: DialogType }) => {
             return {
                 ...state,
-                dialogContext: payload.context,
                 dialogHeader: payload.title,
                 dialogIframeLoading: true,
                 dialogIframeURL: this.createEditContentletUrl(payload.inode),
-                dialogType: 'content'
+                dialogType: payload.type
             };
         }
     );
@@ -274,12 +266,10 @@ export class EditEmaStore extends ComponentStore<EditEmaState> {
                 containerId: string;
                 acceptTypes: string;
                 language_id: string;
-                context: DialogContext;
             }
         ) => {
             return {
                 ...state,
-                dialogContext: payload.context,
                 dialogHeader: 'Search Content', // Does this need translation?
                 dialogIframeLoading: true,
                 dialogIframeURL: this.createAddContentletUrl(payload),
@@ -288,10 +278,9 @@ export class EditEmaStore extends ComponentStore<EditEmaState> {
         }
     );
 
-    readonly initActionAddForm = this.updater((state, payload: { context: DialogContext }) => {
+    readonly initActionAddForm = this.updater((state) => {
         return {
             ...state,
-            dialogContext: payload.context,
             dialogHeader: 'Search Forms', // Does this need translation?
             dialogIframeLoading: true,
             dialogIframeURL: null,
@@ -301,10 +290,9 @@ export class EditEmaStore extends ComponentStore<EditEmaState> {
 
     // This method is called when the user clicks in the + button in the jsp dialog
     readonly initActionCreate = this.updater(
-        (state, payload: { contentType: string; url: string; context: DialogContext }) => {
+        (state, payload: { contentType: string; url: string }) => {
             return {
                 ...state,
-                dialogContext: payload.context,
                 dialogHeader: payload.contentType,
                 dialogIframeLoading: true,
                 dialogIframeURL: payload.url,

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -100,30 +100,30 @@
 <p-dialog
     #dialog
     *ngIf="dialogState$ | async as ds"
-    [visible]="ds.dialogVisible"
+    [visible]="ds.context == 'editor'"
     [style]="{ height: '90vh', width: '90vw' }"
-    [header]="ds.dialogHeader"
+    [header]="ds.header"
     [draggable]="false"
     [resizable]="false"
     [maximizable]="true"
     [modal]="true"
     (visibleChange)="resetDialogIframeData()"
     data-testId="dialog">
-    <ng-container [ngSwitch]="ds.dialogType">
+    <ng-container [ngSwitch]="ds.type">
         <dot-ema-form-selector *ngSwitchCase="'form'" (selected)="addSelectedForm($event)" />
 
         <ng-container *ngSwitchCase="'content'">
             <iframe
                 #dialogIframe
-                [style]="{ border: 'none', display: ds.dialogIframeLoading ? 'none' : 'block' }"
-                [src]="ds.dialogIframeURL | safeUrl"
+                [style]="{ border: 'none', display: ds.iframeLoading ? 'none' : 'block' }"
+                [src]="ds.iframeURL | safeUrl"
                 (load)="onIframeLoad()"
                 title="dialog"
                 data-testId="dialog-iframe"
                 width="100%"
                 height="100%"></iframe>
             <dot-spinner
-                *ngIf="ds.dialogIframeLoading"
+                *ngIf="ds.iframeLoading"
                 [ngStyle]="{ position: 'absolute', top: '50%' }"
                 data-testId="spinner"></dot-spinner>
         </ng-container>

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -100,7 +100,7 @@
 <p-dialog
     #dialog
     *ngIf="dialogState$ | async as ds"
-    [visible]="ds.context == 'editor'"
+    [visible]="!!ds.type && ds.type !== 'shell'"
     [style]="{ height: '90vh', width: '90vw' }"
     [header]="ds.header"
     [draggable]="false"

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -373,7 +373,7 @@ describe('EditEmaEditorComponent', () => {
                     expect(initiEditIframeDialogMock).toHaveBeenCalledWith({
                         inode: 'contentlet-inode-123',
                         title: 'Hello World',
-                        context: 'editor'
+                        type: 'content'
                     });
 
                     const dialogIframe = spectator.debugElement.query(
@@ -459,8 +459,7 @@ describe('EditEmaEditorComponent', () => {
                     expect(initAddIframeDialogMock).toHaveBeenCalledWith({
                         containerId: 'test',
                         acceptTypes: 'test',
-                        language_id: 'test',
-                        context: 'editor'
+                        language_id: 'test'
                     });
 
                     const dialogIframe = spectator.debugElement.query(

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -372,7 +372,8 @@ describe('EditEmaEditorComponent', () => {
                     expect(dialog.getAttribute('ng-reflect-visible')).toBe('true');
                     expect(initiEditIframeDialogMock).toHaveBeenCalledWith({
                         inode: 'contentlet-inode-123',
-                        title: 'Hello World'
+                        title: 'Hello World',
+                        context: 'editor'
                     });
 
                     const dialogIframe = spectator.debugElement.query(
@@ -403,7 +404,7 @@ describe('EditEmaEditorComponent', () => {
             });
 
             describe('add', () => {
-                it('should add contentlet after backend emit SAVE_CONTENTLET', (done) => {
+                it('should add contentlet after backend emit SAVE_CONTENTLET', () => {
                     spectator.detectChanges();
 
                     const initAddIframeDialogMock = jest.spyOn(store, 'initActionAdd');
@@ -429,7 +430,7 @@ describe('EditEmaEditorComponent', () => {
                             title: 'Hello World',
                             identifier: '123'
                         },
-                        pageId: 'test',
+                        pageId: 'test1',
                         language_id: 'test',
                         position: 'before'
                     };
@@ -458,7 +459,8 @@ describe('EditEmaEditorComponent', () => {
                     expect(initAddIframeDialogMock).toHaveBeenCalledWith({
                         containerId: 'test',
                         acceptTypes: 'test',
-                        language_id: 'test'
+                        language_id: 'test',
+                        context: 'editor'
                     });
 
                     const dialogIframe = spectator.debugElement.query(
@@ -498,8 +500,6 @@ describe('EditEmaEditorComponent', () => {
 
                     spectator.detectChanges();
 
-                    const iframe = spectator.debugElement.query(By.css('[data-testId="iframe"]'));
-
                     expect(savePageMock).toHaveBeenCalledWith({
                         pageContainers: [
                             {
@@ -509,17 +509,11 @@ describe('EditEmaEditorComponent', () => {
                                 personaTag: undefined
                             }
                         ],
-                        pageId: 'test',
+                        pageId: 'test1',
                         whenSaved: expect.any(Function)
                     });
 
-                    iframe.nativeElement.contentWindow.addEventListener(
-                        'message',
-                        (event: MessageEvent) => {
-                            expect(event).toBeTruthy();
-                            done();
-                        }
-                    );
+                    spectator.detectChanges();
                 });
 
                 it('should add contentlet after backend emit CONTENT_SEARCH_SELECT', () => {

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -286,7 +286,8 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
         this.store.initActionAdd({
             containerId: payload.container.identifier,
             acceptTypes: payload.container.acceptTypes ?? '*',
-            language_id: payload.language_id
+            language_id: payload.language_id,
+            context: 'editor'
         });
         this.savePayload = payload;
     }
@@ -298,7 +299,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
      * @memberof EditEmaEditorComponent
      */
     addForm(payload: ActionPayload): void {
-        this.store.initActionAddForm(payload);
+        this.store.initActionAddForm({ context: 'editor' });
         this.savePayload = payload;
     }
 
@@ -370,7 +371,8 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
     editContentlet(payload: ActionPayload) {
         this.store.initActionEdit({
             inode: payload.contentlet.inode,
-            title: payload.contentlet.title
+            title: payload.contentlet.title,
+            context: 'editor'
         });
     }
 
@@ -429,7 +431,8 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
             [NG_CUSTOM_EVENTS.CREATE_CONTENTLET]: () => {
                 this.store.initActionCreate({
                     contentType: detail.data.contentType,
-                    url: detail.data.url
+                    url: detail.data.url,
+                    context: 'editor'
                 });
                 this.cd.detectChanges();
             }

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -286,8 +286,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
         this.store.initActionAdd({
             containerId: payload.container.identifier,
             acceptTypes: payload.container.acceptTypes ?? '*',
-            language_id: payload.language_id,
-            context: 'editor'
+            language_id: payload.language_id
         });
         this.savePayload = payload;
     }
@@ -299,7 +298,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
      * @memberof EditEmaEditorComponent
      */
     addForm(payload: ActionPayload): void {
-        this.store.initActionAddForm({ context: 'editor' });
+        this.store.initActionAddForm();
         this.savePayload = payload;
     }
 
@@ -372,7 +371,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
         this.store.initActionEdit({
             inode: payload.contentlet.inode,
             title: payload.contentlet.title,
-            context: 'editor'
+            type: 'content'
         });
     }
 
@@ -431,8 +430,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
             [NG_CUSTOM_EVENTS.CREATE_CONTENTLET]: () => {
                 this.store.initActionCreate({
                     contentType: detail.data.contentType,
-                    url: detail.data.url,
-                    context: 'editor'
+                    url: detail.data.url
                 });
                 this.cd.detectChanges();
             }

--- a/core-web/libs/portlets/dot-ema/src/lib/services/dot-page-api.service.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/services/dot-page-api.service.ts
@@ -20,6 +20,7 @@ export interface DotPageApiResponse {
     page: {
         title: string;
         identifier: string;
+        inode: string;
     };
     site: Site;
     viewAs: {

--- a/ema/nextjs/src/components/dotcms-page.js
+++ b/ema/nextjs/src/components/dotcms-page.js
@@ -28,7 +28,7 @@ export const DotcmsPage = () => {
             {
                 action: 'set-url',
                 payload: {
-                    url: url === '/' ? 'index' : url.pop() //TODO: We need to enhance this, this will break for: nested/pages/like/this
+                    url: url === '/' ? 'index' : pathname.replace('/', '')
                 }
             },
             '*'


### PR DESCRIPTION
### Proposed Changes
* Add a dialog to the shell and use the same logic as in editor.
* Adapt the store to handle the opening and closing of dialogs by context (editor or shell at the moment)
* Add test cases
* Send a timestamp in the iframeURL to trigger a reload when the queryParams do not update. This happens when we edit the page properties. We need to force a reload but we didn't changed any queryParam, so we send a timestamp as a flag to reload.

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Screenshots


https://github.com/dotCMS/core/assets/63567962/e359ca47-ae5b-499a-8bc7-9c1004fac5e2

