### PR TITLE
Issue 27537 updating pg dump version

### DIFF
--- a/docker/dev-env/Dockerfile
+++ b/docker/dev-env/Dockerfile
@@ -22,7 +22,6 @@ COPY --from=dotcms --chown=$USER_NAME:$USER_GROUP /srv/ /srv/
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_RELEASE=jammy
-ARG PG_VERSION=15
 ARG PGDATA=/data/postgres
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DEBCONF_NONINTERACTIVE_SEEN=true
@@ -34,15 +33,13 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends bash zip unzip wget libtcnative-1\
     tzdata tini ca-certificates openssl libapr1 libpq-dev curl gnupg\
-    vim libarchive-tools
+    vim libarchive-tools postgresql-common
 
 
-RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $UBUNTU_RELEASE-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
-RUN wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null \
-  && apt-get update -y \
-  && apt-get upgrade -y \
-  && apt-get install -y postgresql-$PG_VERSION
+RUN /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+RUN apt install -y postgresql-15-pgvector
+
 
 
 # Cleanup
@@ -51,7 +48,7 @@ RUN apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 
-COPY --from=opensearchproject/opensearch:1.3.11 --chown=$USER_NAME:$USER_GROUP /usr/share/opensearch /usr/share/opensearch
+COPY --from=opensearchproject/opensearch:1 --chown=$USER_NAME:$USER_GROUP /usr/share/opensearch /usr/share/opensearch
 
 RUN echo "discovery.type: single-node\nbootstrap.memory_lock: true\ncluster.routing.allocation.disk.threshold_enabled: true\ncluster.routing.allocation.disk.watermark.low: 1g\ncluster.routing.allocation.disk.watermark.high: 500m\ncluster.routing.allocation.disk.watermark.flood_stage: 400m\ncluster.info.update.interval: 5m" >> /usr/share/opensearch/config/opensearch.yml
 

--- a/docker/dev-env/Dockerfile
+++ b/docker/dev-env/Dockerfile
@@ -22,6 +22,7 @@ COPY --from=dotcms --chown=$USER_NAME:$USER_GROUP /srv/ /srv/
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_RELEASE=jammy
+ARG PG_VERSION=15
 ARG PGDATA=/data/postgres
 ARG DEBIAN_FRONTEND=noninteractive
 ARG DEBCONF_NONINTERACTIVE_SEEN=true
@@ -33,13 +34,15 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends bash zip unzip wget libtcnative-1\
     tzdata tini ca-certificates openssl libapr1 libpq-dev curl gnupg\
-    vim libarchive-tools postgresql-common
+    vim libarchive-tools
 
 
+RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $UBUNTU_RELEASE-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
-RUN /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
-RUN apt install -y postgresql-15-pgvector
-
+RUN wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null \
+  && apt-get update -y \
+  && apt-get upgrade -y \
+  && apt-get install -y postgresql-$PG_VERSION
 
 
 # Cleanup
@@ -48,7 +51,7 @@ RUN apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 
-COPY --from=opensearchproject/opensearch:1 --chown=$USER_NAME:$USER_GROUP /usr/share/opensearch /usr/share/opensearch
+COPY --from=opensearchproject/opensearch:1.3.11 --chown=$USER_NAME:$USER_GROUP /usr/share/opensearch /usr/share/opensearch
 
 RUN echo "discovery.type: single-node\nbootstrap.memory_lock: true\ncluster.routing.allocation.disk.threshold_enabled: true\ncluster.routing.allocation.disk.watermark.low: 1g\ncluster.routing.allocation.disk.watermark.high: 500m\ncluster.routing.allocation.disk.watermark.flood_stage: 400m\ncluster.info.update.interval: 5m" >> /usr/share/opensearch/config/opensearch.yml
 

--- a/docker/pg-base/Dockerfile
+++ b/docker/pg-base/Dockerfile
@@ -1,7 +1,7 @@
 # ----------------------------------------------
 # Stage 1:  Minimal image with pg_dump and psql built from source 
 # ----------------------------------------------
