### PR TITLE
fix (import): handle URL field for pages imported (#28306)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
@@ -49,6 +49,7 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
+import com.dotmarketing.util.contentet.pagination.PaginatedContentlets;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
@@ -188,10 +189,10 @@ public class PushPublishigDependencyProcesor implements DependencyProcessor {
                     .forEach(fileContainer -> dependencyProcessor.addAsset(fileContainer,
                             PusheableAsset.CONTAINER));
 
+            PaginatedContentlets contentletsPaginatedByHost = this.contentletAPI.get().findContentletsPaginatedByHost(site,
+                    APILocator.systemUser(), false);
             // Content dependencies
-            tryToAddAllAndProcessDependencies(PusheableAsset.CONTENTLET,
-                    pushPublishigDependencyProvider.getContentletByLuceneQuery(
-                            "+conHost:" + site.getIdentifier()),
+            tryToAddAllAndProcessDependencies(PusheableAsset.CONTENTLET, contentletsPaginatedByHost,
                     ManifestReason.INCLUDE_DEPENDENCY_FROM.getMessage(site));
 
             // Structure dependencies
@@ -911,11 +912,13 @@ public class PushPublishigDependencyProcesor implements DependencyProcessor {
     }
 
     private <T> void tryToAddAllAndProcessDependencies(
-            final PusheableAsset pusheableAsset, final Collection<T> assets, final String reason)
+            final PusheableAsset pusheableAsset, final Iterable<T> assets, final String reason)
             throws DotDataException, DotSecurityException {
 
         if (UtilMethods.isSet(assets)) {
-            assets.stream().forEach(asset -> tryToAddAndProcessDependencies(pusheableAsset, asset, reason));
+            for (T asset : assets) {
+                tryToAddAndProcessDependencies(pusheableAsset, asset, reason);
+            }
         }
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -2,6 +2,7 @@ package com.dotmarketing.util;
 
 import com.dotcms.content.elasticsearch.util.ESUtils;
 import com.dotcms.contenttype.model.field.BinaryField;
+import com.dotcms.contenttype.model.field.HostFolderField;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
@@ -85,6 +86,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class ImportUtil {
 
+    public static final String LINE_NO = "Line #";
     private static PermissionAPI permissionAPI = APILocator.getPermissionAPI();
     private final static ContentletAPI conAPI = APILocator.getContentletAPI();
     private final static CategoryAPI catAPI = APILocator.getCategoryAPI();
@@ -283,8 +285,8 @@ public class ImportUtil {
                             }
                         } catch (final DotRuntimeException ex) {
                             String errorMessage = getErrorMsgFromException(user, ex);
-                            if(errorMessage.indexOf("Line #") == -1){
-                                errorMessage = "Line #" + lineNumber + ": " + errorMessage;
+                            if(errorMessage.indexOf(LINE_NO) == -1){
+                                errorMessage = LINE_NO + lineNumber + ": " + errorMessage;
                             }
                             results.get("errors").add(errorMessage);
                             errors++;
@@ -695,7 +697,7 @@ public class ImportUtil {
             for ( Integer column : headers.keySet() ) {
                 Field field = headers.get( column );
                 if ( line.length < column ) {
-                    throw new DotRuntimeException("Line #" + lineNumber + "doesn't contain all the required columns.");
+                    throw new DotRuntimeException(LINE_NO + lineNumber + "doesn't contain all the required columns.");
                 }
                 String value = line[column];
                 Object valueObj = value;
@@ -712,7 +714,7 @@ public class ImportUtil {
                         for(String catKey : categoryKeys) {
                             Category cat = catAPI.findByKey(catKey.trim(), user, false);
                             if(cat == null)
-                                throw new DotRuntimeException("Line #" + lineNumber + " contains errors. Column: '" + field.getVelocityVarName() +
+                                throw new DotRuntimeException(LINE_NO + lineNumber + " contains errors. Column: '" + field.getVelocityVarName() +
                                         "', value: '" + value + "', invalid category key found. Line will be ignored.");
                             categories.add(cat);
                         }
@@ -751,14 +753,14 @@ public class ImportUtil {
                 } else if (field.getFieldType().equals(Field.FieldType.HOST_OR_FOLDER.toString())) {
                     siteAndFolder = getSiteAndFolderFromIdOrName(value, user);
                     if (siteAndFolder == null) {
-                        throw new DotRuntimeException("Line #" + lineNumber + " contains errors. Column: '" + field.getVelocityVarName() +
+                        throw new DotRuntimeException(LINE_NO + lineNumber + " contains errors. Column: '" + field.getVelocityVarName() +
                                 "', value: '" + value + "', invalid site/folder inode found. Line will be ignored.");
                     } else {
                         valueObj = value;
                     }
                 } else if (new LegacyFieldTransformer(field).from().typeName().equals(BinaryField.class.getName())){
                     if(UtilMethods.isSet(value) && !APILocator.getTempFileAPI().validUrl(value)){
-                        throw new DotRuntimeException("Line #" + lineNumber + " contains errors. URL is malformed or Response is not 200");
+                        throw new DotRuntimeException(LINE_NO + lineNumber + " contains errors. URL is malformed or Response is not 200");
                     }
                 }else if(field.getFieldType().equals(Field.FieldType.IMAGE.toString()) || field.getFieldType().equals(Field.FieldType.FILE.toString())) {
                     String filePath = value;
@@ -835,7 +837,7 @@ public class ImportUtil {
                     values.put(urlValue.getLeft(), assetNameForURL);
                     final Pair<Host, Folder> parentPathForURL = pathAndAssetNameForURL.getLeft();
                     if (parentPathForURL == null) {
-                        throw new DotRuntimeException("Line #" + lineNumber + " contains errors. Column: '"
+                        throw new DotRuntimeException(LINE_NO + lineNumber + " contains errors. Column: '"
                                 + HTMLPageAssetAPI.URL_FIELD + "', value: '" + urlValue.getRight()
                                 + "', invalid parent folder for URL. Line will be ignored.");
                     } else {
@@ -917,8 +919,8 @@ public class ImportUtil {
 
                 if ((contentsSearch == null) || (contentsSearch.size() == 0)) {
 
-                    Logger.warn(ImportUtil.class, "Line #" + lineNumber + ": Content not found with identifier " + identifier + "\n");
-                    throw new DotRuntimeException("Line #" + lineNumber + ": Content not found with identifier " + identifier + "\n");
+                    Logger.warn(ImportUtil.class, LINE_NO + lineNumber + ": Content not found with identifier " + identifier + "\n");
+                    throw new DotRuntimeException(LINE_NO + lineNumber + ": Content not found with identifier " + identifier + "\n");
                 } else {
 
                     Contentlet contentlet;
@@ -927,8 +929,8 @@ public class ImportUtil {
                         if ((contentlet != null) && InodeUtils.isSet(contentlet.getInode())) {
                             contentlets.add(contentlet);
                         } else {
-                            Logger.warn(ImportUtil.class, "Line #" + lineNumber + ": Content not found with identifier " + identifier + "\n");
-                            throw new DotRuntimeException("Line #" + lineNumber + ": Content not found with identifier " + identifier + "\n");
+                            Logger.warn(ImportUtil.class, LINE_NO + lineNumber + ": Content not found with identifier " + identifier + "\n");
+                            throw new DotRuntimeException(LINE_NO + lineNumber + ": Content not found with identifier " + identifier + "\n");
                         }
                     }
                 }
@@ -948,8 +950,8 @@ public class ImportUtil {
                         if ((contentlet != null) && InodeUtils.isSet(contentlet.getInode())) {
                             contentlets.add(contentlet);
                         } else {
-                            Logger.warn(ImportUtil.class, "Line #" + lineNumber + ": Content not found with URL " + urlValue.getRight() + "\n");
-                            throw new DotRuntimeException("Line #" + lineNumber + ": Content not found with URL " + urlValue.getRight() + "\n");
+                            Logger.warn(ImportUtil.class, LINE_NO + lineNumber + ": Content not found with URL " + urlValue.getRight() + "\n");
+                            throw new DotRuntimeException(LINE_NO + lineNumber + ": Content not found with URL " + urlValue.getRight() + "\n");
                         }
                     }
                 }
@@ -979,7 +981,7 @@ public class ImportUtil {
                         text = value.toString();
                     }
                     if(!UtilMethods.isSet(text)){
-                        throw new DotRuntimeException("Line #" + lineNumber + " key field " + field.getVelocityVarName() + " is required since it was defined as a key\n");
+                        throw new DotRuntimeException(LINE_NO + lineNumber + " key field " + field.getVelocityVarName() + " is required since it was defined as a key\n");
                     }else{
                         if (field.getVelocityVarName().equals(HTMLPageAssetAPI.URL_FIELD)
                                 && pathAndAssetNameForURL != null) {
@@ -988,7 +990,7 @@ public class ImportUtil {
                                     .append(HTMLPageAssetAPI.URL_FIELD).append(StringPool.COLON)
                                     .append(pathAndAssetNameForURL.getRight());
                             value = getURLFromFolderAndAssetName(pathAndAssetNameForURL);
-                        } else if(field.getFieldType().equals(Field.FieldType.HOST_OR_FOLDER.toString())) {
+                        } else if(new LegacyFieldTransformer(field).from() instanceof HostFolderField) {
                             appendSiteToQuery = true;
                             siteFieldValue = text;
                         } else {
@@ -1372,7 +1374,7 @@ public class ImportUtil {
                                     new ArrayList<>(categories));
                         }
                     } catch (DotContentletValidationException ex) {
-                        StringBuffer sb = new StringBuffer("Line #" + lineNumber + " contains errors\n");
+                        StringBuffer sb = new StringBuffer(LINE_NO + lineNumber + " contains errors\n");
                         HashMap<String,List<Field>> errors = (HashMap<String,List<Field>>) ex.getNotValidFields();
                         Set<String> keys = errors.keySet();
                         for (String key : keys) {
@@ -2006,7 +2008,7 @@ public class ImportUtil {
                     valueObj = parseExcelDate(value);
                 } catch (ParseException e) {
                     throw new DotRuntimeException(
-                            "Line #" + lineNumber + " contains errors, Column: " + field
+                            LINE_NO + lineNumber + " contains errors, Column: " + field
                                     .getVelocityVarName() +
                                     ", value: " + value
                                     + ", couldn't be parsed as any of the following supported formats: "

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -2,6 +2,8 @@ package com.dotmarketing.util;
 
 import com.dotcms.content.elasticsearch.util.ESUtils;
 import com.dotcms.contenttype.model.field.BinaryField;
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotcms.contenttype.transform.field.LegacyFieldTransformer;
 import com.dotcms.repackage.com.csvreader.CsvReader;
@@ -34,6 +36,7 @@ import com.dotmarketing.portlets.contentlet.model.ContentletDependencies;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI;
 import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.structure.factories.FieldFactory;
@@ -62,6 +65,7 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
@@ -687,6 +691,7 @@ public class ImportUtil {
             HashMap<Integer, Object> values = new HashMap<>();
             Set<Category> categories = new HashSet<>();
             Pair<Host, Folder> siteAndFolder = null;
+            Pair<Integer, String> urlValue = null;
             for ( Integer column : headers.keySet() ) {
                 Field field = headers.get( column );
                 if ( line.length < column ) {
@@ -804,6 +809,39 @@ public class ImportUtil {
                     bean.setLanguageId(language);
                     uniqueFieldBeans.add(bean);
                 }
+
+                if (valueObj != null
+                        && field.getVelocityVarName().equals(HTMLPageAssetAPI.URL_FIELD)) {
+                    final String uri = StringUtils.stripEnd(
+                            StringUtils.strip(valueObj.toString()), StringPool.FORWARD_SLASH);
+                    final StringBuilder uriBuilder = new StringBuilder();
+                    if (!uri.startsWith(StringPool.FORWARD_SLASH)) {
+                        uriBuilder.append(StringPool.FORWARD_SLASH);
+                    }
+                    uriBuilder.append(uri);
+                    urlValue = Pair.of(column, uriBuilder.toString());
+                }
+            }
+
+            // Check if the content type is HTMLPage and the URL field is set
+            final Pair<Pair<Host, Folder>, String> pathAndAssetNameForURL =
+                    urlValue != null ?
+                        checkURLFieldForHTMLPage(contentType,
+                            urlValue.getRight(), siteAndFolder, user) :
+                    null;
+            if (pathAndAssetNameForURL != null) {
+                final String assetNameForURL = pathAndAssetNameForURL.getRight();
+                if (UtilMethods.isSet(assetNameForURL)) {
+                    values.put(urlValue.getLeft(), assetNameForURL);
+                    final Pair<Host, Folder> parentPathForURL = pathAndAssetNameForURL.getLeft();
+                    if (parentPathForURL == null) {
+                        throw new DotRuntimeException("Line #" + lineNumber + " contains errors. Column: '"
+                                + HTMLPageAssetAPI.URL_FIELD + "', value: '" + urlValue.getRight()
+                                + "', invalid parent folder for URL. Line will be ignored.");
+                    } else {
+                        siteAndFolder = parentPathForURL;
+                    }
+                }
             }
 
             //Find the relationships and their related contents
@@ -875,26 +913,49 @@ public class ImportUtil {
             if ( UtilMethods.isSet( identifier ) ) {
                 buffy.append(" +identifier:").append(identifier);
 
-                List<ContentletSearch> contentsSearch = conAPI.searchIndex( buffy.toString(), 0, -1, null, user, true );
+                List<ContentletSearch> contentsSearch = conAPI.searchIndex(buffy.toString(), 0, -1, null, user, true);
 
-                if ( (contentsSearch == null) || (contentsSearch.size() == 0) ) {
+                if ((contentsSearch == null) || (contentsSearch.size() == 0)) {
 
                     Logger.warn(ImportUtil.class, "Line #" + lineNumber + ": Content not found with identifier " + identifier + "\n");
-                    throw new DotRuntimeException( "Line #" + lineNumber + ": Content not found with identifier " + identifier + "\n" );
+                    throw new DotRuntimeException("Line #" + lineNumber + ": Content not found with identifier " + identifier + "\n");
                 } else {
 
                     Contentlet contentlet;
-                    for ( ContentletSearch contentSearch : contentsSearch ) {
-                        contentlet = conAPI.find( contentSearch.getInode(), user, true );
-                        if ( (contentlet != null) && InodeUtils.isSet( contentlet.getInode() ) ) {
-                            contentlets.add( contentlet );
+                    for (ContentletSearch contentSearch : contentsSearch) {
+                        contentlet = conAPI.find(contentSearch.getInode(), user, true);
+                        if ((contentlet != null) && InodeUtils.isSet(contentlet.getInode())) {
+                            contentlets.add(contentlet);
                         } else {
                             Logger.warn(ImportUtil.class, "Line #" + lineNumber + ": Content not found with identifier " + identifier + "\n");
-                            throw new DotRuntimeException( "Line #" + lineNumber + ": Content not found with identifier " + identifier + "\n" );
+                            throw new DotRuntimeException("Line #" + lineNumber + ": Content not found with identifier " + identifier + "\n");
+                        }
+                    }
+                }
+            } else if (pathAndAssetNameForURL != null && keyFields.isEmpty()) {
+                // For HTMLPageAsset, we need to search by URL to math existing pages
+                buffy.append( " +languageId:" ).append( language );
+                buffy.append(addSiteAndFolderToESQuery(siteAndFolder, null));
+                buffy.append(" +").append(contentType.getVelocityVarName()).append(StringPool.PERIOD)
+                        .append(HTMLPageAssetAPI.URL_FIELD).append(StringPool.COLON)
+                        .append(pathAndAssetNameForURL.getRight());
+                List<ContentletSearch> contentsSearch = conAPI.searchIndex(
+                        buffy.toString(), 0, -1, null, user, true);
+                if (contentsSearch != null && !contentsSearch.isEmpty()) {
+                    Contentlet contentlet;
+                    for (ContentletSearch contentSearch : contentsSearch) {
+                        contentlet = conAPI.find(contentSearch.getInode(), user, true);
+                        if ((contentlet != null) && InodeUtils.isSet(contentlet.getInode())) {
+                            contentlets.add(contentlet);
+                        } else {
+                            Logger.warn(ImportUtil.class, "Line #" + lineNumber + ": Content not found with URL " + urlValue.getRight() + "\n");
+                            throw new DotRuntimeException("Line #" + lineNumber + ": Content not found with URL " + urlValue.getRight() + "\n");
                         }
                     }
                 }
             } else if (keyFields.size() > 0) {
+                boolean appendSiteToQuery = false;
+                String siteFieldValue = null;
                 for (Integer column : keyFields.keySet()) {
                     Field field = keyFields.get(column);
                     Object value = values.get(column);
@@ -920,8 +981,16 @@ public class ImportUtil {
                     if(!UtilMethods.isSet(text)){
                         throw new DotRuntimeException("Line #" + lineNumber + " key field " + field.getVelocityVarName() + " is required since it was defined as a key\n");
                     }else{
-                        if(field.getFieldType().equals(Field.FieldType.HOST_OR_FOLDER.toString())) {
-                            buffy.append(addSiteAndFolderToESQuery(siteAndFolder, text));
+                        if (field.getVelocityVarName().equals(HTMLPageAssetAPI.URL_FIELD)
+                                && pathAndAssetNameForURL != null) {
+                            appendSiteToQuery = true;
+                            buffy.append(" +").append(contentType.getVelocityVarName()).append(StringPool.PERIOD)
+                                    .append(HTMLPageAssetAPI.URL_FIELD).append(StringPool.COLON)
+                                    .append(pathAndAssetNameForURL.getRight());
+                            value = getURLFromFolderAndAssetName(pathAndAssetNameForURL);
+                        } else if(field.getFieldType().equals(Field.FieldType.HOST_OR_FOLDER.toString())) {
+                            appendSiteToQuery = true;
+                            siteFieldValue = text;
                         } else {
                             buffy.append(" +").append(contentType.getVelocityVarName()).append(StringPool.PERIOD)
                                     .append(field.getVelocityVarName()).append(field.isUnique()? ESUtils.SHA_256: "_dotraw")
@@ -953,6 +1022,10 @@ public class ImportUtil {
                         }
                     }
 
+                }
+
+                if (appendSiteToQuery) {
+                    buffy.append(addSiteAndFolderToESQuery(siteAndFolder, siteFieldValue));
                 }
 
                 String noLanguageQuery = buffy.toString();
@@ -1010,6 +1083,11 @@ public class ImportUtil {
                                     break;
                                 }
                             }else{
+                                if (field.getVelocityVarName().equals(HTMLPageAssetAPI.URL_FIELD)
+                                        && pathAndAssetNameForURL != null) {
+                                    value = getURLFromFolderAndAssetName(pathAndAssetNameForURL);
+                                    conValue = getURLFromContentId(con.getIdentifier());
+                                }
                                 Logger.debug(ImportUtil.class,"conValue: " + conValue.toString());
                                 Logger.debug(ImportUtil.class,"Value: " + value.toString());
                                 if(conValue.toString().equalsIgnoreCase(value.toString())){
@@ -1053,6 +1131,11 @@ public class ImportUtil {
 
                                 //Ok, comparing our keys with the contentlets we found trying to see if there is a contentlet to update with the specified keys
                                 Object conValue = conAPI.getFieldValue( contentlet, field );
+                                if (field.getVelocityVarName().equals(HTMLPageAssetAPI.URL_FIELD)
+                                        && pathAndAssetNameForURL != null) {
+                                    value = getURLFromFolderAndAssetName(pathAndAssetNameForURL);
+                                    conValue = getURLFromContentId(contentlet.getIdentifier());
+                                }
                                 if ( !conValue.equals( value ) ) {
                                     match = false;
                                 }
@@ -1555,7 +1638,7 @@ public class ImportUtil {
                 final Folder folder = siteAndFolder.getRight();
                 siteAndFolderQuery.append(" +conFolder:").append(folder.getInode());
             }
-        } else {
+        } else if (UtilMethods.isSet(fieldValue)) {
             siteAndFolderQuery.append(" +(conhost:").append(fieldValue).append(" conFolder:")
                     .append(fieldValue).append(")");
         }
@@ -1590,6 +1673,137 @@ public class ImportUtil {
                 cont.setFolder(folder.getInode());
             }
         }
+    }
+
+    /**
+     * Check if the URL field for an HTMLPage content type is set correctly
+     * @param contentType the content type
+     * @param urlValue the URL field value
+     * @param siteAndFolderFromLine the site and folder from the site field in the import line
+     *                              it can be null if the site field is not set
+     * @param user the current user
+     */
+    private static Pair<Pair<Host,Folder>, String> checkURLFieldForHTMLPage(
+            final Structure contentType, final String urlValue,
+            final Pair<Host, Folder> siteAndFolderFromLine, final User user)
+            throws DotDataException, DotSecurityException {
+
+        final ContentType targetContentType = new StructureTransformer(contentType).from();
+        if (UtilMethods.isSet(urlValue) &&
+                BaseContentType.HTMLPAGE.getType() == targetContentType.baseType().getType()) {
+
+            // Check if the URL field value includes parent folder and asset name
+            String assetName = urlValue;
+            String parentPath = null;
+            if (StringUtils.lastIndexOf(urlValue, StringPool.FORWARD_SLASH) >= 0) {
+                assetName = StringUtils.substringAfterLast(urlValue, StringPool.FORWARD_SLASH);
+                parentPath = StringUtils.substringBeforeLast(urlValue, StringPool.FORWARD_SLASH);
+            }
+
+            // If there is parent path and also a site without folder was already read
+            // from the site field in the import line, check if the parent folder exists and return it
+            // If there is a parent path and a site was not read from the site field,
+            // check if the parent folder exists in the default site instead
+            final Host site = siteAndFolderFromLine == null ?
+                    hostAPI.findDefaultHost(user, false) :
+                    siteAndFolderFromLine.getLeft();
+            final Folder folder = siteAndFolderFromLine == null ?
+                    folderAPI.findSystemFolder() : siteAndFolderFromLine.getRight();
+            final Pair<Host, Folder> siteAndFolder = ImmutablePair.of(site, folder);
+
+            if (UtilMethods.isSet(parentPath)) {
+                return ImmutablePair.of(
+                        getHostAndFolderFromParentPathOrSiteField(
+                                siteAndFolder, user, parentPath),
+                        assetName);
+            }
+
+            // If there is no parent path, return the site and folder from the site field
+            return ImmutablePair.of(siteAndFolder, assetName);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the host and folder from given parent path.
+     * Returns the host and folder from the site field in the import line if already set
+     * @param siteAndFolder the site and folder from the site field in the import line
+     * @param user the current user
+     * @param parentPath the parent path for the URL field value
+     * @return the host and folder from the parent path or the site field
+     */
+    private static Pair<Host, Folder> getHostAndFolderFromParentPathOrSiteField(
+            final Pair<Host, Folder> siteAndFolder,
+            final User user, final String parentPath)
+            throws DotDataException, DotSecurityException {
+
+        final Host site = siteAndFolder.getLeft();
+        final Folder siteFolder = siteAndFolder.getRight();
+        final Folder parentFolder = folderAPI.findFolderByPath(
+                parentPath, site, user, false);
+        if (isFolderSet(parentFolder)) {
+            if ((siteFolder == null || siteFolder.isSystemFolder())) {
+                return ImmutablePair.of(site, parentFolder);
+            } else {
+                if (isFolderSet(siteFolder) && !parentFolder.getInode().equals(siteFolder.getInode())) {
+                    Logger.warn(ImportUtil.class, String.format(
+                            "Folder from site field %s doesn't match parent folder for URL: %s",
+                            siteFolder.getPath(), parentFolder.getPath()));
+                }
+                return siteAndFolder;
+            }
+        } else {
+            Logger.warn(ImportUtil.class, String.format(
+                    "Parent folder not found for URL field value: %s", parentPath));
+            return null;
+        }
+
+    }
+
+    /**
+     * Get the URL from the folder path and asset name
+     * @param folderAndAssetName the folder and asset name pair
+     * @return the URL for the given folder path and asset name
+     */
+    private static String getURLFromFolderAndAssetName(
+            final Pair<Pair<Host, Folder>,String> folderAndAssetName) {
+        final Pair<Host, Folder> siteAndFolder = folderAndAssetName.getLeft();
+        final String assetName = folderAndAssetName.getRight();
+        final StringBuilder url = new StringBuilder();
+        if (siteAndFolder != null) {
+            final Folder folder = siteAndFolder.getRight();
+            if (isFolderSet(folder)) {
+                url.append(folder.getPath());
+                if (UtilMethods.isSet(folder.getPath())
+                        && !folder.getPath().endsWith(StringPool.FORWARD_SLASH)) {
+                    url.append(StringPool.FORWARD_SLASH);
+                }
+            }
+        }
+        url.append(assetName);
+        return url.toString();
+    }
+
+    /**
+     * Get the URL from the content identifier
+     * @param contentId the content identifier
+     * @return the URL for the given content identifier
+     */
+    private static String getURLFromContentId(final String contentId) {
+        StringBuilder url = new StringBuilder();
+        if (contentId != null ) {
+            try {
+                final Identifier identifier = APILocator.getIdentifierAPI().find(contentId);
+                if (UtilMethods.isSet(identifier) && UtilMethods.isSet(identifier.getId())) {
+                    url.append(identifier.getURI());
+                }
+            } catch (DotDataException e) {
+                Logger.error(ImportUtil.class, "Unable to get Identifier with id ["
+                        + contentId + "]. Could not get the url", e );
+            }
+        }
+        return url.toString();
     }
 
     private static Contentlet runWorkflowIfCould(final User user, final List<Permission> contentTypePermissions,

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -1,5 +1,6 @@
 package com.dotcms.util;
 
+import com.dotcms.LicenseTestUtil;
 import com.dotcms.contenttype.business.ContentTypeAPIImpl;
 import com.dotcms.contenttype.business.FieldAPI;
 import com.dotcms.contenttype.model.field.BinaryField;
@@ -11,12 +12,15 @@ import com.dotcms.contenttype.model.field.ImmutableTextAreaField;
 import com.dotcms.contenttype.model.field.ImmutableTextField;
 import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.TextField;
+import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.datagen.FieldDataGen;
 import com.dotcms.datagen.FolderDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.TemplateDataGen;
 import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.datagen.TestUserUtils;
 import com.dotcms.mock.request.MockAttributeRequest;
@@ -43,12 +47,15 @@ import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI;
+import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.structure.factories.FieldFactory;
 import com.dotmarketing.portlets.structure.factories.StructureFactory;
 import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
+import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.portlets.workflows.actionlet.PublishContentActionlet;
 import com.dotmarketing.portlets.workflows.actionlet.SaveContentActionlet;
 import com.dotmarketing.portlets.workflows.actionlet.SaveContentAsDraftActionlet;
@@ -2048,6 +2055,112 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
             } catch (Exception e) {
                 Logger.error("Error deleting content type", e);
             }
+        }
+    }
+
+    @Test
+    public void importFile_PagesWithURL_success()
+            throws DotSecurityException, DotDataException, IOException {
+
+        Host site = null;
+        Template template = null;
+        ContentType pageType = null;
+        Folder parentFolder = null;
+        try {
+            site = new SiteDataGen().nextPersisted();
+
+            // create test template
+            template = new TemplateDataGen()
+                    .site(APILocator.systemHost())
+                    .nextPersisted();
+            final String templateId = template.getIdentifier();
+
+            long time = System.currentTimeMillis();
+            final String pageTypeName = "TestPageTypeWithURL_" + time;
+            final String pageTypeVarName = "velocityVarNameTestPageTypeWithURL_" + time;
+
+            // create test page type
+            pageType = new ContentTypeDataGen()
+                    .baseContentType(BaseContentType.HTMLPAGE)
+                    .host(APILocator.systemHost())
+                    .name(pageTypeName)
+                    .velocityVarName(pageTypeVarName)
+                    .nextPersisted();
+
+            // create test folder
+            final String parentFolderName = "test-base-folder_" + time;
+            parentFolder = new FolderDataGen()
+                    .name(parentFolderName)
+                    .site(site)
+                    .nextPersisted();
+            final Folder subFolder = new FolderDataGen()
+                    .name("test-sub-folder")
+                    .parent(parentFolder)
+                    .nextPersisted();
+
+            final String testPageURL = StringPool.FORWARD_SLASH
+                    + parentFolderName + "/test-sub-folder/test-page-1";
+            final Reader reader = createTempFile(
+                    HTMLPageAssetAPI.TITLE_FIELD
+                            + "," + HTMLPageAssetAPI.URL_FIELD
+                            + ",hostFolder"
+                            + "," + HTMLPageAssetAPI.TEMPLATE_FIELD
+                            + "," + HTMLPageAssetAPI.FRIENDLY_NAME_FIELD
+                            + "," + HTMLPageAssetAPI.SORT_ORDER_FIELD
+                            + "," + HTMLPageAssetAPI.CACHE_TTL_FIELD
+                            + "\r\n" +
+                            "Test Page 1," + testPageURL + ","
+                                + site.getIdentifier() + "," + templateId
+                                + ",Test Page 1,0,300\r\n");
+
+            final CsvReader csvreader = new CsvReader(reader);
+            csvreader.setSafetySwitch(false);
+
+            final String[] csvHeaders = csvreader.getHeaders();
+
+            final Map<String, List<String>> results = ImportUtil
+                    .importFile(0L, defaultSite.getInode(), pageType.inode(),
+                            new String[]{}, false, false,
+                            user, defaultLanguage.getId(), csvHeaders, csvreader,
+                            -1, -1,
+                            reader, null, getHttpRequest());
+
+            Logger.info(ImportUtilTest.class, "page errors: " + results.get("errors"));
+            validate(results, false, false, true);
+
+            final List<Contentlet> savedData = contentletAPI
+                    .findByStructure(pageType.inode(), user, false, 0, 0);
+            assertNotNull(savedData);
+            assertEquals(1, savedData.size());
+
+            final Contentlet contentlet = savedData.get(0);
+            final Identifier identifier = APILocator.getIdentifierAPI().find(contentlet);
+            assertNotNull(identifier);
+            assertEquals(testPageURL, identifier.getURI());
+
+        } finally {
+            try {
+                if (parentFolder != null) {
+                    FolderDataGen.remove(parentFolder);
+                }
+
+                if (pageType != null) {
+                    contentTypeApi.delete(pageType);
+                }
+
+                if (template != null) {
+                    TemplateDataGen.remove(template);
+                }
+
+                if (null != site) {
+                    APILocator.getHostAPI().archive(site, APILocator.systemUser(), false);
+                    APILocator.getHostAPI().delete(site, APILocator.systemUser(), false);
+                }
+
+            } catch (Exception e) {
+                Logger.error("Error deleting test page type", e);
+            }
+
         }
     }
 

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -2058,6 +2058,13 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
         }
     }
 
+    /**
+     * Method to test: {@link ImportUtil#importFile}
+     * Case: Import file including a page with URL field set to a valid URL
+     * @throws DotSecurityException when there is a security exception
+     * @throws DotDataException when there is a dotCMS data exception
+     * @throws IOException when there is an IO exception
+     */
     @Test
     public void importFile_PagesWithURL_success()
             throws DotSecurityException, DotDataException, IOException {


### PR DESCRIPTION
### Proposed Changes
* This change will handle the URL field when importing pages to dotCMS
* The URL field will be split in folder parent path and asset name. For example the URL "/parent1/parent2/test-page" will be used to import the page to the folder "/parent1/parent2" with the name "test-page"
* If the import file contains the "hostFolder" field, it it points to a folder instead of a site, that value will take precedence to set the folder target for the imported page. 

### Checklist
- [x] Tests
