### PR TITLE
chore(sonar) new sonarqube requires java17

### DIFF
--- a/.github/workflows/maven-cicd-pipeline.yml
+++ b/.github/workflows/maven-cicd-pipeline.yml
@@ -606,7 +606,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/cleanup-runner
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17

--- a/.github/workflows/maven-cicd-pipeline.yml
+++ b/.github/workflows/maven-cicd-pipeline.yml
@@ -609,7 +609,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
       - name: Get Date
         id: get-date

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,7 +76,7 @@
         <version.rewrite-maven-plugin>4.46.0</version.rewrite-maven-plugin>
         <version.shade.plugin>3.2.1</version.shade.plugin>
         <version.site.plugin>4.0.0-M8</version.site.plugin>
-        <version.sonar.plugin>3.7.0.1746</version.sonar.plugin>
+        <version.sonar.plugin>3.10.0.2594</version.sonar.plugin>
         <version.source.plugin>3.1.0</version.source.plugin>
 
         <version.versions.plugin>2.8.1</version.versions.plugin>


### PR DESCRIPTION
Sonarqube updated and now requires to run under Java 17
