### PR TITLE
feat(edit-ema): Expose the languages that a page is available on via REST #27185

### DIFF
--- a/dotCMS/src/curl-test/PagesResourceTests.json
+++ b/dotCMS/src/curl-test/PagesResourceTests.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "2872cba9-bd34-40e1-9640-b66652bec389",
+		"_postman_id": "13b4e6cd-724d-4b5e-b4cc-9a2b2483b51b",
 		"name": "Page API - [api/v1/page]",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "4500400"
+		"_exporter_id": "5403727"
 	},
 	"item": [
 		{
@@ -5416,6 +5416,165 @@
 			]
 		},
 		{
+			"name": "Check Languages for a Page",
+			"item": [
+				{
+					"name": "Create Test Page in English",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"HTTP Status code must be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Test Page created successfully\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.errors.length).to.eql(0);",
+									"    pm.collectionVariables.set(\"pageIdentifier\", jsonData.entity.identifier);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"const time = new Date().getTime();",
+									"pm.collectionVariables.set(\"testPageTitle\", \"My Test Page \" + time);",
+									"pm.collectionVariables.set(\"testPageUrl\", \"my-test-page-\" + time);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"contentlet\": {\n        \"contentType\": \"htmlpageasset\",\n        \"title\": \"{{testPageTitle}}\",\n        \"url\": \"{{testPageUrl}}\",\n        \"hostFolder\": \"default\",\n        \"template\": \"SYSTEM_TEMPLATE\",\n        \"friendlyName\": \"{{testPageTitle}}\",\n        \"cachettl\": 0\n    }\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"workflow",
+								"actions",
+								"default",
+								"fire",
+								"PUBLISH"
+							],
+							"query": [
+								{
+									"key": "indexPolicy",
+									"value": "WAIT_FOR"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Check page translation only in English",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"HTTP Status code must be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Check that the test HTML Page is available in English, no matter how many languages there are\", function () {",
+									"    const entity = pm.response.json().entity;",
+									"    var isTranslated = false;",
+									"    entity.forEach(function(lang) {",
+									"        if (1 == lang.id && lang.translated) {",
+									"            isTranslated = true;",
+									"        }",
+									"    });",
+									"    pm.expect(isTranslated).to.be.equal(true, 'The test page must be available in English');",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/page/{{pageIdentifier}}/languages",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"page",
+								"{{pageIdentifier}}",
+								"languages"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "These requests are aimed to test the REST Endpoint that takes a Page ID, returns all Languages in the current instance and, for each of them, includes an additional attribute that indicates whether such a page is available in that specific language or not."
+		},
+		{
 			"name": "Put Create Page With CacheTTL 100",
 			"event": [
 				{
@@ -5586,128 +5745,6 @@
 					""
 				]
 			}
-		}
-	],
-	"variable": [
-		{
-			"key": "serverURL",
-			"value": "http://localhost:8080"
-		},
-		{
-			"key": "siteIdTestHost",
-			"value": ""
-		},
-		{
-			"key": "sitevariableIdTestHost",
-			"value": ""
-		},
-		{
-			"key": "containeridentifier",
-			"value": ""
-		},
-		{
-			"key": "inode",
-			"value": ""
-		},
-		{
-			"key": "templateIdToPublishedHost",
-			"value": ""
-		},
-		{
-			"key": "contentletIdentifier",
-			"value": ""
-		},
-		{
-			"key": "contentletInode",
-			"value": ""
-		},
-		{
-			"key": "fireActionLanguageKey",
-			"value": ""
-		},
-		{
-			"key": "pageUrlHostVariablestest",
-			"value": ""
-		},
-		{
-			"key": "pageIdentifier",
-			"value": ""
-		},
-		{
-			"key": "richContentIdentifier",
-			"value": ""
-		},
-		{
-			"key": "containerId",
-			"value": ""
-		},
-		{
-			"key": "contentId",
-			"value": ""
-		},
-		{
-			"key": "pageId",
-			"value": ""
-		},
-		{
-			"key": "personalization",
-			"value": ""
-		},
-		{
-			"key": "relationType",
-			"value": ""
-		},
-		{
-			"key": "treeOrder",
-			"value": ""
-		},
-		{
-			"key": "variantId",
-			"value": ""
-		},
-		{
-			"key": "copiedRichContentIdentifier",
-			"value": ""
-		},
-		{
-			"key": "pageDeepCopyIdentifier",
-			"value": ""
-		},
-		{
-			"key": "firstPageUrl",
-			"value": ""
-		},
-		{
-			"key": "firstPageIdentifier",
-			"value": ""
-		},
-		{
-			"key": "secondPageUrl",
-			"value": ""
-		},
-		{
-			"key": "secondPageIdentifier",
-			"value": ""
-		},
-		{
-			"key": "defaultSiteId",
-			"value": ""
-		},
-		{
-			"key": "path",
-			"value": ""
-		},
-		{
-			"key": "pageid",
-			"value": ""
-		},
-		{
-			"key": "pagepath",
-			"value": ""
-		},
-		{
-			"key": "host_id",
-			"value": ""
 		}
 	]
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/ExistingLanguagesForPageView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/ExistingLanguagesForPageView.java
@@ -1,0 +1,25 @@
+package com.dotcms.rest.api.v1.page;
+
+import com.dotmarketing.portlets.languagesmanager.model.Language;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This View is used to indicate what language an HTML Page is available on, and what language it is not. This is
+ * particularly useful for the UI to be able to know when a page is NOT available in a specific language, and then
+ * provide the user the option to create it.
+ *
+ * @author Jose Castro
+ * @since Jan 5th, 2023
+ */
+public class ExistingLanguagesForPageView extends HashMap<String, Object> implements Serializable {
+
+    public ExistingLanguagesForPageView(final Language language, final boolean translated) {
+        final Map<String, Object> dataMap = new HashMap<>(language.toMap());
+        this.putAll(dataMap);
+        this.put("translated", translated);
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -1152,6 +1152,8 @@ public class PageResource {
      *
      * @return A {@link Response} object containing the list of languages and the flag indicating
      * whether the page is available in such a language or not.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
      */
     @GET
     @Path("/{pageId}/languages")
@@ -1160,21 +1162,15 @@ public class PageResource {
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     public Response checkPageLanguageVersions(@Context final HttpServletRequest request,
                                               @Context final HttpServletResponse response,
-                                              @PathParam("pageId") final String pageId) {
+                                              @PathParam("pageId") final String pageId) throws DotDataException {
         final User user = new WebResource.InitBuilder(webResource).requestAndResponse(request, response)
                 .rejectWhenNoUser(true)
                 .requiredBackendUser(true)
                 .init().getUser();
-        Logger.debug(this, String.format("Check the languages that page '%s' is available on", pageId));
-        try {
-            final List<ExistingLanguagesForPageView> languagesForPage =
-                    this.pageResourceHelper.getExistingLanguagesForPage(pageId, user);
-            return Response.ok(new ResponseEntityView<>(languagesForPage)).build();
-        } catch (final Exception e) {
-            Logger.error(this, String.format("Failed to check available language versions for HTML Page " +
-                    "'%s': %s", pageId, ExceptionUtil.getErrorMessage(e)), e);
-            return ResponseUtil.mapExceptionResponse(e);
-        }
+        Logger.debug(this, () -> String.format("Check the languages that page '%s' is available on", pageId));
+        final List<ExistingLanguagesForPageView> languagesForPage =
+                this.pageResourceHelper.getExistingLanguagesForPage(pageId, user);
+        return Response.ok(new ResponseEntityView<>(languagesForPage)).build();
     }
 
 } // E:O:F:PageResource

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -10,6 +10,7 @@ import com.dotcms.ema.EMAConfigurations;
 import com.dotcms.ema.EMAWebInterceptor;
 import com.dotcms.ema.resolver.EMAConfigStrategy;
 import com.dotcms.ema.resolver.EMAConfigStrategyResolver;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.rest.InitDataObject;
 import com.dotcms.rest.ResponseEntityBooleanView;
 import com.dotcms.rest.ResponseEntityView;
@@ -111,9 +112,6 @@ import java.util.stream.Collectors;
 @Tag(name = "Page")
 public class PageResource {
 
-    private static final String LISTING       = "listing";
-    private static final String EDITING       = "editing";
-
     private final PageResourceHelper pageResourceHelper;
     private final WebResource webResource;
     private final HTMLPageAssetRenderedAPI htmlPageAssetRenderedAPI;
@@ -122,6 +120,7 @@ public class PageResource {
     /**
      * Creates an instance of this REST end-point.
      */
+    @SuppressWarnings("unused")
     public PageResource() {
         this(
                 PageResourceHelper.getInstance(),
@@ -1137,4 +1136,45 @@ public class PageResource {
 
         throw new DoesNotExistException("The page: " + findAvailableActionsForm.getPath() + " do not exist");
     } // findAvailableActions.
+
+    /**
+     * Receives the Identifier of an HTML Page, returns all the available languages in dotCMS and,
+     * for each of them, adds a flag indicating whether the page is available in that language or
+     * not. This may be particularly useful when requiring the system to provide a specific action
+     * when a page is NOT available in a given language. Here's an example of how you can use it:
+     * <pre>
+     *     GET <a href="http://localhost:8080/api/v1/page/${PAGE_ID}/languages">http://localhost:8080/api/v1/page/${PAGE_ID}/languages</a>
+     * </pre>
+     *
+     * @param request  The current instance of the {@link HttpServletRequest}.
+     * @param response The current instance of the {@link HttpServletResponse}.
+     * @param pageId   The Identifier of the HTML Page whose available languages will be checked.
+     *
+     * @return A {@link Response} object containing the list of languages and the flag indicating
+     * whether the page is available in such a language or not.
+     */
+    @GET
+    @Path("/{pageId}/languages")
+    @JSONP
+    @NoCache
+    @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
+    public Response checkPageLanguageVersions(@Context final HttpServletRequest request,
+                                              @Context final HttpServletResponse response,
+                                              @PathParam("pageId") final String pageId) {
+        final User user = new WebResource.InitBuilder(webResource).requestAndResponse(request, response)
+                .rejectWhenNoUser(true)
+                .requiredBackendUser(true)
+                .init().getUser();
+        Logger.debug(this, String.format("Check the languages that page '%s' is available on", pageId));
+        try {
+            final List<ExistingLanguagesForPageView> languagesForPage =
+                    this.pageResourceHelper.getExistingLanguagesForPage(pageId, user);
+            return Response.ok(new ResponseEntityView<>(languagesForPage)).build();
+        } catch (final Exception e) {
+            Logger.error(this, String.format("Failed to check available language versions for HTML Page " +
+                    "'%s': %s", pageId, ExceptionUtil.getErrorMessage(e)), e);
+            return ResponseUtil.mapExceptionResponse(e);
+        }
+    }
+
 } // E:O:F:PageResource

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -8,10 +8,10 @@ import com.dotcms.mock.request.LanguageIdParameterDecorator;
 import com.dotcms.mock.request.ParameterDecorator;
 import com.dotcms.rendering.velocity.directive.ParseContainer;
 import com.dotcms.rendering.velocity.services.ContentletLoader;
-import com.dotcms.rendering.velocity.services.PageLoader;
 import com.dotcms.rest.api.v1.page.PageContainerForm.ContainerEntry;
 import com.dotcms.rest.exception.BadRequestException;
 import com.dotcms.util.CollectionsUtils;
+import com.dotcms.util.DotPreconditions;
 import com.dotcms.variant.VariantAPI;
 import com.dotcms.variant.business.web.VariantWebAPI.RenderContext;
 import com.dotmarketing.beans.Host;
@@ -42,6 +42,7 @@ import com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI;
 import com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetNotFoundException;
 import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
+import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.personas.model.Persona;
 import com.dotmarketing.portlets.templates.business.TemplateAPI;
@@ -50,6 +51,7 @@ import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Table;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
@@ -58,7 +60,6 @@ import com.liferay.util.StringPool;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.control.Try;
-import java.util.Date;
 import org.apache.velocity.exception.ResourceNotFoundException;
 import org.jetbrains.annotations.NotNull;
 
@@ -66,11 +67,13 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Provides the utility methods that interact with HTML Pages in dotCMS. These methods are used by
@@ -93,6 +96,7 @@ public class PageResourceHelper implements Serializable {
     private final MultiTreeAPI multiTreeAPI = APILocator.getMultiTreeAPI();
     private final UserAPI userAPI = APILocator.getUserAPI();
     private final PermissionAPI permissionAPI = APILocator.getPermissionAPI();
+    private final LanguageAPI languageAPI = APILocator.getLanguageAPI();
 
     /**
      * Private constructor
@@ -572,6 +576,33 @@ public class PageResourceHelper implements Serializable {
         Logger.debug(this, ()-> "Contentlet: " + copiedContentlet.getIdentifier() + " has been copied");
 
         return Tuple.of(copiedContentlet, currentContentlet);
+    }
+
+    /**
+     * Returns a list of ALL languages in dotCMS and, for each of them, adds a boolean indicating
+     * whether the specified HTML Page Identifier is available in such a language or not. This is
+     * particularly useful for the UI layer to be able to easily check what languages a page is
+     * available on, and what languages it is not.
+     *
+     * @param pageId The Identifier of the HTML Page whose languages are being checked.
+     * @param user   The {@link User} performing this action.
+     *
+     * @return The list of languages and the flag indicating whether the page is available in such a
+     * language or not.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
+     */
+    public List<ExistingLanguagesForPageView> getExistingLanguagesForPage(final String pageId, final User user) throws DotDataException {
+        DotPreconditions.checkNotNull(pageId, "Page ID cannot be null");
+        DotPreconditions.checkNotNull(user, "User cannot be null");
+        final ImmutableList.Builder<ExistingLanguagesForPageView> languagesForPage = new ImmutableList.Builder<>();
+        final Set<Long> existingPageLanguages = APILocator.getVersionableAPI().findContentletVersionInfos(pageId).stream()
+                .map(ContentletVersionInfo::getLang)
+                .collect(Collectors.toSet());
+        final List<Language> allLanguages = this.languageAPI.getLanguages();
+        allLanguages.forEach(language -> languagesForPage.add(new ExistingLanguagesForPageView(language,
+                existingPageLanguages.contains(language.getId()))));
+        return languagesForPage.build();
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -96,7 +96,7 @@ public class PageResourceHelper implements Serializable {
     private final MultiTreeAPI multiTreeAPI = APILocator.getMultiTreeAPI();
     private final UserAPI userAPI = APILocator.getUserAPI();
     private final PermissionAPI permissionAPI = APILocator.getPermissionAPI();
-    private final LanguageAPI languageAPI = APILocator.getLanguageAPI();
+    private final transient LanguageAPI languageAPI = APILocator.getLanguageAPI();
 
     /**
      * Private constructor

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/languagesmanager/model/Language.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/languagesmanager/model/Language.java
@@ -1,41 +1,38 @@
 package com.dotmarketing.portlets.languagesmanager.model;
 
-import static com.dotcms.util.CollectionsUtils.map;
-
 import com.dotcms.publisher.util.PusheableAsset;
 import com.dotcms.publishing.manifest.ManifestItem;
-import com.dotcms.publishing.manifest.ManifestItem.ManifestInfo;
-import java.io.Serializable;
-import java.util.Locale;
-
+import com.dotmarketing.exception.DotRuntimeException;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
-import com.dotmarketing.exception.DotRuntimeException;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.Map;
 
 /**
+ * This class represents a language in the system.
+ * <p>Languages must be created and configured in dotCMS before contributors may create and edit content in different
+ * languages on your site. Each dotCMS instance has a single Default Language, which both controls which language
+ * version of content is returned when a request is made without a specified language, and which affects how other
+ * language features operate, such as the Default Language Fallthrough Configuration.</p>
  *
  * @author  maria
+ * @since Mar 22nd, 2012
  */
 public class Language implements Serializable, ManifestItem {
     private static final long serialVersionUID = 1L;
 
-    /** identifier field */
     private long id;
 
-    /** identifier field */
     private String languageCode;
 
-    /** identifier field */
     private String countryCode;
 
-    /** identifier field */
     private String language;
 
-    /** nullable persistent field */
     private String country;
 
     private String isoCode;
@@ -98,8 +95,6 @@ public class Language implements Serializable, ManifestItem {
         return new Locale(this.languageCode, this.countryCode);
       }
     }
-    
-    
     
     /**
      * @param country The country to set.
@@ -201,6 +196,19 @@ public class Language implements Serializable, ManifestItem {
                 .build();
     }
 
-
+    /**
+     * Returns a map representation of the properties of this Language.
+     *
+     * @return a map representation of this object.
+     */
+    public Map<String, Object> toMap() {
+        return Map.of(
+                "id", this.id,
+                "languageCode", this.languageCode,
+                "countryCode", this.countryCode,
+                "language", this.language,
+                "country", this.country,
+                "isoCode", this.isoCode);
+    }
 
 }


### PR DESCRIPTION
### Proposed Changes
* Exposes a new method that allows Users to get the list of available languages in dotCMS and, based on the provided page Identifier, adds a flag attribute for each language that indicates whether the page has a version in such a language or not.