### PR TITLE
Update SAML plugin to new version that includes old configuration id

### DIFF
--- a/osgi-base/system-bundles/pom.xml
+++ b/osgi-base/system-bundles/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.dotcms.samlbundle</groupId>
             <artifactId>com.dotcms.samlbundle</artifactId>
-            <version>23.01.01</version>
+            <version>24.02.29</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
### Proposed Changes
* Include new version `24.02.09` for the SAM plugin in dotCMS
* This new plugin version will return the IDP configuration identifier instead of the site identifier in the ACS URL included in the SAML authentication request.
* To enable this functionality these configuration properties have to be set:
  -  `dotcms.saml.use.idp.config.id`: dotCMS configuration property to enable the mapping by IDP configuration id instead of site id when is set to true
  - `idp.config.identifier`: SAML configuration property that includes the IDP configuration property to be returned as part of the ACS URL instead of the site id.
* Also changes were implemented as part of the work for #25636 to map the old IDP configuration id to the site id.

### Checklist
- [x] Tests