### PR TITLE
fix(core): #27740 Removing an opensearch property of docker-compose

### DIFF
--- a/docker/docker-compose-examples/cluster-mode/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/cluster-mode/docker-compose-node-1.yml
@@ -11,14 +11,13 @@ volumes:
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:1.3.6
+    image: opensearchproject/opensearch:1
     environment:
       - cluster.name=elastic-cluster
       - discovery.type=single-node
       - data
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xmx1G "
-      - plugins.security.disabled=true
     ulimits:
       memlock:
         soft: -1 # Set memlock to unlimited (no soft or hard limit)

--- a/docker/docker-compose-examples/push-publish/docker-compose-receiver.yml
+++ b/docker/docker-compose-examples/push-publish/docker-compose-receiver.yml
@@ -10,14 +10,13 @@ volumes:
 
 services:
   opensearch-receiver:
-    image: opensearchproject/opensearch:1.3.6
+    image: opensearchproject/opensearch:1
     environment:
       - cluster.name=elastic-cluster
       - discovery.type=single-node
       - data
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xmx1G "
-      - plugins.security.disabled=true
     ulimits:
       memlock:
         soft: -1 # Set memlock to unlimited (no soft or hard limit)

--- a/docker/docker-compose-examples/push-publish/docker-compose-sender.yml
+++ b/docker/docker-compose-examples/push-publish/docker-compose-sender.yml
@@ -10,14 +10,13 @@ volumes:
 
 services:
   opensearch-sender:
-    image: opensearchproject/opensearch:1.3.6
+    image: opensearchproject/opensearch:1
     environment:
       - cluster.name=elastic-cluster
       - discovery.type=single-node
       - data
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xmx1G "
-      - plugins.security.disabled=true
     ulimits:
       memlock:
         soft: -1 # Set memlock to unlimited (no soft or hard limit)

--- a/docker/docker-compose-examples/push-publish/receiver/docker-compose.yml
+++ b/docker/docker-compose-examples/push-publish/receiver/docker-compose.yml
@@ -10,14 +10,13 @@ volumes:
 
 services:
   opensearch-sender:
-    image: opensearchproject/opensearch:1.3.6
+    image: opensearchproject/opensearch:1
     environment:
       - cluster.name=elastic-cluster
       - discovery.type=single-node
       - data
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xmx1G "
-      - plugins.security.disabled=true
     ulimits:
       memlock:
         soft: -1 # Set memlock to unlimited (no soft or hard limit)
@@ -34,7 +33,7 @@ services:
       - opensearch-net_sender
 
   dotcms-sender:
-    image: dotcms/dotcms:22.12_f479a493_SNAPSHOT
+    image: dotcms/dotcms:latest
     environment:
         CMS_JAVA_OPTS: '-Xmx1g '
         LANG: 'C.UTF-8'


### PR DESCRIPTION
### Proposed Changes
* Removing `plugins.security.disabled=true` property from `cluster-mode` and `push-publish` docker-compose examples.

### Fixes
#27740 