### PR TITLE
ci(report) fix broken report logic attempt 2

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -235,7 +235,7 @@ jobs:
           echo "payload=$(echo $payload | jq -c .)" >> $GITHUB_OUTPUT
           echo "payload=$payload"
       - name: Post to Slack
-        if: steps.workflow-data.outputs.has_json == 'true' && github.repository == 'dotcms/core' && ( steps.workflow-data.outputs.status == 'FAILURE' || inputs.slack-only-on-failure == "false" )
+        if: steps.workflow-data.outputs.has_json == 'true' && github.repository == 'dotcms/core' && ( steps.workflow-data.outputs.status == 'FAILURE' || inputs.slack-only-on-failure == false )
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ vars.SLACK_REPORT_CHANNEL }}


### PR DESCRIPTION
Logic is a bit strange it turns out that when there is no input passed it evaluates to null.  we need this case to evaluate a false and only when inputs.slack-only-on-failure is explicitly set to false should the result be true.

!inputs.slack-only-on-failure : failed as not set "null" is flipped to true. 

inputs.slack-only-on-failure == "false" breaks as it is a boolean and is not automatically converted to a string.

inputs.slack-only-on-failure == false : matches true when input explicitly set to false, false when the default input value "true" is set, and false when input does not exist as null == false,  it should not error checking null here and this would be the correct behavior.

