### PR TITLE
Fixes for workflow changes 

### DIFF
--- a/.github/actions/deploy-artifact-docker/README.md
+++ b/.github/actions/deploy-artifact-docker/README.md
@@ -13,8 +13,10 @@ The action accepts the following inputs:
 - `commit_id`: The commit id that triggered the build. This is required.
 - `image_name`: The name of the image to build. e.g 'dotcms/dotcms'
 - `ref`: The the branch or tag that triggered the build e.g. the docker environment name "trunk", "nightly" if "release" then the name will not be used in the tag.
+- `docker-use-ref`: If true, the ref will be used in the tag if this is false then version must be specified
 - `docker_tag`: The docker tag to use for the image. This is required.
 - `latest` : If true, the image will be tagged as latest, usually reserved for the agile release e.g. dotcms/dotcms:latest
+- `version`: The release version of the image to tag for snapshot builds this is unset and ref is used.
 - `do_deploy`: Actually do the final deploy, set to false for testing. Default is 'true'.
 - `docker_io_username`: Docker.io username.
 - `docker_io_token`: Docker.io token.

--- a/.github/actions/deploy-artifact-docker/action.yml
+++ b/.github/actions/deploy-artifact-docker/action.yml
@@ -24,6 +24,13 @@ inputs:
   ref:
     description: 'The branch or type of build to tag the image with'
     required: true
+  docker-use-ref:
+    description: 'The branch or type of build to tag the image with'
+    required: false
+    default: 'true'
+  version:
+    description: 'The version or tag to apply to the image unless building a snapshot'
+    required: false
   latest:
     description: 'If true, the image will be tagged as latest, usually reserved for the agile release e.g. dotcms/dotcms:latest'
     default: 'false'
@@ -88,16 +95,41 @@ runs:
       env:
         LATEST: ${{ inputs.latest }}
         REF: ${{ inputs.ref }}
+        USE_REF: ${{ inputs.docker-use-ref }}
+        VERSION: ${{ inputs.version }}
       run: |
-        if [ "$REF" = "release" ]; then
-          tag_prefix=""
+        
+        # Set defaults for flags
+        enable_latest=false
+        RESULT=""
+        
+        # Determine REF_TO_USE based on USE_REF
+        REF_TO_USE=""
+        if [[ "$USE_REF" == "true" && -n "$REF" ]]; then
+        REF_TO_USE="$REF"
+        fi
+        
+        # Determine RESULT based on REF_TO_USE and VERSION
+        if [[ -n "$REF_TO_USE" && -n "$VERSION" ]]; then
+          RESULT="${REF_TO_USE}_${VERSION}"
+        elif [[ -n "$REF_TO_USE" ]]; then
+          RESULT="$REF_TO_USE"
+        elif [[ -n "$VERSION" ]]; then
+          RESULT="$VERSION"
         else
-          tag_prefix="${REF}_"
+          echo "ERROR: No version or ref provided"
+          exit 1
+        fi
+        
+        # Conditional for setting latest version flag
+        if [[ -n "$VERSION" && "$USE_REF" != "true" && "$LATEST" == "true" ]]; then
+          enable_latest=true
         fi
         
         echo "FULL_TAGS_OUTPUT<<EOF" >> $GITHUB_ENV
-          echo "type=raw,value=${tag_prefix}{{sha}},enable=true" >> $GITHUB_ENV
-          echo "type=raw,value=${tag_prefix}latest,enable=$LATEST" >> $GITHUB_ENV
+          echo "type=raw,value=${RESULT}_{{sha}},enable=true" >> $GITHUB_ENV
+          echo "type=raw,value=${RESULT},enable=true" >> $GITHUB_ENV
+          echo "type=raw,value=latest,enable=${enable_latest}" >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
 
     - name: Docker.io login

--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -10,17 +10,14 @@ on:
         description: 'The run id of the build to report on'
         type: string
         default: "${{ github.run_id }}"
-      slack-failure:
-        description: 'Indicates if the workflow should post to slack on failure'
+      slack-only-on-failure:
+        description: 'Indicates if the slack notification should only be sent on failure'
         type: boolean
-        default: false
+        default: true
     secrets:
         SLACK_BOT_TOKEN:
           description: 'Slack Bot Token'
           required: false
-        MASTER_BUILD_SLACK_WEBHOOK:
-          required: false
-          description: 'Slack Webhook'
 
 permissions:
   checks: write
@@ -111,6 +108,8 @@ jobs:
           
             if [[ "$status" == "SUCCESS" ]]; then
               echo "status_icon=✅" >> $GITHUB_OUTPUT
+            elif [[ "$status" == "CANCELLED" ]]; then
+              echo "status_icon=🚫" >> $GITHUB_OUTPUT
             else
               echo "status_icon=❌" >> $GITHUB_OUTPUT
             fi
