### PR TITLE
ci(deployment) when run-id for download-artifacts is different then need github token.

### DIFF
--- a/.github/workflows/reusable-finalize.yml
+++ b/.github/workflows/reusable-finalize.yml
@@ -23,6 +23,7 @@ jobs:
           path: /tmp/build-step-reports
           pattern: build-reports-*
           merge-multiple: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ inputs.artifact-run-id }}
       - name: Prepare workflow data
         id: prepare-workflow-data

--- a/.github/workflows/reusable-sonarqube.yml
+++ b/.github/workflows/reusable-sonarqube.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ inputs.artifact-run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           name: maven-repo
           path: ~/.m2/repository
         continue-on-error: true


### PR DESCRIPTION
### Proposed Changes
* When run-id for download-artifacts is different then need the Github token.

## Current behavior
When the build artifacts for the Master build are used the SonarQube step fails to download the maven repo causing the step to fail.   A manual build that runs the build step works.

