### PR TITLE
fix(db) only alter tables if they require it, as the alter table statement always locks a table

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/common/db/DotDatabaseMetaData.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/db/DotDatabaseMetaData.java
@@ -825,5 +825,26 @@ public class DotDatabaseMetaData {
         dotConnect.setSQL(query);
         return (Map<String, String>)dotConnect.loadResults().get(0);
     }
+
+    /**
+     * Checks if the length of a specific column in a table is already what is expected.
+     * Note: since this is going to be used in UT, when using it you need to negate the result,
+     * since the UT should be run when the column length is not what is expected.
+     *
+     * @param tableName
+     * @param columnName
+     * @param expectedLength
+     * @return boolean - true if the column length is equals to the value expected.
+     */
+    public boolean isColumnLengthExpected(final String tableName, final String columnName, final String expectedLength){
+        boolean isColumnLengthExpected = false;
+        try {
+            final Map<String, String> columnData = getModifiedColumnLength(tableName,columnName);
+            isColumnLengthExpected = columnData.get("field_length").equals(expectedLength);
+        } catch (Exception e) {
+            Logger.error(this.getClass(),"An error occurred when trying to pull the field_length");
+        }
+        return isColumnLengthExpected;
+    }
 } // E:O:F:DotDatabaseMetaData.
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230426AlterVarcharLengthOfLockedByCol.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230426AlterVarcharLengthOfLockedByCol.java
@@ -1,10 +1,14 @@
 package com.dotmarketing.startup.runonce;
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.startup.StartupTask;
+import com.dotmarketing.util.Logger;
 
 import java.sql.SQLException;
