### PR TITLE
task(security) update the postgres jdbc driver

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -758,7 +758,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.5.1</version>
+                <version>42.7.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.checkerframework</groupId>


### PR DESCRIPTION
ref: #27894

Upgrades postgres driver to `42.7.2`

Prevents CVE: [CVE-2024-1597](https://nvd.nist.gov/vuln/detail/CVE-2024-1597)  which we are not affected by
