### PR TITLE
Issue 28090 build latest dev image

### DIFF
--- a/.github/workflows/docker-build-dev-image.yml
+++ b/.github/workflows/docker-build-dev-image.yml
@@ -2,13 +2,14 @@
 #  every night.  For more information about this docker image, see
 #  https://github.com/dotCMS/core/tree/master/docker/dev-env
 
-name: Build/Push dotCMS Dev Image (nightly)
+name: Build/Push dotCMS Dev Images (nightly/latest)
 on:
   schedule:
     - cron: "18 2 * * *"
 
 jobs:
-  docker:
+  docker-snapshot-master:
+    name: Build/Push dotCMS Nightly Dev Image
     runs-on: ubuntu-latest
     steps:
       -
@@ -52,3 +53,50 @@ jobs:
           no-cache: true
           build-args: |
             DOTCMS_DOCKER_TAG=master_latest_SNAPSHOT
+
+
+  docker-latest:
+    name: Build/Push dotCMS latest Dev Image
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        uses: ./.github/actions/cleanup-runner
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            dotcms/dotcms-dev
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha,enable=true,priority=100,prefix=latest,format=short
+            type=raw,value=latest
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hubdocker-build-master-branch.yml
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: docker/dev-env
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          pull: true
+          no-cache: true
+          build-args: |
+            DOTCMS_DOCKER_TAG=latest

--- a/.github/workflows/docker-build-dev-image.yml
+++ b/.github/workflows/docker-build-dev-image.yml
@@ -80,7 +80,7 @@ jobs:
             dotcms/dotcms-dev
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=sha,enable=true,priority=100,prefix=latest,format=short
+            type=sha,enable=true,priority=100,prefix=latest-,format=short
             type=raw,value=latest
       -
         name: Set up QEMU

--- a/.github/workflows/docker-build-dev-image.yml
+++ b/.github/workflows/docker-build-dev-image.yml
@@ -7,6 +7,12 @@ on:
   schedule:
     - cron: "18 2 * * *"
 
+  # THIS IS HERE FOR TESTING PURPOSES
+  push:
+    branches:
+      - issue-28090-build-latest-dev-image
+
+
 jobs:
   docker-snapshot-master:
     name: Build/Push dotCMS Nightly Dev Image

--- a/docker/dev-env/README.md
+++ b/docker/dev-env/README.md
@@ -20,13 +20,12 @@ When running this image, if you specify a source environment and a valid means t
 
 
 
-All of these examples expect you to login using:
+All of these examples expect you to login via https on port 8443.  There is a valid certificate if you are running locally using:
 
 https://local.dotcms.site:8443/dotAdmin
 
 #### Clone demo with a dotCMS API Token
-This pulls down the assets and a SQL dump that is then imported into the new dotCMS instance.  You will need to login with the same
-credientals that are used in the target environment.
+This pulls down the assets and a SQL dump that is then imported into the new dotCMS instance.  You will need to login with the same credentials that are used in the target environment.
 ```
 export TOK=XXXXXXX_YOUR_DOTCMS_TOKEN.eXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
@@ -41,8 +40,7 @@ docker run --rm \
 ```
 
 #### Clone demo with UserID/Password
-This pulls down the assets and a SQL dump that is then imported into the new dotCMS instance.  You will need to login with the same
-credientals that are used in the target environment.
+This pulls down the assets and a SQL dump that is then imported into the new dotCMS instance.  You will need to login with the same credentials that are used in the target environment.
 ```
 docker run --rm \
 --pull always \

--- a/docker/pg-base/Dockerfile
+++ b/docker/pg-base/Dockerfile
@@ -1,47 +1,28 @@
-# DEPRECATED: Moved this to java-base/Dockerfile
 # ----------------------------------------------
-# Stage 1:  Minimal image with pg_dump and psql built from source 
+# Stage 1:  Minimal image with pg_dump
 # ----------------------------------------------
 FROM ubuntu:20.04 as pg-base-builder
 
-SHELL ["/bin/bash", "-c"] 
+SHELL ["/bin/bash", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 
-# see https://www.postgresql.org/ftp/source/ for versions
-ARG POSTGRES_VERSION=16.2
-
-ARG POSTGRES_TARBALL=postgresql-${POSTGRES_VERSION}.tar.bz2
-ARG FTP_PATH=https://ftp.postgresql.org/pub/source/v${POSTGRES_VERSION}
-
-# zlib1g-dev is required for pg_dump to support compression
-ARG BUILD_DEPS="build-essential ca-certificates curl zlib1g-dev"
-
-# './configure --without-readline' currently means we won't have shared library
-# dependencies that are not present in the dotcms image
-ARG CONFIGURE_OPTS="--without-readline --without-icu"
+# packages needed to install pg_dump
+ARG BUILD_PACKAGES="postgresql-common gnupg"
 
 # builds client only - see https://www.postgresql.org/docs/current/install-procedure.html
 RUN apt update -y \
   && apt upgrade -y \
-  && apt install -y --no-install-recommends ${BUILD_DEPS} \
-  && mkdir -p /postgres/build \
-  && cd /postgres/build \
-  && curl -o ${POSTGRES_TARBALL} ${FTP_PATH}/${POSTGRES_TARBALL} \
-  && diff <(md5sum postgresql-${POSTGRES_VERSION}.tar.bz2) <(curl -s ${FTP_PATH}/${POSTGRES_TARBALL}.md5) || exit 1 \
-  && tar xf ${POSTGRES_TARBALL} \
-  && cd /postgres/build/postgresql-${POSTGRES_VERSION} \
-  && ./configure ${CONFIGURE_OPTS} \
-  && make -C src/bin/pg_dump install \
-  && make -C src/bin/psql install \
-  && make -C src/include install \
-  && make -C src/interfaces install \
-  && rm -rf /postgres/build \
-  && apt remove -y ${BUILD_DEPS} \
+  && apt install -y --no-install-recommends $BUILD_PACKAGES \
+  && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \
+  && apt install postgresql-client-16 -y \
+  && apt remove -y $BUILD_PACKAGES \
   && apt purge -y \
   && apt autoremove -y \
   && apt clean \
   && rm -rf /var/lib/apt/lists/
-RUN /usr/local/pgsql/bin/pg_dump --version || exit 1
+
+
+RUN /usr/bin/pg_dump --version || exit 1
 
 # ----------------------------------------------
 # Stage 2:  Flatten everything to 1 layer


### PR DESCRIPTION
This PR builds dev images against both the `latest` (agile release) tag and the `master_snapshot` (or nightly build) tags.   

Before this PR, we were only building against the nightly snapshots.

It also includes changes to the soon to be deprecated pg_base image we use to provide the pg_dump binary to the dotcms docker image.  Instead of building the pg tools from src, we install the binaries using the provided debian/ubuntu scripts.

