### PR TITLE
The list of comments is in the correct order

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
@@ -4026,9 +4026,7 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 				CollectionsUtils.join(this.findWorkFlowComments(task),
 						this.findWorkflowHistory (task));
 
-	    return workflowTimelineItems.stream()
-                .sorted(Comparator.comparing(WorkflowTimelineItem::createdDate))
-                .collect(CollectionsUtils.toImmutableList());
+	    return workflowTimelineItems.stream().collect(CollectionsUtils.toImmutableList());
 	}
 
 


### PR DESCRIPTION
The method `getCommentsAndChangeHistory` was unnecessarily sorting the results by date. This sort order was removed.

<img width="1375" alt="image" src="https://github.com/dotCMS/core/assets/127987858/6e561b76-97f7-4c8b-9ed8-88205abfeee4">
