### PR TITLE
fix(edit-page-2): Editor gets stuck in firefox

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.scss
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.scss
@@ -5,6 +5,7 @@
     grid-template-columns: 1fr auto;
     grid-template-rows: 100%;
     height: 100%;
+    background-color: $white;
 
     router-outlet {
         display: none;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2241,6 +2241,8 @@ describe('EditEmaEditorComponent', () => {
                     it('should open dialog when dropping a content-type', () => {
                         const contentType = CONTENT_TYPE_MOCK[0];
 
+                        jest.spyOn(store, 'updateEditorState');
+
                         store.setDragItem({
                             baseType: contentType.baseType,
                             contentType: contentType.variable,
@@ -2292,6 +2294,7 @@ describe('EditEmaEditorComponent', () => {
                         );
 
                         expect(dialog.attributes['ng-reflect-visible']).toBe('true');
+                        expect(store.updateEditorState).toHaveBeenCalledWith(EDITOR_STATE.IDLE);
                     });
 
                     it('should advice and reset the state to IDLE when the dropped file is not an image', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -459,7 +459,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
         fromEvent(this.window, 'dragleave')
             .pipe(
                 takeUntil(this.destroy$),
-                filter((event: DragEvent) => !event.x && !event.y && !event.relatedTarget) // Just reset when is out of the window
+                filter((event: DragEvent) => !event.relatedTarget) // Just reset when is out of the window
             )
             .subscribe(() => {
                 // I need to do this to hide the dropzone but maintain the current dragItem

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -676,6 +676,8 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
 
             return;
         } else if (dragItem.draggedPayload.type === 'content-type') {
+            this.store.updateEditorState(EDITOR_STATE.IDLE); // In case the user cancels the creation of the contentlet, we already have the editor in idle state
+
             this.dialog.createContentletFromPalette({ ...dragItem.draggedPayload.item, payload });
         } else if (dragItem.draggedPayload.type === 'temp') {
             const { pageContainers, didInsert } = insertContentletInContainer({


### PR DESCRIPTION
### Proposed Changes
* Delete check of coordinates on DragLeave (Does not work as the Chromium version of the event)
* Background color was missing in shell
* Set editorState to `IDLE` when opening a create contentlet dialog to avoid editor getting stuck if user cancels the creation

### Screenshots


https://github.com/dotCMS/core/assets/63567962/f402b009-83aa-475b-8f0f-bcb647c958e4

