### PR TITLE
feat(edit-page-2): Bring back the Shortcut Button for Editing VTL in New Editor #27700

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
@@ -162,6 +162,22 @@ describe('DotEmaDialogComponent', () => {
             });
         });
 
+        it('should trigger editVTLContentlet in the store', () => {
+            const editVTLContentletSpy = jest.spyOn(storeSpy, 'editContentlet');
+
+            const vtlFile = {
+                inode: '123',
+                name: 'test.vtl'
+            };
+
+            component.editVTLContentlet(vtlFile);
+
+            expect(editVTLContentletSpy).toHaveBeenCalledWith({
+                inode: vtlFile.inode,
+                title: vtlFile.name
+            });
+        });
+
         it('should trigger editContentlet in the store for url Map', () => {
             const editContentletSpy = jest.spyOn(storeSpy, 'editUrlContentMapContentlet');
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.ts
@@ -25,7 +25,7 @@ import {
 } from './store/dot-ema-dialog.store';
 
 import { NG_CUSTOM_EVENTS } from '../../shared/enums';
-import { ActionPayload } from '../../shared/models';
+import { ActionPayload, VTLFile } from '../../shared/models';
 import { EmaFormSelectorComponent } from '../ema-form-selector/ema-form-selector.component';
 
 @Component({
@@ -118,6 +118,19 @@ export class DotEmaDialogComponent {
         this.store.editContentlet({
             inode: contentlet.inode,
             title: contentlet.title
+        });
+    }
+
+    /**
+     * Edits a VTL contentlet.
+     *
+     * @param {VTLFile} vtlFile - The VTL file to edit.
+     * @memberof DotEmaDialogComponent
+     */
+    editVTLContentlet(vtlFile: VTLFile) {
+        this.store.editContentlet({
+            inode: vtlFile.inode,
+            title: vtlFile.name
         });
     }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.html
@@ -16,6 +16,15 @@
     *ngIf="!isContainerEmpty"
     [ngStyle]="getActionPosition()"
     data-testId="actions">
+    @if (contentlet.payload.vtlFiles?.length) {
+    <p-button
+        (click)="menuVTL.toggle($event)"
+        data-testId="edit-vtl-button"
+        styleClass="p-button-rounded p-button-raised"
+        icon="pi pi-code" />
+    <p-menu #menuVTL [model]="vtlFiles" [popup]="true" appendTo="body" />
+
+    }
     <p-button
         (dragstart)="dragStart($event, contentlet.payload)"
         (dragend)="dragEnd($event)"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.spec.ts
@@ -294,4 +294,36 @@ describe('EmaContentletToolsComponent', () => {
             expect(spectator.query(byTestId('actions'))).toBeNull();
         });
     });
+
+    describe('VTL contentlet', () => {
+        beforeEach(
+            () =>
+                (spectator = createComponent({
+                    props: {
+                        contentlet: {
+                            ...contentletAreaMock,
+                            payload: {
+                                ...contentletAreaMock.payload,
+                                vtlFiles: [
+                                    {
+                                        inode: '123',
+                                        name: 'test.vtl'
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }))
+        );
+
+        it('should set right position for actions', () => {
+            const topButton = spectator.query(byTestId('actions'));
+            expect(topButton).toHaveStyle({
+                position: 'absolute',
+                left: '414px',
+                top: '80px',
+                zIndex: '1'
+            });
+        });
+    });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.ts
@@ -6,6 +6,7 @@ import {
     EventEmitter,
     HostBinding,
     Input,
+    OnInit,
     Output,
     ViewChild,
     inject
@@ -17,12 +18,11 @@ import { MenuModule } from 'primeng/menu';
 
 import { DotMessageService } from '@dotcms/data-access';
 
-import { ActionPayload } from '../../../shared/models';
+import { ActionPayload, VTLFile } from '../../../shared/models';
 import { ContentletArea } from '../ema-page-dropzone/types';
 
 const BUTTON_WIDTH = 40;
 const BUTTON_HEIGHT = 40;
-const ACTIONS_CONTAINER_WIDTH = 128;
 const ACTIONS_CONTAINER_HEIGHT = 40;
 
 @Component({
@@ -33,7 +33,7 @@ const ACTIONS_CONTAINER_HEIGHT = 40;
     styleUrls: ['./ema-contentlet-tools.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EmaContentletToolsComponent {
+export class EmaContentletToolsComponent implements OnInit {
     @ViewChild('dragImage') dragImage: ElementRef;
     private dotMessageService = inject(DotMessageService);
 
@@ -45,6 +45,7 @@ export class EmaContentletToolsComponent {
     @Output() addForm = new EventEmitter<ActionPayload>();
     @Output() addWidget = new EventEmitter<ActionPayload>();
     @Output() edit = new EventEmitter<ActionPayload>();
+    @Output() editVTL = new EventEmitter<VTLFile>();
     @Output() delete = new EventEmitter<ActionPayload>();
 
     @Output() moveStart = new EventEmitter<ActionPayload>();
@@ -79,6 +80,29 @@ export class EmaContentletToolsComponent {
             }
         }
     ];
+
+    vtlFiles: MenuItem[] = [];
+
+    ACTIONS_CONTAINER_WIDTH: number; // Now is dynamic based on the page type (Headless - VTL)
+
+    ngOnInit() {
+        this.setVtlFiles();
+        this.ACTIONS_CONTAINER_WIDTH = this.contentlet.payload.vtlFiles ? 178 : 128;
+    }
+
+    /**
+     * Sets the VTL files for the component.
+     *
+     * @memberof EmaContentletToolsComponent
+     */
+    setVtlFiles() {
+        this.vtlFiles = this.contentlet.payload.vtlFiles?.map((file) => ({
+            label: file.name,
+            command: () => {
+                this.editVTL.emit(file);
+            }
+        }));
+    }
 
     dragStart(event: DragEvent, payload: ActionPayload): void {
         event.dataTransfer.setDragImage(this.dragImage.nativeElement, 0, 0);
@@ -161,7 +185,7 @@ export class EmaContentletToolsComponent {
      */
     getActionPosition(): Record<string, string> {
         const contentletCenterX = this.contentlet.x + this.contentlet.width;
-        const left = contentletCenterX - ACTIONS_CONTAINER_WIDTH - 8;
+        const left = contentletCenterX - this.ACTIONS_CONTAINER_WIDTH - 8;
         const top = this.contentlet.y - ACTIONS_CONTAINER_HEIGHT / 2;
 
         return {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -139,6 +139,7 @@
                 [hide]="es.state === editorState.DRAGGING"
                 [contentlet]="contentlet"
                 (edit)="handleEditContentlet($event)"
+                (editVTL)="handleEditVTL($event)"
                 (delete)="deleteContentlet($event)"
                 (addWidget)="dialog.addWidget($event)"
                 (addForm)="dialog.addForm($event)"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -87,7 +87,8 @@ import {
     SetUrlPayload,
     ContainerPayload,
     ContentletPayload,
-    PageContainer
+    PageContainer,
+    VTLFile
 } from '../shared/models';
 import {
     areContainersEquals,
@@ -793,6 +794,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
             },
             [CUSTOMER_ACTIONS.IFRAME_SCROLL]: () => {
                 this.resetDragProperties();
+                this.store.updateEditorState(EDITOR_STATE.IDLE);
             },
             [CUSTOMER_ACTIONS.PING_EDITOR]: () => {
                 this.iframe?.nativeElement?.contentWindow.postMessage(
@@ -936,6 +938,16 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
             .subscribe((contentlet) => {
                 this.dialog.editContentlet(contentlet);
             });
+    }
+
+    /**
+     * Handles the edit of a VTL file.
+     *
+     * @param {VTLFile} vtlFile - The VTL file to be edited.
+     * @memberof EditEmaEditorComponent
+     */
+    handleEditVTL(vtlFile: VTLFile) {
+        this.dialog.editVTLContentlet(vtlFile);
     }
 
     /**

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
@@ -4,9 +4,15 @@ import { EDITOR_MODE, EDITOR_STATE } from './enums';
 
 import { DotPageApiParams, DotPageApiResponse } from '../services/dot-page-api.service';
 
+export interface VTLFile {
+    inode: string;
+    name: string;
+}
+
 export interface ClientData {
     contentlet?: ContentletPayload;
     container: ContainerPayload;
+    vtlFiles?: VTLFile[];
 }
 
 export interface PositionPayload extends ClientData {

--- a/core-web/libs/sdk/client/src/lib/editor/listeners/listeners.ts
+++ b/core-web/libs/sdk/client/src/lib/editor/listeners/listeners.ts
@@ -2,6 +2,7 @@ import { CUSTOMER_ACTIONS, postMessageToEditor } from '../models/client.model';
 import { DotCMSPageEditorConfig } from '../models/editor.model';
 import { DotCMSPageEditorSubscription, NOTIFY_CUSTOMER } from '../models/listeners.model';
 import {
+    findVTLData,
     findContentletElement,
     getClosestContainerData,
     getPageElementBound
@@ -102,6 +103,7 @@ export function listenHoveredContentlet() {
         if (!target) return;
         const { x, y, width, height } = target.getBoundingClientRect();
 
+        const vtlFiles = findVTLData(target);
         const contentletPayload = {
             container:
                 // Here extract dot-container from contentlet if is Headless
@@ -115,7 +117,8 @@ export function listenHoveredContentlet() {
                 inode: target.dataset?.['dotInode'],
                 contentType: target.dataset?.['dotType'],
                 onNumberOfPages: target.dataset?.['dotOnNumberOfPages']
-            }
+            },
+            vtlFiles
         };
 
         postMessageToEditor({

--- a/core-web/libs/sdk/client/src/lib/editor/utils/editor.utils.ts
+++ b/core-web/libs/sdk/client/src/lib/editor/utils/editor.utils.ts
@@ -149,3 +149,34 @@ export function findContentletElement(element: HTMLElement | null): HTMLElement 
         return findContentletElement(element?.['parentElement']);
     }
 }
+
+export function findVTLElement(element: HTMLElement | null): HTMLElement | null {
+    if (!element) return null;
+
+    if (element.dataset && element.dataset?.['dotObject'] === 'vtl-file') {
+        return element;
+    } else {
+        return findContentletElement(element?.['parentElement']);
+    }
+}
+
+export function findVTLData(target: HTMLElement) {
+    const vltElements = target.querySelectorAll(
+        '[data-dot-object="vtl-file"]'
+    ) as NodeListOf<HTMLElement>;
+
+    if (!vltElements.length) {
+        return null;
+    }
+
+    return Array.from(vltElements).map((vltElement) => {
+        return {
+            inode: vltElement.dataset?.['dotInode'],
+            name: vltElement.dataset?.['dotUrl']
+        };
+    });
+
+    // if (vltElement) {
+    //     return vltElement.dataset?.['dotInode'];
+    // }
+}

--- a/core-web/libs/sdk/client/src/lib/editor/utils/editor.utils.ts
+++ b/core-web/libs/sdk/client/src/lib/editor/utils/editor.utils.ts
@@ -175,8 +175,4 @@ export function findVTLData(target: HTMLElement) {
             name: vltElement.dataset?.['dotUrl']
         };
     });
-
-    // if (vltElement) {
-    //     return vltElement.dataset?.['dotInode'];
-    // }
 }


### PR DESCRIPTION
### Proposed Changes
* Added shortcut to edit VTL files in VTL Pages
* Fixed scrollHandler in EditEmaEditor - Now the contentlet tools disappear on scroll

With VTL Pages:

https://github.com/dotCMS/core/assets/144152756/8273f3aa-03ce-46a4-ade7-88c8e5cb3221

With Headless that option is not showed

https://github.com/dotCMS/core/assets/144152756/1d45bb5e-8758-449f-b8cf-6689b252f2bb

