### PR TITLE
ci(release) normalize repositories, need to deploy to -local versions not virtual

### DIFF
--- a/.github/actions/deploy-artifact-artifactory/action.yml
+++ b/.github/actions/deploy-artifact-artifactory/action.yml
@@ -68,7 +68,7 @@ runs:
     - name: 'Maven settings.xml setup'
       uses: whelk-io/maven-settings-xml-action@v22
       with:
-        servers: '[{ "id": "dotcms-libs", "username": "${{ inputs.artifactory-repo-username }}", "password": "${{ inputs.artifactory-repo-password }}" }, { "id": "dotcms-libs-snapshot", "username": "${{ inputs.artifactory-repo-username }}", "password": "${{ inputs.artifactory-repo-password }}" }]'
+        servers: '[{ "id": "dotcms-libs-local", "username": "${{ inputs.artifactory-repo-username }}", "password": "${{ inputs.artifactory-repo-password }}" }, { "id": "dotcms-libs-snapshot-local", "username": "${{ inputs.artifactory-repo-username }}", "password": "${{ inputs.artifactory-repo-password }}" }]'
 
     # Artifact deployment in the Artifactory excluding 'dotcms-integration' and 'dotcms-postman'
     - name: 'Deploy Artifacts'

--- a/.github/workflows/maven-release-process.yml
+++ b/.github/workflows/maven-release-process.yml
@@ -273,8 +273,7 @@ jobs:
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v20
         with:
-          repositories: '[{ "id": "dotcms-libs", "name": "DotCMS libs Release", "url": "https://repo.dotcms.com/artifactory/libs-release" }]'
-          servers: '[{ "id": "dotcms-libs", "username": "${{ secrets.EE_REPO_USERNAME }}", "password": "${{ secrets.EE_REPO_PASSWORD }}" }]'
+          servers: '[{ "id": "dotcms-libs-local", "username": "${{ secrets.EE_REPO_USERNAME }}", "password": "${{ secrets.EE_REPO_PASSWORD }}" }]'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/dotcms-integration/pom.xml
+++ b/dotcms-integration/pom.xml
@@ -514,28 +514,6 @@
         </profile>
 
     </profiles>
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>dotcms-libs</id>
-            <url>https://repo.dotcms.com/artifactory/libs-release</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>dotcms-libs-snapshot</id>
-            <url>https://repo.dotcms.com/artifactory/libs-snapshot-local</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>jitpack</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
+
 
 </project>

--- a/dotcms-postman/pom.xml
+++ b/dotcms-postman/pom.xml
@@ -146,28 +146,5 @@
     <profiles>
     </profiles>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>dotcms-libs</id>
-            <url>https://repo.dotcms.com/artifactory/libs-release</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>dotcms-libs-snapshot</id>
-            <url>https://repo.dotcms.com/artifactory/libs-snapshot-local</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>jitpack</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
 
 </project>

--- a/independent-projects/core-plugins/tika-api/pom.xml
+++ b/independent-projects/core-plugins/tika-api/pom.xml
@@ -22,18 +22,6 @@
 
     </dependencies>
 
-    <distributionManagement>
-        <repository>
-            <id>dotcms-libs</id>
-            <name>DotCMS libs Release</name>
-            <url>https://repo.dotcms.com/artifactory/libs-release</url>
-        </repository>
-        <snapshotRepository>
-            <id>dotcms-libs-snapshot</id>
-            <name>IDotCMS libs Snapshots</name>
-            <url>https://repo.dotcms.com/artifactory/libs-snapshot-local</url>
-        </snapshotRepository>
-    </distributionManagement>
 
 
 </project>

--- a/osgi-base/system-bundles/pom.xml
+++ b/osgi-base/system-bundles/pom.xml
@@ -21,36 +21,6 @@
         <tika.plugin.bundle.version>2.7.0</tika.plugin.bundle.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <id>dotcms-libs</id>
-            <url>https://repo.dotcms.com/artifactory/libs-release/</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <id>dotcms-libs-snapshot</id>
-            <url>https://repo.dotcms.com/artifactory/libs-snapshot-local/</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>jitpack</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
 
     <dependencies>
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1125,48 +1125,6 @@
         <system>GitHub</system>
         <url>https://github.com/dotCMS/core/issues/</url>
     </issueManagement>
-    <repositories>
-        <repository>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>dotcms-libs</id>
-            <url>https://repo.dotcms.com/artifactory/libs-release/</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>jitpack</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>dotcms-libs</id>
-            <url>https://repo.dotcms.com/artifactory/libs-release</url>
-        </pluginRepository>
-        <pluginRepository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>dotcms-libs-snapshot</id>
-            <url>https://repo.dotcms.com/artifactory/libs-snapshot-local</url>
-        </pluginRepository>
-        <pluginRepository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>jitpack</id>
-            <url>https://jitpack.io</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <profiles>
         <profile>
@@ -1664,14 +1622,53 @@
             </build>
         </profile>
     </profiles>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>dotcms-libs</id>
+            <url>https://repo.dotcms.com/artifactory/libs-release</url>
+        </repository>
+        <repository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>dotcms-libs-snapshot-local</id>
+            <name>IDotCMS libs Snapshots</name>
+            <url>https://repo.dotcms.com/artifactory/libs-snapshot-local</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>dotcms-libs</id>
+            <url>https://repo.dotcms.com/artifactory/libs-release</url>
+        </pluginRepository>
+        <pluginRepository>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>dotcms-libs-snapshot</id>
+            <url>https://repo.dotcms.com/artifactory/libs-snapshot</url>
+        </pluginRepository>
+    </pluginRepositories>
     <distributionManagement>
         <repository>
-            <id>dotcms-libs</id>
+            <id>dotcms-libs-local</id>
             <name>DotCMS libs Release</name>
             <url>https://repo.dotcms.com/artifactory/libs-release-local</url>
         </repository>
         <snapshotRepository>
-            <id>dotcms-libs-snapshot</id>
+            <id>dotcms-libs-snapshot-local</id>
             <name>IDotCMS libs Snapshots</name>
             <url>https://repo.dotcms.com/artifactory/libs-snapshot-local</url>
         </snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -40,16 +40,6 @@
             <id>dotcms-libs</id>
             <url>https://repo.dotcms.com/artifactory/libs-release</url>
         </repository>
-        <repository>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>jitpack</id>
-            <url>https://jitpack.io</url>
-        </repository>
     </repositories>
     <distributionManagement>
         <site>
@@ -57,17 +47,15 @@
             <url>file://${project.build.directory}/staging</url>
         </site>
         <repository>
-            <id>dotcms-libs</id>
+            <id>dotcms-libs-local</id>
             <name>DotCMS libs Release</name>
-            <url>https://repo.dotcms.com/artifactory/libs-release</url>
+            <url>https://repo.dotcms.com/artifactory/libs-release-local</url>
         </repository>
-        <!--
         <snapshotRepository>
-            <id>dotcms-libs-snapshot</id>
+            <id>dotcms-libs-snapshot-local</id>
             <name>DotCMS libs Snapshots</name>
             <url>https://repo.dotcms.com/artifactory/libs-snapshot-local</url>
         </snapshotRepository>
-        -->
     </distributionManagement>
 
     <reporting>


### PR DESCRIPTION

### Proposed Changes
* We should use consistent top level repository configuration
* In distributionManagement section we need to realize we have to push to "local" repository.   The usual repository e.g. dotcms-libs is a virtual repository that links to this but also connects to other repos like maven central.