### PR TITLE
fix(Content Edit) : Binary D&D not working in Firefox

### DIFF
--- a/core-web/libs/ui/src/lib/components/dot-drop-zone/dot-drop-zone.component.spec.ts
+++ b/core-web/libs/ui/src/lib/components/dot-drop-zone/dot-drop-zone.component.spec.ts
@@ -118,6 +118,10 @@ describe('DotDropZoneComponent', () => {
                     dataTransfer: mockDataTransfer
                 });
 
+                // FF does not support clearData:
+                // ERROR DOMException: Modifications are not allowed for this document on FireFox
+                const spyClearData = spyOn(mockDataTransfer, 'clearData'); // It gets cleared automatically
+
                 spectator.component.onDrop(event);
 
                 expect(spy).toHaveBeenCalledWith({
@@ -129,6 +133,7 @@ describe('DotDropZoneComponent', () => {
                         valid: false
                     }
                 });
+                expect(spyClearData).not.toHaveBeenCalled();
             });
         });
 

--- a/core-web/libs/ui/src/lib/components/dot-drop-zone/dot-drop-zone.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-drop-zone/dot-drop-zone.component.ts
@@ -82,9 +82,6 @@ export class DotDropZoneComponent {
         if (files.length === 0) return;
 
         this.setValidity(files);
-
-        dataTransfer.items?.clear();
-        dataTransfer.clearData();
         this.fileDropped.emit({
             file, // Only one file is allowed
             validity: this._validity


### PR DESCRIPTION
- Allow users to `drag and drop` files when creating a new Asset on Firefox.

### Video

https://github.com/dotCMS/core/assets/72418962/d6b673fd-7185-440c-bc6e-957c7442179d

