### PR TITLE
fix(core): Fixing problem with Enterprise-only Metadata Providers not loading #24307

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/license/DotInvalidLicenseException.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/license/DotInvalidLicenseException.java
@@ -47,12 +47,19 @@ package com.dotcms.enterprise.license;
 
 import java.io.IOException;
 
-public class DotInvalidLicenseException extends Exception {
+public class DotInvalidLicenseException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
 	String message;
+
 	@Override
 	public String getMessage() {
-		// TODO Auto-generated method stub
 		return message;
+	}
+
+	public DotInvalidLicenseException(final String string) {
+		this.message = string;
 	}
 
 	public DotInvalidLicenseException(String string, IOException e) {
@@ -60,13 +67,4 @@ public class DotInvalidLicenseException extends Exception {
 		initCause(e);
 	}
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-
-
-
-
-	
 }

--- a/dotCMS/src/main/java/com/dotcms/business/bytebuddy/ByteBuddyFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/business/bytebuddy/ByteBuddyFactory.java
@@ -3,6 +3,7 @@ package com.dotcms.business.bytebuddy;
 import com.dotcms.business.CloseDB;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
+import com.dotcms.util.EnterpriseFeature;
 import com.dotcms.util.LogTime;
 import com.dotmarketing.util.Logger;
 import net.bytebuddy.agent.ByteBuddyAgent;
@@ -23,7 +24,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static net.bytebuddy.matcher.ElementMatchers.*;
+import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 
 /**
  * Initializes ByteBuddy to handle transactional annotations. This replaces AspectJ functionality
@@ -39,7 +44,8 @@ public class ByteBuddyFactory {
             WrapInTransaction.class, WrapInTransactionAdvice.class,
             CloseDB.class, CloseDBAdvice.class,
             CloseDBIfOpened.class, CloseDBIfOpenedAdvice.class,
-            LogTime.class, LogTimeAdvice.class
+            LogTime.class, LogTimeAdvice.class,
+            EnterpriseFeature.class, EnterpriseFeatureAdvice.class
     );
 
 

--- a/dotCMS/src/main/java/com/dotcms/business/bytebuddy/EnterpriseFeatureAdvice.java
+++ b/dotCMS/src/main/java/com/dotcms/business/bytebuddy/EnterpriseFeatureAdvice.java
@@ -1,0 +1,36 @@
+package com.dotcms.business.bytebuddy;
+
+import com.dotcms.enterprise.LicenseUtil;
+import com.dotcms.enterprise.license.DotInvalidLicenseException;
+import com.dotcms.enterprise.license.LicenseLevel;
+import com.dotcms.util.EnterpriseFeature;
+import net.bytebuddy.asm.Advice;
+
+import java.lang.reflect.Method;
+
+/**
+ * This Advice class handles the behavior of the @{@link EnterpriseFeature} Annotation.
+ *
+ * @author Jose Castro
+ * @since Jan 23rd, 2024
+ */
+public class EnterpriseFeatureAdvice {
+
+    /**
+     * Checks that the specified Enterprise License level requirement is met. It allows for all
+     * License levels that are equal or greater than the one set in the Annotation.
+     *
+     * @param method The method that has been annotated with @{@link EnterpriseFeature}
+     */
+    @Advice.OnMethodEnter
+    static void enter(final @Advice.Origin Method method) {
+        final LicenseLevel licenseLevel =
+                method.getAnnotation(EnterpriseFeature.class).licenseLevel();
+        final String errorMsg = method.getAnnotation(EnterpriseFeature.class).errorMsg();
+        final int currenLicenseLevel = LicenseUtil.getLevel();
+        if (currenLicenseLevel < licenseLevel.level) {
+            throw new DotInvalidLicenseException(errorMsg);
+        }
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/storage/DataBaseStoragePersistenceAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/DataBaseStoragePersistenceAPIImpl.java
@@ -486,7 +486,7 @@ public class DataBaseStoragePersistenceAPIImpl implements StoragePersistenceAPI 
         final Map<String, Serializable> metaData = hashFile(file, extraMeta);
         final String fileHash = (String) metaData.get(SHA256_META_KEY.key());
         final String hashRef = (String)extraMeta.get(HASH_REF);
-        Logger.debug(DataBaseStoragePersistenceAPIImpl.class, " fileHash is : " + fileHash);
+        Logger.debug(this, () -> "FileHash is : " + fileHash);
 
             return wrapInTransaction(
                     () -> {
@@ -526,7 +526,7 @@ public class DataBaseStoragePersistenceAPIImpl implements StoragePersistenceAPI 
                             }
                     ).getOrElse(0);
         final boolean found = results.intValue() > 0;
-        Logger.debug(DataBaseStoragePersistenceAPIImpl.class, String.format(" is HashReference [%s] found [%s] ", fileHash,
+        Logger.debug(this, () -> String.format(" is HashReference [%s] found [%s] ", fileHash,
                 BooleanUtils.toStringYesNo(found)));
         exists.setValue(found);
         return exists.getValue();
@@ -535,7 +535,7 @@ public class DataBaseStoragePersistenceAPIImpl implements StoragePersistenceAPI 
     private Object pushFileReference(final String groupName, final String path, final String fileHash, final String hashRef, final Connection connection) throws DotDataException {
         final String groupNameLC = groupName.toLowerCase();
         final String pathLC = path.toLowerCase();
-        Logger.debug(DataBaseStoragePersistenceAPIImpl.class, String.format("Pushing new reference for group [%s] path [%s] hash [%s]", groupNameLC, pathLC, hashRef));
+        Logger.debug(this, () -> String.format("Pushing new reference for group [%s] path [%s] hash [%s]", groupNameLC, pathLC, hashRef));
         try {
             UpsertDelegate.newInstance().pushObjectReference(connection, fileHash, pathLC, groupNameLC, hashRef);
             return true;
@@ -651,18 +651,6 @@ public class DataBaseStoragePersistenceAPIImpl implements StoragePersistenceAPI 
             if(null != file){
                file.delete();
             }
-        }
-    }
-
-    /**
-     * This will write directly from the Serializer delegate right into a file. No in memory loading
-     * takes place like this.
-     */
-    private void writeToFile(final ObjectWriterDelegate writerDelegate,
-            final Serializable object, File file) throws IOException {
-
-        try (final OutputStream outputStream = Files.newOutputStream(file.toPath())) {
-            writerDelegate.write(outputStream, object);
         }
     }
 
@@ -851,7 +839,7 @@ public class DataBaseStoragePersistenceAPIImpl implements StoragePersistenceAPI 
             final int rows = dotConnect.executeUpdate(connection,
                     storageInsertSQL.get(),
                     objectHash, path, groupName, hashRef);
-            Logger.debug(DataBaseStoragePersistenceAPIImpl.class,"pushObjectReference inserted rows "+rows);
+            Logger.debug(this,() -> "pushObjectReference inserted rows "+rows);
         }
 
         /**
@@ -865,7 +853,7 @@ public class DataBaseStoragePersistenceAPIImpl implements StoragePersistenceAPI 
                 throws DotDataException {
             final int rows = dotConnect.executeUpdate(connection,
                     dataInsertSQL.get(), chunkHash, data);
-            Logger.debug(DataBaseStoragePersistenceAPIImpl.class,"pushDataChunk inserted rows "+rows);
+            Logger.debug(this,() -> "pushDataChunk inserted rows "+rows);
         }
 
         /**
@@ -881,7 +869,7 @@ public class DataBaseStoragePersistenceAPIImpl implements StoragePersistenceAPI 
             int order = 1;
             for (final String chunkHash : chunkHashes) {
                 final int rows = dotConnect.executeUpdate(connection, sql, objectHash, chunkHash, order++);
-                Logger.debug(DataBaseStoragePersistenceAPIImpl.class,"pushHashReference inserted rows "+rows);
+                Logger.debug(this,() -> "pushHashReference inserted rows "+rows);
             }
         }
 

--- a/dotCMS/src/main/java/com/dotcms/storage/StoragePersistenceAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/StoragePersistenceAPI.java
@@ -4,17 +4,22 @@ import com.dotcms.enterprise.achecker.parsing.EmptyIterable;
 import com.dotmarketing.exception.DotDataException;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 
 /**
- * Encapsulates an abstract storage, it provide the API to interact with whatever is behind the real storage:
- * it could be file system, db, s3, etc.
+ * This class represents an abstract storage. It provides the API a way to interact with whatever is
+ * behind the real storage: The File System, a database, an Amazon S3 bucket, a Redis server, etc.
+ * <p>A Storage Provider follows the concept of a group, which is a conceptual storage for a space
+ * -- i.e.;  a folder, bucket, etc., depending on the specific storage. In the File System, it could
+ * be a specific folder. In database, it could be a specific type. And in an Amazon AWS S3, it could
+ * be the actual bucket.</p>
  *
- * An Storage follow the concept of a group which is a conceptual storage for an space (such as folder, bucket, etc, depending on the storage),
- * on file system it could be an specific folder, on db a specific type and on s3 an actual bucket.
  * @author jsanca
  */
 public interface StoragePersistenceAPI {
@@ -108,22 +113,30 @@ public interface StoragePersistenceAPI {
             throws DotDataException;
 
     /**
-     * Push a file to the storage, it will block until the operation is done
+     * Pushes a file to this storage provider. It will NOT block the current operation as a
+     * different thread will be used to do the push.
+     *
      * @param groupName {@link String} the bucket to push
-     * @param path       {@link String} path to push the file
-     * @param file       {@link File}   the actual file
-     * @param extraMeta  {@link Map} optional metadata, this could be null but depending on the implementation it would need some meta info.
+     * @param path      {@link String} path to push the file
+     * @param file      {@link File}   the actual file
+     * @param extraMeta {@link Map} optional metadata, this could be null but depending on the
+     *                  implementation it would need some meta info.
+     *
      * @return Object, returns an object since the result will depend
      */
     Future<Object> pushFileAsync(final String groupName, final String path, final File file, final Map<String, Serializable> extraMeta);
 
     /**
-     * Push a stream to the storage, it will block until the operation is done
-     * @param bucketName {@link String} the bucket to upload
-     * @param path       {@link String} path to upload the file
-     * @param writerDelegate     {@link ObjectWriterDelegate} stream to upload
-     * @param object     {@link Serializable} object to write into the storage
-     * @param extraMeta  {@link Map} optional metadata, this could be null but depending on the implementation it would need some meta info.
+     * Pushes a stream to this storage provider. It will NOT block the current operation as a
+     * different thread will be used to do the push.
+     *
+     * @param bucketName     {@link String} the bucket to upload
+     * @param path           {@link String} path to upload the file
+     * @param writerDelegate {@link ObjectWriterDelegate} stream to upload
+     * @param object         {@link Serializable} object to write into the storage
+     * @param extraMeta      {@link Map} optional metadata, this could be null but depending on the
+     *                       implementation it would need some meta info.
+     *
      * @return Object, returns an object since the result will depend
      */
     Future<Object> pushObjectAsync(final String bucketName, final String path, final ObjectWriterDelegate writerDelegate, final Serializable object, final Map<String, Serializable> extraMeta);
@@ -181,6 +194,23 @@ public interface StoragePersistenceAPI {
      */
     default Iterable<? extends ObjectPath> toIterable(String group) {
         return new EmptyIterable<>();
+    }
+
+    /**
+     * Takes the information from the object and writes it to the specified file using the Writer
+     * Delegate to do so. This way, there's no in-memory loading.
+     *
+     * @param writerDelegate The {@link ObjectWriterDelegate} to writes the contents of the object.
+     * @param object         The {@link Serializable} object to write.
+     * @param file           The {@link File} that will contain the contents of the object.
+     *
+     * @throws IOException An error occurred when writing the file.
+     */
+    default void writeToFile(final ObjectWriterDelegate writerDelegate,
+                             final Serializable object, File file) throws IOException {
+        try (final OutputStream outputStream = Files.newOutputStream(file.toPath())) {
+            writerDelegate.write(outputStream, object);
+        }
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/storage/StoragePersistenceProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/StoragePersistenceProvider.java
@@ -1,8 +1,5 @@
 package com.dotcms.storage;
 
-import com.dotcms.enterprise.LicenseUtil;
-import com.dotcms.enterprise.license.LicenseLevel;
-import com.dotmarketing.business.APILocator;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.ConfigUtils;
 import com.dotmarketing.util.Logger;
@@ -36,8 +33,6 @@ public final class StoragePersistenceProvider {
         String storageType= Config.getStringProperty(DEFAULT_STORAGE_TYPE, StorageType.DEFAULT_CHAIN.name());
         return Try.of(()->StorageType.valueOf(storageType)).getOrElse(StorageType.DEFAULT_CHAIN);
     });
-
-    private boolean isLicenseInitialized = false;
 
     private final Map<StorageType, StoragePersistenceAPI> storagePersistenceInstances = new ConcurrentHashMap<>();
     
@@ -104,7 +99,7 @@ public final class StoragePersistenceProvider {
                 initializeStorageChain(CHAIN3_PROVIDERS, defaultProvider);
                 break;
             default:
-                throw new IllegalArgumentException(String.format("Storage Type '%s' not supported", storageType));
+                throw new IllegalArgumentException(String.format("Storage Type '%s' is not supported", storageType));
         }
     }
 
@@ -121,18 +116,12 @@ public final class StoragePersistenceProvider {
         final ChainableStoragePersistenceAPIBuilder builder = new ChainableStoragePersistenceAPIBuilder();
         Arrays.stream(storageTypes).iterator().forEachRemaining(storageTypeName -> {
             final StorageType storageType = StorageType.valueOf(storageTypeName);
-            if (isValidLicense()) {
                 builder.add(this.getStorage(storageType));
-            } else {
-                if (StorageType.FILE_SYSTEM.equals(storageType) || StorageType.DB.equals(storageType)) {
-                    builder.add(this.getStorage(storageType));
-                }
-            }
         });
         if (builder.list().isEmpty()) {
             builder.add(this.getStorage(StorageType.FILE_SYSTEM));
         }
-        Logger.info(this, String.format("Initializing Metadata Storage Chain with '%s'", builder.list()));
+        Logger.info(this, String.format("Initializing Metadata Storage Chain with: '%s'", builder.list()));
         addStorageInitializer(StorageType.DEFAULT_CHAIN, builder);
     }
 
@@ -169,7 +158,9 @@ public final class StoragePersistenceProvider {
         final StorageType finalStorageType = storageType;
         Logger.debug(this, ()-> "Retrieving from storage: " + finalStorageType);
         if (!initializers.containsKey(storageType)) {
-            throw new IllegalArgumentException(String.format("Storage type '%s' is not part of the initializers map", storageType));
+            final String errorMsg = String.format("Storage type '%s' is not part of the initializers map", storageType);
+            Logger.error(this, errorMsg);
+            throw new IllegalArgumentException(errorMsg);
         }
         final StoragePersistenceAPI api = storagePersistenceInstances.putIfAbsent(storageType, initializers.get(storageType).get());
         if(null != api){
@@ -192,28 +183,6 @@ public final class StoragePersistenceProvider {
      */
     public void forceInitialize(){
        storagePersistenceInstances.clear();
-    }
-
-    /**
-     * Utility method that verifies if the current dotCMS instance has an Enterprise License or
-     * not.
-     *
-     * @return If the license level is at least {@link LicenseLevel#PROFESSIONAL}, returns
-     * {@code true}.
-     */
-    private boolean isValidLicense() {
-        if (!isLicenseInitialized) {
-            final String serverId = APILocator.getServerAPI().readServerId();
-            if (serverId == null) {
-                // We can continue, probably a first start
-                Logger.warn(this, "Unable to get License level. Server id is null.");
-                return false;
-            }
-            //We can finally call directly the LicenseUtil.getLevel() method, the cluster_server
-            // was finally created!
-            isLicenseInitialized = true;
-        }
-        return LicenseUtil.getLevel() >= LicenseLevel.PROFESSIONAL.level;
     }
 
     public enum INSTANCE {

--- a/dotCMS/src/main/java/com/dotcms/util/EnterpriseFeature.java
+++ b/dotCMS/src/main/java/com/dotcms/util/EnterpriseFeature.java
@@ -1,0 +1,39 @@
+package com.dotcms.util;
+
+import com.dotcms.enterprise.license.LicenseLevel;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This Annotation allows developers to check whether the current dotCMS instance is running with a
+ * specific Enterprise License level or not. By default, this Annotation will check for a
+ * Professional License -- level 300.
+ *
+ * @author Jose Castro
+ * @since Jan 23rd, 2024
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface EnterpriseFeature {
+
+    /**
+     * Sets the dotCMS License level to check for.
+     *
+     * @return The current License Level, or the Professional License level by default.
+     */
+    LicenseLevel licenseLevel() default LicenseLevel.PROFESSIONAL;
+
+    /**
+     * Sets the specific error message that will be returned if the current dotCMS instance lower
+     * than the one that has been specified
+     *
+     * @return The specified error message, or the default one.
+     */
+    String errorMsg() default "This feature is only available in an Enterprise version of dotCMS";
+
+}


### PR DESCRIPTION
### Proposed Changes
* The existing code was failing to validate the existence of the appropriate dotCMS license because it is not set at the beginning of the startup process.
* Therefore, a new Annotation called `EnterpriseFeature` has been created in order to force the presence of a license equal or higher than the specified value. Such an Annotation ca be set at method level.
* Additional Internal QA surfaced some other code issues that have been solved, including:
  * The AWS S3 bucket failing to persist the metadata file when only saving -- not publishing -- a file.
  * In order to handle concurrent writes, using the Striped Lock when writing the file to S3 just like the File System Provider does.