### PR TITLE
feat(CICD): #27630 Added a release trigger for CLI that will be fired every time a core is released

### DIFF
--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -7,7 +7,8 @@ on:
     inputs:
       version:
         description: 'Release version'
-        required: true
+        default: '1.0.0-SNAPSHOT'
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -227,12 +227,12 @@ jobs:
       - name: 'Compile source code'
         working-directory: ${{ github.workspace }}
         run: |
-          ./mvnw clean install -Dtest.failure.ignore=true -DskipTests=${{ github.event.inputs.skipTests }} -am -pl :dotcms-cli
+          ./mvnw clean install -Dtest.failure.ignore=true -DskipTests=true -am -pl :dotcms-cli
 
       - name: 'Build uber-jar'
         working-directory: ${{ github.workspace }}
         run: |
-          ./mvnw package -Dquarkus.package.type=${{ env.MVN_PACKAGE_TYPE }} -DskipTests=${{ github.event.inputs.skipTests }} -pl :dotcms-cli
+          ./mvnw package -Dquarkus.package.type=${{ env.MVN_PACKAGE_TYPE }} -DskipTests=true -pl :dotcms-cli
 
       # Builds a native image of the CLI using GraalVM (Linux/macOS)
       # Runs on a matrix for different operating systems
@@ -240,7 +240,7 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         working-directory: ${{ github.workspace }}
         run: |
-          ./mvnw package -Pnative -DskipTests=${{ github.event.inputs.skipTests }} -pl :dotcms-cli
+          ./mvnw package -Pnative -DskipTests=true -pl :dotcms-cli
 
       # Builds a native image of the CLI using GraalVM on Windows
       # Uses PowerShell for setup and execution
@@ -254,7 +254,7 @@ jobs:
       - name: 'Create distribution'
         working-directory: ${{ github.workspace }}
         run: |
-          ./mvnw -B -ntp -Pdist package -DskipTests=${{ github.event.inputs.skipTests }} -pl :dotcms-cli
+          ./mvnw -B -ntp -Pdist package -DskipTests=true -pl :dotcms-cli
 
       - name: 'Distribution tree'
         working-directory: ${{ github.workspace }}/tools/dotcms-cli/

--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -1,14 +1,13 @@
 name: dotCLI Release
 on:
+  release:
+    types: [created]
+
   workflow_dispatch:
     inputs:
       version:
         description: 'Release version'
         required: true
-      skipTests:
-        description: 'Skip tests'
-        default: 'true'
-        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -30,6 +29,7 @@ env:
 
 jobs:
   precheck:
+    if: ${{ ( github.event_name == 'release' && !contains(github.event.release.tag_name, 'LTS')) || github.event_name == 'workflow_dispatch' }}
     name: 'Pre-check'
     runs-on: ubuntu-latest
     outputs:
@@ -41,21 +41,32 @@ jobs:
       - name: 'Log GitHub context'
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+        run: |
+          echo "::group::Github Context"
+          echo "$GITHUB_CONTEXT"
+          if [[ "$GITHUB_EVENT_NAME" == 'release' ]]; then
+            TAG_NAME=${{ github.event.release.tag_name }}
+            RELEASE_VERSION=${TAG_NAME:1}
+          else
+            RELEASE_VERSION=${{ github.event.inputs.version }}
+          fi
+          
+          echo "::notice:: Event name: $GITHUB_EVENT_NAME"
+          echo "::notice:: Release version: $RELEASE_VERSION"
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "::endgroup::"
 
       - name: 'Checkout'
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.CI_MACHINE_TOKEN }}
-
-
 
       - name: 'Setup Java'
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
+
       - uses: ./.github/actions/cleanup-runner
+
       - name: 'Get Date'
         id: get-date
         run: |
@@ -80,20 +91,20 @@ jobs:
         id: version
         working-directory: ${{ github.workspace }}/tools/dotcms-cli
         run: |
-          RELEASE_VERSION=${{ github.event.inputs.version }}
+          RELEASE_VERSION=$RELEASE_VERSION
           HEAD=${{ github.ref_name }}
-
+          
           # Create a release branch for versioning updates
           AUXILIARY_BRANCH=version-update-${RELEASE_VERSION}-${{ github.run_id }}
           git checkout -b $AUXILIARY_BRANCH
-
+          
           # Update version in pom.xml
           ./mvnw -B -ntp versions:set versions:commit -DnewVersion=$RELEASE_VERSION
-
+          
           # Commit version changes
           git commit --allow-empty -a -m "Update dotCLI version to $RELEASE_VERSION"
           git push origin $AUXILIARY_BRANCH
-
+          
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           echo "HEAD=$HEAD" >> "$GITHUB_OUTPUT"
           echo "AUXILIARY_BRANCH=$AUXILIARY_BRANCH" >> "$GITHUB_OUTPUT"
@@ -266,7 +277,6 @@ jobs:
       - name: 'Check out repository'
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.CI_MACHINE_TOKEN }}
           ref: ${{ needs.precheck.outputs.AUXILIARY_BRANCH }}
 
       - uses: ./.github/actions/cleanup-runner
@@ -378,7 +388,7 @@ jobs:
               exit 1
             fi
 
-            LAST_RC_VERSION=$(npm view $PACKAGE_FULL_NAME versions --json | jq -r 'map(select(test("-rc\\d+$"))) | max')
+            LAST_RC_VERSION=$(npm view $PACKAGE_FULL_NAME versions --json | jq --arg filter $VERSION_NPM_FORMAT 'map(.| select(. | contains($filter)))' | jq -r 'map(select(test("-rc\\d+$"))) | max')
 
             if [[ $LAST_RC_VERSION == "$VERSION_NPM_FORMAT"* ]]; then
               NEXT_RC_VERSION=$(echo "$LAST_RC_VERSION" | awk -F '-rc' '{print $1 "-rc" $2 + 1}')
@@ -408,6 +418,7 @@ jobs:
         env:
           MVN_PACKAGE_VERSION: ${{ github.event.inputs.version }}
         run: |
+          echo "::group::NPM Package setup"
           echo "Adding bin folder with all the binaries"
           mkdir -p bin
           find ${{ github.workspace }}/artifacts/distributions/ -name "*.zip" -exec unzip -d bin {} \;
@@ -424,6 +435,7 @@ jobs:
 
           cat package.json
           cat src/postinstall.js
+          echo "::endgroup::"
 
       - name: 'NPM Package tree'
         run: ls -R ${{ github.workspace }}/tools/dotcms-cli/npm/
@@ -438,7 +450,7 @@ jobs:
 
   clean-up:
     name: "Clean Up"
-    if: always()
+    if: ${{ needs.precheck.outputs.AUXILIARY_BRANCH != '' }}
     needs: [ precheck, build, release, publish-npm-package ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Proposed Changes
* In this update, we've added a release trigger to run the `CLI release process`. This trigger is designed to be activated every time a` dotCMS core` is released. This automation streamlines our release process by automatically initiating the necessary actions when a core update occurs.

### Fixes
#27630 