### PR TITLE
remove skipping of flatten as it breaks parent dependency resolution #28430

### DIFF
--- a/.github/workflows/maven-release-process.yml
+++ b/.github/workflows/maven-release-process.yml
@@ -135,7 +135,6 @@ jobs:
           ./mvnw -ntp \
             ${JVM_TEST_MAVEN_OPTS} \
             -Dprod=true \
-            -Dflatten.skip=false \
             -Ddocker.buildArchiveOnly=${DOCKER_BUILD_CONTEXT} \
             -DskipTests=true \
             -DskipITs=true \
@@ -287,7 +286,6 @@ jobs:
           ./mvnw -ntp \
             ${JVM_TEST_MAVEN_OPTS} \
             -Dprod=true \
-            -Dflatten.skip=false \
             -DskipTests=true \
             -DskipITs=true \
             deploy

--- a/.github/workflows/reusable-ci-build.yml
+++ b/.github/workflows/reusable-ci-build.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           echo "Creating $DOCKER_BUILD_CONTEXT"
           mkdir -p $DOCKER_BUILD_CONTEXT
-          ./mvnw -Dprod=true -Dflatten.skip=false $JVM_TEST_MAVEN_OPTS -Dcoreit.test.skip=true -Dpostman.test.skip=true -Ddocker.buildArchiveOnly=$DOCKER_BUILD_CONTEXT -Ddotcms.image.name=${DOCKER_IMAGE}:${DOCKER_TAG} --show-version -DskipTests=true -DskipITs=true clean install --file pom.xml
+          ./mvnw -Dprod=true $JVM_TEST_MAVEN_OPTS -Dcoreit.test.skip=true -Dpostman.test.skip=true -Ddocker.buildArchiveOnly=$DOCKER_BUILD_CONTEXT -Ddotcms.image.name=${DOCKER_IMAGE}:${DOCKER_TAG} --show-version -DskipTests=true -DskipITs=true clean install --file pom.xml
       - name: Persist Maven Repo
         uses: actions/upload-artifact@v4
         with:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -14,7 +14,7 @@
         <changelist>-SNAPSHOT</changelist>
         <sha1/>
         <flatten.mode>oss</flatten.mode>
-        <flatten.skip>true</flatten.skip>
+        <flatten.skip>false</flatten.skip>
         <maven.deploy.skip>false</maven.deploy.skip>
         <tomcat.version>9.0.85</tomcat.version>
         <!-- Add any properties here that are to have defaults and overrides set in the environment properties -->


### PR DESCRIPTION
### Proposed Changes Fix for #28430 
* It was thought that we could not run the flatten-maven-plugin as a developer if running off the 1.0.0-SNAPSHOT base version when using ci friendly revisions in maven.    This is not correct due to the fact that the plugin is needed to resolve the actual revision in the parent tag in the pom and without this the initial maven resolve cannot find the version of the parent artifacts and therefore the default values set in the top level parent/pom.xml.   

This is an urgent fix as it can impact developer builds also,  as a workaround a developer can run ./mvnw clean install -DskipTests -Dflatten.skip=false and add -Dflatten.skip to each of the commands to ensure it is run correctly.

This was not observed in development as my local repo already had correctly flattened versions but was repeatable when I removed my maven repository with rm -rf ~/.m2/repository

```
./mvnw clean install -Dtest.failure.ignore=true -DskipTests=false -am -pl :dotcms-cli
./mvnw install -DskipTests=true -pl :dotcms-cli

Error:  Failed to execute goal on project dotcms-cli: Could not resolve dependencies for project com.dotcms:dotcms-cli:jar:1.0.0-SNAPSHOT: Failed to collect dependencies at com.dotcms:dotcms-api-data-model:jar:1.0.0-SNAPSHOT: Failed to read artifact descriptor for com.dotcms:dotcms-api-data-model:jar:1.0.0-SNAPSHOT: The following artifacts could not be resolved: com.dotcms:dotcms-cli-parent:pom:${revision}${sha1}${changelist} (absent): Could not find artifact com.dotcms:dotcms-cli-parent:pom:${revision}${sha1}${changelist} in dotcms-libs (https://repo.dotcms.com/artifactory/libs-release/) -> [Help 1]

```



