### PR TITLE
(chore) Force creation of empty temp and log dirs in assembly descriptors

### DIFF
--- a/dotCMS/src/assembly/descriptor.xml
+++ b/dotCMS/src/assembly/descriptor.xml
@@ -38,6 +38,20 @@
             <directoryMode>0755</directoryMode>
         </fileSet>
         <fileSet>
+            <directory>${assembly-directory}/conf</directory>
+            <outputDirectory>temp</outputDirectory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${assembly-directory}/conf</directory>
+            <outputDirectory>/logs</outputDirectory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
             <directory>${assembly-directory}</directory>
             <outputDirectory></outputDirectory>
             <excludes>
@@ -47,7 +61,6 @@
                 <exclude>**/felix-cache/**</exclude>
                 <exclude>**/webapps/cargorpc/**</exclude>
                 <exclude>**/work/**</exclude>
-                <exclude>**/temp/**</exclude>
                 <exclude>**/logs/**</exclude>
                 <exclude>**/lib/**</exclude>
                 <exclude>**/shared/**</exclude>

--- a/dotCMS/src/main/docker/original/docker-descriptor.xml
+++ b/dotCMS/src/main/docker/original/docker-descriptor.xml
@@ -4,6 +4,21 @@
     <includeBaseDirectory>false</includeBaseDirectory>
 
     <fileSets>
+        <!-- hack to make sure these empty directories get included-->
+        <fileSet>
+            <directory>${assembly-directory}/dotserver/tomcat-${tomcat.version}/config</directory>
+            <outputDirectory>dotserver/tomcat-${tomcat.version}/temp</outputDirectory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${assembly-directory}/dotserver/tomcat-${tomcat.version}/config</directory>
+            <outputDirectory>dotserver/tomcat-${tomcat.version}/logs</outputDirectory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </fileSet>
 
         <fileSet>
             <directory>${assembly-directory}/dotserver/tomcat-${tomcat.version}</directory>
@@ -15,7 +30,6 @@
                 <exclude>**/felix-cache/**</exclude>
                 <exclude>**/webapps/cargorpc/**</exclude>
                 <exclude>**/work/**</exclude>
-                <exclude>**/temp/**</exclude>
                 <exclude>**/logs/**</exclude>
             </excludes>
         </fileSet>


### PR DESCRIPTION
Maven assembly plugin does not copy accross empty folders by default.  This has caused the decault tomcat temp directory to go missing from the docker container and distribution zip.   Unless the tomcat environment variable is set to explicitly change this to another location DotCMs fails to load properly when it tries to write to the temp directory.   

A trick has been used to explicitly create an empty directory by selecting another known directory that is not empty then excluding all the contents and setting a destination.  