### PR TITLE
chore(codeowners) Fix codeowners path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Require workflow changes to be approved by developers who understand the codebase
 # and security implications of changes
 
-./github/ @dotcms/core-workflow-developers
+/.github/ @dotCMS/core-workflow-developers
 


### PR DESCRIPTION
### Proposed Changes
Path Incorrect for code owners and org name for team is case sensitive

### Test
Check files in .github folder on master are maked with the  core-workflow-developers 

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners