### PR TITLE
ci(sonar) Fix sonar scan compilation

### DIFF
--- a/.github/workflows/reusable-ci-build.yml
+++ b/.github/workflows/reusable-ci-build.yml
@@ -109,3 +109,12 @@ jobs:
             target/build-report.json
             LICENSE
           retention-days: 2
+      - name: build-classes # required for sonarqube
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: "build-classes-Initial Artifact Build"
+          path: |
+            **/target/classes/**/*.class
+            LICENSE
+          retention-days: 2

--- a/.github/workflows/reusable-sonarqube.yml
+++ b/.github/workflows/reusable-sonarqube.yml
@@ -66,8 +66,7 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         shell: bash
         run: |
-          ./mvnw $JVM_TEST_MAVEN_OPTS compile -DskipTests=true -Pcoverage -Dcoverage.report.phase=compile
-          ./mvnw $JVM_TEST_MAVEN_OPTS -Dsonar.log.level=DEBUG org.sonarsource.scanner.maven:sonar-maven-plugin:sonar '-Dcoverage.execution.locations=build-reports/**/*.exec' -Dsonar.projectKey=dotCMS_core_AYSbIemxK43eThAXTlt- -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.token=$SONAR_TOKEN
+          ./mvnw $JVM_TEST_MAVEN_OPTS -Dsonar.log.level=DEBUG org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=dotCMS_core_AYSbIemxK43eThAXTlt- -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.token=$SONAR_TOKEN
       - name: SonarQube Quality Gate check
         id: sonarqube-quality-gate-check
         uses: sonarsource/sonarqube-quality-gate-action@master

--- a/.github/workflows/reusable-sonarqube.yml
+++ b/.github/workflows/reusable-sonarqube.yml
@@ -43,6 +43,13 @@ jobs:
           name: maven-repo
           path: ~/.m2/repository
         continue-on-error: true
+      - name: Download Build Classes
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ inputs.artifact-run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: "build-classes-Initial Artifact Build"
+        continue-on-error: true
       - name: Cache SonarQube packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
### Proposed Changes
* Sonarqube needs build classes to run,  currently we run a separate maven build step to generate the classes during the Sonarqube job.  This can cause problems with the classes not matching if using coverage as well as takes a long time to re-run the build.    The issue is made worse because the sonarqube scanner plugin requires java 17 to run but we do not want to build with a different version.   Instead, we can generate a build artifact from the initial build that contains just the classes and drop those into the same path before running just the scanner plugin.  This would also support classes needed for code coverage report generation. 

There is currently a compile error occurring in the Sonarqube build and this change will resolve any issues with this.