### PR TITLE
Removes pg-base image from core Dockerfile

### DIFF
--- a/dotCMS/src/main/docker/original/Dockerfile
+++ b/dotCMS/src/main/docker/original/Dockerfile
@@ -49,13 +49,6 @@ RUN find /srv/ -type f -name "*.sh" -exec chmod a+x {} \; && \
     chown -R $USER_NAME:$USER_NAME /data
 
 # ----------------------------------------------
-# Stage 2:  Copy pg_dump binary
-#     - pg_dump v. 16.2 for Ubuntu 20.04
-# ----------------------------------------------
-FROM dotcms/pg-base:20.04_16.2 as composed-base
-COPY --from=container-base / /
-
-# ----------------------------------------------
 # Stage 3:  Flatten everything to 1 layer
 # ----------------------------------------------
 FROM scratch
@@ -72,7 +65,7 @@ COPY --from=composed-base / /
 # Switching to non-root user to install SDKMAN!
 USER $USER_UID:$USER_GID
 ENV JAVA_HOME="/java"
-ENV PATH=$PATH:/java/bin:/usr/local/pgsql/bin
+ENV PATH=$PATH:/java/bin
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/srv/entrypoint.sh"]
 CMD ["dotcms"]


### PR DESCRIPTION
pg_dump is now installed directly in the `java-base` Docker image 
```
docker run -it dotcms/java-base:ms-jdk-11 /usr/bin/pg_dump -V 
pg_dump (PostgreSQL) 16.2 (Ubuntu 16.2-1.pgdg22.04+1)
```

### Proposed Changes
* Remove `pg-base` image from core Dockerfile

### Additional Info
#27871 refactor pg_dump inclusion in our docker image

