### PR TITLE
fix(edit-ema): Select contentlet is selecting a wrong a contentlet #27554

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
@@ -1289,8 +1289,7 @@ dojo.declare(
             dojo.parser.parse(this.results_table);
 
             if (this.multiple == 'false') {
-                for (var i = 0; i < data.length; i++) {
-                    var asset = data[i];
+                data.map(asset => {
                     var selectButton = dojo.byId(
                         this.searchCounter + asset.inode
                     );
@@ -1300,7 +1299,7 @@ dojo.declare(
                             selected(this, asset);
                         });
                     }
-                }
+                })
             }
 
             // Header based sorting functionality


### PR DESCRIPTION
### Proposed Changes
* Fixed issue when user select contentlet


https://github.com/dotCMS/core/assets/144152756/74bdd6c4-e337-46be-a56c-832a6614a200


### Little context:
This issue probably happened before. I returned the code to how it was before a PR from 1 month ago and the issue was still visible.
It seems like it was strange behavior due to variable references in JS.
Updating to modern code could solve it.
