### PR TITLE
Edit Contentlet: Add TinyMCE V6 WYSIWFY field to the form

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.html
@@ -1,1 +1,5 @@
-<editor [formControlName]="field.variable" [plugins]="plugins()" [toolbar]="toolbar()"> </editor>
+<editor
+    [formControlName]="field.variable"
+    [plugins]="plugins()"
+    [toolbar]="toolbar()"
+    [init]="init"></editor>

--- a/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.scss
@@ -1,7 +1,17 @@
+@use "variables" as *;
+
 :host::ng-deep {
     // Hide the promotion button
     // This button redirect to the tinyMCE premium page
     .tox-promotion {
         display: none;
+    }
+
+    .tox .tox-statusbar {
+        border-top: 1px solid $color-palette-gray-400;
+    }
+
+    .tox-tinymce {
+        border: $field-border-size solid $color-palette-gray-400;
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.scss
@@ -7,6 +7,10 @@
         display: none;
     }
 
+    .tox-statusbar__branding {
+        display: none;
+    }
+
     .tox .tox-statusbar {
         border-top: 1px solid $color-palette-gray-400;
     }

--- a/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.spec.ts
@@ -16,7 +16,7 @@ import { WYSIWYG_MOCK, createFormGroupDirectiveMock } from '../../utils/mocks';
 const ALL_PLUGINS =
     'advlist autolink lists link image charmap preview anchor pagebreak searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking save table directionality emoticons template';
 const ALL_TOOLBAR_ITEMS =
-    'paste print textpattern | insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image hr | preview | validation media | forecolor dotimageclipboard backcolor emoticons';
+    'insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent hr';
 
 describe('DotWYSIWYGFieldComponent', () => {
     let spectator: Spectator<DotWYSIWYGFieldComponent>;

--- a/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.ts
@@ -1,4 +1,5 @@
 import { EditorModule, TINYMCE_SCRIPT_SRC } from '@tinymce/tinymce-angular';
+import { RawEditorOptions } from 'tinymce';
 
 import { ChangeDetectionStrategy, Component, Input, inject, signal } from '@angular/core';
 import { ControlContainer, FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -23,10 +24,14 @@ import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
 export class DotWYSIWYGFieldComponent {
     @Input() field!: DotCMSContentTypeField;
 
+    protected readonly init: RawEditorOptions = {
+        menubar: false
+    };
+
     protected readonly plugins = signal(
         'advlist autolink lists link image charmap preview anchor pagebreak searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking save table directionality emoticons template'
     );
     protected readonly toolbar = signal(
-        'paste print textpattern | insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image hr | preview | validation media | forecolor dotimageclipboard backcolor emoticons'
+        ' insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent hr'
     );
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-wysiwyg-field/dot-wysiwyg-field.component.ts
@@ -32,6 +32,6 @@ export class DotWYSIWYGFieldComponent {
         'advlist autolink lists link image charmap preview anchor pagebreak searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking save table directionality emoticons template'
     );
     protected readonly toolbar = signal(
-        ' insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent hr'
+        'insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent hr'
     );
 }


### PR DESCRIPTION
- Clean up the TinyMCE toolbar.

### Image

<img width="1296" alt="issue-27943-edit-contentlet-add-tinymce-v6-wysiwfy-field-to-the-form-clean-up-toolbar" src="https://github.com/dotCMS/core/assets/72418962/d4adb176-1ae9-4adc-b878-dd1293482769">
