### PR TITLE
chore(edit-page-2): Wrong dojo styles on dialog - UVE

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.html
@@ -21,7 +21,7 @@
                 *ngIf="ds.url"
                 [style]="{
                     border: 'none',
-                    display: ds.status !== dialogStatus.INIT ? 'none' : 'block'
+                    height: ds.status !== dialogStatus.INIT ? '0' : null
                 }"
                 [src]="ds.url | safeUrl"
                 (load)="onIframeLoad()"


### PR DESCRIPTION
### Proposed Changes
* Fixed wrong dojo styles in UVE.
* Now the fix is on all dialogs in UVE, not only in "add contentlet"
* The changes is in the toggle show iframe and spinner 

https://github.com/dotCMS/core/assets/144152756/5a4ba379-93b1-4859-b013-b65a7261cd53


