### PR TITLE
chore(maven) need to cleanup runner due to out of disk space

### DIFF
--- a/.github/workflows/docker-build-dev-image.yml
+++ b/.github/workflows/docker-build-dev-image.yml
@@ -11,6 +11,8 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Cleanup
+        uses: ./.github/actions/cleanup-runner
       -
         name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/maven-build-docker-image.yml
+++ b/.github/workflows/maven-build-docker-image.yml
@@ -60,6 +60,8 @@ jobs:
       version: ${{ steps.set-common-vars.outputs.version }}
     if: success()
     steps:
+      - name: Cleanup
+        uses: ./.github/actions/cleanup-runner
       - run: echo 'GitHub context'
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}


### PR DESCRIPTION

docker-build-master-branch.yml is running out of space we need to cleanup the runner before working on the docker containers. 