### PR TITLE
chore(edit-page-2): Fix nav level in navigation sorting

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/VM_global_library.vm
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/VM_global_library.vm
@@ -192,8 +192,6 @@
 
 #macro(sortNavigation)
     #if ($EDIT_MODE && $PUBLISH_HTMLPAGE_PERMISSION)
-        #set($menuLevel = $VTLSERVLET_URI.split('/').size() - 1)
-
       <button
     onclick="openReorderDialog(event)"
     style="
@@ -228,7 +226,7 @@
     function openReorderDialog(event) {
         event.preventDefault();
         var reorderUrl =
-            '${directorURL}&startLevel=${menuLevel}&depth=2&pagePath=${VTLSERVLET_URI}&hostId=${host.identifier}';
+            '${directorURL}&startLevel=1&depth=2&pagePath=${VTLSERVLET_URI}&hostId=${host.identifier}';
 
         window.parent.postMessage(
             {


### PR DESCRIPTION
### Proposed Changes
* Set the start level of the Navigation to 1, this way it will always show the top navigation instead of just the sub navigations when entering in sub navigation paths

### Screenshots

https://github.com/dotCMS/core/assets/63567962/983c1196-44dc-4414-9764-7c49d607d880

