### PR TITLE
chore(core): Tight up p-dialog header spacing

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_dialog.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_dialog.scss
@@ -12,7 +12,7 @@
     border-bottom: 0 none;
     background: $white;
     color: $black;
-    padding: $spacing-6;
+    padding: $spacing-4;
     border-top-right-radius: $border-radius-md;
     border-top-left-radius: $border-radius-md;
 }


### PR DESCRIPTION
### Proposed Changes
* Tight up dialog header spacing

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
<img width="1403" alt="image" src="https://github.com/dotCMS/core/assets/751424/03fb0409-6389-4f41-9239-ee49436bcbf6">  |  <img width="1397" alt="image" src="https://github.com/dotCMS/core/assets/751424/123a6ea6-5640-418e-8f55-19fc3b25c182">