@@ -154,19 +153,6 @@ jobs:
             echo "test_elapsed=$test_elapsed" >> $GITHUB_OUTPUT
           
           fi
-
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2.3.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.MASTER_BUILD_SLACK_WEBHOOK }}
-          SLACK_USERNAME: dotBot
-          SLACK_TITLE: "Broken build!"
-          SLACK_MSG_AUTHOR: " "
-          MSG_MINIMAL: true
-          SLACK_FOOTER: ""
-          SLACK_ICON: https://slackmojis.com/emojis/5432-this-is-fine/download
-          SLACK_MESSAGE: "Attention <!channel>! Broken build at `${{ github.ref_name }}`.\nPlease check the run at: ${{ steps.workflow-data.outputs.action_run_url }}"
-        if: steps.workflow-data.outputs.status != 'SUCCESS' && inputs.post-failure && github.repository == 'dotcms/core'
 
       - name: Prepare Slack Message Payload
         id: prepare-slack-message
@@ -249,7 +235,7 @@ jobs:
           echo "payload=$(echo $payload | jq -c .)" >> $GITHUB_OUTPUT
           echo "payload=$payload"
       - name: Post to Slack
-        if: steps.workflow-data.outputs.has_json == 'true' && github.repository == 'dotcms/core'
+        if: steps.workflow-data.outputs.has_json == 'true' && github.repository == 'dotcms/core' && ( steps.workflow-data.outputs.status != 'FAILURE' || !inputs.slack-only-on-failure )
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ vars.SLACK_REPORT_CHANNEL }}

--- a/.github/workflows/build-test-master.yml
+++ b/.github/workflows/build-test-master.yml
@@ -84,18 +84,16 @@ jobs:
   finalize:
     name: Finalize
     if: always()
-    needs: [ initialize,sonar,deployment ]
+    needs: [ initialize, build, build-cli, test, sonar, deployment]
     uses: ./.github/workflows/reusable-finalize.yml
     with:
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
+      needsData: ${{ toJson(needs) }}
   report:
     name: Report
     if: always()
     needs: [ finalize ]
     uses: ./.github/workflows/build-report.yml
-    with:
-      slack-failure: true
     secrets:
