### PR TITLE
feat(sdk-experiments): track pageview and send to Analytics by default

### DIFF
--- a/core-web/libs/sdk/experiments/src/lib/constants.ts
+++ b/core-web/libs/sdk/experiments/src/lib/constants.ts
@@ -100,3 +100,5 @@ export enum DEBUG_LEVELS {
     WARN = 'WARN',
     ERROR = 'ERROR'
 }
+
+export const PAGE_VIEW_EVENT_NAME = 'pageview';

--- a/core-web/libs/sdk/experiments/src/lib/dot-experiments.ts
+++ b/core-web/libs/sdk/experiments/src/lib/dot-experiments.ts
@@ -511,7 +511,7 @@ export class DotExperiments {
         }
 
         // trigger the page view event
-        if (this.config.trackPageView !== false) {
+        if (this.config.trackPageView) {
             this.trackPageView();
         }
     }

--- a/core-web/libs/sdk/experiments/src/lib/dot-experiments.ts
+++ b/core-web/libs/sdk/experiments/src/lib/dot-experiments.ts
@@ -1,4 +1,4 @@
-import { jitsuClient, JitsuClient } from '@jitsu/sdk-js';
+import { EventPayload, jitsuClient, JitsuClient } from '@jitsu/sdk-js';
 
 import {
     API_EXPERIMENTS_URL,
@@ -6,7 +6,8 @@ import {
     EXPERIMENT_ALREADY_CHECKED_KEY,
     EXPERIMENT_DB_KEY_PATH,
     EXPERIMENT_DB_STORE_NAME,
-    EXPERIMENT_QUERY_PARAM_KEY
+    EXPERIMENT_QUERY_PARAM_KEY,
+    PAGE_VIEW_EVENT_NAME
 } from './constants';
 import { DotExperimentConfig, Experiment, Variant } from './models';
 import { getExperimentsIds, parseData, parseDataForAnalytics, verifyRegex } from './parser/parser';
@@ -47,6 +48,16 @@ export class DotExperiments {
      */
     private static instance: DotExperiments;
     /**
+     * Represents the default configuration for the DotExperiment library.
+     * @property {boolean} trackPageView - Specifies whether to track page view or not. Default value is true.
+     */
+    private static readonly defaultConfig: Partial<DotExperimentConfig> = {
+        // By default, we track the page view
+        trackPageView: true,
+        // By default, debug is off
+        debug: false
+    };
+    /**
      * Represents the promise for the initialization process.
      * @private
      */
@@ -66,21 +77,21 @@ export class DotExperiments {
      * @private
      */
     private experimentsAssigned: Experiment[] = [];
-
     /**
      * A logger utility for logging messages.
      *
      * @class
      */
     private logger!: DotLogger;
-
     /**
      * Represents the current location.
      * @private
      */
     private currentLocation: Location = location;
 
-    private constructor(private config: DotExperimentConfig) {
+    private constructor(private readonly config: DotExperimentConfig) {
+        // merge default config and the config to the instance
+        this.config = { ...DotExperiments.defaultConfig, ...config };
         if (!this.config['server']) {
             throw new Error('`server` must be provided and should not be empty!');
         }
@@ -197,7 +208,6 @@ export class DotExperiments {
         redirectFunction?: (url: string) => void
     ): Promise<void> {
         this.currentLocation = location;
-        this.refreshAnalyticsForCurrentLocation();
         await this.verifyExperimentData();
         const variantAssigned = this.getVariant(location.href);
 
@@ -221,6 +231,28 @@ export class DotExperiments {
         } else {
             this.logger.log(`No experiment variant matched for the current location.`);
         }
+    }
+
+    /**
+     * Tracks a page view event in the analytics system.
+     *
+     * @return {void}
+     */
+    public trackPageView(): void {
+        this.track(PAGE_VIEW_EVENT_NAME);
+    }
+
+    /**
+     * Tracks an event using the analytics service.
+     *
+     * @param {string} typeName - The type of event to track.
+     * @param {EventPayload} [payload] - Optional payload associated with the event.
+     * @return {void}
+     */
+    private track(typeName: string, payload?: EventPayload): void {
+        this.analytics.track(typeName, payload).then(() => {
+            this.logger.log(`${typeName} event sent`);
+        });
     }
 
     /**
@@ -469,11 +501,18 @@ export class DotExperiments {
 
         if (experimentsData.length > 0) {
             const { experiments } = parseDataForAnalytics(experimentsData, this.currentLocation);
+
             this.analytics.set({ experiments });
+
             this.logger.log('Analytics client updated with experiments data.');
         } else {
             this.analytics.set({ experiments: [] });
             this.logger.log('No experiments data available to update analytics client.');
+        }
+
+        // trigger the page view event
+        if (this.config.trackPageView !== false) {
+            this.trackPageView();
         }
     }
 

--- a/core-web/libs/sdk/experiments/src/lib/mocks/mock.ts
+++ b/core-web/libs/sdk/experiments/src/lib/mocks/mock.ts
@@ -72,7 +72,7 @@ export const NewIsUserIncludedResponse: IsUserIncludedApiResponse = {
     messages: []
 };
 
-export const MOCK_CURRENT_TIMESTAMP = 1710969341000;
+export const MOCK_CURRENT_TIMESTAMP = 1704096000000;
 
 export const TIME_15_DAYS_MILLISECONDS = 1296000 * 1000;
 

--- a/core-web/libs/sdk/experiments/src/lib/models.ts
+++ b/core-web/libs/sdk/experiments/src/lib/models.ts
@@ -10,6 +10,7 @@ export interface DotExperimentConfig {
     'api-key': string;
     server: string;
     debug: boolean;
+    trackPageView?: boolean;
 }
 
 /**
@@ -153,20 +154,4 @@ export interface ExperimentEvent {
     isTargetPage: boolean;
     lookBackWindow: string;
     variant: string;
-}
-
-/**
- * `IndexDbStoredData` is an interface representing the data structure of the elements stored in IndexedDB.
- *
- * This structure includes details regarding the creation of the experiment and the experiments that have been assigned.
- *
- * @property {number} created - This represents the time when the data is stored. It is expressed in terms of a timestamp.
- * This property is used as a time discriminator to discard the store when necessary.
- *
- * @property {AssignedExperiments} experiments - This property is an instance of `AssignedExperiments`.
- * It represents all the experiments that have been assigned when this data was created.
- */
-export interface IndexDbStoredData {
-    created: number;
-    experiments: Experiment[];
 }

--- a/core-web/libs/sdk/experiments/src/lib/persistence/index-db-database-handler.ts
+++ b/core-web/libs/sdk/experiments/src/lib/persistence/index-db-database-handler.ts
@@ -144,7 +144,7 @@ export class IndexDBDatabaseHandler {
      * @return {void}
      */
     setFetchExpiredTime(): void {
-        const expireTime = new Date().getTime() + LOCAL_STORAGE_TIME_DURATION_MILLISECONDS;
+        const expireTime = Date.now() + LOCAL_STORAGE_TIME_DURATION_MILLISECONDS;
         localStorage.setItem(EXPERIMENT_FETCH_EXPIRE_TIME_KEY, expireTime.toString());
     }
 

--- a/core-web/libs/sdk/experiments/src/lib/utils/utils.ts
+++ b/core-web/libs/sdk/experiments/src/lib/utils/utils.ts
@@ -134,8 +134,6 @@ export const isDataCreateValid = (): boolean => {
 
         return timeValidUntil > now;
     } catch (error) {
-        console.error('Error checking data validity', error);
-
         return false;
     }
 };


### PR DESCRIPTION
### Proposed Changes
* Track pageview and send to Analytics by default
** When the class is instanced
** The location change
* Config flag to disable auto trackPageView


### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

<img width="2325" alt="Screenshot 2024-03-22 at 10 51 42 AM" src="https://github.com/dotCMS/core/assets/1909643/bf5839c3-dcdd-46b1-9d68-3864c37020fd">

