### PR TITLE
fix(edit-page-2): Bring back z-index for Dot Dialog

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.scss
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.scss
@@ -13,6 +13,14 @@
 
 // Selectors overlayPanel and dialog
 ::ng-deep {
+    dot-wizard {
+        dot-dialog {
+            &.active {
+                z-index: 1103 !important;
+            }
+        }
+    }
+
     .p-overlaypanel.edit-ema-selector.p-component {
         .p-overlaypanel-content {
             padding: 0;

--- a/core-web/libs/ui/src/lib/modules/dot-dialog/dot-dialog.component.scss
+++ b/core-web/libs/ui/src/lib/modules/dot-dialog/dot-dialog.component.scss
@@ -14,7 +14,7 @@
         position: absolute;
         right: 0;
         top: 0;
-        z-index: 1103;
+        z-index: 1000;
     }
 
     &.no-overflow {


### PR DESCRIPTION
### Proposed Changes
* Bring back z-index for dot-dialog
* Add needed z-index for edit page v2


### Screenshots

https://github.com/dotCMS/core/assets/63567962/4e7b568a-ac5c-4fce-9b3c-a9f57e4a05c3

