### PR TITLE
feat(edit-ema): #27115 Remove personalization

### DIFF
--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/components/edit-ema-persona-selector/edit-ema-persona-selector.component.html
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/components/edit-ema-persona-selector/edit-ema-persona-selector.component.html
@@ -21,7 +21,7 @@
 <p-overlayPanel #op styleClass="edit-ema-selector" data-testId="persona-op">
     <p-listbox
         #listbox
-        [options]="personas$ | async"
+        [options]="personas"
         (onChange)="onSelect($event); op.toggle($event)"
         optionLabel="label"
         data-testId="persona-listbox"
@@ -36,7 +36,19 @@
                         dotAvatar></p-avatar>
                     <span>{{ persona.name }}</span>
                 </div>
-                <i class="pi pi-tag" *ngIf="persona.personalized"></i>
+                <p-chip
+                    *ngIf="persona.personalized"
+                    styleClass="p-chip-sm"
+                    data-testId="persona-chip">
+                    <i
+                        class="pi pi-times-circle p-chip-icon"
+                        (click)="
+                            onRemove($event, persona, value.identifier === persona.identifier);
+                            op.toggle($event)
+                        "
+                        data-testId="persona-chip-remove"></i>
+                    <span class="p-chip-text">{{ 'modes.persona.personalized' | dm }}</span>
+                </p-chip>
             </div>
         </ng-template>
     </p-listbox>

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/components/edit-ema-persona-selector/edit-ema-persona-selector.component.spec.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/components/edit-ema-persona-selector/edit-ema-persona-selector.component.spec.ts
@@ -1,4 +1,5 @@
-import { Spectator, byTestId, createComponentFactory } from '@ngneat/spectator';
+import { expect, describe, it } from '@jest/globals';
+import { Spectator, byTestId, createComponentFactory } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -120,12 +121,12 @@ describe('EditEmaPersonaSelectorComponent', () => {
             expect(component.listbox.value).toEqual(DEFAULT_PERSONA);
         });
 
-        it('should add the check icon to the personalized persona', () => {
+        it('should add the chip to the personalized persona', () => {
             spectator.click(button);
-            expect(spectator.queryAll('.pi').length).toBe(1);
-            expect(spectator.query('.pi').outerHTML).toBe(
-                `<i class="pi pi-tag ng-star-inserted"></i>`
-            );
+
+            const chip = spectator.query(byTestId('persona-chip'));
+
+            expect(chip).not.toBeNull();
         });
     });
 
@@ -155,6 +156,41 @@ describe('EditEmaPersonaSelectorComponent', () => {
                 }
             });
             expect(selectedSpy).not.toHaveBeenCalled();
+        });
+
+        it("should call onRemove when remove icon it's clicked", () => {
+            spectator.click(button);
+
+            const onRemoveSpy = jest.spyOn(component, 'onRemove');
+
+            const removeIcon = spectator.query(byTestId('persona-chip-remove'));
+            spectator.click(removeIcon);
+
+            expect(onRemoveSpy).toHaveBeenCalledWith(
+                expect.anything(), // This is a mouse event, not relevant for this test
+                {
+                    ...CUSTOM_PERSONA
+                },
+                false
+            );
+        });
+
+        it("should pass selected as true when remove icon it's clicked on a selected value", () => {
+            component.value = CUSTOM_PERSONA;
+            spectator.click(button);
+
+            const onRemoveSpy = jest.spyOn(component, 'onRemove');
+
+            const removeIcon = spectator.query(byTestId('persona-chip-remove'));
+            spectator.click(removeIcon);
+
+            expect(onRemoveSpy).toHaveBeenCalledWith(
+                expect.anything(), // This is a mouse event, not relevant for this test
+                {
+                    ...CUSTOM_PERSONA
+                },
+                true
+            );
         });
     });
 });

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/components/edit-ema-persona-selector/edit-ema-persona-selector.component.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/components/edit-ema-persona-selector/edit-ema-persona-selector.component.ts
@@ -1,9 +1,8 @@
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import {
     AfterViewInit,
-    ChangeDetectionStrategy,
     Component,
     EventEmitter,
     Input,
@@ -16,6 +15,7 @@ import { FormsModule } from '@angular/forms';
 
 import { AvatarModule } from 'primeng/avatar';
 import { ButtonModule } from 'primeng/button';
+import { ChipModule } from 'primeng/chip';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { Listbox, ListboxModule } from 'primeng/listbox';
 import { OverlayPanelModule } from 'primeng/overlaypanel';
@@ -39,33 +39,27 @@ import { DotPageApiService } from '../../../services/dot-page-api.service';
         DotMessagePipe,
         ListboxModule,
         ConfirmDialogModule,
-        FormsModule
+        FormsModule,
+        ChipModule
     ],
     templateUrl: './edit-ema-persona-selector.component.html',
