### PR TITLE
feat(apps): support dotCMS App parameters overriding through environment variables

### DIFF
--- a/.github/workflows/maven-cicd-pipeline.yml
+++ b/.github/workflows/maven-cicd-pipeline.yml
@@ -354,7 +354,7 @@ jobs:
           restore-keys: yarn-
       - name: Build # expect node cache to exist from
         shell: bash
-        run: eval ./mvnw -Dprod $JVM_TEST_MAVEN_OPTS $JVM_TEST_MAVEN_OPTS -pl :dotcms-core-web test
+        run: eval ./mvnw -Dprod $JVM_TEST_MAVEN_OPTS -pl :dotcms-core-web test
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.spec.ts
@@ -27,7 +27,8 @@ const secrets = [
         label: 'Name:',
         required: true,
         type: 'STRING',
-        value: 'test'
+        value: 'test',
+        editable: true
     },
     {
         dynamic: false,
@@ -37,7 +38,8 @@ const secrets = [
         label: 'Password:',
         required: true,
         type: 'STRING',
-        value: '****'
+        value: '****',
+        editable: true
     },
     {
         dynamic: false,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.spec.ts
@@ -28,7 +28,9 @@ const secrets = [
         required: true,
         type: 'STRING',
         value: 'test',
-        editable: true
+        hasEnvVar: false,
+        envShow: true,
+        hasEnvVarValue: false
     },
     {
         dynamic: false,
@@ -39,7 +41,9 @@ const secrets = [
         required: true,
         type: 'STRING',
         value: '****',
-        editable: true
+        hasEnvVar: false,
+        envShow: true,
+        hasEnvVarValue: false
     },
     {
         dynamic: false,
@@ -49,7 +53,10 @@ const secrets = [
         label: 'Enabled:',
         required: false,
         type: 'BOOL',
-        value: 'true'
+        value: 'true',
+        hasEnvVar: false,
+        envShow: true,
+        hasEnvVarValue: false
     },
     {
         dynamic: false,
@@ -69,7 +76,10 @@ const secrets = [
         ],
         required: true,
         type: 'SELECT',
-        value: '1'
+        value: '1',
+        hasEnvVar: false,
+        envShow: true,
+        hasEnvVarValue: false
     },
     {
         dynamic: false,
@@ -79,7 +89,10 @@ const secrets = [
         label: 'Integration:',
         required: false,
         type: 'BUTTON',
-        value: 'urlLink'
+        value: 'urlLink',
+        hasEnvVar: false,
+        envShow: true,
+        hasEnvVarValue: false
     }
 ];
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.ts
@@ -10,17 +10,14 @@ import {
 } from '@angular/core';
 import { NgForm, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 
-import { DotAppsSecret } from '@dotcms/dotcms-models';
 import { DotMessageService } from '@dotcms/data-access';
+import { DotAppsSecret } from '@dotcms/dotcms-models';
 
-const getFieldValueFn = {
-    BOOL: (field: DotAppsSecret) => {
-        return field.value ? JSON.parse(field.value) : field.value;
-    },
-    SELECT: (field: DotAppsSecret) => {
-        return field.value === '' ? field.options[0].value : field.value;
-    }
-};
+enum FieldStatus {
+    EDITABLE,
+    DISABLED,
+    DISABLED_WITH_MESSAGE
+}
 
 @Component({
     selector: 'dot-apps-configuration-detail-form',
@@ -43,16 +40,13 @@ export class DotAppsConfigurationDetailFormComponent implements OnInit, AfterVie
         const group = {};
 
         this.formFields.forEach((field: DotAppsSecret) => {
-            const fieldValue = !!field.editable
-                ? field.value
-                : this.dotMessageService.get('apps.param.set.from.env');
+            const status = this.resolveFieldStatus(field);
             group[field.name] = new UntypedFormControl(
-                field.type === 'STRING'
-                    ? { value: fieldValue, disabled: !field.editable }
-                    : fieldValue,
-                field.required && !!field.editable ? Validators.required : null
+                this.getFieldValue(field, status),
+                field.required && status === FieldStatus.EDITABLE ? Validators.required : null
             );
         });
+
         this.myFormGroup = new UntypedFormGroup(group);
 
         this.myFormGroup.valueChanges.subscribe(() => {
@@ -76,12 +70,43 @@ export class DotAppsConfigurationDetailFormComponent implements OnInit, AfterVie
         window.open(url, '_blank');
     }
 
-    private getFieldValue(field: DotAppsSecret): string | boolean {
-        return getFieldValueFn[field.type] ? getFieldValueFn[field.type](field) : field.value;
+    private getFieldValueFn = {
+        BOOL: (field: DotAppsSecret) => {
+            return field.value ? JSON.parse(field.value) : field.value;
+        },
+        SELECT: (field: DotAppsSecret) => {
+            return field.value === '' ? field.options[0].value : field.value;
+        },
+        STRING: (field: DotAppsSecret, status: FieldStatus) => {
+            const fieldValue =
+                status === FieldStatus.DISABLED_WITH_MESSAGE
+                    ? this.dotMessageService.get('apps.param.set.from.env')
+                    : field.value;
+
+            return {
+                value: fieldValue,
+                disabled:
+                    status === FieldStatus.DISABLED || status === FieldStatus.DISABLED_WITH_MESSAGE
+            };
+        }
+    };
+
+    private getFieldValue(field: DotAppsSecret, status: FieldStatus): string | boolean {
+        return this.getFieldValueFn[field.type]
+            ? this.getFieldValueFn[field.type](field, status)
+            : field.value;
     }
 
     private emitValues(): void {
         this.data.emit(this.myFormGroup.value);
         this.valid.emit(this.myFormGroup.status === 'VALID');
+    }
+
+    private resolveFieldStatus(field: DotAppsSecret): FieldStatus {
+        if ((!field.hasEnvVar && !field.value) || !field.hasEnvVarValue) {
+            return FieldStatus.EDITABLE;
+        }
+
+        return field.envShow ? FieldStatus.DISABLED : FieldStatus.DISABLED_WITH_MESSAGE;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.ts
@@ -11,6 +11,7 @@ import {
 import { NgForm, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 
 import { DotAppsSecret } from '@dotcms/dotcms-models';
+import { DotMessageService } from '@dotcms/data-access';
 
 const getFieldValueFn = {
     BOOL: (field: DotAppsSecret) => {
@@ -36,12 +37,20 @@ export class DotAppsConfigurationDetailFormComponent implements OnInit, AfterVie
     @Output() valid = new EventEmitter<boolean>();
     myFormGroup: UntypedFormGroup;
 
+    constructor(private dotMessageService: DotMessageService) {}
+
     ngOnInit() {
         const group = {};
+
         this.formFields.forEach((field: DotAppsSecret) => {
+            const fieldValue = !!field.editable
+                ? field.value
+                : this.dotMessageService.get('apps.param.set.from.env');
             group[field.name] = new UntypedFormControl(
-                this.getFieldValue(field),
-                field.required ? Validators.required : null
+                field.type === 'STRING'
+                    ? { value: fieldValue, disabled: !field.editable }
+                    : fieldValue,
+                field.required && !!field.editable ? Validators.required : null
             );
         });
         this.myFormGroup = new UntypedFormGroup(group);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.module.ts
@@ -11,7 +11,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { InputTextareaModule } from 'primeng/inputtextarea';
 import { TooltipModule } from 'primeng/tooltip';
 
-import {DotIconModule, DotFieldRequiredDirective, DotMessagePipe} from '@dotcms/ui';
+import { DotIconModule, DotFieldRequiredDirective, DotMessagePipe } from '@dotcms/ui';
 
 import { DotAppsConfigurationDetailFormComponent } from './dot-apps-configuration-detail-form.component';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.module.ts
@@ -11,7 +11,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { InputTextareaModule } from 'primeng/inputtextarea';
 import { TooltipModule } from 'primeng/tooltip';
 
-import { DotIconModule, DotFieldRequiredDirective } from '@dotcms/ui';
+import {DotIconModule, DotFieldRequiredDirective, DotMessagePipe} from '@dotcms/ui';
 
 import { DotAppsConfigurationDetailFormComponent } from './dot-apps-configuration-detail-form.component';
 
@@ -27,7 +27,8 @@ import { DotAppsConfigurationDetailFormComponent } from './dot-apps-configuratio
         ReactiveFormsModule,
         TooltipModule,
         MarkdownModule.forChild(),
-        DotFieldRequiredDirective
+        DotFieldRequiredDirective,
+        DotMessagePipe
     ],
     declarations: [DotAppsConfigurationDetailFormComponent],
     exports: [DotAppsConfigurationDetailFormComponent],

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.spec.ts
@@ -49,7 +49,9 @@ const sites = [
                 required: true,
                 type: 'STRING',
                 value: 'John',
-                editable: true
+                hasEnvVar: false,
+                envShow: true,
+                hasEnvVarValue: false
             },
             {
                 dynamic: false,
@@ -60,7 +62,9 @@ const sites = [
                 required: true,
                 type: 'STRING',
                 value: '****',
-                editable: true
+                hasEnvVar: false,
+                envShow: true,
+                hasEnvVarValue: false
             },
             {
                 dynamic: false,
@@ -70,7 +74,10 @@ const sites = [
                 label: 'Enabled:',
                 required: false,
                 type: 'BOOL',
-                value: 'true'
+                value: 'true',
+                hasEnvVar: false,
+                envShow: true,
+                hasEnvVarValue: false
             }
         ]
     }
@@ -309,7 +316,9 @@ describe('DotAppsConfigurationDetailComponent', () => {
                     required: false,
                     type: 'STRING',
                     value: 'test',
-                    editable: true
+                    hasEnvVar: false,
+                    envShow: true,
+                    hasEnvVarValue: false
                 }
             ];
             const mockRoute = { data: {} };

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.spec.ts
@@ -48,7 +48,8 @@ const sites = [
                 label: 'Name:',
                 required: true,
                 type: 'STRING',
-                value: 'John'
+                value: 'John',
+                editable: true
             },
             {
                 dynamic: false,
@@ -58,7 +59,8 @@ const sites = [
                 label: 'Password:',
                 required: true,
                 type: 'STRING',
-                value: '****'
+                value: '****',
+                editable: true
             },
             {
                 dynamic: false,
@@ -306,7 +308,8 @@ describe('DotAppsConfigurationDetailComponent', () => {
                     label: '',
                     required: false,
                     type: 'STRING',
-                    value: 'test'
+                    value: 'test',
+                    editable: true
                 }
             ];
             const mockRoute = { data: {} };

--- a/core-web/libs/dotcms-models/src/lib/dot-apps.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-apps.model.ts
@@ -34,6 +34,7 @@ export interface DotAppsSecret {
     required: boolean;
     type: string;
     value: string;
+    editable?: boolean;
     warnings?: string[];
 }
 

--- a/core-web/libs/dotcms-models/src/lib/dot-apps.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-apps.model.ts
@@ -34,7 +34,9 @@ export interface DotAppsSecret {
     required: boolean;
     type: string;
     value: string;
-    editable?: boolean;
+    hasEnvVar: boolean;
+    hasEnvVarValue: boolean;
+    envShow: boolean;
     warnings?: string[];
 }
 

--- a/dotCMS/src/main/java/com/dotcms/analytics/app/AnalyticsApp.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/app/AnalyticsApp.java
@@ -83,7 +83,7 @@ public class AnalyticsApp {
                 .map(params -> params.get(AnalyticsAppProperty.ANALYTICS_KEY.getPropertyName()))
                 .orElseThrow(() -> new DotDataException("Analytics app descriptor not found"));
         final String name = AnalyticsAppProperty.ANALYTICS_KEY.getPropertyName();
-        final Optional<Secret> secret = AppsUtil.newSecret(
+        final Optional<Secret> secret = AppsUtil.paramSecret(
                 ANALYTICS_APP_KEY,
                 name,
                 analyticsKey.jsKey().toCharArray(),

--- a/dotCMS/src/main/java/com/dotcms/analytics/app/AnalyticsApp.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/app/AnalyticsApp.java
@@ -64,7 +64,7 @@ public class AnalyticsApp {
             .allMatch(StringUtils::isNotBlank);
     }
 
-    /**x`
+    /**
      * Stores the analytics key to App's secrets
      *
      * @param analyticsKey analytics key

--- a/dotCMS/src/main/java/com/dotcms/analytics/app/AnalyticsApp.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/app/AnalyticsApp.java
@@ -3,15 +3,18 @@ package com.dotcms.analytics.app;
 import com.dotcms.analytics.model.AnalyticsProperties;
 import com.dotcms.analytics.model.AnalyticsKey;
 import com.dotcms.analytics.model.AnalyticsAppProperty;
+import com.dotcms.security.apps.AppDescriptor;
 import com.dotcms.security.apps.AppSecrets;
 import com.dotcms.security.apps.AppsAPI;
+import com.dotcms.security.apps.AppsUtil;
+import com.dotcms.security.apps.ParamDescriptor;
 import com.dotcms.security.apps.Secret;
-import com.dotcms.security.apps.Type;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.Logger;
+import com.liferay.portal.model.User;
 import io.vavr.Tuple2;
 import io.vavr.control.Try;
 import org.apache.commons.lang3.StringUtils;
@@ -61,7 +64,7 @@ public class AnalyticsApp {
             .allMatch(StringUtils::isNotBlank);
     }
 
-    /**
+    /**x`
      * Stores the analytics key to App's secrets
      *
      * @param analyticsKey analytics key
@@ -73,13 +76,24 @@ public class AnalyticsApp {
             return;
         }
 
+        final User user = APILocator.systemUser();
+        final Optional<AppDescriptor> appDescriptor =
+                APILocator.getAppsAPI().getAppDescriptor(ANALYTICS_APP_KEY, user);
+        final ParamDescriptor paramDescriptor = appDescriptor.map(AppDescriptor::getParams)
+                .map(params -> params.get(AnalyticsAppProperty.ANALYTICS_KEY.getPropertyName()))
+                .orElseThrow(() -> new DotDataException("Analytics app descriptor not found"));
+        final String name = AnalyticsAppProperty.ANALYTICS_KEY.getPropertyName();
+        final Optional<Secret> secret = AppsUtil.newSecret(
+                ANALYTICS_APP_KEY,
+                name,
+                analyticsKey.jsKey().toCharArray(),
+                paramDescriptor);
+
         APILocator.getAppsAPI().saveSecret(
             ANALYTICS_APP_KEY,
-            new Tuple2<>(
-                AnalyticsAppProperty.ANALYTICS_KEY.getPropertyName(),
-                Secret.newSecret(analyticsKey.jsKey().toCharArray(), Type.STRING, false)),
+            new Tuple2<>(name, secret.orElseThrow(() -> new DotDataException("Secret not found"))),
             host,
-            APILocator.systemUser());
+            user);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/AppsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/AppsResource.java
@@ -258,7 +258,7 @@ public class AppsResource {
                             .init();
             final User user = initData.getUser();
             helper.saveSecretForm(key, siteId, secretForm, user);
-            return Response.ok(new ResponseEntityView(OK)).build(); // 200
+            return Response.ok(new ResponseEntityView<>(OK)).build(); // 200
         } catch (Exception e) {
             //By doing this mapping here. The resource becomes integration test friendly.
             Logger.error(this.getClass(),

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/AppsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/AppsResource.java
@@ -168,7 +168,7 @@ public class AppsResource {
             final Optional<AppView> appSiteDetailedView = helper
                         .getAppSiteDetailedView(key, siteId, user);
             if (appSiteDetailedView.isPresent()) {
-                return Response.ok(new ResponseEntityView(appSiteDetailedView.get()))
+                return Response.ok(new ResponseEntityView<>(appSiteDetailedView.get()))
                 .build(); // 200
             }
             throw new DoesNotExistException(String.format(

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/view/SecretView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/view/SecretView.java
@@ -129,29 +129,28 @@ public class SecretView {
             map.put("hidden", property.isHidden());
             if (type.equals(Type.BOOL)) {
                 map.put("value", property.getBoolean());
-            } else {
-                if (type.equals(Type.SELECT)) {
-                    if (property instanceof Secret) {
-                        map.put("value", property.getValue());
-                    } else {
-                        final List<Map> list = property.getList();
-                        map.put("options", list);
-                        final Optional<Map> selectedOptional = list.stream()
-                                .filter(m -> m.containsKey("selected")).findFirst();
-                        if (selectedOptional.isPresent()) {
-                            final Map selected = selectedOptional.get();
-                            selected.remove("selected");
-                            map.put("value", selected.get("value"));
-                        } else {
-                            map.put("value", BLANK);
-                        }
-                    }
+            } else if (type.equals(Type.SELECT)) {
+                if (property instanceof Secret) {
+                    map.put("value", property.getValue());
                 } else {
-                    final String value = property.getString();
-                    map.put("value",
-                            property.isHidden() && UtilMethods.isSet(value) ? HIDDEN_SECRET_MASK
-                                    : value);
+                    final List<Map> list = property.getList();
+                    map.put("options", list);
+                    final Optional<Map> selectedOptional = list.stream()
+                            .filter(m -> m.containsKey("selected")).findFirst();
+                    if (selectedOptional.isPresent()) {
+                        final Map selected = selectedOptional.get();
+                        selected.remove("selected");
+                        map.put("value", selected.get("value"));
+                    } else {
+                        map.put("value", BLANK);
+                    }
                 }
+            } else {
+                final String value = property.getString();
+                map.put("value",
+                        property.isHidden() && UtilMethods.isSet(value) ? HIDDEN_SECRET_MASK
+                                : value);
+                map.put("editable", property.isEditable());
             }
         }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/view/SecretView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/view/SecretView.java
@@ -119,7 +119,6 @@ public class SecretView {
             ViewUtil.pushSecret(map);
             final String json = mapper.writeValueAsString(map);
             jsonGenerator.writeRawValue(json);
-
         }
 
         private void buildCommonJson(final AbstractProperty property,
@@ -127,30 +126,32 @@ public class SecretView {
             final Type type = property.getType();
             map.put("type", type);
             map.put("hidden", property.isHidden());
+            map.put("hasEnvVar", property.hasEnvVar());
+            map.put("envShow", property.isEnvShow());
+            map.put("hasEnvVarValue", property.hasEnvVarValue());
             if (type.equals(Type.BOOL)) {
                 map.put("value", property.getBoolean());
-            } else if (type.equals(Type.SELECT)) {
-                if (property instanceof Secret) {
-                    map.put("value", property.getValue());
-                } else {
-                    final List<Map> list = property.getList();
-                    map.put("options", list);
-                    final Optional<Map> selectedOptional = list.stream()
-                            .filter(m -> m.containsKey("selected")).findFirst();
-                    if (selectedOptional.isPresent()) {
-                        final Map selected = selectedOptional.get();
-                        selected.remove("selected");
-                        map.put("value", selected.get("value"));
-                    } else {
-                        map.put("value", BLANK);
-                    }
-                }
             } else {
-                final String value = property.getString();
-                map.put("value",
-                        property.isHidden() && UtilMethods.isSet(value) ? HIDDEN_SECRET_MASK
-                                : value);
-                map.put("editable", property.isEditable());
+                if (type.equals(Type.SELECT)) {
+                    if (property instanceof Secret) {
+                        map.put("value", property.getValue());
+                    } else {
+                        final List<Map> list = property.getList();
+                        map.put("options", list);
+                        final Optional<Map> selectedOptional = list.stream()
+                                .filter(m -> m.containsKey("selected")).findFirst();
+                        if (selectedOptional.isPresent()) {
+                            final Map selected = selectedOptional.get();
+                            selected.remove("selected");
+                            map.put("value", selected.get("value"));
+                        } else {
+                            map.put("value", BLANK);
+                        }
+                    }
+                } else {
+                    final String value = property.getString();
+                    map.put("value", property.isHidden() && UtilMethods.isSet(value) ? HIDDEN_SECRET_MASK : value);
+                }
             }
         }
 

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AbstractProperty.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AbstractProperty.java
@@ -3,6 +3,7 @@ package com.dotcms.security.apps;
 import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import java.util.Optional;
  * This is a super class that serves as the base form both Params and Secrets.
  * @param <T>
  */
+
 public abstract class AbstractProperty<T> implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -22,9 +24,12 @@ public abstract class AbstractProperty<T> implements Serializable {
     protected final T value;
     protected final Boolean hidden;
     protected final Type type;
+    @JsonProperty("envvar")
     protected final String envVar;
+    @JsonProperty("envshow")
     protected final Boolean envShow;
-    protected char[] envValue;
+    @JsonIgnore
+    protected char[] envVarValue;
 
     public AbstractProperty(final T value,
                             final Boolean hidden,
@@ -35,11 +40,7 @@ public abstract class AbstractProperty<T> implements Serializable {
         this.hidden = hidden;
         this.type = type;
         this.envVar = envVar;
-        if (UtilMethods.isSet(this.envVar)) {
-            this.envShow = Optional.ofNullable(envShow).orElse(true);
-        } else {
-            this.envShow = null;
-        }
+        this.envShow = Optional.ofNullable(envShow).orElse(true);
     }
 
     public T getValue() {
@@ -70,36 +71,34 @@ public abstract class AbstractProperty<T> implements Serializable {
         return UtilMethods.isSet(envShow) ? envShow : true;
     }
 
-    public char[] getEnvValue() {
-        return envValue;
+    public char[] getEnvVarValue() {
+        return envVarValue;
     }
 
-    public void setEnvValue(char[] envValue) {
-        this.envValue = envValue;
+    public void setEnvVarValue(char[] envVarValue) {
+        this.envVarValue = envVarValue;
     }
 
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonIgnore
     public boolean isEditable() {
-        return isEnvShow();
+        return !(hasEnvVar() || hasEnvVarValue()) && StringUtils.isNotBlank(String.valueOf(value));
     }
 
     @JsonIgnore
     public String getString() {
-        if (isEnvValueSet()) {
-            return String.valueOf(envValue);
+        if (hasEnvVarValue()) {
+            return String.valueOf(envVarValue);
         }
 
         return value instanceof char[] ? String.valueOf((char[]) value) : String.valueOf(value);
     }
 
-    @JsonIgnore
-    public boolean isEnvVarSet() {
-        return UtilMethods.isSet(envVar);
+    public boolean hasEnvVar() {
+        return StringUtils.isNotBlank(envVar);
     }
 
-    @JsonIgnore
-    public boolean isEnvValueSet() {
-        return Objects.nonNull(envValue);
+    public boolean hasEnvVarValue() {
+        return Objects.nonNull(envVarValue);
     }
 
     @JsonIgnore
@@ -131,4 +130,5 @@ public abstract class AbstractProperty<T> implements Serializable {
     public int hashCode() {
         return Objects.hash(value, hidden, type);
     }
+
 }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppSchema.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppSchema.java
@@ -23,7 +23,9 @@ import java.util.Objects;
  *   type: "STRING"
  *   label: "label"
  *   hint: "hint"
- *  required: false
+ *   required: false
+ *   envvar: "some value set via environment variable"
+ *   envshow: true
  *
  */
 public class AppSchema implements Serializable{
@@ -111,9 +113,16 @@ public class AppSchema implements Serializable{
         return new LinkedHashMap<>(params);
     }
 
-    public void addParam(final String name, final Object value, final boolean hidden,
-            final Type type, final String label, final String hint, final boolean required) {
-        params.put(name, ParamDescriptor.newParam(value, hidden, type, label, hint, required));
+    public void addParam(final String name,
+                         final Object value,
+                         final boolean hidden,
+                         final Type type,
+                         final String envVar,
+                         final boolean envShow,
+                         final String label,
+                         final String hint,
+                         final boolean required) {
+        params.put(name, ParamDescriptor.newParam(value, hidden, type, envVar, envShow, label, hint, required));
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppSchema.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppSchema.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  *   envshow: true
  *
  */
-public class AppSchema implements Serializable{
+public class AppSchema implements Serializable {
 
     protected final String name;
 
@@ -111,18 +111,6 @@ public class AppSchema implements Serializable{
      */
     public Map<String, ParamDescriptor> getParams() {
         return new LinkedHashMap<>(params);
-    }
-
-    public void addParam(final String name,
-                         final Object value,
-                         final boolean hidden,
-                         final Type type,
-                         final String envVar,
-                         final boolean envShow,
-                         final String label,
-                         final String hint,
-                         final boolean required) {
-        params.put(name, ParamDescriptor.newParam(value, hidden, type, envVar, envShow, label, hint, required));
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppSecrets.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppSecrets.java
@@ -51,6 +51,10 @@ public class AppSecrets implements Serializable {
         return key.equals(that.key) && this.secrets.equals(that.secrets); //areEqual(this.secrets, that.secrets);
     }
 
+    public static Builder builder(){
+        return new Builder();
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(key, secrets);
@@ -70,37 +74,37 @@ public class AppSecrets implements Serializable {
             return this;
         }
 
-        public Builder withHiddenSecret(final String name, final String value) {
-            secretMap.put(
-                    name, Secret.newSecret(value.toCharArray(), true, Type.STRING)
-            );
+        public Builder withSecret(final String name, final Secret secret) {
+            secretMap.put(name, secret);
             return this;
+        }
+
+        public Builder withHiddenSecret(final String name, final String value) {
+            return withSecret(
+                    name,
+                    Secret.builder()
+                            .withValue(value)
+                            .withHidden(true)
+                            .withType(Type.STRING)
+                            .build());
         }
 
         public Builder withHiddenSecret(final String name, final boolean value){
-            secretMap.put(
-                    name, Secret.newSecret(String.valueOf(value).toCharArray(), true, Type.BOOL)
-            );
-            return this;
+            return withHiddenSecret(name, String.valueOf(value));
         }
 
         public Builder withSecret(final String name, final String value){
-            secretMap.put(
-                    name, Secret.newSecret(value.toCharArray(), false, Type.STRING)
-            );
-            return this;
+            return withSecret(
+                    name,
+                    Secret.builder()
+                            .withValue(value)
+                            .withHidden(false)
+                            .withType(Type.STRING)
+                            .build());
         }
 
-        public Builder withSecret(final String name, final boolean value){
-            secretMap.put(
-                    name, Secret.newSecret(String.valueOf(value).toCharArray(), false, Type.STRING)
-            );
-            return this;
-        }
-
-        public Builder withSecret(final String name, final Secret secret){
-            secretMap.put(name, secret);
-            return this;
+        public Builder withSecret(final String name, final boolean value) {
+            return withSecret(name, String.valueOf(value));
         }
 
     }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppSecrets.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppSecrets.java
@@ -72,28 +72,28 @@ public class AppSecrets implements Serializable {
 
         public Builder withHiddenSecret(final String name, final String value) {
             secretMap.put(
-                    name, Secret.newSecret(value.toCharArray(), Type.STRING, true)
+                    name, Secret.newSecret(value.toCharArray(), true, Type.STRING)
             );
             return this;
         }
 
         public Builder withHiddenSecret(final String name, final boolean value){
             secretMap.put(
-                    name, Secret.newSecret(String.valueOf(value).toCharArray(), Type.BOOL, true)
+                    name, Secret.newSecret(String.valueOf(value).toCharArray(), true, Type.BOOL)
             );
             return this;
         }
 
         public Builder withSecret(final String name, final String value){
             secretMap.put(
-                    name, Secret.newSecret(value.toCharArray(), Type.STRING, false)
+                    name, Secret.newSecret(value.toCharArray(), false, Type.STRING)
             );
             return this;
         }
 
         public Builder withSecret(final String name, final boolean value){
             secretMap.put(
-                    name, Secret.newSecret(String.valueOf(value).toCharArray(), Type.STRING, false)
+                    name, Secret.newSecret(String.valueOf(value).toCharArray(), false, Type.STRING)
             );
             return this;
         }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -19,21 +19,18 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.LayoutAPI;
-import com.dotmarketing.common.model.ContentletSearch;
 import com.dotmarketing.exception.AlreadyExistException;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.exception.InvalidLicenseException;
-import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
-import com.google.common.collect.ImmutableSet;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.Tuple2;
@@ -66,24 +63,20 @@ public class AppsAPIImpl implements AppsAPI {
 
     private final LayoutAPI layoutAPI;
     private final HostAPI hostAPI;
-    private final ContentletAPI contentletAPI;
     private final SecretsStore secretsStore;
     private final AppsCache appsCache;
     private final LocalSystemEventsAPI localSystemEventsAPI;
-
     private final LicenseValiditySupplier licenseValiditySupplier;
     private final AppDescriptorHelper appDescriptorHelper;
 
     @VisibleForTesting
     public AppsAPIImpl(final LayoutAPI layoutAPI, final HostAPI hostAPI,
-            final ContentletAPI contentletAPI,
             final SecretsStore secretsRepository, final AppsCache appsCache,
             final LocalSystemEventsAPI localSystemEventsAPI,
             final AppDescriptorHelper appDescriptorHelper,
             final LicenseValiditySupplier licenseValiditySupplier) {
         this.layoutAPI = layoutAPI;
         this.hostAPI = hostAPI;
-        this.contentletAPI = contentletAPI;
         this.secretsStore = secretsRepository;
         this.appsCache = appsCache;
         this.localSystemEventsAPI = localSystemEventsAPI;
@@ -95,12 +88,14 @@ public class AppsAPIImpl implements AppsAPI {
      * default constructor
      */
     public AppsAPIImpl() {
-        this(APILocator.getLayoutAPI(), APILocator.getHostAPI(),
-                APILocator.getContentletAPI(), SecretsStore.INSTANCE.get(),
-                CacheLocator.getAppsCache(), APILocator.getLocalSystemEventsAPI(),
+        this(
+                APILocator.getLayoutAPI(),
+                APILocator.getHostAPI(),
+                SecretsStore.INSTANCE.get(),
+                CacheLocator.getAppsCache(),
+                APILocator.getLocalSystemEventsAPI(),
                 new AppDescriptorHelper(),
-                new LicenseValiditySupplier() {
-                });
+                new LicenseValiditySupplier() {});
     }
 
     private boolean userDoesNotHaveAccess(final User user) throws DotDataException {
@@ -832,7 +827,7 @@ public class AppsAPIImpl implements AppsAPI {
                                     appSecrets.getKey(), failSilentlyMessage));
                 }
                 try {
-                    validateForSave(mapForValidation(appSecrets), appDescriptor.get());
+                    validateForSave(mapForValidation(appSecrets), appDescriptor.get(), Optional.empty());
                 } catch (IllegalArgumentException ae) {
                     if (failSilently) {
                         Logger.warn(AppsAPIImpl.class, () -> String

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -454,22 +454,22 @@ public class AppsAPIImpl implements AppsAPI {
         }
         Logger.debug(AppsAPIImpl.class, () -> " ymlFiles are set under:  " + ymlFilesPath);
 
-            final AppSchema appSchema = appDescriptorHelper.readAppFile(file.toPath());
-            // Now validate the incoming file.. see if we're rewriting an existing file or attempting to re-use an already in use service-key.
-            if (appDescriptorHelper.validateAppDescriptor(appSchema)) {
-                final File incomingFile = new File(basePath, file.getName());
-                if (incomingFile.exists()) {
-                    throw new AlreadyExistException(
-                            String.format(
-                                    "Invalid attempt to override an existing file named '%s'.",
-                                    incomingFile.getName()));
-                }
-
-                appDescriptorHelper.writeAppFile(incomingFile, appSchema);
-
-                invalidateCache();
+        final AppSchema appSchema = appDescriptorHelper.readAppFile(file.toPath());
+        // Now validate the incoming file.. see if we're rewriting an existing file or attempting to re-use an already in use service-key.
+        if (appDescriptorHelper.validateAppDescriptor(appSchema)) {
+            final File incomingFile = new File(basePath, file.getName());
+            if (incomingFile.exists()) {
+                throw new AlreadyExistException(
+                        String.format(
+                                "Invalid attempt to override an existing file named '%s'.",
+                                incomingFile.getName()));
             }
-            return new AppDescriptorImpl(file.getName(), false, appSchema);
+
+            appDescriptorHelper.writeAppFile(incomingFile, appSchema);
+
+            invalidateCache();
+        }
+        return new AppDescriptorImpl(file.getName(), false, appSchema);
 
     }
 

--- a/dotCMS/src/main/java/com/dotcms/security/apps/ParamDescriptor.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/ParamDescriptor.java
@@ -4,6 +4,9 @@ import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+import java.util.Optional;
+
 /**
  * This is an implementation of a Parameter
  * Class used to collect properties or secrets set from the front-end
@@ -17,17 +20,17 @@ public final class ParamDescriptor extends AbstractProperty<Object>{
 
     private final Boolean required;
 
-    /**
-     * Private Constructor
-     * @param value
-     * @param hidden
-     * @param type
-     * @param label
-     * @param hint
-     * @param required
-     */
-    private ParamDescriptor(final Object value, final Boolean hidden, final Type type, final String label, final String hint, final Boolean required) {
-        super(value, hidden, type);
+    private ParamDescriptor(final Object value,
+                            final Boolean hidden,
+                            final Type type,
+                            final String envVar,
+                            final Boolean envShow,
+                            final String envValue,
+                            final String label,
+                            final String hint,
+                            final Boolean required) {
+        super(value, hidden, type, envVar, envShow);
+        Optional.ofNullable(envValue).ifPresent(ev -> setEnvValue(ev.toCharArray()));
         this.label = label;
         this.hint = hint;
         this.required = required;
@@ -65,15 +68,38 @@ public final class ParamDescriptor extends AbstractProperty<Object>{
         return required;
     }
 
+    @Override
+    public boolean isHidden() {
+        return super.isHidden();
+    }
+
+    @Override
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public boolean isEditable() {
+        return isEnvShow() || !UtilMethods.isSet(String.valueOf(value));
+    }
+
     @JsonCreator
     public static ParamDescriptor newParam(
             @JsonProperty("value") final Object value,
             @JsonProperty("hidden") final Boolean hidden,
             @JsonProperty("type") final Type type,
+            @JsonProperty("envvar") final String envVar,
+            @JsonProperty("envshow") final Boolean envShow,
             @JsonProperty("label") final String label,
             @JsonProperty("hint") final String hint,
             @JsonProperty("required") final Boolean required) {
-        return new ParamDescriptor(value, hidden, type, label, hint, required);
+        return new ParamDescriptor(value, hidden, type, envVar, envShow, null, label, hint, required);
+    }
+
+    public static ParamDescriptor newParam(
+            final Object value,
+            final Boolean hidden,
+            final Type type,
+            final String label,
+            final String hint,
+            final Boolean required) {
+        return newParam(value, hidden, type, null, null, label, hint, required);
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/ParamDescriptor.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/ParamDescriptor.java
@@ -1,17 +1,18 @@
 package com.dotcms.security.apps;
 
 import com.dotmarketing.util.UtilMethods;
-import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.Objects;
-import java.util.Optional;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
  * This is an implementation of a Parameter
  * Class used to collect properties or secrets set from the front-end
  * This is mostly used to pass values from the front-end into the Resource.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(builder = ParamDescriptor.Builder.class)
 public final class ParamDescriptor extends AbstractProperty<Object>{
 
     private final String label;
@@ -25,12 +26,10 @@ public final class ParamDescriptor extends AbstractProperty<Object>{
                             final Type type,
                             final String envVar,
                             final Boolean envShow,
-                            final String envValue,
                             final String label,
                             final String hint,
                             final Boolean required) {
         super(value, hidden, type, envVar, envShow);
-        Optional.ofNullable(envValue).ifPresent(ev -> setEnvValue(ev.toCharArray()));
         this.label = label;
         this.hint = hint;
         this.required = required;
@@ -68,38 +67,75 @@ public final class ParamDescriptor extends AbstractProperty<Object>{
         return required;
     }
 
-    @Override
-    public boolean isHidden() {
-        return super.isHidden();
+    public static Builder builder() {
+        return new Builder();
     }
 
-    @Override
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    public boolean isEditable() {
-        return isEnvShow() || !UtilMethods.isSet(String.valueOf(value));
-    }
+    /**
+     * ParamDescriptor Builder class
+     */
+    @JsonPOJOBuilder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
 
-    @JsonCreator
-    public static ParamDescriptor newParam(
-            @JsonProperty("value") final Object value,
-            @JsonProperty("hidden") final Boolean hidden,
-            @JsonProperty("type") final Type type,
-            @JsonProperty("envvar") final String envVar,
-            @JsonProperty("envshow") final Boolean envShow,
-            @JsonProperty("label") final String label,
-            @JsonProperty("hint") final String hint,
-            @JsonProperty("required") final Boolean required) {
-        return new ParamDescriptor(value, hidden, type, envVar, envShow, null, label, hint, required);
-    }
+        private Object value;
+        private Boolean hidden;
+        private Type type;
+        @JsonProperty("envvar")
+        private String envVar;
+        @JsonProperty("envshow")
+        private Boolean envShow;
+        private String label;
+        private String hint;
+        private Boolean required;
 
-    public static ParamDescriptor newParam(
-            final Object value,
-            final Boolean hidden,
-            final Type type,
-            final String label,
-            final String hint,
-            final Boolean required) {
-        return newParam(value, hidden, type, null, null, label, hint, required);
+        private Builder() {
+        }
+
+        public Builder withValue(final Object value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder withHidden(final Boolean hidden) {
+            this.hidden = hidden;
+            return this;
+        }
+
+        public Builder withType(final Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withEnvVar(final String envVar) {
+            this.envVar = envVar;
+            return this;
+        }
+
+        public Builder withEnvShow(final Boolean envShow) {
+            this.envShow = envShow;
+            return this;
+        }
+
+        public Builder withLabel(final String label) {
+            this.label = label;
+            return this;
+        }
+
+        public Builder withHint(final String hint) {
+            this.hint = hint;
+            return this;
+        }
+
+        public Builder withRequired(final Boolean required) {
+            this.required = required;
+            return this;
+        }
+
+        public ParamDescriptor build() {
+            return new ParamDescriptor(value, hidden, type, envVar, envShow, label, hint, required);
+        }
+
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/Secret.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/Secret.java
@@ -1,64 +1,102 @@
 package com.dotcms.security.apps;
 
-import com.dotmarketing.util.UtilMethods;
-import com.fasterxml.jackson.annotation.JsonCreator;
+import com.dotmarketing.util.StringUtils;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
  * This is an implementation of a Secret
  * Class used to collect secrets destined to be stored into safe keeping.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(builder = Secret.Builder.class)
 public final class Secret extends AbstractProperty<char[]> {
 
     public Secret(final char[] value,
                   final Boolean hidden,
                   final Type type,
                   final String envVar,
-                  final boolean envShow,
+                  final Boolean envShow,
                   final char[] envValue) {
         super(value, hidden, type, envVar, envShow);
-        setEnvValue(envValue);
+        setEnvVarValue(envValue);
     }
 
-    /*@Override
-    public boolean isHidden() {
-        return (UtilMethods.isSet(hidden) ? hidden : false) || (!isEnvShow() && isEnvValueSet());
-    }*/
-
-    @Override
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    public boolean isEditable() {
-        return isEnvShow() || (!UtilMethods.isSet(String.valueOf(value)) && Objects.isNull(envValue));
-    }
-
-    @JsonCreator
-    public static Secret newSecret(@JsonProperty("value") final char[] value,
-                                   @JsonProperty("hidden") final boolean hidden,
-                                   @JsonProperty("type") final Type type,
-                                   @JsonProperty("envvar") final String envVar,
-                                   @JsonProperty("envshow") final boolean envShow,
-                                   @JsonProperty("envvalue") final String envValue) {
-
-        final char[] valueCopy = defensiveCopy(value);
-        final char[] envValueCopy = defensiveCopy(Optional.ofNullable(envValue).map(String::toCharArray).orElse(new char[0]));
-        return new Secret(valueCopy, hidden, type, envVar, envShow, envValueCopy);
-    }
-
-    public static Secret newSecret(final char[] value, final boolean hidden, final Type type) {
-        return newSecret(value, hidden, type, null, true, null);
-    }
-
-    public void destroy(){
+    public void destroy() {
         Arrays.fill(value, (char) 0);
-        Optional.ofNullable(envValue).ifPresent(value -> Arrays.fill(value, (char) 0));
+        Optional.ofNullable(envVarValue).ifPresent(value -> Arrays.fill(value, (char) 0));
     }
 
-    private static char[] defensiveCopy(final char[] value) {
-        return Optional.ofNullable(value).map(v -> Arrays.copyOf(v, v.length)).orElse(null);
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Secret Builder class.
+     */
+    @JsonPOJOBuilder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Builder {
+
+        private char[] value;
+        private Boolean hidden;
+        private Type type;
+        @JsonProperty("envvar")
+        private String envVar;
+        @JsonProperty("envshow")
+        private Boolean envShow;
+        private char[] envValue;
+
+        private Builder() {
+        }
+
+        public Builder withValue(final char[] value) {
+            this.value = StringUtils.defensiveCopy(value);
+            return this;
+        }
+
+        public Builder withValue(final String value) {
+            return withValue(StringUtils.toCharArray(value));
+        }
+
+        public Builder withHidden(final Boolean hidden) {
+            this.hidden = hidden;
+            return this;
+        }
+
+        public Builder withType(final Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withEnvVar(final String envVar) {
+            this.envVar = envVar;
+            return this;
+        }
+
+        public Builder withEnvShow(final Boolean envShow) {
+            this.envShow = envShow;
+            return this;
+        }
+
+        public Builder withEnvValue(final char[] envValue) {
+            this.envValue = StringUtils.defensiveCopy(envValue);
+            return this;
+        }
+
+        public Builder withEnvValue(final String envValue) {
+            return withEnvValue(StringUtils.toCharArray(envValue));
+        }
+
+        public Secret build() {
+            return new Secret(value, hidden, type, envVar, envShow, envValue);
+        }
+
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/Secret.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/Secret.java
@@ -1,8 +1,12 @@
 package com.dotcms.security.apps;
 
+import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * This is an implementation of a Secret
@@ -10,21 +14,51 @@ import java.util.Arrays;
  */
 public final class Secret extends AbstractProperty<char[]> {
 
-    private Secret(final char[] value, final Type type, final boolean hidden) {
-        super(value, hidden, type);
+    public Secret(final char[] value,
+                  final Boolean hidden,
+                  final Type type,
+                  final String envVar,
+                  final boolean envShow,
+                  final char[] envValue) {
+        super(value, hidden, type, envVar, envShow);
+        setEnvValue(envValue);
+    }
+
+    /*@Override
+    public boolean isHidden() {
+        return (UtilMethods.isSet(hidden) ? hidden : false) || (!isEnvShow() && isEnvValueSet());
+    }*/
+
+    @Override
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public boolean isEditable() {
+        return isEnvShow() || (!UtilMethods.isSet(String.valueOf(value)) && Objects.isNull(envValue));
     }
 
     @JsonCreator
     public static Secret newSecret(@JsonProperty("value") final char[] value,
+                                   @JsonProperty("hidden") final boolean hidden,
                                    @JsonProperty("type") final Type type,
-                                   @JsonProperty("hidden") final boolean hidden) {
-        
-        final char[] defensiveCopy = Arrays.copyOf(value, value.length);
-        return new Secret(defensiveCopy, type, hidden);
+                                   @JsonProperty("envvar") final String envVar,
+                                   @JsonProperty("envshow") final boolean envShow,
+                                   @JsonProperty("envvalue") final String envValue) {
+
+        final char[] valueCopy = defensiveCopy(value);
+        final char[] envValueCopy = defensiveCopy(Optional.ofNullable(envValue).map(String::toCharArray).orElse(new char[0]));
+        return new Secret(valueCopy, hidden, type, envVar, envShow, envValueCopy);
+    }
+
+    public static Secret newSecret(final char[] value, final boolean hidden, final Type type) {
+        return newSecret(value, hidden, type, null, true, null);
     }
 
     public void destroy(){
         Arrays.fill(value, (char) 0);
+        Optional.ofNullable(envValue).ifPresent(value -> Arrays.fill(value, (char) 0));
+    }
+
+    private static char[] defensiveCopy(final char[] value) {
+        return Optional.ofNullable(value).map(v -> Arrays.copyOf(v, v.length)).orElse(null);
     }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/structure/action/ViewRelationshipsAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/structure/action/ViewRelationshipsAction.java
@@ -10,16 +10,16 @@ import com.dotcms.repackage.org.apache.struts.action.ActionForm;
 import com.dotcms.repackage.org.apache.struts.action.ActionForward;
 import com.dotcms.repackage.org.apache.struts.action.ActionMapping;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.FactoryLocator;
 import com.dotmarketing.common.util.SQLUtil;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portal.struts.DotPortletAction;
 import com.dotmarketing.portlets.structure.model.Relationship;
-import com.dotmarketing.util.StringUtils;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,7 +41,7 @@ public class ViewRelationshipsAction extends DotPortletAction {
 		req.setAttribute(ASCENDING + orderBy, ascending);
 
 		structureId = (UtilMethods.isSet(structureId) ? structureId : "all");
-		orderBy = orderBy + ((StringUtils.TRUE.equalsIgnoreCase(ascending))? SQLUtil._ASC:SQLUtil._DESC);
+		orderBy = orderBy + ((StringPool.TRUE.equalsIgnoreCase(ascending))? SQLUtil._ASC:SQLUtil._DESC);
 		_loadRelationships(form, req, res, orderBy, structureId);
 
 		return mapping.findForward("portlet.ext.structure.view_relationships");

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecrets.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecrets.java
@@ -39,6 +39,7 @@ import java.security.Key;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -114,7 +115,7 @@ public class Task00050LoadAppsSecrets implements StartupTask {
                                                 .get(secrets.getKey().toLowerCase());
                                         if (null != descriptor) {
                                             try {
-                                                validateForSave(mapForValidation(secrets), descriptor);
+                                                validateForSave(mapForValidation(secrets), descriptor, Optional.empty());
                                                 final char[] chars = toJsonAsChars(secrets);
                                                 final String internalKey = internalKey(secrets.getKey(), siteId);
                                                 keyStoreHelper.saveValue(internalKey, chars);

--- a/dotCMS/src/main/java/com/dotmarketing/util/StringUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/StringUtils.java
@@ -15,19 +15,18 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class StringUtils {
 
-    public static final String TRUE = "true";
-
     private final static char COMMA = ',';
-    
+    public static final char[] BLANK_CHARS = StringPool.BLANK.toCharArray();
+
     // Pattern is threadsafe
     private static final Pattern camelCaseLowerPattern = Pattern.compile("^[a-z]([a-zA-Z0-9]+)*$");
     private static final Pattern camelCaseUpperPattern = Pattern.compile("^[A-Z]([a-zA-Z0-9]+)*$");
@@ -481,4 +480,21 @@ public class StringUtils {
         // return the result string
         return result.toString();
     }
+
+    public static char[] toCharArray(final String value) {
+        return toCharArray(value, null);
+    }
+
+    public static char[] toCharArraySafe(final String value) {
+        return toCharArray(value, BLANK_CHARS);
+    }
+
+    public static char[] defensiveCopy(final char[] value) {
+        return Optional.ofNullable(value).map(v -> Arrays.copyOf(v, v.length)).orElse(BLANK_CHARS);
+    }
+
+    private static char[] toCharArray(final String value, final char[] defaultChars) {
+        return Optional.ofNullable(value).map(String::toCharArray).orElse(defaultChars);
+    }
+
 }

--- a/dotCMS/src/main/java/com/liferay/util/StringPool.java
+++ b/dotCMS/src/main/java/com/liferay/util/StringPool.java
@@ -87,4 +87,6 @@ public class StringPool {
 
 	public static final String PIPE = "|";
 
+	public static final String TRUE = Boolean.TRUE.toString();
+
 }

--- a/dotCMS/src/main/resources/apps/dotAnalytics-config.yml
+++ b/dotCMS/src/main/resources/apps/dotAnalytics-config.yml
@@ -11,7 +11,6 @@ params:
     label: "Analytics Client ID"
     hint: "Client ID is required to resolve access token from IDP"
     required: true
-    envvar: "ANALYTICS_CLIENT_ID"
   clientSecret:
     value: ""
     hidden: true

--- a/dotCMS/src/main/resources/apps/dotAnalytics-config.yml
+++ b/dotCMS/src/main/resources/apps/dotAnalytics-config.yml
@@ -11,6 +11,7 @@ params:
     label: "Analytics Client ID"
     hint: "Client ID is required to resolve access token from IDP"
     required: true
+    envvar: "ANALYTICS_CLIENT_ID"
   clientSecret:
     value: ""
     hidden: true

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5104,6 +5104,7 @@ apps.form.dialog.success.header=App configuration saved!
 apps.form.dialog.success.message=The App configuration was saved successfully.
 apps.invalid.configurations=Invalid Configuration(s)
 apps.invalid.secrets=Invalid Secret(s)
+apps.param.set.from.env=Set from the environment
 DotAsset=DotAsset
 VersionPath=Version Path
 IdPath=Id Path

--- a/dotCMS/src/test/java/com/dotmarketing/util/StringUtilsTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/StringUtilsTest.java
@@ -1,10 +1,12 @@
 package com.dotmarketing.util;
 
-
 import static com.dotcms.content.elasticsearch.business.ESContentFactoryImpl.LUCENE_RESERVED_KEYWORDS_REGEX;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.liferay.util.StringPool;
@@ -48,11 +50,8 @@ public class StringUtilsTest {
 
     @Test
     public void testCheckNullInterpolate() {
-
-
         final Map<String, Object> params = createParams();
-        final String expression = null;
-        final String expected = StringUtils.interpolate(expression, params);
+        final String expected = StringUtils.interpolate(null, params);
 
         assertNotNull(expected);
         assertEquals(expected, StringPool.BLANK);
@@ -60,11 +59,8 @@ public class StringUtilsTest {
 
     @Test
     public void testCheckNull2Interpolate() {
-
-
-        final Map<String, Object> params = null;
         final String expression = "nothing";
-        final String expected = StringUtils.interpolate(expression, params);
+        final String expected = StringUtils.interpolate(expression, null);
 
         assertNotNull(expected);
         assertEquals(expression, expected);
@@ -72,11 +68,7 @@ public class StringUtilsTest {
 
     @Test
     public void testCheckNull3Interpolate() {
-
-
-        final Map<String, Object> params = null;
-        final String expression = null;
-        final String expected = StringUtils.interpolate(expression, params);
+        final String expected = StringUtils.interpolate(null, null);
 
         assertNotNull(expected);
         assertEquals(expected, StringPool.BLANK);
@@ -96,11 +88,8 @@ public class StringUtilsTest {
 
     @Test
     public void testDoInterpolateParamsNull() {
-
-
-        final Map<String, Object> params = null;
         final String expression = "{hostId}-mycustomname";
-        final String expected = StringUtils.interpolate(expression, params);
+        final String expected = StringUtils.interpolate(expression, null);
 
         assertNotNull(expected);
         assertEquals("{hostId}-mycustomname", expected);
@@ -192,9 +181,8 @@ public class StringUtilsTest {
 
     @Test
     public void test_Null_Sequence() {
-
         assertEquals("", StringUtils.builder().toString());
-        assertEquals("", StringUtils.builder(null).toString());
+        assertEquals("", StringUtils.builder((CharSequence) null).toString());
         assertEquals("", StringUtils.builder(null, null, null, null).toString());
     }
 
@@ -399,4 +387,39 @@ public class StringUtilsTest {
         final String output =  StringUtils.convertCamelToSnake("input_string");
         assertEquals("input_string", output);
     }
+
+    @Test
+    public void testToCharArray() {
+        // Test when input string is not null
+        final String input = "Hello";
+        final char[] expected = {'H', 'e', 'l', 'l', 'o'};
+        assertArrayEquals(expected, StringUtils.toCharArray(input));
+
+        // Test when input string is null
+        assertNull(StringUtils.toCharArray(null));
+    }
+
+    @Test
+    public void testToCharArraySafe() {
+        // Test when input string is not null
+        final String input = "Hello";
+        final char[] expected = {'H', 'e', 'l', 'l', 'o'};
+        assertArrayEquals(expected, StringUtils.toCharArraySafe(input));
+
+        // Test when input string is null
+        assertArrayEquals(StringUtils.BLANK_CHARS, StringUtils.toCharArraySafe(null));
+    }
+
+    @Test
+    public void testDefensiveCopy() {
+        // Test when input array is not null
+        final char[] input = {'a', 'b', 'c'};
+        final char[] result = StringUtils.defensiveCopy(input);
+        assertArrayEquals(input, result); // Check if the content is equal
+        assertNotSame(input, result); // Check if it's a different instance
+
+        // Test when input array is null
+        assertArrayEquals(StringUtils.BLANK_CHARS, StringUtils.defensiveCopy(null)); // Check if the content is equal
+    }
+
 }

--- a/dotcms-integration/pom.xml
+++ b/dotcms-integration/pom.xml
@@ -327,7 +327,10 @@
                             <reuseForks>true</reuseForks>
                             <rerunFailingTestsCount>3</rerunFailingTestsCount>
                             <!--<skipAfterFailureCount>2</skipAfterFailureCount>-->
-                            <environmentVariables/>
+                            <environmentVariables>
+                                <SOME_APP_ENV_VAR>overriddenValue</SOME_APP_ENV_VAR>
+                                <DOT_APP_TEST_APP_PARAM_TEST_PARAM>overriddenValue</DOT_APP_TEST_APP_PARAM_TEST_PARAM>
+                            </environmentVariables>
                             <systemPropertyVariables>
                                 <!-- Following is a hack to make Intellij pick up the fork number in systemProperites
                                     for tests correctly

--- a/dotcms-integration/src/test/java/com/dotcms/datagen/AppDescriptorDataGen.java
+++ b/dotcms-integration/src/test/java/com/dotcms/datagen/AppDescriptorDataGen.java
@@ -17,7 +17,6 @@ import com.google.common.collect.Ordering;
 import com.liferay.util.StringPool;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -36,7 +35,7 @@ public class AppDescriptorDataGen extends AbstractDataGen<AppDescriptor> {
     private String key = String.format("app_%d", System.currentTimeMillis());
     private String name = key;
     private String fileName = String.format("%s.yml", key);
-    private  String description = "";
+    private String description = "";
     private Boolean allowExtraParameters;
     private String iconUrl = "none.ico";
 
@@ -49,7 +48,8 @@ public class AppDescriptorDataGen extends AbstractDataGen<AppDescriptor> {
        return paramMap;
     }
 
-    private final ImmutableSortedMap.Builder<String, ParamDescriptor> builder = new ImmutableSortedMap.Builder<>(Ordering.natural());
+    private final ImmutableSortedMap.Builder<String, ParamDescriptor> builder =
+            new ImmutableSortedMap.Builder<>(Ordering.natural());
 
     /**
      * Next new non-persisted object
@@ -208,20 +208,23 @@ public class AppDescriptorDataGen extends AbstractDataGen<AppDescriptor> {
      * @param required
      * @return
      */
-    public AppDescriptorDataGen param(final String name, final boolean hidden, final Type type,
-            final String label, final String hint, final boolean required) {
-       return param(name, ParamDescriptor.newParam(StringPool.BLANK, hidden, type, label, hint, required));
-    }
-
-    /**
-     * Param builder method
-     * @param name
-     * @param hidden
-     * @param required
-     * @return
-     */
-    public AppDescriptorDataGen stringParam(final String name, final Boolean hidden, final Boolean required) {
-        return param(name, ParamDescriptor.newParam(StringPool.BLANK, hidden, Type.STRING, "label", "hint", required));
+    public AppDescriptorDataGen param(final String name,
+                                      final Boolean hidden,
+                                      final Type type,
+                                      final String label,
+                                      final String hint,
+                                      final Boolean required,
+                                      final Object value) {
+       return param(
+               name,
+               ParamDescriptor.builder()
+                       .withHidden(hidden)
+                       .withType(type)
+                       .withLabel(label)
+                       .withHint(hint)
+                       .withRequired(required)
+                       .withValue(value)
+                       .build());
     }
 
     /**
@@ -232,10 +235,25 @@ public class AppDescriptorDataGen extends AbstractDataGen<AppDescriptor> {
      * @param value
      * @return
      */
-    public AppDescriptorDataGen stringParam(final String name, final Boolean hidden, final Boolean required, final Object value, final String label, final String hint) {
-        return param(name, ParamDescriptor.newParam(value, hidden, Type.STRING, label, hint, required));
+    public AppDescriptorDataGen stringParam(final String name,
+                                            final Boolean hidden,
+                                            final Boolean required,
+                                            final String label,
+                                            final String hint,
+                                            final Object value) {
+        return param(name, hidden, Type.STRING, label, hint, required, value);
     }
 
+    /**
+     * Param builder method
+     * @param name
+     * @param hidden
+     * @param required
+     * @return
+     */
+    public AppDescriptorDataGen stringParam(final String name, final Boolean hidden, final Boolean required) {
+        return stringParam(name, hidden, required, "label", "hint", StringPool.BLANK);
+    }
 
     /**
      * Param builder method
@@ -245,7 +263,7 @@ public class AppDescriptorDataGen extends AbstractDataGen<AppDescriptor> {
      * @return
      */
     public AppDescriptorDataGen boolParam(final String name, final Boolean hidden, final Boolean required) {
-        return param(name, ParamDescriptor.newParam(Boolean.TRUE.toString(), hidden, Type.BOOL, "label", "hint", required));
+        return param(name, hidden, Type.BOOL, "label", "hint", required, Boolean.TRUE.toString());
     }
 
     /**
@@ -254,8 +272,10 @@ public class AppDescriptorDataGen extends AbstractDataGen<AppDescriptor> {
      * @param required
      * @return
      */
-    public AppDescriptorDataGen selectParam(final String name, final Boolean required, final List<Map<String,String>> items) {
-        return param(name, ParamDescriptor.newParam(items, false, Type.SELECT, "label", "hint", required));
+    public AppDescriptorDataGen selectParam(final String name,
+                                            final Boolean required,
+                                            final List<Map<String,String>> items) {
+        return param(name, false, Type.SELECT, "label", "hint", required, items);
     }
 
     /**
@@ -266,7 +286,10 @@ public class AppDescriptorDataGen extends AbstractDataGen<AppDescriptor> {
      * @param hint
      * @return
      */
-    public AppDescriptorDataGen buttonParam(final String name,  final String url, final String label, final String hint) {
-        return param(name, ParamDescriptor.newParam(url, false, Type.BUTTON, label, hint, false));
+    public AppDescriptorDataGen buttonParam(final String name,
+                                            final String url,
+                                            final String label,
+                                            final String hint) {
+        return param(name, false, Type.BUTTON, label, hint, false, url);
     }
 }

--- a/dotcms-integration/src/test/java/com/dotcms/junit/CustomDataProviderRunner.java
+++ b/dotcms-integration/src/test/java/com/dotcms/junit/CustomDataProviderRunner.java
@@ -1,21 +1,10 @@
 package com.dotcms.junit;
 
-import com.dotcms.aspects.DotAspectException;
-import com.dotcms.business.bytebuddy.ByteBuddyFactory;
-import com.dotcms.util.IntegrationTestInitService;
-import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Logger;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.internal.DataConverter;
 import com.tngtech.java.junit.dataprovider.internal.TestGenerator;
 import com.tngtech.java.junit.dataprovider.internal.TestValidator;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
-import org.apache.commons.logging.Log;
 import org.junit.Ignore;
 import org.junit.rules.RunRules;
 import org.junit.runner.Description;
@@ -23,8 +12,9 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
-public class CustomDataProviderRunner extends DataProviderRunner {
+import java.util.List;
 
+public class CustomDataProviderRunner extends DataProviderRunner {
 
     public CustomDataProviderRunner(Class<?> clazz) throws InitializationError {
         super(clazz);
@@ -41,13 +31,12 @@ public class CustomDataProviderRunner extends DataProviderRunner {
             runLeaf(runRules, description, notifier);
         }
     }
+
     @Override
     protected void initializeHelpers() {
         dataConverter = new DataConverter();
         testGenerator = new TestGenerator(dataConverter) {
-
-
-                @Override
+            @Override
             public List<FrameworkMethod> generateExplodedTestMethodsFor(FrameworkMethod testMethod,
                     FrameworkMethod dataProviderMethod) {
 
@@ -71,4 +60,5 @@ public class CustomDataProviderRunner extends DataProviderRunner {
         };
         testValidator = new TestValidator(dataConverter);
     }
+
 }

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/apps/AppsResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/apps/AppsResourceTest.java
@@ -297,8 +297,9 @@ public class AppsResourceTest extends IntegrationTestBase {
      * This method tests quite a few things on the resource. First we create a yml file that exist physically on disc.
      * Then we upload the file with an app definition. Then we Create an App Then list the available apps.
      * Then we Verify the New app is listed. under the right Host.
-     * Then We delete the app and verify the pagination results make sense.
-     * Given scenario: Test we can create an app then delete it.
+     * Then we delete the app and verify the pagination results make sense.
+     * Then we verify for app input parameters overriding through the use of environment variables (check dotcms-integration/pom.xml file for used env-vars definitions).
+     * Given scenario: Test we can create an app then delete it with overridden app parameters through environment variables.
      * Expected Result: Pagination shows all available sites with no configurations
      *
      * @throws DotDataException

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/apps/AppsResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/apps/AppsResourceTest.java
@@ -112,7 +112,7 @@ public class AppsResourceTest extends IntegrationTestBase {
                 appsHelper);
 
         final AppsAPI appsAPI = new AppsAPIImpl(APILocator.getLayoutAPI(),
-                APILocator.getHostAPI(), APILocator.getContentletAPI(),
+                APILocator.getHostAPI(),
                 SecretsStore.INSTANCE.get(), CacheLocator.getAppsCache(),
                 APILocator.getLocalSystemEventsAPI(),
                 new AppDescriptorHelper(),

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/apps/view/AppsInterpolationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/apps/view/AppsInterpolationTest.java
@@ -79,7 +79,7 @@ public class AppsInterpolationTest {
                 new SiteView("48190c8c-42c4-46af-8d1a-0cd5db894797", "demo.dotcms.com",  ImmutableList.of(
                         new SecretView("param1", null, descriptorParams.get("param1"),
                                 ImmutableList.of()),
-                        new SecretView("param2", Secret.newSecret("This is me Param2's Value".toCharArray(), Type.STRING, false), descriptorParams.get("param2"),
+                        new SecretView("param2", Secret.newSecret("This is me Param2's Value".toCharArray(), false, Type.STRING), descriptorParams.get("param2"),
                                 ImmutableList.of()),
                         new SecretView("selectParam", null, descriptorParams.get("selectParam"),
                                 ImmutableList.of()),
@@ -92,7 +92,7 @@ public class AppsInterpolationTest {
         final String json = mapper.writeValueAsString(appView);
         assertFalse(json.contains("$"));
         final Map<String, Object> map = mapper
-              .readValue(json, new TypeReference<Map<String, Object>>() {});
+              .readValue(json, new TypeReference<>() {});
         final String name = (String)map.get("name");
         assertTrue(map.get("description").toString().contains(name));
         List<Map<String,Object>> sites = (List<Map<String, Object>>) map.get("sites");

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/apps/view/AppsInterpolationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/apps/view/AppsInterpolationTest.java
@@ -52,8 +52,8 @@ public class AppsInterpolationTest {
         );
 
         final AppDescriptorDataGen dataGen = new AppDescriptorDataGen()
-                .stringParam("param1", false, true, "lol", "name is `$param1.name`.", "This is `$param2.value`'s hint.")
-                .stringParam("param2", false, true, "none", "name is `$param2.name`.", "This is `$param1.value`'s hint.")
+                .stringParam("param1", false, true, "name is `$param1.name`.", "This is `$param2.value`'s hint.", "lol")
+                .stringParam("param2", false, true, "name is `$param2.name`.", "This is `$param1.value`'s hint.", "none")
                 .selectParam("selectParam", true, list)
                 .buttonParam("buttonParam","https://www.google.com/search?q=$param1.name","Button","button's hint.")
                 .withName("any")
@@ -79,7 +79,14 @@ public class AppsInterpolationTest {
                 new SiteView("48190c8c-42c4-46af-8d1a-0cd5db894797", "demo.dotcms.com",  ImmutableList.of(
                         new SecretView("param1", null, descriptorParams.get("param1"),
                                 ImmutableList.of()),
-                        new SecretView("param2", Secret.newSecret("This is me Param2's Value".toCharArray(), false, Type.STRING), descriptorParams.get("param2"),
+                        new SecretView(
+                                "param2",
+                                 Secret.builder()
+                                         .withValue("This is me Param2's Value")
+                                         .withHidden(false)
+                                         .withType(Type.STRING)
+                                         .build(),
+                                descriptorParams.get("param2"),
                                 ImmutableList.of()),
                         new SecretView("selectParam", null, descriptorParams.get("selectParam"),
                                 ImmutableList.of()),
@@ -104,9 +111,6 @@ public class AppsInterpolationTest {
         final Map<String,Object> secrets2 = secrets.get(1);
         assertEquals(secrets2.get("hint").toString(), "This is `lol`'s hint.");
         assertEquals(secrets2.get("label").toString(), "name is `param2`.");
-
     }
-
-
 
 }

--- a/dotcms-integration/src/test/java/com/dotcms/saml/IdentityProviderConfigurationFactoryTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/saml/IdentityProviderConfigurationFactoryTest.java
@@ -72,7 +72,7 @@ public class IdentityProviderConfigurationFactoryTest {
 
         final AppSecrets appSecrets = mock(AppSecrets.class);
         when(appSecrets.getSecrets()).thenReturn(Map.of("idp.config.identifier",
-                Secret.newSecret(testConfigId.toCharArray(), Type.STRING, false)));
+                Secret.newSecret(testConfigId.toCharArray(), false, Type.STRING)));
         when(appsAPI.getSecrets(anyString(), any(), any())).thenReturn(Optional.of(appSecrets));
         when(appsAPI.getSecrets(anyString(), anyBoolean(), any(), any())).thenReturn(Optional.of(appSecrets));
 

--- a/dotcms-integration/src/test/java/com/dotcms/saml/IdentityProviderConfigurationFactoryTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/saml/IdentityProviderConfigurationFactoryTest.java
@@ -71,8 +71,10 @@ public class IdentityProviderConfigurationFactoryTest {
         when(hostAPI.find(anyString(), any(), anyBoolean())).thenReturn(testHost);
 
         final AppSecrets appSecrets = mock(AppSecrets.class);
-        when(appSecrets.getSecrets()).thenReturn(Map.of("idp.config.identifier",
-                Secret.newSecret(testConfigId.toCharArray(), false, Type.STRING)));
+        when(appSecrets.getSecrets()).thenReturn(
+                Map.of(
+                        "idp.config.identifier",
+                        Secret.builder().withValue(testConfigId).withHidden(false).withType(Type.STRING).build()));
         when(appsAPI.getSecrets(anyString(), any(), any())).thenReturn(Optional.of(appSecrets));
         when(appsAPI.getSecrets(anyString(), anyBoolean(), any(), any())).thenReturn(Optional.of(appSecrets));
 

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/AppsAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/AppsAPIImplTest.java
@@ -300,7 +300,7 @@ public class AppsAPIImplTest {
 
         //Now we want to update one of the values within the secret.
         //We want to change the value from `secret3` to `secret-3` for the secret named "test:secret3"
-        final Secret secret = newSecret("secret-3".toCharArray(), Type.STRING, false);
+        final Secret secret = newSecret("secret-3".toCharArray(), false, Type.STRING);
         //Update the individual secret
         api.saveSecret("appKey-1-Host-1", Tuple.of("test:secret3",secret), host, admin);
         //The other properties of the object should remind the same so lets verify so.
@@ -367,7 +367,7 @@ public class AppsAPIImplTest {
         assertEquals("secret-4", recoveredBean1.getSecrets().get("test:secret4").getString());
 
         //Now lets re-introduce again the property we just deleted
-        final Secret secret = newSecret("lol".toCharArray(), Type.STRING, false);
+        final Secret secret = newSecret("lol".toCharArray(), false, Type.STRING);
 
         //This should create again the entry we just removed.
         api.saveSecret("appKeyHost-1", Tuple.of("test:secret3",secret), host, admin);
@@ -740,7 +740,7 @@ public class AppsAPIImplTest {
 
     private final AppsAPI nonValidLicenseAppsAPI = new AppsAPIImpl(
             APILocator.getLayoutAPI(),
-            APILocator.getHostAPI(), APILocator.getContentletAPI(), SecretsStore.INSTANCE.get(),
+            APILocator.getHostAPI(), SecretsStore.INSTANCE.get(),
             CacheLocator.getAppsCache(), APILocator.getLocalSystemEventsAPI(), new AppDescriptorHelper(),
             new LicenseValiditySupplier() {
                 public boolean hasValidLicense() {

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/AppsAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/AppsAPIImplTest.java
@@ -1,7 +1,5 @@
 package com.dotcms.security.apps;
 
-import static com.dotcms.security.apps.ParamDescriptor.newParam;
-import static com.dotcms.security.apps.Secret.newSecret;
 import static com.google.common.collect.ImmutableMap.of;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -70,6 +68,34 @@ import org.junit.runner.RunWith;
 
 @RunWith(DataProviderRunner.class)
 public class AppsAPIImplTest {
+
+    private static final Map<String, ParamDescriptor> PARAMS = of(
+            "requiredNoDefault",
+            ParamDescriptor.builder()
+                    .withHidden(false)
+                    .withType(Type.STRING)
+                    .withLabel("any")
+                    .withHint("hint")
+                    .withRequired(true)
+                    .build(),
+            "requiredDefault",
+            ParamDescriptor.builder()
+                    .withValue("default")
+                    .withHidden(false)
+                    .withType(Type.STRING)
+                    .withLabel("any")
+                    .withHint("hint")
+                    .withRequired(true)
+                    .build(),
+            "nonRequiredNoDefault",
+            ParamDescriptor.builder()
+                    .withHidden(false)
+                    .withType(Type.STRING)
+                    .withLabel("any")
+                    .withHint("hint")
+                    .withRequired(false)
+                    .build()
+    );
 
     @BeforeClass
     public static void prepare() throws Exception {
@@ -300,7 +326,7 @@ public class AppsAPIImplTest {
 
         //Now we want to update one of the values within the secret.
         //We want to change the value from `secret3` to `secret-3` for the secret named "test:secret3"
-        final Secret secret = newSecret("secret-3".toCharArray(), false, Type.STRING);
+        final Secret secret = Secret.builder().withValue("secret-3").withHidden(false).withType(Type.STRING).build();
         //Update the individual secret
         api.saveSecret("appKey-1-Host-1", Tuple.of("test:secret3",secret), host, admin);
         //The other properties of the object should remind the same so lets verify so.
@@ -367,7 +393,7 @@ public class AppsAPIImplTest {
         assertEquals("secret-4", recoveredBean1.getSecrets().get("test:secret4").getString());
 
         //Now lets re-introduce again the property we just deleted
-        final Secret secret = newSecret("lol".toCharArray(), false, Type.STRING);
+        final Secret secret = Secret.builder().withValue("lol").withHidden(false).withType(Type.STRING).build();
 
         //This should create again the entry we just removed.
         api.saveSecret("appKeyHost-1", Tuple.of("test:secret3",secret), host, admin);
@@ -470,12 +496,7 @@ public class AppsAPIImplTest {
 
         final AppDescriptor descriptor = mock(AppDescriptor.class);
         when(descriptor.isAllowExtraParameters()).thenReturn(false);
-        final Map<String, ParamDescriptor> params = of(
-        "requiredNoDefault",newParam(null, false, Type.STRING, "any", "hint", true), // This is the rule we intend to break
-        "requiredDefault", newParam("default", false, Type.STRING, "any", "hint", true),
-        "nonRequiredNoDefault", newParam(null, false, Type.STRING, "any", "hint", false)
-         );
-        when(descriptor.getParams()).thenReturn(params);
+        when(descriptor.getParams()).thenReturn(PARAMS);
         when(descriptor.getName()).thenReturn("any-name");
         when(descriptor.getKey()).thenReturn(appKey);
 
@@ -512,12 +533,7 @@ public class AppsAPIImplTest {
 
         final AppDescriptor descriptor = mock(AppDescriptor.class);
         when(descriptor.isAllowExtraParameters()).thenReturn(false);
-        final Map<String, ParamDescriptor> params = of(
-                "requiredNoDefault",newParam(null, false, Type.STRING, "any", "hint", true),
-                "requiredDefault", newParam("default", false, Type.STRING, "any", "hint", true),
-                "nonRequiredNoDefault", newParam(null, false, Type.STRING, "any", "hint", false)
-        );
-        when(descriptor.getParams()).thenReturn(params);
+        when(descriptor.getParams()).thenReturn(PARAMS);
         when(descriptor.getName()).thenReturn("any-name");
         when(descriptor.getKey()).thenReturn(appKey);
 
@@ -574,7 +590,7 @@ public class AppsAPIImplTest {
     }
 
     @DataProvider
-    public static Object[] getExpectedExceptionTestCases() throws Exception {
+    public static Object[] getExpectedExceptionTestCases() {
         final Map<String, ParamDescriptor> emptyParams = ImmutableMap.of();
         return new Object[]{
                 //The following test that the general required fields are mandatory.
@@ -595,38 +611,100 @@ public class AppsAPIImplTest {
                 //The following test paramDefinition.
                 //Null type  is not allowed.
                 new AppTestCase("any-key", "any-name", "desc", "icon", false,
-                       ImmutableSortedMap.of("p1", newParam("", true, null, "", "", true)
-                )),
+                        ImmutableSortedMap.of(
+                               "p1",
+                               ParamDescriptor.builder()
+                                       .withValue("")
+                                       .withHidden(true)
+                                       .withType(null)
+                                       .withLabel("")
+                                       .withHint("")
+                                       .withRequired(true)
+                                       .build())),
                 //Hidden bool param is not allowed.
                 new AppTestCase("any-key", "any-name", "desc", "icon", false,
-                       ImmutableSortedMap.of("p1", newParam("", true, Type.BOOL, "label", "hint", true)
-                )),
+                       ImmutableSortedMap.of(
+                               "p2",
+                               ParamDescriptor.builder()
+                                       .withValue("")
+                                       .withHidden(true)
+                                       .withType(Type.BOOL)
+                                       .withLabel("label")
+                                       .withHint("hint")
+                                       .withRequired(true)
+                                       .build())),
                 //emptyLabel.
                 new AppTestCase("any-key", "any-name", "desc", "icon", false,
-                       ImmutableSortedMap.of("p1", newParam("v1", true, Type.STRING, "", "", true)
-                )),
+                       ImmutableSortedMap.of(
+                               "p3",
+                               ParamDescriptor.builder()
+                                       .withValue("v1")
+                                       .withHidden(true)
+                                       .withType(Type.STRING)
+                                       .withLabel("")
+                                       .withHint("")
+                                       .withRequired(true)
+                                       .build())),
                 //emptyHint.
                 new AppTestCase("any-key", "any-name", "desc", "icon", false,
-                       ImmutableSortedMap.of("p1", newParam("v1", true, Type.STRING, "label", "", true)
-                )),
+                       ImmutableSortedMap.of(
+                               "p4",
+                               ParamDescriptor.builder()
+                                       .withValue("v1")
+                                       .withHidden(true)
+                                       .withType(Type.STRING)
+                                       .withLabel("label")
+                                       .withHint("")
+                                       .withRequired(true)
+                                       .build())),
                 //Required param with null default.
                 new AppTestCase("any-key", "any-name", "desc", "icon", false,
-                       ImmutableSortedMap.of("p1", newParam("null", false, Type.STRING, "label", "hint", true)
-                )),
+                       ImmutableSortedMap.of(
+                               "p5",
+                               ParamDescriptor.builder()
+                                       .withValue(null)
+                                       .withHidden(false)
+                                       .withType(Type.STRING)
+                                       .withLabel("label")
+                                       .withHint("hint")
+                                       .withRequired(true)
+                                       .build())),
                 //non parsable to bool string.
                 new AppTestCase("any-key", "any-name", "desc", "icon", false,
-                        ImmutableSortedMap.of("p1", newParam("lol", false, Type.BOOL, "label", "hint", true)
-                )),
+                        ImmutableSortedMap.of(
+                                "p6",
+                                ParamDescriptor.builder()
+                                        .withValue("lol")
+                                        .withHidden(false)
+                                        .withType(Type.BOOL)
+                                        .withLabel("label")
+                                        .withHint("hint")
+                                        .withRequired(true)
+                                        .build())),
                 //Null hidden to emulate missing hidden field.
                 new AppTestCase("any-key", "any-name", "desc", "icon", false,
                         ImmutableSortedMap.of(
-                                "p1", newParam("false", null, Type.BOOL, "label", "hint", true)
-                        )),
+                                "p7",
+                                ParamDescriptor.builder()
+                                        .withValue("false")
+                                        .withHidden(null)
+                                        .withType(Type.BOOL)
+                                        .withLabel("label")
+                                        .withHint("hint")
+                                        .withRequired(true)
+                                        .build())),
                 //Null required to emulate missing hidden field.
                 new AppTestCase("any-key", "any-name", "desc", "icon", false,
                         ImmutableSortedMap.of(
-                                "p1", newParam("false", false, Type.BOOL, "label", "hint", null)
-                        ))
+                                "p8",
+                                ParamDescriptor.builder()
+                                        .withValue("false")
+                                        .withHidden(false)
+                                        .withType(Type.BOOL)
+                                        .withLabel("label")
+                                        .withHint("hint")
+                                        .withRequired(null)
+                                        .build()))
         };
     }
 
@@ -649,20 +727,48 @@ public class AppsAPIImplTest {
         return new Object[]{
                 new AppTestCase("key1_" + postfix, "any-name", "desc", "icon", true,
                         ImmutableSortedMap.of(
-                                "p1", newParam("", true, Type.STRING, "label", "hint", true)
-                        )),
+                                "p1",
+                                ParamDescriptor.builder()
+                                        .withValue("")
+                                        .withHidden(true)
+                                        .withType(Type.STRING)
+                                        .withLabel("label")
+                                        .withHint("hint")
+                                        .withRequired(true)
+                                        .build())),
                 new AppTestCase("key2_" + postfix, "any-name", "desc", "icon", true,
                         ImmutableSortedMap.of(
-                                "p1", newParam("", true, Type.STRING, "label", "hint", false)
-                        )),
+                                "p1",
+                                ParamDescriptor.builder()
+                                        .withValue("")
+                                        .withHidden(true)
+                                        .withType(Type.STRING)
+                                        .withLabel("label")
+                                        .withHint("hint")
+                                        .withRequired(false)
+                                        .build())),
                 new AppTestCase("key3_" + postfix, "any-name", "desc", "icon", false,
                         ImmutableSortedMap.of(
-                                "p1", newParam("true", false, Type.BOOL, "label", "hint", true)
-                        )),
+                                "p1",
+                                ParamDescriptor.builder()
+                                        .withValue("true")
+                                        .withHidden(false)
+                                        .withType(Type.BOOL)
+                                        .withLabel("label")
+                                        .withHint("hint")
+                                        .withRequired(true)
+                                        .build())),
                 new AppTestCase("key4_" + postfix, "any-name", "desc", "icon", false,
                         ImmutableSortedMap.of(
-                                "p1", newParam("false", false, Type.BOOL, "label", "hint", true)
-                        ))
+                                "p1",
+                                ParamDescriptor.builder()
+                                        .withValue("false")
+                                        .withHidden(false)
+                                        .withType(Type.BOOL)
+                                        .withLabel("label")
+                                        .withHint("hint")
+                                        .withRequired(true)
+                                        .build()))
         };
     }
 
@@ -867,12 +973,7 @@ public class AppsAPIImplTest {
 
         final AppDescriptor descriptor = mock(AppDescriptor.class);
         when(descriptor.isAllowExtraParameters()).thenReturn(false);
-        final Map<String, ParamDescriptor> params = of(
-                "requiredNoDefault",newParam(null, false, Type.STRING, "any", "hint", true),
-                "requiredDefault", newParam("default", false, Type.STRING, "any", "hint", true),
-                "nonRequiredNoDefault", newParam(null, false, Type.STRING, "any", "hint", false)
-        );
-        when(descriptor.getParams()).thenReturn(params);
+        when(descriptor.getParams()).thenReturn(PARAMS);
         when(descriptor.getName()).thenReturn("any-name");
         when(descriptor.getKey()).thenReturn(appKey);
 


### PR DESCRIPTION
Changing `AbstractProperty` extending classes to include new `envvar` and `envshow` fields and adding necessary logic to override them at saving and reading time.

Refs: #25953
