### PR TITLE
fix(backend): Stream concurrency issue in Metadata class (#28470)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/storage/FileStorageAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileStorageAPIImpl.java
@@ -10,7 +10,6 @@ import com.dotmarketing.util.FileUtil;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
@@ -24,6 +23,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -52,7 +52,7 @@ public class FileStorageAPIImpl implements FileStorageAPI {
     private final StoragePersistenceProvider persistenceProvider;
     private final MetadataCache metadataCache;
     // Create a ConcurrentHashMap to store locks for each cache key
-    private final ConcurrentHashMap<String, WeakReference<ReadWriteLock>> locks = new ConcurrentHashMap<>();/**
+    private final ConcurrentHashMap<StorageKey, WeakReference<ReadWriteLock>> locks = new ConcurrentHashMap<>();/**
      * Constructor used by Integration Tests.
      *
      * @param objectReaderDelegate The {@link ObjectReaderDelegate} that reads an object.
@@ -99,7 +99,7 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      * We can get it without having to call tika
      * @param binary {@link File} file to get the information
      * @param metaDataKeyFilter  {@link Predicate} filter the meta data key for the map result generation
-     * @return
+     * @return Map with the metadata
      */
     private Map<String, Serializable> generateBasicMetaData(final File binary,
             final Predicate<String> metaDataKeyFilter) {
@@ -124,7 +124,7 @@ public class FileStorageAPIImpl implements FileStorageAPI {
             return ensureTypes(standAloneMetadata);
         }
 
-        return ImmutableMap.of();
+        return Map.of();
     }
 
     /**
@@ -159,7 +159,7 @@ public class FileStorageAPIImpl implements FileStorageAPI {
             return Collections.emptyMap();
         }
 
-        metadataMap = ensureTypes(metadataMap);
+        ensureTypes(metadataMap);
 
         return ImmutableSortedMap.copyOf(metadataMap);
     }
@@ -171,21 +171,19 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      */
     private TreeMap<String, Serializable> ensureTypes(TreeMap<String, Serializable> metadataMap){
         final Map<String, BasicMetadataFields> metadataFieldsMap = BasicMetadataFields.keyMap();
-        final Iterator<Entry<String, Serializable>> iterator = metadataMap.entrySet().iterator();
-        while(iterator.hasNext()){
-            final Entry<String, Serializable> entry = iterator.next();
+        for (Entry<String, Serializable> entry : metadataMap.entrySet()) {
             final Serializable value = entry.getValue();
             if (isSet(value)) {
                 final BasicMetadataFields field = metadataFieldsMap.get(entry.getKey());
-                if(null == field) {
-                   continue;
+                if (null == field) {
+                    continue;
                 }
                 if (field.isNumericType()) {
-                     Try.of(()-> entry.setValue(Integer.parseInt(value.toString())));
+                    Try.of(() -> entry.setValue(Integer.parseInt(value.toString())));
                 }
 
                 if (field.isBooleanType()) {
-                     Try.of(()-> entry.setValue(Boolean.parseBoolean(value.toString())));
+                    Try.of(() -> entry.setValue(Boolean.parseBoolean(value.toString())));
                 }
             }
         }
@@ -205,7 +203,7 @@ public class FileStorageAPIImpl implements FileStorageAPI {
         }
         final boolean objectExists = storage.existsObject(storageKey.getGroup(), storageKey.getPath());
 
-        Map<String, Serializable> metadataMap = objectExists ? retrieveMetadata(storageKey, storage) : Map.of();
+        Map<String, Serializable> metadataMap = objectExists ? retrieveMetaData(storageKey, storage) : Map.of();
         final Map<String, Serializable> onlyHasCustomMetadataMap = configuration.getIfOnlyHasCustomMetadata().apply(metadataMap);
 
         // here we test quite a few things:
@@ -240,44 +238,44 @@ public class FileStorageAPIImpl implements FileStorageAPI {
      * @throws DotDataException An error occurred when persisting the generated metadata.
      */
     private Map<String, Serializable> generateMetadataFromFile(final File binary,
-                                                               final GenerateMetadataConfig configuration, final StorageKey storageKey, final Map<String, Serializable> onlyHasCustomMetadataMap, final StoragePersistenceAPI storage) throws DotDataException {
-        Map<String, Serializable> metadataMap;
+            final GenerateMetadataConfig configuration, final StorageKey storageKey, final Map<String, Serializable> onlyHasCustomMetadataMap, final StoragePersistenceAPI storage) throws DotDataException {
+        validateBinary(binary);
+
+        final long maxLength = configuration.getMaxLength();
+        Map<String, Serializable> metadataMap = generateMetaDataBasedOnConfig(binary, configuration, maxLength);
+
+        if (configuration.isStore()) {
+            metadataMap = prepareMetadataForStorage(configuration, onlyHasCustomMetadataMap, metadataMap);
+            storeMetadata(storageKey, storage, metadataMap);
+        }
+        return metadataMap;
+    }
+
+    private void validateBinary(final File binary) {
         if (!validBinary(binary)) {
             throw new IllegalArgumentException(String.format("the binary `%s` isn't accessible ",
                     binary != null ? binary : "unknown"));
         }
+    }
 
-        Logger.debug(FileStorageAPIImpl.class, () -> String.format(
-                "Object identified by `/%s/%s` didn't exist in storage %s. It will be generated",
-                storageKey.getGroup(), storageKey,
-                configuration.isFull() ? "full-metadata" : "basic-metadata"));
-        final long maxLength = configuration.getMaxLength();
-        metadataMap = configuration.isFull() ?
-                generateFullMetaData(binary,
-                        configuration.getMetaDataKeyFilter(), maxLength) :
-                generateBasicMetaData(binary,
-                        configuration.getMetaDataKeyFilter());
+    private Map<String, Serializable> generateMetaDataBasedOnConfig(final File binary, final GenerateMetadataConfig configuration, final long maxLength) {
+        return configuration.isFull() ?
+                generateFullMetaData(binary, configuration.getMetaDataKeyFilter(), maxLength) :
+                generateBasicMetaData(binary, configuration.getMetaDataKeyFilter());
+    }
 
-        if (configuration.isStore()) {
-            if (null != configuration.getMergeWithMetadata()) {
-                final Map<String, Serializable> patchMap =
-                        configuration.getMergeWithMetadata().getCustomMetaWithPrefix();
-                //we need to include the prefix since we're saving it directly into persistence
-                if (!patchMap.isEmpty()) {
-                    //This is necessary since metadataMap is immutable.
-                    metadataMap = new HashMap<>(metadataMap);
-                    patchMap.forEach(metadataMap::putIfAbsent);
-                }
-            } else {
-                //Carry the custom metadata
-                if (!onlyHasCustomMetadataMap.isEmpty()) {
-                    //This metadata is expected to have prefix that's fine.
-                    //This is necessary since metadataMap is immutable.
-                    metadataMap = new HashMap<>(metadataMap);
-                    onlyHasCustomMetadataMap.forEach(metadataMap::putIfAbsent);
-                }
+    private Map<String, Serializable> prepareMetadataForStorage(final GenerateMetadataConfig configuration, final Map<String, Serializable> onlyHasCustomMetadataMap, Map<String, Serializable> metadataMap) {
+        if (null != configuration.getMergeWithMetadata()) {
+            final Map<String, Serializable> patchMap = configuration.getMergeWithMetadata().getCustomMetaWithPrefix();
+            if (!patchMap.isEmpty()) {
+                metadataMap = new HashMap<>(metadataMap);
+                patchMap.forEach(metadataMap::putIfAbsent);
             }
-            storeMetadata(storageKey, storage, metadataMap);
+        } else {
+            if (!onlyHasCustomMetadataMap.isEmpty()) {
+                metadataMap = new HashMap<>(metadataMap);
+                onlyHasCustomMetadataMap.forEach(metadataMap::putIfAbsent);
+            }
         }
         return metadataMap;
     }
@@ -285,11 +283,11 @@ public class FileStorageAPIImpl implements FileStorageAPI {
     /**
      * Gets the lock for the given cache key. If the lock does not exist, it will be created.
      * We use a {@link WeakReference} to avoid memory leaks.
-     * @param key The cache key.
+     * @param key The storage key.
      *
      * @return The {@link ReadWriteLock} for the given cache key.
      */
-    private ReadWriteLock getLock(String key) {
+    private ReadWriteLock getLock(StorageKey key) {
         return locks.compute(key, (k, v) -> {
             ReadWriteLock lock = (v != null) ? v.get() : null;
             if (lock == null) {
@@ -302,8 +300,8 @@ public class FileStorageAPIImpl implements FileStorageAPI {
 
     /**
      * Group existence verifier
-     * @param storageKey
-     * @param storage
+     * @param storageKey The {@link StorageKey} that identifies the binary file and how it will be stored.
+     * @param storage The {@link StoragePersistenceAPI} that will be used to persist the metadata.
      */
     private void checkBucket(final StorageKey storageKey, final StoragePersistenceAPI storage)
             throws DotDataException {
@@ -314,8 +312,8 @@ public class FileStorageAPIImpl implements FileStorageAPI {
 
     /**
      * save into cache
-     * @param cacheKey
-     * @param metadataMap
+     * @param cacheKey The cache key.
+     * @param metadataMap The metadata map.
      */
     private void putIntoCache(final String cacheKey, final Map<String, Serializable> metadataMap) {
         if(metadataMap.isEmpty()){
@@ -327,12 +325,12 @@ public class FileStorageAPIImpl implements FileStorageAPI {
 
     /**
      * meta-data retriever
-     * @param storageKey
-     * @param storage
-     * @return
+     * @param storageKey The {@link StorageKey} that identifies the binary file and how it will be stored.
+     * @param storage The {@link StoragePersistenceAPI} that will be used to persist the metadata.
+     * @return The metadata map.
      */
     @SuppressWarnings("unchecked")
-    private Map<String, Serializable> retrieveMetadata(final StorageKey storageKey,
+    private Map<String, Serializable> retrieveMetaData(final StorageKey storageKey,
             final StoragePersistenceAPI storage) throws DotDataException {
         final Map<String, Serializable> objectMap = (Map<String, Serializable>) storage
                 .pullObject(storageKey.getGroup(), storageKey.getPath(), this.objectReaderDelegate);
@@ -343,9 +341,9 @@ public class FileStorageAPIImpl implements FileStorageAPI {
 
     /**
      * sends metadata to the respective configured storage
-     * @param storageKey
-     * @param storage
-     * @param metadataMap
+     * @param storageKey The {@link StorageKey} that identifies the binary file and how it will be stored.
+     * @param storage The {@link StoragePersistenceAPI} that will be used to persist the metadata.
+     * @param metadataMap The metadata map.
      */
     private void storeMetadata(final StorageKey storageKey, final StoragePersistenceAPI storage,
             final Map<String, Serializable> metadataMap) throws DotDataException {
@@ -360,8 +358,8 @@ public class FileStorageAPIImpl implements FileStorageAPI {
 
     /**
      * Check's file is readable and valid
-     * @param binary
-     * @return
+     * @param binary The binary file.
+     * @return {@code true} if the file is valid, {@code false} otherwise.
      */
     private boolean validBinary(final File binary) {
         return null != binary && binary.exists() && binary.canRead();
@@ -369,8 +367,8 @@ public class FileStorageAPIImpl implements FileStorageAPI {
 
     /**
      * if the given configuration states we must override the previously existing file. It will be deleted before re-generating.
-     * @param storage
-     * @param generateMetaDataConfiguration
+     * @param storage The {@link StoragePersistenceAPI} that will be used to persist the metadata.
+     * @param generateMetaDataConfiguration The {@link GenerateMetadataConfig} that specifies the constraints and how the metadata will be generated.
      */
     private void checkOverride(final StoragePersistenceAPI storage,
             final GenerateMetadataConfig generateMetaDataConfiguration) throws DotDataException {
@@ -379,9 +377,9 @@ public class FileStorageAPIImpl implements FileStorageAPI {
 
     /**
      * if the given configuration states we must override the previously existing file will be deleted before re-generating.
-     * @param storage
-     * @param storageKey
-     * @param override
+     * @param storage The {@link StoragePersistenceAPI} that will be used to persist the metadata.
+     * @param storageKey The {@link StorageKey} that identifies the binary file and how it will be stored.
+     * @param override {@code true} if the file must be overridden, {@code false} otherwise.
      */
     private void checkOverride(final StoragePersistenceAPI storage, final StorageKey storageKey, final boolean override) throws DotDataException {
         if (override && storage.existsObject(storageKey.getGroup(), storageKey.getPath())) {
@@ -399,28 +397,31 @@ public class FileStorageAPIImpl implements FileStorageAPI {
     @Override
     public Map<String, Serializable> retrieveMetaData(final FetchMetadataParams requestMetaData)
             throws DotDataException {
-        final String cacheKey = requestMetaData.getCacheKeySupplier().get();
-        Map<String, Serializable> metadataMap = this.metadataCache.getMetadataMap(cacheKey);
-        // Don't like that we check and fixup this one property here. SteveB
-        boolean updatedEditable = checkUpdateEditableAsText(metadataMap);
-
+        Map<String, Serializable> metadataMap = null;
+        final StorageKey storageKey = requestMetaData.getStorageKey();
+        final Optional<String> cacheKeyOptional = requestMetaData.isCache() ? Optional.of(requestMetaData.getCacheKeySupplier().get()) : Optional.empty();
+        if (cacheKeyOptional.isPresent()) {
+            metadataMap = this.metadataCache.getMetadataMap(cacheKeyOptional.get());
+        }
+        boolean updatedEditable = metadataMap != null && checkUpdateEditableAsText(metadataMap);
         if (metadataMap == null || updatedEditable)  {
-            final ReadWriteLock lock = getLock(cacheKey);
+            final ReadWriteLock lock = getLock(storageKey);
             lock.writeLock().lock();
             try {
-                // Double-check pattern inside the lock to ensure data hasn't been loaded.
-                // Also we can be here if we need to update the editable as text property and
-                // do not want to get again in this case.
-                if (metadataMap != null) {
-                    putIntoCache(cacheKey, metadataMap);
+                // We need to update the cache with the new value
+
+                if (updatedEditable) {
+                    putIntoCache(cacheKeyOptional.get(), metadataMap);
                     return metadataMap;
                 }
 
-                metadataMap = this.metadataCache.getMetadataMap(cacheKey);
-                checkUpdateEditableAsText(metadataMap);
 
+                if (cacheKeyOptional.isPresent()) {
+                    metadataMap = this.metadataCache.getMetadataMap(cacheKeyOptional.get());
+                    checkUpdateEditableAsText(metadataMap);
+                }
                 if (metadataMap == null) {
-                    metadataMap = fetchAndCacheMetadata(requestMetaData, cacheKey);
+                    metadataMap = fetchAndCacheMetadata(requestMetaData, cacheKeyOptional.orElse(null));
                 }
             } finally {
                 lock.writeLock().unlock();
@@ -435,7 +436,7 @@ public class FileStorageAPIImpl implements FileStorageAPI {
         final StoragePersistenceAPI storage = this.persistenceProvider.getStorage(storageKey.getStorage());
         this.checkBucket(storageKey, storage);
         if (storage.existsObject(storageKey.getGroup(), storageKey.getPath())) {
-            Map<String, Serializable> metadataMap = retrieveMetadata(storageKey, storage);
+            Map<String, Serializable>  metadataMap = retrieveMetaData(storageKey, storage);
             Logger.debug(FileStorageAPIImpl.class, () -> "Retrieve the meta data from storage path: " + storageKey.getPath());
             checkUpdateEditableAsText(metadataMap);
             if (null != cacheKey) {
@@ -443,8 +444,9 @@ public class FileStorageAPIImpl implements FileStorageAPI {
                 putIntoCache(cacheKey, projection);
                 return projection;
             }
+            return metadataMap;
         }
-        return Collections.emptyMap();
+        return null;
     }
 
     /**
@@ -500,59 +502,73 @@ public class FileStorageAPIImpl implements FileStorageAPI {
             final FetchMetadataParams fetchMetadataParams,
             final Map<String, Serializable> customAttributes) throws DotDataException {
 
-        final Map<String, Serializable> prefixedCustomAttributes = customAttributes.entrySet().stream()
-                .collect(Collectors.toMap(o -> Metadata.CUSTOM_PROP_PREFIX + o.getKey(), Entry::getValue));
-
+        final Map<String, Serializable> prefixedCustomAttributes = prefixCustomAttributes(customAttributes);
         final StorageKey storageKey = fetchMetadataParams.getStorageKey();
         final StoragePersistenceAPI storage = persistenceProvider.getStorage(storageKey.getStorage());
 
         this.checkBucket(storageKey, storage);
         if (storage.existsObject(storageKey.getGroup(), storageKey.getPath())) {
-            final Map<String, Serializable> retrievedMetadata = retrieveMetadata(storageKey, storage);
-            if(null != retrievedMetadata){
-                final Map<String,Serializable> newMetadataMap = new HashMap<>(retrievedMetadata);
+            handleExistingObject(fetchMetadataParams, prefixedCustomAttributes, storageKey, storage);
+        } else {
+            handleNonExistingObject(fetchMetadataParams, prefixedCustomAttributes, storageKey, storage);
+        }
+    }
 
-                if(prefixedCustomAttributes.isEmpty()){
-                   //Delete all custom attributes
-                    newMetadataMap.keySet().removeAll(newMetadataMap.entrySet().stream()
-                            .filter(entry -> entry.getKey().startsWith(Metadata.CUSTOM_PROP_PREFIX))
-                            .map(Entry::getKey).collect(Collectors.toSet()));
-                } else {
-                    //merge maps
-                    prefixedCustomAttributes.forEach((key, serializable) -> {
-                        if (!newMetadataMap.containsKey(key)) {
-                            newMetadataMap.remove(key);
-                        }
-                    });
-                    newMetadataMap.putAll(prefixedCustomAttributes);
-                }
+    private Map<String, Serializable> prefixCustomAttributes(final Map<String, Serializable> customAttributes) {
+        return customAttributes.entrySet().stream()
+                .collect(Collectors.toMap(o -> Metadata.CUSTOM_PROP_PREFIX + o.getKey(), Entry::getValue));
+    }
 
-                checkOverride(storage, fetchMetadataParams.getStorageKey(), true);
-                storeMetadata(storageKey, storage, newMetadataMap);
+    private void handleExistingObject(final FetchMetadataParams fetchMetadataParams, final Map<String, Serializable> prefixedCustomAttributes, final StorageKey storageKey, final StoragePersistenceAPI storage) throws DotDataException {
+        final Map<String, Serializable> retrievedMetadata = retrieveMetaData(storageKey, storage);
+        if(null != retrievedMetadata){
+            final Map<String,Serializable> newMetadataMap = mergeMetadataMaps(prefixedCustomAttributes, retrievedMetadata);
 
-                if(null != fetchMetadataParams.getCacheKeySupplier()){
-                    final String cacheKey = fetchMetadataParams.getCacheKeySupplier().get();
-                    putIntoCache(cacheKey, newMetadataMap);
-                } else {
-                    Logger.warn(FileStorageAPIImpl.class, "No Cache Key has been provided for stored object "+storageKey);
-                }
+            checkOverride(storage, fetchMetadataParams.getStorageKey(), true);
+            storeMetadata(storageKey, storage, newMetadataMap);
+
+            if(null != fetchMetadataParams.getCacheKeySupplier()){
+                final String cacheKey = fetchMetadataParams.getCacheKeySupplier().get();
+                putIntoCache(cacheKey, newMetadataMap);
             } else {
-                Logger.warn(FileStorageAPIImpl.class, String.format("Unable to locate object: `%s` ",storageKey));
+                Logger.warn(FileStorageAPIImpl.class, "No Cache Key has been provided for stored object "+storageKey);
             }
         } else {
-           if(fetchMetadataParams.isForceInsertion()){
-              storeMetadata(storageKey, storage, prefixedCustomAttributes);
-               if(null != fetchMetadataParams.getCacheKeySupplier()){
-                   final String cacheKey = fetchMetadataParams.getCacheKeySupplier().get();
-                   putIntoCache(cacheKey, prefixedCustomAttributes);
-               }
-           } else {
-               Logger.warn(FileStorageAPIImpl.class, String.format(
+            Logger.warn(FileStorageAPIImpl.class, String.format("Unable to locate object: `%s` ",storageKey));
+        }
+    }
+
+    private Map<String, Serializable> mergeMetadataMaps(final Map<String, Serializable> prefixedCustomAttributes, final Map<String, Serializable> retrievedMetadata) {
+        final Map<String,Serializable> newMetadataMap = new HashMap<>(retrievedMetadata);
+
+        if(prefixedCustomAttributes.isEmpty()){
+            //Delete all custom attributes
+            newMetadataMap.keySet().removeAll(newMetadataMap.keySet().stream()
+                    .filter(serializable -> serializable.startsWith(Metadata.CUSTOM_PROP_PREFIX)).collect(Collectors.toSet()));
+        } else {
+            //merge maps
+            prefixedCustomAttributes.forEach((key, serializable) -> {
+                if (!newMetadataMap.containsKey(key)) {
+                    newMetadataMap.remove(key);
+                }
+            });
+            newMetadataMap.putAll(prefixedCustomAttributes);
+        }
+        return newMetadataMap;
+    }
+
+    private void handleNonExistingObject(final FetchMetadataParams fetchMetadataParams, final Map<String, Serializable> prefixedCustomAttributes, final StorageKey storageKey, final StoragePersistenceAPI storage) throws DotDataException {
+        if(fetchMetadataParams.isForceInsertion()){
+            storeMetadata(storageKey, storage, prefixedCustomAttributes);
+            if(null != fetchMetadataParams.getCacheKeySupplier()){
+                final String cacheKey = fetchMetadataParams.getCacheKeySupplier().get();
+                putIntoCache(cacheKey, prefixedCustomAttributes);
+            }
+        } else {
+            Logger.warn(FileStorageAPIImpl.class, String.format(
                     "Unable to set custom attribute for the given group: `%s` and path: `%s` ",
                     storageKey.getGroup(), storageKey.getPath()));
-            }
         }
-
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/storage/FileStorageAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileStorageAPIImpl.java
@@ -435,8 +435,9 @@ public class FileStorageAPIImpl implements FileStorageAPI {
         final StorageKey storageKey = requestMetaData.getStorageKey();
         final StoragePersistenceAPI storage = this.persistenceProvider.getStorage(storageKey.getStorage());
         this.checkBucket(storageKey, storage);
+        Map<String, Serializable>  metadataMap = null;
         if (storage.existsObject(storageKey.getGroup(), storageKey.getPath())) {
-            Map<String, Serializable>  metadataMap = retrieveMetaData(storageKey, storage);
+            metadataMap = retrieveMetaData(storageKey, storage);
             Logger.debug(FileStorageAPIImpl.class, () -> "Retrieve the meta data from storage path: " + storageKey.getPath());
             checkUpdateEditableAsText(metadataMap);
             if (null != cacheKey) {
@@ -444,9 +445,8 @@ public class FileStorageAPIImpl implements FileStorageAPI {
                 putIntoCache(cacheKey, projection);
                 return projection;
             }
-            return metadataMap;
         }
-        return null;
+        return metadataMap;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/storage/StorageKey.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/StorageKey.java
@@ -1,6 +1,7 @@
 package com.dotcms.storage;
 
 import java.io.Serializable;
+import java.util.Objects;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -59,6 +60,26 @@ public class StorageKey implements Serializable {
                "StorageKey{ storage=`%s`,\n group=`%s`, \n path=`%s` \n }",
                storage, group, path
         );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        StorageKey that = (StorageKey) o;
+
+        if (!Objects.equals(path, that.path)) return false;
+        if (!Objects.equals(group, that.group)) return false;
+        return Objects.equals(storage, that.storage);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = path != null ? path.hashCode() : 0;
+        result = 31 * result + (group != null ? group.hashCode() : 0);
+        result = 31 * result + (storage != null ? storage.hashCode() : 0);
+        return result;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/storage/model/Metadata.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/model/Metadata.java
@@ -14,183 +14,276 @@ import static com.dotcms.storage.model.BasicMetadataFields.VERSION_KEY;
 import static com.dotcms.storage.model.BasicMetadataFields.WIDTH_META_KEY;
 
 import com.dotmarketing.util.Logger;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
-import io.vavr.control.Try;
+import io.vavr.Lazy;
 import java.io.Serializable;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+/**
+ * Class intended to represent metadata for a field
+
+ * Metadata is a class that represents the metadata for a field. It contains the field name and a map of metadata for the field.
+ * The class provides methods to access the metadata for the field, as well as methods to access specific metadata values.
+ * The class is immutable, meaning that once a Metadata object is created, its values cannot be changed.
+ * */
 public class Metadata implements Serializable {
 
     public static final String CUSTOM_PROP_PREFIX = "dot:";
+    public static final String UNKNOWN = "unknown";
 
     private final String fieldName;
 
     private final Map<String, Serializable> fieldsMeta;
 
-    public Metadata(final String fieldName,
-            final Map<String, Serializable> fieldsMeta) {
-
+    // Lazy initialization of custom metadata
+    private final transient Lazy<Map<String, Serializable>> customMeta =
+            Lazy.of(() -> {
+                TreeMap<String, Serializable> myMap = getFieldsMeta().entrySet().stream()
+                        .filter(entry -> entry.getKey().startsWith(CUSTOM_PROP_PREFIX))
+                        .collect(Collectors.toMap(
+                                entry -> entry.getKey().substring(CUSTOM_PROP_PREFIX.length()),
+                                Entry::getValue,
+                                (oldValue, newValue) -> oldValue, // Merge function in case of key collisions
+                                TreeMap::new)
+                        );
+                return ImmutableSortedMap.copyOf(myMap);
+            });
+    // Lazy initialization of custom metadata with prefix
+    private final transient Lazy<Map<String, Serializable>> customMetaWithPrefix =
+            Lazy.of(() -> {
+                TreeMap<String, Serializable>  myMap = getFieldsMeta().entrySet().stream()
+                        .filter(entry -> entry.getKey().startsWith(CUSTOM_PROP_PREFIX))
+                        .collect(Collectors.toMap(
+                                Entry::getKey,
+                                Entry::getValue,
+                                (oldValue, newValue) -> oldValue, // Merge function in case of key collisions
+                                TreeMap::new)
+                        );
+                return ImmutableSortedMap.copyOf(myMap);
+            });
+    /**
+     * Constructor for Metadata
+     * @param fieldName The name of the field
+     * @param fieldsMeta The metadata for the field
+     */
+    public Metadata(String fieldName, Map<String, Serializable> fieldsMeta) {
         this.fieldName = fieldName;
-        if (null != fieldsMeta) {
-            this.fieldsMeta = fieldsMeta;
-        } else {
-            this.fieldsMeta = ImmutableMap.of();
-        }
+        // If we use sorted map here we do not need to sort it later
+        this.fieldsMeta = fieldsMeta == null ? Map.of() : ImmutableSortedMap.copyOf(fieldsMeta);
     }
 
+    /**
+     * Returns the name of the field
+     * @return fieldName
+     */
     public String getFieldName() {
         return fieldName;
     }
 
+    /**
+     * Returns the metadata for the field
+     * @return fieldsMeta
+     */
     public Map<String, Serializable> getFieldsMeta() {
-        return fieldsMeta.entrySet().stream()
-                .filter(entry -> !entry.getKey().startsWith(CUSTOM_PROP_PREFIX))
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-
+        return fieldsMeta;
     }
 
+    /**
+     * Returns the custom metadata
+     * @return customMeta
+     */
     public Map<String, Serializable> getCustomMeta() {
-        return new ImmutableSortedMap.Builder<String, Serializable>(
-                Comparator.naturalOrder()).putAll(fieldsMeta.entrySet().stream()
-                .filter(entry -> entry.getKey().startsWith(CUSTOM_PROP_PREFIX))
-                .collect(Collectors.toMap(o ->
-                        o.getKey().substring(CUSTOM_PROP_PREFIX.length()
-                        ), Entry::getValue))).build();
+        return customMeta.get();
     }
 
+    /**
+     * Returns the custom metadata with prefix
+     * @return customMetaWithPrefix
+     */
     public Map<String, Serializable> getCustomMetaWithPrefix() {
-        return new ImmutableSortedMap.Builder<String, Serializable>(
-                Comparator.naturalOrder()).putAll(fieldsMeta.entrySet().stream()
-                .filter(entry -> entry.getKey().startsWith(CUSTOM_PROP_PREFIX))
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue))).build();
+        return customMetaWithPrefix.get();
     }
 
+    /**
+     * Returns the field value for the given key
+     * @param key The key for the field
+     * @return The value of the field
+     */
+    public Serializable getField(String key) {
+        return fieldsMeta.get(key);
+    }
+
+    /**
+     * Returns the metadata map
+     * @return fieldsMeta
+     */
     public Map<String, Serializable> getMap() {
-        return new ImmutableSortedMap.Builder<String, Serializable>(Comparator.naturalOrder()).putAll(fieldsMeta).build();
+        // See if we can remove merge this duplicate method
+        return getFieldsMeta();
     }
 
+    /**
+     * Returns the title of the metadata
+     * @return title
+     */
     public String getTitle(){
-        return Try.of(()->getFieldsMeta().get(TITLE_META_KEY.key()).toString()).getOrElse("unknown");
+        return safelyCast(fieldsMeta.get(TITLE_META_KEY.key()), String.class)
+                .orElse(UNKNOWN);
     }
 
+    /**
+     * Returns the name of the metadata
+     * @return name
+     */
     public String getName(){
-        return Try.of(()->getFieldsMeta().get(NAME_META_KEY.key()).toString()).getOrElse("unknown");
+        return safelyCast(fieldsMeta.get(NAME_META_KEY.key()), String.class)
+                .orElse(UNKNOWN);
     }
 
-    public int getLength(){
-        final Object value = getFieldsMeta().get(LENGTH_META_KEY.key());
-        if(value instanceof Number){
-            final Number numericValue = (Number) value;
-            return numericValue.intValue();
-        }
-        Logger.debug(Metadata.class, ()->String.format("Invalid non numeric value found on metadata.length `%s` returning 0 ",value));
-        return 0;
+    /**
+     * Returns the length of the metadata
+     * @return length
+     */
+    public int getLength() {
+        return getNumericValue(LENGTH_META_KEY.key());
     }
 
-    public int getSize(){
-        final Object value = getFieldsMeta().get(SIZE_META_KEY.key());
-        if(value instanceof Number){
-            final Number numericValue = (Number) value;
-            return numericValue.intValue();
-        }
-        Logger.debug(Metadata.class, ()->String.format("Invalid non numeric value found on metadata.size `%s` returning 0 ",value));
-        return 0;
+    /**
+     * Returns the size of the metadata
+     * @return size
+     */
+    public int getSize() {
+        return getNumericValue(SIZE_META_KEY.key());
     }
 
-    public String getPath(){
-        return Try.of(()->getFieldsMeta().get(PATH_META_KEY.key()).toString()).getOrElse("unknown");
+    /**
+     * Returns the path of the metadata
+     * @return path
+     */
+    public String getPath() {
+        return safelyCast(fieldsMeta.get(PATH_META_KEY.key()), String.class)
+                .orElse(UNKNOWN);
     }
 
-    public String getSha256(){
-        return Try.of(()->getFieldsMeta().get(SHA256_META_KEY.key()).toString()).getOrElse("unknown");
+    /**
+     * Returns the SHA256 hash of the metadata
+     * @return sha256
+     */
+    public String getSha256() {
+        return safelyCast(fieldsMeta.get(SHA256_META_KEY.key()), String.class)
+                .orElse(UNKNOWN);
     }
 
-    public String getContentType(){
-       return Try.of(()->getFieldsMeta().get(CONTENT_TYPE_META_KEY.key()).toString()).getOrElse("unknown");
+    /**
+     * Returns the content type of the metadata
+     * @return contentType
+     */
+    public String getContentType() {
+        return safelyCast(fieldsMeta.get(CONTENT_TYPE_META_KEY.key()), String.class)
+                .orElse(UNKNOWN);
     }
 
-    public boolean isImage(){
-        try{
-           final Object value = getFieldsMeta().get(IS_IMAGE_META_KEY.key());
-           if(value instanceof Boolean){
-              return (Boolean) value;
-           }
-        }catch (Exception e){
-           //quite
-        }
-        return false;
+    /**
+     * Returns whether the metadata is an image
+     * @return isImage
+     */
+    public boolean isImage() {
+        return safelyCast(fieldsMeta.get(IS_IMAGE_META_KEY.key()), Boolean.class)
+                .orElse(false);
     }
 
-    public int getWidth(){
-        final Object value = getFieldsMeta().get(WIDTH_META_KEY.key());
-        if(value instanceof Number){
-           final Number numericValue = (Number) value;
-           return numericValue.intValue();
-        }
-        Logger.debug(Metadata.class, ()->String.format("Invalid non numeric value found on metadata.width `%s` returning 0 ",value));
-        return 0;
+    /**
+     * Returns the width of the metadata
+     * @return width
+     */
+    public int getWidth() {
+        return getNumericValue(WIDTH_META_KEY.key());
     }
 
-    public int getHeight(){
-        final Object value = getFieldsMeta().get(HEIGHT_META_KEY.key());
-        if(value instanceof Number){
-            final Number numericValue = (Number) value;
-            return numericValue.intValue();
-        }
-        Logger.debug(Metadata.class, ()->String.format("Invalid non numeric value found on metadata.height `%s` returning 0 ",value));
-        return 0;
+    /**
+     * Returns the height of the metadata
+     * @return height
+     */
+    public int getHeight() {
+        return getNumericValue(HEIGHT_META_KEY.key());
     }
 
-    public long getModDate(){
-        final Object value = getFieldsMeta().get(MOD_DATE_META_KEY.key());
-        if(value instanceof Number){
-            final Number numericValue = (Number) value;
-            return numericValue.longValue();
-        }
-        Logger.debug(Metadata.class, ()->String.format("Invalid non numeric value found on metadata.modDate `%s` returning 0 ",value));
-        return 0;
+    /**
+     * Returns the modification date of the metadata
+     * @return modDate
+     */
+    public long getModDate() {
+        return safelyCast(fieldsMeta.get(MOD_DATE_META_KEY.key()), Number.class)
+                .map(Number::longValue)
+                .orElseGet(() -> {
+                    Logger.debug(Metadata.class, () -> "Invalid or missing numeric value for modification date");
+                    return 0L;
+                });
     }
 
-    public int getVersion(){
-        final Object value = getFieldsMeta().get(VERSION_KEY.key());
-        if(value instanceof Number){
-            final Number numericValue = (Number) value;
-            return numericValue.intValue();
-        }
-        Logger.debug(Metadata.class, ()->"No metadata version was specified defaulting to 0. ");
-        return 0;
+    /**
+     * Returns the version of the metadata
+     * @return version
+     */
+    public int getVersion() {
+        return getNumericValue(VERSION_KEY.key());
     }
 
+    /**
+     * Returns whether the metadata is equal to the given object
+     * @param o The object to compare
+     * @return true if equal, false otherwise
+     */
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final Metadata metadata = (Metadata) o;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Metadata metadata = (Metadata) o;
         return Objects.equals(fieldName, metadata.fieldName) &&
-                fieldsMeta.hashCode() == metadata.fieldsMeta.hashCode();
+                Objects.equals(fieldsMeta, metadata.fieldsMeta);
     }
 
+    /**
+     * Returns the hash code of the metadata
+     * @return hashCode
+     */
     @Override
     public int hashCode() {
-
         return Objects.hash(fieldName, fieldsMeta);
     }
 
+    /**
+     * Returns the string representation of the metadata
+     * @return string representation
+     */
     @Override
     public String toString() {
         return "Metadata{" +
                 "fieldName='" + fieldName + '\'' +
-                ", fieldsMeta=" + getFieldsMeta() +
+                ", fieldsMeta=" + fieldsMeta +
                 ", customMeta=" + getCustomMeta() +
                 '}';
+    }
+
+    // Helper method to safely cast types
+    private <T> Optional<T> safelyCast(Object value, Class<T> type) {
+        return Optional.ofNullable(value)
+                .filter(type::isInstance)
+                .map(type::cast);
+    }
+
+    // General method for getting numeric values safely
+    private int getNumericValue(String key) {
+        return safelyCast(fieldsMeta.get(key), Number.class)
+                .map(Number::intValue)
+                .orElseGet(() -> {
+                    Logger.debug(Metadata.class, () -> String.format("Invalid or missing numeric value for key `%s`", key));
+                    return 0;
+                });
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/storage/model/Metadata.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/model/Metadata.java
@@ -40,6 +40,19 @@ public class Metadata implements Serializable {
 
     private final Map<String, Serializable> fieldsMeta;
 
+    private final transient Lazy<Map<String, Serializable>> stdMeta =
+            Lazy.of(() -> {
+                TreeMap<String, Serializable> myMap = getFieldsMeta().entrySet().stream()
+                        .filter(entry -> !entry.getKey().startsWith(CUSTOM_PROP_PREFIX))
+                        .collect(Collectors.toMap(
+                                Entry::getKey,
+                                Entry::getValue,
+                                (oldValue, newValue) -> oldValue, // Merge function in case of key collisions
+                                TreeMap::new)
+                        );
+                return ImmutableSortedMap.copyOf(myMap);
+            });
+
     // Lazy initialization of custom metadata
     private final transient Lazy<Map<String, Serializable>> customMeta =
             Lazy.of(() -> {
@@ -90,7 +103,7 @@ public class Metadata implements Serializable {
      * @return fieldsMeta
      */
     public Map<String, Serializable> getFieldsMeta() {
-        return fieldsMeta;
+        return stdMeta.get();
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/MetadataCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/MetadataCacheImpl.java
@@ -5,6 +5,7 @@ import com.dotmarketing.business.DotCacheAdministrator;
 import com.dotmarketing.util.UtilMethods;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 public class MetadataCacheImpl implements MetadataCache {
@@ -49,7 +50,9 @@ public class MetadataCacheImpl implements MetadataCache {
     @Override
     @SuppressWarnings("unchecked")
     public Map<String, Serializable> getMetadataMap(final String key) {
-        return (Map<String, Serializable>)cache.getNoThrow(key, metadataGroup);
+        Map<String, Serializable> cachedMap = (Map<String, Serializable>)cache.getNoThrow(key, metadataGroup);
+        // The cache is shared and if returning the cachedMap directly, the contents could be modified by the caller impacting other threads
+        return cachedMap != null ? new HashMap<>(cachedMap) : null;
     }
 
     public void removeMetadata(final String key) {


### PR DESCRIPTION
### Proposed Changes
* Fix Metadata class to handle stream concurrency issue by safely cloning passed in map.
* Improve filtering of metadata to avoid issues on concurrent access.
* Use lazy loading to only create internal filtered maps when required.
* Add effective write locks based upon write key for metadata to prevent concurrency issues when generating binary metadata for the same item. 


### Additional Info
Related to #28470 (Stream concurrency issue in Metadata class).