### PR TITLE
fix(edit-content): Autocomplete file fields from binary field content #27389

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.spec.ts
@@ -130,7 +130,10 @@ describe('DotEditContentBinaryFieldComponent', () => {
         const spyEmit = jest.spyOn(spectator.component.valueUpdated, 'emit');
         spectator.detectChanges();
         store.setTempFile(TEMP_FILE_MOCK);
-        expect(spyEmit).toHaveBeenCalledWith(TEMP_FILE_MOCK.id);
+        expect(spyEmit).toHaveBeenCalledWith({
+            value: TEMP_FILE_MOCK.id,
+            fileName: TEMP_FILE_MOCK.fileName
+        });
     });
 
     it('should not emit new value is is equal to current value', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.ts
@@ -90,7 +90,7 @@ export class DotEditContentBinaryFieldComponent
     @Input() contentlet: DotCMSContentlet;
     @Input() imageEditor = false;
 
-    @Output() valueUpdated = new EventEmitter<string>();
+    @Output() valueUpdated = new EventEmitter<{ value: string; fileName: string }>();
     @ViewChild('inputFile') inputFile: ElementRef;
 
     private onChange: (value: string) => void;
@@ -144,11 +144,11 @@ export class DotEditContentBinaryFieldComponent
         this.dotBinaryFieldStore.value$
             .pipe(
                 skip(1),
-                filter((value) => value !== this.value)
+                filter(({ value }) => value !== this.value)
             )
-            .subscribe((value) => {
+            .subscribe(({ value, fileName }) => {
                 this.tempId = value; // If the value changes, it means that a new file was uploaded
-                this.valueUpdated.emit(value);
+                this.valueUpdated.emit({ value, fileName });
 
                 if (this.onChange) {
                     this.onChange(value);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/store/binary-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/store/binary-field.store.spec.ts
@@ -159,7 +159,10 @@ describe('DotBinaryFieldStore', () => {
 
                 // Skip initial state
                 store.value$.pipe(skip(1)).subscribe((value) => {
-                    expect(value).toBe(TEMP_FILE_MOCK.id);
+                    expect(value).toEqual({
+                        value: TEMP_FILE_MOCK.id,
+                        fileName: TEMP_FILE_MOCK.fileName
+                    });
                     done();
                 });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/store/binary-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/store/binary-field.store.ts
@@ -53,7 +53,10 @@ export class DotBinaryFieldStore extends ComponentStore<BinaryFieldState> {
         isLoading: state.status === BinaryFieldStatus.UPLOADING
     }));
 
-    readonly value$ = this.select((state) => state.value);
+    readonly value$ = this.select((state) => ({
+        value: state.value,
+        fileName: state.tempFile?.fileName
+    }));
 
     constructor(
         private readonly dotUploadService: DotUploadService,

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -760,7 +760,7 @@
                         const contentlet = contentlets[0];
                         const field = document.querySelector('#binary-field-input-<%=field.getFieldContentlet()%>ValueField');
                         const variable = "<%=field.getVelocityVarName()%>";
-                        const fielData = {
+                        const fieldData = {
                             ...(<%=jsonField%>),
                             hint: '<%=hint%>',
                             variable,
@@ -776,12 +776,22 @@
                         binaryField.id = "binary-field-<%=field.getVelocityVarName()%>";
                         binaryField.setAttribute("fieldName", "<%=field.getVelocityVarName()%>");
 
-                        binaryField.field = fielData;
+                        binaryField.field = fieldData;
                         binaryField.contentlet = contentlet;
                         binaryField.imageEditor = true;
+                        console.log({fieldData,contentlet, field})
+
+                        const contentBaseType = <%= contentlet.getContentType().baseType().getType() %>;
 
                         binaryField.addEventListener('valueUpdated', ({ detail }) => {
-                            field.value = detail;
+                            const { id, fileName } = detail;
+                            field.value = id;
+                            if(contentBaseType === 4){ // FileAsset
+                                let titleField = dijit.byId("title");
+                                let fileNameField = dijit.byId("fileName");
+                                titleField?.setValue(fileName);
+                                fileNameField?.setValue(fileName);
+                            }
                         });
 
                         binaryFieldContainer.innerHTML = '';
@@ -992,6 +1002,7 @@
 
         String bnFlag = Config.getStringProperty("FEATURE_FLAG_NEW_BINARY_FIELD");
         Boolean newBinaryOn = bnFlag != null && bnFlag.equalsIgnoreCase("true");
+
         Boolean isBinaryField = field.getFieldType().equals(Field.FieldType.BINARY.toString());
         Boolean shouldShowEditFileOnBn = isBinaryField && !newBinaryOn; // If the new binary field is on, we don't show the edit field
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -779,7 +779,6 @@
                         binaryField.field = fieldData;
                         binaryField.contentlet = contentlet;
                         binaryField.imageEditor = true;
-                        console.log({fieldData,contentlet, field})
 
                         const contentBaseType = <%= contentlet.getContentType().baseType().getType() %>;
 


### PR DESCRIPTION
### Proposed Changes
* When user loads an image in File ContentType, both FileName and Title changed their value to the Asset fileName 
* This autocomplete is only for File ContentType, for other ContentTypes that uses Binary field and have Title/FileName fields (Like blogs) this behavior it shouldn't happen


https://github.com/dotCMS/core/assets/144152756/0561ae79-ea94-44a4-91c4-687e81563448

