### PR TITLE
fix(block-editor): Thumbnails Not Showing in Contentlet Block #28055

### DIFF
--- a/core-web/libs/block-editor/src/lib/extensions/asset-form/components/dot-asset-search/components/dot-asset-card/dot-asset-card.component.html
+++ b/core-web/libs/block-editor/src/lib/extensions/asset-form/components/dot-asset-search/components/dot-asset-card/dot-asset-card.component.html
@@ -3,10 +3,8 @@
         <div class="thumbnail-container">
             <dot-contentlet-thumbnail
                 [contentlet]="contentlet"
-                [cover]="false"
                 [iconSize]="'72px'"
-                [showVideoThumbnail]="showVideoThumbnail"
-            ></dot-contentlet-thumbnail>
+                [showVideoThumbnail]="showVideoThumbnail"></dot-contentlet-thumbnail>
         </div>
     </ng-template>
     <h2 class="title" *pTemplate="'title'">{{ contentlet?.fileName || contentlet?.title }}</h2>

--- a/core-web/libs/dotcms-webcomponents/src/components.d.ts
+++ b/core-web/libs/dotcms-webcomponents/src/components.d.ts
@@ -348,8 +348,8 @@ export namespace Components {
     }
     interface DotContentletThumbnail {
         "alt": string;
+        "backgroundImage": boolean;
         "contentlet": DotContentletItem;
-        "cover": boolean;
         "fieldVariable": string;
         "height": string;
         "iconSize": string;
@@ -2005,8 +2005,8 @@ declare namespace LocalJSX {
     }
     interface DotContentletThumbnail {
         "alt"?: string;
+        "backgroundImage"?: boolean;
         "contentlet"?: DotContentletItem;
-        "cover"?: boolean;
         "fieldVariable"?: string;
         "height"?: string;
         "iconSize"?: string;

--- a/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.e2e.ts
+++ b/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.e2e.ts
@@ -35,11 +35,24 @@ describe('dot-contentlet-thumbnail', () => {
                 element.setProperty('width', '100');
                 element.setProperty('alt', 'Alt test');
                 element.setProperty('iconSize', '30px');
+                element.setProperty('backgroundImage', false);
                 await page.waitForChanges();
             });
 
             // TODO: find a way to avoid the onError with an invalid image.
             xit('should show image', async () => {});
+
+            it('should not have the `background-image` class', async () => {
+                const imageContainer = await page.find('dot-contentlet-thumbnail .thumbnail');
+                expect(imageContainer).not.toHaveClass('background-image');
+            });
+
+            it('should have the `background-image` class', async () => {
+                element.setProperty('backgroundImage', true);
+                await page.waitForChanges();
+                const imageContainer = await page.find('dot-contentlet-thumbnail .thumbnail');
+                expect(imageContainer).toHaveClass('background-image');
+            });
 
             it('should show dot-contentlet-icon with FileAsset icon', async () => {
                 element.setProperty('contentlet', { ...contentletMock, hasTitleImage: 'false' });
@@ -51,7 +64,12 @@ describe('dot-contentlet-thumbnail', () => {
             });
 
             it('should show dot-contentlet-icon with custom icon', async () => {
-                element.setProperty('contentlet', { ...contentletMock, hasTitleImage: 'false', baseType:'CONTENT', contentTypeIcon: '360' });
+                element.setProperty('contentlet', {
+                    ...contentletMock,
+                    hasTitleImage: 'false',
+                    baseType: 'CONTENT',
+                    contentTypeIcon: '360'
+                });
                 await page.waitForChanges();
                 const icon = await page.find('dot-contentlet-icon');
                 expect(await icon.getAttribute('icon')).toEqual('360');

--- a/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.scss
+++ b/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.scss
@@ -21,7 +21,7 @@ dot-contentlet-icon {
     }
 }
 
-.cover {
+.background-image {
     position: absolute;
     background-size: cover;
     background-position: center center;

--- a/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.tsx
+++ b/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.tsx
@@ -18,8 +18,10 @@ export class DotContentletThumbnail {
     @Prop({ reflect: true })
     iconSize = '';
 
+    // JSP elements need the image to be rendered as a background image because of the way they are styled
+    // New elements should use the default image tag for accessibility
     @Prop({ reflect: true })
-    cover = true;
+    backgroundImage = false;
 
     @Prop()
     showVideoThumbnail = true;
@@ -49,8 +51,9 @@ export class DotContentletThumbnail {
     }
 
     render() {
-        const image = this.contentlet && this.cover ? `url(${this.getImageURL()})` : '';
-        const imgClass = this.cover ? 'cover' : '';
+        const backgroundImageURL =
+            this.contentlet && this.backgroundImage ? `url(${this.getImageURL()})` : '';
+        const imgClass = this.backgroundImage ? 'background-image' : '';
 
         return (
             <Host>
@@ -58,11 +61,13 @@ export class DotContentletThumbnail {
                     <dot-video-thumbnail
                         contentlet={this.contentlet}
                         variable={this.fieldVariable}
-                        cover={this.cover}
+                        cover={this.backgroundImage}
                         playable={this.playableVideo}
                     />
                 ) : this.renderImage ? (
-                    <div class={`thumbnail ${imgClass}`} style={{ 'background-image': image }}>
+                    <div
+                        class={`thumbnail ${imgClass}`}
+                        style={{ 'background-image': backgroundImageURL }}>
                         <img
                             src={this.getImageURL()}
                             alt={this.alt}

--- a/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/readme.md
+++ b/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/readme.md
@@ -8,8 +8,8 @@
 | Property             | Attribute              | Description | Type                | Default     |
 | -------------------- | ---------------------- | ----------- | ------------------- | ----------- |
 | `alt`                | `alt`                  |             | `string`            | `''`        |
+| `backgroundImage`    | `background-image`     |             | `boolean`           | `false`     |
 | `contentlet`         | --                     |             | `DotContentletItem` | `undefined` |
-| `cover`              | `cover`                |             | `boolean`           | `true`      |
 | `fieldVariable`      | `field-variable`       |             | `string`            | `''`        |
 | `height`             | `height`               |             | `string`            | `''`        |
 | `iconSize`           | `icon-size`            |             | `string`            | `''`        |

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.html
@@ -19,7 +19,6 @@
                 <dot-contentlet-thumbnail
                     [fieldVariable]="contentlet.fieldVariable"
                     [iconSize]="'48px'"
-                    [cover]="false"
                     [contentlet]="contentlet"
                     [playableVideo]="true"
                     data-testId="contentlet-thumbnail">

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/components/edit-ema-palette-contentlets/edit-ema-palette-contentlets.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/components/edit-ema-palette-contentlets/edit-ema-palette-contentlets.component.html
@@ -44,10 +44,7 @@
                     draggable="true">
                     <dot-icon [size]="20" name="drag_indicator"></dot-icon>
 
-                    <dot-contentlet-thumbnail
-                        [iconSize]="'24px'"
-                        [cover]="false"
-                        [contentlet]="contentlet">
+                    <dot-contentlet-thumbnail [iconSize]="'24px'" [contentlet]="contentlet">
                     </dot-contentlet-thumbnail>
 
                     <span>{{ contentlet.title }}</span>

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
@@ -2118,7 +2118,7 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
                     let cardThumbnail = document.createElement("dot-contentlet-thumbnail");
 
                     cardThumbnail.iconSize="48px";
-                    cardThumbnail.cover="true";
+                    cardThumbnail.backgroundImage="true";
                     cardThumbnail.contentlet=cellData;
 
                     holderDiv.appendChild(cardThumbnail);


### PR DESCRIPTION
- Display thumbnails in Contentlet Block. [Original Issue](https://github.com/dotCMS/core/issues/28055)

### Video
https://github.com/dotCMS/core/assets/72418962/f81f9b07-52e9-40ba-9a89-7c90fdd481fa

