### PR TITLE
fix(backend): Flakey Test Postman sync bundle api still returns  (#28380)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/quartz/DotStatefulJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/DotStatefulJob.java
@@ -157,19 +157,16 @@ public abstract class DotStatefulJob extends DotJob implements StatefulJob {
             triggersData.put(nextTriggerName, nextExecutionData);
             jobProperties.put(TRIGGER_JOB_DETAIL, triggersData);
 
-            final Calendar calendar = Calendar.getInstance();
-            final String cronString = new SimpleDateFormat("ss mm H d M ? yyyy")
-                    .format(calendar.getTime());
-            final ScheduledTask task = new CronScheduledTask(jobName,
+            final ScheduledTask task = new SimpleScheduledTask(jobName,
                     groupName, description,
-                    jobClass.getCanonicalName(), false,
+                    jobClass.getCanonicalName(),false,
                     nextTriggerName, triggerGroup, new Date(), null,
-                    SimpleTrigger.MISFIRE_INSTRUCTION_FIRE_NOW, 10, jobProperties,
-                    cronString);
+                    SimpleTrigger.MISFIRE_INSTRUCTION_FIRE_NOW, 10, false, jobProperties,0,0);
+
             task.setDurability(true); //must be durable to preserve the detail across triggers.
 
             QuartzUtils.scheduleTask(task);
-            Logger.info(DotStatefulJob.class, String.format("New Task for job `%s` scheduled for execution `%s`.", jobName, cronString));
+            Logger.info(DotStatefulJob.class, String.format("New Task for job `%s` scheduled`.", jobName));
 
         }
     }


### PR DESCRIPTION
### Proposed Changes
* This should schedule to run now without relying on a Cron trigger. Setting the cron trigger to the current second does not work reliably as Quartz may only check the time has passed already in the next second
* This should resolve flakey result that were returning the "RECEIVED_BUNDLE" occationally in postman tests
* There was some concern that we may end up with lots of concurrent jobs but this should be prevented as the Job uses the StatefulJob interface that forces serial execution.