### PR TITLE
chore: fix unnamed db volumes created for integration test module (#28018)

### DIFF
--- a/dotcms-integration/pom.xml
+++ b/dotcms-integration/pom.xml
@@ -405,7 +405,7 @@
                                 <database>
                                     <run>
                                         <volumes>
-                                            <bind>
+                                            <bind combine.children="append">
                                                 <volume>${project.basedir}/src/docker-compose/it-test/initdb.sh:/docker-entrypoint-initdb.d/initdb.sh</volume>
                                             </bind>
                                         </volumes>


### PR DESCRIPTION
### Proposed Changes
* Set the correct inherit option

Start up the integration test service, check volumes in docker desktop

```
test-integration-ide:
    ./mvnw -pl :dotcms-integration -Pdocker-start -Dcoreit.test.skip=false
```
### Additional Info
Related to #28018 (fix-unnamed-db-volumes-created-for-integration-tes).


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **