### PR TITLE
ci(deployment): replace-dockerbuildmasterbranch.yml-with-deploymen (#27857)

### DIFF
--- a/.github/actions/deploy-artifact-docker/action.yml
+++ b/.github/actions/deploy-artifact-docker/action.yml
@@ -63,7 +63,7 @@ runs:
       with:
         username: ${{ inputs.docker_io_username }}
         password: ${{ inputs.docker_io_token }}
-      if: (inputs.docker_registry == 'DOCKER.IO' || inputs.docker_registry == 'BOTH') && !inputs.do_deploy
+      if: (inputs.docker_registry == 'DOCKER.IO' || inputs.docker_registry == 'BOTH') && inputs.do_deploy == 'true'
 
     - name: GHCR.io login
       uses: docker/login-action@v3.0.0
@@ -71,7 +71,7 @@ runs:
         registry: ghcr.io
         username: ${{ inputs.ghcr_io_username }}
         password: ${{ inputs.ghcr_io_token }}
-      if: (inputs.docker_registry == 'GHCR.IO' || inputs.docker_registry == 'BOTH') && !inputs.do_deploy
+      if: (inputs.docker_registry == 'GHCR.IO' || inputs.docker_registry == 'BOTH') && inputs.do_deploy == 'true'
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.0.0

--- a/.github/workflows/deployment-trunk.yml
+++ b/.github/workflows/deployment-trunk.yml
@@ -55,7 +55,7 @@ jobs:
           commit_id: ${{ github.event.workflow_run.head_sha }}"
           variant: dotcms/dotcms:master
           docker_tag: dotcms/dotcms:master_latest_SNAPSHOT
-          do_deploy: false
+          do_deploy: ${{ vars.DOCKER_DEPLOY || 'true' }} # default to true, set to disable in fork
           docker_io_username: ${{ secrets.DOCKER_USERNAME }}
           docker_io_token: ${{ secrets.DOCKER_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Proposed Changes
* Fixes do_push flag so built docker image is pushed to registry.  
* This can be desabled in fork with gihub "trunk" variable DOCKER_DEPLOY set to false.