### PR TITLE
chore(versions) Cleanup dependency versions and single top level tomcat.version property

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1450,14 +1450,14 @@
                 <!-- Jasper is the Tomcat JSP Engine -->
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jasper</artifactId>
-                <version>9.0.73</version>
+                <version>${tomcat.version}</version>
             </dependency>
 
 
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jdbc</artifactId>
-                <version>9.0.73</version>
+                <version>${tomcat.version}</version>
             </dependency>
 
 

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -29,7 +29,6 @@
 
         <clean.docker.volumes>false</clean.docker.volumes>
         <!-- Tomcat -->
-        <tomcat.version>9.0.85</tomcat.version>
         <enableDebug>true</enableDebug>
         <debugPort>8000</debugPort>
         <debugHost>localhost</debugHost>
@@ -78,7 +77,6 @@
         <docker.platforms></docker.platforms>
 
         <tomcat.redis-session-manager.version>1.1</tomcat.redis-session-manager.version>
-        <tomcat.catalina.version>9.0.41</tomcat.catalina.version>
         <commons-pool2.version>2.11.1</commons-pool2.version>
         <org.slfj4.version>1.7.36</org.slfj4.version>
         <jedis.version>4.4.6</jedis.version>
@@ -166,7 +164,6 @@
         <dependency>
             <groupId>com.dotcms.lib</groupId>
             <artifactId>dot.commons-jci-eclipse</artifactId>
-            <version>3.2.0.666_2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -176,7 +173,6 @@
         <dependency>
             <groupId>com.dotcms.lib</groupId>
             <artifactId>dot.commons-pool</artifactId>
-            <version>1.5.4_2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -210,7 +206,6 @@
         <dependency>
             <groupId>com.dotcms.lib</groupId>
             <artifactId>dot.gif89</artifactId>
-            <version>ukv_2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -224,7 +219,6 @@
         <dependency>
             <groupId>com.dotcms.lib</groupId>
             <artifactId>dot.hibernate</artifactId>
-            <version>2.1.7_3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -238,7 +232,6 @@
         <dependency>
             <groupId>com.dotcms.lib</groupId>
             <artifactId>dot.httpclient</artifactId>
-            <version>4.2.2_2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -430,7 +423,6 @@
         <dependency>
             <groupId>com.dotcms.lib</groupId>
             <artifactId>dot.quartz-all</artifactId>
-            <version>1.8.6_2</version>
             <scope>compile</scope>
         </dependency>
 
@@ -1078,7 +1070,6 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.http.api</artifactId>
-            <version>3.0.0</version>
             <scope>compile</scope>
         </dependency>
 
@@ -1258,17 +1249,6 @@
             <artifactId>value</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <!--
-
-        Are we using this?
-        <dependency>
-             <groupId>org.openjdk.jmh</groupId>
-             <artifactId>jmh-core</artifactId>
-             <version>0.1</version>
-             <scope>compile</scope>
-         </dependency>-->
-
 
         <dependency>
             <!-- Helps to load native libraries from JAR files -->
@@ -1519,14 +1499,6 @@
                                     <groupId>com.dotcms</groupId>
                                     <artifactId>tomcat-redis-session-manager</artifactId>
                                     <version>${tomcat.redis-session-manager.version}</version>
-                                    <type>jar</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${tomcat-lib-folder}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.tomcat</groupId>
-                                    <artifactId>tomcat-catalina</artifactId>
-                                    <version>${tomcat.catalina.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${tomcat-lib-folder}</outputDirectory>

--- a/dotcms-integration/pom.xml
+++ b/dotcms-integration/pom.xml
@@ -30,7 +30,6 @@
         <clean.docker.volumes>true</clean.docker.volumes>
 
         <!-- Tomcat -->
-        <tomcat.version>9.0.53</tomcat.version>
         <enableDebug>true</enableDebug>
         <debugPort>8000</debugPort>
         <debugHost>localhost</debugHost>
@@ -124,25 +123,21 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>javax.servlet.jsp-api</artifactId>
-            <version>2.2.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper</artifactId>
-            <version>9.0.73</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.5.1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -154,13 +149,11 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>7.4.1.jre8</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -173,25 +166,21 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.tngtech.junit.dataprovider</groupId>
             <artifactId>junit4-dataprovider</artifactId>
-            <version>2.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -264,7 +253,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${version.compiler.plugin}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/dotcms-postman/pom.xml
+++ b/dotcms-postman/pom.xml
@@ -13,7 +13,6 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <tomcat.version>9.0.85</tomcat.version>
         <db.port>5432</db.port>
         <es.port>9200</es.port>
         <tomcat.port>8080</tomcat.port>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -9,6 +9,7 @@
     <packaging>pom</packaging>
     <description>DotCMS</description>
     <properties>
+        <tomcat.version>9.0.85</tomcat.version>
         <dependency-check-maven.version>8.3.1</dependency-check-maven.version>
         <surefire-report-maven.version>3.1.0</surefire-report-maven.version>
         <project-info-reports.version>3.4.5</project-info-reports.version>


### PR DESCRIPTION
Conflicting versions of tomcat jars were being installed and there were multiple sources of the correct version to use.   This PR cleans up some versions specified in pom.xml that should not be defined locally but rely on version in the bom/application/pom.xml pulled into the dependencyManagement section as well as specify tomcat.version in the top lavel parent/pom.xml so it can be used throughout consistently 