### PR TITLE
fix(CICD): #27630 Fixing binary names on cli release NPM package.

### DIFF
--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -419,7 +419,7 @@ jobs:
       - name: 'NPM Package setup'
         working-directory: ${{ github.workspace }}/tools/dotcms-cli/npm/
         env:
-          MVN_PACKAGE_VERSION: ${{ github.event.inputs.version }}
+          MVN_PACKAGE_VERSION: ${{ needs.precheck.outputs.RELEASE_VERSION }}
         run: |
           echo "::group::NPM Package setup"
           echo "Adding bin folder with all the binaries"


### PR DESCRIPTION
### Proposed Changes
* Although the CLI release was successfully triggered after the core release, the `release version` is missing from the names of the latest CLI binaries in the NPM package, which are needed to build the script installer.

### Fixes
#27630 
