### PR TITLE
fix(CLI): #27679 fix cli release generation from master branch

### DIFF
--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -315,18 +315,6 @@ jobs:
         run: |
           tools/dotcms-cli/mvnw -B -Prelease jreleaser:full-release -DartifactsDir=artifacts -Djreleaser.git.root.search=true -pl :dotcms-cli-parent -Dmaven.plugin.validation=VERBOSE
 
-      - name: 'Setup git config'
-        run: |
-          git config user.name "${{ secrets.CI_MACHINE_USER }}"
-          git config user.email "dotCMS-Machine-User@dotcms.com"
-
-      - name: 'Tag release version in ${{ github.ref }}'
-        if: ${{ !contains(github.event.inputs.version, 'SNAPSHOT') }}
-        run: |
-          git checkout ${{ needs.precheck.outputs.HEAD }}
-          git tag -a "dotcms-cli${{ needs.precheck.outputs.RELEASE_VERSION }}" -m "Release dotCLI version ${{ needs.precheck.outputs.RELEASE_VERSION }}"
-          git push origin "dotcms-cli${{ needs.precheck.outputs.RELEASE_VERSION }}"
-
   publish-npm-package:
     name: "Publish NPM Package"
     if: success()  # Run only if explicitly indicated and successful

--- a/tools/dotcms-cli/jreleaser.yml
+++ b/tools/dotcms-cli/jreleaser.yml
@@ -20,12 +20,12 @@ project:
 
   snapshot:
     pattern: .*-SNAPSHOT
-    label: 'dotcms-cli{{projectVersion}}'
+    label: 'dotcms-cli-{{projectVersion}}'
     fullChangelog: true
 
 release:
   github:
-    tagName: 'dotcms-cli{{projectVersion}}'
+    tagName: 'dotcms-cli-{{projectVersion}}'
     releaseName: 'dotcms-cli - {{projectVersion}}'
     overwrite: false
     changelog:


### PR DESCRIPTION
### Proposed Changes
* Removing unnecessary tagging after creating release through `JReleaser` tool.
* Renaming tags to make it `CLI release` tag more readable.

### Fixes
#27679 