-FROM ubuntu:22.04 as pg-base-builder
+FROM ubuntu:20.04 as pg-base-builder
 
 SHELL ["/bin/bash", "-c"] 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/docker/pg-base/Dockerfile
+++ b/docker/pg-base/Dockerfile
@@ -1,13 +1,13 @@
 # ----------------------------------------------
 # Stage 1:  Minimal image with pg_dump and psql built from source 
 # ----------------------------------------------
-FROM ubuntu:20.04 as pg-base-builder
+FROM ubuntu:22.04 as pg-base-builder
 
 SHELL ["/bin/bash", "-c"] 
 ARG DEBIAN_FRONTEND=noninteractive
 
 # see https://www.postgresql.org/ftp/source/ for versions
-ARG POSTGRES_VERSION=15.3
+ARG POSTGRES_VERSION=16.2
 
 ARG POSTGRES_TARBALL=postgresql-${POSTGRES_VERSION}.tar.bz2
 ARG FTP_PATH=https://ftp.postgresql.org/pub/source/v${POSTGRES_VERSION}
@@ -17,7 +17,7 @@ ARG BUILD_DEPS="build-essential ca-certificates curl zlib1g-dev"
 
 # './configure --without-readline' currently means we won't have shared library
 # dependencies that are not present in the dotcms image
-ARG CONFIGURE_OPTS="--without-readline"
+ARG CONFIGURE_OPTS="--without-readline --without-icu"
 
 # builds client only - see https://www.postgresql.org/docs/current/install-procedure.html
 RUN apt update -y \

--- a/docker/pg-base/README.md
+++ b/docker/pg-base/README.md
@@ -1,0 +1,29 @@
+# BUILD dotCMS pg_dump
+
+This Dockerfile builds postgres so we can extract a valid pg_dump binary.  pg_dump is backwards compatible so any version greater than our cloud db version should work future forward.
+
+### Building Multiarch
+To enable "multiarch" building, you need to use `docker buildx` and have defined a new builder (you might need to enable "experimental" features in order to enable `docker buildx`). If you have `buildx` installed, you can see what buildx builders you have available by doing a `ls`:
+
+```
+docker buildx ls
+```
+
+To create and use a new multiarch builder run:
+```
+docker buildx create --name multiarch
+docker buildx use multiarch
+```
+
+At this point, you can use `buildx` to build your image and target the platform(s) you want to build for.  Mostly, the same arguements apply, though `buildx` also allows you to immediatly push your new image to docker hub after it is built.
+
+Use the version specified
+```
+docker buildx build --platform linux/amd64,linux/arm64 --pull --push -t dotcms/pg-base:16.2 .
+```
+
+or specify a version
+```
+docker buildx build --platform linux/amd64,linux/arm64 --pull --push -t dotcms/pg-base:21.2.0.r11-grl .
+
+```

--- a/dotCMS/src/main/docker/original/Dockerfile
+++ b/dotCMS/src/main/docker/original/Dockerfile
@@ -51,7 +51,7 @@ RUN find /srv/ -type f -name "*.sh" -exec chmod a+x {} \; && \
 # ----------------------------------------------
 # Stage 2:  Copy pg_dump binary
 # ----------------------------------------------
-FROM dotcms/pg-base:22.02 as composed-base
+FROM dotcms/pg-base:20.04_16.2 as composed-base
 COPY --from=container-base / /
 
 # ----------------------------------------------

--- a/dotCMS/src/main/docker/original/Dockerfile
+++ b/dotCMS/src/main/docker/original/Dockerfile
@@ -50,6 +50,7 @@ RUN find /srv/ -type f -name "*.sh" -exec chmod a+x {} \; && \
 
 # ----------------------------------------------
 # Stage 2:  Copy pg_dump binary
+#     - pg_dump v. 16.2 for Ubuntu 20.04
 # ----------------------------------------------
 FROM dotcms/pg-base:20.04_16.2 as composed-base
 COPY --from=container-base / /


### PR DESCRIPTION
This PR updates the pg_dump version included in dotcms to 16.2

ref: #27537

