### PR TITLE
feat(edit-content): Allow WYSIWYG user configuration through tinymceprops Field Variable #27944

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.spec.ts
@@ -97,8 +97,8 @@ describe('DotEditContentWYSIWYGFieldComponent', () => {
                     clazz: 'com.dotcms.contenttype.model.field.ImmutableFieldVariable',
                     fieldId: '1',
                     id: '1',
-                    key: 'toolbar1',
-                    value: 'undo redo'
+                    key: 'tinymceprops',
+                    value: '{ "toolbar1": "undo redo"}'
                 }
             ];
 
@@ -121,8 +121,8 @@ describe('DotEditContentWYSIWYGFieldComponent', () => {
                     clazz: 'com.dotcms.contenttype.model.field.ImmutableFieldVariable',
                     fieldId: '1',
                     id: '1',
-                    key: 'theme',
-                    value: 'modern'
+                    key: 'tinymceprops',
+                    value: '{theme: "modern"}'
                 }
             ];
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.ts
@@ -10,7 +10,7 @@ import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
 
 import { DotWysiwygPluginService } from './dot-wysiwyg-plugin/dot-wysiwyg-plugin.service';
 
-import { getFieldVariablesParsed } from '../../utils/functions.util';
+import { getFieldVariablesParsed, stringToJson } from '../../utils/functions.util';
 
 const DEFAULT_CONFIG = {
     menubar: false,
@@ -57,7 +57,8 @@ export class DotEditContentWYSIWYGFieldComponent implements OnInit {
     }
 
     private variables() {
-        const variables = getFieldVariablesParsed(this.field.fieldVariables);
+        const { tinymceprops } = getFieldVariablesParsed(this.field.fieldVariables);
+        const variables = stringToJson(tinymceprops as string);
 
         /**
          * Old theme are not supported in the new version of TinyMCE

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -496,14 +496,6 @@ describe('Utils Functions', () => {
             expect(result).toEqual({ key: 'value' });
         });
 
-        it('should format the JSON and return parsed object when provided with valid JSON string', () => {
-            const jsonString = '{ key: "value" }';
-
-            const result = stringToJson(jsonString);
-
-            expect(result).toEqual({ key: 'value' });
-        });
-
         it('should return empty object when provided with invalid JSON string', () => {
             const jsonString = '{ key: value }';
 

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -496,6 +496,14 @@ describe('Utils Functions', () => {
             expect(result).toEqual({ key: 'value' });
         });
 
+        it('should format the JSON and return parsed object when provided with valid JSON string', () => {
+            const jsonString = '{ key: "value" }';
+
+            const result = stringToJson(jsonString);
+
+            expect(result).toEqual({ key: 'value' });
+        });
+
         it('should return empty object when provided with invalid JSON string', () => {
             const jsonString = '{ key: value }';
 

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -175,8 +175,5 @@ export const stringToJson = (value: string) => {
         return {};
     }
 
-    // Add double quotes around keys
-    const json = value.replace(/(\w+):/g, '"$1":');
-
-    return isValidJson(json) ? JSON.parse(json) : {};
+    return isValidJson(value) ? JSON.parse(value) : {};
 };

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -171,9 +171,12 @@ export const getFieldVariablesParsed = <T extends Record<string, string | boolea
  *       not valid JSON, an empty object will be returned.
  */
 export const stringToJson = (value: string) => {
-    if (value && isValidJson(value)) {
-        return JSON.parse(value);
+    if (!value) {
+        return {};
     }
 
-    return {};
+    // Add double quotes around keys
+    const json = value.replace(/(\w+):/g, '"$1":');
+
+    return isValidJson(json) ? JSON.parse(json) : {};
 };


### PR DESCRIPTION
- Use `tinymcepops` key to set field variables.

### Video

https://github.com/dotCMS/core/assets/72418962/e974362c-9aae-488a-b29d-474583db7c1e

