### PR TITLE
Null in endpoint column when PP to 2 diff envs

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publisher/util/PublisherUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/PublisherUtil.java
@@ -112,7 +112,7 @@ public class PublisherUtil {
 		b.setAssetType(row.get("asset_type").toString());
 		b.setPushDate((Date)row.get("push_date"));
 		b.setEnvironmentId(row.get("environment_id").toString());
-		b.setEndpointId(row.get("endpoint_ids").toString());
+		b.setEndpointId(UtilMethods.isSet(row.get("endpoint_ids"))?row.get("endpoint_ids").toString():"");
 
 		final Object publisher = row.get("publisher");
 

--- a/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushedAssetUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushedAssetUtil.java
@@ -30,6 +30,7 @@ public class PushedAssetUtil {
         this.config = config;
 
         environments = getEnvironments(config);
+        final List<Environment> environmentsToRemove = new ArrayList<>();
 
         try {
             for (Environment environment : environments) {
@@ -58,9 +59,14 @@ public class PushedAssetUtil {
                             endpointIds);
                     environmentsEndpointsAndPublisher.put(environment.getId() + PUBLISHER_SUFFIX,
                             publisher);
+                } else {
+                    //Remove env since env is Static, we don't to insert into publishing_pushed_assets table
+                    environmentsToRemove.add(environment);
                 }
 
             }
+
+            environments.removeAll(environmentsToRemove);
 
         } catch (SecurityException | IllegalArgumentException | DotDataException e) {
             Logger.error(getClass(), "Can't get environments endpoints and publishers", e);

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite2a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite2a.java
@@ -11,6 +11,7 @@ import com.dotcms.junit.MainBaseSuite;
 import com.dotcms.mock.request.CachedParameterDecoratorTest;
 import com.dotcms.publisher.bundle.business.BundleFactoryTest;
 import com.dotcms.publisher.business.PublishAuditAPITest;
+import com.dotcms.publisher.util.PushedAssetUtilTest;
 import com.dotcms.publishing.PublisherFilterImplTest;
 import com.dotcms.publishing.PushPublishFiltersInitializerTest;
 import com.dotcms.rendering.velocity.directive.DotParseTest;
@@ -200,7 +201,8 @@ import org.junit.runners.Suite.SuiteClasses;
         IdentityProviderConfigurationFactoryTest.class,
         EMAWebInterceptorTest.class,
         GoogleTranslationServiceIntegrationTest.class,
-        Task240131UpdateLanguageVariableContentTypeTest.class
+        Task240131UpdateLanguageVariableContentTypeTest.class,
+        PushedAssetUtilTest.class
 })
 
 public class MainSuite2a {

--- a/dotcms-integration/src/test/java/com/dotcms/datagen/StaticPublishingEndPointDataGen.java
+++ b/dotcms-integration/src/test/java/com/dotcms/datagen/StaticPublishingEndPointDataGen.java
@@ -1,0 +1,89 @@
+package com.dotcms.datagen;
+
+
+import com.dotcms.publisher.endpoint.bean.impl.StaticPublishingEndPoint;
+import com.dotcms.publisher.environment.bean.Environment;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.cms.factories.PublicEncryptionFactory;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+
+public class StaticPublishingEndPointDataGen extends AbstractDataGen<StaticPublishingEndPoint> {
+
+    private String address = "127.0.0.1";
+    private boolean sending = false;
+    private String authKey = "123567";
+    private String port = "8080";
+    private String protocol = "http";
+    private boolean enabled = true;
+    private String serverName = null;
+    private Environment environment;
+
+    public StaticPublishingEndPointDataGen address(final String address){
+        this.address = address;
+        return this;
+    }
+
+    public StaticPublishingEndPointDataGen sending(final boolean sending){
+        this.sending = sending;
+        return this;
+    }
+
+    public StaticPublishingEndPointDataGen authKey(final String authKey){
+        this.authKey = authKey;
+        return this;
+    }
+
+    public StaticPublishingEndPointDataGen port(final String port){
+        this.port = port;
+        return this;
+    }
+
+    public StaticPublishingEndPointDataGen protocol(final String protocol){
+        this.protocol = protocol;
+        return this;
+    }
+
+    public StaticPublishingEndPointDataGen enabled(final boolean enabled){
+        this.enabled = enabled;
+        return this;
+    }
+
+    public StaticPublishingEndPointDataGen serverName(final String serverName){
+        this.serverName = serverName;
+        return this;
+    }
+
+    public StaticPublishingEndPointDataGen environment(final Environment environment){
+        this.environment = environment;
+        return this;
+    }
+
+    @Override
+    public StaticPublishingEndPoint next() {
+        final StaticPublishingEndPoint publishingEndPoint = new StaticPublishingEndPoint();
+        publishingEndPoint.setAddress(address);
+        publishingEndPoint.setSending(sending);
+        publishingEndPoint.setAuthKey(PublicEncryptionFactory.encryptString(authKey));
+        publishingEndPoint.setPort(port);
+        publishingEndPoint.setEnabled(enabled);
+        publishingEndPoint.setServerName(
+                new StringBuilder(serverName == null ? "ServerName_" + System.currentTimeMillis()
+                        : serverName)
+        );
+        publishingEndPoint.setGroupId(environment.getId());
+        publishingEndPoint.setProtocol(protocol);
+
+        return publishingEndPoint;
+    }
+
+    @Override
+    public StaticPublishingEndPoint persist(StaticPublishingEndPoint publishingEndPoint) {
+        try {
+            APILocator.getPublisherEndPointAPI().saveEndPoint(publishingEndPoint);
+            return (StaticPublishingEndPoint) APILocator.getPublisherEndPointAPI().findEndPointById(publishingEndPoint.getId());
+        } catch (DotDataException e) {
+            throw new DotRuntimeException(e);
+        }
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/publisher/util/PushedAssetUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/publisher/util/PushedAssetUtilTest.java
@@ -1,0 +1,112 @@
+package com.dotcms.publisher.util;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.datagen.*;
+import com.dotcms.publisher.assets.bean.PushedAsset;
+import com.dotcms.publisher.bundle.bean.Bundle;
+import com.dotcms.publisher.endpoint.bean.impl.PushPublishingEndPoint;
+import com.dotcms.publisher.endpoint.bean.impl.StaticPublishingEndPoint;
+import com.dotcms.publisher.environment.bean.Environment;
+import com.dotcms.publisher.pusher.PushPublisherConfig;
+import com.dotcms.publisher.util.dependencies.PushedAssetUtil;
+import com.dotcms.publishing.PublisherConfig;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.languagesmanager.business.LanguageDataGen;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.liferay.portal.model.User;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PushedAssetUtilTest extends IntegrationTestBase {
+
+    private final User systemUser = APILocator.systemUser();
+
+    @BeforeClass
+    public static void prepare() throws Exception{
+        //Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * <b>Method to test:</b> {@link PushedAssetUtil#savePushedAssetForAllEnv(Object, PusheableAsset)} <p>
+     * <b>Given Scenario:</b> PP a content to 2 diff environments (one static and one dynamic) <p>
+     * <b>ExpectedResult:</b> In the pushed assets table, only one entry should be inserted, for the dynamic one.
+     */
+    @Test
+    public void savePushedAssetForAllEnv() throws DotDataException {
+        final Environment dynamicEnv = new EnvironmentDataGen().nextPersisted();
+        final Environment staticEnv = new EnvironmentDataGen().nextPersisted();
+        final PushPublishingEndPoint dynamic_endPoint = new PushPublishingEndPointDataGen()
+                .environment(dynamicEnv)
+                .nextPersisted();
+        final StaticPublishingEndPoint static_endPoint = new StaticPublishingEndPointDataGen()
+                .protocol("static")
+                .address("static.dotcms.com")
+                .port("80")
+                .authKey("static_publish_to=dotcms-static-{hostname}-{languageIso}")
+                .environment(staticEnv)
+                .nextPersisted();
+
+        final Bundle testBundle = createTestBundle(false, List.of(dynamicEnv,staticEnv));
+
+        final PushPublisherConfig config = createPushPublisherConfigMock(
+                testBundle, false, false, PublisherConfig.Operation.PUBLISH);
+
+        final PushedAssetUtil pushedAssetUtil = new PushedAssetUtil(config);
+
+        final Host host = new SiteDataGen().nextPersisted();
+        final Language language = new LanguageDataGen().nextPersisted();
+
+        final ContentType contentType =  new ContentTypeDataGen()
+                .host(host)
+                .nextPersisted();
+
+        final Contentlet contentlet =  new ContentletDataGen(contentType.id())
+                .languageId(language.getId())
+                .host(host)
+                .modeDate(new Date())
+                .nextPersisted();
+
+        pushedAssetUtil.savePushedAssetForAllEnv(contentlet,PusheableAsset.CONTENTLET);
+
+        final List<PushedAsset> pushedAssetList = APILocator.getPushedAssetsAPI().getPushedAssets(contentlet.getIdentifier());
+        Assert.assertEquals(1,pushedAssetList.size());
+        Assert.assertEquals(dynamicEnv.getId(),pushedAssetList.get(0).getEnvironmentId());
+
+    }
+
+    private Bundle createTestBundle(final boolean forcePush, final List<Environment> environments)
+            throws DotDataException {
+        final Bundle bundle = new Bundle();
+        bundle.setName("testBundle"+System.currentTimeMillis());
+        bundle.setForcePush(forcePush);
+        bundle.setPublishDate(new Date());
+        bundle.setOwner(systemUser.getUserId());
+        APILocator.getBundleAPI().saveBundle(bundle, environments);
+        return bundle;
+    }
+
+    private PushPublisherConfig createPushPublisherConfigMock(Bundle testBundle,
+                                                              boolean isDownloading,
+                                                              boolean isStatic, PublisherConfig.Operation operation) {
+
+        final PushPublisherConfig config = mock(PushPublisherConfig.class);
+        when(config.getId()).thenReturn(testBundle.getId());
+        when(config.isStatic()).thenReturn(isStatic);
+        when(config.isDownloading()).thenReturn(isDownloading);
+        when(config.getOperation()).thenReturn(operation);
+        return config;
+    }
+}


### PR DESCRIPTION
When PP to 2 different environments, one static and one dynamic, we inserted the entry for the static one in the pushed assets table with a null endpoint (we don't track pushed assets for static environments).

We now remove this environment before inserting it on this table, and also, in case there is an old entry, we set it to empty to avoid NPE.