### PR TITLE
Issue 28760 find page in it's language not only in default one

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
@@ -458,7 +458,7 @@ public class PushPublishigDependencyProcesor implements DependencyProcessor {
             for (final Contentlet contentletVersion : contentList) {
 
                 if (contentletVersion.isHTMLPage()) {
-                    processHTMLPagesDependency(contentletVersion.getIdentifier());
+                    processHTMLPagesDependency(contentletVersion.getIdentifier(),contentletVersion.getLanguageId());
                 }
                 processStoryBockDependencies(contentletVersion);
 
@@ -715,7 +715,7 @@ public class PushPublishigDependencyProcesor implements DependencyProcessor {
      * </ul>
      *
      */
-    private void processHTMLPagesDependency(final String pageId) {
+    private void processHTMLPagesDependency(final String pageId, final long languageId) {
         try {
 
             final IdentifierAPI idenAPI = APILocator.getIdentifierAPI();
@@ -730,7 +730,7 @@ public class PushPublishigDependencyProcesor implements DependencyProcessor {
             final IHTMLPage workingPage = Try.of(
                     ()->APILocator.getHTMLPageAssetAPI().findByIdLanguageFallback(
                             identifier,
-                            APILocator.getLanguageAPI().getDefaultLanguage().getId(),
+                            languageId,
                             false,
                             user,
                             false)
@@ -753,8 +753,13 @@ public class PushPublishigDependencyProcesor implements DependencyProcessor {
             final IHTMLPage livePage = workingPage.isLive()
                     ? workingPage
                     : Try.of(()->
-                            APILocator.getHTMLPageAssetAPI().findByIdLanguageFallback(identifier, APILocator.getLanguageAPI().getDefaultLanguage().getId(), true, user, false))
-                            .onFailure(e->Logger.warnAndDebug(DependencyManager.class, e)).getOrNull();
+                            APILocator.getHTMLPageAssetAPI().findByIdLanguageFallback(
+                                    identifier,
+                                    languageId,
+                                    true,
+                                    user,
+                                    false))
+                    .onFailure(e->Logger.warnAndDebug(DependencyManager.class, e)).getOrNull();
 
             // working template working page
             addTemplateAsDependency(workingPage);

--- a/dotcms-integration/src/test/java/com/dotcms/publisher/util/DependencyManagerTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/publisher/util/DependencyManagerTest.java
@@ -29,6 +29,7 @@ import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.containers.model.Container;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships.ContentletRelationshipRecords;
 import com.dotmarketing.portlets.structure.model.Relationship;
@@ -599,6 +600,35 @@ public class DependencyManagerTest {
         dependencyManager.setDependencies();
 
         assertTrue(dependencyManager.getTemplates().contains(template.getIdentifier()));
+    }
+
+    /**
+     * <b>Method to test:</b> {@link com.dotcms.publisher.util.dependencies.PushPublishigDependencyProcesor#tryToAdd(PusheableAsset, Object, String)}<p>
+     * <b>Given Scenario:</b>  A page that only exist in a non default lang should PP the template/layout if required <p>
+     * <b>ExpectedResult:</b> The template/layout should be included in the dependencies
+     * @throws DotSecurityException
+     * @throws DotBundleException
+     * @throws DotDataException
+     */
+    @Test
+    public void test_PP_page_non_default_language_should_contains_template_layout_in_dependencies() throws DotDataException, DotBundleException, DotSecurityException {
+        final PushPublisherConfig config = new PushPublisherConfig();
+        //Layout templates are identified by the prefix 'anonymous_layout_'
+        final Template template = new TemplateDataGen().title(Template.ANONYMOUS_PREFIX+"shouldBeIncluded"+System.currentTimeMillis()).nextPersisted();
+        final Host host = new SiteDataGen().nextPersisted();
+        final Language language = new LanguageDataGen().nextPersisted();
+        final HTMLPageAsset htmlPageAsset = new HTMLPageDataGen(host, template).languageId(language.getId()).nextPersisted();
+        //Create a bundle with filter 'Only Selected Items'
+        final String filterKey = "ShallowPush.yml";
+        if(!APILocator.getPublisherAPI().existsFilterDescriptor(filterKey)){
+            createShallowPushFilter();
+        }
+        createBundle(config, htmlPageAsset, filterKey);
+        createBundle(config, htmlPageAsset, "ShallowPush.yml");
+        DependencyManager dependencyManager = new DependencyManager(DependencyManagerTest.user, config);
+        dependencyManager.setDependencies();
+
+        assertTrue("Template isn't in the bundle",dependencyManager.getTemplates().contains(template.getIdentifier()));
     }
 
 }


### PR DESCRIPTION
We were calling the method `findByIdLanguageFallback` but we were always passing the default language instead of the language of the page, so if a page only existed in a non default language it never found it.

Added a new test for this scenario
