### PR TITLE
fix(perf) optimizing validation queries

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -8404,7 +8404,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                                 cve.addInvalidContentRelationship(relationship,
                                         contentsInRelationship);
                             }
-                        } catch (final DotSecurityException | DotDataException e) {
+                        } catch (final DotDataException e) {
                             Logger.error(this,
                                     "An error occurred when retrieving information from related Contentlet"
                                             +
@@ -8510,7 +8510,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 cve.addBadCardinalityRelationship(relationship, contentsInRelationship);
                 return false;
             }
-        } catch (final DotSecurityException | DotDataException e) {
+        } catch (final DotDataException e) {
             Logger.error(this,
                     "An error occurred when retrieving information from related Contentlet" +
                             " [" + contentsInRelationship.get(0).getIdentifier() + "]", e);

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -8368,10 +8368,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             // In order to get the related content we should use method getRelatedContent
                             // that has -boolean pullByParent- as parameter so we can pass -false-
                             // to get related content where we are parents.
-                            final List<Contentlet> relatedContents = getRelatedContentFromIndex(
+                            final List<Contentlet> relatedContents = getRelatedContent(
                                     contentInRelationship, relationship, false,
                                     APILocator.getUserAPI()
-                                            .getSystemUser(), true);
+                                            .getSystemUser(), true, 1, 0, null);
                             // If there's a 1-N relationship and the parent
                             // content is relating to a child that already has
                             // a parent...
@@ -8498,7 +8498,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             List<Contentlet> relatedContents = getRelatedContent(
                     contentsInRelationship.get(0), relationship, null,
                     APILocator.getUserAPI()
-                            .getSystemUser(), true);
+                            .getSystemUser(), true, 1, 0, null);
             if (relatedContents.size() > 0 && !relatedContents.get(0).getIdentifier()
                     .equals(contentlet.getIdentifier())) {
                 Logger.error(this,


### PR DESCRIPTION
Specifically when there are a lot of relationships.  The `validateRelationships` method would pull back and hydrate all the related content in all relationships to check if, for example, a required relationship had been fulfilled or that the content is not related to itself.  These changes do not change or fix any of the mystics of the `validateRelationships` method - it just calls the same `getRelatedContent` that was called by the `getRelatedContentFromIndex` but sends a `1` as a limit, as that is all that is checked against.