### PR TITLE
Homologated classes and logic between Angular and React sdk

### DIFF
--- a/core-web/libs/sdk/angular/src/lib/layout/container/container.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/layout/container/container.component.ts
@@ -11,7 +11,8 @@ import {
 } from '@angular/core';
 
 import { NoComponent } from '../../components/no-component/no-component.component';
-import { DotCMSContainer, DotCMSContentlet, DynamicComponentEntity } from '../../models';
+import { DynamicComponentEntity } from '../../models';
+import { DotCMSContainer, DotCMSContentlet } from '../../models/dotcms.model';
 import { PageContextService } from '../../services/dotcms-context/page-context.service';
 import { getContainersData } from '../../utils';
 import { ContentletComponent } from '../contentlet/contentlet.component';

--- a/core-web/libs/sdk/angular/src/lib/layout/dotcms-layout/dotcms-layout.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/layout/dotcms-layout/dotcms-layout.component.ts
@@ -13,7 +13,8 @@ import { filter } from 'rxjs/operators';
 
 import { initEditor, isInsideEditor, updateNavigation } from '@dotcms/client';
 
-import { DotCMSPageAsset, DynamicComponentEntity } from '../../models';
+import { DynamicComponentEntity } from '../../models';
+import { DotCMSPageAsset } from '../../models/dotcms.model';
 import { PageContextService } from '../../services/dotcms-context/page-context.service';
 import { RowComponent } from '../row/row.component';
 

--- a/core-web/libs/sdk/angular/src/lib/models/dotcms.model.ts
+++ b/core-web/libs/sdk/angular/src/lib/models/dotcms.model.ts
@@ -121,6 +121,20 @@ export interface DotCMSContentlet {
     [key: string]: any; // This is a catch-all for any other custom properties that might be on the contentlet.
 }
 
