### PR TITLE
Remove Running Experiment Cache when any Experiment is Started or Sto…

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPI.java
@@ -220,8 +220,6 @@ public interface ExperimentsAPI {
     ExperimentResults getResults(Experiment experiment, User user)
             throws DotDataException, DotSecurityException;
 
-    List<Experiment> cacheRunningExperiments() throws DotDataException;
-
     /*
      * Ends finalized {@link com.dotcms.experiments.model.Experiment}s
      * <p>

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCache.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCache.java
@@ -48,8 +48,7 @@ public interface ExperimentsCache extends Cachable {
     /**
      * Remove a list of {@link Experiment} from cache identified by the provided name.
      *
-     * @return
      */
-    void removeList();
+    void removeList(final String key);
 
 }

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsCacheImpl.java
@@ -66,10 +66,10 @@ public class ExperimentsCacheImpl implements ExperimentsCache {
      * {@inheritDoc}
      */
     @Override
-    public void removeList() {
+    public void removeList(final String key) {
 
         DotCacheAdministrator cache = CacheLocator.getCacheAdministrator();
-        cache.remove(CACHED_EXPERIMENTS_KEY, getPrimaryGroup());
+        cache.remove(key, getPrimaryGroup());
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotcms/experiments/business/ExperimentsCacheTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/experiments/business/ExperimentsCacheTest.java
@@ -67,7 +67,7 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link ExperimentsCacheImpl#removeList()}
+     * Method to test: {@link ExperimentsCacheImpl#removeList(String)}
      * When: Remove a Experiment from cache
      * Should: get Null when call {@link ExperimentsCacheImpl#getList(String)}
      */
@@ -81,7 +81,7 @@ public class ExperimentsCacheTest extends IntegrationTestBase {
             .putList(ExperimentsCache.CACHED_EXPERIMENTS_KEY, List.of(experiment1, experiment2));
         checkFromCacheNotNull(2);
 
-        CacheLocator.getExperimentsCache().removeList();
+        CacheLocator.getExperimentsCache().removeList(ExperimentsCache.CACHED_EXPERIMENTS_KEY);
         checkFromCacheNull();
     }
 


### PR DESCRIPTION
Right now when we start or stop a Experiment we get the new List of Running Experiment from Database and put it on the cache, we are not removing the old List we just put the new one to override the old one.

The problem is that the put operation is not cluster aware so we need to change the Put Operation by a remove operation in order to make the Running Experiment List Cache cluster aware.

### Proposed Changes
* Not Put a new list on Start/Stop Experiment operation, remove the old one instead

https://github.com/dotCMS/core/pull/28540/files#diff-5aa71567ff53ee229d25c2386cce3169c657f37a3e04cf27b75b3fd029537a7cR768

https://github.com/dotCMS/core/pull/28540/files#diff-5aa71567ff53ee229d25c2386cce3169c657f37a3e04cf27b75b3fd029537a7cR845

* Refactor the removeList method to receive the key of the List that you want to remove

https://github.com/dotCMS/core/pull/28540/files#diff-eb3ee0fc96b84c1ab7bb771cdd2682ce779aaa3d64540440a9825c439dfa4d2fR52

With this change the removeList method match with the putList method now both receive the parameter.

- Change the Test to chack that the Running Experiment List is empty after start or stop an Experiment

[[ with this c](https://github.com/dotCMS/core/pull/28540/files#diff-fad94d09d18233a324e27a58867ff9f9967a3106d0cff91d359fb2327967fbecR377-R394)](https://github.com/dotCMS/core/pull/28540/files#diff-fad94d09d18233a324e27a58867ff9f9967a3106d0cff91d359fb2327967fbecR377-R394)

### Checklist
- [x] Tests
