### PR TITLE
fix(CICD): #27805 Setting the correct token for NPM publishing.

### DIFF
--- a/.github/workflows/build-test-nightly.yml
+++ b/.github/workflows/build-test-nightly.yml
@@ -72,7 +72,7 @@ jobs:
       EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
       EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}
       DEVELOPERS_SLACK_WEBHOOK: ${{ secrets.DEVELOPERS_SLACK_WEBHOOK }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_ORG_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
   finalize:
     name: Finalize
     if: always()

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -37,7 +37,7 @@ on:
         DEVELOPERS_SLACK_WEBHOOK:
           required: false
           description: 'Slack webhook for developers'
-        NPM_TOKEN:
+        NPM_ORG_TOKEN:
           required: false
           description: 'NPM token'
 jobs:
@@ -100,7 +100,7 @@ jobs:
         uses: ./.github/actions/publish-npm-cli
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
+          npm-token: ${{ secrets.NPM_ORG_TOKEN }}
           reuse-previous-build: ${{ inputs.reuse-previous-build }}
 
       # A Slack notification is sent using the 'action-slack-notify' action if the repository is 'dotcms/core'.


### PR DESCRIPTION
### Proposed Changes
* We must use `secrets.NPM_ORG_TOKEN` instead of `secrets.NPM_TOKEN`.

### Fixes
#27630 