### PR TITLE
chore: fix ide docker run

### DIFF
--- a/dotcms-integration/pom.xml
+++ b/dotcms-integration/pom.xml
@@ -196,18 +196,6 @@
     </dependencyManagement>
 
     <build>
-        <plugins/>
-    </build>
-    <profiles>
-        <profile>
-            <id>run-it-tests</id>
-            <activation>
-                <property>
-                    <name>coreit.test.skip</name>
-                    <value>!true</value>
-                </property>
-            </activation>
-            <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -477,8 +465,7 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <!-- Full test profile -->
+ <profiles>
         <profile>
             <id>quick-test</id>
             <activation>

--- a/justfile
+++ b/justfile
@@ -92,12 +92,12 @@ dev-tomcat-stop:
 # Testing Commands
 
 # Executes a specified set of Postman tests
-test-postman collections='':
+test-postman collections='page':
     ./mvnw -pl :dotcms-postman verify -Dpostman.test.skip=false -Pdebug -Dpostman.collections={{ collections }}
 
 # Stops Postman-related Docker containers
 postman-stop:
-    ./mvnw -pl :dotcms-postman -Pdocker-stop
+    ./mvnw -pl :dotcms-postman -Pdocker-stop -Dpostman.test.skip=false
 
 # Runs all integration tests
 test-integration:
@@ -109,11 +109,11 @@ test-integration-debug-suspend:
 
 # Prepares the environment for running integration tests in an IDE
 test-integration-ide:
-    ./mvnw -pl :dotcms-integration -Pdocker-start
+    ./mvnw -pl :dotcms-integration -Pdocker-start -Dcoreit.test.skip=false
 
 # Stops integration test services
 test-integration-stop:
-    ./mvnw -pl :dotcms-integration -Pdocker-stop
+    ./mvnw -pl :dotcms-integration -Pdocker-stop -Dcoreit.test.skip=false
 # Docker Commands
 
 # Runs a published dotCMS Docker image on a dynamic port

--- a/justfile
+++ b/justfile
@@ -109,11 +109,7 @@ test-integration-debug-suspend:
 
 # Prepares the environment for running integration tests in an IDE
 test-integration-ide:
-<<<<<<< Updated upstream
     ./mvnw -pl :dotcms-integration -Pdocker-start -Dcoreit.test.skip=false
-=======
-    ./mvnw -pl :dotcms-integration -Pdocker-start -Dcoreit.test.skip=false -Ddocker.skip=false
->>>>>>> Stashed changes
 
 # Stops integration test services
 test-integration-stop:

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ build:
 
 # Builds the project without running tests, skip using docker or creating image
 build-no-docker:
-    ./mvnw -DskipTests clean install -Dskip.docker=true
+    ./mvnw -DskipTests clean install -Dxd=true
 
 # Builds the project and runs the default test suite
 build-test:
@@ -60,15 +60,15 @@ build-select-module-deps module=":dotcms-core":
 
 # Starts the dotCMS application in a Docker container on a dynamic port, running in the foreground
 dev-run:
-    ./mvnw -pl :dotcms-core -Pdocker-run
+    ./mvnw -pl :dotcms-core -Pdocker-start
 
 # Maps paths in the docker container to local paths, useful for development
 dev-run-map-dev-paths:
-    ./mvnw -pl :dotcms-core -Pdocker-run -Pmap-dev-paths
+    ./mvnw -pl :dotcms-core -Pocker-start -Pmap-dev-paths
 
 # Starts the dotCMS application in debug mode with suspension, useful for troubleshooting
 dev-run-debug-suspend:
-    ./mvnw -pl :dotcms-core -Pdocker-run,debug-suspend
+    ./mvnw -pl :dotcms-core -Pdocker-start,debug-suspend
 
 # Starts the dotCMS Docker container in the background
 dev-start:
@@ -109,7 +109,11 @@ test-integration-debug-suspend:
 
 # Prepares the environment for running integration tests in an IDE
 test-integration-ide:
+<<<<<<< Updated upstream
     ./mvnw -pl :dotcms-integration -Pdocker-start -Dcoreit.test.skip=false
+=======
+    ./mvnw -pl :dotcms-integration -Pdocker-start -Dcoreit.test.skip=false -Ddocker.skip=false
+>>>>>>> Stashed changes
 
 # Stops integration test services
 test-integration-stop:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1345,7 +1345,7 @@
                         <configuration/>
                         <executions>
                             <execution>
-                                <id>docker-pre-stop</id>
+                                <id>docker-pre-stop-runner</id>
                                 <goals>
                                     <goal>stop</goal>
                                 </goals>
@@ -1355,7 +1355,7 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>docker-start</id>
+                                <id>docker-start-runner</id>
                                 <goals>
                                     <goal>start</goal>
                                 </goals>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1342,7 +1342,9 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration/>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>docker-pre-stop-runner</id>
@@ -1351,6 +1353,7 @@
                                 </goals>
                                 <phase>validate</phase>
                                 <configuration>
+                                    <skip>false</skip>
                                     <allContainers>true</allContainers>
                                 </configuration>
                             </execution>
@@ -1360,7 +1363,9 @@
                                     <goal>start</goal>
                                 </goals>
                                 <phase>validate</phase>
-                                <configuration/>
+                                <configuration>
+                                    <skip>false</skip>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -1390,66 +1395,7 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>docker-run</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <docker.follow>true</docker.follow>
-            </properties>
-            <build>
-                <defaultGoal>validate</defaultGoal>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration/>
-                        <executions>
-                            <execution>
-                                <id>docker-pre-stop</id>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                                <phase>validate</phase>
-                                <configuration/>
-                            </execution>
-                            <execution>
-                                <id>docker-start</id>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <phase>validate</phase>
-                                <configuration/>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <phase>validate</phase>
-                                <configuration>
-                                    <target>
-                                        <!-- Here is where you define your Ant tasks -->
-                                        <!--suppress UnresolvedMavenProperty -->
-                                        <echo message="DotCMS starting on    : http://localhost:${tomcat.port}/dotAdmin"/>
-                                        <!--suppress UnresolvedMavenProperty -->
-                                        <echo message="Postgres starting on   : jdbc:postgresql://localhost:${db.port}/dotcms user = postgres pass = postgres"/>
-                                        <!--suppress UnresolvedMavenProperty -->
-                                        <echo message="Opensearch starting on : http://localhost:${es.port}"/>
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+
         <profile>
             <id>docker-stop</id>
             <activation>
@@ -1480,7 +1426,9 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration/>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>docker-stop</id>
@@ -1510,7 +1458,7 @@
                         <configuration/>
                         <executions>
                             <execution>
-                                <id>docker-stop</id>
+                                <id>docker-stop-runner</id>
                                 <goals>
                                     <goal>stop</goal>
                                 </goals>


### PR DESCRIPTION
### Proposed Changes
* Fixes where docker was not starting in some cases when run on developer machine including the startup of services for maunal testing of integration tests in the ide
e.g.
Prepares the environment for running integration tests in an IDE
test-integration-ide:
    ./mvnw -pl :dotcms-integration -Pdocker-start
    