### PR TITLE
ci(github): fix cleanup processing after checkout

### DIFF
--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -47,14 +47,14 @@ jobs:
         with:
           token: ${{ secrets.CI_MACHINE_TOKEN }}
 
-      - uses: ./.github/actions/cleanup-runner
+
 
       - name: 'Setup Java'
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
-
+      - uses: ./.github/actions/cleanup-runner
       - name: 'Get Date'
         id: get-date
         run: |

--- a/.github/workflows/docker-build-dev-image.yml
+++ b/.github/workflows/docker-build-dev-image.yml
@@ -11,8 +11,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Cleanup
-        uses: ./.github/actions/cleanup-runner
       -
         name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/maven-build-docker-image.yml
+++ b/.github/workflows/maven-build-docker-image.yml
@@ -69,8 +69,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: ./.github/actions/cleanup-runner
-
       - name: Cleanup
         uses: ./.github/actions/cleanup-runner
 


### PR DESCRIPTION
A runner cleanup script was added but in some places it was put before the checkout step.  As the action is in the checked out code it needs to go after. 