### PR TITLE
[Issue-25739]  Fix typo for starter description

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -3821,7 +3821,7 @@ Start-with-a-blank-Host=Start with a blank Site
 starter.show.getting.started=Show Getting Started
 com.dotcms.repackage.javax.portlet.title.starter=Welcome
 starter.title=Welcome!
-starter.description==You are logged in as <em>{0}</em>. To help you get started building with dotCMS we provided some quick links.
+starter.description=You are logged in as <em>{0}</em>. To help you get started building with dotCMS we provided some quick links.
 starter.dont.show=Don't show this again
 starter.main.link.data.model.title=Create data model
 starter.main.link.data.model.description=Define your contents’ structure and relationships using multiple types of fields.


### PR DESCRIPTION
### Proposed Changes

Fix typo in the starter description

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
![image](https://github.com/dotCMS/core/assets/3438705/32b7ce84-9dfb-467f-b310-65cea0ba24fc)
