### PR TITLE
dotCMS/core#26308 POC of run experiment with NextJS

### DIFF
--- a/ema/nextjs/package-lock.json
+++ b/ema/nextjs/package-lock.json
@@ -10,6 +10,9 @@
             "dependencies": {
                 "@dotcms/client": "0.0.1-alpha.7",
                 "@dotcms/nextjs": "0.0.1-alpha.7",
+                "@jitsu/nextjs": "^3.1.5",
+                "@jitsu/react": "^3.1.5",
+                "@jitsu/sdk-js": "^3.1.5",
                 "next": "14.1.0",
                 "react": "^18",
                 "react-dom": "^18"
@@ -215,6 +218,39 @@
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
+        },
+        "node_modules/@jitsu/nextjs": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@jitsu/nextjs/-/nextjs-3.1.5.tgz",
+            "integrity": "sha512-JdRxa+iy9w9rTf33XBAUQYdHDATPEt1X3HV6UpsoIHYqJQqAwsSBb226Kno/uVoVBrGqjdpa4ae6+7BSprxz0g==",
+            "deprecated": "This package is for legacy Jitsu Classic version. For latest version of Jitsu please use @jitsu/jitsu-react",
+            "dependencies": {
+                "@jitsu/sdk-js": "^3.1.5",
+                "cookie": "^0.5.0"
+            },
+            "peerDependencies": {
+                "next": "^10.0.8 || ^11.0 || ^12.0",
+                "react": "15.x || 16.x || 17.x || 18.x"
+            }
+        },
+        "node_modules/@jitsu/react": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@jitsu/react/-/react-3.1.5.tgz",
+            "integrity": "sha512-MqjYmAU3fxW204tcsVhKFu+2QSz7o0IeGykd7VdfQXSj5SXNdhG7NwH5IGTHdQ4hVHBWxqyIIXbDvC3GKYXckw==",
+            "deprecated": "This package is for legacy Jitsu Classic version. For latest version of Jitsu please use @jitsu/jitsu-react",
+            "dependencies": {
+                "@jitsu/sdk-js": "^3.1.5"
+            },
+            "peerDependencies": {
+                "react": "15.x || 16.x || 17.x || 18.x",
+                "react-router": "5.x || 6.x"
+            }
+        },
+        "node_modules/@jitsu/sdk-js": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@jitsu/sdk-js/-/sdk-js-3.1.5.tgz",
+            "integrity": "sha512-e7P8uvGBNwWCC864MItcYSv0IT2+nwYiX8QXZ0lfyG8hutEXXX9Yt2/+MynXuGxMIoIrJ+j0bWVu20k9rrhxSg==",
+            "deprecated": "This package is for legacy Jitsu Classic version. For latest version of Jitsu please use @jitsu/js"
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.3",
@@ -456,6 +492,15 @@
             "optional": true,
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@remix-run/router": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.0.tgz",
+            "integrity": "sha512-HOil5aFtme37dVQTB6M34G95kPM3MMuqSmIRVCC52eKV+Y/tGSqw9P3rWhlAx6A+mz+MoX+XxsGsNJbaI5qCgQ==",
+            "peer": true,
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@rushstack/eslint-patch": {
@@ -1147,6 +1192,14 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
+        },
+        "node_modules/cookie": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -3614,6 +3667,21 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "dev": true
+        },
+        "node_modules/react-router": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.0.tgz",
+            "integrity": "sha512-q2yemJeg6gw/YixRlRnVx6IRJWZD6fonnfZhN1JIOhV2iJCPeRNSH3V1ISwHf+JWcESzLC3BOLD1T07tmO5dmg==",
+            "peer": true,
+            "dependencies": {
+                "@remix-run/router": "1.15.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8"
+            }
         },
         "node_modules/read-cache": {
             "version": "1.0.0",

--- a/ema/nextjs/package.json
+++ b/ema/nextjs/package.json
@@ -11,6 +11,9 @@
     "dependencies": {
         "@dotcms/client": "0.0.1-alpha.7",
         "@dotcms/nextjs": "0.0.1-alpha.7",
+        "@jitsu/nextjs": "^3.1.5",
+        "@jitsu/react": "^3.1.5",
+        "@jitsu/sdk-js": "^3.1.5",
         "next": "14.1.0",
         "react": "^18",
         "react-dom": "^18"

--- a/ema/nextjs/public/experiment_logic.js
+++ b/ema/nextjs/public/experiment_logic.js
@@ -1,0 +1,250 @@
+// TODO: Move this to the sdk/experiment lib
+// WIP: missing logic and implemetation from 'dotCMS/src/main/resources/experiment/js/init_script.js'
+
+const LOCAL_STORAGE_KEY = 'experiment_data';
+const LOCAL_STORAGE_TIME_KEY = 'experiment_time';
+const LOCAL_STORAGE_TIME_DURATION_MILLISECONDS = 24 * 60 * 60 * 1000; // a day
+// const LOCAL_STORAGE_TIME_DURATION_MILLISECONDS = 5 * 1000; // a minute for test
+
+export const QUERY_PARAM_VARIANT_KEY = 'variantName';
+const QUERY_PARAM_REDIRECT_KEY = 'redirect';
+
+//Todo: usar TS para esto en un lib
+class ExperimentHelper {
+    #pageLocationUrl;
+    #pageExperiment;
+    #regexsChecks = [];
+
+    getPageExperiment() {
+        return this.#pageExperiment;
+    }
+
+    async check(currentUrl) {
+        this.#pageLocationUrl = currentUrl;
+
+        console.info('shouldCheckAPI', this.#shouldCheckAPI());
+        if (this.#shouldCheckAPI()) {
+            const experiments = await this.#getExperimentConfig();
+            this.#setLocalStorageData(this.#mergeParseAndCleanData(experiments));
+        } else {
+            console.info('data exist and valid not implemented yet');
+        }
+    }
+
+    /**
+     * Retrieves the experiment configuration by making a request to the server.
+     *
+     * @returns {Promise<Object>} A Promise that resolves with the experiment configuration.
+     * @throws {Error} If there is an HTTP error during the request.
+     */
+    async #getExperimentConfig() {
+        const { includedExperimentIds } = this.getLocalStorageData();
+
+        // TODO: fix this url
+        const response = await fetch('http://localhost:8080/api/v1/experiments/isUserIncluded', {
+            method: 'POST',
+            body: JSON.stringify({ exclude: includedExperimentIds || [] }),
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json'
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const { entity } = await response.json();
+
+        return entity;
+    }
+
+    /**
+     * Gets the data stored in the local storage.
+     *
+     * @returns {Object} - The parsed local storage data or an empty object if parsing fails.
+     */
+    getLocalStorageData() {
+        let experimentData = localStorage.getItem(LOCAL_STORAGE_KEY);
+        try {
+            return experimentData ? JSON.parse(experimentData) : {};
+        } catch (e) {
+            console.error('Error parsing localStorage data: ', e);
+            return false;
+        }
+    }
+
+    /**
+     * Sets the Jitsu experiment data by retrieving the experiments from local storage,
+     * formatting and sending the data to the Jitsu server.
+     *
+     * @private
+     * @returns {void}
+     */
+    #getParsedDataForJitsu() {
+        const { experiments } = this.getLocalStorageData();
+        console.log(this.getLocalStorageData());
+
+        return experiments
+            ? {
+                  experiments: experiments.map((experiment) => ({
+                      experiment: experiment.id,
+                      runningId: experiment.runningId,
+                      variant: experiment.variant.name,
+                      lookBackWindow: experiment.lookBackWindow.value,
+                      ...this.#parseExperimentRegexChecksForJitsu().filter(
+                          (regexCheked) => regexCheked.id === experiment.id
+                      )[0].checks
+                  }))
+              }
+            : { experiments: [] };
+    }
+
+    getExperimentJitsuData() {
+        return this.#getParsedDataForJitsu() || { experiments: false };
+    }
+
+    /**
+     * Sets experiment data to the local storage.
+     *
+     * @private
+     * @returns {void}
+     */
+    #setLocalStorageData(cleanDataToSave) {
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(cleanDataToSave));
+        localStorage.setItem(LOCAL_STORAGE_TIME_KEY, Date.now().toString());
+    }
+
+    /**
+     * Generates regular expression checks for each experiment in the experiment data.
+     * @return {void}
+     */
+    #parseExperimentRegexChecksForJitsu() {
+        const regexsChecks = [];
+
+        const { experiments } = this.getLocalStorageData();
+        experiments.forEach((experiment) => {
+            const experimentId = experiment.id;
+            const experimentRegex = { id: experimentId, checks: {} };
+
+            Object.keys(experiment.regexs).forEach((key) => {
+                const pattern = new RegExp(experiment.regexs[key]);
+                let indexOf = location.href.indexOf('?');
+                let urlWithoutParameters =
+                    indexOf > -1 ? location.href.substring(0, indexOf) : location.href;
+                let parameters = indexOf > -1 ? location.href.substring(indexOf) : '';
+                let url = urlWithoutParameters.toLowerCase() + parameters;
+                experimentRegex.checks[key] = pattern.test(url);
+            });
+
+            regexsChecks.push(experimentRegex);
+        });
+
+        return regexsChecks;
+    }
+
+    /**
+     * Parses and cleans the given experiment data.
+     *
+     * @param {Object} experiments - The new experiment data to be parsed and cleaned.
+     * @returns {Object} - The parsed and cleaned experiment data with updated time.
+     */
+    #mergeParseAndCleanData(experiments) {
+        let now = Date.now();
+        // Retrieve existing data from localStorage or default to an object with an empty 'experiments' field.
+        let oldExperimentData = this.getLocalStorageData() || { experiments: [] };
+        delete oldExperimentData['excludedExperimentIds'];
+
+        return {
+            // Retain all existing properties of oldExperimentData.
+            ...oldExperimentData,
+
+            // Merge existing and new Experiment Ids.
+            includedExperimentIds: [
+                ...(oldExperimentData.includedExperimentIds || []),
+                ...experiments.excludedExperimentIds
+            ],
+
+            // Merge existing and new Experiments, and set new expiration time.
+            experiments: [...(oldExperimentData.experiments || []), ...experiments.experiments].map(
+                (experiment) => ({
+                    ...experiment,
+                    lookBackWindow: {
+                        ...experiment.lookBackWindow,
+                        expireTime: now + experiment.lookBackWindow.expireMillis
+                    }
+                })
+            )
+        };
+    }
+
+    /**
+     * Determines whether to make a request to the API or not based on the token status.
+     *
+     * @returns {boolean} Returns true if a request should be made to the API, otherwise false.
+     */
+    #shouldCheckAPI() {
+        const token = localStorage.getItem(LOCAL_STORAGE_KEY);
+        const tokenTimeStamp = localStorage.getItem(LOCAL_STORAGE_TIME_KEY);
+
+        if (token === null) {
+            return true;
+        }
+
+        if (Date.now() - tokenTimeStamp > LOCAL_STORAGE_TIME_DURATION_MILLISECONDS) {
+            localStorage.removeItem(LOCAL_STORAGE_KEY);
+            localStorage.removeItem(LOCAL_STORAGE_TIME_KEY);
+            return true;
+        }
+
+        this.identifyExperimentPage();
+
+        // the token exists and it is not outdated, hence no need to make a request to the API
+        return false;
+    }
+
+    #redirectRules() {
+        if (!this.#pageExperiment) {
+            return false;
+        }
+
+        const { checks } = this.#parseExperimentRegexChecksForJitsu().find(
+            (rule) => rule.id === this.#pageExperiment.id
+        );
+
+        if (checks.isExperimentPage) {
+            // yes this page has an experiment
+            console.info(this.#pageLocationUrl.searchParams.get(QUERY_PARAM_VARIANT_KEY));
+            if (this.#pageLocationUrl.searchParams.get(QUERY_PARAM_VARIANT_KEY) === null) {
+                const variant = this.#pageExperiment.variant.name;
+
+                this.#pageLocationUrl.searchParams.set(QUERY_PARAM_VARIANT_KEY, variant);
+            } else if (
+                this.#pageLocationUrl.searchParams.get(QUERY_PARAM_VARIANT_KEY) ===
+                this.#pageExperiment.variant.name
+            ) {
+            }
+        }
+        return false;
+    }
+
+    removeVariantQueryParam() {
+        this.#pageLocationUrl.searchParams.delete(QUERY_PARAM_VARIANT_KEY);
+        window.history.replaceState(null, '', this.#pageLocationUrl.toString());
+    }
+
+    /**
+     * Identifies the experiment page.
+     *
+     * @returns {void}
+     */
+    identifyExperimentPage() {
+        const { pathname } = this.#pageLocationUrl;
+        const { experiments } = this.getLocalStorageData();
+
+        this.#pageExperiment =
+            experiments.find((experiment) => experiment.pageUrl === pathname) || false;
+    }
+}
+
+module.exports = { ExperimentHelper };

