### PR TITLE
ci(deployment)  fix nightly arguments when run from cron #28125

### DIFF
--- a/.github/workflows/build-test-nightly.yml
+++ b/.github/workflows/build-test-nightly.yml
@@ -21,8 +21,8 @@ jobs:
     name: Initialize
     uses: ./.github/workflows/reusable-initialize.yml
     with:
-      reuse-previous-build: ${{ inputs.reuse-previous-build }} # false unless set manually on workflow_dispatch
-      build-on-missing-artifacts: ${{ inputs.build-on-missing-artifacts }} # false unless set manually on workflow_dispatch
+      reuse-previous-build: ${{ inputs.reuse-previous-build || false }} # false unless set manually on workflow_dispatch
+      build-on-missing-artifacts: ${{ inputs.build-on-missing-artifacts || false }} # false unless set manually on workflow_dispatch
   build:
     name: Nightly Build
     needs: [ initialize ]


### PR DESCRIPTION
### Proposed Changes
* This update will only affect and be tested by running the nightly build.  Manual running of nightly was working previously and should behave the same,   this fix should default the arguments to initialize to false that will ensure that a full build is done. 