### PR TITLE
fix(Block Editor): Bubble Menu actions and marks are not working

### DIFF
--- a/core-web/libs/block-editor/src/lib/extensions/bubble-menu/plugins/dot-bubble-menu.plugin.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-menu/plugins/dot-bubble-menu.plugin.ts
@@ -188,9 +188,9 @@ export class DotBubbleMenuPluginView extends BubbleMenuView {
             }
         });
 
-        this.updateComponent();
-        this.setMenuItems(doc, from);
         this.show();
+        this.setMenuItems(doc, from);
+        this.updateComponent();
     }
 
     /* @Overrrider */
@@ -324,8 +324,8 @@ export class DotBubbleMenuPluginView extends BubbleMenuView {
     /* Run commands */
     exeCommand(item: BubbleMenuItem) {
         const { markAction: action, active } = item;
-        const { inode, languageId } = this.selectionNode.attrs.data;
-
+        const { data = {} } = this.selectionNode.attrs;
+        const { inode, languageId } = data;
         const currentInode = this.getQueryParam('inode');
 
         switch (action) {


### PR DESCRIPTION
### Proposed Changes
* Allow users to set styles/marks using the `bubble menu`

### Video

https://github.com/dotCMS/core/assets/72418962/a51a69d9-66d6-4050-a7db-8c0ed3f851f2

