### PR TITLE
ci: add codesee workflow

### DIFF
--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+name: CodeSee
+
+permissions: read-all
+
+jobs:
+  codesee:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    name: Analyse the repo with CodeSee
+    steps:
+      - uses: Codesee-io/codesee-action@v2
+        with:
+          codesee-token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}


### PR DESCRIPTION
### Proposed Changes
Previously we tried adding Codesee https://www.codesee.io/ to help analyze and visualize our code, it did not work well while gradle was still in the system and got confused about which dependencies and the project structure to use.   Adding this to see if it works any better now we have maven. 

This will not effect the application running or build and we will not see the analysis until this is deployed on the master branch.   