### PR TITLE
fix(edit-page-v2): Loop created by weak regex when navigating

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.spec.ts
@@ -72,6 +72,27 @@ describe('EditEmaGuard', () => {
         expect(didEnteredPortlet).toBe(true);
     });
 
+    it('should just return true when the url has an "index-something" in the url', () => {
+        const route: ActivatedRouteSnapshot = {
+            firstChild: {
+                url: [{ path: 'content' }]
+            },
+            queryParams: {
+                url: '/im-just-a-cool-index-index/index-something',
+                'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                language_id: 1
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        const didEnteredPortlet = TestBed.runInInjectionContext(
+            () => editEmaGuard(route, state) as boolean
+        );
+
+        expect(router.navigate).not.toHaveBeenCalled();
+        expect(didEnteredPortlet).toBe(true);
+    });
+
     it('should navigate to "edit-page" and sanitize url', () => {
         const route: ActivatedRouteSnapshot = {
             firstChild: {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.spec.ts
@@ -1,3 +1,4 @@
+import { it, describe, expect } from '@jest/globals';
 import { Observable } from 'rxjs';
 
 import { TestBed } from '@angular/core/testing';
@@ -36,6 +37,27 @@ describe('EditEmaGuard', () => {
             },
             queryParams: {
                 url: '/some-url',
+                'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                language_id: 1
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        const didEnteredPortlet = TestBed.runInInjectionContext(
+            () => editEmaGuard(route, state) as boolean
+        );
+
+        expect(router.navigate).not.toHaveBeenCalled();
+        expect(didEnteredPortlet).toBe(true);
+    });
+
+    it('should just return true when the url has an "index" in the url', () => {
+        const route: ActivatedRouteSnapshot = {
+            firstChild: {
+                url: [{ path: 'content' }]
+            },
+            queryParams: {
+                url: '/im-just-a-cool-index-index',
                 'com.dotmarketing.persona.id': 'modes.persona.no.persona',
                 language_id: 1
             }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.ts
@@ -43,7 +43,7 @@ function confirmQueryParams(queryParams: Params): {
             } else if (
                 curr.key === 'url' &&
                 queryParams[curr.key] !== 'index' &&
-                /\/index$/.test(queryParams[curr.key])
+                queryParams[curr.key].endsWith('/index')
             ) {
                 acc[curr.key] = sanitizeURL(queryParams[curr.key]);
                 acc.missing = true;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.ts
@@ -43,7 +43,7 @@ function confirmQueryParams(queryParams: Params): {
             } else if (
                 curr.key === 'url' &&
                 queryParams[curr.key] !== 'index' &&
-                /index$/g.test(queryParams[curr.key])
+                /\/index$/.test(queryParams[curr.key])
             ) {
                 acc[curr.key] = sanitizeURL(queryParams[curr.key]);
                 acc.missing = true;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -161,11 +161,7 @@ function insertPositionedContentletInContainer(payload: ActionPayload): {
 export function sanitizeURL(url?: string): string {
     return url
         ?.replace(/(^\/)|(\/$)/g, '') // Remove slashes from the beginning and end of the url
-        .split('/')
-        .filter((part, i) => {
-            return !i || part !== 'index'; // Filter the index from the url if it is at the last position
-        })
-        .join('/');
+        .replace(/\/index$/, ''); // Remove index from the end of the url
 }
 
 /**


### PR DESCRIPTION
### Proposed Changes
* Fix regex to not enter in a loop while trying to sanitize an URL

### Screenshots

https://github.com/dotCMS/core/assets/63567962/11fa62c1-41b5-47bf-9537-691348e1faaf


