### PR TITLE
fix(edit-page-2): Fixed contentlets inserts in wrong position when using contentlet tools

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.html
@@ -9,7 +9,7 @@
     (click)="setPositionFlag('after'); menu.toggle($event)"
     data-testId="add-bottom-button"
     icon="pi pi-plus"></p-button>
-<p-menu #menu [model]="items" [popup]="true" appendTo="body"></p-menu>
+<p-menu #menu [model]="items" [popup]="true" appendTo="body" data-testId="menu-add"></p-menu>
 
 <div
     class="actions"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.spec.ts
@@ -72,6 +72,23 @@ describe('EmaContentletToolsComponent', () => {
             expect(spectator.query(byTestId('drag-image'))).toHaveText('test');
         });
 
+        it('should close menus when contentlet @input was changed', () => {
+            const spyHideMenus = jest.spyOn(spectator.component, 'hideMenus');
+
+            spectator.setInput('contentlet', {
+                ...contentletAreaMock,
+                payload: {
+                    ...contentletAreaMock.payload,
+                    contentlet: {
+                        ...contentletAreaMock.payload.contentlet,
+                        identifier: 'new-identifier'
+                    }
+                }
+            });
+
+            expect(spyHideMenus).toHaveBeenCalled();
+        });
+
         describe('events', () => {
             it('should emit delete on delete button click', () => {
                 const deleteSpy = jest.spyOn(spectator.component.delete, 'emit');

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.spec.ts
@@ -75,6 +75,11 @@ describe('EmaContentletToolsComponent', () => {
         it('should close menus when contentlet @input was changed', () => {
             const spyHideMenus = jest.spyOn(spectator.component, 'hideMenus');
 
+            const hideMenu = jest.spyOn(spectator.component.menu, 'hide');
+            // Open menu
+            spectator.click('[data-testId="menu-add"]');
+
+            //Change contentlet hover
             spectator.setInput('contentlet', {
                 ...contentletAreaMock,
                 payload: {
@@ -87,6 +92,7 @@ describe('EmaContentletToolsComponent', () => {
             });
 
             expect(spyHideMenus).toHaveBeenCalled();
+            expect(hideMenu).toHaveBeenCalled();
         });
 
         describe('events', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.ts
@@ -36,19 +36,6 @@ const ACTIONS_CONTAINER_HEIGHT = 40;
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EmaContentletToolsComponent implements OnInit, OnChanges {
-    ngOnChanges(changes: SimpleChanges): void {
-        if (!changes.contentlet) {
-            return;
-        }
-
-        if (
-            changes.contentlet.currentValue?.payload.contentlet.identifier !==
-            changes.contentlet.previousValue?.payload.contentlet.identifier
-        ) {
-            this.hideMenus();
-        }
-    }
-
     @ViewChild('menu') menu: Menu;
     @ViewChild('menuVTL') menuVTL: Menu;
     @ViewChild('dragImage') dragImage: ElementRef;
@@ -105,6 +92,19 @@ export class EmaContentletToolsComponent implements OnInit, OnChanges {
     ngOnInit() {
         this.setVtlFiles();
         this.ACTIONS_CONTAINER_WIDTH = this.contentlet.payload.vtlFiles ? 178 : 128;
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if (!changes.contentlet) {
+            return;
+        }
+
+        if (
+            changes.contentlet.currentValue?.payload.contentlet.identifier !==
+            changes.contentlet.previousValue?.payload.contentlet.identifier
+        ) {
+            this.hideMenus();
+        }
     }
 
     /**

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.ts
@@ -6,15 +6,17 @@ import {
     EventEmitter,
     HostBinding,
     Input,
+    OnChanges,
     OnInit,
     Output,
+    SimpleChanges,
     ViewChild,
     inject
 } from '@angular/core';
 
 import { MenuItem } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
-import { MenuModule } from 'primeng/menu';
+import { Menu, MenuModule } from 'primeng/menu';
 
 import { DotMessageService } from '@dotcms/data-access';
 
@@ -33,7 +35,22 @@ const ACTIONS_CONTAINER_HEIGHT = 40;
     styleUrls: ['./ema-contentlet-tools.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EmaContentletToolsComponent implements OnInit {
+export class EmaContentletToolsComponent implements OnInit, OnChanges {
+    ngOnChanges(changes: SimpleChanges): void {
+        if (!changes.contentlet) {
+            return;
+        }
+
+        if (
+            changes.contentlet.currentValue?.payload.contentlet.identifier !==
+            changes.contentlet.previousValue?.payload.contentlet.identifier
+        ) {
+            this.hideMenus();
+        }
+    }
+
+    @ViewChild('menu') menu: Menu;
+    @ViewChild('menuVTL') menuVTL: Menu;
     @ViewChild('dragImage') dragImage: ElementRef;
     private dotMessageService = inject(DotMessageService);
 
@@ -194,6 +211,16 @@ export class EmaContentletToolsComponent implements OnInit {
             top: `${top}px`,
             zIndex: '1'
         };
+    }
+
+    /**
+     * Hide all context menus when the contentlet changes
+     *
+     * @memberof EmaContentletToolsComponent
+     */
+    hideMenus() {
+        this.menu?.hide();
+        this.menuVTL?.hide();
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes
* When the hover is changed to other contentlet, the menus are closed.
* If the user continue hovering the same contentlet (moving the mouse inside), nothing happens

With this, when the user hover other contentlet, the menus are closed and the reference to "old contentlet" is broken, so the user always have the right reference to insert other contentlet

https://github.com/dotCMS/core/assets/144152756/ed9058ea-a95d-4724-a60b-31aaee1b0b5e



