### PR TITLE
fix(edit-ema): 🐛 Custom Event select-contentlet is triggering twice on ng-contentlet-selector #26958

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -20,7 +20,7 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { ProgressBarModule } from 'primeng/progressbar';
 
-import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 
 import { CUSTOMER_ACTIONS } from '@dotcms/client';
 import { DotPersonalizeService, DotMessageService } from '@dotcms/data-access';
@@ -162,13 +162,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
             this.dialogIframe.nativeElement.contentWindow.document,
             'ng-event'
         )
-            .pipe(
-                takeUntil(this.destroy$),
-                distinctUntilChanged(
-                    (prev: CustomEvent, current: CustomEvent) =>
-                        prev.detail.name === current.detail.name
-                )
-            )
+            .pipe(takeUntil(this.destroy$))
             .subscribe((event: CustomEvent) => {
                 this.handleNgEvent(event)?.();
             });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -20,7 +20,7 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { ProgressBarModule } from 'primeng/progressbar';
 
-import { takeUntil } from 'rxjs/operators';
+import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 import { CUSTOMER_ACTIONS } from '@dotcms/client';
 import { DotPersonalizeService, DotMessageService } from '@dotcms/data-access';
@@ -162,7 +162,13 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
             this.dialogIframe.nativeElement.contentWindow.document,
             'ng-event'
         )
-            .pipe(takeUntil(this.destroy$))
+            .pipe(
+                takeUntil(this.destroy$),
+                distinctUntilChanged(
+                    (prev: CustomEvent, current: CustomEvent) =>
+                        prev.detail.name === current.detail.name
+                )
+            )
             .subscribe((event: CustomEvent) => {
                 this.handleNgEvent(event)?.();
             });

--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
@@ -1295,12 +1295,10 @@ dojo.declare(
                         this.searchCounter + asset.inode
                     );
                     if (selectButton.onclick == undefined) {
-                        selectButton.onclick = dojo.hitch(
-                            this,
-                            selected,
-                            this,
-                            asset
-                        );
+                        selectButton.onclick = dojo.hitch(this, function (event) {
+                            event.stopPropagation();
+                            selected(this, asset);
+                        });
                     }
                 }
             }


### PR DESCRIPTION
### Proposed Changes
* Now only trigger one time when user clicks on select button

Updated video:

https://github.com/dotCMS/core/assets/144152756/fe8a6311-322e-4dec-b8e8-18c2b9e4e683



Note: In the video i show console.logs, but is only for show the problem, console.logs are not in PR

This internal change doesnt break the old edit mode

https://github.com/dotCMS/core/assets/144152756/6b3d9160-fc03-4b2f-a545-1b51a41e3ad4

