### PR TITLE
ci: Skip git command failing build in master branch. 

### DIFF
--- a/.github/workflows/maven-cicd-pipeline.yml
+++ b/.github/workflows/maven-cicd-pipeline.yml
@@ -541,6 +541,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup master branch locally without switching current branch
+        if: github.ref != 'refs/heads/master'
         run: git fetch origin master:master
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
An issue in maven-cicd-pipeline.yml is only breaking master branch.  A git fetch is used to make master available when comparing changes from base.  This fails when run on master itself so we need to skip this step.

