### PR TITLE
#27815: load categories into workflow variable when executing velocity in a workflow subaction

### DIFF
--- a/dotcms-integration/src/test/resources/com/dotmarketing/portlets/browser/ajax/list-categories.vtl
+++ b/dotcms-integration/src/test/resources/com/dotmarketing/portlets/browser/ajax/list-categories.vtl
@@ -1,0 +1,18 @@
+#set($cats = $categories.getChildrenCategories($categories.getCategoryByKey('{{rootCategoryKey}}')))
+<div>Category list:</div>
+<ul>
+#foreach($item in $cats)
+    #set($desiredCategoryName = $item.categoryName)
+    #set($categoryFound = false)
+
+    #foreach($contentletCategoryName in $workflow.contentletDependencies.categories)
+        #if($contentletCategoryName.categoryName == $desiredCategoryName)
+            #set($categoryFound = true)
+            #break
+        #end
+    #end
+    #if($categoryFound)
+        <li>$desiredCategoryName</li>
+    #end
+#end
+</ul>


### PR DESCRIPTION
### Proposed Changes
* Workflow subactions that execute velocity include a 'workflow' variable in the velocity context, so it can be used by the velocity code. When the workflow action is executed from the Edit Content window, the 'contentDependencies' property including content categories is loaded in the 'workflow' variable, but when the workflow action is executed with the context menu or with the 'Available Workflows' option on the Search Content window,  the property isn't set. With this change, when executing the workflow action from the Search Content window, the  'contentDependencies'  property including categories will be set for the 'workflow' variable.

### Checklist
- [x] Tests