### PR TITLE
feat(edit-ema): Allow js sdk client to pass options to fetch

### DIFF
--- a/core-web/libs/sdk/client/README.md
+++ b/core-web/libs/sdk/client/README.md
@@ -6,9 +6,9 @@ This client library provides a streamlined, promise-based interface to fetch pag
 
 ## Features
 
-- Easy-to-use methods to interact with the [DotCMS Page](https://www.dotcms.com/docs/latest/page-rest-api-layout-as-a-service-laas) and [Navigation APIs](https://www.dotcms.com/docs/latest/navigation-rest-api).
-- Support for custom actions to communicate with the DotCMS page editor.
-- Comprehensive TypeScript typings for better development experience.
+-   Easy-to-use methods to interact with the [DotCMS Page](https://www.dotcms.com/docs/latest/page-rest-api-layout-as-a-service-laas) and [Navigation APIs](https://www.dotcms.com/docs/latest/navigation-rest-api).
+-   Support for custom actions to communicate with the DotCMS page editor.
+-   Comprehensive TypeScript typings for better development experience.
 
 ## Installation
 
@@ -82,11 +82,9 @@ Retrieves the specified page's elements from your DotCMS system in JSON format.
 
 Retrieves information about the DotCMS file and folder tree.
 
-
 ## Contributing
 
 GitHub pull requests are the preferred method to contribute code to dotCMS. Before any pull requests can be accepted, an automated tool will ask you to agree to the [dotCMS Contributor's Agreement](https://gist.github.com/wezell/85ef45298c48494b90d92755b583acb3).
-
 
 ## Licensing
 

--- a/core-web/libs/sdk/client/README.md
+++ b/core-web/libs/sdk/client/README.md
@@ -43,7 +43,7 @@ const client = dotcmsClient.init({
 Retrieve the elements of any page in your DotCMS system in JSON format.
 
 ```javascript
-const pageData = await client.getPage({
+const pageData = await client.page.get({
     path: '/your-page-path',
     language_id: 1,
     personaId: 'optional-persona-id'
@@ -57,7 +57,7 @@ console.log(pageData);
 Retrieve information about the DotCMS file and folder tree.
 
 ```javascript
-const navData = await client.getNav({
+const navData = await client.nav.get({
     path: '/',
     depth: 2,
     languageId: 1
@@ -74,11 +74,11 @@ Detailed documentation of the `@dotcms/client` methods, parameters, and types ca
 
 Initializes the DotCMS client with the specified configuration.
 
-### `DotCmsClient.getPage(options: PageApiOptions): Promise<unknown>`
+### `DotCmsClient.page.get(options: PageApiOptions): Promise<unknown>`
 
 Retrieves the specified page's elements from your DotCMS system in JSON format.
 
-### `DotCmsClient.getNav(options: NavApiOptions): Promise<unknown>`
+### `DotCmsClient.nav.get(options: NavApiOptions): Promise<unknown>`
 
 Retrieves information about the DotCMS file and folder tree.
 

--- a/core-web/libs/sdk/client/src/lib/sdk-js-client.spec.ts
+++ b/core-web/libs/sdk/client/src/lib/sdk-js-client.spec.ts
@@ -77,12 +77,12 @@ describe('DotCmsClient', () => {
             });
         });
 
-        describe('getPage', () => {
+        describe('page.get', () => {
             it('should fetch page data successfully', async () => {
                 const mockResponse = { content: 'Page data' };
                 mockFetchResponse(mockResponse);
 
-                const data = await client.getPage({ path: '/home' });
+                const data = await client.page.get({ path: '/home' });
 
                 expect(fetch).toHaveBeenCalledTimes(1);
                 expect(fetch).toHaveBeenCalledWith(
@@ -95,7 +95,7 @@ describe('DotCmsClient', () => {
             });
 
             it('should throw an error if the path is not provided', async () => {
-                await expect(client.getPage({} as any)).rejects.toThrowError(
+                await expect(client.page.get({} as any)).rejects.toThrowError(
                     `The 'path' parameter is required for the Page API`
                 );
             });
@@ -104,7 +104,7 @@ describe('DotCmsClient', () => {
                 const mockResponse = { content: 'Page data' };
                 mockFetchResponse(mockResponse);
 
-                client.getPage({ path: '/home', personaId: 'doe123' });
+                client.page.get({ path: '/home', personaId: 'doe123' });
 
                 expect(fetch).toHaveBeenCalledWith(
                     'http://localhost/api/v1/page/json/home?com.dotmarketing.persona.id=doe123&host_id=123456',
@@ -118,7 +118,7 @@ describe('DotCmsClient', () => {
                 const mockResponse = { content: 'Page data' };
                 mockFetchResponse(mockResponse);
 
-                client.getPage({ path: '/home', siteId: 'host-123' });
+                client.page.get({ path: '/home', siteId: 'host-123' });
 
                 expect(fetch).toHaveBeenCalledWith(
                     'http://localhost/api/v1/page/json/home?host_id=host-123',
@@ -132,7 +132,7 @@ describe('DotCmsClient', () => {
                 const mockResponse = { content: 'Page data' };
                 mockFetchResponse(mockResponse);
 
-                client.getPage({ path: '/home', language_id: 99 });
+                client.page.get({ path: '/home', language_id: 99 });
 
                 expect(fetch).toHaveBeenCalledWith(
                     'http://localhost/api/v1/page/json/home?language_id=99&host_id=123456',
@@ -143,12 +143,12 @@ describe('DotCmsClient', () => {
             });
         });
 
-        describe('getNav', () => {
+        describe('nav.get', () => {
             it('should fetch navigation data successfully', async () => {
                 const mockResponse = { nav: 'Navigation data' };
                 mockFetchResponse(mockResponse);
 
-                const data = await client.getNav({ path: '/', depth: 1 });
+                const data = await client.nav.get({ path: '/', depth: 1 });
 
                 expect(fetch).toHaveBeenCalledTimes(1);
                 expect(fetch).toHaveBeenCalledWith('http://localhost/api/v1/nav/?depth=1', {
@@ -161,7 +161,7 @@ describe('DotCmsClient', () => {
                 const mockResponse = { nav: 'Root nav data' };
                 mockFetchResponse(mockResponse);
 
-                const data = await client.getNav({ path: '/' });
+                const data = await client.nav.get({ path: '/' });
 
                 expect(fetch).toHaveBeenCalledWith('http://localhost/api/v1/nav/', {
                     headers: { Authorization: 'Bearer ABC' }
@@ -170,7 +170,7 @@ describe('DotCmsClient', () => {
             });
 
             it('should throw an error if the path is not provided', async () => {
-                await expect(client.getNav({} as any)).rejects.toThrowError(
+                await expect(client.nav.get({} as any)).rejects.toThrowError(
                     `The 'path' parameter is required for the Nav API`
                 );
             });
@@ -193,11 +193,65 @@ describe('DotCmsClient', () => {
             const mockResponse = { content: 'Page data' };
             mockFetchResponse(mockResponse);
 
-            client.getPage({ path: '/home' });
+            client.page.get({ path: '/home' });
 
             expect(fetch).toHaveBeenCalledWith('http://localhost/api/v1/page/json/home', {
                 headers: { Authorization: 'Bearer ABC' }
             });
+        });
+    });
+
+    describe('with requestOptions', () => {
+        let client: DotCmsClient;
+
+        beforeEach(() => {
+            (fetch as jest.Mock).mockClear();
+
+            client = dotcmsClient.init({
+                dotcmsUrl: 'http://localhost',
+                siteId: '123456',
+                authToken: 'ABC',
+                requestOptions: {
+                    headers: {
+                        'X-My-Header': 'my-value'
+                    },
+                    cache: 'no-cache'
+                }
+            });
+        });
+
+        it('should fetch page data with extra headers and cache', async () => {
+            const mockResponse = { content: 'Page data' };
+            mockFetchResponse(mockResponse);
+
+            const data = await client.page.get({ path: '/home' });
+
+            expect(fetch).toHaveBeenCalledTimes(1);
+            expect(fetch).toHaveBeenCalledWith(
+                'http://localhost/api/v1/page/json/home?host_id=123456',
+                {
+                    headers: { Authorization: 'Bearer ABC', 'X-My-Header': 'my-value' },
+                    cache: 'no-cache'
+                }
+            );
+            expect(data).toEqual(mockResponse);
+        });
+
+        it('should fetch bav data with extra headers and cache', async () => {
+            const mockResponse = { content: 'Page data' };
+            mockFetchResponse(mockResponse);
+
+            const data = await client.nav.get();
+
+            expect(fetch).toHaveBeenCalledTimes(1);
+            expect(fetch).toHaveBeenCalledWith(
+                'http://localhost/api/v1/nav/?depth=0&languageId=1',
+                {
+                    headers: { Authorization: 'Bearer ABC', 'X-My-Header': 'my-value' },
+                    cache: 'no-cache'
+                }
+            );
+            expect(data).toEqual(mockResponse);
         });
     });
 });

--- a/ema/nextjs/src/app/[[...slug]]/page.js
+++ b/ema/nextjs/src/app/[[...slug]]/page.js
@@ -3,13 +3,17 @@ import { dotcmsClient } from '@dotcms/client';
 const client = dotcmsClient.init({
     dotcmsUrl: process.env.NEXT_PUBLIC_DOTCMS_HOST,
     authToken: process.env.DOTCMS_AUTH_TOKEN,
-    siteId: '59bb8831-6706-4589-9ca0-ff74016e02b2'
+    siteId: '59bb8831-6706-4589-9ca0-ff74016e02b2',
+    requestOptions: {
+        // In production you might want to deal with this differently
+        cache: 'no-cache'
+    }
 });
 
 import { MyPage } from '@/components/my-page';
 
 export async function generateMetadata({ params, searchParams }) {
-    const data = await client.getPage({
+    const data = await client.page.get({
         path: params?.slug ? params.slug.join('/') : 'index',
         language_id: searchParams.language_id,
         'com.dotmarketing.persona.id': searchParams['com.dotmarketing.persona.id'] || ''
@@ -21,13 +25,13 @@ export async function generateMetadata({ params, searchParams }) {
 }
 
 export default async function Home({ searchParams, params }) {
-    const data = await client.getPage({
+    const data = await client.page.get({
         path: params?.slug ? params.slug.join('/') : 'index',
         language_id: searchParams.language_id,
         personaId: searchParams['com.dotmarketing.persona.id'] || ''
     });
 
-    const nav = await client.getNav({
+    const nav = await client.nav.get({
         path: '/',
         depth: 2,
         languageId: searchParams.language_id


### PR DESCRIPTION
### Proposed Changes
* Add request options to client
* Change the api to `page.get` and `nav.get`
* Update nextjs to the new client

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
