### PR TITLE
chore(edit-ema): Support widgets in warning drag and drop #26644

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/components/edit-ema-palette-content-type/edit-ema-palette-content-type.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/components/edit-ema-palette-content-type/edit-ema-palette-content-type.component.html
@@ -26,7 +26,8 @@
                 {
                     variable: contenttype.variable,
                     name: contenttype.name,
-                    contentType: contenttype.variable
+                    contentType: contenttype.variable,
+                    baseType: contenttype.baseType
                 } | json
             "
             [attr.data-testId]="'content-type-' + i"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/components/edit-ema-palette-content-type/edit-ema-palette-content-type.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/components/edit-ema-palette-content-type/edit-ema-palette-content-type.component.spec.ts
@@ -12,12 +12,14 @@ export const CONTENT_TYPE_MOCK = [
     {
         name: 'Test Content Type',
         variable: 'Test1',
-        icon: 'icon'
+        icon: 'icon',
+        baseType: 'CONTENT'
     },
     {
         name: 'Test Content Type 2',
         variable: 'Test2',
-        icon: 'icon'
+        icon: 'icon',
+        baseType: 'CONTENT'
     }
 ];
 
@@ -54,12 +56,14 @@ describe('EditEmaPaletteContentTypeComponent', () => {
         spectator.triggerEventHandler('[data-testId="content-type-0"]', 'dragstart', {
             variable: 'test',
             name: 'Test',
-            contentType: 'test'
+            contentType: 'test',
+            baseType: 'CONTENT'
         });
         expect(dragSpy).toHaveBeenCalledWith({
             variable: 'test',
             name: 'Test',
-            contentType: 'test'
+            contentType: 'test',
+            baseType: 'CONTENT'
         });
     });
 
@@ -69,12 +73,14 @@ describe('EditEmaPaletteContentTypeComponent', () => {
         spectator.triggerEventHandler('[data-testId="content-type-0"]', 'dragend', {
             variable: 'test',
             name: 'Test',
-            contentType: 'test'
+            contentType: 'test',
+            baseType: 'CONTENT'
         });
         expect(dragSpy).toHaveBeenCalledWith({
             variable: 'test',
             name: 'Test',
-            contentType: 'test'
+            contentType: 'test',
+            baseType: 'CONTENT'
         });
     });
 
