### PR TITLE
feat(CICD): #27805 CLI NPM package Nightly build

### DIFF
--- a/.github/workflows/cli-npm-build-nightly.yml
+++ b/.github/workflows/cli-npm-build-nightly.yml
@@ -1,0 +1,36 @@
+#  This job publish the dotCLI NPM package: @dotcms/dotcli@rc
+#  every night. The package is built from the master branch.
+
+name: CLI NPM build (nightly)
+on:
+  schedule:
+    - cron: "18 5 * * *" # every night
+  workflow_dispatch:
+
+jobs:
+  build-package:
+    name: Build NPM Package
+    uses: ./.github/workflows/cli-npm-package.yml
+    with:
+      ref: master
+      npm-package-name: 'dotcli'
+      npm-package-scope: '@dotcms'
+    permissions:
+      contents: read
+      packages: write
+
+  publish-package:
+    name: Publish NPM Package
+    needs: [ build-package ]
+    if: success()
+    uses: ./.github/workflows/cli-npm-publish.yml
+    with:
+      ref: master
+      artifact-id: ${{ needs.build-package.outputs.artifact-id }}
+      run-id: ${{ needs.build-package.outputs.run-id }}
+      npm-package-version-tag: ${{ needs.build-package.outputs.npm-package-version-tag }}
+    secrets:
+      npm-token: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/cli-npm-package.yml
+++ b/.github/workflows/cli-npm-package.yml
@@ -1,0 +1,219 @@
+name: 'NPM Package'
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Branch to build from'
+        required: false
+        type: string
+      npm-package-name:
+        description: 'NPM package name'
+        required: false
+        type: string
+      npm-package-scope:
+        description: 'NPM package scope'
+        required: false
+        type: string
+    outputs:
+      run-id:
+        description: 'Run id'
+        value: ${{ jobs.package.outputs.run-id }}
+      artifact-id:
+        description: 'Artifact id'
+        value: ${{ jobs.package.outputs.artifact-id }}
+      npm-package-version:
+        description: 'NPM package version'
+        value: ${{ jobs.package.outputs.npm-package-version }}
+      npm-package-version-tag:
+        description: 'NPM package version tag'
+        value: ${{ jobs.package.outputs.npm-package-version-tag }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    outputs:
+      run-id: ${{ steps.extract-metadata.outputs.run-id }}
+      artifact-id: npm-package-artifact
+      npm-package-version: ${{ steps.npm-version-tag.outputs.npm-package-version }}
+      npm-package-version-tag: ${{ steps.npm-version-tag.outputs.npm-package-version-tag }}
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: ./.github/actions/cleanup-runner
+
+      - name: Download Build Artifact
+        id: data-download
+        uses: dawidd6/action-download-artifact@v3.1.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build-test-master.yml
+          #commit: ${{ github.sha }}
+          workflow_conclusion: success
+          search_artifacts: true
+          dry_run: true
+          name: cli-artifacts-*
+          name_is_regexp: true
+          path: .
+          if_no_artifact_found: warn
+
+      - name: Get SHAs and check if we should deploy
+        id: check
+        run: |
+          build_artifact_exists=${{ steps.data-download.outputs.found_artifact }}
+          if [[ ${build_artifact_exists} == "true" ]]; then
+              run_id=`echo '${{ steps.data-download.outputs.artifacts }}' | jq -r '.[0].workflow_run.id'`
+              found_artifacts=true
+              echo "Artifact Run id: $run_id"
+          else
+             echo "No artifact found"
+             run_id="${{ github.run_id }}"
+             found_artifacts=false
+          fi
+          echo "run_id=$run_id" >> $GITHUB_OUTPUT
+          echo "found_artifacts=$found_artifacts" >> $GITHUB_OUTPUT
+
+      - name: 'Download all build artifacts'
+        id: download-cli-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cli-artifacts-*
+          path: ${{ github.workspace }}/artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN  }}
+          merge-multiple: true
+          run-id: ${{ steps.check.outputs.run_id }}
+
+      - name: 'List CLI Artifacts'
+        run: |
+          echo "::group::CLI Artifacts"
+          echo "Artifacts"
+          ls -R ${{ github.workspace }}/artifacts
+          echo "::endgroup::"
+
+      - name: 'Extract run-id'
+        id: extract-metadata
+        run: |
+          echo "run-id=${{ github.run_id }}" >> $GITHUB_OUTPUT
+
+      - name: 'Extract package version'
+        id: project
+        run: |
+          echo "::group::Extract package version"
+          version=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout -pl :dotcms-cli)
+          echo "PROJECT VERSION: $version"
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
+
+      # Determines the NPM package version and tag
+      # Distinguishes between snapshots and releases
+      - name: 'Dynamic configuration of NPM package Version and Tag'
+        id: npm-version-tag
+        run: |
+          echo "::group::NPM package Version and Tag"
+          MVN_PACKAGE_VERSION=$(echo ${{ steps.project.outputs.version }} | tr '[:lower:]' '[:upper:]')
+          PACKAGE_FULL_NAME=${{ inputs.npm-package-scope }}/${{ inputs.npm-package-name }}
+          
+          # Check if the npm package exists
+          if ! npm view $PACKAGE_FULL_NAME &> /dev/null; then
+            echo "::error::The package $PACKAGE_FULL_NAME does not exist on npm."
+            exit 1
+          fi
+          
+          # Check if the package is a snapshot
+          REGEX="([0-9]+\.[0-9]+\.[0-9]+)-SNAPSHOT"
+          
+          if [[ $MVN_PACKAGE_VERSION =~ $REGEX ]]; then
+            echo "::debug::Snapshot version found."
+          
+            NPM_PACKAGE_VERSION_TAG="rc"
+            MVN_BASE_VERSION="${BASH_REMATCH[1]}"
+          
+            # Use regular expression to extract version components
+            if [[ $MVN_BASE_VERSION =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+              MAJOR=$(echo "${BASH_REMATCH[1]}" | sed "s/\b0\+\([1-9]\)/\1/g")
+              MINOR=$(echo "${BASH_REMATCH[2]}" | sed "s/\b0\+\([1-9]\)/\1/g")
+              PATCH=$(echo "${BASH_REMATCH[3]}" | sed "s/\b0\+\([1-9]\)/\1/g")
+              VERSION_NPM_FORMAT="${MAJOR}.${MINOR}.${PATCH}"
+          
+              echo "::debug::VERSION_NPM_FORMAT: ${VERSION_NPM_FORMAT}"
+            else
+              echo "::error::Invalid Maven version format: $MVN_BASE_VERSION"
+              exit 1
+            fi
+          
+            echo "VERSION_NPM_FORMAT: ${VERSION_NPM_FORMAT}"
+            LAST_RC_VERSIONS=$(npm view $PACKAGE_FULL_NAME versions --json)
+            echo "LAST_RC_VERSIONS: ${LAST_RC_VERSIONS}"
+          
+            LAST_RC_VERSION=$(npm view $PACKAGE_FULL_NAME versions --json | jq --arg filter $VERSION_NPM_FORMAT 'map(.| select(. | contains($filter)))' | jq -r 'map(select(test("-rc\\d+$"))) | max')
+          
+            if [[ $LAST_RC_VERSION == "$VERSION_NPM_FORMAT"* ]]; then
+              NEXT_RC_VERSION=$(echo "$LAST_RC_VERSION" | awk -F '-rc' '{print $1 "-rc" $2 + 1}')
+              RC_SUFFIX=$(echo "$NEXT_RC_VERSION" | sed -n 's/.*-rc\([0-9]*\)/-rc\1/p')
+            else
+              RC_SUFFIX="-rc1"
+            fi;
+          
+            NPM_PACKAGE_VERSION=${MVN_BASE_VERSION}${RC_SUFFIX}
+          else
+            echo "::debug::Release version found."
+            NPM_PACKAGE_VERSION_TAG="latest"
+            NPM_PACKAGE_VERSION=${MVN_PACKAGE_VERSION}
+          fi;
+          echo "::debug::NPM_PACKAGE_VERSION: $NPM_PACKAGE_VERSION"
+          echo "::debug::NPM_PACKAGE_VERSION_TAG: $NPM_PACKAGE_VERSION_TAG"
+          
+          echo "npm-package-version=$NPM_PACKAGE_VERSION" >> $GITHUB_OUTPUT
+          echo "npm-package-version-tag=$NPM_PACKAGE_VERSION_TAG" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
+
+      - name: 'Install Jinja2'
+        run: pip install jinja2-cli
+
+      # Sets up the NPM package
+      # Creates the bin folder with the binaries
+      # Adds the postinstall.js script
+      # Generates the package.json file with Jinja2
+      - name: 'NPM Package setup'
+        working-directory: ${{ github.workspace }}/tools/dotcms-cli/npm/
+        env:
+          NPM_PACKAGE_NAME: ${{ inputs.npm-package-name }}
+          NPM_PACKAGE_VERSION: ${{ steps.npm-version-tag.outputs.npm-package-version }}
+          MVN_PACKAGE_NAME: dotcms-cli
+          MVN_PACKAGE_VERSION: ${{ steps.project.outputs.version }}
+        run: |
+          echo "::group::NPM Package setup"
+          echo "Adding bin folder with all the binaries"
+          mkdir -p bin
+          find ${{ github.workspace }}/artifacts/distributions/ -name "*.zip" -exec unzip -d bin {} \;
+          
+          echo "Adding wrapper script"
+          mv src/postinstall.js.seed src/postinstall.js
+          
+          echo "Adding README.md file"
+          cp ${{ github.workspace }}/tools/dotcms-cli/README.md .
+          
+          echo "Adding package.json file"
+          jinja2 package.j2 -D packageName=${MVN_PACKAGE_NAME} -D npmPackageName=${NPM_PACKAGE_NAME} -D npmPackageVersion=${NPM_PACKAGE_VERSION} -D packageVersion=${MVN_PACKAGE_VERSION} --format json -o package.json
+          rm -f package.j2
+          
+          cat package.json
+          cat src/postinstall.js
+          echo "::endgroup::"
+
+      - name: 'NPM Package tree'
+        run: ls -R ${{ github.workspace }}/tools/dotcms-cli/npm/
+
+      - name: 'Upload NPM Package Artifact'
+        id: upload-package
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-package-artifact
+          path: ${{ github.workspace }}/tools/dotcms-cli/npm/
+          retention-days: 2

--- a/.github/workflows/cli-npm-publish.yml
+++ b/.github/workflows/cli-npm-publish.yml
@@ -1,4 +1,4 @@
-name: 'Publish NPM Package'
+name: 'NPM Publish'
 on:
   workflow_call:
     inputs:
@@ -13,15 +13,12 @@ on:
       run-id:
         description: 'Run id'
         required: true
-        type: number
+        type: string
       npm-package-version-tag:
         description: 'NPM package version tag'
         required: true
         type: string
     secrets:
-      gh-pat:
-        description: 'GitHub Personal Access Token'
-        required: true
       npm-token:
         description: 'NPM registry token'
         required: false
@@ -30,9 +27,15 @@ env:
   NODE_VERSION: 19
 
 jobs:
-  publish-npm-package:
+  publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Inputs
+        run: |
+          echo "::notice::Artifact-Id: ${{ inputs.artifact-id }}"
+          echo "::notice::Run-Id: ${{ inputs.run-id }}"
+          echo "::notice::NPM-Package-Version-Tag: ${{ inputs.npm-package-version-tag }}"
+
       - name: 'Checkout'
         uses: actions/checkout@v4
         with:
@@ -51,7 +54,7 @@ jobs:
           path: ${{ github.workspace }}/npm-package
           name: ${{ inputs.artifact-id }}
           run-id: ${{ inputs.run-id }}
-          github-token: ${{ secrets.gh-pat }} # token with actions:read permissions on target repo
+          github-token: ${{ secrets.GITHUB_TOKEN }} # token with actions:read permissions on target repo
 
       - name: 'Validate NPM package'
         run: |
@@ -63,6 +66,7 @@ jobs:
             echo "::notice::NPM package found. Proceeding..."
             cat ${{ github.workspace }}/npm-package/package.json
           fi
+          echo "::endgroup::"
 
       - name: 'Publish to NPM registry'
         if: success()


### PR DESCRIPTION
### Proposed Changes

## NPM package build workflow. 

This workflow automates the process of building, configuring, and distributing an NPM package based on a Maven project, handling versioning and artifact management along the way.

**Workflow Inputs:** Accepts inputs like branch name (ref), NPM package name (`npm-package-name`), and NPM package scope (`npm-package-scope`).

**Dynamic Artifact Download:** Downloads build artifacts from a specified workflow (`build-test-master.yml`) based on the provided branch. It checks for artifacts matching a certain pattern (`cli-artifacts-*`) and handles scenarios where no artifact is found.

**Artifact Management:** Manages downloaded artifacts, extracts metadata such as run ID, and organizes artifacts for further processing.

**Version Extraction:** Determines the version of the Maven project and configures the corresponding NPM package version and tag dynamically. It distinguishes between snapshot and release versions, handling them appropriately.

**NPM Package Setup:** Sets up the NPM package by creating necessary folders, adding binaries, wrapper scripts, README.md files, and generating package.json using Jinja2 templating. It utilizes metadata obtained earlier to populate package information.

**Artifact Upload:** Uploads the prepared NPM package artifact for distribution, setting a retention period.

## NPM package publish workflow.  

This workflow streamlines the process of publishing an NPM package to the NPM registry, handling authentication, artifact retrieval, validation, and publishing with appropriate version tagging.

**Workflow Inputs:** Accepts inputs such as the branch to checkout (ref), artifact ID (`artifact-id`), run ID (`run-id`), and NPM package version tag (`npm-package-version-tag`). These inputs are crucial for identifying the correct artifact and version to publish.

**Environment Configuration:** Sets the Node.js version to 19, which is used for executing subsequent steps.

**Artifact Retrieval:** Downloads the build artifact containing the NPM package from the workflow run identified by the provided run ID. This artifact is stored in the workspace under the npm-package directory.

**NPM Package Validation:** Validates the presence of the NPM package by checking for the existence of the package.json file. If the file is not found, an error is reported and the workflow exits; otherwise, the contents of the package.json file are displayed.

**Publishing to NPM Registry:** Publishes the NPM package to the NPM registry using the npm publish command. It sets the authentication token (`NPM_AUTH_TOKEN`) for accessing the registry, ensures public access to the package (`--access public`), and assigns the specified version tag (`--tag ${NPM_PACKAGE_VERSION_TAG}`). This step executes only if the preceding steps are successful.

## Main CLI NPM build workflow.

This GitHub Actions workflow automates the nightly build and publication of the dotCLI NPM package (@dotcms/dotcli@rc) from the master branch. Here's a summary of its main functionalities:

**Nightly Schedule:** The workflow is triggered every night at` 5:18 AM` using a cron schedule.

**Build NPM Package:** The build-package job is responsible for building the NPM package. It utilizes another workflow file (cli-npm-package.yml) and specifies the master branch as the reference. It configures the package name (dotcli) and scope (@dotcms). Permissions are set to read contents and write packages.

**Publish NPM Package:** The publish-package job is dependent on the successful completion of the build-package job. It uses a separate workflow file (`cli-npm-publish.yml`) to publish the NPM package. It passes necessary parameters like the reference, artifact ID, run ID, and NPM package version tag obtained from the build-package job. It also requires an NPM token stored in secrets for authentication. Permissions are set to read contents and write packages.


### Fixes
#27805 
