### PR TITLE
#28391 Upgrading graalvm version to build native-images

### DIFF
--- a/.github/workflows/cli-build-artifacts.yml
+++ b/.github/workflows/cli-build-artifacts.yml
@@ -19,7 +19,7 @@ on:
 env:
   JAVA_VERSION: 11
   JAVA_DISTRO: temurin
-  GRAALVM_VERSION: '22.1.0'
+  GRAALVM_VERSION: '22.3.1'
   BRANCH: ${{ inputs.branch || github.ref_name }}
   SKIP_TESTS: true
 

--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -21,7 +21,7 @@ defaults:
 env:
   JAVA_VERSION: 11
   JAVA_DISTRO: temurin
-  GRAALVM_VERSION: '22.1.0'
+  GRAALVM_VERSION: '22.3.1'
   MVN_PACKAGE_TYPE: 'uber-jar'
   NPM_PACKAGE_SCOPE: '@dotcms'
   NPM_PACKAGE_NAME: 'dotcli'


### PR DESCRIPTION
### Proposed Changes
* Upgrade `GRAALVM` version is required. The latest GRAALVM version available to use along with `Quarkus 2.16.12`, `Java 11` and `macOS AARCH `

https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-22.3.1

### Fixes
#28391 