### PR TITLE
fix(core): Style containers detail when empty #26686

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.html
@@ -7,8 +7,8 @@
     <p-tabView
         [@contentCodeAnimation]
         [(activeIndex)]="activeTabIndex"
-        [scrollable]="true"
         [controlClose]="true"
+        [scrollable]="true"
         (onChange)="handleTabClick($event, $event.index)"
         (onClose)="removeItem($event.index)">
         <p-tabPanel headerStyleClass="tab-panel-btn">
@@ -17,13 +17,14 @@
                     class="pi pi-plus add-tab-icon"
                     *ngIf="contentTypes.length > 0; else contentTypesLoader"
                     (click)="handleTabClick($event); actionsMenu.toggle($event)"></i>
+
                 <ng-template #contentTypesLoader>
-                    <p-skeleton borderRadius="0px" width="4rem" height="3.9rem"></p-skeleton>
+                    <p-skeleton borderRadius="0px" height="3.9rem" width="4rem"></p-skeleton>
                 </ng-template>
                 <p-menu
                     #actionsMenu
-                    [popup]="true"
                     [model]="menuItems"
+                    [popup]="true"
                     [style]="{
                         'max-height': '300px',
                         overflow: 'auto'
@@ -44,9 +45,9 @@
                             {{ 'message.containers.empty.content_type_need_help' | dm }}?
                         </span>
                         <a
+                            data-testId="empty-content-link"
                             href="https://www.dotcms.com/docs/latest/containers"
-                            target="_blank"
-                            data-testId="empty-content-link">
+                            target="_blank">
                             {{ 'message.containers.empty.content_type_go_to_documentation' | dm }}
                         </a>
                     </div>
@@ -64,17 +65,17 @@
             <div [formGroupName]="i">
                 <button
                     class="p-button-outlined dot-container-code__variable-btn ml-3 mb-2 mt-2 p-button-sm"
-                    [label]="'add-variable' | dm"
                     [disabled]="contentTypes.length === 0"
+                    [label]="'add-variable' | dm"
                     (click)="handleAddVariable(containerContent.value)"
                     pButton></button>
                 <dot-textarea-content
                     #body
                     [attr.data-testid]="containerContent.value.structureId"
-                    [value]="containerContent.value.code"
+                    [customStyles]="{ border: 'none', height: '500px' }"
                     [editorName]="containerContent.value.structureId"
                     [show]="['code']"
-                    [customStyles]="{ border: 'none', height: '500px' }"
+                    [value]="containerContent.value.code"
                     (monacoInit)="monacoInit($event)"
                     formControlName="code"
                     language="html"></dot-textarea-content>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.scss
@@ -29,7 +29,8 @@
         border: 1px solid $color-palette-gray-500;
     }
 
-    .tab-panel-btn:not(.p-highlight):not(.p-disabled) {
+    .tab-panel-btn:first-child {
+        min-height: 63.79px;
         a.p-tabview-nav-link {
             align-items: center;
             background: $color-palette-primary-500;
@@ -40,16 +41,17 @@
             padding: 0;
             width: 48px;
 
+            i {
+                width: 100%;
+                height: 100%;
+                color: $white;
+                text-align: center;
+            }
+
             &:hover {
                 background-color: $color-palette-primary-700;
+                border: 0;
             }
         }
     }
-}
-
-.add-tab-icon {
-    width: 100%;
-    height: 100%;
-    color: $white;
-    text-align: center;
 }


### PR DESCRIPTION
### Proposed Changes
* Show the add content type when not exist tabs


### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
<img width="1515" alt="Screenshot 2024-01-19 at 1 03 47 PM" src="https://github.com/dotCMS/core/assets/1909643/12786c9d-2c42-4ce7-9744-a3e4f13cc0a6">
