### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose-examples/analytics/docker-compose.yml
+++ b/docker/docker-compose-examples/analytics/docker-compose.yml
@@ -112,7 +112,7 @@ services:
 
   cube:
     container_name: cube
-    image: cubejs/cube:latest
+    image: cubejs/cube:v0.35.12
     ports:
       - ${CUBE_HOST_PORT:-4001}:4000
     environment:


### PR DESCRIPTION
In the docker-compose of our dev analytics infrastructure we are pointing to cube/cube:latest. 
This can break upon any breaking changes, which just recently happened. 
This change is to point to a specific version in which we know things work. 