### PR TITLE
#28238 Avoid breaking isUserIncluded when there is orphan running exp…

### DIFF
--- a/dotCMS/src/curl-test/User_Include_Into_Experiment.postman_collection.json
+++ b/dotCMS/src/curl-test/User_Include_Into_Experiment.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "7ba4cd78-baf3-4d1b-84d0-62c2708a2406",
+		"_postman_id": "30c49eb5-58a2-4f61-8f19-f10d38064f51",
 		"name": "User Include Into Experiment",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "30436704"
+		"_exporter_id": "4500400"
 	},
 	"item": [
 		{
@@ -2730,6 +2730,685 @@
 				}
 			],
 			"description": "*   Create two no pages\n*   Create two new Experiments without rules\n*   Starting the two experiments.\n*   Hit the ens point should return both Experiments\n*   Create and start a new Experiment without rules\n*   Hit the End point again end send the fisrt two experiment as excluded list.\n*   Should return just the last experiment."
+		},
+		{
+			"name": "Given_orphanRunningExperiment_shouldReturnEmptyList",
+			"item": [
+				{
+					"name": "pre_createOrphanRunningExperiment",
+					"item": [
+						{
+							"name": "pre_ImportBundleWithPage",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Bundle uploaded sucessfully\", function () {",
+											"    pm.response.to.have.status(200);",
+											"",
+											"    var jsonData = pm.response.json();",
+											"    console.log(jsonData);",
+											"",
+											"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"page_experiment.tar.gz\");",
+											"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/octet-stream"
+									},
+									{
+										"key": "Content-Disposition",
+										"type": "text",
+										"value": "attachment"
+									}
+								],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "resources/Experiments/page_experiment.tar.gz"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/bundle?sync=true",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"bundle"
+									],
+									"query": [
+										{
+											"key": "sync",
+											"value": "true"
+										},
+										{
+											"key": "AUTH_TOKEN",
+											"value": "",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Imports a Bundle that includes:\n* A piece of content with a tag field without any tags selected"
+							},
+							"response": []
+						},
+						{
+							"name": "pre_createExperiment",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = pm.response.json();",
+											"",
+											"",
+											"pm.test(\"Status code should be ok 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.collectionVariables.set(\"orphanExperiment\", jsonData.entity.id);",
+											"",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"pageId\": \"e424abd7e2e7a9031c5a0a3c18182f1b\",\n    \"name\": \"futureOrphanExperiment\",\n    \"description\": \"future orphan experiment\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/experiments/",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"experiments",
+										""
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "pre_addVariantToExperiment",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = pm.response.json();",
+											"",
+											"",
+											"pm.test(\"Variants with correct weight\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.expect(jsonData.entity.trafficProportion.type).equal(\"SPLIT_EVENLY\");",
+											"    pm.expect(jsonData.entity.trafficProportion.variants.length).equal(2);",
+											"    pm.expect(jsonData.entity.trafficProportion.variants[0].name).equal(\"Original\");",
+											"    pm.expect(jsonData.entity.trafficProportion.variants[0].weight).equal(50.0);",
+											"    pm.expect(jsonData.entity.trafficProportion.variants[1].name).equal(\"I wanna be promoted!\");",
+											"    pm.expect(jsonData.entity.trafficProportion.variants[1].weight).equal(50.0);",
+											"    ",
+											"    pm.collectionVariables.set(\"originalVariant\", jsonData.entity.trafficProportion.variants[0].id);",
+											"    pm.collectionVariables.set(\"variantToPromote\", jsonData.entity.trafficProportion.variants[1].id);",
+											"",
+											"});",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"description\": \"I wanna be promoted!\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/experiments/{{orphanExperiment}}/variants",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"experiments",
+										"{{orphanExperiment}}",
+										"variants"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "pre_setExperimentGoal",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = pm.response.json();",
+											"",
+											"",
+											"pm.test(\"Status code should be ok 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Experiment should have the expected values\", function () {",
+											"    pm.expect(jsonData.entity.goals.primary.type).equal(\"REACH_PAGE\");",
+											"    pm.expect(jsonData.entity.goals.primary.name).equal(\"Reach thank-you page\");",
+											"    pm.expect(jsonData.entity.goals.primary.conditions[0].operator).equal(\"EQUALS\");",
+											"    pm.expect(jsonData.entity.goals.primary.conditions[0].parameter).equal(\"url\");",
+											"    pm.expect(jsonData.entity.goals.primary.conditions[0].value).equal(\"thank-you\");",
+											"});",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PATCH",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"goals\": {\n        \"primary\": {\n            \"name\": \"Reach thank-you page\",\n            \"type\": \"REACH_PAGE\",\n            \"conditions\": [\n                {\n                    \"parameter\": \"url\",\n                    \"operator\": \"EQUALS\",\n                    \"value\": \"thank-you\"\n                }\n            ]\n        }\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/experiments/{{orphanExperiment}}",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"experiments",
+										"{{orphanExperiment}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "startExperiment_shouldSucceed",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = pm.response.json();",
+											"",
+											"",
+											"pm.test(\"Started Experiment with expected values\", function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.expect(jsonData.entity.status).equal(\"RUNNING\");",
+											"    pm.expect(jsonData.entity.scheduling.startDate).to.be.not.null;",
+											"    pm.expect(jsonData.entity.scheduling.endDate).to.be.not.null;",
+											"",
+											"    var runningIds = jsonData.entity.runningIds.ids;",
+											"    console.log('runningIds', runningIds);",
+											"    console.log('jsonData.entity.runningIds.ids', jsonData.entity.runningIds.ids);",
+											"    pm.expect(1).equal(runningIds.length);",
+											"",
+											"    var runningId = runningIds[0];",
+											"    pm.expect(runningId.id).not.null;",
+											"    pm.expect(runningId.startDate).not.null;",
+											"    pm.expect(runningId.endDate).be.null;",
+											"    ",
+											"    // Experiments needs to last for 14 days",
+											"    var endDate = jsonData.entity.scheduling.endDate;",
+											"    var startDate = jsonData.entity.scheduling.startDate;",
+											"    var length = (endDate - startDate) / 3600 / 1000 / 24;",
+											"    pm.expect(length).equal(14)",
+											"});",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/experiments/{{orphanExperiment}}/_start",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"experiments",
+										"{{orphanExperiment}}",
+										"_start"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Unpublish Page",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200 \", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"",
+											"var jsonData = pm.response.json();",
+											"pm.collectionVariables.set(\"live\", false);",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/UNPUBLISH?identifier=e424abd7e2e7a9031c5a0a3c18182f1b",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"UNPUBLISH"
+									],
+									"query": [
+										{
+											"key": "identifier",
+											"value": "e424abd7e2e7a9031c5a0a3c18182f1b"
+										}
+									]
+								},
+								"description": "Fire any action using the actionId\n\nOptional: If you pass ?inode={inode}, you don't need body here.\n\n@Path(\"/actions/{actionId}/fire\")"
+							},
+							"response": []
+						},
+						{
+							"name": "Archive Page",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200 \", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"",
+											"var jsonData = pm.response.json();",
+											"pm.collectionVariables.set(\"archived\", true);",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/ARCHIVE?identifier=e424abd7e2e7a9031c5a0a3c18182f1b",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"ARCHIVE"
+									],
+									"query": [
+										{
+											"key": "identifier",
+											"value": "e424abd7e2e7a9031c5a0a3c18182f1b"
+										}
+									]
+								},
+								"description": "Fire any action using the actionId\n\nOptional: If you pass ?inode={inode}, you don't need body here.\n\n@Path(\"/actions/{actionId}/fire\")"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete Page",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200 \", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/DELETE?identifier=e424abd7e2e7a9031c5a0a3c18182f1b",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"DELETE"
+									],
+									"query": [
+										{
+											"key": "identifier",
+											"value": "e424abd7e2e7a9031c5a0a3c18182f1b"
+										}
+									]
+								},
+								"description": "Fire any action using the actionId\n\nOptional: If you pass ?inode={inode}, you don't need body here.\n\n@Path(\"/actions/{actionId}/fire\")"
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "isUserIncluded",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/experiments/isUserIncluded",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"experiments",
+								"isUserIncluded"
+							],
+							"query": [
+								{
+									"key": "host_id",
+									"value": "8a7d5e23-da1e-420a-b4f0-471e7da8ea2d",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"variable": [
@@ -2815,6 +3494,38 @@
 		},
 		{
 			"key": "excludedExperimentIdsEndedShortId_2",
+			"value": ""
+		},
+		{
+			"key": "orphanExperiment",
+			"value": ""
+		},
+		{
+			"key": "originalVariant",
+			"value": ""
+		},
+		{
+			"key": "variantToPromote",
+			"value": ""
+		},
+		{
+			"key": "contentletIdentifier",
+			"value": ""
+		},
+		{
+			"key": "contentletInode",
+			"value": ""
+		},
+		{
+			"key": "fireActionLanguageKey",
+			"value": ""
+		},
+		{
+			"key": "live",
+			"value": ""
+		},
+		{
+			"key": "archived",
 			"value": ""
 		}
 	]

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -1130,7 +1130,7 @@ public class ExperimentsAPIImpl implements ExperimentsAPI {
             try {
                 final HTMLPageAsset  htmlPageAsset = getHtmlPageAsset(experiment);
                 return host.getIdentifier().equals(htmlPageAsset.getHost());
-            } catch (DotDataException e) {
+            } catch (DotStateException | DotDataException e) {
                 return false;
             }
 


### PR DESCRIPTION
fix(experiments): Avoid breaking isUserIncluded when there is orphan running experimente

This change prevents breaking the API call to the `isUserIncluded` endpoint when there's an orphan running experiment. An orphan experiment is an experiment whose parent page was deleted. 

Refs: #28238 