### PR TITLE
feat(multi tenant): Hide the ability to copy Content Types when copying Sites behind a Feature Flag #27755

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/priv/HostAssetsJobImpl.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/priv/HostAssetsJobImpl.java
@@ -98,6 +98,7 @@ import com.dotmarketing.portlets.templates.design.bean.TemplateLayout;
 import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.quartz.QuartzUtils;
 import com.dotmarketing.quartz.job.HostCopyOptions;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.StringUtils;
@@ -520,7 +521,7 @@ public class HostAssetsJobImpl extends ParentProxy{
 			HibernateUtil.startTransaction();
 			this.siteCopyStatus.updateProgress(70);
 
-			if (copyOptions.isCopyContentTypes()) {
+			if (Config.getBooleanProperty("FEATURE_FLAG_ENABLE_CONTENT_TYPE_COPY", false) && copyOptions.isCopyContentTypes()) {
 				final List<Relationship> copiedRelationships = new ArrayList<>();
 				Logger.info(this, "----------------------------------------------------------------------");
 				Logger.info(this, String.format(":::: Copying Content Types to new Site '%s'", destinationSite.getHostname()));
@@ -1002,7 +1003,7 @@ public class HostAssetsJobImpl extends ParentProxy{
                     }
                 }
 				ContentletRelationshipRecords related;
-				if (!copyOptions.isCopyContentTypes()) {
+				if (!Config.getBooleanProperty("FEATURE_FLAG_ENABLE_CONTENT_TYPE_COPY", false) || !copyOptions.isCopyContentTypes()) {
 					related = new ContentletRelationships(
 							destinationContent).new ContentletRelationshipRecords(r, true);
 				} else {

--- a/dotCMS/src/main/webapp/html/portlet/ext/hostadmin/view_hosts.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/hostadmin/view_hosts.jsp
@@ -5,6 +5,7 @@
 <%@page import="com.dotmarketing.business.PermissionAPI"%>
 <%@page import="com.dotmarketing.beans.Host"%>
 <%@page import="com.dotcms.enterprise.license.LicenseLevel"%>
+<%@ page import="com.dotmarketing.util.Config" %>
 
 <%
 	PermissionAPI permAPI = APILocator.getPermissionAPI();
@@ -216,12 +217,16 @@
 						    </div>
 						</div>
 						<div class="yui-g" style="margin-bottom: 16px;">
+							<% if (Config.getBooleanProperty("FEATURE_FLAG_ENABLE_CONTENT_TYPE_COPY", false)) { %>
 							<div class="yui-u first" style="text-align: left">
 								<input type="checkbox" id="copyContentTypes" disabled="true" checked="checked" dojoType="dijit.form.CheckBox">
 								<label for="copyContentTypes">
 									<%= LanguageUtil.get(pageContext, "Content Types") %>
 								</label>
 							</div>
+						    <% } else { %>
+								<input style="display: none" type="checkbox" id="copyContentTypes" disabled="true" dojoType="dijit.form.CheckBox">
+							<% } %>
 							<div class="yui-u" style="text-align: left">
 								<input type="checkbox" id="copyLinks" disabled="true" checked="checked" dojoType="dijit.form.CheckBox">
 								<label for="copyLinks">


### PR DESCRIPTION
### Proposed Changes
* Hiding the ability to copy Content Types when copying Sites behind a Feature Flag called `FEATURE_FLAG_ENABLE_CONTENT_TYPE_COPY`. For now, it will be disabled by default.