### PR TITLE
fix(ui): Code tag was not breaking lines and generating overflows #26602

### DIFF
--- a/core-web/libs/dotcms-scss/angular/styles.scss
+++ b/core-web/libs/dotcms-scss/angular/styles.scss
@@ -113,4 +113,5 @@ code {
     background-color: $color-accessible-text-purple-bg;
     padding: $spacing-0 $spacing-1;
     font-family: $font-code;
+    line-break: anywhere;
 }


### PR DESCRIPTION
### Proposed Changes
* Add line break `anywhere` for code tag

### Screenshots
<img width="823" alt="Screenshot 2024-01-23 at 2 51 33 PM" src="https://github.com/dotCMS/core/assets/63567962/61a58d26-bfdc-4cdf-a613-d6d91417d975">
