### PR TITLE
Added ImageConfig to render images from dotcms path

### DIFF
--- a/examples/angular/README.md
+++ b/examples/angular/README.md
@@ -1,26 +1,48 @@
-# Angular
+DotCMS provides an Angular example that shows how to build dotCMS pages heedlessly with Angular JavaScript framework.
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 17.0.7.
+## What do you need?
 
-## Development server
+1. A dotCMS instance or you can use https://demo.dotcms.com
+2. [Node.js](https://nodejs.org) and npm installed
+3. Terminal
+4. And a code editor.
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+### Get the Angular example code
 
-## Code scaffolding
+Get the code from the next directory
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+```bash
+https://github.com/dotCMS/core/tree/master/examples/angular
+```
 
-## Build
+## Add the dotCMS configuration
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+Now we need to tell the Angular app what dotCMS instance is going to use to get the data to build its pages.
 
-## Running unit tests
+1. Open the folder `YOUR_NAME` in your code editor
+2. Go to `src/environments`
+3. Open the `environment.development.ts` file and update the environment variable:
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+- `authToken` this is the auth token for dotCMS, you can use the dotCMS UI to create one.
+- `dotcmsUrl` this is the instance of dotCMS where your pages and content lives (license needed) if you don’t have one, you can use [https://demo.dotcms.com](https://demo.dotcms.com) (be careful it restarts every 24h)
 
-## Running end-to-end tests
+## Run the app
 
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
+Once all the configuration is in place, it is time to run the web app.
+
+1. Go back to your terminal and from the folder YOUR_NAME
+2. Run `ng serve`
+3. Open http://localhost:3000 in your browser
+
+🎉 And that’s it.
+
+Consider that if you go to `localhost:4200/about`, the page `/about` needs to exist in your dotCMS instance.
+
+## Handling Vanity URLs
+
+In dotCMS, Vanity URLs serve as alternative reference paths to internal or external URLs. They are simple yet powerful tools that can significantly aid in site maintenance and SEO.
+
+Next.js is a robust framework that provides the capability to handle vanity URLs. It allows you to redirect or forward users to the appropriate content based on predefined logic. You can seamlessly integrate this feature of Next.js with dotCMS. For an implementation example, refer to this [link](https://github.com/dotCMS/core/blob/master/examples/nextjs/src/app/utils/index.js).
 
 ## Further help
 

--- a/examples/angular/src/app/app.config.ts
+++ b/examples/angular/src/app/app.config.ts
@@ -29,12 +29,15 @@ export const appConfig: ApplicationConfig = {
     {
       provide: IMAGE_LOADER,
       useValue: (config: ImageLoaderConfig) => {
-        let url = config.loaderParams?.['isOutsideSRC']
-          ? config.src
-          : `${environment.dotcmsUrl}${config.src}`;
-        if (config.loaderParams?.['languageId']) {
-          url = `${url}/${config.width}?language_id=${config.loaderParams['languageId']}`;
-        }
+        const { loaderParams, src, width } = config;
+        const isOutsideSRC = loaderParams?.['isOutsideSRC'];
+        if (isOutsideSRC) return src;
+
+        const languageId = loaderParams?.['languageId'];
+        let url = `${environment.dotcmsUrl}${src}`;
+
+        url = `${url}/${width}?language_id=${languageId || '1'}`;
+
         return url;
       },
     },

--- a/examples/angular/src/app/app.config.ts
+++ b/examples/angular/src/app/app.config.ts
@@ -6,16 +6,37 @@ import { ClientConfig } from '@dotcms/client';
 import { routes } from './app.routes';
 import { environment } from '../environments/environment';
 import { provideDotcmsClient } from './client-token/dotcms-client';
+import { IMAGE_LOADER, ImageLoaderConfig } from '@angular/common';
 
 const DOTCMS_CLIENT_CONFIG: ClientConfig = {
-    dotcmsUrl: environment.dotcmsUrl,
-    authToken: environment.authToken,
-    siteId: environment.siteId
+  dotcmsUrl: environment.dotcmsUrl,
+  authToken: environment.authToken,
+  siteId: environment.siteId,
 };
 
 export const appConfig: ApplicationConfig = {
-    providers: [
-        provideDotcmsClient(DOTCMS_CLIENT_CONFIG),
-        provideRouter(routes),
-    ],
+  providers: [
+    provideDotcmsClient(DOTCMS_CLIENT_CONFIG),
+    provideRouter(routes),
+    /**
+     * This is a custom image loader that will be used by the NgOptimizedImage component.
+     * It will prepend the dotCMS URL to the image src if the image is not an external URL.
+     * It will also append the language_id query parameter if the loaderParams object contains a languageId key.
+     * If you need to use an imagen from an external URL, you can set the isOutsideSRC key to true in the loaderParams object.
+     * <img [ngSrc]="https://my-url.com/some.jpg" [loaderParams]="{isOutsideSRC: true}" />
+     * If you need to customize the image loader, you can provide your own implementation.
+     */
+    {
+      provide: IMAGE_LOADER,
+      useValue: (config: ImageLoaderConfig) => {
+        let url = config.loaderParams?.['isOutsideSRC']
+          ? config.src
+          : `${environment.dotcmsUrl}${config.src}`;
+        if (config.loaderParams?.['languageId']) {
+          url = `${url}/${config.width}?language_id=${config.loaderParams['languageId']}`;
+        }
+        return url;
+      },
+    },
+  ],
 };

--- a/examples/angular/src/app/components/blogs/blogs.component.ts
+++ b/examples/angular/src/app/components/blogs/blogs.component.ts
@@ -10,7 +10,9 @@ import { Contentlet } from '@dotcms/client/src/lib/client/content/shared/types';
   imports: [ContentletsComponent],
   template: ` <div class="flex flex-col">
     <h2 class="text-2xl font-bold mb-7 text-black">Latest Blog Posts</h2>
-    @if(!!blogs().length) { <app-contentlets [contentlets]="blogs()" /> }
+    @if (!!blogs().length) {
+      <app-contentlets [contentlets]="blogs()" />
+    }
   </div>`,
 })
 export class BlogsComponent implements OnInit {

--- a/examples/angular/src/app/components/contentlets/contentlets.component.ts
+++ b/examples/angular/src/app/components/contentlets/contentlets.component.ts
@@ -1,19 +1,18 @@
 import { Component, Input } from '@angular/core';
 import { Contentlet } from '@dotcms/client/src/lib/client/content/shared/types';
 import { GenericContentlet } from '../../utils';
-import { environment } from '../../../environments/environment';
-import { NgOptimizedImage } from '@angular/common';
+import { DatePipe, NgOptimizedImage } from '@angular/common';
 
 @Component({
   selector: 'app-contentlets',
   standalone: true,
-  imports: [NgOptimizedImage],
+  imports: [NgOptimizedImage, DatePipe],
   template: `<ul class="flex flex-col gap-7">
     @for(contentlet of contentlets; track contentlet.identifier) {
     <li class="flex gap-7 min-h-16">
       <a class="min-w-32 relative" [href]="contentlet.urlMap ?? contentlet.url">
         <img
-          [ngSrc]="getImageUrl(contentlet)"
+          [ngSrc]="contentlet.image"
           [fill]="true"
           [alt]="contentlet.urlTitle ?? contentlet.title"
           class="object-cover"
@@ -27,7 +26,7 @@ import { NgOptimizedImage } from '@angular/common';
           {{ contentlet.title }}
         </a>
         <time class="text-zinc-600">
-          {{ getDateString(contentlet.modDate) }}
+          {{ contentlet.modDate | date:'mediumDate' }}
         </time>
       </div>
     </li>
@@ -42,15 +41,4 @@ export class ContentletsComponent {
     month: 'long',
     day: 'numeric',
   };
-
-  getDateString(date: string): string {
-    return new Date(date).toLocaleDateString('en-US', this.dateFormatOptions);
-  }
-
-  getImageUrl(contentlet: Contentlet<GenericContentlet>): string {
-    const host = environment.dotcmsUrl;
-    return `${host}${contentlet.image}?language_id=${
-      contentlet.languageId || 1
-    }`;
-  }
 }

--- a/examples/angular/src/app/components/contentlets/contentlets.component.ts
+++ b/examples/angular/src/app/components/contentlets/contentlets.component.ts
@@ -18,6 +18,7 @@ import { DatePipe, NgOptimizedImage } from '@angular/common';
             [ngSrc]="contentlet.image"
             [fill]="true"
             [alt]="contentlet.urlTitle ?? contentlet.title"
+            [loaderParams]="{ languageId: contentlet.languageId || 1 }" 
             class="object-cover"
           />
         </a>

--- a/examples/angular/src/app/components/contentlets/contentlets.component.ts
+++ b/examples/angular/src/app/components/contentlets/contentlets.component.ts
@@ -8,28 +8,31 @@ import { DatePipe, NgOptimizedImage } from '@angular/common';
   standalone: true,
   imports: [NgOptimizedImage, DatePipe],
   template: `<ul class="flex flex-col gap-7">
-    @for(contentlet of contentlets; track contentlet.identifier) {
-    <li class="flex gap-7 min-h-16">
-      <a class="min-w-32 relative" [href]="contentlet.urlMap ?? contentlet.url">
-        <img
-          [ngSrc]="contentlet.image"
-          [fill]="true"
-          [alt]="contentlet.urlTitle ?? contentlet.title"
-          class="object-cover"
-        />
-      </a>
-      <div class="flex flex-col gap-1">
+    @for (contentlet of contentlets; track contentlet.identifier) {
+      <li class="flex gap-7 min-h-16">
         <a
-          class="text-sm text-zinc-900 font-bold"
+          class="min-w-32 relative"
           [href]="contentlet.urlMap ?? contentlet.url"
         >
-          {{ contentlet.title }}
+          <img
+            [ngSrc]="contentlet.image"
+            [fill]="true"
+            [alt]="contentlet.urlTitle ?? contentlet.title"
+            class="object-cover"
+          />
         </a>
-        <time class="text-zinc-600">
-          {{ contentlet.modDate | date:'mediumDate' }}
-        </time>
-      </div>
-    </li>
+        <div class="flex flex-col gap-1">
+          <a
+            class="text-sm text-zinc-900 font-bold"
+            [href]="contentlet.urlMap ?? contentlet.url"
+          >
+            {{ contentlet.title }}
+          </a>
+          <time class="text-zinc-600">
+            {{ contentlet.modDate | date: 'mediumDate' }}
+          </time>
+        </div>
+      </li>
     }
   </ul> `,
 })

--- a/examples/angular/src/app/components/destinations/destinations.component.ts
+++ b/examples/angular/src/app/components/destinations/destinations.component.ts
@@ -10,8 +10,9 @@ import { Contentlet } from '@dotcms/client/src/lib/client/content/shared/types';
   imports: [ContentletsComponent],
   template: ` <div class="flex flex-col">
     <h2 class="text-2xl font-bold mb-7 text-black">Popular Destinations</h2>
-    @if(!!destinations().length) {
-    <app-contentlets [contentlets]="destinations()" /> }
+    @if (!!destinations().length) {
+      <app-contentlets [contentlets]="destinations()" />
+    }
   </div>`,
 })
 export class DestinationsComponent implements OnInit {

--- a/examples/angular/src/app/pages/components/footer/footer.component.ts
+++ b/examples/angular/src/app/pages/components/footer/footer.component.ts
@@ -23,7 +23,6 @@ import { NgOptimizedImage } from '@angular/common';
         </p>
         <img
           [ngSrc]="
-            environment.dotcmsUrl +
             '/contentAsset/image/82da90eb-044d-44cc-a71b-86f79820b61b/fileAsset'
           "
           height="53"

--- a/examples/angular/src/app/pages/content-types/activity/activity.component.ts
+++ b/examples/angular/src/app/pages/content-types/activity/activity.component.ts
@@ -1,19 +1,17 @@
+import { NgOptimizedImage } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DotCMSContentlet } from '@dotcms/angular';
 
-
 @Component({
   selector: 'app-activity',
   standalone: true,
-  imports: [RouterLink],
-  template: ` <article
-    class="p-4 overflow-hidden bg-white rounded shadow-lg"
-  >
-    @if(contentlet.image; as image ) {
+  imports: [RouterLink, NgOptimizedImage],
+  template: ` <article class="p-4 overflow-hidden bg-white rounded shadow-lg">
+    @if (contentlet.image; as image) {
       <img
         class="w-full"
-        [src]="image + '?language_id=' + contentlet.languageId"
+        [ngSrc]="image"
         width="100"
         height="100"
         alt="Activity Image"

--- a/examples/angular/src/app/pages/content-types/banner/banner.component.ts
+++ b/examples/angular/src/app/pages/content-types/banner/banner.component.ts
@@ -1,19 +1,24 @@
+import { NgOptimizedImage } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DotCMSContentlet } from '@dotcms/angular';
 
-
-
 @Component({
   selector: 'app-banner',
   standalone: true,
-  imports: [RouterLink],
-  template: `<div class="relative w-full bg-gray-200 h-96 flex justify-center items-center overflow-hidden">
-    <img
-      class="object-cover w-full"
-      [src]="contentlet.image + '?language_id' + contentlet.languageId"
-      [alt]="contentlet.title"
-    />
+  imports: [RouterLink, NgOptimizedImage],
+  template: `<div
+    class="relative w-full bg-gray-200 h-96 flex justify-center items-center overflow-hidden"
+  >
+    @if (contentlet.image; as image) {
+      <img
+        class="object-cover w-full"
+        [ngSrc]="image"
+        [alt]="contentlet.title"
+        fill
+        priority
+      />
+    }
     <div
       class="absolute inset-0 flex flex-col items-center justify-center p-4 text-center text-white"
     >

--- a/examples/angular/src/app/pages/content-types/image/image.component.ts
+++ b/examples/angular/src/app/pages/content-types/image/image.component.ts
@@ -1,26 +1,29 @@
-import { CommonModule } from '@angular/common';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { DotCMSContentlet } from '@dotcms/angular';
 
 @Component({
   selector: 'app-image',
   standalone: true,
-  imports: [
-    CommonModule,
-  ],
-  template: `<div class="relative overflow-hidden bg-white rounded shadow-lg group mb-4">
-  <div class="relative w-full bg-gray-200 h-96">
+  imports: [CommonModule, NgOptimizedImage],
+  template: `<div
+    class="relative overflow-hidden bg-white rounded shadow-lg group mb-4"
+  >
+    <div class="relative w-full bg-gray-200 h-96">
       <img
         class="object-cover"
-          [src]="contentlet['fileAsset'] + '?language_id=' + contentlet.languageId"
-          [alt]="contentlet.title"
+        [ngSrc]="contentlet['fileAsset']"
+        [alt]="contentlet.title"
+        fill
       />
-  </div>
-  <div class="absolute bottom-0 w-full px-6 py-8 text-white transition-transform duration-300 translate-y-full bg-orange-500 bg-opacity-80 w-100 group-hover:translate-y-0">
-      <div class="mb-2 text-2xl font-bold">{{contentlet.title}}</div>
-      <p class="text-base">{{contentlet['description']}}</p>
-  </div>
-</div>`,
+    </div>
+    <div
+      class="absolute bottom-0 w-full px-6 py-8 text-white transition-transform duration-300 translate-y-full bg-orange-500 bg-opacity-80 w-100 group-hover:translate-y-0"
+    >
+      <div class="mb-2 text-2xl font-bold">{{ contentlet.title }}</div>
+      <p class="text-base">{{ contentlet['description'] }}</p>
+    </div>
+  </div>`,
   styleUrl: './image.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/examples/angular/src/app/pages/content-types/product/product.component.ts
+++ b/examples/angular/src/app/pages/content-types/product/product.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -12,35 +12,37 @@ import { DotCMSContentlet } from '@dotcms/angular';
 @Component({
   selector: 'app-product',
   standalone: true,
-  imports: [RouterLink],
-  template: `        <div class="overflow-hidden bg-white rounded shadow-lg">
-  <div class="p-4">
-  <img
-                    class="w-full"
-                    [src]="contentlet.image + '?language_id=' + contentlet.languageId"
-                    width="100"
-                    height="100"
-                    alt="Product Image"
-                />
-  </div>
-  <div class="px-6 py-4 bg-slate-100">
-      <div class="mb-2 text-xl font-bold">{{contentlet.title}}</div>
-      @if(contentlet[retailPrice] && contentlet[salePrice] ) {
-          <div class="text-gray-500 line-through">{{retailPrice}}</div>
-          <div class="text-3xl font-bold ">{{salePrice}}</div>
-
+  imports: [RouterLink, NgOptimizedImage],
+  template: ` <div class="overflow-hidden bg-white rounded shadow-lg">
+    <div class="p-4">
+      @if (contentlet.image; as image) {
+        <img
+          class="w-full"
+          [ngSrc]="image"
+          width="100"
+          height="100"
+          alt="Product Image"
+        />
+      }
+    </div>
+    <div class="px-6 py-4 bg-slate-100">
+      <div class="mb-2 text-xl font-bold">{{ contentlet.title }}</div>
+      @if (contentlet[retailPrice] && contentlet[salePrice]) {
+        <div class="text-gray-500 line-through">{{ retailPrice }}</div>
+        <div class="text-3xl font-bold ">{{ salePrice }}</div>
       } @else {
-          <div class="text-3xl font-bold">
-              {{contentlet[retailPrice] ? retailPrice : salePrice}}
-          </div>
+        <div class="text-3xl font-bold">
+          {{ contentlet[retailPrice] ? retailPrice : salePrice }}
+        </div>
       }
       <a
-          [routerLink]="('/store/products/' + contentlet['urlTitle'])|| '#'"
-          class="inline-block px-4 py-2 mt-4 text-white bg-green-500 rounded hover:bg-green-600">
-          Buy Now
+        [routerLink]="'/store/products/' + contentlet['urlTitle'] || '#'"
+        class="inline-block px-4 py-2 mt-4 text-white bg-green-500 rounded hover:bg-green-600"
+      >
+        Buy Now
       </a>
-  </div>
-</div>`,
+    </div>
+  </div>`,
   styleUrl: './product.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -56,8 +58,8 @@ export class ProductComponent implements OnInit {
   }
 
   formatPrice(price: number) {
-    if(!price || price === null) {
-        return ''
+    if (!price || price === null) {
+      return '';
     }
 
     return new Intl.NumberFormat('en-US', {


### PR DESCRIPTION
### Proposed Changes
* Added ImageConfigLoader to render images from dotcms-url

With this config, all imagen loaded with [ngSrc] will have the prefix of dotcmsUrl
If the users needs to config the url, they can modify the ImageConfigLoader, so they dont depend of the sdk
 

This PR fixes: #28887