### PR TITLE
Adds DOT_STARTER_DATA_LOAD to docker-compose demo site example

### DIFF
--- a/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
@@ -47,6 +47,7 @@ services:
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
         CUSTOM_STARTER_URL: https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240213/starter-20240213.zip
+        DOT_STARTER_DATA_LOAD: /data/shared/custom_starter.zip
     depends_on:
       - opensearch
       - db


### PR DESCRIPTION
### Proposed Changes
Adds the newly-required `DOT_STARTER_DATA_LOAD` env var to demo site docker compose example

