### PR TITLE
Changing default pubsub provider

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/dotpubsub/DotPubSubProviderLocator.java
+++ b/dotCMS/src/main/java/com/dotcms/dotpubsub/DotPubSubProviderLocator.java
@@ -10,7 +10,7 @@ public class DotPubSubProviderLocator {
     public final static String DOT_PUBSUB_PROVIDER_OVERRIDE = "DOT_PUBSUB_PROVIDER_OVERRIDE";
     public final static String DOT_PUBSUB_USE_QUEUE = "DOT_PUBSUB_USE_QUEUE";
     /**
-     * Default provider is postgres, can be overriden by setting config: DOT_PUBSUB_PROVIDER_OVERRIDE
+     * Default provider is JDBCPubSubImpl, can be overriden by setting config: DOT_PUBSUB_PROVIDER_OVERRIDE
      * DOT_PUBSUB_USE_QUEUE is a boolean, and will wrap the Pubsub in a queue
      */
     public static Lazy<DotPubSubProvider> provider = Lazy.of(() -> {
@@ -20,9 +20,9 @@ public class DotPubSubProviderLocator {
                         : Config.getBooleanProperty(DOT_PUBSUB_USE_QUEUE, true);
 
         final String pubsubClazz = System.getProperty(DOT_PUBSUB_PROVIDER_OVERRIDE) != null
-                        ? System.getProperty(DOT_PUBSUB_PROVIDER_OVERRIDE)
-                        : Config.getStringProperty(DOT_PUBSUB_PROVIDER_OVERRIDE,
-                                        PostgresPubSubImpl.class.getCanonicalName());
+                ? System.getProperty(DOT_PUBSUB_PROVIDER_OVERRIDE)
+                : Config.getStringProperty(DOT_PUBSUB_PROVIDER_OVERRIDE,
+                JDBCPubSubImpl.class.getCanonicalName());
 
         DotPubSubProvider provider = (DotPubSubProvider) Try.of(() -> Class.forName(pubsubClazz).newInstance())
                         .getOrElseThrow(e -> new DotRuntimeException(e));

--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -370,8 +370,8 @@ PULLPERSONALIZED_PERSONA_WEIGHT=100
 
 ##################### dotCMS PUB/SUB #####################
 ## If you want to use a custom DOT_PUBSUB_PROVIDER, you can set the the DOT_PUBSUB_PROVIDER_OVERRIDE
-## to the class you would like to use.  By default we use the com.dotcms.dotpubsub.PostgresPubSubImpl
-#DOT_PUBSUB_PROVIDER_OVERRIDE=com.dotcms.dotpubsub.PostgresPubSubImpl
+## to the class you would like to use.  By default we use the com.dotcms.dotpubsub.JDBCPubSubImpl
+#DOT_PUBSUB_PROVIDER_OVERRIDE=com.dotcms.dotpubsub.JDBCPubSubImpl
 
 ## Setting this to true will send all PUB/SUB messages async, through an async queuing mechanism
 ## Setting this to false will send all PUB/SUB messages sync through the pub/sub system of your choice


### PR DESCRIPTION
Changing the `DOT_PUBSUB_PROVIDER_OVERRIDE` default value `com.dotcms.dotpubsub. PostgresPubSubImpl`  to `com.dotcms.dotpubsub.JDBCPubSubImpl`