### PR TITLE
chore(maven) need to run cleanup after checkout - cleanup needs to go after checkout

### DIFF
--- a/.github/workflows/maven-build-docker-image.yml
+++ b/.github/workflows/maven-build-docker-image.yml
@@ -60,8 +60,6 @@ jobs:
       version: ${{ steps.set-common-vars.outputs.version }}
     if: success()
     steps:
-      - name: Cleanup
-        uses: ./.github/actions/cleanup-runner
       - run: echo 'GitHub context'
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -70,7 +68,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-
+      - name: Cleanup
+        uses: ./.github/actions/cleanup-runner
       - name: Restore Docker Context
         id: restore-docker-context
         uses: actions/cache/restore@v3


### PR DESCRIPTION
This is an update to the workflow cleanup fails if put before checkout step.