### PR TITLE
chore(edit-ema): Change app config API on guards #27372

### DIFF
--- a/core-web/libs/data-access/src/lib/ema-app-configuration/ema-app-configuration.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/ema-app-configuration/ema-app-configuration.service.spec.ts
@@ -1,50 +1,22 @@
 import { createHttpFactory, SpectatorService } from '@ngneat/spectator';
-import { of } from 'rxjs';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { SiteService } from '@dotcms/dotcms-js';
-
 import { EmaAppConfigurationService } from './ema-app-configuration.service';
-
-import { DotLicenseService } from '../dot-license/dot-license.service';
 
 describe('EmaAppConfigurationService', () => {
     let spectator: SpectatorService<EmaAppConfigurationService>;
-    let licenseService: DotLicenseService;
-    let siteService: SiteService;
     let httpTestingController: HttpTestingController;
 
     const createService = createHttpFactory({
         service: EmaAppConfigurationService,
         imports: [HttpClientTestingModule, RouterTestingModule],
-        providers: [
-            {
-                provide: DotLicenseService,
-                useValue: {
-                    isEnterprise() {
-                        return of(true);
-                    }
-                }
-            },
-            {
-                provide: SiteService,
-                useValue: {
-                    getCurrentSite() {
-                        return of({
-                            identifier: '123'
-                        });
-                    }
-                }
-            }
-        ]
+        providers: []
     });
 
     beforeEach(() => {
         spectator = createService();
-        licenseService = spectator.inject(DotLicenseService);
-        siteService = spectator.inject(SiteService);
         httpTestingController = spectator.inject(HttpTestingController);
 
         jest.resetAllMocks(); // Reset all mocks before each test
@@ -52,44 +24,13 @@ describe('EmaAppConfigurationService', () => {
 
     describe('get', () => {
         describe('should return null', () => {
-            it('if license isEnterprise is `false`', (done) => {
-                jest.spyOn(licenseService, 'isEnterprise').mockReturnValue(of(false));
-
-                spectator.service.get('test').subscribe((res) => {
-                    expect(res).toBeNull();
-
-                    done();
-                });
-            });
-
-            it('if siteService getCurrentSite throws error', (done) => {
-                jest.spyOn(licenseService, 'isEnterprise').mockReturnValue(of(true));
-                jest.spyOn(siteService, 'getCurrentSite').mockImplementation(() => {
-                    throw new Error('getCurrentSite error');
-                });
-
-                spectator.service.get('test').subscribe((res) => {
-                    expect(res).toBeNull();
-                    done();
-                });
-            });
-
             it('if get app config return bad request', (done) => {
-                jest.spyOn(licenseService, 'isEnterprise').mockReturnValue(of(true));
-                jest.spyOn(siteService, 'getCurrentSite').mockReturnValue(
-                    of({
-                        identifier: '123'
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    }) as any
-                );
-
                 spectator.service.get('test').subscribe((res) => {
                     expect(res).toBeNull();
-
                     done();
                 });
 
-                const req = httpTestingController.expectOne('/api/v1/apps/dotema-config-v2/123');
+                const req = httpTestingController.expectOne('/api/v1/ema');
 
                 const mockErrorResponse = { status: 400, statusText: 'Bad Request' };
                 const mockResponse = { data: null };
@@ -97,20 +38,12 @@ describe('EmaAppConfigurationService', () => {
             });
 
             it('if config does not match current site', (done) => {
-                jest.spyOn(licenseService, 'isEnterprise').mockReturnValue(of(true));
-                jest.spyOn(siteService, 'getCurrentSite').mockReturnValue(
-                    of({
-                        identifier: '123'
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    }) as any
-                );
-
                 spectator.service.get('test').subscribe((res) => {
                     expect(res).toBeNull();
                     done();
                 });
 
-                const req = httpTestingController.expectOne('/api/v1/apps/dotema-config-v2/123');
+                const req = httpTestingController.expectOne('/api/v1/ema');
 
                 const mockResponse = {
                     entity: {
@@ -131,20 +64,12 @@ describe('EmaAppConfigurationService', () => {
             });
 
             it('if pattern in value does not match url', (done) => {
-                jest.spyOn(licenseService, 'isEnterprise').mockReturnValue(of(true));
-                jest.spyOn(siteService, 'getCurrentSite').mockReturnValue(
-                    of({
-                        identifier: '123'
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    }) as any
-                );
-
                 spectator.service.get('test').subscribe((res) => {
                     expect(res).toBeNull();
                     done();
                 });
 
-                const req = httpTestingController.expectOne('/api/v1/apps/dotema-config-v2/123');
+                const req = httpTestingController.expectOne('/api/v1/ema');
 
                 const mockResponse = {
                     entity: {
@@ -165,20 +90,12 @@ describe('EmaAppConfigurationService', () => {
             });
 
             it('if value is not valid json', (done) => {
-                jest.spyOn(licenseService, 'isEnterprise').mockReturnValue(of(true));
-                jest.spyOn(siteService, 'getCurrentSite').mockReturnValue(
-                    of({
-                        identifier: '123'
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    }) as any
-                );
-
                 spectator.service.get('test').subscribe((res) => {
                     expect(res).toBeNull();
                     done();
                 });
 
-                const req = httpTestingController.expectOne('/api/v1/apps/dotema-config-v2/123');
+                const req = httpTestingController.expectOne('/api/v1/ema');
 
                 const mockResponse = {
                     entity: {
@@ -200,74 +117,24 @@ describe('EmaAppConfigurationService', () => {
         });
 
         it('should return value', (done) => {
-            jest.spyOn(licenseService, 'isEnterprise').mockReturnValue(of(true));
-            jest.spyOn(siteService, 'getCurrentSite').mockReturnValue(
-                of({
-                    identifier: '123'
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                }) as any
-            );
-
             spectator.service.get('test').subscribe((res) => {
                 expect(res).toEqual({
                     options: { 'X-CONTENT-APP': 'dotCMS', authenticationToken: '123' },
-                    pattern: '(.*)',
+                    pattern: '.*',
                     url: 'https://myspa.blogs.com:3000'
                 });
                 done();
             });
 
-            const req = httpTestingController.expectOne('/api/v1/apps/dotema-config-v2/123');
+            const req = httpTestingController.expectOne('/api/v1/ema');
 
             const mockResponse = {
                 entity: {
-                    sites: [
+                    config: [
                         {
-                            id: '123',
-                            configured: true,
-                            secrets: [
-                                {
-                                    value: '[ { "pattern":"(.*)", "url":"https://myspa.blogs.com:3000", "options": { "authenticationToken": "123", "X-CONTENT-APP": "dotCMS" } } ]'
-                                }
-                            ]
-                        }
-                    ]
-                }
-            };
-            req.flush(mockResponse);
-        });
-
-        it('should return value even when the url have trailing and leading slashes', (done) => {
-            jest.spyOn(licenseService, 'isEnterprise').mockReturnValue(of(true));
-            jest.spyOn(siteService, 'getCurrentSite').mockReturnValue(
-                of({
-                    identifier: '123'
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                }) as any
-            );
-
-            spectator.service.get('/blog/test/').subscribe((res) => {
-                expect(res).toEqual({
-                    options: { 'X-CONTENT-APP': 'dotCMS', authenticationToken: '123' },
-                    pattern: '/blog/(.*)/',
-                    url: 'https://myspa.blogs.com:3000'
-                });
-                done();
-            });
-
-            const req = httpTestingController.expectOne('/api/v1/apps/dotema-config-v2/123');
-
-            const mockResponse = {
-                entity: {
-                    sites: [
-                        {
-                            id: '123',
-                            configured: true,
-                            secrets: [
-                                {
-                                    value: '[ { "pattern":"/blog/(.*)/", "url":"https://myspa.blogs.com:3000", "options": { "authenticationToken": "123", "X-CONTENT-APP": "dotCMS" } } ]'
-                                }
-                            ]
+                            pattern: '.*',
+                            url: 'https://myspa.blogs.com:3000',
+                            options: { authenticationToken: '123', 'X-CONTENT-APP': 'dotCMS' }
                         }
                     ]
                 }

--- a/core-web/libs/data-access/src/lib/ema-app-configuration/ema-app-configuration.service.ts
+++ b/core-web/libs/data-access/src/lib/ema-app-configuration/ema-app-configuration.service.ts
@@ -42,7 +42,7 @@ export class EmaAppConfigurationService {
                             return secret;
                         }
                     } catch (error) {
-                        throw new Error('Error parsing JSON');
+                        throw new Error('Error on match URL pattern');
                     }
                 }
 

--- a/core-web/libs/data-access/src/lib/ema-app-configuration/ema-app-configuration.service.ts
+++ b/core-web/libs/data-access/src/lib/ema-app-configuration/ema-app-configuration.service.ts
@@ -4,12 +4,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { pluck, switchMap, map, defaultIfEmpty, catchError } from 'rxjs/operators';
-
-import { SiteService } from '@dotcms/dotcms-js';
-import { DotAppsSite, DotApp } from '@dotcms/dotcms-models';
-
-import { DotLicenseService } from '../dot-license/dot-license.service';
+import { pluck, map, defaultIfEmpty, catchError } from 'rxjs/operators';
 
 interface EmaAppSecretValue {
     pattern: string;
@@ -26,8 +21,6 @@ interface EmaAppOptions {
 export class EmaAppConfigurationService {
     http = inject(HttpClient);
     router = inject(Router);
-    licenseService = inject(DotLicenseService);
-    siteService = inject(SiteService);
 
     /**
      * Get the EMA app configuration for the current site.
@@ -40,78 +33,27 @@ export class EmaAppConfigurationService {
         // Remove trailing and leading slashes
         url = url.replace(/^\/+|\/+$/g, '');
 
-        return this.licenseService
-            .isEnterprise()
-            .pipe(
-                map((isEnterprise) => {
-                    if (!isEnterprise) {
-                        throw new Error('Not enterprise');
-                    }
-
-                    return isEnterprise;
-                })
-            )
-            .pipe(
-                switchMap(() => this.getCurrentSiteIdentifier()),
-                switchMap((currentSiteId: string) => {
-                    return this.getEmaAppConfiguration(currentSiteId).pipe(
-                        map(getConfigurationForCurrentSite(currentSiteId))
-                    );
-                }),
-                map(getSecretByUrlMatch(url)),
-                catchError(() => {
-                    return EMPTY;
-                }),
-                defaultIfEmpty<EmaAppSecretValue | null>(null)
-            );
-    }
-
-    private getCurrentSiteIdentifier(): Observable<string> {
-        return this.siteService.getCurrentSite().pipe(pluck('identifier'));
-    }
-
-    private getEmaAppConfiguration(id: string): Observable<DotApp> {
-        return this.http
-            .get<{ entity: DotApp }>(`/api/v1/apps/dotema-config-v2/${id}`)
-            .pipe(pluck('entity'));
-    }
-}
-
-function getConfigurationForCurrentSite(currentSiteId: string): (app: DotApp) => DotAppsSite {
-    return (app) => {
-        const site =
-            app?.sites?.find((site) => site.id === currentSiteId && site.configured) || null;
-
-        if (!site) {
-            throw new Error('No site configuration found');
-        }
-
-        return site;
-    };
-}
-
-function getSecretByUrlMatch(url: string): (site: DotAppsSite) => EmaAppSecretValue | null {
-    return (site: DotAppsSite) => {
-        const secrets = site.secrets || [];
-
-        for (const secret of secrets) {
-            try {
-                const parsedSecrets: EmaAppSecretValue[] = JSON.parse(secret.value);
-
-                for (const parsedSecret of parsedSecrets) {
-                    if (doesPathMatch(parsedSecret.pattern, url)) {
-                        return parsedSecret;
+        return this.http.get<{ entity: { config: EmaAppSecretValue[] } }>(`/api/v1/ema`).pipe(
+            pluck('entity', 'config'),
+            map((config) => {
+                for (const secret of config) {
+                    try {
+                        if (doesPathMatch(secret.pattern, url)) {
+                            return secret;
+                        }
+                    } catch (error) {
+                        throw new Error('Error parsing JSON');
                     }
                 }
-            } catch (error) {
-                console.error(error);
 
-                throw new Error('Error parsing JSON');
-            }
-        }
-
-        throw new Error('Current URL did not match any pattern');
-    };
+                throw new Error('Current URL did not match any pattern');
+            }),
+            catchError(() => {
+                return EMPTY;
+            }),
+            defaultIfEmpty<EmaAppSecretValue | null>(null)
+        );
+    }
 }
 
 function doesPathMatch(pattern: string, path: string): boolean {


### PR DESCRIPTION
### Proposed Changes
* When the user tries to enter to any page, the guard now check to new API (api/v1/ema) and check if any route matches with the configuration
* The user doesnt need to have access to Apps portlet to get the api/v1/ema data


https://github.com/dotCMS/core/assets/144152756/65bf7c0d-e5e6-4b96-92e7-fa87686d2913

