### PR TITLE
dotCMS/core#26505 Make AI Image Block Production-ready

### DIFF
--- a/core-web/libs/block-editor/src/lib/extensions/ai-content-actions/plugins/ai-content-actions.plugin.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/ai-content-actions/plugins/ai-content-actions.plugin.ts
@@ -156,7 +156,15 @@ export class AIContentActionsView {
             case DOT_AI_IMAGE_CONTENT_KEY:
                 // eslint-disable-next-line no-case-declarations
                 const placeholder = getAIPlaceholderImage(this.editor);
+
                 delete placeholder.node.attrs.data[AI_IMAGE_PLACEHOLDER_PROPERTY];
+
+                this.view.dispatch(
+                    this.view.state.tr.setNodeMarkup(placeholder.from, undefined, {
+                        data: placeholder.node.attrs.data
+                    })
+                );
+
                 break;
         }
     }


### PR DESCRIPTION
### Proposed Changes
* After delete the `isAIPlaceholder` flag, fire a editor transaction to capture the change. 
