### PR TITLE
feat(CICD): Implement Slack notification for dotCLI publishing on NPM registry (#28674)

### DIFF
--- a/.github/actions/publish-npm-cli/action.yml
+++ b/.github/actions/publish-npm-cli/action.yml
@@ -30,6 +30,13 @@ inputs:
   reuse-previous-build:
     description: 'Indicates if the workflow should reuse the previous build'
     required: false
+outputs:
+  npm-package-version:
+    description: 'NPM package version'
+    value: ${{ steps.npm-version-tag.outputs.npm-package-version }}
+  npm-package-version-tag:
+    description: 'NPM package version tag'
+    value: ${{ steps.npm-version-tag.outputs.npm-package-version-tag }}
 
 runs:
   using: "composite"

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -114,7 +114,7 @@ jobs:
         if: inputs.publish-npm-package
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.DEVELOPERS_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL: "log-dotcli"
           SLACK_TITLE: "Important news!"
           SLACK_MESSAGE: "This automated script is happy to announce that a new dotCLI version has been built for *${{ inputs.environment }}* with tags: [ ${{ steps.cli_publish.outputs.npm-package-version }}, ${{ steps.cli_publish.outputs.npm-package-version-tag }} ] is now available on the NPM registry :package:!"

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -102,12 +102,27 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: CLI Publish
+        id: cli_publish
         if: inputs.publish-npm-package
         uses: ./.github/actions/publish-npm-cli
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_ORG_TOKEN }}
           reuse-previous-build: ${{ inputs.reuse-previous-build }}
+
+      - name: Slack Notification (dotCLI announcement)
+        if: inputs.publish-npm-package
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.DEVELOPERS_SLACK_WEBHOOK }}
+          SLACK_CHANNEL: "log-dotcli"
+          SLACK_TITLE: "Important news!"
+          SLACK_MESSAGE: "This automated script is happy to announce that a new dotCLI version has been built for *${{ inputs.environment }}* with tags: [ ${{ steps.cli_publish.outputs.npm-package-version }}, ${{ steps.cli_publish.outputs.npm-package-version-tag }} ] is now available on the NPM registry :package:!"
+          SLACK_USERNAME: dotBot
+          SLACK_MSG_AUTHOR: " "
+          MSG_MINIMAL: true
+          SLACK_FOOTER: ""
+          SLACK_ICON: https://avatars.slack-edge.com/temp/2021-12-08/2830145934625_e4e464d502865ff576e4.png
 
       # A Slack notification is sent using the 'action-slack-notify' action if the repository is 'dotcms/core'.
       - name: Slack Notification


### PR DESCRIPTION
### Proposed Changes
* Adding a step to send a Slack Notification when a new dotCLI version is published on the NPM registry during the Nightly Build process.

### Additional Info
Related to #28674 (CICD Implement Slack notification for dotCLI publishing on the NPM Registry).