### PR TITLE
ci(deployment): replace-dockerbuilddevimage.yml-with-buildnightly. (#27858)

### DIFF
--- a/.github/workflows/deployment-trunk.yml
+++ b/.github/workflows/deployment-trunk.yml
@@ -8,8 +8,6 @@ run-name: Trunk Deployment - ${{ github.event.workflow_run.name }}
 
 # The concurrency group is 'trunk-deployment'. This ensures that only one run of this workflow can be in progress at a time.
 concurrency: trunk-deployment
-env:
-  DEPLOYMENT_ENV: trunk
 on:
   workflow_run:
     workflows: ['Maven CICD Pipeline']
@@ -19,97 +17,139 @@ on:
       - master
   workflow_dispatch:
     inputs:
-      trigger_sha:
-        description: 'SHA for manual trigger (leave empty for HEAD of master)'
+      build_run_id:
+        description: 'The run id of the build to pull the artifact from'
         required: false
       skip_checks:
         description: 'Set to true to skip checks'
+        type: boolean
         required: false
-        default: 'false'
+        default: false
       force_latest:
         description: 'Force upload of latest artifact even if conditions are not met does nothing if skip_checks is false'
+        type: boolean
         required: false
-        default: 'false'
+        default: false
 
 # The workflow has read access to the repository contents and actions.
 permissions:
   contents: read
   actions: read # allow access to other job artifacts with GITHUB_TOKEN
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      calculated_run_id: ${{ steps.set_run_id.outputs.calculated_run_id }}
-    steps:
-      - name: Set manual run ID
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_id }}
-        id: set_run_id
-        run: echo "calculated_run_id=${{ github.event.inputs.run_id }}" >> $GITHUB_OUTPUT
-
-      - name: Fetch latest successful Maven CICD Pipeline run ID
-        if: ${{ github.event_name == 'workflow_dispatch' && !github.event.inputs.run_id }}
-        id: get_latest_successful_run
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data } = await github.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'maven-cicd-pipeline.yml', // Replace with your Maven CICD Pipeline workflow file name
-              branch: 'master',
-              status: 'success',
-              event: 'push',
-              per_page: 1
-            });
-            return data.total_count > 0 ? data.workflow_runs[0].id : null;
-          result-encoding: string
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set dynamic run ID
-        if: ${{ github.event_name == 'workflow_dispatch' && !github.event.inputs.run_id }}
-        id: set_run_id
-        run: echo "calculated_run_id=${{ steps.get_latest_successful_run.outputs.result }}" >> $GITHUB_OUTPUT
-
   deploy_check:
     runs-on: ubuntu-latest
     outputs:
       should_deploy: ${{ steps.check.outputs.should_deploy }}
+      is_latest: ${{ steps.check.outputs.is_latest }}
+      build_sha: ${{ steps.check.outputs.build_sha }}
+      run_id: ${{ steps.check.outputs.run_id }}
     steps:
       - name: Checkout core
         uses: actions/checkout@v4
+        with:
+          ref: master         # Specify the branch to check out
+          fetch-depth: 0      # Indicates to fetch all history for all branches and tags
 
       - name: Download latest artifact
+        id: deployment-status
         uses: dawidd6/action-download-artifact@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: deployment-trunk.yml
-          name: ${{ env.DEPLOYMENT_ENV }}_latest_sha
+          branch: master
+          workflow_conclusion: success
+          search_artifacts: true
+          name: trunk_latest_sha
           path: .
+          if_no_artifact_found: warn
+      - name: Set options for artifact lookup
+        id: lookup-type
+        run: |
+          if [[ "${{ github.event.inputs.build_run_id || github.event.workflow_run.id }}" != "" ]]; then
+            echo 'branch=master' >> $GITHUB_OUTPUT
+            echo 'runid=' >> $GITHUB_OUTPUT
+          else
+            echo 'branch=' >> $GITHUB_OUTPUT
+            echo 'runid=${{ github.event.inputs.build_run_id || github.event.workflow_run.id }}' >> $GITHUB_OUTPUT
+          fi
 
-      - name: Get the latest commit SHA from master and compare
+      - name: Download Build Status
+        id: data-download
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: 'workflow-data'
+          workflow: maven-cicd-pipeline.yml
+          workflow_conclusion: success
+          branch: ${{ steps.lookup-type.outputs.branch }}
+          event: push
+          run_id: ${{ steps.lookup-type.outputs.runid }}
+          search_artifacts: true
+          if_no_artifact_found: warn
+
+      - name: Get SHAs and check if we should deploy
         id: check
         run: |