-      MASTER_BUILD_SLACK_WEBHOOK: ${{ secrets.MASTER_BUILD_SLACK_WEBHOOK }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/build-test-merge_group.yml
+++ b/.github/workflows/build-test-merge_group.yml
@@ -33,3 +33,5 @@ jobs:
     if: always()
     needs: [ test ]
     uses: ./.github/workflows/reusable-finalize.yml
+    with:
+      needsData: ${{ toJson(needs) }}

--- a/.github/workflows/build-test-nightly.yml
+++ b/.github/workflows/build-test-nightly.yml
@@ -69,15 +69,15 @@ jobs:
   finalize:
     name: Finalize
     if: always()
-    needs: [ initialize,deployment ]
+    needs: [ initialize, build, build-cli, test, deployment ]
     uses: ./.github/workflows/reusable-finalize.yml
     with:
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
+      needsData: ${{ toJson(needs) }}
   report:
     name: Report
     if: always()
     needs: [ finalize ]
     uses: ./.github/workflows/build-report.yml
     secrets:
-      MASTER_BUILD_SLACK_WEBHOOK: ${{ secrets.MASTER_BUILD_SLACK_WEBHOOK }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -51,3 +51,5 @@ jobs:
     if: always()
     needs: [ sonar,test ]
     uses: ./.github/workflows/reusable-finalize.yml
+    with:
+      needsData: ${{ toJson(needs) }}

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -83,7 +83,7 @@ jobs:
           artifactory-repo-username: ${{ secrets.EE_REPO_USERNAME }}
           artifactory-repo-password: ${{ secrets.EE_REPO_PASSWORD }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          build-run-id: ${{ inputs.artifact-run-id }}
+          build-run-id: ${{ github.run_id }} # We are currently building these artifacts in the current run
           commit-id: ${{ github.sha }}
 
       # A Slack notification is sent using the 'action-slack-notify' action if the repository is 'dotcms/core'.

--- a/.github/workflows/reusable-finalize.yml
+++ b/.github/workflows/reusable-finalize.yml
@@ -5,6 +5,9 @@ on:
       artifact-run-id:
         default: ${{ github.run_id }}
         type: string
+      needsData:
+        required: true
+        type: string
 jobs:
   prepare-report-data:
     name: Prepare Report Data
@@ -25,24 +28,25 @@ jobs:
         id: prepare-workflow-data
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          NEEDS_DATA: ${{ inputs.needsData }}
         run: |
+          echo "NEEDS_DATA=${NEEDS_DATA}"
+          # Check for 'cancelled' and 'failure' results
+          cancelled=false
+          failure=false
+          
+          # Using jq to parse the JSON and check the conditions, with -e option
+          if echo "$NEEDS_DATA" | jq -e 'any(.[]; .result == "cancelled")' >/dev/null; then
+            cancelled=true
+          elif echo "$NEEDS_DATA" | jq -e 'any(.[]; .result == "failure")' >/dev/null; then
+            failure=true
+          fi
+
+          # Output the results
+          echo "Cancelled: $cancelled"
+          echo "Failure: $failure"
+          
           AGGREGATE_STATUS="SUCCESS"
-          jobs_status="${{ toJson(needs) }}"
-          echo "job status=${jobs_status}"
-          while IFS=" " read -r key result; do
-            key=$(echo $key | tr -d ' {')
-            result=$(echo $result | tr -d ',')
-          
-            echo "Job: $key, Result: $result"
-          
-            if [[ $result == "cancelled" ]]; then
-              AGGREGATE_STATUS="CANCELLED"
-              break
-            elif [[ $result == "failure" ]]; then
-              AGGREGATE_STATUS="FAILURE"
-            fi
-          done < <(echo "$jobs_status" | awk -F': ' '/result:/ {print $1,$2}')
-          
           FIRST_FAIL_STEP=""
           FIRST_FAIL_MODULE=""
           
@@ -120,15 +124,24 @@ jobs:
           fi
           
           echo '],' >> workflow-data.json
+          if [[ "$AGGREGATE_STATUS" == "SUCCESS" ]]; then
+            if [[ "$cancelled" == "true" ]]; then
+              echo "Setting cancelled status from job status"
+              AGGREGATE_STATUS="CANCELLED"
+            elif [[ "$failure" == "true" ]]; then
+              echo "Setting failure status from job status"
+              AGGREGATE_STATUS="FAILURE"
+            fi
+          fi
           echo '"aggregate_status": "'$AGGREGATE_STATUS'"' >> workflow-data.json
-          if [[ "$AGGREGATE_STATUS" != "SUCCESS" ]]; then
+          if [[ "$AGGREGATE_STATUS" == "FAILURE" ]]; then
             echo ',' >> workflow-data.json
             echo '"first_fail_step": "'$FIRST_FAIL_STEP'",' >> workflow-data.json
             echo '"first_fail_module": "'$FIRST_FAIL_MODULE'",' >> workflow-data.json
             echo '"first_fail_error": "'$FIRST_FAIL_ERROR'"' >> workflow-data.json
           fi
           echo '}' >> workflow-data.json
-          
+         
           echo "aggregate_status=${AGGREGATE_STATUS}" >> $GITHUB_OUTPUT
       - name: Upload workflow data
         uses: actions/upload-artifact@v4
@@ -145,6 +158,6 @@ jobs:
       - name: Check Final Status
         run: |
           if [ "${{ needs.prepare-report-data.outputs.aggregate_status }}" != "SUCCESS" ]; then
-            echo "One or more jobs failed!"
+            echo "One or more jobs failed or cancelled!"
             exit 1
           fi

--- a/.github/workflows/reusable-initialize.yml
+++ b/.github/workflows/reusable-initialize.yml
@@ -54,11 +54,12 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           #workflow: build-test-merge_group.yml
+          workflow_search: true # artifacts can come from merge_group build. Cannot specify a list of workflows without multiple calls
           commit: ${{ github.sha }}
           workflow_conclusion: success
           search_artifacts: true
           dry_run: true
-          name: maven-repo
+          name: maven-repo # If using the same branch for different environments artifact names must be unique
           path: .
           if_no_artifact_found: warn
       - name: Set Outputs

--- a/.github/workflows/reusable-sonarqube.yml
+++ b/.github/workflows/reusable-sonarqube.yml
@@ -17,7 +17,7 @@ jobs:
     name: SonarQube Scan
     runs-on: ubuntu-latest
     if: |
-      (github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
+      (github.ref == 'refs/heads/master' || github.event_name == 'pull_request') && github.repository == 'dotCMS/core'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,7 +25,6 @@ jobs:
       - name: Setup master branch locally without switching current branch
         if: github.ref != 'refs/heads/master'
         run: git fetch origin master:master
-        continue-on-error: ${{ github.repository != 'dotCMS/core' }}
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
### Proposed Changes
* Pass needs data to reusable-finalize to properly check previous job status
  * Failures or cancellation in build steps not producing a build report were not being picked up in reusable-deployment.yml as "needs" object containing status was not being passed
* remove noise in report slack messaging to only post on failures
* Fix master build finding build queue artifacts fixes #28233
* use correct tag naming e.g. trunk_{{sha}} and trunk fixes #28235
* Fix deploy-artifact-cli should always use current run id
