### PR TITLE
ci(deployment): replace-dockerbuildmasterbranch.yml-with-deploymen (#27857)

### DIFF
--- a/.github/actions/deploy-artifact-docker/action.yml
+++ b/.github/actions/deploy-artifact-docker/action.yml
@@ -40,6 +40,10 @@ inputs:
   github_token:
     description: 'github token'
     required: true
+outputs:
+  tags:
+    description: "The tags that were used to build the image"
+    value: ${{ steps.meta.outputs.tags }}
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
On deployment to trunk the tags in the slack message to #docker channel are empty
The composite action .github/actions/deploy-artifact-docker/action.yml does not have any outputs specified so the 
reference to ${{ steps.docker_build.outputs.tags }} in the slack message is empty 

Related to #27857 (replace-dockerbuildmasterbranch.yml-with-deploymen).