### PR TITLE
ci(release) fix consistency of tika plugin versioning

### DIFF
--- a/independent-projects/core-plugins/pom.xml
+++ b/independent-projects/core-plugins/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tika.api.version>1.0.0-SNAPSHOT</tika.api.version>
+        <tika.api.version>${project.version}</tika.api.version>
     </properties>
 
     <modules>

--- a/independent-projects/core-plugins/tika-plugin/pom.xml
+++ b/independent-projects/core-plugins/tika-plugin/pom.xml
@@ -17,7 +17,7 @@
         <osgi.compendium.version>7.0.0</osgi.compendium.version>
         <tika.version>2.8.0</tika.version>
         <skip.rewrite>true</skip.rewrite>
-        <tika.api.version>1.0.0-SNAPSHOT</tika.api.version>
+        <tika.api.version>${project.version}</tika.api.version>
     </properties>
     <dependencies>
 

--- a/independent-projects/pom.xml
+++ b/independent-projects/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tika.api.version>1.0.0-SNAPSHOT</tika.api.version>
+        <tika.api.version>${project.version}</tika.api.version>
     </properties>
 
     <modules>

--- a/osgi-base/system-bundles/pom.xml
+++ b/osgi-base/system-bundles/pom.xml
@@ -54,6 +54,18 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.dotcms.core.plugins</groupId>
+            <artifactId>com.dotcms.tika</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.dotcms.samlbundle</groupId>
             <artifactId>com.dotcms.samlbundle</artifactId>
             <version>24.02.29</version>
@@ -139,54 +151,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>use-legacy-tika-plugin</id>
-            <activation>
-                <property>
-                    <name>useLegacyTikaPlugin</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.dotcms.tika</groupId>
-                    <artifactId>com.dotcms.tika</artifactId>
-                    <version>${tika.plugin.bundle.version}</version>
-                    <scope>provided</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-            <!-- dependencies -->
-        </profile>
-        <profile>
-            <id>use-local-tika-plugin</id>
-            <activation>
-                <property>
-                    <name>!useLegacyTikaPlugin</name>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.dotcms.core.plugins</groupId>
-                    <artifactId>com.dotcms.tika</artifactId>
-                    <version>${project.version}</version>
-                    <scope>provided</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-        </profile>
-
-    </profiles>
-
 </project>


### PR DESCRIPTION
### Proposed Changes
* We want to make sure all parts of the release build are consistent taking into account the ci friendly release number mechanism.   We previously we had a more complex mechanism to try and select and an already released version of the plugin instead of using and building the current code.   Although we can later split versions we need to make sure we can deliver consistent versions on release.
* Secondly there were still references to the specific version 1.0.0-SNAPSHOT which we are not longer updating with the versions plugin.   Within the body of the pom.xml we should use the ${project.version} variable to set this as this will get updated automatically during build.   The default version is only set within the parent.pom.xml 

