### PR TITLE
ci(report) Fix conditional logic to only send to slack on FAILURE

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -235,7 +235,7 @@ jobs:
           echo "payload=$(echo $payload | jq -c .)" >> $GITHUB_OUTPUT
           echo "payload=$payload"
       - name: Post to Slack
-        if: steps.workflow-data.outputs.has_json == 'true' && github.repository == 'dotcms/core' && ( steps.workflow-data.outputs.status == 'FAILURE' || !inputs.slack-only-on-failure )
+        if: steps.workflow-data.outputs.has_json == 'true' && github.repository == 'dotcms/core' && ( steps.workflow-data.outputs.status == 'FAILURE' || inputs.slack-only-on-failure == "false" )
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ vars.SLACK_REPORT_CHANNEL }}


### PR DESCRIPTION

Even though the inputs parameter has a default value of false this is not run when triggered from a PR or Merge Queue when triggered from completion of the main workflow.   By specifically testing for the input value to be "false" we make this result default to false when no input is set requiring the status to be FAILURE to run

