### PR TITLE
fix(announcments): clickable links in announcements close menu and mark as read

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.html
@@ -2,7 +2,6 @@
 <p-overlayPanel
     #toolbarAnnouncements
     (onHide)="hideDialog()"
-    data-testId=""
     appendTo="body"
     styleClass="toolbar-announcements__container">
     <div class="announcements__main-container">

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.html
@@ -2,6 +2,7 @@
 <p-overlayPanel
     #toolbarAnnouncements
     (onHide)="hideDialog()"
+    data-testId=""
     appendTo="body"
     styleClass="toolbar-announcements__container">
     <div class="announcements__main-container">
@@ -18,6 +19,7 @@
                 <a
                     class="announcements__url"
                     [href]="item.url"
+                    (click)="toggleDialog($event)"
                     target="_blank"
                     rel="noopener noreferrer"
                     data-testId="announcement_link"
@@ -39,6 +41,7 @@
                 <a
                     class="announcements__link"
                     [href]="linkToDotCms()"
+                    (click)="toggleDialog($event)"
                     target="_blank"
                     data-testId="announcement_link_all"
                     rel="noopener"
@@ -54,6 +57,7 @@
             <a
                 class="announcements__about-link"
                 [href]="item.url"
+                (click)="toggleDialog($event)"
                 data-testId="announcements__about-link"
                 target="_blank"
                 rel="noopener"

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.scss
@@ -104,6 +104,7 @@
 .announcements__url {
     text-decoration: none;
     color: $black;
+    width: 100%;
 }
 
 .announcements__badge {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.spec.ts
@@ -132,6 +132,5 @@ describe('DotToolbarAnnouncementsComponent', () => {
         links.forEach((link) => link.dispatchEvent(new MouseEvent('click')));
         spectator.detectChanges();
         expect(announcementPanel).toBeFalsy();
-
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.spec.ts
@@ -125,4 +125,13 @@ describe('DotToolbarAnnouncementsComponent', () => {
         spectator.component.ngOnChanges({ showUnreadAnnouncement: { currentValue: false } });
         expect(refreshUtmParametersSpy).not.toHaveBeenCalled();
     });
+
+    it('should close the overlaypanel when clicking on the links', () => {
+        const announcementPanel = spectator.query(byTestId('announcement_link'));
+        const links = spectator.queryAll(byTestId('announcement_link'));
+        links.forEach((link) => link.dispatchEvent(new MouseEvent('click')));
+        spectator.detectChanges();
+        expect(announcementPanel).toBeFalsy();
+
+    });
 });


### PR DESCRIPTION
### Proposed Changes

 - When clicking any of the links it closes the menu and mark as read 

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

###  Screenshots


https://github.com/dotCMS/core/assets/3438705/1ad9df4a-b814-46ce-8f51-0daa24bff21a



