### PR TITLE
fix(CICD): #28535 Adding a bypass to failing deployment step.

### DIFF
--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -88,6 +88,7 @@ jobs:
 
       # The artifacts are uploaded to Artifactory using the 'deploy-artifact-artifactory' action.
       - name: CLI Deploy
+        continue-on-error: true
         id: cli_deploy
         uses: ./.github/actions/deploy-artifact-artifactory
         with:


### PR DESCRIPTION
### Proposed Changes
* Add the `continue-on-error: true` attribute on the` reusable-deployment` workflow bypass the failing deployment.

### Fixes
#28535 
