### PR TITLE
Retrieve previous version of template

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.spec.ts
@@ -15,7 +15,7 @@ const templateMock: DotTemplate = {
     anonymous: false,
     friendlyName: 'Published template',
     identifier: '123Published',
-    inode: '1AreSD',
+    inode: 'inode123',
     name: 'Published template',
     type: 'type',
     versionType: 'type',

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.ts
@@ -20,10 +20,13 @@ export class DotTemplateCreateEditResolver implements Resolve<DotTemplate> {
             ? this.service.getFiltered(inode).pipe(
                   map((templates: DotTemplate[]) => {
                       if (templates.length) {
-                          return templates[0];
-                      } else {
-                          this.dotRouterService.gotoPortlet('templates');
+                          const firstTemplate = templates.find(
+                              (t) => t.inode === inode);
+                          if (firstTemplate) {
+                              return firstTemplate;
+                          }
                       }
+                      this.dotRouterService.gotoPortlet('templates');
                   })
               )
             : this.service.getById(route.paramMap.get('id'));

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.ts
@@ -20,12 +20,12 @@ export class DotTemplateCreateEditResolver implements Resolve<DotTemplate> {
             ? this.service.getFiltered(inode).pipe(
                   map((templates: DotTemplate[]) => {
                       if (templates.length) {
-                          const firstTemplate = templates.find(
-                              (t) => t.inode === inode);
+                          const firstTemplate = templates.find((t) => t.inode === inode);
                           if (firstTemplate) {
                               return firstTemplate;
                           }
                       }
+
                       this.dotRouterService.gotoPortlet('templates');
                   })
               )


### PR DESCRIPTION
### Proposed Changes
* This PR fixes an issue when the user clicks on a previous version in the template history tab: now the previous version is retrieved and shown in the template builder portlet as expected. Previously, because of a bug, the system template was retrieved instead.

### Checklist
- [x] Tests
