### PR TITLE
fix(edit-page-v2):Check if the containers are different by uuid when dropping

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-page-dropzone/pipes/error/dot-error.pipe.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-page-dropzone/pipes/error/dot-error.pipe.spec.ts
@@ -131,7 +131,7 @@ describe('DotErrorPipe', () => {
         });
     });
 
-    it('should return message when maxContentlet is greater than 1 and the drag item is from another container', () => {
+    it('should return message when maxContentlet is greater than 1 and the drag item is from another container (identifier case)', () => {
         const container: Container = {
             x: 10,
             y: 10,
@@ -198,6 +198,74 @@ describe('DotErrorPipe', () => {
             args: ['3']
         });
     });
+    it('should return message when maxContentlet is greater than 1 and the drag item is from another container (uuid case)', () => {
+        const container: Container = {
+            x: 10,
+            y: 10,
+            width: 10,
+            height: 10,
+            contentlets: [
+                {
+                    x: 10,
+                    y: 10,
+                    width: 10,
+                    height: 10,
+                    payload: PAYLOAD_MOCK
+                },
+                {
+                    x: 10,
+                    y: 10,
+                    width: 10,
+                    height: 10,
+                    payload: PAYLOAD_MOCK
+                },
+                {
+                    x: 10,
+                    y: 10,
+                    width: 10,
+                    height: 10,
+                    payload: PAYLOAD_MOCK
+                }
+            ],
+            payload: JSON.stringify({
+                container: {
+                    acceptTypes: 'kenobi,theChosenOne,yoda',
+                    maxContentlets: 3,
+                    identifier: '123',
+                    uuid: '321'
+                }
+            })
+        };
+
+        const dragItem: EmaDragItem = {
+            baseType: 'CONTENT',
+            contentType: 'kenobi',
+            draggedPayload: {
+                type: 'contentlet',
+                item: {
+                    container: {
+                        identifier: '123',
+                        acceptTypes: 'kenobi,theChosenOne,yoda',
+                        maxContentlets: 3,
+                        uuid: '456',
+                        variantId: '123'
+                    },
+                    contentlet: {
+                        identifier: '321',
+                        inode: '123',
+                        title: 'title',
+                        contentType: 'kenobi'
+                    }
+                },
+                move: true
+            }
+        };
+
+        expect(pipe.transform(container, dragItem)).toEqual({
+            message: 'edit.ema.page.dropzone.max.contentlets',
+            args: ['3']
+        });
+    });
 
     it('should not return message when maxContentlet is greater than 1 and the drag item is from the same container', () => {
         const container: Container = {
@@ -232,7 +300,8 @@ describe('DotErrorPipe', () => {
                 container: {
                     acceptTypes: 'kenobi,theChosenOne,yoda',
                     maxContentlets: 3,
-                    identifier: '123'
+                    identifier: '123',
+                    uuid: '321'
                 }
             })
         };
@@ -247,7 +316,7 @@ describe('DotErrorPipe', () => {
                         identifier: '123',
                         acceptTypes: 'kenobi,theChosenOne,yoda',
                         maxContentlets: 3,
-                        uuid: '123',
+                        uuid: '321',
                         variantId: '123'
                     },
                     contentlet: {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-page-dropzone/pipes/error/dot-error.pipe.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-page-dropzone/pipes/error/dot-error.pipe.ts
@@ -37,7 +37,8 @@ export class DotErrorPipe implements PipeTransform {
             ?.container;
 
         if (
-            container?.identifier !== originContainer?.identifier && // If it is not from the same container then we are adding a new contentlet
+            (container?.identifier !== originContainer?.identifier ||
+                container.uuid !== originContainer?.uuid) && // If it is not from the same container then we are adding a new contentlet
             !this.contentCanFitInContainer(container.maxContentlets, contentletsLength)
         ) {
             const message =

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-page-dropzone/pipes/error/dot-error.pipe.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-page-dropzone/pipes/error/dot-error.pipe.ts
@@ -2,7 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 import { DotCMSBaseTypesContentTypes } from '@dotcms/dotcms-models';
 
-import { ContentletDragPayload } from '../../../../../shared/models';
+import { ContainerPayload, ContentletDragPayload } from '../../../../../shared/models';
 import { Container, EmaDragItem } from '../../types';
 
 interface DotErrorPipeResponse {
@@ -37,8 +37,7 @@ export class DotErrorPipe implements PipeTransform {
             ?.container;
 
         if (
-            (container?.identifier !== originContainer?.identifier ||
-                container.uuid !== originContainer?.uuid) && // If it is not from the same container then we are adding a new contentlet
+            !this.isSameTheContainer(container, originContainer) && // If it is not from the same container then we are adding a new contentlet
             !this.contentCanFitInContainer(container.maxContentlets, contentletsLength)
         ) {
             const message =
@@ -74,5 +73,15 @@ export class DotErrorPipe implements PipeTransform {
 
     private contentCanFitInContainer(maxContentlets: number, contentletsLength: number): boolean {
         return contentletsLength < maxContentlets;
+    }
+
+    private isSameTheContainer(
+        container?: ContainerPayload,
+        originContainer?: ContainerPayload
+    ): boolean {
+        return (
+            container?.identifier === originContainer?.identifier &&
+            container?.uuid === originContainer?.uuid
+        );
     }
 }


### PR DESCRIPTION
### Proposed Changes
* Add uuid constrain when checking if a contentlet fits inside a container


### Screenshots


https://github.com/dotCMS/core/assets/63567962/2809d283-8f7b-4917-98e6-bf8466f74561

