### PR TITLE
chore(EMA) #28402 : SDK: Support Vanity URLs in Page API

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -562,9 +562,11 @@ public class PageResourceHelper implements Serializable {
      * @return The Optional {@link CachedVanityUrl} object if the URI matches a Vanity URL.
      */
     public Optional<CachedVanityUrl> resolveVanityUrlIfPresent(final HttpServletRequest request,
-                                                     final String uri, final String languageId) {
+                                                               final String uri,
+                                                               final String languageId) {
         final Host site = this.hostWebAPI.getCurrentHostNoThrow(request);
-        final Language language = this.languageAPI.getLanguage(languageId);
+        final Language language = UtilMethods.isSet(languageId) ?
+                this.languageAPI.getLanguage(languageId) : this.languageAPI.getDefaultLanguage();
         final String correctedUri = !uri.startsWith(StringPool.SLASH) ? StringPool.SLASH + uri :
                 uri;
         final Optional<CachedVanityUrl> vanityUrlOpt =

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
@@ -1,9 +1,5 @@
 package com.dotcms.vanityurl.business;
 
-
-import java.util.List;
-import java.util.Optional;
-import javax.servlet.http.HttpServletResponse;
 import com.dotcms.vanityurl.filters.VanityUrlRequestWrapper;
 import com.dotcms.vanityurl.model.CachedVanityUrl;
 import com.dotcms.vanityurl.model.VanityUrl;
@@ -13,6 +9,10 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.contentlet.business.DotContentletValidationException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * This API provides access to the information related to Vanity URLs in dotCMS. Vanity URLs are
@@ -25,8 +25,6 @@ import com.dotmarketing.portlets.languagesmanager.model.Language;
  * @since June 12, 2017
  */
 public interface VanityUrlAPI {
-
-    String DEFAULT_VANITY_URL_STRUCTURE_VARNAME = "Vanityurl";
 
     /**
      * Verifies that the Vanity URL as Contentlet has all the required fields. the list of mandatory fields can be
@@ -118,5 +116,13 @@ public interface VanityUrlAPI {
      * @return
      */
     List<CachedVanityUrl> findByForward(Host host, Language language, String forward, int action);
+
+    /**
+     *
+     * @param vanityUrl
+     * @param uri
+     * @return
+     */
+    boolean isSelfReferenced(final CachedVanityUrl vanityUrl, final String uri);
 
 }

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
@@ -1,27 +1,15 @@
 package com.dotcms.vanityurl.business;
 
-import java.net.URISyntaxException;
-import java.text.MessageFormat;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.servlet.http.HttpServletResponse;
-
-import com.dotmarketing.util.URLUtils;
-import org.apache.http.HttpStatus;
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.contenttype.model.type.VanityUrlContentType;
 import com.dotcms.http.CircuitBreakerUrl;
+import com.dotcms.regex.MatcherTimeoutFactory;
 import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
 import com.dotcms.vanityurl.cache.VanityUrlCache;
 import com.dotcms.vanityurl.filters.VanityUrlRequestWrapper;
 import com.dotcms.vanityurl.model.CachedVanityUrl;
 import com.dotcms.vanityurl.model.DefaultVanityUrl;
-import com.dotcms.regex.MatcherTimeoutFactory;
 import com.dotcms.vanityurl.model.VanityUrl;
 import com.dotcms.vanityurl.model.VanityUrlResult;
 import com.dotcms.vanityurl.util.VanityUrlUtil;
@@ -41,11 +29,22 @@ import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.URLUtils;
 import com.dotmarketing.util.UtilMethods;
-
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
+
+import javax.servlet.http.HttpServletResponse;
+import java.net.URISyntaxException;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Implementation class for the {@link VanityUrlAPI}.
@@ -459,5 +458,10 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public boolean isSelfReferenced(final CachedVanityUrl cachedVanityUrl, final String uri) {
+        return null != cachedVanityUrl && null != cachedVanityUrl.forwardTo
+                && cachedVanityUrl.forwardTo.equals(uri);
+    }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityURLFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityURLFilter.java
@@ -84,11 +84,9 @@ public class VanityURLFilter implements Filter {
           if (null != cachedVanity
                   && cachedVanity.isPresent()
                   && null != cachedVanity.get()
-                  // if it is not 404
-                 // && !VanityUrlCache.NOT_FOUND404.vanityUrlId.equals(cachedVanity.get().vanityUrlId)
                   // checks if the current destiny is not exactly the forward of the vanity
                   // we do this to avoid infinite loop
-                 && vanityApi.isSelfReferenced(cachedVanity.get(), uri)) {
+                 && !vanityApi.isSelfReferenced(cachedVanity.get(), uri)) {
 
               request.setAttribute(VANITY_URL_OBJECT, cachedVanity.get());
               if(addVanityHeader) {

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityURLFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityURLFilter.java
@@ -1,24 +1,5 @@
 package com.dotcms.vanityurl.filters;
 
-import static com.dotmarketing.filters.Constants.VANITY_URL_OBJECT;
-
-import com.dotcms.http.CircuitBreakerUrl;
-import com.dotcms.vanityurl.cache.VanityUrlCache;
-import com.dotmarketing.exception.DotRuntimeException;
-import com.dotmarketing.util.Config;
-import com.dotmarketing.util.UtilMethods;
-import com.liferay.util.StringPool;
-import io.vavr.control.Try;
-import java.io.IOException;
-import java.util.Optional;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
 import com.dotcms.vanityurl.business.VanityUrlAPI;
 import com.dotcms.vanityurl.model.CachedVanityUrl;
@@ -31,6 +12,20 @@ import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.filters.CMSUrlUtil;
 import com.dotmarketing.filters.Constants;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.dotmarketing.util.Config;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.dotmarketing.filters.Constants.VANITY_URL_OBJECT;
 
 /**
  * This Filter handles the vanity url logic
@@ -40,12 +35,12 @@ import com.dotmarketing.portlets.languagesmanager.model.Language;
 // todo: change this to an interceptor
 public class VanityURLFilter implements Filter {
 
-
   private final CMSUrlUtil urlUtil;
   private final HostWebAPI hostWebAPI;
   private final LanguageWebAPI languageWebAPI;
   private final VanityUrlAPI vanityApi;
   private final boolean addVanityHeader;
+
   public VanityURLFilter() {
 
     this(CMSUrlUtil.getInstance(), WebAPILocator.getHostWebAPI(), WebAPILocator.getLanguageWebAPI(),
@@ -93,13 +88,13 @@ public class VanityURLFilter implements Filter {
                  // && !VanityUrlCache.NOT_FOUND404.vanityUrlId.equals(cachedVanity.get().vanityUrlId)
                   // checks if the current destiny is not exactly the forward of the vanity
                   // we do this to avoid infinite loop
-                 && this.forwardToIsnotTheSameOfUri(cachedVanity.get(), uri)) {
+                 && vanityApi.isSelfReferenced(cachedVanity.get(), uri)) {
 
               request.setAttribute(VANITY_URL_OBJECT, cachedVanity.get());
               if(addVanityHeader) {
                   response.setHeader("X-DOT-VanityUrl",cachedVanity.get().vanityUrlId );
               }
-              final VanityUrlResult vanityUrlResult = cachedVanity.get().handle( uri, response);
+              final VanityUrlResult vanityUrlResult = cachedVanity.get().handle(uri);
               final VanityUrlRequestWrapper vanityUrlRequestWrapper = new VanityUrlRequestWrapper(request, vanityUrlResult);
               // If the handler already resolved the requested URI we stop the processing here
               if (this.vanityApi.handleVanityURLRedirects(vanityUrlRequestWrapper, response, vanityUrlResult)) {
@@ -114,20 +109,9 @@ public class VanityURLFilter implements Filter {
       filterChain.doFilter(request, response);
   } // doFilter.
 
-    private boolean forwardToIsnotTheSameOfUri(final CachedVanityUrl cachedVanityUrl, final String uri) {
-
-        // if the forward to is not actually the same of uri, is ok
-        return null != cachedVanityUrl && null != cachedVanityUrl.forwardTo && null != uri?
-                !cachedVanityUrl.forwardTo.equals(uri): false;
-    }
-
   @Override
   public void destroy() {
- 
-    
+    // Not implemented
   }
-
-
-
 
 } // E:O:F:VanityURLFilter.

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/model/CachedVanityUrl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/model/CachedVanityUrl.java
@@ -1,13 +1,10 @@
 package com.dotcms.vanityurl.model;
 
-import com.dotcms.http.CircuitBreakerUrl;
 import com.dotcms.vanityurl.util.VanityUrlUtil;
-import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.util.StringPool;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
-import io.vavr.control.Try;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.Serializable;
@@ -26,7 +23,8 @@ import static com.liferay.util.StringUtil.GROUP_REPLACEMENT_PREFIX;
  */
 public class CachedVanityUrl implements Serializable, Comparable<CachedVanityUrl> {
 
-    static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
+
     final public Pattern pattern;
     final public String vanityUrlId;
     final public String url;
@@ -41,7 +39,6 @@ public class CachedVanityUrl implements Serializable, Comparable<CachedVanityUrl
      *
      * @param vanityUrl The vanityurl Url to cache
      */
-
     public CachedVanityUrl(final VanityUrl vanityUrl) {
         this(vanityUrl.getIdentifier(),vanityUrl.getURI(),vanityUrl.getLanguageId(),vanityUrl.getSite(),vanityUrl.getForwardTo(),vanityUrl.getAction(), vanityUrl.getOrder());
     }
@@ -124,13 +121,38 @@ public class CachedVanityUrl implements Serializable, Comparable<CachedVanityUrl
      *
      * @return The appropriate result based on the selected action for the incoming URL.
      */
-    public VanityUrlResult handle(final String uriIn,
-                    final HttpServletResponse response) {
-        
+    public VanityUrlResult handle(final String uriIn) {
         final Tuple2<String,String> rewritten = processForward(uriIn);
         final String rewrite = rewritten._1;
         final String queryString = rewritten._2;
         return new VanityUrlResult(rewrite, queryString, this.response);
+    }
+
+    /**
+     * Returns whether the Vanity URL represents a {@code 200 Forward} or not.
+     *
+     * @return If the Vanity URL represents a {@code 200 Forward}, returns {@code true}.
+     */
+    public boolean isForward() {
+        return this.response == HttpServletResponse.SC_OK;
+    }
+
+    /**
+     * Returns whether the Vanity URL represents a {@code 302 Temporary Redirect} or not.
+     *
+     * @return If the Vanity URL represents a {@code 302 Temporary Redirect}, returns {@code true}.
+     */
+    public boolean isTemporaryRedirect() {
+        return this.response == HttpServletResponse.SC_MOVED_TEMPORARILY;
+    }
+
+    /**
+     * Returns whether the Vanity URL represents a {@code 301 Permanent Redirect} or not.
+     *
+     * @return If the Vanity URL represents a {@code 301 Permanent Redirect}, returns {@code true}.
+     */
+    public boolean isPermanentRedirect() {
+        return this.response == HttpServletResponse.SC_MOVED_PERMANENTLY;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/EmptyPageView.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/EmptyPageView.java
@@ -1,0 +1,59 @@
+package com.dotmarketing.portlets.htmlpageasset.business.render.page;
+
+import com.dotcms.vanityurl.model.CachedVanityUrl;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * This View represent a special version of the {@link PageView} that is used to represent an empty
+ * page. This is useful when we need to return information on an HTML Page that is mapped to a
+ * Vanity URL using a Temporary or Permanent Redirect, or any other scenario in which a request to
+ * the {@link com.dotcms.rest.api.v1.page.PageResource} needs to handle a page in a non-conventional
+ * way.
+ *
+ * @author Jose Castro
+ * @since May 8th, 2024
+ */
+@JsonSerialize(using = EmptyPageViewSerializer.class)
+public class EmptyPageView extends PageView {
+
+    @JsonProperty("vanityUrl")
+    private CachedVanityUrl cachedVanityUrl;
+
+    /**
+     * Creates a new instance of the {@link EmptyPageView} object using the Builder.
+     *
+     * @param builder The {@link Builder} object to use to create the {@link EmptyPageView}.
+     */
+    private EmptyPageView(final Builder builder) {
+        this.cachedVanityUrl = builder.cachedVanityUrl;
+    }
+
+    /**
+     * Returns the Vanity URL associated with this {@link EmptyPageView}.
+     *
+     * @return The {@link CachedVanityUrl} object associated with this {@link EmptyPageView}.
+     */
+    public CachedVanityUrl getVanityUrl() {
+        return this.cachedVanityUrl;
+    }
+
+    /**
+     * Returns a new instance of the {@link Builder} object to create a new {@link EmptyPageView}.
+     */
+    public static class Builder extends PageView.Builder {
+
+        private CachedVanityUrl cachedVanityUrl;
+
+        public Builder vanityUrl(final CachedVanityUrl cachedVanityUrl) {
+            this.cachedVanityUrl = cachedVanityUrl;
+            return this;
+        }
+
+        public EmptyPageView build() {
+            return new EmptyPageView(this);
+        }
+
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/EmptyPageView.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/EmptyPageView.java
@@ -50,6 +50,7 @@ public class EmptyPageView extends PageView {
             return this;
         }
 
+        @Override
         public EmptyPageView build() {
             return new EmptyPageView(this);
         }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/EmptyPageViewSerializer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/EmptyPageViewSerializer.java
@@ -1,0 +1,59 @@
+package com.dotmarketing.portlets.htmlpageasset.business.render.page;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * This JSON Serializer is used to transform an {@link EmptyPageView} object into a JSON string. It
+ * uses default or empty data structures that simulate an empty HTML Page, but includes other
+ * objects, such as the associated Vanity URL.
+ *
+ * @author Jose Castro
+ * @since May 8th, 2024
+ */
+public class EmptyPageViewSerializer extends JsonSerializer<EmptyPageView> {
+
+    @Override
+    public void serialize(final EmptyPageView emptyPageView, final JsonGenerator jsonGenerator,
+                          final SerializerProvider serializerProvider) throws IOException {
+        final ObjectWriter objectWriter = JsonMapper.mapper.writer().withDefaultPrettyPrinter();
+        final ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
+        builder.putAll(getObjectMap(emptyPageView));
+        final String json = objectWriter.writeValueAsString(builder.build());
+        jsonGenerator.writeRawValue(json);
+    }
+
+    /**
+     * Generates a Map with empty properties for the empty HTML Page.
+     *
+     * @param emptyPageView The {@link EmptyPageView} object to serialize.
+     *
+     * @return A Map with empty properties for the empty HTML Page.
+     */
+    protected Map<String, Object> getObjectMap(final EmptyPageView emptyPageView) {
+        final Map<String, Object> pageViewMap = new TreeMap<>();
+        pageViewMap.put("vanityUrl", emptyPageView.getVanityUrl());
+        pageViewMap.put("page", new HashMap<>());
+        pageViewMap.put("containers", new HashMap<>());
+        pageViewMap.put("template", new HashMap<>());
+        
+        pageViewMap.put("site", new HashMap<>());
+        pageViewMap.put("viewAs", new HashMap<>());
+        pageViewMap.put("canCreateTemplate", emptyPageView.canCreateTemplate());
+        pageViewMap.put("numberContents", emptyPageView.getNumberContents());
+
+        if (emptyPageView.getLayout() != null) {
+            pageViewMap.put("layout", emptyPageView.getLayout());
+        }
+        return pageViewMap;
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/PageView.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/PageView.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -22,11 +23,12 @@ import java.util.Optional;
  * Represents the different parts that make up the structure of an HTML Page in the system and its
  * associated data structures. A dotCMS page is basically composed of:
  * <ul>
- * <li>The HTML Page.</li>
- * <li>Its template.</li>
- * <li>The site it's located in.</li>
- * <li>The list of containers.</li>
- * <li>Its template layout.</li>
+ *  <li>The HTML Page.</li>
+ *  <li>Its template.</li>
+ *  <li>The site it's located in.</li>
+ *  <li>The list of containers.</li>
+ *  <li>Its template layout.</li>
+ *  <li>Any other required piece of information related to the page and how it should be rendered.</li>
  * </ul>
  *
  * @author Will Ezell
@@ -54,6 +56,25 @@ public class PageView implements Serializable {
     final boolean live;
 
     final Experiment runningExperiment;
+
+    /**
+     * Creates an instance of this class with default values.
+     */
+    PageView() {
+        this.site = new Host();
+        this.template = new Template();
+        this.containers = Collections.emptyList();
+        this.htmlPageAsset = new HTMLPageAsset();
+        this.layout = null;
+        this.viewAs = new ViewAsPageStatus.Builder().build();
+        this.canCreateTemplate = false;
+        this.canEditTemplate = false;
+        this.pageUrlMapper = null;
+        this.numberContents = 0;
+        this.live = false;
+        this.urlContent = null;
+        this.runningExperiment = null;
+    }
 
     /**
      * Creates an instance of this class based on a builder.

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
@@ -154,6 +154,7 @@ public class PageResourceTest {
         when(webResource.init(nullable(String.class), any(HttpServletRequest.class), any(HttpServletResponse.class), any(Boolean.class), nullable(String.class))).thenReturn(initDataObject);
         when(webResource.init(any(HttpServletRequest.class), any(HttpServletResponse.class), any(Boolean.class))).thenReturn(initDataObject);
         when(webResource.init(false, request, true)).thenReturn(initDataObject);
+        when(webResource.init(any(WebResource.InitBuilder.class))).thenReturn(initDataObject);
         when(initDataObject.getUser()).thenReturn(user);
         pageResource = new PageResource(pageResourceHelper, webResource, htmlPageAssetRenderedAPI, esapi);
         this.pageResourceWithHelper = new PageResource(PageResourceHelper.getInstance(), webResource, htmlPageAssetRenderedAPI, this.esapi);

--- a/dotcms-postman/src/main/resources/postman/PagesResourceTests.json
+++ b/dotcms-postman/src/main/resources/postman/PagesResourceTests.json
@@ -1,9 +1,10 @@
 {
 	"info": {
-		"_postman_id": "dc3c0b1e-5343-47c0-b17a-c18786018f1a",
+		"_postman_id": "b328b373-7743-4f65-9346-df740942b0d4",
 		"name": "Page API - [api/v1/page]",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5403727"
+		"_exporter_id": "5403727",
+		"_collection_link": "https://cloudy-robot-285072.postman.co/workspace/JCastro-Workspace~5bfa586e-54db-429b-b7d5-c4ff997e3a0d/collection/5403727-b328b373-7743-4f65-9346-df740942b0d4?action=share&source=collection_link&creator=5403727"
 	},
 	"item": [
 		{
@@ -168,12 +169,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -755,630 +754,1145 @@
 			"name": "Render [api/v1/page/render]",
 			"item": [
 				{
-					"name": "invalidateSession",
-					"event": [
+					"name": "Using Actual Page URIs",
+					"item": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});"
+							"name": "invalidate Session",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v1/logout",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"logout"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get Page Metadata With Invalid User",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											"pm.test(\"Status code is 401, Need credentials\", function () {",
+											"    pm.response.to.have.status(401);",
+											"});",
+											"",
+											"",
+											"",
+											"pm.test(\"Response body matches\", function () {",
+											"    pm.expect(pm.response.text()).to.include(\"Invalid User\");",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v1/page/render/destinations/costa-rica",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"page",
+										"render",
+										"destinations",
+										"costa-rica"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Switch to 'demo.dotcms.com'",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200 \", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"",
+											"",
+											"pm.test(\"Valid response\", function () {",
+											"    var jsonData = pm.response.json();",
+											"",
+											"    pm.expect(jsonData.entity.hostSwitched).equal(true);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
 								],
-								"type": "text/javascript"
-							}
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/site/switch/48190c8c-42c4-46af-8d1a-0cd5db894797",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"site",
+										"switch",
+										"48190c8c-42c4-46af-8d1a-0cd5db894797"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get Valid HTML Page Metadata",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"",
+											"",
+											"pm.test(\"Response body contains\", function () {",
+											"    pm.expect(pm.response.text()).to.include(\"rendered\");",
+											"});",
+											"",
+											"pm.test(\"Response body contains\", function () {",
+											"    pm.expect(pm.response.text()).to.include(\"uuid\");",
+											"});",
+											"",
+											"pm.test(\"'page' element includes all properties\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    var page = jsonData[\"entity\"][\"page\"];",
+											"    pm.expect(page[\"__icon__\"]).equal(\"pageIcon\");",
+											"    pm.expect(page[\"archived\"], 'FAILED:[archived]').equal(false);",
+											"    pm.expect(page[\"baseType\"]).equal(\"HTMLPAGE\");",
+											"    pm.expect(page[\"cachettl\"]).equal(\"0\");",
+											"    pm.expect(page[\"canEdit\"], 'FAILED:[canEdit]').equal(true);",
+											"    pm.expect(page[\"canLock\"], 'FAILED:[canLock]').equal(true);",
+											"    pm.expect(page[\"canRead\"], 'FAILED:[canRead]').equal(true);",
+											"    pm.expect(page[\"deleted\"], 'FAILED:[deleted]').equal(false);",
+											"    pm.expect(page[\"description\"]).equal(\"Costa Rica Rain Forest\");",
+											"    pm.expect(page[\"extension\"]).equal(\"page\");",
+											"    pm.expect(page[\"folder\"]).equal(\"6c8a2ac4-36a7-4b01-b9c0-c2c1d91ddfdb\");",
+											"    pm.expect(page[\"friendlyName\"]).equal(\"Costa Rica Rain Forest\");",
+											"    pm.expect(page[\"hasLiveVersion\"], 'FAILED:[hasLiveVersion]').equal(true);",
+											"    pm.expect(page[\"hasTitleImage\"], 'FAILED:[hasTitleImage]').equal(true);",
+											"    pm.expect(page[\"host\"]).equal(\"48190c8c-42c4-46af-8d1a-0cd5db894797\");",
+											"    pm.expect(page[\"hostName\"]).equal(\"demo.dotcms.com\");",
+											"    ////",
+											"    pm.expect(page[\"httpsRequired\"], 'FAILED:[httpsRequired]').equal(false);",
+											"    pm.expect(page[\"identifier\"]).equal(\"bec7b960-a8bf-4f14-a22b-0d94caf217f0\");",
+											"    pm.expect(page[\"image\"]).equal(\"/dA/bec7b960-a8bf-4f14-a22b-0d94caf217f0/image/costa-rica-tree-frog.jpg\");",
+											"    pm.expect(page[\"imageContentAsset\"]).equal(\"bec7b960-a8bf-4f14-a22b-0d94caf217f0/image\");",
+											"    pm.expect(page[\"inode\"]).not.equal(null)",
+											"    pm.expect(page[\"isContentlet\"], 'FAILED:[isContentlet]').equal(true);",
+											"    pm.expect(page[\"languageId\"]).equal(1);",
+											"    pm.expect(page[\"live\"], 'FAILED:[live]').equal(true);",
+											"    pm.expect(page[\"liveInode\"]).not.equal(null)",
+											"    pm.expect(page[\"locked\"], 'FAILED:[locked]').equal(false);",
+											"    pm.expect(page[\"mimeType\"]).equal(\"application/dotpage\");",
+											"    pm.expect(page[\"modDate\"]).not.equal(null)",
+											"    ///",
+											"    pm.expect(page[\"modUser\"]).equal(\"system\");",
+											"    pm.expect(page[\"modUserName\"]).equal(\"system user system user\");",
+											"    pm.expect(page[\"name\"]).equal(\"costa-rica\");",
+											"    pm.expect(page[\"owner\"]).equal(\"dotcms.org.1\");",
+											"    pm.expect(page[\"pageURI\"]).equal(\"/destinations/costa-rica\");",
+											"    pm.expect(page[\"pageUrl\"]).equal(\"costa-rica\");",
+											"    pm.expect(page[\"path\"]).equal(\"/destinations/costa-rica\");",
+											"    pm.expect(page[\"publishDate\"]).not.equal(null)",
+											"    pm.expect(page[\"seoTitle\"]).equal(\"Costa Rica Travel Destinations\");",
+											"    pm.expect(page[\"seodescription\"]).equal(\"Visit Costa Rica a rugged, rainforested Central American country with coastlines on the Caribbean and Pacific.\");",
+											"    pm.expect(page[\"shortDescription\"]).equal(\"Costa Rica is a rugged, rainforested Central American country with coastlines on the Caribbean and Pacific. Costa Rica is known for its beaches, volcanoes, and biodiversity. Roughly a quarter of its area is made up of protected jungle, teeming with wildlife including spider monkeys and quetzal birds.\");",
+											"    pm.expect(page[\"shortyLive\"]).not.equal(null)",
+											"    //",
+											"    pm.expect(page[\"shortyWorking\"]).not.equal(null)",
+											"    pm.expect(page[\"sortOrder\"]).equal(0);",
+											"    pm.expect(page[\"stInode\"]).equal(\"91812c8b-0441-4139-8d4d-7423cfb0e979\");",
+											"    pm.expect(page[\"statusIcons\"]).equal(\"<span class='greyDotIcon' style='opacity:.4'></span><span class='liveIcon'></span>\");",
+											"    pm.expect(page[\"tags\"]).equal(\"diving\");",
+											"    pm.expect(page[\"template\"]).equal(\"0c556e37-99e0-4458-a2cd-d42cc7a11045\");",
+											"    pm.expect(page[\"title\"]).equal(\"Costa Rica Rain Forest\");",
+											"    pm.expect(page[\"titleImage\"]).equal(\"image\");",
+											"    pm.expect(page[\"type\"]).equal(\"htmlpage\");",
+											"    pm.expect(page[\"url\"]).equal(\"/destinations/costa-rica\");",
+											"    pm.expect(page[\"working\"], 'FAILED:[working]').equal(true);",
+											"    pm.expect(page[\"workingInode\"]).not.equal(null)",
+											"",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v1/page/render/destinations/costa-rica",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"page",
+										"render",
+										"destinations",
+										"costa-rica"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get Metadata From Non-Existing HTML Page",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											"pm.test(\"Status code is 404\", function () {",
+											"    pm.response.to.have.status(404);",
+											"});",
+											"",
+											"",
+											"pm.test(\"Response body contains\", function () {",
+											"   ",
+											"    pm.expect( pm.response.json().message).to.eq(\"Page 'about-us/index2' not found\");",
+											"});",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v1/page/render/about-us/index2",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"page",
+										"render",
+										"about-us",
+										"index2"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Reset workflow for contentlet",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200 \", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"",
+											"",
+											"pm.test(\"Correct identifier\", function () {",
+											"    pm.expect(pm.response.json().entity.identifier).equal(\"57ee7cd3-66fc-4f01-9b7e-11e53553c220\");",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/2d1dc7718f/fire?identifier=57ee7cd3-66fc-4f01-9b7e-11e53553c220",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"2d1dc7718f",
+										"fire"
+									],
+									"query": [
+										{
+											"key": "identifier",
+											"value": "57ee7cd3-66fc-4f01-9b7e-11e53553c220"
+										}
+									]
+								},
+								"description": "The piece of content \"Ecoturism in Costarica\" gets somehow archived at this point after being imported in a previous bundle. This resets its workflow so it can be published in the next request"
+							},
+							"response": []
+						},
+						{
+							"name": "Publish Archived Content",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200 \", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"",
+											"",
+											"pm.test(\"Correct identifier\", function () {",
+											"    pm.expect(pm.response.json().entity.identifier).equal(\"57ee7cd3-66fc-4f01-9b7e-11e53553c220\");",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/175009d69e/fire?identifier=57ee7cd3-66fc-4f01-9b7e-11e53553c220",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"175009d69e",
+										"fire"
+									],
+									"query": [
+										{
+											"key": "identifier",
+											"value": "57ee7cd3-66fc-4f01-9b7e-11e53553c220"
+										}
+									]
+								},
+								"description": "This publishes the content `Ecotourism in Costa Rica` so it can be tested in the next request"
+							},
+							"response": []
+						},
+						{
+							"name": "Get Metadata From URL Map",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"No errors\", function () {",
+											"    ",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0);",
+											"});",
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"}); ",
+											"",
+											"pm.test(\"Has Rows and Columns\", function () {",
+											"    ",
+											"    var jsonData = pm.response.json();",
+											"    ",
+											"    pm.expect(jsonData.entity.layout.body.rows.length).to.equal(1);",
+											"    pm.expect(jsonData.entity.layout.body.rows[0].columns.length).to.equal(1);",
+											"     ",
+											"});",
+											"",
+											"pm.test(\"Number of Contents\", function () {",
+											"    ",
+											"    var jsonData = pm.response.json();",
+											"    ",
+											"    pm.expect(jsonData.entity.numberContents).to.equal(1);",
+											"    ",
+											"     ",
+											"});",
+											"",
+											"pm.test(\"Page checks\", function () {",
+											"    ",
+											"    var jsonData = pm.response.json();",
+											"    ",
+											"    pm.expect(jsonData.entity.page.pageURI).to.equal('/blog/post/ecotourism-in-costa-rica');",
+											"    pm.expect(jsonData.entity.page.title).to.equal('Blog Detail');",
+											"    pm.expect(jsonData.entity.page.type).to.equal('htmlpage');",
+											"     ",
+											"});",
+											"",
+											"pm.test(\"Site checks\", function () {",
+											"    ",
+											"    var jsonData = pm.response.json();",
+											"    ",
+											"    pm.expect(jsonData.entity.site.hostname).to.equal('demo.dotcms.com');",
+											"    pm.expect(jsonData.entity.site.type).to.equal('contentlet');",
+											"     ",
+											"});",
+											"",
+											"pm.test(\"Template checks\", function () {",
+											"    ",
+											"    var jsonData = pm.response.json();",
+											"    ",
+											"    pm.expect(jsonData.entity.template.title).to.equal('anonymous_layout_1582562696562');",
+											"    pm.expect(jsonData.entity.template.type).to.equal('template');",
+											"     ",
+											"});",
+											"",
+											"pm.test(\"Url Content Map checks\", function () {",
+											"    ",
+											"    var jsonData = pm.response.json();",
+											"",
+											"    pm.expect(jsonData.entity.urlContentMap.hostName).to.equal('demo.dotcms.com');",
+											"    pm.expect(jsonData.entity.urlContentMap.baseType).to.equal('CONTENT');",
+											"    pm.expect(jsonData.entity.urlContentMap.contentType).to.equal('Blog');",
+											"    pm.expect(jsonData.entity.urlContentMap.urlTitle).to.equal('ecotourism-in-costa-rica');",
+											"    pm.expect(jsonData.entity.urlContentMap['URL_MAP_FOR_CONTENT']).to.equal('/blog/post/ecotourism-in-costa-rica');",
+											"    pm.expect(jsonData.entity.urlContentMap['urlMap']).to.equal('/blog/post/ecotourism-in-costa-rica');",
+											"});",
+											"",
+											"",
+											"",
+											"",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v1/page/render/blog/post/ecotourism-in-costa-rica?mode=EDIT_MODE",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"page",
+										"render",
+										"blog",
+										"post",
+										"ecotourism-in-costa-rica"
+									],
+									"query": [
+										{
+											"key": "mode",
+											"value": "EDIT_MODE"
+										}
+									]
+								},
+								"description": "Gets an Url content map"
+							},
+							"response": []
 						}
 					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{serverURL}}/api/v1/logout",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"logout"
-							]
-						}
-					},
-					"response": []
+					"description": "Tests calling the `render` method passing down the actual URI of an HTML Page."
 				},
 				{
-					"name": "GivenInvalidUser_ShouldReturn401",
+					"name": "Using Vanity URLs",
+					"item": [
+						{
+							"name": "Create Test Forward Vanity URL",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Forward Vanity URL was created successfully\", function () {",
+											"    var jsonData = pm.response.json().entity;",
+											"    pm.expect(jsonData.summary.failCount).to.eql(0, \"An error occurred when creating the test Vanity URL\");",
+											"    pm.expect(jsonData.summary.successCount).to.eql(1, \"One piece of content should have been created\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"Vanityurl\",\n            \"languageId\": 1,\n            \"title\": \"Test Forward Vanity URL\",\n            \"site\": \"demo.dotcms.com\",\n            \"uri\": \"/forward\",\n            \"action\": 200,\n            \"forwardTo\": \"/destinations/costa-rica\",\n            \"order\": 0\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									]
+								},
+								"description": "Create the original Contentlet."
+							},
+							"response": []
+						},
+						{
+							"name": "Create Test Temporary Redirect Vanity URL",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Temporary Redirect Vanity URL was created successfully\", function () {",
+											"    var jsonData = pm.response.json().entity;",
+											"    pm.expect(jsonData.summary.failCount).to.eql(0, \"An error occurred when creating the test Vanity URL\");",
+											"    pm.expect(jsonData.summary.successCount).to.eql(1, \"One piece of content should have been created\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"Vanityurl\",\n            \"languageId\": 1,\n            \"title\": \"Test Temporary Vanity URL\",\n            \"site\": \"demo.dotcms.com\",\n            \"uri\": \"/temporary\",\n            \"action\": 302,\n            \"forwardTo\": \"/destinations/costa-rica\",\n            \"order\": 0\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									]
+								},
+								"description": "Create the original Contentlet."
+							},
+							"response": []
+						},
+						{
+							"name": "Create Test Permanent Redirect Vanity URL",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Permanent Redirect Vanity URL was created successfully\", function () {",
+											"    var jsonData = pm.response.json().entity;",
+											"    pm.expect(jsonData.summary.failCount).to.eql(0, \"An error occurred when creating the test Vanity URL\");",
+											"    pm.expect(jsonData.summary.successCount).to.eql(1, \"One piece of content should have been created\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"Vanityurl\",\n            \"languageId\": 1,\n            \"title\": \"Test Permanent Vanity URL\",\n            \"site\": \"demo.dotcms.com\",\n            \"uri\": \"/permanent\",\n            \"action\": 301,\n            \"forwardTo\": \"/destinations/costa-rica\",\n            \"order\": 0\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									]
+								},
+								"description": "Create the original Contentlet."
+							},
+							"response": []
+						},
+						{
+							"name": "Get HTML Page Metadata - Forward",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response body contains\", function () {",
+											"    pm.expect(pm.response.text()).to.include(\"rendered\");",
+											"});",
+											"",
+											"pm.test(\"Response body contains\", function () {",
+											"    pm.expect(pm.response.text()).to.include(\"uuid\");",
+											"});",
+											"",
+											"pm.test(\"'page' element includes all properties\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    var page = jsonData[\"entity\"][\"page\"];",
+											"    pm.expect(page[\"__icon__\"]).equal(\"pageIcon\");",
+											"    pm.expect(page[\"archived\"], 'FAILED:[archived]').equal(false);",
+											"    pm.expect(page[\"baseType\"]).equal(\"HTMLPAGE\");",
+											"    pm.expect(page[\"cachettl\"]).equal(\"0\");",
+											"    pm.expect(page[\"canEdit\"], 'FAILED:[canEdit]').equal(true);",
+											"    pm.expect(page[\"canLock\"], 'FAILED:[canLock]').equal(true);",
+											"    pm.expect(page[\"canRead\"], 'FAILED:[canRead]').equal(true);",
+											"    pm.expect(page[\"deleted\"], 'FAILED:[deleted]').equal(false);",
+											"    pm.expect(page[\"description\"]).equal(\"Costa Rica Rain Forest\");",
+											"    pm.expect(page[\"extension\"]).equal(\"page\");",
+											"    pm.expect(page[\"folder\"]).equal(\"6c8a2ac4-36a7-4b01-b9c0-c2c1d91ddfdb\");",
+											"    pm.expect(page[\"friendlyName\"]).equal(\"Costa Rica Rain Forest\");",
+											"    pm.expect(page[\"hasLiveVersion\"], 'FAILED:[hasLiveVersion]').equal(true);",
+											"    pm.expect(page[\"hasTitleImage\"], 'FAILED:[hasTitleImage]').equal(true);",
+											"    pm.expect(page[\"host\"]).equal(\"48190c8c-42c4-46af-8d1a-0cd5db894797\");",
+											"    pm.expect(page[\"hostName\"]).equal(\"demo.dotcms.com\");",
+											"    ////",
+											"    pm.expect(page[\"httpsRequired\"], 'FAILED:[httpsRequired]').equal(false);",
+											"    pm.expect(page[\"identifier\"]).equal(\"bec7b960-a8bf-4f14-a22b-0d94caf217f0\");",
+											"    pm.expect(page[\"image\"]).equal(\"/dA/bec7b960-a8bf-4f14-a22b-0d94caf217f0/image/costa-rica-tree-frog.jpg\");",
+											"    pm.expect(page[\"imageContentAsset\"]).equal(\"bec7b960-a8bf-4f14-a22b-0d94caf217f0/image\");",
+											"    pm.expect(page[\"inode\"]).not.equal(null)",
+											"    pm.expect(page[\"isContentlet\"], 'FAILED:[isContentlet]').equal(true);",
+											"    pm.expect(page[\"languageId\"]).equal(1);",
+											"    pm.expect(page[\"live\"], 'FAILED:[live]').equal(true);",
+											"    pm.expect(page[\"liveInode\"]).not.equal(null)",
+											"    pm.expect(page[\"locked\"], 'FAILED:[locked]').equal(false);",
+											"    pm.expect(page[\"mimeType\"]).equal(\"application/dotpage\");",
+											"    pm.expect(page[\"modDate\"]).not.equal(null)",
+											"    ///",
+											"    pm.expect(page[\"modUser\"]).equal(\"system\");",
+											"    pm.expect(page[\"modUserName\"]).equal(\"system user system user\");",
+											"    pm.expect(page[\"name\"]).equal(\"costa-rica\");",
+											"    pm.expect(page[\"owner\"]).equal(\"dotcms.org.1\");",
+											"    pm.expect(page[\"pageURI\"]).equal(\"/destinations/costa-rica\");",
+											"    pm.expect(page[\"pageUrl\"]).equal(\"costa-rica\");",
+											"    pm.expect(page[\"path\"]).equal(\"/destinations/costa-rica\");",
+											"    pm.expect(page[\"publishDate\"]).not.equal(null)",
+											"    pm.expect(page[\"seoTitle\"]).equal(\"Costa Rica Travel Destinations\");",
+											"    pm.expect(page[\"seodescription\"]).equal(\"Visit Costa Rica a rugged, rainforested Central American country with coastlines on the Caribbean and Pacific.\");",
+											"    pm.expect(page[\"shortDescription\"]).equal(\"Costa Rica is a rugged, rainforested Central American country with coastlines on the Caribbean and Pacific. Costa Rica is known for its beaches, volcanoes, and biodiversity. Roughly a quarter of its area is made up of protected jungle, teeming with wildlife including spider monkeys and quetzal birds.\");",
+											"    pm.expect(page[\"shortyLive\"]).not.equal(null)",
+											"    //",
+											"    pm.expect(page[\"shortyWorking\"]).not.equal(null)",
+											"    pm.expect(page[\"sortOrder\"]).equal(0);",
+											"    pm.expect(page[\"stInode\"]).equal(\"91812c8b-0441-4139-8d4d-7423cfb0e979\");",
+											"    pm.expect(page[\"statusIcons\"]).equal(\"<span class='greyDotIcon' style='opacity:.4'></span><span class='liveIcon'></span>\");",
+											"    pm.expect(page[\"tags\"]).equal(\"diving\");",
+											"    pm.expect(page[\"template\"]).equal(\"0c556e37-99e0-4458-a2cd-d42cc7a11045\");",
+											"    pm.expect(page[\"title\"]).equal(\"Costa Rica Rain Forest\");",
+											"    pm.expect(page[\"titleImage\"]).equal(\"image\");",
+											"    pm.expect(page[\"type\"]).equal(\"htmlpage\");",
+											"    pm.expect(page[\"url\"]).equal(\"/destinations/costa-rica\");",
+											"    pm.expect(page[\"working\"], 'FAILED:[working]').equal(true);",
+											"    pm.expect(page[\"workingInode\"]).not.equal(null)",
+											"",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v1/page/render/forward",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"page",
+										"render",
+										"forward"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get HTML Page Metadata - Temporary Redirect",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"The test Temporary Redirect Vanity URL must be returned\", function () {",
+											"    var entity = pm.response.json().entity;",
+											"    pm.expect(entity.vanityUrl).to.not.equal(undefined, \"The 'vanityUrl' attribute must be present\");",
+											"    pm.expect(entity.vanityUrl.temporaryRedirect).to.equal(true, \"The returned Vanity URL MUST be a temporary redirect\");",
+											"    pm.expect(entity.vanityUrl.permanentRedirect).to.equal(false, \"The returned Vanity URL MUST NOT be a permanent redirect\");",
+											"    pm.expect(entity.vanityUrl.forward).to.equal(false, \"The returned Vanity URL MUST NOT be a forward\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v1/page/render/temporary",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"page",
+										"render",
+										"temporary"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get HTML Page Metadata - Permanent Redirect",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"The test Permanent Redirect Vanity URL must be returned\", function () {",
+											"    var entity = pm.response.json().entity;",
+											"    pm.expect(entity.vanityUrl).to.not.equal(undefined, \"The 'vanityUrl' attribute must be present\");",
+											"    pm.expect(entity.vanityUrl.permanentRedirect).to.equal(true, \"The returned Vanity URL MUST be a permanent redirect\");",
+											"    pm.expect(entity.vanityUrl.temporaryRedirect).to.equal(false, \"The returned Vanity URL MUST NOT be a temporary redirect\");",
+											"    pm.expect(entity.vanityUrl.forward).to.equal(false, \"The returned Vanity URL MUST NOT be a forward\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v1/page/render/permanent",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"page",
+										"render",
+										"permanent"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"description": "Tests calling the `render` method passing down a Vanity URL that references an HTML Page, using the three redirect options:\n\n1. Forward.\n    \n2. Temporary Redirect.\n    \n3. Permanent Redirect.",
 					"event": [
 						{
-							"listen": "test",
+							"listen": "prerequest",
 							"script": {
+								"type": "text/javascript",
+								"packages": {},
 								"exec": [
-									"",
-									"pm.test(\"Status code is 401, Need credentials\", function () {",
-									"    pm.response.to.have.status(401);",
-									"});",
-									"",
-									"",
-									"",
-									"pm.test(\"Response body matches\", function () {",
-									"    pm.expect(pm.response.text()).to.include(\"Invalid User\");",
-									"});",
 									""
-								],
-								"type": "text/javascript"
+								]
 							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "noauth"
 						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{serverURL}}/api/v1/page/render/destinations/costa-rica",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"page",
-								"render",
-								"destinations",
-								"costa-rica"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Switch site to 'demo.dotcms.com' Copy",
-					"event": [
 						{
 							"listen": "test",
 							"script": {
+								"type": "text/javascript",
+								"packages": {},
 								"exec": [
-									"pm.test(\"Status code is 200 \", function () {",
+									"pm.test(\"HTTP Status must be 200\", function() {",
 									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"",
-									"",
-									"pm.test(\"Valid response\", function () {",
-									"    var jsonData = pm.response.json();",
-									"",
-									"    pm.expect(jsonData.entity.hostSwitched).equal(true);",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"type": "any"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/site/switch/48190c8c-42c4-46af-8d1a-0cd5db894797",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"site",
-								"switch",
-								"48190c8c-42c4-46af-8d1a-0cd5db894797"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "GivenValidPageURL_ShouldReturnPageInfoAndRenderHTML",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"",
-									"",
-									"pm.test(\"Response body contains\", function () {",
-									"    pm.expect(pm.response.text()).to.include(\"rendered\");",
-									"});",
-									"",
-									"pm.test(\"Response body contains\", function () {",
-									"    pm.expect(pm.response.text()).to.include(\"uuid\");",
-									"});",
-									"",
-									"pm.test(\"'page' element includes all properties\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    var page = jsonData[\"entity\"][\"page\"];",
-									"    pm.expect(page[\"__icon__\"]).equal(\"pageIcon\");",
-									"    pm.expect(page[\"archived\"], 'FAILED:[archived]').equal(false);",
-									"    pm.expect(page[\"baseType\"]).equal(\"HTMLPAGE\");",
-									"    pm.expect(page[\"cachettl\"]).equal(\"0\");",
-									"    pm.expect(page[\"canEdit\"], 'FAILED:[canEdit]').equal(true);",
-									"    pm.expect(page[\"canLock\"], 'FAILED:[canLock]').equal(true);",
-									"    pm.expect(page[\"canRead\"], 'FAILED:[canRead]').equal(true);",
-									"    pm.expect(page[\"deleted\"], 'FAILED:[deleted]').equal(false);",
-									"    pm.expect(page[\"description\"]).equal(\"Costa Rica Rain Forest\");",
-									"    pm.expect(page[\"extension\"]).equal(\"page\");",
-									"    pm.expect(page[\"folder\"]).equal(\"6c8a2ac4-36a7-4b01-b9c0-c2c1d91ddfdb\");",
-									"    pm.expect(page[\"friendlyName\"]).equal(\"Costa Rica Rain Forest\");",
-									"    pm.expect(page[\"hasLiveVersion\"], 'FAILED:[hasLiveVersion]').equal(true);",
-									"    pm.expect(page[\"hasTitleImage\"], 'FAILED:[hasTitleImage]').equal(true);",
-									"    pm.expect(page[\"host\"]).equal(\"48190c8c-42c4-46af-8d1a-0cd5db894797\");",
-									"    pm.expect(page[\"hostName\"]).equal(\"demo.dotcms.com\");",
-									"    ////",
-									"    pm.expect(page[\"httpsRequired\"], 'FAILED:[httpsRequired]').equal(false);",
-									"    pm.expect(page[\"identifier\"]).equal(\"bec7b960-a8bf-4f14-a22b-0d94caf217f0\");",
-									"    pm.expect(page[\"image\"]).equal(\"/dA/bec7b960-a8bf-4f14-a22b-0d94caf217f0/image/costa-rica-tree-frog.jpg\");",
-									"    pm.expect(page[\"imageContentAsset\"]).equal(\"bec7b960-a8bf-4f14-a22b-0d94caf217f0/image\");",
-									"    pm.expect(page[\"inode\"]).not.equal(null)",
-									"    pm.expect(page[\"isContentlet\"], 'FAILED:[isContentlet]').equal(true);",
-									"    pm.expect(page[\"languageId\"]).equal(1);",
-									"    pm.expect(page[\"live\"], 'FAILED:[live]').equal(true);",
-									"    pm.expect(page[\"liveInode\"]).not.equal(null)",
-									"    pm.expect(page[\"locked\"], 'FAILED:[locked]').equal(false);",
-									"    pm.expect(page[\"mimeType\"]).equal(\"application/dotpage\");",
-									"    pm.expect(page[\"modDate\"]).not.equal(null)",
-									"    ///",
-									"    pm.expect(page[\"modUser\"]).equal(\"system\");",
-									"    pm.expect(page[\"modUserName\"]).equal(\"system user system user\");",
-									"    pm.expect(page[\"name\"]).equal(\"costa-rica\");",
-									"    pm.expect(page[\"owner\"]).equal(\"dotcms.org.1\");",
-									"    pm.expect(page[\"pageURI\"]).equal(\"/destinations/costa-rica\");",
-									"    pm.expect(page[\"pageUrl\"]).equal(\"costa-rica\");",
-									"    pm.expect(page[\"path\"]).equal(\"/destinations/costa-rica\");",
-									"    pm.expect(page[\"publishDate\"]).not.equal(null)",
-									"    pm.expect(page[\"seoTitle\"]).equal(\"Costa Rica Travel Destinations\");",
-									"    pm.expect(page[\"seodescription\"]).equal(\"Visit Costa Rica a rugged, rainforested Central American country with coastlines on the Caribbean and Pacific.\");",
-									"    pm.expect(page[\"shortDescription\"]).equal(\"Costa Rica is a rugged, rainforested Central American country with coastlines on the Caribbean and Pacific. Costa Rica is known for its beaches, volcanoes, and biodiversity. Roughly a quarter of its area is made up of protected jungle, teeming with wildlife including spider monkeys and quetzal birds.\");",
-									"    pm.expect(page[\"shortyLive\"]).not.equal(null)",
-									"    //",
-									"    pm.expect(page[\"shortyWorking\"]).not.equal(null)",
-									"    pm.expect(page[\"sortOrder\"]).equal(0);",
-									"    pm.expect(page[\"stInode\"]).equal(\"91812c8b-0441-4139-8d4d-7423cfb0e979\");",
-									"    pm.expect(page[\"statusIcons\"]).equal(\"<span class='greyDotIcon' style='opacity:.4'></span><span class='liveIcon'></span>\");",
-									"    pm.expect(page[\"tags\"]).equal(\"diving\");",
-									"    pm.expect(page[\"template\"]).equal(\"0c556e37-99e0-4458-a2cd-d42cc7a11045\");",
-									"    pm.expect(page[\"title\"]).equal(\"Costa Rica Rain Forest\");",
-									"    pm.expect(page[\"titleImage\"]).equal(\"image\");",
-									"    pm.expect(page[\"type\"]).equal(\"htmlpage\");",
-									"    pm.expect(page[\"url\"]).equal(\"/destinations/costa-rica\");",
-									"    pm.expect(page[\"working\"], 'FAILED:[working]').equal(true);",
-									"    pm.expect(page[\"workingInode\"]).not.equal(null)",
-									"",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{serverURL}}/api/v1/page/render/destinations/costa-rica",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"page",
-								"render",
-								"destinations",
-								"costa-rica"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "GivenInvalidPageURL_ShouldReturn404",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"",
-									"pm.test(\"Status code is 404\", function () {",
-									"    pm.response.to.have.status(404);",
-									"});",
-									"",
-									"",
-									"pm.test(\"Response body contains\", function () {",
-									"   ",
-									"    pm.expect( pm.response.json().message).to.eq(\"Page 'about-us/index2' not found\");",
 									"});",
 									"",
 									""
-								],
-								"type": "text/javascript"
+								]
 							}
 						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{serverURL}}/api/v1/page/render/about-us/index2",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"page",
-								"render",
-								"about-us",
-								"index2"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Reset workflow for contentlet",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200 \", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"",
-									"",
-									"pm.test(\"Correct identifier\", function () {",
-									"    pm.expect(pm.response.json().entity.identifier).equal(\"57ee7cd3-66fc-4f01-9b7e-11e53553c220\");",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"type": "any"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/workflow/actions/2d1dc7718f/fire?identifier=57ee7cd3-66fc-4f01-9b7e-11e53553c220",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"workflow",
-								"actions",
-								"2d1dc7718f",
-								"fire"
-							],
-							"query": [
-								{
-									"key": "identifier",
-									"value": "57ee7cd3-66fc-4f01-9b7e-11e53553c220"
-								}
-							]
-						},
-						"description": "The piece of content \"Ecoturism in Costarica\" gets somehow archived at this point after being imported in a previous bundle. This resets its workflow so it can be published in the next request"
-					},
-					"response": []
-				},
-				{
-					"name": "Publish archived content Copy",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200 \", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"",
-									"",
-									"pm.test(\"Correct identifier\", function () {",
-									"    pm.expect(pm.response.json().entity.identifier).equal(\"57ee7cd3-66fc-4f01-9b7e-11e53553c220\");",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"type": "any"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/workflow/actions/175009d69e/fire?identifier=57ee7cd3-66fc-4f01-9b7e-11e53553c220",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"workflow",
-								"actions",
-								"175009d69e",
-								"fire"
-							],
-							"query": [
-								{
-									"key": "identifier",
-									"value": "57ee7cd3-66fc-4f01-9b7e-11e53553c220"
-								}
-							]
-						},
-						"description": "This publishes the content `Ecotourism in Costa Rica` so it can be tested in the next request"
-					},
-					"response": []
-				},
-				{
-					"name": "GivenURLMappedPage_ShouldReturnPageInfo",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"No errors\", function () {",
-									"    ",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.errors.length).to.eql(0);",
-									"});",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"}); ",
-									"",
-									"pm.test(\"Has Rows and Columns\", function () {",
-									"    ",
-									"    var jsonData = pm.response.json();",
-									"    ",
-									"    pm.expect(jsonData.entity.layout.body.rows.length).to.equal(1);",
-									"    pm.expect(jsonData.entity.layout.body.rows[0].columns.length).to.equal(1);",
-									"     ",
-									"});",
-									"",
-									"pm.test(\"Number of Contents\", function () {",
-									"    ",
-									"    var jsonData = pm.response.json();",
-									"    ",
-									"    pm.expect(jsonData.entity.numberContents).to.equal(1);",
-									"    ",
-									"     ",
-									"});",
-									"",
-									"pm.test(\"Page checks\", function () {",
-									"    ",
-									"    var jsonData = pm.response.json();",
-									"    ",
-									"    pm.expect(jsonData.entity.page.pageURI).to.equal('/blog/post/ecotourism-in-costa-rica');",
-									"    pm.expect(jsonData.entity.page.title).to.equal('Blog Detail');",
-									"    pm.expect(jsonData.entity.page.type).to.equal('htmlpage');",
-									"     ",
-									"});",
-									"",
-									"pm.test(\"Site checks\", function () {",
-									"    ",
-									"    var jsonData = pm.response.json();",
-									"    ",
-									"    pm.expect(jsonData.entity.site.hostname).to.equal('demo.dotcms.com');",
-									"    pm.expect(jsonData.entity.site.type).to.equal('contentlet');",
-									"     ",
-									"});",
-									"",
-									"pm.test(\"Template checks\", function () {",
-									"    ",
-									"    var jsonData = pm.response.json();",
-									"    ",
-									"    pm.expect(jsonData.entity.template.title).to.equal('anonymous_layout_1582562696562');",
-									"    pm.expect(jsonData.entity.template.type).to.equal('template');",
-									"     ",
-									"});",
-									"",
-									"pm.test(\"Url Content Map checks\", function () {",
-									"    ",
-									"    var jsonData = pm.response.json();",
-									"",
-									"    pm.expect(jsonData.entity.urlContentMap.hostName).to.equal('demo.dotcms.com');",
-									"    pm.expect(jsonData.entity.urlContentMap.baseType).to.equal('CONTENT');",
-									"    pm.expect(jsonData.entity.urlContentMap.contentType).to.equal('Blog');",
-									"    pm.expect(jsonData.entity.urlContentMap.urlTitle).to.equal('ecotourism-in-costa-rica');",
-									"    pm.expect(jsonData.entity.urlContentMap['URL_MAP_FOR_CONTENT']).to.equal('/blog/post/ecotourism-in-costa-rica');",
-									"    pm.expect(jsonData.entity.urlContentMap['urlMap']).to.equal('/blog/post/ecotourism-in-costa-rica');",
-									"});",
-									"",
-									"",
-									"",
-									"",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{serverURL}}/api/v1/page/render/blog/post/ecotourism-in-costa-rica?mode=EDIT_MODE",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"page",
-								"render",
-								"blog",
-								"post",
-								"ecotourism-in-costa-rica"
-							],
-							"query": [
-								{
-									"key": "mode",
-									"value": "EDIT_MODE"
-								}
-							]
-						},
-						"description": "Gets an Url content map"
-					},
-					"response": []
+					]
 				}
 			]
 		},
@@ -1859,12 +2373,10 @@
 								"header": [
 									{
 										"key": "Content-Type",
-										"type": "text",
 										"value": "application/octet-stream"
 									},
 									{
 										"key": "Content-Disposition",
-										"type": "text",
 										"value": "attachment"
 									}
 								],
@@ -2736,12 +3248,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -2970,12 +3480,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -3287,9 +3795,7 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"value": "application/json",
-								"type": "text"
+								"value": "application/json"
 							}
 						],
 						"body": {


### PR DESCRIPTION
### Proposed Changes
* Supporting Vanity URLs in the `render` method of the Page Resource REST Endpoint.
* When a `200 Forward` Vanity URL is requested, simply returns the usual JSON metadata object with the HTML Page information.
* When a `301 Permanent Redirect` or a `302 Temporary Redirect` is requested, returns an empty object for HTML Page data, and the information of the Vanity URL so that third-party server knows how to handle it.