### PR TITLE
ci(release) fix maven.config not added with git.

### DIFF
--- a/.github/workflows/maven-release-process.yml
+++ b/.github/workflows/maven-release-process.yml
@@ -116,6 +116,8 @@ jobs:
           echo "-Drelease=${release_version}" >> .mvn/maven.config
           echo "-Dchangelist=" >> .mvn/maven.config
           
+          git add .mvn/maven.config
+          
           git status
           git commit -a -m "🏁 Publishing release version [${release_version}]"
           git push origin ${release_branch}


### PR DESCRIPTION
### Proposed Changes
* Fix issue in release workflow where git add is not run to add .mvn/maven.config https://github.com/dotCMS/core/pull/28453

## Error in Release Build

```
Switched to a new branch 'release-24.05.08'
On branch release-24.05.08
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.mvn/maven.config

nothing added to commit but untracked files present (use "git add" to track)
On branch release-24.05.08
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.mvn/maven.config

nothing added to commit but untracked files present (use "git add" to track)
```