+export interface DotcmsNavigationItem {
+    code?: any;
+    folder: string;
+    children?: DotcmsNavigationItem[];
+    host: string;
+    languageId: number;
+    href: string;
+    title: string;
+    type: string;
+    hash: number;
+    target: string;
+    order: number;
+}
+
 interface DotCMSTemplate {
     iDate: number;
     type: string;

--- a/core-web/libs/sdk/angular/src/lib/models/index.ts
+++ b/core-web/libs/sdk/angular/src/lib/models/index.ts
@@ -4,6 +4,7 @@ export * from './dotcms.model';
 import { Type } from '@angular/core';
 
 import { DotCMSPageAsset } from './dotcms.model';
+
 export type DynamicComponentEntity = Promise<Type<any>>;
 
 export interface DotCMSPageContext {

--- a/core-web/libs/sdk/angular/src/lib/services/dotcms-context/page-context.service.ts
+++ b/core-web/libs/sdk/angular/src/lib/services/dotcms-context/page-context.service.ts
@@ -4,7 +4,8 @@ import { Injectable } from '@angular/core';
 
 import { isInsideEditor } from '@dotcms/client';
 
-import { DotCMSPageAsset, DotCMSPageComponent, DotCMSPageContext } from '../../models';
+import { DotCMSPageComponent, DotCMSPageContext } from '../../models';
+import { DotCMSPageAsset } from '../../models/dotcms.model';
 
 @Injectable({
     providedIn: 'root'

--- a/core-web/libs/sdk/angular/src/lib/utils/index.ts
+++ b/core-web/libs/sdk/angular/src/lib/utils/index.ts
@@ -1,4 +1,4 @@
-import { DotCMSContainer, DotCMSPageAssetContainer } from '../models';
+import { DotCMSContainer, DotCMSPageAssetContainer } from '../models/dotcms.model';
 
 //Changed the type, to avoid SQ issue.
 //This should be put inside a lib

--- a/core-web/libs/sdk/experiments/src/lib/components/DotExperimentHandlingComponent.tsx
+++ b/core-web/libs/sdk/experiments/src/lib/components/DotExperimentHandlingComponent.tsx
@@ -24,7 +24,7 @@ export const DotExperimentHandlingComponent: React.FC<ExperimentHandlingProps> =
     WrappedComponent,
     ...props
 }) => {
-    const { shouldWaitForVariant } = useExperimentVariant(props.entity);
+    const { shouldWaitForVariant } = useExperimentVariant(props.pageContext);
 
     if (shouldWaitForVariant) {
         return (

--- a/core-web/libs/sdk/react/src/lib/components/Column/Column.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/Column/Column.tsx
@@ -5,14 +5,14 @@ import styles from './column.module.css';
 import { PageContext } from '../../contexts/PageContext';
 import { combineClasses, getPositionStyleClasses } from '../../utils/utils';
 import { Container } from '../Container/Container';
-import { PageProviderContext } from '../PageProvider/PageProvider';
+import { DotCMSPageContext } from '../PageProvider/PageProvider';
 
 export interface ColumnProps {
-    readonly column: PageProviderContext['layout']['body']['rows'][0]['columns'][0];
+    readonly column: DotCMSPageContext['pageAsset']['layout']['body']['rows'][0]['columns'][0];
 }
 
 export function Column({ column }: ColumnProps) {
-    const { isInsideEditor } = useContext(PageContext) as PageProviderContext;
+    const { isInsideEditor } = useContext(PageContext) as DotCMSPageContext;
 
     const { startClass, endClass } = getPositionStyleClasses(
         column.leftOffset,

--- a/core-web/libs/sdk/react/src/lib/components/Column/Column.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/Column/Column.tsx
@@ -3,9 +3,9 @@ import { useContext } from 'react';
 import styles from './column.module.css';
 
 import { PageContext } from '../../contexts/PageContext';
+import { DotCMSPageContext } from '../../models';
 import { combineClasses, getPositionStyleClasses } from '../../utils/utils';
 import { Container } from '../Container/Container';
-import { DotCMSPageContext } from '../PageProvider/PageProvider';
 
 export interface ColumnProps {
     readonly column: DotCMSPageContext['pageAsset']['layout']['body']['rows'][0]['columns'][0];

--- a/core-web/libs/sdk/react/src/lib/components/Container/Container.spec.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/Container/Container.spec.tsx
@@ -74,7 +74,7 @@ describe('Container', () => {
 
             const container = getContainer({
                 containerRef: mockContainer,
-                containers: updatedContext.containers
+                containers: updatedContext.pageAsset.containers
             });
 
             const contentlet = screen.getByTestId('dot-contentlet');

--- a/core-web/libs/sdk/react/src/lib/components/Container/Container.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/Container/Container.tsx
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
 
 import { PageContext } from '../../contexts/PageContext';
+import { DotCMSPageContext } from '../../models';
 import { getContainersData } from '../../utils/utils';
-import { DotCMSPageContext } from '../PageProvider/PageProvider';
 
 function NoContent({ contentType }: { readonly contentType: string }) {
     return <div data-testid="no-component">No Component for {contentType}</div>;

--- a/core-web/libs/sdk/react/src/lib/components/Container/Container.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/Container/Container.tsx
@@ -2,25 +2,26 @@ import { useContext } from 'react';
 
 import { PageContext } from '../../contexts/PageContext';
 import { getContainersData } from '../../utils/utils';
-import { PageProviderContext } from '../PageProvider/PageProvider';
+import { DotCMSPageContext } from '../PageProvider/PageProvider';
 
 function NoContent({ contentType }: { readonly contentType: string }) {
     return <div data-testid="no-component">No Component for {contentType}</div>;
 }
 
 export interface ContainerProps {
-    readonly containerRef: PageProviderContext['layout']['body']['rows'][0]['columns'][0]['containers'][0];
+    readonly containerRef: DotCMSPageContext['pageAsset']['layout']['body']['rows'][0]['columns'][0]['containers'][0];
 }
 
 export function Container({ containerRef }: ContainerProps) {
-    const { isInsideEditor } = useContext(PageContext) as PageProviderContext;
+    const { isInsideEditor } = useContext(PageContext) as DotCMSPageContext;
 
     const { identifier, uuid } = containerRef;
 
     // Get the containers from the global context
-    const { containers, components } = useContext<PageProviderContext | null>(
-        PageContext
-    ) as PageProviderContext;
+    const {
+        pageAsset: { containers },
+        components
+    } = useContext<DotCMSPageContext | null>(PageContext) as DotCMSPageContext;
 
     const { acceptTypes, contentlets, maxContentlets, variantId, path } = getContainersData(
         containers,

--- a/core-web/libs/sdk/react/src/lib/components/DotcmsLayout/DotcmsLayout.spec.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/DotcmsLayout/DotcmsLayout.spec.tsx
@@ -33,9 +33,9 @@ jest.mock('../PageProvider/PageProvider', () => {
 
 describe('DotcmsLayout', () => {
     it('renders correctly with PageProvider and rows', () => {
-        render(<DotcmsLayout entity={{ ...mockPageContext, isInsideEditor: true }} />);
+        render(<DotcmsLayout pageContext={{ ...mockPageContext, isInsideEditor: true }} />);
         expect(screen.getAllByTestId('mockRow').length).toBe(
-            mockPageContext.layout.body.rows.length
+            mockPageContext.pageAsset.layout.body.rows.length
         );
     });
 });

--- a/core-web/libs/sdk/react/src/lib/components/DotcmsLayout/DotcmsLayout.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/DotcmsLayout/DotcmsLayout.tsx
@@ -1,7 +1,7 @@
 import { DotCMSPageEditorConfig } from '@dotcms/client';
 
 import { useDotcmsEditor } from '../../hooks/useDotcmsEditor';
-import { PageProvider, PageProviderContext } from '../PageProvider/PageProvider';
+import { DotCMSPageContext, PageProvider } from '../PageProvider/PageProvider';
 import { Row } from '../Row/Row';
 
 /**
@@ -10,7 +10,7 @@ import { Row } from '../Row/Row';
  *
  * @typedef {Object} DotcmsPageProps
  *
- * @property {PageProviderContext} entity - The context for a DotCMS page.
+ * @property {DotCMSPageContext} entity - The context for a DotCMS page.
  * @readonly
  */
 export type DotcmsPageProps = {
@@ -20,10 +20,10 @@ export type DotcmsPageProps = {
      *
      * @property {PageProviderContext} entity
      * @memberof DotcmsPageProps
-     * @type {PageProviderContext}
+     * @type {DotCMSPageContext}
      * @readonly
      */
-    readonly entity: PageProviderContext;
+    readonly pageContext: DotCMSPageContext;
 
     readonly config?: DotCMSPageEditorConfig;
 };
@@ -36,12 +36,12 @@ export type DotcmsPageProps = {
  * @param {DotcmsPageProps} props - The properties for the DotCMS page.
  * @returns {JSX.Element} - A JSX element that represents the layout for a DotCMS page.
  */
-export function DotcmsLayout({ entity, config }: DotcmsPageProps): JSX.Element {
+export function DotcmsLayout({ pageContext, config }: DotcmsPageProps): JSX.Element {
     const isInsideEditor = useDotcmsEditor(config);
 
     return (
-        <PageProvider entity={{ ...entity, isInsideEditor }}>
-            {entity.layout.body.rows.map((row, index) => (
+        <PageProvider pageContext={{ ...pageContext, isInsideEditor }}>
+            {pageContext.pageAsset.layout.body.rows.map((row, index) => (
                 <Row key={index} row={row} />
             ))}
         </PageProvider>

--- a/core-web/libs/sdk/react/src/lib/components/DotcmsLayout/DotcmsLayout.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/DotcmsLayout/DotcmsLayout.tsx
@@ -1,7 +1,8 @@
 import { DotCMSPageEditorConfig } from '@dotcms/client';
 
 import { useDotcmsEditor } from '../../hooks/useDotcmsEditor';
-import { DotCMSPageContext, PageProvider } from '../PageProvider/PageProvider';
+import { DotCMSPageContext } from '../../models';
+import { PageProvider } from '../PageProvider/PageProvider';
 import { Row } from '../Row/Row';
 
 /**
@@ -15,10 +16,10 @@ import { Row } from '../Row/Row';
  */
 export type DotcmsPageProps = {
     /**
-     * `entity` is a readonly property of the `DotcmsPageProps` type.
+     * `pageContext` is a readonly property of the `DotcmsPageProps` type.
      * It represents the context for a DotCMS page and is of type `PageProviderContext`.
      *
-     * @property {PageProviderContext} entity
+     * @property {PageProviderContext} pageContext
      * @memberof DotcmsPageProps
      * @type {DotCMSPageContext}
      * @readonly

--- a/core-web/libs/sdk/react/src/lib/components/PageProvider/PageProvider.spec.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/PageProvider/PageProvider.spec.tsx
@@ -9,46 +9,51 @@ import { PageContext } from '../../contexts/PageContext';
 const MockChildComponent = () => {
     const context = React.useContext(PageContext);
 
-    return <div data-testid="mockChild">{JSON.stringify(context?.page.title)}</div>;
+    return <div data-testid="mockChild">{JSON.stringify(context?.pageAsset.page.title)}</div>;
 };
 
 describe('PageProvider', () => {
     const mockEntity = {
-        page: {
-            title: 'Test Page',
-            identifier: 'test-page-1'
+        pageAsset: {
+            page: {
+                title: 'Test Page',
+                identifier: 'test-page-1'
+            }
+            // ... add other context properties as needed
         }
-        // ... add other context properties as needed
     };
 
     it('provides the context to its children', () => {
         render(
-            <PageProvider entity={mockEntity}>
+            <PageProvider pageContext={mockEntity}>
                 <MockChildComponent />
             </PageProvider>
         );
-        expect(screen.getByTestId('mockChild')).toHaveTextContent(mockEntity.page.title);
+        expect(screen.getByTestId('mockChild')).toHaveTextContent(mockEntity.pageAsset.page.title);
     });
 
     it('updates context when entity changes', () => {
         const { rerender } = render(
-            <PageProvider entity={mockEntity}>
+            <PageProvider pageContext={mockEntity}>
                 <MockChildComponent />
             </PageProvider>
         );
         // Change the context
         const newEntity = {
             ...mockEntity,
-            page: {
-                ...mockEntity.page,
-                title: 'Updated Test Page'
+            pageAsset: {
+                ...mockEntity.pageAsset,
+                page: {
+                    ...mockEntity.pageAsset.page,
+                    title: 'Updated Test Page'
+                }
             }
         };
         rerender(
-            <PageProvider entity={newEntity}>
+            <PageProvider pageContext={newEntity}>
                 <MockChildComponent />
             </PageProvider>
         );
-        expect(screen.getByTestId('mockChild')).toHaveTextContent(newEntity.page.title);
+        expect(screen.getByTestId('mockChild')).toHaveTextContent(newEntity.pageAsset.page.title);
     });
 });

--- a/core-web/libs/sdk/react/src/lib/components/PageProvider/PageProvider.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/PageProvider/PageProvider.tsx
@@ -1,39 +1,15 @@
 import { ReactNode } from 'react';
 
 import { PageContext } from '../../contexts/PageContext';
+import { DotCMSPageAsset } from '../../models';
 
 export interface PageProviderProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly entity: any;
+    readonly pageContext: any;
     readonly children: ReactNode;
 }
 
-export interface ContainerData {
-    [key: string]: {
-        container: {
-            path: string;
-            identifier: string;
-            maxContentlets: number;
-            parentPermissionable: Record<string, string>;
-        };
-        containerStructures: {
-            contentTypeVar: string;
-        }[];
-        contentlets: {
-            [key: string]: {
-                contentType: string;
-                identifier: string;
-                title: string;
-                inode: string;
-                onNumberOfPages: number;
-                baseType: string;
-                widgetTitle?: string;
-            }[];
-        };
-    };
-}
-
-export interface PageProviderContext {
+export interface DotCMSPageContext {
     /**
      * `components` is a property of the `PageProviderProps` type.
      * It is an object that maps content type variables to their corresponding React components.
@@ -47,39 +23,7 @@ export interface PageProviderContext {
     components: {
         [contentTypeVariable: string]: React.ElementType;
     };
-    containers: ContainerData;
-    layout: {
-        header: boolean;
-        footer: boolean;
-        body: {
-            rows: {
-                styleClass: string;
-                columns: {
-                    styleClass: string;
-                    width: number;
-                    leftOffset: number;
-                    containers: {
-                        identifier: string;
-                        uuid: string;
-                    }[];
-                }[];
-            }[];
-        };
-    };
-    page: {
-        title: string;
-        identifier: string;
-    };
-    viewAs: {
-        language: {
-            id: string;
-        };
-        persona: {
-            keyTag: string;
-        };
-        // variant requested
-        variantId: string;
-    };
+    pageAsset: DotCMSPageAsset;
     isInsideEditor: boolean;
     // If the page is part of an experiment, this will be the experiment id
     runningExperimentId?: string;
@@ -94,7 +38,7 @@ export interface PageProviderContext {
  * @returns {JSX.Element} - A JSX element that provides a context for a DotCMS page.
  */
 export function PageProvider(props: PageProviderProps): JSX.Element {
-    const { entity, children } = props;
+    const { pageContext, children } = props;
 
-    return <PageContext.Provider value={entity}>{children}</PageContext.Provider>;
+    return <PageContext.Provider value={pageContext}>{children}</PageContext.Provider>;
 }

--- a/core-web/libs/sdk/react/src/lib/components/PageProvider/PageProvider.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/PageProvider/PageProvider.tsx
@@ -1,32 +1,11 @@
 import { ReactNode } from 'react';
 
 import { PageContext } from '../../contexts/PageContext';
-import { DotCMSPageAsset } from '../../models';
 
 export interface PageProviderProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly pageContext: any;
     readonly children: ReactNode;
-}
-
-export interface DotCMSPageContext {
-    /**
-     * `components` is a property of the `PageProviderProps` type.
-     * It is an object that maps content type variables to their corresponding React components.
-     *
-     * It will be use to render the contentlets in the page.
-     *
-     * @property {Object} components
-     * @memberof PageProviderProps
-     * @type {Object.<string, React.ElementType>}
-     */
-    components: {
-        [contentTypeVariable: string]: React.ElementType;
-    };
-    pageAsset: DotCMSPageAsset;
-    isInsideEditor: boolean;
-    // If the page is part of an experiment, this will be the experiment id
-    runningExperimentId?: string;
 }
 
 /**

--- a/core-web/libs/sdk/react/src/lib/components/Row/Row.spec.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/Row/Row.spec.tsx
@@ -4,7 +4,7 @@ import { Row } from './Row';
 
 import { MockContextRender } from '../../mocks/mockPageContext';
 import { ColumnProps } from '../Column/Column';
-import { PageProviderContext } from '../PageProvider/PageProvider';
+import { DotCMSPageContext } from '../PageProvider/PageProvider';
 
 import '@testing-library/jest-dom';
 
@@ -17,7 +17,7 @@ jest.mock('../Column/Column', () => {
 });
 
 describe('Row', () => {
-    const mockRowData: PageProviderContext['layout']['body']['rows'][0] = {
+    const mockRowData: DotCMSPageContext['layout']['body']['rows'][0] = {
         columns: [
             {
                 width: 60,

--- a/core-web/libs/sdk/react/src/lib/components/Row/Row.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/Row/Row.tsx
@@ -3,9 +3,9 @@ import { forwardRef, useContext } from 'react';
 import styles from './row.module.css';
 
 import { PageContext } from '../../contexts/PageContext';
+import { DotCMSPageContext } from '../../models';
 import { combineClasses } from '../../utils/utils';
 import { Column } from '../Column/Column';
-import { DotCMSPageContext } from '../PageProvider/PageProvider';
 
 /**
  * Props for the row component

--- a/core-web/libs/sdk/react/src/lib/components/Row/Row.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/Row/Row.tsx
@@ -5,7 +5,7 @@ import styles from './row.module.css';
 import { PageContext } from '../../contexts/PageContext';
 import { combineClasses } from '../../utils/utils';
 import { Column } from '../Column/Column';
-import { PageProviderContext } from '../PageProvider/PageProvider';
+import { DotCMSPageContext } from '../PageProvider/PageProvider';
 
 /**
  * Props for the row component
@@ -17,10 +17,10 @@ export interface RowProps {
     /**
      * Row data
      *
-     * @type {PageProviderContext['layout']['body']['rows'][0]}
+     * @type {DotCMSPageContext['layout']['body']['rows'][0]}
      * @memberof RowProps
      */
-    row: PageProviderContext['layout']['body']['rows'][0];
+    row: DotCMSPageContext['pageAsset']['layout']['body']['rows'][0];
 }
 
 /**
@@ -31,9 +31,9 @@ export interface RowProps {
  * @return {*}
  */
 export const Row = forwardRef<HTMLDivElement, RowProps>((props: RowProps, ref) => {
-    const { isInsideEditor } = useContext<PageProviderContext | null>(
+    const { isInsideEditor } = useContext<DotCMSPageContext | null>(
         PageContext
-    ) as PageProviderContext;
+    ) as DotCMSPageContext;
 
     const { row } = props;
 

--- a/core-web/libs/sdk/react/src/lib/contexts/PageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/contexts/PageContext.tsx
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
 
-import { DotCMSPageContext } from '../components/PageProvider/PageProvider';
+import { DotCMSPageContext } from '../models';
 
 export const PageContext = createContext<DotCMSPageContext | null>(null);

--- a/core-web/libs/sdk/react/src/lib/contexts/PageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/contexts/PageContext.tsx
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
 
-import { PageProviderContext } from '../components/PageProvider/PageProvider';
+import { DotCMSPageContext } from '../components/PageProvider/PageProvider';
 
-export const PageContext = createContext<PageProviderContext | null>(null);
+export const PageContext = createContext<DotCMSPageContext | null>(null);

--- a/core-web/libs/sdk/react/src/lib/hooks/useDotcmsPageContext.spec.tsx
+++ b/core-web/libs/sdk/react/src/lib/hooks/useDotcmsPageContext.spec.tsx
@@ -3,10 +3,10 @@ import { ReactNode } from 'react';
 
 import { useDotcmsPageContext } from './useDotcmsPageContext'; // Adjust the import path based on your file structure.
 
-import { PageProviderContext } from '../components/PageProvider/PageProvider';
+import { DotCMSPageContext } from '../components/PageProvider/PageProvider';
 import { PageContext } from '../contexts/PageContext';
 
-const mockContextValue: PageProviderContext = {
+const mockContextValue: DotCMSPageContext = {
     components: {},
     containers: {},
     layout: {

--- a/core-web/libs/sdk/react/src/lib/hooks/useDotcmsPageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/hooks/useDotcmsPageContext.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 
-import { DotCMSPageContext } from '../components/PageProvider/PageProvider';
 import { PageContext } from '../contexts/PageContext';
+import { DotCMSPageContext } from '../models';
 
 /**
  * `useDotcmsPageContext` is a custom React hook that provides access to the `PageProviderContext`.

--- a/core-web/libs/sdk/react/src/lib/hooks/useDotcmsPageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/hooks/useDotcmsPageContext.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 
-import { PageProviderContext } from '../components/PageProvider/PageProvider';
+import { DotCMSPageContext } from '../components/PageProvider/PageProvider';
 import { PageContext } from '../contexts/PageContext';
 
 /**
@@ -8,8 +8,8 @@ import { PageContext } from '../contexts/PageContext';
  * It takes no parameters and returns the context value or `null` if it's not available.
  *
  * @category Hooks
- * @returns {PageProviderContext | null} - The context value or `null` if it's not available.
+ * @returns {DotCMSPageContext | null} - The context value or `null` if it's not available.
  */
 export function useDotcmsPageContext() {
-    return useContext<PageProviderContext | null>(PageContext);
+    return useContext<DotCMSPageContext | null>(PageContext);
 }

--- a/core-web/libs/sdk/react/src/lib/mocks/mockPageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/mocks/mockPageContext.tsx
@@ -1,4 +1,5 @@
-import { PageProvider, DotCMSPageContext } from '../components/PageProvider/PageProvider';
+import { PageProvider } from '../components/PageProvider/PageProvider';
+import { DotCMSPageContext } from '../models';
 
 export const mockPageContext: DotCMSPageContext = {
     pageAsset: {

--- a/core-web/libs/sdk/react/src/lib/mocks/mockPageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/mocks/mockPageContext.tsx
@@ -1,75 +1,77 @@
-import { PageProvider, PageProviderContext } from '../components/PageProvider/PageProvider';
+import { PageProvider, DotCMSPageContext } from '../components/PageProvider/PageProvider';
 
-export const mockPageContext: PageProviderContext = {
-    layout: {
-        header: true,
-        footer: true,
-        body: {
-            rows: [
-                {
-                    styleClass: 'row',
-                    columns: [
-                        {
-                            styleClass: 'col-md-12',
-                            width: 6,
-                            leftOffset: 3,
-                            containers: [
-                                {
-                                    identifier: 'container-1',
-                                    uuid: 'uuid-1'
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        }
-    },
-    containers: {
-        'container-1': {
-            container: {
-                path: 'path/to/container',
-                identifier: 'container-1',
-                maxContentlets: 100,
-                parentPermissionable: {}
-            },
-            containerStructures: [
-                {
-                    contentTypeVar: 'content-type-1'
-                }
-            ],
-            contentlets: {
-                'uuid-1': [
+export const mockPageContext: DotCMSPageContext = {
+    pageAsset: {
+        layout: {
+            header: true,
+            footer: true,
+            body: {
+                rows: [
                     {
-                        contentType: 'content-type-1',
-                        identifier: 'contentlet-1',
-                        title: 'Contentlet 1',
-                        inode: 'inode-1',
-                        onNumberOfPages: 1,
-                        baseType: 'base-type-1'
+                        styleClass: 'row',
+                        columns: [
+                            {
+                                styleClass: 'col-md-12',
+                                width: 6,
+                                leftOffset: 3,
+                                containers: [
+                                    {
+                                        identifier: 'container-1',
+                                        uuid: 'uuid-1'
+                                    }
+                                ]
+                            }
+                        ]
                     }
                 ]
             }
         },
-        'container-2': {
-            container: {
-                path: 'path/to/container',
-                identifier: 'container-2',
-                maxContentlets: 100,
-                parentPermissionable: {}
-            },
-            containerStructures: [
-                {
-                    contentTypeVar: 'content-type-2'
+        containers: {
+            'container-1': {
+                container: {
+                    path: 'path/to/container',
+                    identifier: 'container-1',
+                    maxContentlets: 100,
+                    parentPermissionable: {}
+                },
+                containerStructures: [
+                    {
+                        contentTypeVar: 'content-type-1'
+                    }
+                ],
+                contentlets: {
+                    'uuid-1': [
+                        {
+                            contentType: 'content-type-1',
+                            identifier: 'contentlet-1',
+                            title: 'Contentlet 1',
+                            inode: 'inode-1',
+                            onNumberOfPages: 1,
+                            baseType: 'base-type-1'
+                        }
+                    ]
                 }
-            ],
-            contentlets: {
-                'uuid-2': []
+            },
+            'container-2': {
+                container: {
+                    path: 'path/to/container',
+                    identifier: 'container-2',
+                    maxContentlets: 100,
+                    parentPermissionable: {}
+                },
+                containerStructures: [
+                    {
+                        contentTypeVar: 'content-type-2'
+                    }
+                ],
+                contentlets: {
+                    'uuid-2': []
+                }
             }
-        }
+        },
+        page: { identifier: 'page-1', title: 'Hello Page' },
+        viewAs: { language: { id: 'en' }, persona: { keyTag: 'persona-1' }, variantId: 'variant-1' }
     },
-    page: { identifier: 'page-1', title: 'Hello Page' },
-    viewAs: { language: { id: 'en' }, persona: { keyTag: 'persona-1' }, variantId: 'variant-1' },
     components: {},
     isInsideEditor: false
 };
@@ -79,7 +81,7 @@ export const MockContextRender = ({
     mockContext
 }: {
     children: JSX.Element;
-    mockContext: Partial<PageProviderContext>;
+    mockContext: Partial<DotCMSPageContext>;
 }) => {
-    return <PageProvider entity={mockContext}>{children}</PageProvider>;
+    return <PageProvider pageContext={mockContext}>{children}</PageProvider>;
 };

--- a/core-web/libs/sdk/react/src/lib/models/index.ts
+++ b/core-web/libs/sdk/react/src/lib/models/index.ts
@@ -15,7 +15,7 @@ export interface DotPageAssetLayoutRow {
     value?: string;
     id?: string;
     columns: DotPageAssetLayoutColumn[];
-    styleClass?: string;
+    styleClass: string;
 }
 
 export interface DotPageAssetLayoutColumn {
@@ -25,7 +25,7 @@ export interface DotPageAssetLayoutColumn {
     width: number;
     leftOffset: number;
     left: number;
-    styleClass?: string;
+    styleClass: string;
 }
 
 export interface DotCMSPageAssetContainer {

--- a/core-web/libs/sdk/react/src/lib/models/index.ts
+++ b/core-web/libs/sdk/react/src/lib/models/index.ts
@@ -1,407 +1,76 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-export interface DotCMSPageAsset {
-    canCreateTemplate: boolean;
-    containers: DotCMSPageAssetContainer;
-    layout: DotCMSLayout;
-    page: DotCMSPage;
-    site: DotCMSSite;
-    template: DotCMSTemplate;
-    viewAs: DotCMSViewAs;
-}
-
-export interface DotPageAssetLayoutRow {
-    identifier: number;
-    value?: string;
-    id?: string;
-    columns: DotPageAssetLayoutColumn[];
-    styleClass: string;
-}
-
-export interface DotPageAssetLayoutColumn {
-    preview: boolean;
-    containers: DotCMSContainer[];
-    widthPercent: number;
-    width: number;
-    leftOffset: number;
-    left: number;
-    styleClass: string;
-}
-
-export interface DotCMSPageAssetContainer {
+export interface ContainerData {
     [key: string]: {
-        container: DotCMSContainer;
-        containerStructures: DotCMSContainerStructure[];
+        container: {
+            path: string;
+            identifier: string;
+            maxContentlets: number;
+            parentPermissionable: Record<string, string>;
+        };
+        containerStructures: {
+            contentTypeVar: string;
+        }[];
         contentlets: {
-            [key: string]: DotCMSContentlet[];
+            [key: string]: {
+                contentType: string;
+                identifier: string;
+                title: string;
+                inode: string;
+                onNumberOfPages: number;
+                widgetTitle?: string;
+                baseType: string;
+            }[];
         };
     };
 }
 
-export interface DotCMSContainer {
-    identifier: string;
-    uuid: string;
-    iDate: number;
-    type: string;
-    owner?: string;
-    inode: string;
-    source: string;
-    title: string;
-    friendlyName: string;
-    modDate: number;
-    modUser: string;
-    sortOrder: number;
-    showOnMenu: boolean;
-    code?: string;
-    maxContentlets: number;
-    useDiv: boolean;
-    sortContentletsBy?: string;
-    preLoop: string;
-    postLoop: string;
-    staticify: boolean;
-    luceneQuery?: string;
-    notes: string;
-    languageId?: number;
-    path?: string;
-    live: boolean;
-    locked: boolean;
-    working: boolean;
-    deleted: boolean;
-    name: string;
-    archived: boolean;
-    permissionId: string;
-    versionId: string;
-    versionType: string;
-    permissionType: string;
-    categoryId: string;
-    idate: number;
-    new: boolean;
-    acceptTypes: string;
-    contentlets: DotCMSContentlet[];
-    parentPermissionable: DotCMSSiteParentPermissionable;
-}
-
-export interface DotCMSContentlet {
-    archived: boolean;
-    baseType: string;
-    deleted?: boolean;
-    binary?: string;
-    binaryContentAsset?: string;
-    binaryVersion?: string;
-    contentType: string;
-    file?: string;
-    folder: string;
-    hasLiveVersion?: boolean;
-    hasTitleImage: boolean;
-    host: string;
-    hostName: string;
-    identifier: string;
-    inode: string;
-    image?: string;
-    languageId: number;
-    language?: string;
-    live: boolean;
-    locked: boolean;
-    mimeType?: string;
-    modDate: string;
-    modUser: string;
-    modUserName: string;
-    owner: string;
-    sortOrder: number;
-    stInode: string;
-    title: string;
-    titleImage: string;
-    text?: string;
-    url: string;
-    working: boolean;
-    body?: string;
-    contentTypeIcon?: string;
-    variant?: string;
-    __icon__?: string;
-    [key: string]: any; // This is a catch-all for any other custom properties that might be on the contentlet.
-}
-
-interface DotCMSTemplate {
-    iDate: number;
-    type: string;
-    owner: string;
-    inode: string;
-    identifier: string;
-    source: string;
-    title: string;
-    friendlyName: string;
-    modDate: number;
-    modUser: string;
-    sortOrder: number;
-    showOnMenu: boolean;
-    image: string;
-    drawed: boolean;
-    drawedBody: string;
-    theme: string;
-    anonymous: boolean;
-    template: boolean;
-    name: string;
-    live: boolean;
-    archived: boolean;
-    locked: boolean;
-    working: boolean;
-    permissionId: string;
-    versionId: string;
-    versionType: string;
-    deleted: boolean;
-    permissionType: string;
-    categoryId: string;
-    idate: number;
-    new: boolean;
-    canEdit: boolean;
-}
-
-interface DotCMSPage {
-    template: string;
-    modDate: number;
-    metadata: string;
-    cachettl: string;
-    pageURI: string;
-    title: string;
-    type: string;
-    showOnMenu: string;
-    httpsRequired: boolean;
-    inode: string;
-    disabledWYSIWYG: any[];
-    seokeywords: string;
-    host: string;
-    lastReview: number;
-    working: boolean;
-    locked: boolean;
-    stInode: string;
-    friendlyName: string;
-    live: boolean;
-    owner: string;
-    identifier: string;
-    nullProperties: any[];
-    friendlyname: string;
-    pagemetadata: string;
-    languageId: number;
-    url: string;
-    seodescription: string;
-    modUserName: string;
-    folder: string;
-    deleted: boolean;
-    sortOrder: number;
-    modUser: string;
-    pageUrl: string;
-    workingInode: string;
-    shortyWorking: string;
-    canEdit: boolean;
-    canRead: boolean;
-    canLock: boolean;
-    lockedOn: number;
-    lockedBy: string;
-    lockedByName: string;
-    liveInode: string;
-    shortyLive: string;
-}
-
-interface DotCMSViewAs {
-    language: {
-        id: number;
-        languageCode: string;
-        countryCode: string;
-        language: string;
-        country: string;
+export interface DotCMSPageContext {
+    /**
+     * `components` is a property of the `PageProviderProps` type.
+     * It is an object that maps content type variables to their corresponding React components.
+     *
+     * It will be use to render the contentlets in the page.
+     *
+     * @property {Object} components
+     * @memberof PageProviderProps
+     * @type {Object.<string, React.ElementType>}
+     */
+    components: {
+        [contentTypeVariable: string]: React.ElementType;
     };
-    mode: string;
-}
-
-interface DotCMSLayout {
-    pageWidth: string;
-    width: string;
-    layout: string;
-    title: string;
-    header: boolean;
-    footer: boolean;
-    body: DotPageAssetLayoutBody;
-    sidebar: DotPageAssetLayoutSidebar;
-}
-
-interface DotCMSContainerStructure {
-    id: string;
-    structureId: string;
-    containerInode: string;
-    containerId: string;
-    code: string;
-    contentTypeVar: string;
-}
-
-interface DotPageAssetLayoutSidebar {
-    preview: boolean;
-    containers: DotCMSContainer[];
-    location: string;
-    widthPercent: number;
-    width: string;
-}
-
-interface DotPageAssetLayoutBody {
-    rows: DotPageAssetLayoutRow[];
-}
-
-interface DotCMSSite {
-    lowIndexPriority: boolean;
-    name: string;
-    default: boolean;
-    aliases: string;
-    parent: boolean;
-    tagStorage: string;
-    systemHost: boolean;
-    inode: string;
-    versionType: string;
-    structureInode: string;
-    hostname: string;
-    hostThumbnail?: any;
-    owner: string;
-    permissionId: string;
-    permissionType: string;
-    type: string;
-    identifier: string;
-    modDate: number;
-    host: string;
-    live: boolean;
-    indexPolicy: string;
-    categoryId: string;
-    actionId?: any;
-    new: boolean;
-    archived: boolean;
-    locked: boolean;
-    disabledWysiwyg: any[];
-    modUser: string;
-    working: boolean;
-    titleImage: {
-        present: boolean;
+    pageAsset: {
+        containers: ContainerData;
+        layout: {
+            header: boolean;
+            footer: boolean;
+            body: {
+                rows: {
+                    styleClass: string;
+                    columns: {
+                        styleClass: string;
+                        width: number;
+                        leftOffset: number;
+                        containers: {
+                            identifier: string;
+                            uuid: string;
+                        }[];
+                    }[];
+                }[];
+            };
+        };
+        page: {
+            title: string;
+            identifier: string;
+        };
+        viewAs: {
+            language: {
+                id: string;
+            };
+            persona: {
+                keyTag: string;
+            };
+            // variant requested
+            variantId: string;
+        };
     };
-    folder: string;
-    htmlpage: boolean;
-    fileAsset: boolean;
-    vanityUrl: boolean;
-    keyValue: boolean;
-    structure?: DotCMSSiteStructure;
-    title: string;
-    languageId: number;
-    indexPolicyDependencies: string;
-    contentTypeId: string;
-    versionId: string;
-    lastReview: number;
-    nextReview?: any;
-    reviewInterval?: any;
-    sortOrder: number;
-    contentType: DotCMSSiteContentType;
-}
-
-interface DotCMSSiteContentType {
-    owner?: any;
-    parentPermissionable: DotCMSSiteParentPermissionable;
-    permissionId: string;
-    permissionType: string;
-}
-
-export interface DotCMSSiteParentPermissionable {
-    Inode: string;
-    Identifier: string;
-    permissionByIdentifier: boolean;
-    type: string;
-    owner?: any;
-    identifier: string;
-    permissionId: string;
-    parentPermissionable?: any;
-    permissionType: string;
-    inode: string;
-    childrenPermissionable?: any;
-    variantId?: string;
-}
-
-interface DotCMSSiteStructure {
-    iDate: number;
-    type: string;
-    owner?: any;
-    inode: string;
-    identifier: string;
-    name: string;
-    description: string;
-    defaultStructure: boolean;
-    reviewInterval?: any;
-    reviewerRole?: any;
-    pagedetail?: any;
-    structureType: number;
-    fixed: boolean;
-    system: boolean;
-    velocityVarName: string;
-    urlMapPattern?: any;
-    host: string;
-    folder: string;
-    publishDateVar?: any;
-    expireDateVar?: any;
-    modDate: number;
-    fields: DotCMSSiteField[];
-    widget: boolean;
-    detailPage?: any;
-    fieldsBySortOrder: DotCMSSiteField[];
-    form: boolean;
-    htmlpageAsset: boolean;
-    content: boolean;
-    fileAsset: boolean;
-    persona: boolean;
-    permissionId: string;
-    permissionType: string;
-    live: boolean;
-    categoryId: string;
-    idate: number;
-    new: boolean;
-    archived: boolean;
-    locked: boolean;
-    modUser: string;
-    working: boolean;
-    title: string;
-    versionId: string;
-    versionType: string;
-}
-
-interface DotCMSSiteField {
-    iDate: number;
-    type: string;
-    owner?: any;
-    inode: string;
-    identifier: string;
-    structureInode: string;
-    fieldName: string;
-    fieldType: string;
-    fieldRelationType?: any;
-    fieldContentlet: string;
-    required: boolean;
-    velocityVarName: string;
-    sortOrder: number;
-    values?: any;
-    regexCheck?: any;
-    hint?: any;
-    defaultValue?: any;
-    indexed: boolean;
-    listed: boolean;
-    fixed: boolean;
-    readOnly: boolean;
-    searchable: boolean;
-    unique: boolean;
-    modDate: number;
-    dataType: string;
-    live: boolean;
-    categoryId: string;
-    idate: number;
-    new: boolean;
-    archived: boolean;
-    locked: boolean;
-    modUser: string;
-    working: boolean;
-    permissionId: string;
-    parentPermissionable?: any;
-    permissionType: string;
-    title: string;
-    versionId: string;
-    versionType: string;
+    isInsideEditor: boolean;
 }

--- a/core-web/libs/sdk/react/src/lib/utils/utils.ts
+++ b/core-web/libs/sdk/react/src/lib/utils/utils.ts
@@ -1,4 +1,5 @@
-import { ContainerData, PageProviderContext } from '../components/PageProvider/PageProvider';
+import { DotCMSPageContext } from '../components/PageProvider/PageProvider';
+import { DotCMSPageAssetContainer } from '../models';
 
 const endClassMap: Record<number, string> = {
     1: 'col-end-1',
@@ -32,8 +33,8 @@ const startClassMap: Record<number, string> = {
 };
 
 export const getContainersData = (
-    containers: ContainerData,
-    containerRef: PageProviderContext['layout']['body']['rows'][0]['columns'][0]['containers'][0]
+    containers: DotCMSPageAssetContainer,
+    containerRef: DotCMSPageContext['pageAsset']['layout']['body']['rows'][0]['columns'][0]['containers'][0]
 ) => {
     const { identifier, uuid } = containerRef;
 

--- a/core-web/libs/sdk/react/src/lib/utils/utils.ts
+++ b/core-web/libs/sdk/react/src/lib/utils/utils.ts
@@ -1,5 +1,4 @@
-import { DotCMSPageContext } from '../components/PageProvider/PageProvider';
-import { DotCMSPageAssetContainer } from '../models';
+import { ContainerData, DotCMSPageContext } from '../models';
 
 const endClassMap: Record<number, string> = {
     1: 'col-end-1',
@@ -33,7 +32,7 @@ const startClassMap: Record<number, string> = {
 };
 
 export const getContainersData = (
-    containers: DotCMSPageAssetContainer,
+    containers: ContainerData,
     containerRef: DotCMSPageContext['pageAsset']['layout']['body']['rows'][0]['columns'][0]['containers'][0]
 ) => {
     const { identifier, uuid } = containerRef;

--- a/examples/nextjs/jsconfig.json
+++ b/examples/nextjs/jsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "paths": {
-            "@/*": ["./src/*"]
+            "@/*": ["./src/*"],
         }
     }
 }

--- a/examples/nextjs/src/app/[[...slug]]/page.js
+++ b/examples/nextjs/src/app/[[...slug]]/page.js
@@ -52,5 +52,5 @@ export default async function Home({ searchParams, params }) {
         handleVanityUrlRedirect(vanityUrl);
     }
 
-    return <MyPage nav={nav.entity.children} data={data.entity}></MyPage>;
+    return <MyPage nav={nav.entity.children} pageAsset={data.entity}></MyPage>;
 }

--- a/examples/nextjs/src/components/content-types/activity.js
+++ b/examples/nextjs/src/components/content-types/activity.js
@@ -4,7 +4,7 @@ import { useDotcmsPageContext } from '@dotcms/react';
 
 function Activity({ title, description, image, urlTitle }) {
     const {
-        viewAs: { language }
+        pageAsset: {viewAs: { language }}
     } = useDotcmsPageContext();
 
     return (

--- a/examples/nextjs/src/components/content-types/banner.js
+++ b/examples/nextjs/src/components/content-types/banner.js
@@ -1,10 +1,12 @@
-import Image from 'next/image';
-import Link from 'next/link';
-import { useDotcmsPageContext } from '@dotcms/react';
+import Image from "next/image";
+import Link from "next/link";
+import { useDotcmsPageContext } from "@dotcms/react";
 
 function Banner({ title, image, caption, buttonText, link }) {
     const {
-        viewAs: { language }
+        pageAsset: {
+            viewAs: { language },
+        },
     } = useDotcmsPageContext();
 
     return (
@@ -20,7 +22,8 @@ function Banner({ title, image, caption, buttonText, link }) {
                 <p className="mb-4 text-xl text-shadow">{caption}</p>
                 <Link
                     className="p-4 text-xl transition duration-300 bg-purple-500 rounded hover:bg-purple-600"
-                    href={link || '#'}>
+                    href={link || "#"}
+                >
                     {buttonText}
                 </Link>
             </div>

--- a/examples/nextjs/src/components/content-types/image.js
+++ b/examples/nextjs/src/components/content-types/image.js
@@ -3,7 +3,7 @@ import Image from 'next/image';
 
 function ImageComponent({ fileAsset, title, description }) {
     const {
-        viewAs: { language }
+        pageAsset: {viewAs: { language }}
     } = useDotcmsPageContext();
 
     return (

--- a/examples/nextjs/src/components/content-types/product.js
+++ b/examples/nextjs/src/components/content-types/product.js
@@ -4,7 +4,7 @@ import { useDotcmsPageContext } from '@dotcms/react';
 
 function Product({ image, title, salePrice, retailPrice, urlTitle }) {
     const {
-        viewAs: { language }
+        pageAsset: {viewAs: { language }}
     } = useDotcmsPageContext();
 
     const formatPrice = (price) => {

--- a/examples/nextjs/src/components/my-page.js
+++ b/examples/nextjs/src/components/my-page.js
@@ -33,7 +33,7 @@ const componentsMap = {
 };
 
 
-export function MyPage({ data, nav }) {
+export function MyPage({ pageAsset, nav }) {
   const { refresh, replace } = useRouter();
   const pathname = usePathname();
 
@@ -52,18 +52,18 @@ export function MyPage({ data, nav }) {
 
   return (
     <div className="flex flex-col min-h-screen gap-6 bg-lime-50">
-      {data.layout.header && (
+      {pageAsset.layout.header && (
         <Header>
           <Navigation items={nav} />
         </Header>
       )}
       <main className="container flex flex-col gap-8 m-auto">
         <DotLayoutComponent
-          entity={{ components: componentsMap, ...data }}
+          pageContext={{ components: componentsMap, pageAsset: pageAsset }}
           config={{ onReload: refresh, pathname }}
         />
       </main>
-      {data.layout.footer && <Footer />}
+      {pageAsset.layout.footer && <Footer />}
     </div>
   );
 


### PR DESCRIPTION
### Proposed Changes
* Homologate "context" to shared info between components in both SDK (Angular - React)
* Now both context have this structure

```
{
components: Components Map,
pageAssets: Response of PageAPI,
isInsideEditor: boolean from @dotcms/client
}

```
And have same naming convention