### PR TITLE
fix(edit-page-2): Experiments had dirty state when navigating to a variant

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/store/dot-ema.store.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/store/dot-ema.store.spec.ts
@@ -452,7 +452,7 @@ describe('EditEmaStore', () => {
                         state: EDITOR_STATE.IDLE,
                         code: undefined,
                         isVTL: false,
-                        changedFromLoading: true
+                        shouldReload: true
                     });
                     done();
                 });
@@ -619,7 +619,8 @@ describe('EditEmaStore', () => {
                                 isLocked: false,
                                 lockedByUser: ''
                             }
-                        }
+                        },
+                        shouldReload: true
                     });
                     done();
                 });
@@ -659,8 +660,10 @@ describe('EditEmaStore', () => {
                                 canLock: true,
                                 isLocked: false,
                                 lockedByUser: ''
-                            }
-                        }
+                            },
+                            variantId: undefined
+                        },
+                        shouldReload: true
                     });
                     expect(spyGetPage).toHaveBeenCalledWith(params);
                     expect(spyWhenReloaded).toHaveBeenCalled();
@@ -1073,7 +1076,7 @@ describe('EditEmaStore', () => {
                         state: EDITOR_STATE.IDLE,
                         code: '<html><body><h1>Hello, World!</h1></body></html>',
                         isVTL: true,
-                        changedFromLoading: true
+                        shouldReload: true
                     });
                     done();
                 });
@@ -1148,7 +1151,8 @@ describe('EditEmaStore', () => {
                                 lockedByUser: ''
                             },
                             variantId: undefined
-                        }
+                        },
+                        shouldReload: true
                     });
                     done();
                 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2735,11 +2735,6 @@ describe('EditEmaEditorComponent', () => {
                         jest.useFakeTimers(); // Mock the timers
                         spectator.detectChanges();
 
-                        // We need to force the editor state to loading for this test
-                        // because first we get the pageapi of "1" person
-                        // and then we get the pageapi of "3" person
-                        store.updateEditorState(EDITOR_STATE.LOADING);
-
                         store.load({
                             url: 'index',
                             language_id: '3',

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -248,7 +248,11 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
                 requestAnimationFrame(() => {
                     const win = this.iframe.nativeElement.contentWindow;
 
-                    if (mode === EDITOR_MODE.EDIT || mode === EDITOR_MODE.INLINE_EDITING) {
+                    if (
+                        mode === EDITOR_MODE.EDIT ||
+                        mode === EDITOR_MODE.EDIT_VARIANT ||
+                        mode === EDITOR_MODE.INLINE_EDITING
+                    ) {
                         this.inlineEditingService.injectInlineEdit(this.iframe);
                         fromEvent(win, 'click').subscribe((e: MouseEvent) => {
                             this.handleInlineEditing(e);
@@ -543,13 +547,14 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
     handleReloadContent() {
         this.store.contentState$
             .pipe(takeUntilDestroyed(this.destroyRef))
-            .subscribe(({ changedFromLoading, code, isVTL }) => {
+            .subscribe(({ shouldReload, code, isVTL }) => {
                 // If we are idle then we are not dragging
+
                 this.resetDragProperties();
 
-                if (!changedFromLoading) {
+                if (!shouldReload) {
                     /** We have some EDITOR_STATE values that we don't want to reload the content
-                     * Only when the state is changed from LOADING to IDLE we need to reload the content
+                     *  Only when we should realod the content we do it
                      */
                     return;
                 }
@@ -559,6 +564,8 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
                 } else {
                     this.reloadIframe();
                 }
+
+                this.store.setShouldReload(false);
             });
     }
 
@@ -803,7 +810,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
      * @param code - The code to be added to the iframe.
      * @memberof EditEmaEditorComponent
      */
-    setIframeContent(code) {
+    setIframeContent(code: string) {
         requestAnimationFrame(() => {
             const doc = this.iframe?.nativeElement.contentDocument;
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
@@ -114,6 +114,7 @@ export interface EditEmaState {
     editorData: EditorData;
     currentExperiment?: DotExperiment;
     dragItem?: EmaDragItem;
+    shouldReload: boolean;
 }
 
 export interface MessageInfo {


### PR DESCRIPTION
### Proposed Changes
* Add new property to the state to indicate a reload in the iframe
* Activate inline editing for variants, which was disabled due to logic error


### Screenshots


https://github.com/dotCMS/core/assets/63567962/7f18d5fe-db0b-402c-8668-f56a4ea35477




