### PR TITLE
chore(content) #28183 : Edit Content: Expose Date and User Information in Content API Response

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/constants/ESMappingConstants.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/constants/ESMappingConstants.java
@@ -54,6 +54,7 @@ public final class ESMappingConstants {
     public static final String SYSTEM_TYPE = "systemType";
 
     public static final String MOD_DATE = "modDate";
+    public static final String CREATION_DATE = "creationDate";
     public static final String OWNER = "owner";
     public static final String MOD_USER = "modUser";
     public static final String LIVE = "live";
@@ -81,6 +82,7 @@ public final class ESMappingConstants {
     public static final String EXPIRE_DATE = "expdate";
     public static final String VERSION_TS = "versionTs";
     public static final String SYS_PUBLISH_DATE = "sysPublishDate";
+    public static final String SYS_PUBLISH_USER = "sysPublishUser";
     public static final String URL_MAP = "urlMap";
     public static final String VANITY_URL = "vanityUrl";
     public static final String CATEGORIES = "categories";

--- a/dotCMS/src/main/java/com/dotcms/graphql/ContentFields.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/ContentFields.java
@@ -90,7 +90,7 @@ public final class ContentFields {
                 GraphQLArgument.newArgument().name("render").defaultValue(false)
                         .type(GraphQLBoolean).build()));
         contentFields.put(PUBLISH_DATE_KEY, new TypeFetcher(GraphQLString, PropertyDataFetcher
-                .fetching((Function<Contentlet, String>) (contentlet) ->
+                .fetching((Function<Contentlet, String>) contentlet ->
                         UtilMethods.isSet(contentlet.getStringProperty("publishDate"))
                                 ? contentlet.getStringProperty("publishDate")
                                 : "")));

--- a/dotCMS/src/main/java/com/dotcms/graphql/ContentFields.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/ContentFields.java
@@ -1,7 +1,26 @@
 package com.dotcms.graphql;
 
+import com.dotcms.graphql.datafetcher.ContentMapDataFetcher;
+import com.dotcms.graphql.datafetcher.FolderFieldDataFetcher;
+import com.dotcms.graphql.datafetcher.LanguageDataFetcher;
+import com.dotcms.graphql.datafetcher.SiteFieldDataFetcher;
+import com.dotcms.graphql.datafetcher.TitleImageFieldDataFetcher;
+import com.dotcms.graphql.datafetcher.UserDataFetcher;
+import com.dotcms.graphql.util.TypeUtil.TypeFetcher;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.util.UtilMethods;
+import graphql.scalars.ExtendedScalars;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLTypeReference;
+import graphql.schema.PropertyDataFetcher;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.BASE_TYPE;
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.CONTENT_TYPE;
+import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.CREATION_DATE;
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.IDENTIFIER;
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.INODE;
 import static com.dotcms.content.elasticsearch.constants.ESMappingConstants.LIVE;
@@ -20,28 +39,13 @@ import static com.dotmarketing.portlets.contentlet.model.Contentlet.HOST_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.LOCKED_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.MOD_USER_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.OWNER_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.PUBLISH_DATE_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.PUBLISH_USER_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.TITLE_IMAGE_KEY;
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLID;
 import static graphql.Scalars.GraphQLInt;
 import static graphql.Scalars.GraphQLString;
-
-import com.dotcms.graphql.datafetcher.ContentMapDataFetcher;
-import com.dotcms.graphql.datafetcher.FolderFieldDataFetcher;
-import com.dotcms.graphql.datafetcher.LanguageDataFetcher;
-import com.dotcms.graphql.datafetcher.SiteFieldDataFetcher;
-import com.dotcms.graphql.datafetcher.TitleImageFieldDataFetcher;
-import com.dotcms.graphql.datafetcher.UserDataFetcher;
-import com.dotcms.graphql.util.TypeUtil.TypeFetcher;
-import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.util.UtilMethods;
-import graphql.scalars.ExtendedScalars;
-import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLTypeReference;
-import graphql.schema.PropertyDataFetcher;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
 
 /**
  * Utility class that defines and returns the available fields for the {@link InterfaceType#CONTENTLET}
@@ -52,6 +56,7 @@ public final class ContentFields {
 
     public static Map<String, TypeFetcher> getContentFields() {
         final Map<String, TypeFetcher> contentFields = new HashMap<>();
+        contentFields.put(CREATION_DATE, new TypeFetcher(GraphQLString));
         contentFields.put(MOD_DATE, new TypeFetcher(GraphQLString));
         contentFields.put(TITLE, new TypeFetcher(GraphQLString));
         contentFields.put(TITLE_IMAGE_KEY, new TypeFetcher(GraphQLTypeReference.typeRef(BINARY.getTypeName()),
@@ -84,6 +89,13 @@ public final class ContentFields {
                 GraphQLArgument.newArgument().name("depth").defaultValue(0).type(GraphQLInt).build(),
                 GraphQLArgument.newArgument().name("render").defaultValue(false)
                         .type(GraphQLBoolean).build()));
+        contentFields.put(PUBLISH_DATE_KEY, new TypeFetcher(GraphQLString, PropertyDataFetcher
+                .fetching((Function<Contentlet, String>) (contentlet) ->
+                        UtilMethods.isSet(contentlet.getStringProperty("publishDate"))
+                                ? contentlet.getStringProperty("publishDate")
+                                : "")));
+        contentFields.put(PUBLISH_USER_KEY, new TypeFetcher(GraphQLTypeReference.typeRef(USER.getTypeName()),
+                new UserDataFetcher()));
         return contentFields;
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -114,9 +114,15 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 	public static final String ARCHIVED_KEY = "archived";
 	public static final String LIVE_KEY = "live";
 	public static final String WORKING_KEY = "working";
+	public static final String CREATION_DATE_KEY = "creationDate";
 	public static final String MOD_DATE_KEY = "modDate";
 	public static final String MOD_USER_KEY = "modUser";
+	public static final String MOD_USER_NAME_KEY = "modUserName";
 	public static final String OWNER_KEY = "owner";
+	public static final String OWNER_NAME_KEY = "ownerName";
+	public static final String PUBLISH_DATE_KEY = "publishDate";
+	public static final String PUBLISH_USER_KEY = "publishUser";
+	public static final String PUBLISH_USER_NAME_KEY = "publishUserName";
 	public static final String HOST_KEY = "host";
 	public static final String FOLDER_KEY = "folder";
 	public static final String SORT_ORDER_KEY = "sortOrder";

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
@@ -20,6 +20,7 @@ import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
 import com.google.common.collect.ImmutableMap;
 import com.liferay.portal.model.User;
 import io.vavr.control.Try;
@@ -182,7 +183,7 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
             contentletProperties.put(OWNER_NAME_KEY, null != owner ? owner.getFullName() : NOT_APPLICABLE);
         }
         final Identifier identifier = toolBox.identifierAPI.find(contentlet.getIdentifier());
-        if (!identifier.getAssetType().equals(IdentifierAPI.IDENT404)) {
+        if (null != identifier && UtilMethods.isSet(identifier.getId()) && !IdentifierAPI.IDENT404.equals(identifier.getAssetType())) {
             contentletProperties.put(CREATION_DATE_KEY, identifier.getCreateDate());
         }
         if (contentlet.isLive()) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
@@ -1,8 +1,43 @@
 package com.dotmarketing.portlets.contentlet.transform.strategy;
 
+import com.dotcms.api.APIProvider;
+import com.dotcms.content.elasticsearch.constants.ESMappingConstants;
+import com.dotcms.contenttype.model.field.BinaryField;
+import com.dotcms.contenttype.model.field.CategoryField;
+import com.dotcms.contenttype.model.field.ConstantField;
+import com.dotcms.contenttype.model.field.Field;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.storage.model.Metadata;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.beans.Identifier;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.IdentifierAPI;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.categories.model.Category;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
+import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.dotmarketing.util.Logger;
+import com.google.common.collect.ImmutableMap;
+import com.liferay.portal.model.User;
+import io.vavr.control.Try;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.ARCHIVED_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.BASE_TYPE_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.CONTENT_TYPE_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.CREATION_DATE_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.HAS_TITLE_IMAGE_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.HOST_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.HOST_NAME;
@@ -11,6 +46,13 @@ import static com.dotmarketing.portlets.contentlet.model.Contentlet.INODE_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.LANGUAGEID_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.LIVE_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.LOCKED_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.MOD_USER_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.MOD_USER_NAME_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.OWNER_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.OWNER_NAME_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.PUBLISH_DATE_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.PUBLISH_USER_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.PUBLISH_USER_NAME_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.TITLE_IMAGE_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.TITLE_IMAGE_NOT_FOUND;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.TITTLE_KEY;
@@ -28,39 +70,6 @@ import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformO
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.USE_ALIAS;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.VERSION_INFO;
 import static com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI.URL_FIELD;
-
-import com.dotcms.api.APIProvider;
-import com.dotcms.content.elasticsearch.constants.ESMappingConstants;
-import com.dotcms.contenttype.model.field.BinaryField;
-import com.dotcms.contenttype.model.field.CategoryField;
-import com.dotcms.contenttype.model.field.ConstantField;
-import com.dotcms.contenttype.model.field.Field;
-import com.dotcms.contenttype.model.type.ContentType;
-import com.dotcms.storage.model.Metadata;
-import com.dotmarketing.beans.Host;
-import com.dotmarketing.beans.Identifier;
-import com.dotmarketing.business.APILocator;
-import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.portlets.categories.model.Category;
-import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
-import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
-import com.dotmarketing.portlets.languagesmanager.model.Language;
-import com.dotmarketing.util.Logger;
-import com.google.common.collect.ImmutableMap;
-import com.liferay.portal.model.User;
-import io.vavr.control.Try;
-import java.io.File;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * If any Options marked as property is found this class gets instantiated since props are most likely to be resolved here
@@ -132,9 +141,9 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
            map.put(TITLE_IMAGE_KEY, TITLE_IMAGE_NOT_FOUND);
         }
 
-        final Host host = toolBox.hostAPI.find(contentlet.getHost(), APILocator.systemUser(), true);
-        map.put(HOST_NAME, host != null ? host.getHostname() : NOT_APPLICABLE);
-        map.put(HOST_KEY, host != null ? host.getIdentifier() : NOT_APPLICABLE);
+        final Host site = toolBox.hostAPI.find(contentlet.getHost(), APILocator.systemUser(), true);
+        map.put(HOST_NAME, site != null ? site.getHostname() : NOT_APPLICABLE);
+        map.put(HOST_KEY, site != null ? site.getIdentifier() : NOT_APPLICABLE);
 
         final String urlMap = toolBox.contentletAPI
                 .getUrlMapForContentlet(contentlet, toolBox.userAPI.getSystemUser(), true);
@@ -149,6 +158,39 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
             if (null != url) {
                 map.put(URL_FIELD, url);
             }
+        }
+        this.addAuditProperties(contentlet, map);
+    }
+
+    /**
+     * Adds all the required audit attributes to the Contentlet's data map.
+     *
+     * @param contentlet           The Contentlet to add the audit properties to.
+     * @param contentletProperties The map of properties to add the audit properties to.
+     *
+     * @throws DotDataException     An error occurred when retrieving data from the database.
+     * @throws DotSecurityException A User permission error has occurred.
+     */
+    private void addAuditProperties(final Contentlet contentlet,
+                                    final Map<String, Object> contentletProperties) throws DotDataException, DotSecurityException {
+        final User modUser = Try.of(() -> toolBox.userAPI.loadUserById(contentlet.getModUser())).getOrNull();
+        final User owner = Try.of(() -> toolBox.userAPI.loadUserById(contentlet.getOwner())).getOrNull();
+        if (contentletProperties.containsKey(MOD_USER_KEY)) {
+            contentletProperties.put(MOD_USER_NAME_KEY, null != modUser ? modUser.getFullName() : NOT_APPLICABLE);
+        }
+        if (contentletProperties.containsKey(OWNER_KEY)) {
+            contentletProperties.put(OWNER_NAME_KEY, null != owner ? owner.getFullName() : NOT_APPLICABLE);
+        }
+        final Identifier identifier = toolBox.identifierAPI.find(contentlet.getIdentifier());
+        if (!identifier.getAssetType().equals(IdentifierAPI.IDENT404)) {
+            contentletProperties.put(CREATION_DATE_KEY, identifier.getCreateDate());
+        }
+        if (contentlet.isLive()) {
+            final Optional<ContentletVersionInfo> versionInfoOpt =
+                    this.toolBox.versionableAPI.getContentletVersionInfo(contentlet.getIdentifier(), contentlet.getLanguageId(), contentlet.getVariantId());
+            versionInfoOpt.ifPresent(contentletVersionInfo -> contentletProperties.put(PUBLISH_DATE_KEY, contentletVersionInfo.getPublishDate()));
+            contentletProperties.put(PUBLISH_USER_KEY, null != modUser ? modUser.getUserId() : NOT_APPLICABLE);
+            contentletProperties.put(PUBLISH_USER_NAME_KEY, null != modUser ? modUser.getFullName() : NOT_APPLICABLE);
         }
     }
 

--- a/dotcms-postman/src/main/resources/postman/ContentResourceV1.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/ContentResourceV1.postman_collection.json
@@ -1,10 +1,211 @@
 {
 	"info": {
-		"_postman_id": "a7037756-a113-4775-888b-9a96d00896bc",
+		"_postman_id": "b266d3ff-f351-46a7-b796-9f793963cedb",
 		"name": "ContentResourceV1",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "5403727"
 	},
 	"item": [
+		{
+			"name": "Checking JSON Attributes",
+			"item": [
+				{
+					"name": "Checking Content Audit Attributes",
+					"item": [
+						{
+							"name": "Creating Test Generic Content",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test content created successfully\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0);",
+											"    var contentId = Object.keys(jsonData.entity.results[0]);",
+											"    pm.collectionVariables.set(\"testContentId\", jsonData.entity.results[0][contentId].identifier);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"webPageContent\",\n            \"title\": \"Test Generic Content\",\n            \"contentHost\": \"default\",\n            \"body\": \"This is my Test Generic Content\"\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieving Test Generic Content",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Checking that audit properties are present\", function () {",
+											"    var entity = pm.response.json().entity;",
+											"    ",
+											"    pm.expect(entity.creationDate).to.not.equal(undefined, \"The 'creationDate' attribute must be present\");",
+											"    pm.expect(entity.owner).to.not.equal(undefined, \"The 'owner' attribute must be present\");",
+											"    pm.expect(entity.ownerName).to.not.equal(undefined, \"The 'ownerName' attribute must be present\");",
+											"    pm.expect(entity.modDate).to.not.equal(undefined, \"The 'modDate' attribute must be present\");",
+											"    pm.expect(entity.modUser).to.not.equal(undefined, \"The 'modUser' attribute must be present\");",
+											"    pm.expect(entity.modUserName).to.not.equal(undefined, \"The 'modUserName' attribute must be present\");",
+											"    pm.expect(entity.publishDate).to.not.equal(undefined, \"The 'publishDate' attribute must be present\");",
+											"    pm.expect(entity.publishUser).to.not.equal(undefined, \"The 'publishUser' attribute must be present\");",
+											"    pm.expect(entity.publishUserName).to.not.equal(undefined, \"The 'publishUserName' attribute must be present\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/{{testContentId}}",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"{{testContentId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									"pm.test(\"HTTP Status code must be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
 		{
 			"name": "Content not exists",
 			"event": [
@@ -1429,42 +1630,26 @@
 			"response": []
 		}
 	],
-	"variable": [
+	"event": [
 		{
-			"key": "contentletIdentifier",
-			"value": ""
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
 		},
 		{
-			"key": "contentletInode",
-			"value": ""
-		},
-		{
-			"key": "fireActionLanguageKey",
-			"value": ""
-		},
-		{
-			"key": "parentId1",
-			"value": ""
-		},
-		{
-			"key": "parentInode1",
-			"value": ""
-		},
-		{
-			"key": "parentId2",
-			"value": ""
-		},
-		{
-			"key": "parentInode2",
-			"value": ""
-		},
-		{
-			"key": "parent1contentlets",
-			"value": ""
-		},
-		{
-			"key": "parent2contentlets",
-			"value": ""
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
 		}
 	]
 }

--- a/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
@@ -1,11 +1,10 @@
 {
 	"info": {
-		"_postman_id": "e7d6d683-f049-4c68-8712-0f2c8513bda8",
+		"_postman_id": "19eae33b-46d1-4607-83d4-d79afe27e8a0",
 		"name": "Content Resource",
 		"description": "Content Resource test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5403727",
-		"_collection_link": "https://cloudy-robot-285072.postman.co/workspace/JCastro-Workspace~5bfa586e-54db-429b-b7d5-c4ff997e3a0d/collection/5403727-e7d6d683-f049-4c68-8712-0f2c8513bda8?action=share&creator=5403727&source=collection_link"
+		"_exporter_id": "5403727"
 	},
 	"item": [
 		{
@@ -65,8 +64,6 @@
 								"header": [
 									{
 										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
 										"value": "application/json"
 									}
 								],
@@ -357,8 +354,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -572,12 +567,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -1628,8 +1621,7 @@
 						"header": [
 							{
 								"key": "Origin",
-								"value": "{{serverURL}}",
-								"type": "text"
+								"value": "{{serverURL}}"
 							}
 						],
 						"body": {
@@ -1782,8 +1774,7 @@
 						"header": [
 							{
 								"key": "Origin",
-								"value": "{{serverURL}}",
-								"type": "text"
+								"value": "{{serverURL}}"
 							}
 						],
 						"body": {
@@ -1867,8 +1858,7 @@
 						"header": [
 							{
 								"key": "Origin",
-								"value": "{{serverURL}}",
-								"type": "text"
+								"value": "{{serverURL}}"
 							}
 						],
 						"body": {
@@ -1952,8 +1942,7 @@
 						"header": [
 							{
 								"key": "Origin",
-								"value": "{{serverURL}}",
-								"type": "text"
+								"value": "{{serverURL}}"
 							}
 						],
 						"body": {
@@ -2050,8 +2039,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -2488,6 +2475,206 @@
 				}
 			],
 			"description": "The Auto-Save feature allows dotCMS to automatically save any changes made to a given Contentlet by the User after X amount of seconds have passed.\n\nThe new Endpoint method created for this: **`/api/v1/_draft`** , works like this:\n\n- If the User is working **on the live version of the current Contentlet** and make changes to it, the draft request will create a working version in order to auto-save any changes.\n- When a second change is made, the draft method will re-use the previously generated Inode and will overwrite it with the new changes.\n- Finally, any incoming changes will keep overwriting the previous working Inode. This way, dotCMS will overwrite one single working Inode instead of creating hundreds if not thousands of \"useless\" records for any change."
+		},
+		{
+			"name": "Checking JSON Attributes",
+			"item": [
+				{
+					"name": "Checking Content Audit Attributes",
+					"item": [
+						{
+							"name": "Creating Test Generic Content",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test content created successfully\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0);",
+											"    var contentId = Object.keys(jsonData.entity.results[0]);",
+											"    pm.collectionVariables.set(\"testContentId\", jsonData.entity.results[0][contentId].identifier);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"webPageContent\",\n            \"title\": \"Test Generic Content\",\n            \"contentHost\": \"default\",\n            \"body\": \"This is my Test Generic Content\"\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieving Test Generic Content",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Checking that audit properties are present\", function () {",
+											"    var entity = pm.response.json().contentlets[0];",
+											"    ",
+											"    pm.expect(entity.creationDate).to.not.equal(undefined, \"The 'creationDate' attribute must be present\");",
+											"    pm.expect(entity.owner).to.not.equal(undefined, \"The 'owner' attribute must be present\");",
+											"    pm.expect(entity.ownerName).to.not.equal(undefined, \"The 'ownerName' attribute must be present\");",
+											"    pm.expect(entity.modDate).to.not.equal(undefined, \"The 'modDate' attribute must be present\");",
+											"    pm.expect(entity.modUser).to.not.equal(undefined, \"The 'modUser' attribute must be present\");",
+											"    pm.expect(entity.modUserName).to.not.equal(undefined, \"The 'modUserName' attribute must be present\");",
+											"    pm.expect(entity.publishDate).to.not.equal(undefined, \"The 'publishDate' attribute must be present\");",
+											"    pm.expect(entity.publishUser).to.not.equal(undefined, \"The 'publishUser' attribute must be present\");",
+											"    pm.expect(entity.publishUserName).to.not.equal(undefined, \"The 'publishUserName' attribute must be present\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/content/id/{{testContentId}}",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"content",
+										"id",
+										"{{testContentId}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									"pm.test(\"HTTP Status code must be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				}
+			]
 		},
 		{
 			"name": "invalidateSession",
@@ -3121,60 +3308,6 @@
 					""
 				]
 			}
-		}
-	],
-	"variable": [
-		{
-			"key": "contentTypeId",
-			"value": ""
-		},
-		{
-			"key": "fieldId",
-			"value": ""
-		},
-		{
-			"key": "contentTypeName",
-			"value": ""
-		},
-		{
-			"key": "identifier22756",
-			"value": ""
-		},
-		{
-			"key": "fileId",
-			"value": ""
-		},
-		{
-			"key": "fileInode",
-			"value": ""
-		},
-		{
-			"key": "fileName",
-			"value": ""
-		},
-		{
-			"key": "originalTitle",
-			"value": ""
-		},
-		{
-			"key": "contentInode",
-			"value": ""
-		},
-		{
-			"key": "contentIdentifier",
-			"value": ""
-		},
-		{
-			"key": "firstAutoSaveTitle",
-			"value": ""
-		},
-		{
-			"key": "secondAutoSaveTitle",
-			"value": ""
-		},
-		{
-			"key": "thirdAutoSaveTitle",
-			"value": ""
 		}
 	]
 }

--- a/dotcms-postman/src/main/resources/postman/GraphQLTests.json
+++ b/dotcms-postman/src/main/resources/postman/GraphQLTests.json
@@ -5231,7 +5231,7 @@
 									"    pm.expect(imageFieldJson.fileAsset.mime).to.eql(\"image/jpeg\");",
 									"    ",
 									"    // metaData",
-									"    pm.expect(imageFieldJson.metaData.length).to.eql(12);",
+									"    pm.expect(imageFieldJson.metaData.length).to.eql(13);",
 									"    pm.expect(hasProperty(imageFieldJson.metaData, \"fileSize\", \"5494\"), 'FAILED:[fileSize]').to.be.true;",
 									"    pm.expect(hasProperty(imageFieldJson.metaData, \"length\", \"5494\"), 'FAILED:[length]').to.be.true;",
 									"    pm.expect(hasProperty(imageFieldJson.metaData, \"width\", \"139\"), 'FAILED:[width]').to.be.true;",
@@ -5241,6 +5241,9 @@
 									"    pm.expect(hasProperty(imageFieldJson.metaData, \"sha256\", \"d6b09b7a7d42e6a84e455e7257faf32c4351aa9bb491ceb939f7f3443c2150ae\"), 'FAILED:[sha256]').to.be.true;",
 									"    pm.expect(hasProperty(imageFieldJson.metaData, \"title\", \"tommylee18005.jpeg\"), 'FAILED:[title]').to.be.true;",
 									"    pm.expect(hasProperty(imageFieldJson.metaData, \"isImage\", \"true\"), 'FAILED:[isImage]').to.be.true;",
+									"    pm.expect(hasProperty(imageFieldJson.metaData, \"editableAsText\", \"false\"), 'FAILED:[editableAsText]').to.be.true;",
+									"    pm.expect(hasProperty(imageFieldJson.metaData, \"name\", \"tommylee18005.jpeg\"), 'FAILED:[name]').to.be.true;",
+									"    pm.expect(imageFieldJson.metaData.version).to.be.not.null;",
 									"    pm.expect(imageFieldJson.metaData.modDate).to.be.not.null;    ",
 									"});",
 									"",
@@ -5287,7 +5290,8 @@
 									"}",
 									""
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],

--- a/dotcms-postman/src/main/resources/postman/GraphQLTests.json
+++ b/dotcms-postman/src/main/resources/postman/GraphQLTests.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "611b379f-e7c5-4732-8b92-2d34993515d4",
+		"_postman_id": "7d417544-c1a3-4b9c-a227-0869ee7c27df",
 		"name": "GraphQL",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "5403727"
@@ -256,411 +256,1159 @@
 			"name": "Page API",
 			"item": [
 				{
-					"name": "pre_ImportBundleWithContext",
-					"event": [
+					"name": "Init And Test Data Import",
+					"item": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Bundle uploaded sucessfully\", function () {",
-									"    pm.response.to.have.status(200);",
-									"",
-									"    var jsonData = pm.response.json();",
-									"    console.log(jsonData);",
-									"",
-									"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"assets.tar.gz\");",
-									"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
+							"name": "pre_ImportBundleWithContext",
+							"event": [
 								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Bundle uploaded sucessfully\", function () {",
+											"    pm.response.to.have.status(200);",
+											"",
+											"    var jsonData = pm.response.json();",
+											"    console.log(jsonData);",
+											"",
+											"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"assets.tar.gz\");",
+											"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										}
+									]
 								},
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/octet-stream"
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/octet-stream"
+									},
+									{
+										"key": "Content-Disposition",
+										"value": "attachment"
+									}
+								],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "resources/GraphQL/assets.tar.gz"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/bundle?sync=true",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"bundle"
+									],
+									"query": [
+										{
+											"key": "sync",
+											"value": "true"
+										},
+										{
+											"key": "AUTH_TOKEN",
+											"value": "",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Imports a Bundle that includes:\n* A piece of content with a tag field without any tags selected"
 							},
-							{
-								"key": "Content-Disposition",
-								"type": "text",
-								"value": "attachment"
-							}
-						],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "file",
-									"type": "file",
-									"src": "resources/GraphQL/assets.tar.gz"
-								}
-							]
+							"response": []
 						},
-						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"bundle",
-								"sync"
-							],
-							"query": [
+						{
+							"name": "pre_ImportBundleWithPersonas",
+							"event": [
 								{
-									"key": "AUTH_TOKEN",
-									"value": "",
-									"disabled": true
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Bundle uploaded sucessfully\", function () {",
+											"    pm.response.to.have.status(200);",
+											"",
+											"    var jsonData = pm.response.json();",
+											"    console.log(jsonData);",
+											"",
+											"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"personas.tar.gz\");",
+											"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
 								}
-							]
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/octet-stream"
+									},
+									{
+										"key": "Content-Disposition",
+										"value": "attachment"
+									}
+								],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "resources/GraphQL/personas.tar.gz"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/bundle?sync=true",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"bundle"
+									],
+									"query": [
+										{
+											"key": "sync",
+											"value": "true"
+										},
+										{
+											"key": "AUTH_TOKEN",
+											"value": "",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Imports a Bundle that includes:\n* Imports personas"
+							},
+							"response": []
 						},
-						"description": "Imports a Bundle that includes:\n* A piece of content with a tag field without any tags selected"
-					},
-					"response": []
+						{
+							"name": "pre_ImportBundleWithDemoHost",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Bundle uploaded sucessfully\", function () {",
+											"    pm.response.to.have.status(200);",
+											"",
+											"    var jsonData = pm.response.json();",
+											"    console.log(jsonData);",
+											"",
+											"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"demo.dotcms.com.tar.gz\");",
+											"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/octet-stream"
+									},
+									{
+										"key": "Content-Disposition",
+										"value": "attachment"
+									}
+								],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "resources/GraphQL/demo.dotcms.com.tar.gz"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/bundle?sync=true",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"bundle"
+									],
+									"query": [
+										{
+											"key": "sync",
+											"value": "true"
+										},
+										{
+											"key": "AUTH_TOKEN",
+											"value": "",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Imports a Bundle that includes:\n* Imports demo.dotcms.com"
+							},
+							"response": []
+						},
+						{
+							"name": "pre_ImportBundleWithTestPage",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Bundle uploaded sucessfully\", function () {",
+											"    pm.response.to.have.status(200);",
+											"",
+											"    var jsonData = pm.response.json();",
+											"    console.log(jsonData);",
+											"",
+											"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"test-page-graphql-render.tar.gz\");",
+											"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/octet-stream"
+									},
+									{
+										"key": "Content-Disposition",
+										"value": "attachment"
+									}
+								],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "resources/GraphQL/test-page-graphql-render.tar.gz"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/bundle?sync=true",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"bundle"
+									],
+									"query": [
+										{
+											"key": "sync",
+											"value": "true"
+										},
+										{
+											"key": "AUTH_TOKEN",
+											"value": "",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Imports a Bundle that includes:\n\n*   pp-test page with all the dependencies. pp-test page was created on a demo.dotcms.com site"
+							},
+							"response": []
+						},
+						{
+							"name": "Switch site to 'demo.dotcms.com'",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200 \", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"",
+											"",
+											"pm.test(\"Valid response\", function () {",
+											"    var jsonData = pm.response.json();",
+											"",
+											"    pm.expect(jsonData.entity.hostSwitched).equal(true);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "saveHelperData",
+											"type": "any"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/site/switch/48190c8c-42c4-46af-8d1a-0cd5db894797",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"site",
+										"switch",
+										"48190c8c-42c4-46af-8d1a-0cd5db894797"
+									]
+								}
+							},
+							"response": []
+						}
+					]
 				},
 				{
-					"name": "pre_ImportBundleWithPersonas",
-					"event": [
+					"name": "Checking Content Audit Attributes",
+					"item": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Bundle uploaded sucessfully\", function () {",
-									"    pm.response.to.have.status(200);",
-									"",
-									"    var jsonData = pm.response.json();",
-									"    console.log(jsonData);",
-									"",
-									"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"personas.tar.gz\");",
-									"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
+							"name": "Page API",
+							"item": [
+								{
+									"name": "Retrieving HTML Page Data",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Checking that audit properties are present\", function () {",
+													"    var entity = pm.response.json().data.page;",
+													"    pm.expect(entity.creationDate).to.not.equal(undefined, \"The 'creationDate' attribute must be present\");",
+													"    pm.expect(entity.owner).to.not.equal(undefined, \"The 'owner' attribute must be present\");",
+													"    pm.expect(entity.owner.firstName).to.not.equal(undefined, \"The 'owner.firstName' attribute must be present\");",
+													"    pm.expect(entity.owner.lastName).to.not.equal(undefined, \"The 'owner.lastName' attribute must be present\");",
+													"    pm.expect(entity.modDate).to.not.equal(undefined, \"The 'modDate' attribute must be present\");",
+													"    pm.expect(entity.modUser).to.not.equal(undefined, \"The 'modUser' attribute must be present\");",
+													"    pm.expect(entity.modUser.firstName).to.not.equal(undefined, \"The 'modUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.modUser.lastName).to.not.equal(undefined, \"The 'modUser.lastName' attribute must be present\");",
+													"    pm.expect(entity.publishDate).to.not.equal(undefined, \"The 'publishDate' attribute must be present\");",
+													"    pm.expect(entity.publishUser).to.not.equal(undefined, \"The 'publishUser' attribute must be present\");",
+													"    pm.expect(entity.publishUser.firstName).to.not.equal(undefined, \"The 'publishUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.publishUser.lastName).to.not.equal(undefined, \"The 'publishUser.lastName' attribute must be present\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "basic",
+											"basic": [
+												{
+													"key": "password",
+													"value": "admin",
+													"type": "string"
+												},
+												{
+													"key": "username",
+													"value": "admin@dotcms.com",
+													"type": "string"
+												},
+												{
+													"key": "saveHelperData",
+													"type": "any"
+												},
+												{
+													"key": "showPassword",
+													"value": false,
+													"type": "boolean"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query PageAPI {\n  page(url: \"/pp-test\") {\n    title\n    creationDate\n    owner {\n      firstName\n      lastName\n      userId\n      email\n    }\n    modDate\n    modUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n    publishDate\n    publishUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n  }\n}",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/graphql",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"graphql"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Page Render",
+							"item": [
+								{
+									"name": "Retrieving HTML Page Data",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Checking that audit properties are present\", function () {",
+													"    var entity = pm.response.json().data.page;",
+													"    pm.expect(entity.creationDate).to.not.equal(undefined, \"The 'creationDate' attribute must be present\");",
+													"    pm.expect(entity.owner).to.not.equal(undefined, \"The 'owner' attribute must be present\");",
+													"    pm.expect(entity.owner.firstName).to.not.equal(undefined, \"The 'owner.firstName' attribute must be present\");",
+													"    pm.expect(entity.owner.lastName).to.not.equal(undefined, \"The 'owner.lastName' attribute must be present\");",
+													"    pm.expect(entity.modDate).to.not.equal(undefined, \"The 'modDate' attribute must be present\");",
+													"    pm.expect(entity.modUser).to.not.equal(undefined, \"The 'modUser' attribute must be present\");",
+													"    pm.expect(entity.modUser.firstName).to.not.equal(undefined, \"The 'modUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.modUser.lastName).to.not.equal(undefined, \"The 'modUser.lastName' attribute must be present\");",
+													"    pm.expect(entity.publishDate).to.not.equal(undefined, \"The 'publishDate' attribute must be present\");",
+													"    pm.expect(entity.publishUser).to.not.equal(undefined, \"The 'publishUser' attribute must be present\");",
+													"    pm.expect(entity.publishUser.firstName).to.not.equal(undefined, \"The 'publishUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.publishUser.lastName).to.not.equal(undefined, \"The 'publishUser.lastName' attribute must be present\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "basic",
+											"basic": [
+												{
+													"key": "password",
+													"value": "admin",
+													"type": "string"
+												},
+												{
+													"key": "username",
+													"value": "admin@dotcms.com",
+													"type": "string"
+												},
+												{
+													"key": "saveHelperData",
+													"type": "any"
+												},
+												{
+													"key": "showPassword",
+													"value": false,
+													"type": "boolean"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query PageRender {\n  page(url: \"/pp-test\") {\n    title\n    creationDate\n    owner {\n      firstName\n      lastName\n      userId\n      email\n    }\n    modDate\n    modUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n    publishDate\n    publishUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n  }\n}",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/graphql",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"graphql"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Container Rendered",
+							"item": [
+								{
+									"name": "Retrieving Test Generic Content Data",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Checking that audit properties are present\", function () {",
+													"    var entity = pm.response.json().data.page;",
+													"    pm.expect(entity.creationDate).to.not.equal(undefined, \"The 'creationDate' attribute must be present\");",
+													"    pm.expect(entity.owner).to.not.equal(undefined, \"The 'owner' attribute must be present\");",
+													"    pm.expect(entity.owner.firstName).to.not.equal(undefined, \"The 'owner.firstName' attribute must be present\");",
+													"    pm.expect(entity.owner.lastName).to.not.equal(undefined, \"The 'owner.lastName' attribute must be present\");",
+													"    pm.expect(entity.modDate).to.not.equal(undefined, \"The 'modDate' attribute must be present\");",
+													"    pm.expect(entity.modUser).to.not.equal(undefined, \"The 'modUser' attribute must be present\");",
+													"    pm.expect(entity.modUser.firstName).to.not.equal(undefined, \"The 'modUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.modUser.lastName).to.not.equal(undefined, \"The 'modUser.lastName' attribute must be present\");",
+													"    pm.expect(entity.publishDate).to.not.equal(undefined, \"The 'publishDate' attribute must be present\");",
+													"    pm.expect(entity.publishUser).to.not.equal(undefined, \"The 'publishUser' attribute must be present\");",
+													"    pm.expect(entity.publishUser.firstName).to.not.equal(undefined, \"The 'publishUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.publishUser.lastName).to.not.equal(undefined, \"The 'publishUser.lastName' attribute must be present\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "basic",
+											"basic": [
+												{
+													"key": "password",
+													"value": "admin",
+													"type": "string"
+												},
+												{
+													"key": "username",
+													"value": "admin@dotcms.com",
+													"type": "string"
+												},
+												{
+													"key": "saveHelperData",
+													"type": "any"
+												},
+												{
+													"key": "showPassword",
+													"value": false,
+													"type": "boolean"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query PageRender {\n  page(url: \"/pp-test\") {\n    title\n    creationDate\n    owner {\n      firstName\n      lastName\n      userId\n      email\n    }\n    modDate\n    modUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n    publishDate\n    publishUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n  }\n}",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/graphql",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"graphql"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Retrieving HTML Page Data",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Checking that audit properties are present\", function () {",
+													"    var entity = pm.response.json().data.page;",
+													"    pm.expect(entity.creationDate).to.not.equal(undefined, \"The 'creationDate' attribute must be present\");",
+													"    pm.expect(entity.owner).to.not.equal(undefined, \"The 'owner' attribute must be present\");",
+													"    pm.expect(entity.owner.firstName).to.not.equal(undefined, \"The 'owner.firstName' attribute must be present\");",
+													"    pm.expect(entity.owner.lastName).to.not.equal(undefined, \"The 'owner.lastName' attribute must be present\");",
+													"    pm.expect(entity.modDate).to.not.equal(undefined, \"The 'modDate' attribute must be present\");",
+													"    pm.expect(entity.modUser).to.not.equal(undefined, \"The 'modUser' attribute must be present\");",
+													"    pm.expect(entity.modUser.firstName).to.not.equal(undefined, \"The 'modUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.modUser.lastName).to.not.equal(undefined, \"The 'modUser.lastName' attribute must be present\");",
+													"    pm.expect(entity.publishDate).to.not.equal(undefined, \"The 'publishDate' attribute must be present\");",
+													"    pm.expect(entity.publishUser).to.not.equal(undefined, \"The 'publishUser' attribute must be present\");",
+													"    pm.expect(entity.publishUser.firstName).to.not.equal(undefined, \"The 'publishUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.publishUser.lastName).to.not.equal(undefined, \"The 'publishUser.lastName' attribute must be present\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "basic",
+											"basic": [
+												{
+													"key": "password",
+													"value": "admin",
+													"type": "string"
+												},
+												{
+													"key": "username",
+													"value": "admin@dotcms.com",
+													"type": "string"
+												},
+												{
+													"key": "saveHelperData",
+													"type": "any"
+												},
+												{
+													"key": "showPassword",
+													"value": false,
+													"type": "boolean"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query PageRender {\n  page(url: \"/pp-test\") {\n    title\n    creationDate\n    owner {\n      firstName\n      lastName\n      userId\n      email\n    }\n    modDate\n    modUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n    publishDate\n    publishUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n  }\n}",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/graphql",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"graphql"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Content API",
+							"item": [
+								{
+									"name": "Creating Test Generic Content",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test content created successfully\", function () {",
+													"    var jsonData = pm.response.json();",
+													"    pm.expect(jsonData.errors.length).to.eql(0);",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "basic",
+											"basic": [
+												{
+													"key": "password",
+													"value": "admin",
+													"type": "string"
+												},
+												{
+													"key": "username",
+													"value": "admin@dotcms.com",
+													"type": "string"
+												},
+												{
+													"key": "saveHelperData",
+													"type": "any"
+												},
+												{
+													"key": "showPassword",
+													"value": false,
+													"type": "boolean"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"webPageContent\",\n            \"title\": \"Test Generic Content for GraphQL Tests\",\n            \"contentHost\": \"demo.dotcms.com\",\n            \"body\": \"This is my Test Generic Content for GraphQL Tests\"\n        }\n    ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"workflow",
+												"actions",
+												"default",
+												"fire",
+												"PUBLISH"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Retrieving Test Generic Content Data",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Checking that audit properties are present\", function () {",
+													"    var entity = pm.response.json().data.webPageContentCollection[0];",
+													"    pm.expect(entity.creationDate).to.not.equal(undefined, \"The 'creationDate' attribute must be present\");",
+													"    pm.expect(entity.owner).to.not.equal(undefined, \"The 'owner' attribute must be present\");",
+													"    pm.expect(entity.owner.firstName).to.not.equal(undefined, \"The 'owner.firstName' attribute must be present\");",
+													"    pm.expect(entity.owner.lastName).to.not.equal(undefined, \"The 'owner.lastName' attribute must be present\");",
+													"    pm.expect(entity.modDate).to.not.equal(undefined, \"The 'modDate' attribute must be present\");",
+													"    pm.expect(entity.modUser).to.not.equal(undefined, \"The 'modUser' attribute must be present\");",
+													"    pm.expect(entity.modUser.firstName).to.not.equal(undefined, \"The 'modUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.modUser.lastName).to.not.equal(undefined, \"The 'modUser.lastName' attribute must be present\");",
+													"    pm.expect(entity.publishDate).to.not.equal(undefined, \"The 'publishDate' attribute must be present\");",
+													"    pm.expect(entity.publishUser).to.not.equal(undefined, \"The 'publishUser' attribute must be present\");",
+													"    pm.expect(entity.publishUser.firstName).to.not.equal(undefined, \"The 'publishUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.publishUser.lastName).to.not.equal(undefined, \"The 'publishUser.lastName' attribute must be present\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "basic",
+											"basic": [
+												{
+													"key": "password",
+													"value": "admin",
+													"type": "string"
+												},
+												{
+													"key": "username",
+													"value": "admin@dotcms.com",
+													"type": "string"
+												},
+												{
+													"key": "saveHelperData",
+													"type": "any"
+												},
+												{
+													"key": "showPassword",
+													"value": false,
+													"type": "boolean"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query ContentAPI {\n  webPageContentCollection(\n    query: \"+title:Test Generic Content for GraphQL Tests\"\n    limit: 10\n    offset: 0\n    sortBy: \"score\"\n  ) {\n    title\n    creationDate\n    owner {\n      firstName\n      lastName\n      userId\n      email\n    }\n    modDate\n    modUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n    publishDate\n    publishUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n  }\n}\n",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/graphql",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"graphql"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Search",
+							"item": [
+								{
+									"name": "Creating Test Generic Content",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test content created successfully\", function () {",
+													"    var jsonData = pm.response.json();",
+													"    pm.expect(jsonData.errors.length).to.eql(0);",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "basic",
+											"basic": [
+												{
+													"key": "password",
+													"value": "admin",
+													"type": "string"
+												},
+												{
+													"key": "username",
+													"value": "admin@dotcms.com",
+													"type": "string"
+												},
+												{
+													"key": "saveHelperData",
+													"type": "any"
+												},
+												{
+													"key": "showPassword",
+													"value": false,
+													"type": "boolean"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"webPageContent\",\n            \"title\": \"Test Generic Content for GraphQL Tests 2\",\n            \"contentHost\": \"demo.dotcms.com\",\n            \"body\": \"This is my Test Generic Content for GraphQL Tests 2\"\n        }\n    ]\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"workflow",
+												"actions",
+												"default",
+												"fire",
+												"PUBLISH"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Retrieving Test Generic Content Data",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Checking that audit properties are present\", function () {",
+													"    var entity = pm.response.json().data.search[0];",
+													"    pm.expect(entity.creationDate).to.not.equal(undefined, \"The 'creationDate' attribute must be present\");",
+													"    pm.expect(entity.owner).to.not.equal(undefined, \"The 'owner' attribute must be present\");",
+													"    pm.expect(entity.owner.firstName).to.not.equal(undefined, \"The 'owner.firstName' attribute must be present\");",
+													"    pm.expect(entity.owner.lastName).to.not.equal(undefined, \"The 'owner.lastName' attribute must be present\");",
+													"    pm.expect(entity.modDate).to.not.equal(undefined, \"The 'modDate' attribute must be present\");",
+													"    pm.expect(entity.modUser).to.not.equal(undefined, \"The 'modUser' attribute must be present\");",
+													"    pm.expect(entity.modUser.firstName).to.not.equal(undefined, \"The 'modUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.modUser.lastName).to.not.equal(undefined, \"The 'modUser.lastName' attribute must be present\");",
+													"    pm.expect(entity.publishDate).to.not.equal(undefined, \"The 'publishDate' attribute must be present\");",
+													"    pm.expect(entity.publishUser).to.not.equal(undefined, \"The 'publishUser' attribute must be present\");",
+													"    pm.expect(entity.publishUser.firstName).to.not.equal(undefined, \"The 'publishUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.publishUser.lastName).to.not.equal(undefined, \"The 'publishUser.lastName' attribute must be present\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "basic",
+											"basic": [
+												{
+													"key": "password",
+													"value": "admin",
+													"type": "string"
+												},
+												{
+													"key": "username",
+													"value": "admin@dotcms.com",
+													"type": "string"
+												},
+												{
+													"key": "saveHelperData",
+													"type": "any"
+												},
+												{
+													"key": "showPassword",
+													"value": false,
+													"type": "boolean"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "{\n  search(query: \"+contentType:webPageContent +title:Test Generic Content for GraphQL Tests\", limit: 10) {\n    title\n    creationDate\n    modDate\n    modUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n    owner {\n      firstName\n      lastName\n      userId\n      email\n    }\n    publishDate\n    publishUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n  }\n}\n",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/graphql",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"graphql"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Relationship Query",
+							"item": [
+								{
+									"name": "Retrieving Related Content Data",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Checking that audit properties are present\", function () {",
+													"    var entity = pm.response.json().data.destinationCollection[0];",
+													"    pm.expect(entity.creationDate).to.not.equal(undefined, \"The 'creationDate' attribute must be present\");",
+													"    pm.expect(entity.owner).to.not.equal(undefined, \"The 'owner' attribute must be present\");",
+													"    pm.expect(entity.owner.firstName).to.not.equal(undefined, \"The 'owner.firstName' attribute must be present\");",
+													"    pm.expect(entity.owner.lastName).to.not.equal(undefined, \"The 'owner.lastName' attribute must be present\");",
+													"    pm.expect(entity.modDate).to.not.equal(undefined, \"The 'modDate' attribute must be present\");",
+													"    pm.expect(entity.modUser).to.not.equal(undefined, \"The 'modUser' attribute must be present\");",
+													"    pm.expect(entity.modUser.firstName).to.not.equal(undefined, \"The 'modUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.modUser.lastName).to.not.equal(undefined, \"The 'modUser.lastName' attribute must be present\");",
+													"    pm.expect(entity.publishDate).to.not.equal(undefined, \"The 'publishDate' attribute must be present\");",
+													"    pm.expect(entity.publishUser).to.not.equal(undefined, \"The 'publishUser' attribute must be present\");",
+													"    pm.expect(entity.publishUser.firstName).to.not.equal(undefined, \"The 'publishUser.firstName' attribute must be present\");",
+													"    pm.expect(entity.publishUser.lastName).to.not.equal(undefined, \"The 'publishUser.lastName' attribute must be present\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "basic",
+											"basic": [
+												{
+													"key": "password",
+													"value": "admin",
+													"type": "string"
+												},
+												{
+													"key": "username",
+													"value": "admin@dotcms.com",
+													"type": "string"
+												},
+												{
+													"key": "saveHelperData",
+													"type": "any"
+												},
+												{
+													"key": "showPassword",
+													"value": false,
+													"type": "boolean"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query relationshipQuery {\n  destinationCollection(\n    limit: 10,\n    offset: 0,\n    sortBy: \"score\"\n  ){\n    title\n    creationDate\n    modDate\n    modUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n    owner {\n      firstName\n      lastName\n      userId\n      email\n    }\n    publishDate\n    publishUser {\n      firstName\n      lastName\n      userId\n      email\n    }\n    activities{\n      title\n      urlTitle\n      image{\n         idPath\n      }\n    }\n  } \n}",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/graphql",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"graphql"
+											]
+										}
+									},
+									"response": []
+								}
+							]
 						}
 					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/octet-stream"
-							},
-							{
-								"key": "Content-Disposition",
-								"type": "text",
-								"value": "attachment"
-							}
-						],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "file",
-									"type": "file",
-									"src": "resources/GraphQL/personas.tar.gz"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"bundle",
-								"sync"
-							],
-							"query": [
-								{
-									"key": "AUTH_TOKEN",
-									"value": "",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Imports a Bundle that includes:\n* Imports personas"
-					},
-					"response": []
-				},
-				{
-					"name": "pre_ImportBundleWithDemoHost",
 					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
 						{
 							"listen": "test",
 							"script": {
+								"type": "text/javascript",
+								"packages": {},
 								"exec": [
-									"pm.test(\"Bundle uploaded sucessfully\", function () {",
-									"    pm.response.to.have.status(200);",
-									"",
-									"    var jsonData = pm.response.json();",
-									"    console.log(jsonData);",
-									"",
-									"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"demo.dotcms.com.tar.gz\");",
-									"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/octet-stream"
-							},
-							{
-								"key": "Content-Disposition",
-								"type": "text",
-								"value": "attachment"
-							}
-						],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "file",
-									"type": "file",
-									"src": "resources/GraphQL/demo.dotcms.com.tar.gz"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"bundle",
-								"sync"
-							],
-							"query": [
-								{
-									"key": "AUTH_TOKEN",
-									"value": "",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Imports a Bundle that includes:\n* Imports demo.dotcms.com"
-					},
-					"response": []
-				},
-				{
-					"name": "pre_ImportBundleWithTestPage",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Bundle uploaded sucessfully\", function () {",
-									"    pm.response.to.have.status(200);",
-									"",
-									"    var jsonData = pm.response.json();",
-									"    console.log(jsonData);",
-									"",
-									"    pm.expect(jsonData[\"bundleName\"]).to.eql(\"test-page-graphql-render.tar.gz\");",
-									"    pm.expect(jsonData[\"status\"]).to.eql(\"SUCCESS\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/octet-stream"
-							},
-							{
-								"key": "Content-Disposition",
-								"type": "text",
-								"value": "attachment"
-							}
-						],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "file",
-									"type": "file",
-									"src": "resources/GraphQL/test-page-graphql-render.tar.gz"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"bundle",
-								"sync"
-							],
-							"query": [
-								{
-									"key": "sync",
-									"value": "true"
-								},
-								{
-									"key": "AUTH_TOKEN",
-									"value": "",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Imports a Bundle that includes:\n\n*   pp-test page with all the dependencies. pp-test page was created on a demo.dotcms.com site"
-					},
-					"response": []
-				},
-				{
-					"name": "Switch site to 'demo.dotcms.com'",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200 \", function () {",
+									"pm.test(\"HTTP Status code must be 200\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
-									"",
-									"",
-									"",
-									"pm.test(\"Valid response\", function () {",
-									"    var jsonData = pm.response.json();",
-									"",
-									"    pm.expect(jsonData.entity.hostSwitched).equal(true);",
-									"});"
-								],
-								"type": "text/javascript"
+									""
+								]
 							}
 						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								},
-								{
-									"key": "saveHelperData",
-									"type": "any"
-								},
-								{
-									"key": "showPassword",
-									"value": false,
-									"type": "boolean"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/site/switch/48190c8c-42c4-46af-8d1a-0cd5db894797",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"site",
-								"switch",
-								"48190c8c-42c4-46af-8d1a-0cd5db894797"
-							]
-						}
-					},
-					"response": []
+					]
 				},
 				{
 					"name": "RenderDestinationsCostaRicaPage",
@@ -774,8 +1522,7 @@
 						"header": [
 							{
 								"key": "User-Agent",
-								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36",
-								"type": "text"
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
 						"url": {
@@ -903,8 +1650,7 @@
 						"header": [
 							{
 								"key": "User-Agent",
-								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36",
-								"type": "text"
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
 						"body": {
@@ -1008,8 +1754,7 @@
 						"header": [
 							{
 								"key": "User-Agent",
-								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36",
-								"type": "text"
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
 						"body": {
@@ -1120,8 +1865,7 @@
 						"header": [
 							{
 								"key": "User-Agent",
-								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36",
-								"type": "text"
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
 						"body": {
@@ -1276,13 +2020,11 @@
 							{
 								"key": "Cookie",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
-								"type": "text",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36",
-								"type": "text"
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
 						"body": {
@@ -1360,13 +2102,11 @@
 							{
 								"key": "Cookie",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
-								"type": "text",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36",
-								"type": "text"
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
 						"body": {
@@ -1431,12 +2171,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -1451,16 +2189,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -1538,13 +2279,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -1610,12 +2349,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -1630,16 +2367,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -1745,13 +2485,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -1866,13 +2604,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -1941,13 +2677,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -2062,13 +2796,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -2176,13 +2908,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -2296,13 +3026,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -2371,12 +3099,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -2391,16 +3117,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -2527,13 +3256,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -2599,12 +3326,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -2619,16 +3344,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -2689,13 +3417,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -2771,13 +3497,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -2844,12 +3568,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -2864,16 +3586,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -2936,13 +3661,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -3014,12 +3737,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -3034,16 +3755,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -3096,12 +3820,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -3116,16 +3838,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -3178,12 +3903,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -3198,16 +3921,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -3260,12 +3986,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -3280,16 +4004,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -3342,12 +4069,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -3362,16 +4087,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -3424,12 +4152,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -3444,16 +4170,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -3506,12 +4235,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -3526,16 +4253,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -3961,8 +4691,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -4023,8 +4751,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -4065,9 +4791,7 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"value": "application/json",
-								"type": "text"
+								"value": "application/json"
 							}
 						],
 						"body": {
@@ -4202,8 +4926,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -4268,8 +4990,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -4317,8 +5037,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -4391,8 +5109,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -4456,8 +5172,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -4517,7 +5231,7 @@
 									"    pm.expect(imageFieldJson.fileAsset.mime).to.eql(\"image/jpeg\");",
 									"    ",
 									"    // metaData",
-									"    pm.expect(imageFieldJson.metaData.length).to.eql(13, \"Returned Metadata attributes is \" + imageFieldJson.metaData.length);",
+									"    pm.expect(imageFieldJson.metaData.length).to.eql(12);",
 									"    pm.expect(hasProperty(imageFieldJson.metaData, \"fileSize\", \"5494\"), 'FAILED:[fileSize]').to.be.true;",
 									"    pm.expect(hasProperty(imageFieldJson.metaData, \"length\", \"5494\"), 'FAILED:[length]').to.be.true;",
 									"    pm.expect(hasProperty(imageFieldJson.metaData, \"width\", \"139\"), 'FAILED:[width]').to.be.true;",
@@ -4642,12 +5356,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -4662,16 +5374,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -4840,8 +5555,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -4902,8 +5615,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -4960,8 +5671,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -5002,8 +5711,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -5060,8 +5767,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -5201,8 +5906,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -5309,12 +6012,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -5329,16 +6030,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -5391,12 +6095,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -5411,16 +6113,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -5532,12 +6237,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -5552,16 +6255,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -5672,8 +6378,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -5818,12 +6522,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -5838,16 +6540,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -5958,12 +6663,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -5978,16 +6681,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -6099,12 +6805,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -6119,16 +6823,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -6456,13 +7163,11 @@
 						"header": [
 							{
 								"key": "Cookie",
-								"type": "text",
 								"value": "JSESSIONID=1DF38761AD8B360EF1AD42C4AF07EC35",
 								"disabled": true
 							},
 							{
 								"key": "User-Agent",
-								"type": "text",
 								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36"
 							}
 						],
@@ -6537,12 +7242,10 @@
 								"header": [
 									{
 										"key": "Content-Type",
-										"type": "text",
 										"value": "application/octet-stream"
 									},
 									{
 										"key": "Content-Disposition",
-										"type": "text",
 										"value": "attachment"
 									}
 								],
@@ -6557,16 +7260,19 @@
 									]
 								},
 								"url": {
-									"raw": "{{serverURL}}/api/bundle/sync",
+									"raw": "{{serverURL}}/api/bundle?sync=true",
 									"host": [
 										"{{serverURL}}"
 									],
 									"path": [
 										"api",
-										"bundle",
-										"sync"
+										"bundle"
 									],
 									"query": [
+										{
+											"key": "sync",
+											"value": "true"
+										},
 										{
 											"key": "AUTH_TOKEN",
 											"value": "",
@@ -6679,12 +7385,10 @@
 								"header": [
 									{
 										"key": "Content-Type",
-										"type": "text",
 										"value": "application/octet-stream"
 									},
 									{
 										"key": "Content-Disposition",
-										"type": "text",
 										"value": "attachment"
 									}
 								],
@@ -6699,16 +7403,19 @@
 									]
 								},
 								"url": {
-									"raw": "{{serverURL}}/api/bundle/sync",
+									"raw": "{{serverURL}}/api/bundle?sync=true",
 									"host": [
 										"{{serverURL}}"
 									],
 									"path": [
 										"api",
-										"bundle",
-										"sync"
+										"bundle"
 									],
 									"query": [
+										{
+											"key": "sync",
+											"value": "true"
+										},
 										{
 											"key": "AUTH_TOKEN",
 											"value": "",
@@ -6817,8 +7524,6 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
 												"value": "application/json"
 											}
 										],
@@ -6864,9 +7569,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"body": {
@@ -6975,9 +7678,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"body": {
@@ -7224,9 +7925,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"body": {
@@ -7353,8 +8052,6 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
 												"value": "application/json"
 											}
 										],
@@ -7400,9 +8097,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"body": {
@@ -7461,8 +8156,7 @@
 										"header": [
 											{
 												"key": "dotcachettl",
-												"value": "30",
-												"type": "text"
+												"value": "30"
 											}
 										],
 										"body": {
@@ -7511,9 +8205,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"body": {
@@ -7572,8 +8264,7 @@
 										"header": [
 											{
 												"key": "dotcachettl",
-												"value": "0",
-												"type": "text"
+												"value": "0"
 											}
 										],
 										"body": {
@@ -7662,8 +8353,7 @@
 										"header": [
 											{
 												"key": "dotcachettl",
-												"value": "-1",
-												"type": "text"
+												"value": "-1"
 											}
 										],
 										"body": {
@@ -7710,8 +8400,7 @@
 										"header": [
 											{
 												"key": "dotcachettl",
-												"value": "30",
-												"type": "text"
+												"value": "30"
 											}
 										],
 										"body": {
@@ -7760,9 +8449,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"body": {
@@ -7897,8 +8584,6 @@
 												"header": [
 													{
 														"key": "Content-Type",
-														"name": "Content-Type",
-														"type": "text",
 														"value": "application/json"
 													}
 												],
@@ -7944,9 +8629,7 @@
 												"header": [
 													{
 														"key": "Content-Type",
-														"name": "Content-Type",
-														"value": "application/json",
-														"type": "text"
+														"value": "application/json"
 													}
 												],
 												"body": {
@@ -8059,9 +8742,7 @@
 												"header": [
 													{
 														"key": "Content-Type",
-														"name": "Content-Type",
-														"value": "application/json",
-														"type": "text"
+														"value": "application/json"
 													}
 												],
 												"body": {
@@ -8329,8 +9010,6 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
 												"value": "application/json"
 											}
 										],
@@ -8376,9 +9055,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"body": {
@@ -8438,13 +9115,11 @@
 										"header": [
 											{
 												"key": "dotcachettl",
-												"value": "30",
-												"type": "text"
+												"value": "30"
 											},
 											{
 												"key": "dotcachekey",
-												"value": "mykeyRH",
-												"type": "text"
+												"value": "mykeyRH"
 											}
 										],
 										"body": {
@@ -8493,9 +9168,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"body": {
@@ -8596,8 +9269,7 @@
 										"header": [
 											{
 												"key": "dotcachekey",
-												"value": "mykeyRH",
-												"type": "text"
+												"value": "mykeyRH"
 											}
 										],
 										"body": {
@@ -8644,13 +9316,11 @@
 										"header": [
 											{
 												"key": "dotcachettl",
-												"value": "-1",
-												"type": "text"
+												"value": "-1"
 											},
 											{
 												"key": "dotcachekey",
-												"value": "mykeyRH",
-												"type": "text"
+												"value": "mykeyRH"
 											}
 										],
 										"body": {
@@ -8697,8 +9367,7 @@
 										"header": [
 											{
 												"key": "dotcachekey",
-												"value": "mykeyRH",
-												"type": "text"
+												"value": "mykeyRH"
 											}
 										],
 										"body": {
@@ -8767,8 +9436,6 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"type": "text",
 												"value": "application/json"
 											}
 										],
@@ -8814,9 +9481,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"body": {
@@ -8925,9 +9590,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"body": {
@@ -9652,12 +10315,10 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"type": "text",
 								"value": "application/octet-stream"
 							},
 							{
 								"key": "Content-Disposition",
-								"type": "text",
 								"value": "attachment"
 							}
 						],
@@ -9672,16 +10333,19 @@
 							]
 						},
 						"url": {
-							"raw": "{{serverURL}}/api/bundle/sync",
+							"raw": "{{serverURL}}/api/bundle?sync=true",
 							"host": [
 								"{{serverURL}}"
 							],
 							"path": [
 								"api",
-								"bundle",
-								"sync"
+								"bundle"
 							],
 							"query": [
+								{
+									"key": "sync",
+									"value": "true"
+								},
 								{
 									"key": "AUTH_TOKEN",
 									"value": "",
@@ -9793,8 +10457,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],
@@ -9842,8 +10504,6 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
 								"value": "application/json"
 							}
 						],

--- a/dotcms-postman/src/main/resources/postman/PagesResourceTests.json
+++ b/dotcms-postman/src/main/resources/postman/PagesResourceTests.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "fec7e83b-7dfc-4ec1-bcca-b4af2cc0072a",
+		"_postman_id": "553f0974-ec29-4c85-9d73-57478a3f39bc",
 		"name": "Page API - [api/v1/page]",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "5403727"
@@ -6598,6 +6598,126 @@
 				}
 			],
 			"description": "These requests are aimed to test the REST Endpoint that takes a Page ID, returns all Languages in the current instance and, for each of them, includes an additional attribute that indicates whether such a page is available in that specific language or not."
+		},
+		{
+			"name": "Checking JSON Attributes",
+			"item": [
+				{
+					"name": "Checking Page Audit Attributes",
+					"item": [
+						{
+							"name": "Retrieving HTML Page Data",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Checking that audit properties are present\", function () {",
+											"    var entity = pm.response.json().entity.page;",
+											"    ",
+											"    pm.expect(entity.creationDate).to.not.equal(undefined, \"The 'creationDate' attribute must be present\");",
+											"    pm.expect(entity.owner).to.not.equal(undefined, \"The 'owner' attribute must be present\");",
+											"    pm.expect(entity.ownerName).to.not.equal(undefined, \"The 'ownerName' attribute must be present\");",
+											"    pm.expect(entity.modDate).to.not.equal(undefined, \"The 'modDate' attribute must be present\");",
+											"    pm.expect(entity.modUser).to.not.equal(undefined, \"The 'modUser' attribute must be present\");",
+											"    pm.expect(entity.modUserName).to.not.equal(undefined, \"The 'modUserName' attribute must be present\");",
+											"    pm.expect(entity.publishDate).to.not.equal(undefined, \"The 'publishDate' attribute must be present\");",
+											"    pm.expect(entity.publishUser).to.not.equal(undefined, \"The 'publishUser' attribute must be present\");",
+											"    pm.expect(entity.publishUserName).to.not.equal(undefined, \"The 'publishUserName' attribute must be present\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v1/page/json/destinations/costa-rica",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"page",
+										"json",
+										"destinations",
+										"costa-rica"
+									]
+								},
+								"description": "http://localhost:8080/api/v1/page/json/{page-url}"
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									"pm.test(\"HTTP Status code must be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				}
+			]
 		},
 		{
 			"name": "Put Create Page With CacheTTL 100",


### PR DESCRIPTION
### Proposed Changes
* Exposes audit information to all Contentlets in dotCMS.

Here's the list of audit properties that are being exposed, and how they can be accessed by the different consumers:

| Attribute | REST Endpoint | Elasticsearch | GraphQL |
| -------- | ------- | ------- | ------- |
| `creationDate` | `creationDate` | `creationDate` | `creationDate` |
| `owner` | `owner` | `owner` | `owner` |
| `ownerName` | `ownerName` | Only the User ID is available | Reachable inside the "owner" object |
| `modDate` | `modDate` | `modDate` | `modDate` |
| `modUser` | `modUser` | `modUser` | `modUser` |
| `modUserName` | `modUserName` | Only the User ID is available | Reachable inside the "modUser" object |
| `publishDate` | `publishDate` | `sysPublishDate` | `publishDate` |
| `publishUser` | `publishUser` | `sysPublishUser` | `publishUser` |
| `publishUserName` | `publishUserName` | Only the User ID is available | Reachable inside the "publishUser" object |