--- a/ema/nextjs/public/experiment_logic.js
+++ b/ema/nextjs/public/experiment_logic.js
@@ -247,4 +247,4 @@ class ExperimentHelper {
     }
 }
 
-module.exports = { ExperimentHelper };
+export default ExperimentHelper;

--- a/ema/nextjs/src/app/[[...slug]]/page.js
+++ b/ema/nextjs/src/app/[[...slug]]/page.js
@@ -1,4 +1,6 @@
 import { dotcmsClient } from '@dotcms/client';
+import { MyPage } from '@/components/my-page';
+import PageWithExperiment from '@/components/experiments/experimentPage';
 
 const client = dotcmsClient.init({
     dotcmsUrl: process.env.NEXT_PUBLIC_DOTCMS_HOST,
@@ -10,15 +12,16 @@ const client = dotcmsClient.init({
     }
 });
 
-import { MyPage } from '@/components/my-page';
-
 export async function generateMetadata({ params, searchParams }) {
     const data = await client.page.get({
         path: params?.slug ? params.slug.join('/') : 'index',
         language_id: searchParams.language_id,
+        // Get the correct title page to render
+        variantName: searchParams['variantName'] ? searchParams['variantName'] : 'DEFAULT',
         'com.dotmarketing.persona.id': searchParams['com.dotmarketing.persona.id'] || ''
     });
 
+    console.log(data.entity.page);
     return {
         title: data.entity.page.friendlyName || data.entity.page.title
     };
@@ -28,7 +31,9 @@ export default async function Home({ searchParams, params }) {
     const data = await client.page.get({
         path: params?.slug ? params.slug.join('/') : 'index',
         language_id: searchParams.language_id,
-        personaId: searchParams['com.dotmarketing.persona.id'] || ''
+        personaId: searchParams['com.dotmarketing.persona.id'] || '',
+        // Get the correct page to render
+        variantName: searchParams['variantName'] ? searchParams['variantName'] : 'DEFAULT'
     });
 
     const nav = await client.nav.get({
@@ -37,5 +42,10 @@ export default async function Home({ searchParams, params }) {
         languageId: searchParams.language_id
     });
 
-    return <MyPage nav={nav.entity.children} data={data.entity}></MyPage>;
+    // If the page need to handle experiments wrap with PageWithExperiment component
+    return (
+        <PageWithExperiment>
+            <MyPage nav={nav.entity.children} data={data.entity}></MyPage>
+        </PageWithExperiment>
+    );
 }

--- a/ema/nextjs/src/components/experiments/experimentContent.js
+++ b/ema/nextjs/src/components/experiments/experimentContent.js
@@ -1,0 +1,50 @@
+'use client';
+// TODO: Pass this to sdk/nextjs
+
+import { useEffect } from 'react';
+import { ExperimentHelper } from '../../../public/experiment_logic';
+import { useJitsu } from '@jitsu/react';
+import { useRouter } from 'next/navigation';
+
+const helper = new ExperimentHelper();
+
+function ExperimentContent({ children }) {
+    const router = useRouter();
+
+    const { trackPageView, id, set, unset } = useJitsu();
+    useEffect(() => {
+        set(helper.getExperimentJitsuData());
+        async function checkExperiments() {
+            if (typeof window !== 'undefined') {
+                const currentPageUrl = new URL(window.location);
+                await helper.check(currentPageUrl);
+
+                const { experiments } = helper.getLocalStorageData();
+
+                experiments.forEach(({ pageUrl, variant }) => {
+                    document.querySelectorAll(`a[href*='${pageUrl}']`).forEach((enlace) => {
+                        const urlFinal = `${window.location.origin}${variant.url}`;
+
+                        // Only update if the href is different to avoid unnecessary work
+                        if (enlace.href !== urlFinal) {
+                            enlace.href = urlFinal;
+
+                            enlace.addEventListener('click', function (event) {
+                                event.preventDefault(); // not allow the default behavior
+                                router.replace(urlFinal); // Next.js Router
+                            });
+                        }
+                    });
+                });
+
+                trackPageView(); // Auto pageview from Jitsue
+            }
+        }
+
+        checkExperiments(); // All the logic to handle Experiments (future sdk/experiments)
+    }, [router, set, trackPageView]);
+
+    return <div>{children}</div>;
+}
+
+export default ExperimentContent;

--- a/ema/nextjs/src/components/experiments/experimentContent.js
+++ b/ema/nextjs/src/components/experiments/experimentContent.js
@@ -2,16 +2,17 @@
 // TODO: Pass this to sdk/nextjs
 
 import { useEffect } from 'react';
-import { ExperimentHelper } from '../../../public/experiment_logic';
+
 import { useJitsu } from '@jitsu/react';
 import { useRouter } from 'next/navigation';
+import ExperimentHelper from '../../../public/experiment_logic';
 
 const helper = new ExperimentHelper();
 
 function ExperimentContent({ children }) {
     const router = useRouter();
 
-    const { trackPageView, id, set, unset } = useJitsu();
+    const { trackPageView, id, set, unset, track } = useJitsu();
     useEffect(() => {
         set(helper.getExperimentJitsuData());
         async function checkExperiments() {

--- a/ema/nextjs/src/components/experiments/experimentPage.js
+++ b/ema/nextjs/src/components/experiments/experimentPage.js
@@ -1,0 +1,28 @@
+'use client';
+// TODO: meter esto en otro lugar
+
+import ExperimentContent from '@/components/experiments/experimentContent';
+import { createClient, JitsuProvider } from '@jitsu/react';
+
+const host = process.env.NEXT_PUBLIC_DOTCMS_HOST;
+const token = 'js.cluster1.customer1.tpw8gbup16ekrnasj9';
+console.info('NEXT_PUBLIC_DOTCMS_HOST', host);
+console.info('EXPERIMENT_TOKEN_APP', process.env.EXPERIMENT_TOKEN_APP);
+
+const jitsuClient = createClient({
+    tracking_host: `${host}`,
+    key: `${token}`,
+    log_level: 'DEBUG'
+});
+
+function PageWithExperiment({ children }) {
+    return (
+        <div>
+            <JitsuProvider client={jitsuClient}>
+                <ExperimentContent>{children}</ExperimentContent>
+            </JitsuProvider>
+        </div>
+    );
+}
+
+export default PageWithExperiment;

--- a/ema/nextjs/src/components/experiments/experimentPage.js
+++ b/ema/nextjs/src/components/experiments/experimentPage.js
@@ -1,5 +1,5 @@
 'use client';
-// TODO: meter esto en otro lugar
+// TODO: move this to sdk/next/ or sdk/experiments/next/components
 
 import ExperimentContent from '@/components/experiments/experimentContent';
 import { createClient, JitsuProvider } from '@jitsu/react';

--- a/ema/nextjs/src/components/layout/navigation.js
+++ b/ema/nextjs/src/components/layout/navigation.js
@@ -1,8 +1,13 @@
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
+import { LOCAL_STORAGE_KEY, QUERY_PARAM_VARIANT_KEY } from '../../../public/experiment_logic';
 
 function Navigation({ items, className }) {
     const searchParams = useSearchParams();
+    // I dont want mantain the queryParam of Experiment
+    const queryParams = Object.fromEntries(
+        [...searchParams.entries()].filter(([key]) => key !== QUERY_PARAM_VARIANT_KEY)
+    );
 
     return (
         <nav className={className}>
@@ -11,7 +16,7 @@ function Navigation({ items, className }) {
                     <Link
                         href={{
                             pathname: '/',
-                            query: Object.fromEntries(searchParams.entries()) // We need to maintain the query params on the navigation, this way next loads the page with the same query params
+                            query: queryParams // We need to maintain the query params on the navigation, this way next loads the page with the same query params
                         }}>
                         Home
                     </Link>
@@ -21,13 +26,22 @@ function Navigation({ items, className }) {
                         <Link
                             href={{
                                 pathname: item.href,
-                                query: Object.fromEntries(searchParams.entries()) // We need to maintain the query params on the navigation, this way next loads the page with the same query params
+                                query: queryParams // We need to maintain the query params on the navigation, this way next loads the page with the same query params
                             }}
                             target={item.target}>
                             {item.title}
                         </Link>
                     </li>
                 ))}
+                <li>
+                    <Link
+                        href={{
+                            pathname: '/sale',
+                            query: queryParams // We need to maintain the query params on the navigation, this way next loads the page with the same query params
+                        }}>
+                        Sale
+                    </Link>
+                </li>
             </ul>
         </nav>
     );


### PR DESCRIPTION
### Proposed Changes
* POC of how implement Experiments with NextJS (SPA)


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

P.O.C.
A page ( `/sale`) was created to generate an experiment with 1 variant.
Used: NextJS 14 (js) in "Client Side Rendering (CSR)" way (logic running in the browser/client)

Discoveries:
- We can run the Experiment and switch between variants depending on the assigned experiment. Unlike what was done before, the JS logic was centralized in obtaining the experiments and manipulating the localstorage which is the persistent source of the experiments. Tracking detect and listen events are handle direct in a Component in NextJS.
- I recommend migrating the logic to a library, to centralize and reuse in the various ways an experiment can be run (dotcms default, Sever Side Generated (SSG), Static Site Rendered (SSR), Static generation with dotCMS)
- Jitsu was used directly with the SDK.
- Instead of doing redirect, I filtered the 'a' with the href that matched the `pathurl` and to these I added the `variantName` queryparam and triggered the Jitsu event manually (in my case I didn't do it like that, Jitsu has a method to register the pageview automatically), this opens the door so that if we have defined in other goals such as `Click On Element`, being able to add a listener to those specific elements and trigger events from that element to Jitsu.
- It is necessary to verify the extra cases to take into account in javascript so that it works 100% the same as its current state in DotCMS.

Page/Experiment
Default
<img width="1605" alt="Screenshot 2024-02-05 at 11 59 54 AM" src="https://github.com/dotCMS/core/assets/1909643/72edb4ee-6478-460a-b739-c6ffdacbe187">

Variant
<img width="1606" alt="Screenshot 2024-02-05 at 11 59 44 AM" src="https://github.com/dotCMS/core/assets/1909643/586630b1-2119-4287-9874-26dbf9339edf">

Experiment and Variant Switch
<img width="3008" alt="Screenshot 2024-02-05 at 11 59 02 AM" src="https://github.com/dotCMS/core/assets/1909643/9652cdb0-ddc9-43d4-b904-323ed4901a61">

`PageView` event dispatched
<img width="1489" alt="Screenshot 2024-02-05 at 11 59 22 AM" src="https://github.com/dotCMS/core/assets/1909643/55c7baaa-747d-4b90-aeb5-8f5e90fe926c">
