### PR TITLE
ci: Fix base image build to use sdkman version for tag

### DIFF
--- a/.github/workflows/build-java-base.yml
+++ b/.github/workflows/build-java-base.yml
@@ -1,4 +1,5 @@
-name: Build SDKMan Base java image
+name: Build SDKMan Base Java Image
+run-name: Base Image for ${{ inputs.sdkman_java_version }} by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:
@@ -51,7 +52,7 @@ jobs:
         with:
           context: ./docker/java-base
           push: ${{ github.event.inputs.push }}
-          tags: ${{ github.event.inputs.tags }}
+          tags: ${{ github.event.inputs.sdkman_java_version }}
           platforms: ${{ env.PLATFORMS }}
           build-args:
             SDKMAN_JAVA_VERSION=${{ github.event.inputs.sdkman_java_version }}


### PR DESCRIPTION
### Proposed Changes
* Use run-name showing version created
* Fix tag to match sdkman version string

This PR fixes: #27998