### PR TITLE
fix: decode colon and comma ref: #25903

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformer.java
@@ -89,7 +89,8 @@ public class ContentletTransformer implements DBTransformer<Contentlet> {
         final boolean hasJsonFields = (contentletJsonAPI.isPersistContentAsJson() && UtilMethods.isSet(map.get(ContentletJsonAPI.CONTENTLET_AS_JSON)));
         if(hasJsonFields){
           try {
-              final String json = map.get(ContentletJsonAPI.CONTENTLET_AS_JSON).toString();
+              String json = map.get(ContentletJsonAPI.CONTENTLET_AS_JSON).toString();
+              json = json.replaceAll("&#58;",":").replaceAll("&#44;",",");//Escape HTML chars from JSON
               contentlet = contentletJsonAPI.mapContentletFieldsFromJson(json);
           }catch (Exception e){
               final String errorMsg = String.format("Unable to populate contentlet from json for ID='%s', Inode='%s', Content-Type '%s': %s", contentletId, inode, contentTypeId, e.getMessage());

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformer.java
@@ -90,7 +90,7 @@ public class ContentletTransformer implements DBTransformer<Contentlet> {
         if(hasJsonFields){
           try {
               String json = map.get(ContentletJsonAPI.CONTENTLET_AS_JSON).toString();
-              json = json.replaceAll("&#58;",":").replaceAll("&#44;",",");//Escape HTML chars from JSON
+              json = UtilMethods.escapeHTMLCodeFromJSON(json);//Escape HTML chars from JSON
               contentlet = contentletJsonAPI.mapContentletFieldsFromJson(json);
           }catch (Exception e){
               final String errorMsg = String.format("Unable to populate contentlet from json for ID='%s', Inode='%s', Content-Type '%s': %s", contentletId, inode, contentTypeId, e.getMessage());

--- a/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
@@ -1389,6 +1389,12 @@ public class UtilMethods {
         return "";
     }
 
+    public static String escapeHTMLCodeFromJSON(String json) {
+        json = json.replace("&#58;",":")
+                .replace("&#44;",",");
+        return json;
+    }
+
 
 
     // Used by the code generated in the contentletmapservices

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformerTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformerTest.java
@@ -914,6 +914,32 @@ public class ContentletTransformerTest extends BaseWorkflowIntegrationTest {
     }
 
     /**
+     * Given Scenario: This tests that the transformer used to transform content from the DB decode colons and commas
+     * Expected Result: Colons and commas shouldn't be HTML encoded when transform them from the DB.
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    @Test
+    public void Transformer_content_Decode_JSON()
+            throws Exception {
+
+        final ContentType contentType = TestDataUtils.newContentTypeFieldTypesGalore();
+        final ContentletDataGen contentletDataGen = new ContentletDataGen(contentType.inode())
+                .setProperty("title", "test_KeyValueFieldDecode" + System.currentTimeMillis())
+                .setProperty("keyValueField", "{\"origin\":\"https&#58;//test.com &#44; http&#58;//test2.com\"}");
+
+        final Contentlet contentlet = contentletDataGen.nextPersisted();
+
+        final Contentlet findContentlet = APILocator.getContentletAPI().find(contentlet.getInode(),APILocator.systemUser(),false);
+
+        final Map<String, Object> keyValueField = findContentlet.getKeyValueProperty("keyValueField");
+
+        Assert.assertFalse(keyValueField.get("origin").toString().contains("&#58;"));
+        Assert.assertFalse(keyValueField.get("origin").toString().contains("&#44;"));
+
+    }
+
+    /**
      * Utitlity method to validate a string date against the ISO8601 format
      * @param dateString
      * @return


### PR DESCRIPTION
Colon and comma are still showing encoding when exporting a CSV or using the ContentResource, with this change we decode them.