### PR TITLE
refactor(deployment): CICD Develop GitHub Action to Deploy dotCLI Artifa (#28598)

### DIFF
--- a/.github/actions/deploy-artifact-jfrog/README.md
+++ b/.github/actions/deploy-artifact-jfrog/README.md
@@ -1,0 +1,43 @@
+# Deploy Artifact to Artifactory GitHub Action
+
+This GitHub Action is used to deploy the dotCMS artifacts to Artifactory. It includes steps to extract project modules, version, and repository details from the POM file and deploy artifacts to the specified Artifactory repository.
+
+## Inputs
+
+- **modules**: (Optional) Comma-separated list of modules to deploy. If not provided, it will be extracted from the project POM file.
+- **exclude-ext**: (Optional) Comma-separated list of extensions to be excluded.
+- **dry-run**: (Optional) Enable dry-run mode. If it sets `true` the action will not deploy artifacts to Artifactory.
+- **version**: (Optional) Version of the artifacts to deploy. If not provided, it will be extracted from the project POM file.
+- **artifactory-repository**: (Optional) Artifactory Repository. If not provided, it will be extracted from the project POM file.
+- **artifactory-url**: (Optional) Artifactory URL. If not provided, it will be extracted from the project POM file.
+- **artifactory-access-token**: (Optional) Artifactory Access Token. It takes precedence over `artifactory-username` and
+  `artifactory-password`.
+- **artifactory-username**: (Optional) Artifactory username.
+- **artifactory-password**: (Optional) Artifactory password.
+- **github-token**: (Required) GitHub Token.
+
+## Outputs
+
+This action does not produce explicit outputs but uses extracted values within the workflow.
+
+## Example Usage
+
+```yaml
+name: Deploy Artifact to Artifactory
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy Artifact
+        uses: ./.github/actions/deploy-artifact-jfrog
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          artifactory-access-token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}

--- a/.github/actions/deploy-artifact-jfrog/action.yml
+++ b/.github/actions/deploy-artifact-jfrog/action.yml
@@ -1,0 +1,264 @@
+name: 'Deploy Artifact to Artifactory'
+description: 'Deploy the dotCMS artifacts to Artifactory'
+inputs:
+  modules:
+    description: 'Comma-separated list of modules to deploy, if not provided, will be extracted from the project POM file.'
+    required: false
+  exclude-ext:
+    description: 'Comma-separated list of extensions to be excluded.'
+    required: false
+  dry-run:
+    description: 'Enable dry-run mode'
+    required: false
+  version:
+    description: 'Version of the artifacts to deploy, if not provided, will be extracted from the project POM file.'
+    required: false
+  artifactory-repository:
+    description: 'Artifactory Repository, if not provided, will be extracted from the project POM file.'
+    required: false
+  artifactory-url:
+    description: 'Artifactory URL, if not provided, will be extracted from the project POM file.'
+    required: false
+  artifactory-access-token:
+    description: 'Artifactory Access Token. It takes precedence over artifactory-username and artifactory-password.'
+    required: false
+  artifactory-username:
+    description: 'Artifactory username'
+    required: false
+  artifactory-password:
+    description: 'Artifactory password'
+    required: false
+  github-token:
+    description: 'GitHub Token'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: 'Set up JDK'
+      uses: actions/setup-java@v4
+      with:
+        java-version: 11
+        distribution: temurin
+
+    - name: Install xmllint
+      run: |
+        sudo apt-get update && sudo apt-get install -y libxml2-utils
+      shell: bash
+
+    - name: 'Get Date'
+      id: get-date
+      run: |
+        echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Download Build Artifact
+      id: data-download
+      uses: dawidd6/action-download-artifact@v3.1.4
+      with:
+        github_token: ${{ inputs.github-token }}
+        workflow_search: true
+        commit: ${{ github.sha }}
+        workflow_conclusion: success
+        search_artifacts: true
+        dry_run: true
+        name: maven-repo
+        path: .
+        if_no_artifact_found: warn
+
+    - name: 'Check if artifact exists'
+      id: check
+      run: |
+        build_artifact_exists=${{ steps.data-download.outputs.found_artifact }}
+        if [[ ${build_artifact_exists} == "true" ]]; then
+            run_id=`echo '${{ steps.data-download.outputs.artifacts }}' | jq -r '.[0].workflow_run.id'`
+            found_artifacts=true
+            echo "Artifact Run id: $run_id"
+        else
+           echo "No artifact found"
+           run_id="${{ github.run_id }}"
+           found_artifacts=false
+        fi
+        echo "run_id=$run_id" >> $GITHUB_OUTPUT
+        echo "found_artifacts=$found_artifacts" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: 'Download Maven Repo'
+      uses: actions/download-artifact@v4
+      with:
+        run-id: ${{ steps.check.outputs.run_id }}
+        github-token: ${{ inputs.github-token }}
+        name: maven-repo
+        path: ~/.m2/repository
+
+    - uses: jfrog/setup-jfrog-cli@v4
+
+    - name: 'Extract project modules'
+      if: ${{ inputs.modules == '' || inputs.modules == null }}
+      id: maven-modules
+      run: |
+        echo "::group::Extract project modules"
+        POM_PATH="${{ inputs.pom-path }}"
+        artifact_ids=""
+
+        # Function to extract artifact ID from POM file
+        extract_artifact_id() {
+          mvn -f "$1" help:evaluate -Dexpression=project.artifactId -q -DforceStdout 2>/dev/null || true
+        }
+
+        # Function to get submodules from POM file
+        get_submodules() {
+          mvn -f "$1" help:evaluate -Dexpression=project.modules -q -DforceStdout 2>/dev/null | sed 's/<[^>]*>//g' | tr -d '\n' | tr -s ' ' | tr ' ' ',' || true
+        }
+
+        # Function to process each module and its submodules
+        process_module() {
+        
+          local module_path="$1"
+          local module_pom="$module_path/pom.xml"
+        
+          if [ -f "$module_pom" ]; then
+            artifactId=$(extract_artifact_id "$module_pom")
+        
+            if [[ -z "$artifactId" || "$artifactId" == *"[ERROR]"* ]]; then
+              artifact_ids+="$module_path,"
+            else
+              artifact_ids+="$artifactId,"
+            fi
+
+            submodules=$(get_submodules "$module_pom")
+            if [[ -z "$submodules" || "$submodules" == *"[ERROR]"* ]]; then
+              return
+            fi
+
+            submodules=$(echo $submodules | sed 's/^,//' || true)
+
+            # Process each module and submodule recursively
+            for submodule in ${submodules//,/ }; do
+              process_module "$module_path/$submodule"
+            done
+          else
+            artifact_ids+="$module_path,"
+          fi
+        }
+
+        modules=$(mvn -f "$POM_PATH" help:evaluate -Dexpression=project.modules -q -DforceStdout 2>/dev/null | sed 's/<[^>]*>//g' | tr -d '\n' | tr -s ' ' | tr ' ' ',' || true)
+        modules=$(echo $modules | sed 's/^,//' || true)
+
+        for module in ${modules//,/ }; do
+          process_module "$module"
+        done
+
+        artifact_ids=$(echo $artifact_ids | sed 's/,$/,dotcms-root/' || true)
+        echo "::notice::modules: $artifact_ids"
+        echo "artifact-ids=${artifact_ids}" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 'Extract project version'
+      if: ${{ inputs.version == '' || inputs.version == null }}
+      id: maven-version
+      run: |
+        echo "::group::Extract project version"
+        version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        echo "::notice::version: $version"
+        echo "version=$version" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 'Extract project repo'
+      if: ${{ inputs.artifactory-repository == '' || inputs.artifactory-repository == null }}
+      id: maven-artifact-repository
+      env:
+        VERSION: ${{ inputs.version || steps.maven-version.outputs.version }}
+      run: |
+        echo "::group::Extract artifact repository"
+        echo ""
+        
+        POM_FILE="pom.xml"
+        
+        if [[ ! -f "$POM_FILE" ]]; then
+          echo "$POM_FILE file is missing."
+          exit 1
+        fi
+
+        # Determine the node type based on the version
+        if [[ "$VERSION" =~ [Ss][Nn][Aa][Pp][Ss][Hh][Oo][Tt] ]]; then
+          NODE_TYPE="snapshotRepository"
+        else 
+          NODE_TYPE="repository"
+        fi
+
+        echo "NODE_TYPE=$NODE_TYPE"
+
+        # Extract the repository URL from the POM file
+        REPO=$(xmllint --xpath "//*[local-name()='distributionManagement']/*[local-name()='$NODE_TYPE']/*[local-name()='url']/text()" "$POM_FILE" 2>/dev/null)
+        
+        if [[ "$REPO" =~ ^(https://[^/]+/[^/]+)/(.+)$ ]]; then
+          SERVER_URL="${BASH_REMATCH[1]}"
+          REPO_NAME="${BASH_REMATCH[2]}"
+        
+          echo "url=$SERVER_URL" >> $GITHUB_OUTPUT
+          echo "repo=$REPO_NAME" >> $GITHUB_OUTPUT
+        else
+          echo "Invalid REPO format"
+          exit 1
+        fi
+
+        echo "::notice::ARTIFACTORY_URL=$SERVER_URL"
+        echo "::notice::ARTIFACTORY_REPO=$REPO_NAME"
+        
+        echo "::endgroup::"
+      shell: bash
+
+    - name:
+      env:
+        ARTIFACTORY_URL: ${{ inputs.artifactory-url || steps.maven-artifact-repository.outputs.url }}
+        ARTIFACTORY_ACCESS_TOKEN: ${{ inputs.artifactory-access-token }}
+      run: |
+        echo "::group::JFrog CLI context"
+        jf rt ping --url=$ARTIFACTORY_URL --access-token=$ARTIFACTORY_ACCESS_TOKEN
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 'Deploy artifacts'
+      env:
+        ARTIFACTORY_ACCESS_TOKEN: ${{ inputs.artifactory-access-token }}
+        ARTIFACTORY_URL: ${{ inputs.artifactory-url || steps.maven-artifact-repository.outputs.url }}
+        ARTIFACTORY_USERNAME: ${{ inputs.artifactory-username }}
+        ARTIFACTORY_PASSWORD: ${{ inputs.artifactory-password }}
+        ARTIFACTORY_REPO: ${{ inputs.artifactory-repository || steps.maven-artifact-repository.outputs.repo }}
+        VERSION: ${{ inputs.version || steps.maven-version.outputs.version }}
+        PRJ_MODULES: ${{ inputs.modules || steps.maven-modules.outputs.artifact-ids }}
+        EXCLUDE_EXT: ${{ inputs.exclude-ext || 'repositories,excludeext' }}
+        DRY_RUN_MODE: ${{ inputs.dry-run }}
+      run: |
+        echo "::group::Deploy Artifacts"
+        
+        MAVEN_DIR=${HOME}/.m2/repository
+        cd $MAVEN_DIR
+
+        # Replace ',' with '|'
+        MODULES=$(echo $PRJ_MODULES | sed 's/,/|/g')
+        # Replace '.' with '\.'
+        ESCAPED_VERSION=$(echo $VERSION | sed 's/\./\\./g')
+        # Replace ',' with '|'
+        EXCLUDE=$(echo $EXCLUDE_EXT | sed 's/,/|/g')
+
+        if [[ $DRY_RUN_MODE == true ]]; then
+          DRY_RUN='--dry-run'
+        fi
+
+        # Deploy the artifacts using JFrog CLI with appropriate credentials and options
+        if [[ -n "$ARTIFACTORY_ACCESS_TOKEN" ]]; then
+          jf rt u "com/dotcms/(${MODULES})/${ESCAPED_VERSION}" $ARTIFACTORY_REPO --url=$ARTIFACTORY_URL --access-token=$ARTIFACTORY_ACCESS_TOKEN --flat=false --exclusions ".*\.(${EXCLUDE})$" --recursive --regexp $DRY_RUN
+        elif [[ -n "$ARTIFACTORY_USERNAME" && -n "$ARTIFACTORY_PASSWORD" ]]; then
+          jf rt u "com/dotcms/(${MODULES})/${ESCAPED_VERSION}" $ARTIFACTORY_REPO --url=$ARTIFACTORY_URL --user=$ARTIFACTORY_USERNAME --password=$ARTIFACTORY_PASSWORD --flat=false --exclusions ".*\.(${EXCLUDE})$" --recursive --regexp $DRY_RUN
+        else
+          echo "Credentials not provided."
+          exit 1          
+        fi
+        echo "::endgroup::"
+      shell: bash

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -91,14 +91,14 @@ jobs:
             # This is a secret that is used to request a dev license from license.dotcms.com
             DEV_REQUEST_TOKEN=${{ secrets.DEV_REQUEST_TOKEN }} 
 
-      # The artifacts are uploaded to Artifactory using the 'deploy-artifact-artifactory' action.
+      # The artifacts are uploaded to Artifactory using the 'deploy-artifact-jfrog' action.
       - name: CLI Deploy
         continue-on-error: true
         id: cli_deploy
-        uses: ./.github/actions/deploy-artifact-artifactory
+        uses: ./.github/actions/deploy-artifact-jfrog
         with:
-          artifactory-repo-username: ${{ secrets.EE_REPO_USERNAME }}
-          artifactory-repo-password: ${{ secrets.EE_REPO_PASSWORD }}
+          artifactory-username: ${{ secrets.EE_REPO_USERNAME }}
+          artifactory-password: ${{ secrets.EE_REPO_PASSWORD }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: CLI Publish


### PR DESCRIPTION
### Proposed Changes
* A new GHA is created to deploy the dotCMS artifacts to Artifactory through JFrog utility. It includes steps to extract project modules, version, and repository details from the POM file and deploy artifacts to the specified Artifactory repository.


### Additional Info
Related to #28598 (CICD Develop GitHub Action to Deploy Artifacts to Artifactory through JFrog).