+import java.util.Map;
 
 /**
  * This class alter the locked_by column in four different tables.
@@ -21,22 +25,15 @@ public class Task230426AlterVarcharLengthOfLockedByCol implements StartupTask {
     }
     @Override
     public boolean forceRun() {
-
-
-        return new DotConnect()
-                .setSQL("select "
-                        + "character_maximum_length "
-                        + "from INFORMATION_SCHEMA.COLUMNS "
-                        + "where "
-                        + "table_name='contentlet_version_info' "
-                        + "and column_name='locked_by'")
-                .getInt("character_maximum_length") < 100;
-
-
-
-
-
-
+        boolean shouldRun = false;
+        try {
+            final Map<String, String> columnData = new DotDatabaseMetaData().getModifiedColumnLength("contentlet_version_info",
+                    "locked_by");
+            shouldRun = columnData.get("field_length").equals("100");
+        } catch (Exception e) {
+            Logger.error(this.getClass(),"An error occurred when trying to pull the field_length");
+        }
+        return !shouldRun;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230426AlterVarcharLengthOfLockedByCol.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230426AlterVarcharLengthOfLockedByCol.java
@@ -21,7 +21,22 @@ public class Task230426AlterVarcharLengthOfLockedByCol implements StartupTask {
     }
     @Override
     public boolean forceRun() {
-        return true;
+
+
+        return new DotConnect()
+                .setSQL("select "
+                        + "character_maximum_length "
+                        + "from INFORMATION_SCHEMA.COLUMNS "
+                        + "where "
+                        + "table_name='contentlet_version_info' "
+                        + "and column_name='locked_by'")
+                .getInt("character_maximum_length") < 100;
+
+
+
+
+
+
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230426AlterVarcharLengthOfLockedByCol.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230426AlterVarcharLengthOfLockedByCol.java
@@ -1,7 +1,6 @@
 package com.dotmarketing.startup.runonce;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.db.DotDatabaseMetaData;
-import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.startup.StartupTask;
@@ -25,15 +24,8 @@ public class Task230426AlterVarcharLengthOfLockedByCol implements StartupTask {
     }
     @Override
     public boolean forceRun() {
-        boolean shouldRun = false;
-        try {
-            final Map<String, String> columnData = new DotDatabaseMetaData().getModifiedColumnLength("contentlet_version_info",
-                    "locked_by");
-            shouldRun = columnData.get("field_length").equals("100");
-        } catch (Exception e) {
-            Logger.error(this.getClass(),"An error occurred when trying to pull the field_length");
-        }
-        return !shouldRun;
+        return !(new DotDatabaseMetaData().isColumnLengthExpected("contentlet_version_info",
+                "locked_by","100"));
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230713IncreaseDisabledWysiwygColumnSize.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230713IncreaseDisabledWysiwygColumnSize.java
@@ -2,9 +2,13 @@ package com.dotmarketing.startup.runonce;
 
 import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.startup.StartupTask;
+import com.dotmarketing.util.Logger;
+
+import java.util.Map;
 
 /**
  * This Upgrade Task increases the size of the {@code contentlet.disabled_wysiwyg} column to 1000.
@@ -25,7 +29,15 @@ public class Task230713IncreaseDisabledWysiwygColumnSize implements StartupTask 
 
     @Override
     public boolean forceRun() {
-        return true;
+        boolean shouldRun = false;
+        try {
+            final Map<String, String> columnData = new DotDatabaseMetaData().getModifiedColumnLength("contentlet",
+                    "disabled_wysiwyg");
+            shouldRun = columnData.get("field_length").equals("1000");
+        } catch (Exception e) {
+            Logger.error(this.getClass(),"An error occurred when trying to pull the disabled Wysiwyg size");
+        }
+        return !shouldRun;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230713IncreaseDisabledWysiwygColumnSize.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task230713IncreaseDisabledWysiwygColumnSize.java
@@ -29,15 +29,8 @@ public class Task230713IncreaseDisabledWysiwygColumnSize implements StartupTask 
 
     @Override
     public boolean forceRun() {
-        boolean shouldRun = false;
-        try {
-            final Map<String, String> columnData = new DotDatabaseMetaData().getModifiedColumnLength("contentlet",
-                    "disabled_wysiwyg");
-            shouldRun = columnData.get("field_length").equals("1000");
-        } catch (Exception e) {
-            Logger.error(this.getClass(),"An error occurred when trying to pull the disabled Wysiwyg size");
-        }
-        return !shouldRun;
+        return !(new DotDatabaseMetaData().isColumnLengthExpected("contentlet",
+                "disabled_wysiwyg", "1000"));
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task240102AlterVarcharLengthOfRelationType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task240102AlterVarcharLengthOfRelationType.java
@@ -21,15 +21,8 @@ public class Task240102AlterVarcharLengthOfRelationType implements StartupTask {
 
     @Override
     public boolean forceRun() {
-        boolean shouldRun = false;
-        try {
-            final Map<String, String> columnData = new DotDatabaseMetaData().getModifiedColumnLength("tree",
-                    "relation_type");
-            shouldRun = columnData.get("field_length").equals("255");
-        } catch (Exception e) {
-            Logger.error(this.getClass(),"An error occurred when trying to pull the field_length");
-        }
-        return !shouldRun;
+        return !(new DotDatabaseMetaData().isColumnLengthExpected("tree",
+                "relation_type","255"));
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task240102AlterVarcharLengthOfRelationType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task240102AlterVarcharLengthOfRelationType.java
@@ -1,11 +1,14 @@
 package com.dotmarketing.startup.runonce;
 
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.startup.StartupTask;
+import com.dotmarketing.util.Logger;
 
 import java.sql.SQLException;
+import java.util.Map;
 
 /**
  * Increased the size of the varchar column {@code relation_type} in the {@code tree} table
@@ -18,7 +21,15 @@ public class Task240102AlterVarcharLengthOfRelationType implements StartupTask {
 
     @Override
     public boolean forceRun() {
-        return true;
+        boolean shouldRun = false;
+        try {
+            final Map<String, String> columnData = new DotDatabaseMetaData().getModifiedColumnLength("tree",
+                    "relation_type");
+            shouldRun = columnData.get("field_length").equals("255");
+        } catch (Exception e) {
+            Logger.error(this.getClass(),"An error occurred when trying to pull the field_length");
+        }
+        return !shouldRun;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task240131UpdateLanguageVariableContentType.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task240131UpdateLanguageVariableContentType.java
@@ -2,6 +2,7 @@ package com.dotmarketing.startup.runonce;
 
 import com.dotcms.languagevariable.business.LanguageVariableAPI;
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.startup.StartupTask;
@@ -13,7 +14,11 @@ import com.dotmarketing.startup.StartupTask;
 public class Task240131UpdateLanguageVariableContentType implements StartupTask {
     @Override
     public boolean forceRun() {
-        return true;
+        final String isSystem = new DotConnect().setSQL(
+                        "select system from structure where velocity_var_name like ?")
+                .addParam(LanguageVariableAPI.LANGUAGEVARIABLE_VAR_NAME).getString("system");
+
+        return DbConnectionFactory.isDBTrue(isSystem);
     }
 
     @Override


### PR DESCRIPTION
These UTs were backported, meaning they are running with every restart and might cause table locks.

Added validations to determine if they need to run or not.

ref: #28110