-    styleUrls: ['./edit-ema-persona-selector.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush
+    styleUrls: ['./edit-ema-persona-selector.component.scss']
 })
 export class EditEmaPersonaSelectorComponent implements OnInit, AfterViewInit {
     @ViewChild('listbox') listbox: Listbox;
 
     private readonly pageApiService = inject(DotPageApiService);
-    personas$: Observable<DotPersona[]>;
+    personas: DotPersona[];
 
     @Input() pageId: string;
     @Input() value: DotPersona;
 
     @Output() selected: EventEmitter<DotPersona & { pageId: string }> = new EventEmitter();
+    @Output() despersonalize: EventEmitter<DotPersona & { pageId: string; selected: boolean }> =
+        new EventEmitter();
 
     ngOnInit(): void {
-        this.personas$ = this.pageApiService
-            .getPersonas({
-                pageId: this.pageId,
-                perPage: 5000
-            })
-            .pipe(
-                map((res) => res.data),
-                catchError(() => of([]))
-            );
+        this.fetchPersonas();
     }
 
     ngAfterViewInit(): void {
@@ -95,5 +89,40 @@ export class EditEmaPersonaSelectorComponent implements OnInit, AfterViewInit {
     resetValue(): void {
         this.listbox.value = this.value;
         this.listbox.cd.detectChanges();
+    }
+
+    /**
+     * Handle the remove of the persona
+     *
+     * @param {MouseEvent} event
+     * @param {DotPersona} persona
+     * @memberof EditEmaPersonaSelectorComponent
+     */
+    onRemove(event: MouseEvent, persona: DotPersona, selected: boolean) {
+        event.stopPropagation();
+
+        this.despersonalize.emit({
+            ...persona,
+            selected,
+            pageId: this.pageId
+        });
+    }
+
+    /**
+     * Fetch personas from the API
+     *
+     * @memberof EditEmaPersonaSelectorComponent
+     */
+    fetchPersonas() {
+        this.pageApiService
+            .getPersonas({
+                pageId: this.pageId,
+                perPage: 5000
+            })
+            .pipe(
+                map((res) => res.data),
+                catchError(() => of([]))
+            )
+            .subscribe((personas) => (this.personas = personas));
     }
 }

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -31,7 +31,7 @@
                 [pageId]="es.editor.page.identifier"
                 [value]="es.editor.viewAs.persona"
                 (selected)="onPersonaSelected($event)"
-                (despersonalize)="onDespersonalizePersona($event)"
+                (despersonalize)="onDespersonalize($event)"
                 data-testId="persona-selector" />
             <p-button class="p-button-sm" label="Save" />
         </ng-container>

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -31,6 +31,7 @@
                 [pageId]="es.editor.page.identifier"
                 [value]="es.editor.viewAs.persona"
                 (selected)="onPersonaSelected($event)"
+                (despersonalize)="onDespersonalizePersona($event)"
                 data-testId="persona-selector" />
             <p-button class="p-button-sm" label="Save" />
         </ng-container>

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -18,6 +18,7 @@ import {
 
 import { EditEmaLanguageSelectorComponent } from './components/edit-ema-language-selector/edit-ema-language-selector.component';
 import { EditEmaPersonaSelectorComponent } from './components/edit-ema-persona-selector/edit-ema-persona-selector.component';
+import { CUSTOM_PERSONA } from './components/edit-ema-persona-selector/edit-ema-persona-selector.component.spec';
 import { EmaContentletToolsComponent } from './components/ema-contentlet-tools/ema-contentlet-tools.component';
 import { EmaPageDropzoneComponent } from './components/ema-page-dropzone/ema-page-dropzone.component';
 import { BOUNDS_MOCK } from './components/ema-page-dropzone/ema-page-dropzone.component.spec';
@@ -253,6 +254,158 @@ describe('EditEmaEditorComponent', () => {
                 spectator.detectChanges();
 
                 expect(confirmDialogOpen).toHaveBeenCalled();
+            });
+
+            it('should fetchPersonas and navigate when confirming the personalization', () => {
+                const confirmDialogOpen = jest.spyOn(confirmationService, 'confirm');
+                spectator.detectChanges();
+
+                spectator.triggerEventHandler(EditEmaPersonaSelectorComponent, 'selected', {
+                    ...DEFAULT_PERSONA,
+                    identifier: '123',
+                    pageId: '123',
+                    personalized: false
+                });
+                spectator.detectChanges();
+
+                expect(confirmDialogOpen).toHaveBeenCalled();
+
+                const confirmDialog = spectator.query(byTestId('confirm-dialog'));
+                const personaSelector = spectator.debugElement.query(
+                    By.css('[data-testId="persona-selector"]')
+                ).componentInstance;
+                const routerSpy = jest.spyOn(spectator.inject(Router), 'navigate');
+                const fetchPersonasSpy = jest.spyOn(personaSelector, 'fetchPersonas');
+
+                spectator.detectChanges();
+
+                expect(confirmDialogOpen).toHaveBeenCalled();
+
+                confirmDialog
+                    .querySelector('.p-confirm-dialog-accept')
+                    .dispatchEvent(new Event('click')); // This is the internal button, coudln't find a better way to test it
+
+                spectator.detectChanges();
+
+                expect(routerSpy).toBeCalledWith([], {
+                    queryParams: { 'com.dotmarketing.persona.id': '123' },
+                    queryParamsHandling: 'merge'
+                });
+                expect(fetchPersonasSpy).toHaveBeenCalled();
+            });
+
+            it('should reset the value on personalization rejection', () => {
+                const confirmDialogOpen = jest.spyOn(confirmationService, 'confirm');
+                spectator.detectChanges();
+
+                spectator.triggerEventHandler(EditEmaPersonaSelectorComponent, 'selected', {
+                    ...DEFAULT_PERSONA,
+                    identifier: '123',
+                    pageId: '123',
+                    personalized: false
+                });
+                spectator.detectChanges();
+
+                expect(confirmDialogOpen).toHaveBeenCalled();
+
+                const confirmDialog = spectator.query(byTestId('confirm-dialog'));
+                const personaSelector = spectator.debugElement.query(
+                    By.css('[data-testId="persona-selector"]')
+                ).componentInstance;
+
+                const resetValueSpy = jest.spyOn(personaSelector, 'resetValue');
+
+                spectator.detectChanges();
+
+                expect(confirmDialogOpen).toHaveBeenCalled();
+
+                confirmDialog
+                    .querySelector('.p-confirm-dialog-reject')
+                    .dispatchEvent(new Event('click')); // This is the internal button, coudln't find a better way to test it
+
+                spectator.detectChanges();
+
+                expect(resetValueSpy).toHaveBeenCalled();
+            });
+
+            it('should open a confirmation dialog when despersonalize is triggered', () => {
+                const confirmDialogOpen = jest.spyOn(confirmationService, 'confirm');
+                spectator.detectChanges();
+
+                spectator.triggerEventHandler(EditEmaPersonaSelectorComponent, 'despersonalize', {
+                    ...DEFAULT_PERSONA,
+                    pageId: '123',
+                    selected: false
+                });
+                spectator.detectChanges();
+
+                expect(confirmDialogOpen).toHaveBeenCalled();
+            });
+
+            it('should fetchPersonas when confirming the despersonalization', () => {
+                const confirmDialogOpen = jest.spyOn(confirmationService, 'confirm');
+                spectator.detectChanges();
+
+                spectator.triggerEventHandler(EditEmaPersonaSelectorComponent, 'despersonalize', {
+                    ...DEFAULT_PERSONA,
+                    pageId: '123',
+                    selected: false
+                });
+                spectator.detectChanges();
+
+                expect(confirmDialogOpen).toHaveBeenCalled();
+
+                const confirmDialog = spectator.query(byTestId('confirm-dialog'));
+                const personaSelector = spectator.debugElement.query(
+                    By.css('[data-testId="persona-selector"]')
+                ).componentInstance;
+
+                const fetchPersonasSpy = jest.spyOn(personaSelector, 'fetchPersonas');
+
+                spectator.detectChanges();
+
+                expect(confirmDialogOpen).toHaveBeenCalled();
+
+                confirmDialog
+                    .querySelector('.p-confirm-dialog-accept')
+                    .dispatchEvent(new Event('click')); // This is the internal button, coudln't find a better way to test it
+
+                spectator.detectChanges();
+
+                expect(fetchPersonasSpy).toHaveBeenCalled();
+            });
+
+            it('should navigate with default persona as current persona when the selected is the same as the despersonalized', () => {
+                const confirmDialogOpen = jest.spyOn(confirmationService, 'confirm');
+                spectator.detectChanges();
+
+                spectator.triggerEventHandler(EditEmaPersonaSelectorComponent, 'despersonalize', {
+                    ...CUSTOM_PERSONA,
+                    pageId: '123',
+                    selected: true
+                });
+                spectator.detectChanges();
+
+                expect(confirmDialogOpen).toHaveBeenCalled();
+
+                const confirmDialog = spectator.query(byTestId('confirm-dialog'));
+
+                const routerSpy = jest.spyOn(spectator.inject(Router), 'navigate');
+
+                spectator.detectChanges();
+
+                expect(confirmDialogOpen).toHaveBeenCalled();
+
+                confirmDialog
+                    .querySelector('.p-confirm-dialog-accept')
+                    .dispatchEvent(new Event('click')); // This is the internal button, coudln't find a better way to test it
+
+                spectator.detectChanges();
+
+                expect(routerSpy).toHaveBeenCalledWith([], {
+                    queryParams: { 'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier },
+                    queryParamsHandling: 'merge'
+                });
             });
         });
 

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -210,7 +210,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
      * @param {(DotPersona & { pageId: string })} persona
      * @memberof EditEmaEditorComponent
      */
-    onDespersonalizePersona(persona: DotPersona & { pageId: string; selected: boolean }) {
+    onDespersonalize(persona: DotPersona & { pageId: string; selected: boolean }) {
         this.confirmationService.confirm({
             header: this.dotMessageService.get('editpage.personalization.delete.confirm.header'),
             message: this.dotMessageService.get(

--- a/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/dot-ema/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -193,6 +193,8 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
                             this.updateQueryParams({
                                 'com.dotmarketing.persona.id': persona.identifier
                             });
+
+                            this.personaSelector.fetchPersonas();
                         }); // This does a take 1 under the hood
                 },
                 reject: () => {
@@ -200,6 +202,37 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
                 }
             });
         }
+    }
+
+    /**
+     * Handle the persona despersonalization
+     *
+     * @param {(DotPersona & { pageId: string })} persona
+     * @memberof EditEmaEditorComponent
+     */
+    onDespersonalizePersona(persona: DotPersona & { pageId: string; selected: boolean }) {
+        this.confirmationService.confirm({
+            header: this.dotMessageService.get('editpage.personalization.delete.confirm.header'),
+            message: this.dotMessageService.get(
+                'editpage.personalization.delete.confirm.message',
+                persona.name
+            ),
+            acceptLabel: this.dotMessageService.get('dot.common.dialog.accept'),
+            rejectLabel: this.dotMessageService.get('dot.common.dialog.reject'),
+            accept: () => {
+                this.personalizeService
+                    .despersonalized(persona.pageId, persona.keyTag)
+                    .subscribe(() => {
+                        this.personaSelector.fetchPersonas();
+
+                        if (persona.selected) {
+                            this.updateQueryParams({
+                                'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier
+                            });
+                        }
+                    }); // This does a take 1 under the hood
+            }
+        });
     }
 
     triggerCopyToast() {


### PR DESCRIPTION
### Proposed Changes
* Add chip component with custom content to add a better handling on removing the personalization
* Emit an event that indicates the persona to despersonalize, the pageID and whether or not is the current selected persona
* Handle the logic inside a confirmation dialog
* Be sure that we fetch the personas everytime we made changes on the state of the personas

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots


https://github.com/dotCMS/core/assets/63567962/14f413e8-d627-4680-b886-3b1f0914f174

