### PR TITLE
fix(core): Fields content type list scrolling correctly #27399

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.scss
@@ -1,6 +1,10 @@
 @use "variables" as *;
 $icon-size: 24px;
 
+:host {
+    overflow: auto;
+    margin-bottom: 1.5rem;
+}
 .content-types-fields-list {
     margin: 0;
     padding: 0;

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.scss
@@ -87,10 +87,6 @@ $top-height: ($toolbar-height + $tabview-nav-height + $dot-secondary-toolbar-mai
         flex-direction: column;
         flex-shrink: 0;
 
-        dot-content-types-fields-list {
-            overflow: auto;
-        }
-
         dot-content-type-fields-row-list {
             height: 200px;
         }


### PR DESCRIPTION
### Proposed Changes
* Now the latest item on Content-Types-List is showed and isnt too below
* 

https://github.com/dotCMS/core/assets/144152756/207bc4f9-a212-4888-ac70-c4d7dfe1fb24