@@ -94,7 +100,8 @@ describe('EditEmaPaletteContentTypeComponent', () => {
         expect(data).toEqual({
             variable: 'Test1',
             name: 'Test Content Type',
-            contentType: 'Test1'
+            contentType: 'Test1',
+            baseType: 'CONTENT'
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/components/edit-ema-palette-contentlets/edit-ema-palette-contentlets.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/components/edit-ema-palette-contentlets/edit-ema-palette-contentlets.component.html
@@ -31,8 +31,11 @@
                     class="contentlet-card"
                     *ngFor="let contentlet of contentlets.items; let i = index"
                     [attr.data-item]="
-                        { identifier: contentlet.identifier, contentType: contentlet?.contentType }
-                            | json
+                        {
+                            identifier: contentlet.identifier,
+                            contentType: contentlet?.contentType,
+                            baseType: contentlet.baseType
+                        } | json
                     "
                     [attr.data-testId]="'contentlet-' + i"
                     (dragstart)="dragStart.emit($event)"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/components/edit-ema-palette-contentlets/edit-ema-palette-contentlets.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/components/edit-ema-palette-contentlets/edit-ema-palette-contentlets.component.spec.ts
@@ -87,7 +87,8 @@ describe('EditEmaPaletteContentletsComponent', () => {
         expect(spectator.query('[data-testId="contentlet-0"]')).toHaveAttribute('data-item');
         expect(data).toEqual({
             identifier: CONTENTLETS_MOCK[0].identifier,
-            contentType: CONTENTLETS_MOCK[0].contentType
+            contentType: CONTENTLETS_MOCK[0].contentType,
+            baseType: CONTENTLETS_MOCK[0].baseType
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-page-dropzone/ema-page-dropzone.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-page-dropzone/ema-page-dropzone.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 
 import { DotMessageService } from '@dotcms/data-access';
+import { DotCMSBaseTypesContentTypes } from '@dotcms/dotcms-models';
 
 import { ActionPayload, ContainerPayload } from '../../../shared/models';
 
@@ -38,6 +39,11 @@ interface Column {
     containers: Container[];
 }
 
+export interface EmaDragItem {
+    baseType: string;
+    contentType: string;
+}
+
 export interface Row {
     x: number;
     y: number;
@@ -56,7 +62,7 @@ export interface Row {
 })
 export class EmaPageDropzoneComponent {
     @Input() rows: Row[] = [];
-    @Input() contentType: string;
+    @Input() item: EmaDragItem;
     @Output() place = new EventEmitter<ActionPayload>();
 
     private readonly dotMessageService: DotMessageService = inject(DotMessageService);
@@ -160,7 +166,7 @@ export class EmaPageDropzoneComponent {
         if (!this.isValidContentType(acceptTypes)) {
             return this.dotMessageService.get(
                 'edit.ema.page.dropzone.invalid.contentlet.type',
-                this.contentType
+                this.item.contentType
             );
         }
 
@@ -185,9 +191,13 @@ export class EmaPageDropzoneComponent {
     }
 
     private isValidContentType(acceptTypes: string) {
+        if (this.item.baseType === DotCMSBaseTypesContentTypes.WIDGET) {
+            return true;
+        }
+
         const acceptTypesArr = acceptTypes.split(',');
 
-        return acceptTypesArr.includes(this.contentType);
+        return acceptTypesArr.includes(this.item.contentType);
     }
 
     private contentCanFitInContainer({ contentletsId, maxContentlets }: ContainerPayload): boolean {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -93,9 +93,9 @@
                 (addContent)="addContentlet($event)"
                 data-testId="contentlet-tools" />
             <dot-ema-page-dropzone
-                *ngIf="!!rows.length && !!dragItemType && !currentDevice"
+                *ngIf="!!rows.length && !!dragItem.contentType && !currentDevice"
                 [rows]="rows"
-                [contentType]="dragItemType"
+                [item]="dragItem"
                 (place)="onPlaceItem($event)"
                 data-testId="dropzone" />
         </div>

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -93,7 +93,7 @@
                 (addContent)="addContentlet($event)"
                 data-testId="contentlet-tools" />
             <dot-ema-page-dropzone
-                *ngIf="!!rows.length && !!dragItem.contentType && !currentDevice"
+                *ngIf="!!rows.length && !!dragItem && !currentDevice"
                 [rows]="rows"
                 [item]="dragItem"
                 (place)="onPlaceItem($event)"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -68,7 +68,8 @@ const dragEventMock = {
             item: JSON.stringify({
                 identifier: '123',
                 title: 'hello world',
-                contentType: 'File'
+                contentType: 'File',
+                baseType: 'CONTENT'
             })
         }
     }
@@ -1314,7 +1315,10 @@ describe('EditEmaEditorComponent', () => {
                 dropZone = spectator.query(EmaPageDropzoneComponent);
 
                 expect(dropZone.rows).toBe(BOUNDS_MOCK);
-                expect(dropZone.contentType).toBe('File');
+                expect(dropZone.item).toEqual({
+                    contentType: 'File',
+                    baseType: 'CONTENT'
+                });
             });
 
             it('should hide drop zone on palette drop', () => {
@@ -1336,8 +1340,11 @@ describe('EditEmaEditorComponent', () => {
 
                 let dropZone = spectator.query(EmaPageDropzoneComponent);
 
+                expect(dropZone.item).toEqual({
+                    contentType: 'File',
+                    baseType: 'CONTENT'
+                });
                 expect(dropZone.rows).toBe(BOUNDS_MOCK);
-                expect(dropZone.contentType).toBe('File');
 
                 spectator.triggerEventHandler(EditEmaPaletteComponent, 'dragEnd', {});
                 spectator.detectComponentChanges();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -37,6 +37,7 @@ import { EmaContentletToolsComponent } from './components/ema-contentlet-tools/e
 import { EmaFormSelectorComponent } from './components/ema-form-selector/ema-form-selector.component';
 import {
     ContentletArea,
+    EmaDragItem,
     EmaPageDropzoneComponent,
     Row
 } from './components/ema-page-dropzone/ema-page-dropzone.component';
@@ -122,7 +123,10 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
 
     rows: Row[] = [];
     contentlet!: ContentletArea;
-    dragItemType: string;
+    dragItem: EmaDragItem = {
+        baseType: '',
+        contentType: ''
+    };
 
     // This should be in the store, but experienced an issue that triggers a reload in the whole store when the device is updated
     currentDevice: DotDevice & { icon?: string };
@@ -291,7 +295,10 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
         };
 
         const item = JSON.parse(dataset.item);
-        this.dragItemType = item?.contentType;
+        this.dragItem = {
+            baseType: item.baseType,
+            contentType: item.contentType
+        };
 
         this.draggedPayload = {
             type: dataset.type,
@@ -312,6 +319,10 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
      */
     onDragEnd(_event: DragEvent) {
         this.rows = [];
+        this.dragItem = {
+            baseType: '',
+            contentType: ''
+        };
     }
 
     /**

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -123,10 +123,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
 
     rows: Row[] = [];
     contentlet!: ContentletArea;
-    dragItem: EmaDragItem = {
-        baseType: '',
-        contentType: ''
-    };
+    dragItem: EmaDragItem;
 
     // This should be in the store, but experienced an issue that triggers a reload in the whole store when the device is updated
     currentDevice: DotDevice & { icon?: string };


### PR DESCRIPTION
- Enable users to drag and drop widgets into any container.

https://github.com/dotCMS/core/assets/72418962/8a5eb511-e49c-4a12-b897-1f0cd227b59a

