### PR TITLE
ci(report) only send on failure status attempt #3

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -235,7 +235,7 @@ jobs:
           echo "payload=$(echo $payload | jq -c .)" >> $GITHUB_OUTPUT
           echo "payload=$payload"
       - name: Post to Slack
-        if: steps.workflow-data.outputs.has_json == 'true' && github.repository == 'dotcms/core' && ( steps.workflow-data.outputs.status == 'FAILURE' || inputs.slack-only-on-failure == false )
+        if: steps.workflow-data.outputs.has_json == 'true' && github.repository == 'dotcms/core' && ( steps.workflow-data.outputs.status == 'FAILURE' || ( github.event_name == 'workflow_call' && inputs.slack-only-on-failure == false ) )
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ vars.SLACK_REPORT_CHANNEL }}


### PR DESCRIPTION
Still not working properly to send only with a false status.  Going crazy,  think this must be it but can check my logic.  

An actual check of the workflow trigger is required to distinguish between an overridden default value to be set as false, and the value just not being set which is resolved as false also.  If we are not being called as a reusable workflow with workflow_call trigger then we will need the failure status to run.
