### PR TITLE
fix(CICD): #27286 Removing cli deployment step.

### DIFF
--- a/.github/workflows/maven-cicd-pipeline.yml
+++ b/.github/workflows/maven-cicd-pipeline.yml
@@ -735,18 +735,6 @@ jobs:
           name: workflow-data
           path: ./workflow-data.json
 
-  linux-cli-deploy:
-    needs: [ prepare-report-data ]
-    if: ${{ github.event_name == 'push' &&  needs.prepare-report-data.outputs.aggregate_status == 'SUCCESS' }}
-    name: CLI Build and Deploy
-    uses: ./.github/workflows/cli-build-artifacts.yml
-    with:
-      skipTests: true
-      buildNativeImage: false
-      uploadArtifacts: true
-      branch: ${{ github.ref_name }}
-    secrets: inherit
-
   final-status:
     name: Final Status
     needs: prepare-report-data


### PR DESCRIPTION
### Proposed Changes
* We have removed the cli deployment step to fix the failure generated by its addition. Besides, we have to review the pattern that we have to use,  in order to avoid security issues within the main workflow, and we need to create a separation between the main workflow build, test and deployment steps.

### Fixes
#27286 
