### PR TITLE
ci(release) fix ci friendly revisions wrong property for revision

### DIFF
--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -101,7 +101,7 @@ jobs:
           
           # set version in .mvn/maven.config
           echo "-Dprod=true" > .mvn/maven.config
-          echo "-Drelease=${release_version}" >> .mvn/maven.config
+          echo "-Drevision=${release_version}" >> .mvn/maven.config
           echo "-Dchangelist=" >> .mvn/maven.config
           
           # Commit version changes

--- a/.github/workflows/maven-release-process.yml
+++ b/.github/workflows/maven-release-process.yml
@@ -113,7 +113,7 @@ jobs:
           
           # set version in .mvn/maven.config
           echo "-Dprod=true" > .mvn/maven.config
-          echo "-Drelease=${release_version}" >> .mvn/maven.config
+          echo "-Drevision=${release_version}" >> .mvn/maven.config
           echo "-Dchangelist=" >> .mvn/maven.config
           
           git add .mvn/maven.config


### PR DESCRIPTION
### Proposed Changes
* Property "release" was being set in .mvn/maven.config instead of "revision"  in release branch causing revision to be fixed at the default 1.0.0 

### Test 

* Make sure that maven build shows correct version number for modules and not just "1.0.0"
* Pulling release branch and building without any properties should build with the correct release number. 
* Check .mvn/maven.config  has revision set correctly the blow is an example,  changelist should be set to empty string to override the default of "-SNAPSHOT"

```
-Dprod=true
-Drevision=24.05.08
-Dchangelist=
```