### PR TITLE
task(cpu) remove the systemLoadAverage as it reports wrong data

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/JVMInfoResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/JVMInfoResource.java
@@ -91,7 +91,7 @@ public class JVMInfoResource implements Serializable {
         resultMap.put("cpuLoadJava",  percentage.format(os.getProcessCpuLoad()));
         resultMap.put("arch",  os.getArch());
         resultMap.put("cpuLoadSystem",  percentage.format(os.getSystemCpuLoad()));
-        resultMap.put("systemLoadAverage",  percentage.format(os.getSystemLoadAverage()));
+        //resultMap.put("systemLoadAverage",  percentage.format(os.getSystemLoadAverage()));
         resultMap.put("os",  os.getName());
         resultMap.put("osVersion",  os.getVersion());
         resultMap.put("hostname", Try.of(()->InetAddress.getLocalHost().getHostName()).getOrElse("ukn") );

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/JVMInfoResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/JVMInfoResource.java
@@ -91,7 +91,6 @@ public class JVMInfoResource implements Serializable {
         resultMap.put("cpuLoadJava",  percentage.format(os.getProcessCpuLoad()));
         resultMap.put("arch",  os.getArch());
         resultMap.put("cpuLoadSystem",  percentage.format(os.getSystemCpuLoad()));
-        //resultMap.put("systemLoadAverage",  percentage.format(os.getSystemLoadAverage()));
         resultMap.put("os",  os.getName());
         resultMap.put("osVersion",  os.getVersion());
         resultMap.put("hostname", Try.of(()->InetAddress.getLocalHost().getHostName()).getOrElse("ukn") );


### PR DESCRIPTION
ref: #28742

After the change, the property is gone:

![Screenshot 2024-06-03 at 12 04 27 PM](https://github.com/dotCMS/core/assets/934364/9e5da2d3-5298-42d4-813c-d32c21bdad73)