-          LAST_DEPLOY_SHA=$(cat ${{ env.DEPLOYMENT_ENV }}_latest_sha.txt)
-          TRIGGER_SHA=${{ github.event.inputs.trigger_sha || github.event.workflow_run.head_sha }}
-          WORKFLOW_SUCCESS=${{ github.event.workflow_run.conclusion == 'success' || github.event.inputs.skip_checks == 'true' }}
-          FORCE_LATEST=${{ github.event.inputs.force_latest == 'true' }}
-          echo "Last Deploy SHA: $LAST_DEPLOY_SHA, Trigger SHA: $TRIGGER_SHA, Workflow success: $WORKFLOW_SUCCESS, Force latest: $FORCE_LATEST"
-
-          # Determine if deployment should proceed
-          SKIP_CHECKS=${{ github.event.inputs.skip_checks == 'true' }}
-          if [[ "$SKIP_CHECKS" == "true" ]] || (git merge-base --is-ancestor $LAST_DEPLOY_SHA $TRIGGER_SHA && [ "$WORKFLOW_SUCCESS" == "true" ]); then
-            echo "should_deploy=true" >> $GITHUB_ENV
+          build_artifact_exists=${{ steps.data-download.outputs.found_artifact }}
+          last_deployed_exists=${{ steps.deployment-status.outputs.found_artifact }} 
+          if [[ ${last_deployed_exists} == "true" ]]; then
+              last_deployed_sha=`echo '${{ steps.deployment-status.outputs.artifacts }}' | jq -r '.[0].workflow_run.head_sha'`
           else
-            echo "Conditions for deployment not met. Latest: $LAST_DEPLOY_SHA, Trigger: $TRIGGER_SHA, Workflow success: $WORKFLOW_SUCCESS"
-            echo "should_deploy=false" >> $GITHUB_ENV
+              echo "No Last Deployed SHA found"
           fi
+          
+          if [[ ${build_artifact_exists} == "true" ]]; then
+              build_sha=`echo '${{ steps.data-download.outputs.artifacts }}' | jq -r '.[0].workflow_run.head_sha'`
+              run_id=`echo '${{ steps.data-download.outputs.artifacts }}' | jq -r '.[0].workflow_run.id'`
+              echo "Build SHA: $build_sha"
+              echo "Run id: $run_id"
+          else
+             echo "No build artifact found, nothing to deploy"
+             echo "should_deploy=false" >> $GITHUB_OUTPUT
+             exit 0
+          fi
+          
+          if [[ ${last_deployed_exists} == "true" ]]; then
+              echo "Found last deployed artifact with SHA: $last_deployed_sha"
+             if [[ "${last_deployed_sha}" == "${build_sha}" ]]; then
+                  echo "Last deployed SHA and build SHA are the same."
+                  last_deployed_is_ancestor=false
+              else
+                  if git merge-base --is-ancestor ${last_deployed_sha} ${build_sha}; then
+                      echo "The last deployed SHA is an ancestor of the build SHA."
+                      last_deployed_is_ancestor=true
+                  else
+                      echo "The last deployed SHA is not an ancestor of the build SHA."
+                      last_deployed_is_ancestor=false
+                  fi
+              fi
+          else
+              last_deployed_is_ancestor=false
+          fi
+          
+          
+          SKIP_CHECKS="${{ github.event.inputs.skip_checks == 'true' }}"
+          FORCE_LATESST="${{ github.event.inputs.force_latest == 'true' }}"
+          
+          if [[ ${SKIP_CHECKS} == "true" || "${last_deployed_is_ancestor}" == "true" || "${last_deployed_exists}" != "true" ]]; then
+                echo "should_deploy=true" >> $GITHUB_OUTPUT
+            else
+                echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
+          
+          if [[ ${FORCE_LATESST} == "true" || ${last_deployed_is_ancestor} == true ]]; then
+                echo "setting latest on deployment"
+                echo "is_latest=true" >> $GITHUB_OUTPUT
+            else
+                echo "is_latest=false" >> $GITHUB_OUTPUT
+          fi
+          echo "build_sha=${build_sha}" >> $GITHUB_OUTPUT
+          echo "run_id=${run_id}" >> $GITHUB_OUTPUT
         shell: bash
-
   deployment:
     if: needs.deploy_check.outputs.should_deploy == 'true'
