### PR TITLE
chore(binary-field): Hide file resolution when it is not an image

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.html
@@ -108,10 +108,12 @@
     <div class="file-info__item">
         <span class="file-info__title">{{ 'Size' | dm }}:</span>
         <div class="file-info__link">
-            <div class="file-info__size">
+            @if(metadata.width && metadata.height) {
+            <div class="file-info__size" data-testId="file-resolution">
                 <i class="pi pi-arrows-alt"></i>
                 <span>{{ metadata.width }}px, {{ metadata.height }}px</span>
             </div>
+            }
             <div class="file-info__size">
                 <i class="pi pi-file"></i>
                 <span>{{ metadata.fileSize | dotFileSizeFormat }}</span>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.scss
@@ -173,7 +173,7 @@ code {
 
 .file-info__size {
     display: flex;
-    align-items: flex-end;
+    align-items: center;
     gap: $spacing-0;
 }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.spec.ts
@@ -298,5 +298,23 @@ describe('DotBinaryFieldPreviewComponent', () => {
                 inodeOrIdentifier: CONTENTLET_MOCK.identifier
             });
         }));
+
+        it('should not show file resolution', () => {
+            spectator.setInput('contentlet', {
+                ...CONTENTLET_MOCK,
+                BinaryMetaData: {
+                    ...BINARY_FIELD_CONTENTLET.binaryMetaData,
+                    height: 0,
+                    width: 0
+                }
+            });
+
+            spectator.detectChanges();
+
+            clickOnInfoButton(spectator);
+
+            const resolution = spectator.query(byTestId('file-resolution'));
+            expect(resolution).toBeNull();
+        });
     });
 });


### PR DESCRIPTION
### Images

#### Before
![Image](https://github.com/dotCMS/core/assets/751424/febe9785-2144-4efb-ae41-f27bfcdc17c9)

#### After
![fix-issue-28115-ui-we-lost-any-way-to-download-or-get-the-url-of-an-asset-pixels](https://github.com/dotCMS/core/assets/72418962/886791d8-2a16-4312-a9fc-90d8774a5e18)
