### PR TITLE
#27809 Changing dotcms-cli.log default location

### DIFF
--- a/tools/dotcms-cli/api-data-model/src/main/resources/application.properties
+++ b/tools/dotcms-cli/api-data-model/src/main/resources/application.properties
@@ -9,7 +9,7 @@ quarkus.log.file.enable=true
 # To override the level: ./mvnw quarkus:dev -Dquarkus.log.file.level=DEBUG
 # For debug change this level to DEBUG
 quarkus.log.file.level=INFO
-quarkus.log.file.path=dotcms-cli.log
+quarkus.log.file.path=${user.home}/.dotcms/dotcms-cli.log
 quarkus.log.file.rotation.max-file-size=10M
 quarkus.log.file.rotation.max-backup-index=5
 quarkus.log.file.rotation.rotate-on-boot=false


### PR DESCRIPTION
Changed the `dotcms-cli.log` default location to the `~/.dotcms` folder