-    needs: [setup,deploy_check]
+    needs: [deploy_check]
     runs-on: ubuntu-latest
-    environment: ${{ env.DEPLOYMENT_ENV }}
+    environment: trunk
     steps:
       # The repository is checked out using the 'actions/checkout' action.
       - name: Checkout core
@@ -121,25 +161,27 @@ jobs:
         uses: ./.github/actions/deploy-artifact-docker
         with:
           docker_platforms: linux/amd64,linux/arm64
-          build_run_id: ${{ needs.setup.outputs.calculated_run_id }}
-          commit_id: ${{ github.event.workflow_run.head_sha }}"
+          build_run_id: ${{ needs.deploy_check.outputs.run_id }}
+          commit_id: ${{ needs.deploy_check.outputs.build_sha }}
           ref: master
           snapshot: true
-          latest: true
+          latest: ${{ needs.deploy_check.outputs.is_latest == 'true' }}
           do_deploy: ${{ vars.DOCKER_DEPLOY || 'true' }} # default to true, set to disable in fork
           docker_io_username: ${{ secrets.DOCKER_USERNAME }}
           docker_io_token: ${{ secrets.DOCKER_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create artifact with commit id
+        if: needs.deploy_check.outputs.is_latest == 'true'
         run: |
-          echo "${{ github.event.workflow_run.head_sha }}" > ${{ env.DEPLOYMENT_ENV }}_latest_sha.txt
+          echo "${{ needs.deploy_check.outputs.build_sha }}" > trunk_latest_sha.txt
         shell: bash
       - name: Upload artifact
+        if: needs.deploy_check.outputs.is_latest == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.DEPLOYMENT_ENV }}_latest_sha
-          path: ${{ env.DEPLOYMENT_ENV }}_latest_sha.txt
+          name: trunk_latest_sha
+          path: trunk_latest_sha.txt
 
       # A Slack notification is sent using the 'action-slack-notify' action if the repository is 'dotcms/core'.
       - name: Slack Notification

--- a/.github/workflows/deployment-trunk.yml
+++ b/.github/workflows/deployment-trunk.yml
@@ -8,7 +8,8 @@ run-name: Trunk Deployment - ${{ github.event.workflow_run.name }}
 
 # The concurrency group is 'trunk-deployment'. This ensures that only one run of this workflow can be in progress at a time.
 concurrency: trunk-deployment
-
+env:
+  DEPLOYMENT_ENV: trunk
 on:
   workflow_run:
     workflows: ['Maven CICD Pipeline']
@@ -16,12 +17,59 @@ on:
       - completed
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      trigger_sha:
+        description: 'SHA for manual trigger (leave empty for HEAD of master)'
+        required: false
+      skip_checks:
+        description: 'Set to true to skip checks'
+        required: false
+        default: 'false'
+      force_latest:
+        description: 'Force upload of latest artifact even if conditions are not met does nothing if skip_checks is false'
+        required: false
+        default: 'false'
 
 # The workflow has read access to the repository contents and actions.
 permissions:
   contents: read
   actions: read # allow access to other job artifacts with GITHUB_TOKEN
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      calculated_run_id: ${{ steps.set_run_id.outputs.calculated_run_id }}
+    steps:
+      - name: Set manual run ID
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_id }}
+        id: set_run_id
+        run: echo "calculated_run_id=${{ github.event.inputs.run_id }}" >> $GITHUB_OUTPUT
+
+      - name: Fetch latest successful Maven CICD Pipeline run ID
+        if: ${{ github.event_name == 'workflow_dispatch' && !github.event.inputs.run_id }}
+        id: get_latest_successful_run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'maven-cicd-pipeline.yml', // Replace with your Maven CICD Pipeline workflow file name
+              branch: 'master',
+              status: 'success',
+              event: 'push',
+              per_page: 1
+            });
+            return data.total_count > 0 ? data.workflow_runs[0].id : null;
+          result-encoding: string
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set dynamic run ID
+        if: ${{ github.event_name == 'workflow_dispatch' && !github.event.inputs.run_id }}
+        id: set_run_id
+        run: echo "calculated_run_id=${{ steps.get_latest_successful_run.outputs.result }}" >> $GITHUB_OUTPUT
+
   deploy_check:
     runs-on: ubuntu-latest
     outputs:
@@ -30,28 +78,38 @@ jobs:
       - name: Checkout core
         uses: actions/checkout@v4
 
