### PR TITLE
test(tests): fix flakey postman tests when no body is sent (#28108)

### DIFF
--- a/dotCMS/src/curl-test/Content_Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Content_Resource.postman_collection.json
@@ -1789,6 +1789,15 @@
 								"type": "text"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/UNPUBLISH?inode={{fileInode}}&identifier={{fileId}}&indexPolicy=WAIT_FOR",
 							"host": [
@@ -1865,6 +1874,15 @@
 								"type": "text"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/ARCHIVE?inode={{fileInode}}&identifier={{fileId}}&indexPolicy=WAIT_FOR",
 							"host": [
@@ -1941,6 +1959,15 @@
 								"type": "text"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/DELETE?inode={{fileInode}}&identifier={{fileId}}&indexPolicy=WAIT_FOR",
 							"host": [

--- a/dotCMS/src/curl-test/Experiments_Resource.postman_collection.json
+++ b/dotCMS/src/curl-test/Experiments_Resource.postman_collection.json
@@ -153,7 +153,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": ""
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?identifier=e424abd7e2e7a9031c5a0a3c18182f1b",
@@ -324,7 +329,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": ""
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?identifier=9044ec0fdb3788a814ccabf789f376d4",
@@ -500,7 +510,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": ""
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?identifier=e424abd7e2e7a9031c5a0a3c18182f1b",


### PR DESCRIPTION
### Proposed Changes
Some postman tests are failing but not every time and in the log we can see it is complaining about "Entity is empty". the cause of this is that the endpoint is expecting a body of type FormDataMultiPart and in these cases the postman test is not sending any body. We still do not know why this does not fail every time but the solution in this case is to make sure the test is passing an empty json object in the body.

The main test that breaks is "File Asset Metadata" in Content_Resource.postman_collection.json

This has been tested in Postman after starting services with
./mvnw -pl :dotcms-postman pre-integration-test -Dpostman.test.skip=false -Pdebug

and the whole of Content_Resource.postman_collection can be tested locally with
./mvnw -pl :dotcms-postman verify -Dpostman.test.skip=false -Pdebug -Dpostman.collections=Content_Resource.postman_collection

of with just installed as
just test-postman Content_Resource.postman_collection


### Additional Info
Related to #28108 (fix-flakey-postman-tests-when-no-body-is-sent-to-w).