### PR TITLE
fix(Edit Contentlet): Show edit button when a file is editable

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.spec.ts
@@ -112,6 +112,12 @@ describe('DotBinaryFieldPreviewComponent', () => {
         );
     });
 
+    it('should be editable', () => {
+        spectator.detectChanges();
+        const editButton = spectator.query(byTestId('edit-button'));
+        expect(editButton).toBeTruthy();
+    });
+
     it('should show download button responsive', () => {
         spectator.detectChanges();
         const downloadButtonResponsive = spectator.query(byTestId('download-btn-responsive'));

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.ts
@@ -99,14 +99,17 @@ export class DotBinaryFieldPreviewComponent implements OnInit, OnChanges {
     }
 
     ngOnInit() {
-        this.isEditable = this.metadata.editableAsText || this.isEditableImage();
         if (this.contentlet) {
             this.content.set(this.contentlet?.content);
             this.fetchResourceLinks();
         }
     }
 
-    ngOnChanges({ tempFile }: SimpleChanges): void {
+    ngOnChanges({ tempFile, editableImage }: SimpleChanges): void {
+        if (editableImage) {
+            this.isEditable = this.isFileEditable();
+        }
+
         if (tempFile?.currentValue) {
             this.content.set(tempFile.currentValue.content);
         }
@@ -190,7 +193,17 @@ export class DotBinaryFieldPreviewComponent implements OnInit, OnChanges {
     }
 
     /**
-     * Emits event to remove the file
+     * Check if the file is editable
+     *
+     * @return {*}  {boolean}
+     * @memberof DotBinaryFieldPreviewComponent
+     */
+    private isFileEditable(): boolean {
+        return this.metadata.editableAsText || this.isEditableImage();
+    }
+
+    /**
+     * Check if the file is an editable image
      *
      * @private
      * @return {*}  {boolean}


### PR DESCRIPTION
- Show edit button when a file is editable

### Image

<img width="1840" alt="fix-issue-28115-ui-we-lost-any-way-to-download-or-get-the-url-of-an-asset" src="https://github.com/dotCMS/core/assets/72418962/fd5b59ca-5de8-4d10-bf63-47d30615ccf5">
