### PR TITLE
feat(CICD): #28673 Adding a slack notification to the dotCLI release workflow.

### DIFF
--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -9,6 +9,10 @@ on:
         description: 'Release version'
         default: '1.0.0-SNAPSHOT'
         required: false
+      notify_slack:
+        description: 'Notify Slack'
+        default: 'true'
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -459,6 +463,19 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
           npm publish --access public --tag ${NPM_PACKAGE_VERSION_TAG}
+          
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.RELEASE_SLACK_WEBHOOK }}
+          SLACK_TITLE: "Important news!"
+          SLACK_MESSAGE: "<!channel> This automated script is excited to announce the release of a new version of *dotCLI* `${{ needs.precheck.outputs.RELEASE_VERSION }}` :package: is available on the `NPM` registry!"
+          SLACK_USERNAME: dotBot
+          SLACK_MSG_AUTHOR: " "
+          MSG_MINIMAL: true
+          SLACK_FOOTER: ""
+          SLACK_ICON: https://avatars.slack-edge.com/temp/2021-12-08/2830145934625_e4e464d502865ff576e4.png
+        if: success() && github.event.inputs.notify_slack == 'true'
 
   clean-up:
     name: "Clean Up"


### PR DESCRIPTION
### Proposed Changes
* Added a Slack notification to announce a new dotCLI release at the end of dotCLI release workflow.

### Fixes
#28673 
