### PR TITLE
feat(CICD): Now that post-pr.yml workflow is in master test link-pr feature

### DIFF
--- a/.github/workflows/link-pr-to-issue.yml
+++ b/.github/workflows/link-pr-to-issue.yml
@@ -16,17 +16,19 @@ on:
         type: boolean
         required: false
         default: true
+env:
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
   link-pr-to-issue:
     runs-on: ubuntu-20.04
-    continue-on-error: true
     steps:
       - run: echo 'GitHub context'
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Link PR to Issue
+        continue-on-error: true
         shell: bash
         run: |
           pr_json=$(\
@@ -54,7 +56,9 @@ jobs:
           [[ -z "${fetched_issue_number}" ]] && echo "Issue [${issue_number}] could not be resolved" && exit 3
           
           pr_body=$(echo "${pr_json}" | jq -r '.body')
-          pr_body="${pr_body}"$'\n\n'"This PR fixes: #${issue_number}"
+          [[ "${pr_body}" == 'null' ]] && pr_body=
+          [[ -n "${pr_body}" ]] && pr_body="${pr_body}"$'\n\n'
+          pr_body="${pr_body}This PR fixes: #${issue_number}"
           echo "pr_body=${pr_body}"
           
           gh api \
@@ -62,4 +66,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/pulls/${{ inputs.pr_number }} \
-            -f "body=\"${pr_body}\""
+            -f "body=${pr_body}"

--- a/.github/workflows/post-pr-merge.yml
+++ b/.github/workflows/post-pr-merge.yml
@@ -1,15 +1,29 @@
 name: Post PR Merge
 on:
+  workflow_dispatch:
+    inputs:
+        pr_number:
+            description: 'Pull Request number'
+            type: number
+            required: true
+        pr_branch:
+            description: 'Pull Request branch'
+            type: string
+            required: true
+        validate_merge:
+            description: 'Validate merge'
+            type: boolean
+            required: false
+            default: true
   pull_request:
-    branches:
-      - 28716-test
     types:
-      - closed
+      [closed]
 
 jobs:
   post-pr-merge:
     name: Post Merge PR
     if: github.event.pull_request.merged == true
+    continue-on-error: true
     uses: ./.github/workflows/link-pr-to-issue.yml
     with:
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
An initial workflow was created and merged to master since Github does not recognize any until they exists in `master`.
This PR is about to test the implementation for #28716. The initial PR is: https://github.com/dotCMS/core/pull/28808.

"This PR fixes: #28716"