### PR TITLE
ci(report) logic error currently in reporting status for slack

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -235,7 +235,7 @@ jobs:
           echo "payload=$(echo $payload | jq -c .)" >> $GITHUB_OUTPUT
           echo "payload=$payload"
       - name: Post to Slack
-        if: steps.workflow-data.outputs.has_json == 'true' && github.repository == 'dotcms/core' && ( steps.workflow-data.outputs.status != 'FAILURE' || !inputs.slack-only-on-failure )
+        if: steps.workflow-data.outputs.has_json == 'true' && github.repository == 'dotcms/core' && ( steps.workflow-data.outputs.status == 'FAILURE' || !inputs.slack-only-on-failure )
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ vars.SLACK_REPORT_CHANNEL }}


### PR DESCRIPTION
### Proposed Changes
* This is a simple logic change to make sure it reports ONLY failures by default,  currently it will report anything but failures.  Fixes bug introduced by https://github.com/dotCMS/core/pull/28247