+      - name: Download latest artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: deployment-trunk.yml
+          name: ${{ env.DEPLOYMENT_ENV }}_latest_sha
+          path: .
+
       - name: Get the latest commit SHA from master and compare
         id: check
         run: |
-         TRIGGER_SHA=${{ github.event.workflow_run.head_sha }}
-         LATEST_SHA=$(git rev-parse origin/master)
-         WORKFLOW_SUCCESS=${{ github.event.workflow_run.conclusion == 'success' }}
-        
-         echo "Latest SHA: $LATEST_SHA, Trigger SHA: $TRIGGER_SHA, Workflow success: $WORKFLOW_SUCCESS"
-        
-         # Only proceed if the workflow was successful and the SHAs match
-         if [[ "$TRIGGER_SHA" == "$LATEST_SHA" && "$WORKFLOW_SUCCESS" == "true" ]]; then
-           echo "should_deploy=true" >> $GITHUB_OUTPUT
-         else
-           echo "Conditions for deployment not met. Latest: $LATEST_SHA, Trigger: $TRIGGER_SHA, Workflow success: $WORKFLOW_SUCCESS"
-           echo "should_deploy=false" >> $GITHUB_OUTPUT
-         fi
+          LAST_DEPLOY_SHA=$(cat ${{ env.DEPLOYMENT_ENV }}_latest_sha.txt)
+          TRIGGER_SHA=${{ github.event.inputs.trigger_sha || github.event.workflow_run.head_sha }}
+          WORKFLOW_SUCCESS=${{ github.event.workflow_run.conclusion == 'success' || github.event.inputs.skip_checks == 'true' }}
+          FORCE_LATEST=${{ github.event.inputs.force_latest == 'true' }}
+          echo "Last Deploy SHA: $LAST_DEPLOY_SHA, Trigger SHA: $TRIGGER_SHA, Workflow success: $WORKFLOW_SUCCESS, Force latest: $FORCE_LATEST"
+
+          # Determine if deployment should proceed
+          SKIP_CHECKS=${{ github.event.inputs.skip_checks == 'true' }}
+          if [[ "$SKIP_CHECKS" == "true" ]] || (git merge-base --is-ancestor $LAST_DEPLOY_SHA $TRIGGER_SHA && [ "$WORKFLOW_SUCCESS" == "true" ]); then
+            echo "should_deploy=true" >> $GITHUB_ENV
+          else
+            echo "Conditions for deployment not met. Latest: $LAST_DEPLOY_SHA, Trigger: $TRIGGER_SHA, Workflow success: $WORKFLOW_SUCCESS"
+            echo "should_deploy=false" >> $GITHUB_ENV
+          fi
+        shell: bash
 
   deployment:
     if: needs.deploy_check.outputs.should_deploy == 'true'
-    needs: [deploy_check]
+    needs: [setup,deploy_check]
     runs-on: ubuntu-latest
-    environment: trunk
+    environment: ${{ env.DEPLOYMENT_ENV }}
     steps:
       # The repository is checked out using the 'actions/checkout' action.
       - name: Checkout core
@@ -63,7 +121,7 @@ jobs:
         uses: ./.github/actions/deploy-artifact-docker
         with:
           docker_platforms: linux/amd64,linux/arm64
-          build_run_id: ${{ github.event.workflow_run.id }}
+          build_run_id: ${{ needs.setup.outputs.calculated_run_id }}
           commit_id: ${{ github.event.workflow_run.head_sha }}"
           ref: master
           snapshot: true
@@ -73,6 +131,15 @@ jobs:
           docker_io_token: ${{ secrets.DOCKER_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Create artifact with commit id
+        run: |
+          echo "${{ github.event.workflow_run.head_sha }}" > ${{ env.DEPLOYMENT_ENV }}_latest_sha.txt
+        shell: bash
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.DEPLOYMENT_ENV }}_latest_sha
+          path: ${{ env.DEPLOYMENT_ENV }}_latest_sha.txt
 
       # A Slack notification is sent using the 'action-slack-notify' action if the repository is 'dotcms/core'.
       - name: Slack Notification


### PR DESCRIPTION

Updates deployment-trunk to compare commit to be deployed against the last successfully deployed commit.  Also adds workflow dispatch trigger to help in testing or to force a deployment
It should no longer prevent deploying of versions other than the current trunk head, but only deploy commits more recent than the currently deployed by default

Related to #27858 (replace-dockerbuilddevimage.yml-with-buildnightly.).