### PR TITLE
ci(deployment) fixup secret passing to reusable workflows #28125

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -14,6 +14,14 @@ on:
         description: 'Indicates if the workflow should post to slack on failure'
         type: boolean
         default: false
+    secrets:
+        SLACK_BOT_TOKEN:
+          description: 'Slack Bot Token'
+          required: false
+        MASTER_BUILD_SLACK_WEBHOOK:
+          required: false
+          description: 'Slack Webhook'
+
 permissions:
   checks: write
 

--- a/.github/workflows/build-test-master.yml
+++ b/.github/workflows/build-test-master.yml
@@ -79,7 +79,6 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
       EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}
       DEVELOPERS_SLACK_WEBHOOK: ${{ secrets.DEVELOPERS_SLACK_WEBHOOK }}

--- a/.github/workflows/build-test-master.yml
+++ b/.github/workflows/build-test-master.yml
@@ -76,6 +76,14 @@ jobs:
       environment: trunk
       snapshot: true
       latest: true
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
+      EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}
+      DEVELOPERS_SLACK_WEBHOOK: ${{ secrets.DEVELOPERS_SLACK_WEBHOOK }}
+
   finalize:
     name: Finalize
     if: always()
@@ -90,3 +98,7 @@ jobs:
     uses: ./.github/workflows/build-report.yml
     with:
       slack-failure: true
+    secrets:
+      DEVELOPERS_SLACK_WEBHOOK: ${{ secrets.DEVELOPERS_SLACK_WEBHOOK }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+

--- a/.github/workflows/build-test-nightly.yml
+++ b/.github/workflows/build-test-nightly.yml
@@ -62,6 +62,13 @@ jobs:
       snapshot: true
       latest: true
       deploy-dev-image: true
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
+      EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}
+      DEVELOPERS_SLACK_WEBHOOK: ${{ secrets.DEVELOPERS_SLACK_WEBHOOK }}
   finalize:
     name: Finalize
     if: always()
@@ -74,3 +81,6 @@ jobs:
     if: always()
     needs: [ finalize ]
     uses: ./.github/workflows/build-report.yml
+    secrets:
+      DEVELOPERS_SLACK_WEBHOOK: ${{ secrets.DEVELOPERS_SLACK_WEBHOOK }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/build-test-nightly.yml
+++ b/.github/workflows/build-test-nightly.yml
@@ -65,7 +65,6 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
       EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}
       DEVELOPERS_SLACK_WEBHOOK: ${{ secrets.DEVELOPERS_SLACK_WEBHOOK }}

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -18,6 +18,25 @@ on:
       deploy-dev-image:
         default: false
         type: boolean
+    secrets:
+        DOCKER_USERNAME:
+          required: false
+          description: 'Docker.io username'
+        DOCKER_TOKEN:
+          required: false
+          description: 'Docker.io token'
+        GITHUB_TOKEN:
+          required: false
+          description: 'github token'
+        EE_REPO_USERNAME:
+          required: false
+          description: 'Artifactory username'
+        EE_REPO_PASSWORD:
+          required: false
+          description: 'Artifactory password'
+        DEVELOPERS_SLACK_WEBHOOK:
+          required: false
+          description: 'Slack webhook for developers'
 jobs:
   deployment:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -25,9 +25,6 @@ on:
         DOCKER_TOKEN:
           required: false
           description: 'Docker.io token'
-        GITHUB_TOKEN:
-          required: false
-          description: 'github token'
         EE_REPO_USERNAME:
           required: false
           description: 'Artifactory username'


### PR DESCRIPTION
### Proposed Changes
Reusable workflows do not get access to secrets by default and they need to either be passed explicitly or set to inherit.  To keep a good record of the secrets we are using we will explicitly pass the secrets.

This change will not impact PR build and will only take impact after merge.  This hopefully should resolve the deploy section in the master build.  
