### PR TITLE
ci(security) secure .github with codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Require workflow changes to be approved by developers who understand the codebase
+# and security implications of changes
+
+./github/ @dotcms/core-workflow-developers
+


### PR DESCRIPTION
Adds codeowners requiring PR approvals with workflow changes from specified team of experienced develoers #28293 
