### PR TITLE
fix(edit-content): fix error with node select on init state

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/dot-edit-content-host-folder-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/dot-edit-content-host-folder-field.component.html
@@ -1,5 +1,5 @@
 <p-treeSelect
-    (onNodeSelect)="onNodeSelect($event)"
+    (onNodeSelect)="store.chooseNode($event)"
     (onNodeExpand)="store.loadChildren($event)"
     [formControl]="pathControl"
     [filter]="true"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/dot-edit-content-host-folder-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/dot-edit-content-host-folder-field.component.spec.ts
@@ -1,4 +1,3 @@
-import { createFakeEvent } from '@ngneat/spectator';
 import { Spectator, SpyObject, createComponentFactory } from '@ngneat/spectator/jest';
 
 import { signal } from '@angular/core';
@@ -31,6 +30,7 @@ class MockHostFolderFiledStore {
 
     loadSites = newFakeRxMethod();
     loadChildren = newFakeRxMethod();
+    chooseNode = newFakeRxMethod();
 }
 
 type TypeMock = SpyObject<MockHostFolderFiledStore>;
@@ -140,41 +140,6 @@ describe('DotEditContentHostFolderFieldComponent', () => {
             expect(component.formControl.value).toBe('demo.dotcms.com/level1/child1/');
             expect(component.pathControl.value.key).toBe(nodeSelected.key);
             expect(component.treeSelect.value.label).toBe(nodeSelected.label);
-        });
-    });
-
-    describe('Select levels: onNodeSelect', () => {
-        it('should update the form value with the correct format with root path', () => {
-            spectator.detectChanges();
-            const mockItem = {
-                originalEvent: createFakeEvent('input'),
-                node: { ...TREE_SELECT_MOCK[0] }
-            };
-            component.onNodeSelect(mockItem);
-            const value = component.formControl.value;
-            expect(value).toBe('demo.dotcms.com:/');
-        });
-
-        it('should update the form value with the correct format with one level', () => {
-            spectator.detectChanges();
-            const mockItem = {
-                originalEvent: createFakeEvent('input'),
-                node: { ...TREE_SELECT_MOCK[0].children[0] }
-            };
-            component.onNodeSelect(mockItem);
-            const value = component.formControl.value;
-            expect(value).toBe('demo.dotcms.com:/level1/');
-        });
-
-        it('should update the form value with the correct format with two level', () => {
-            spectator.detectChanges();
-            const mockItem = {
-                originalEvent: createFakeEvent('input'),
-                node: { ...TREE_SELECT_MOCK[0].children[0].children[0] }
-            };
-            component.onNodeSelect(mockItem);
-            const value = component.formControl.value;
-            expect(value).toBe('demo.dotcms.com:/level1/child1/');
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/dot-edit-content-host-folder-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/dot-edit-content-host-folder-field.component.ts
@@ -15,7 +15,6 @@ import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
 import { TreeSelect, TreeSelectModule } from './componentes/treeselect.component';
 import { HostFolderFiledStore } from './store/host-folder-field.store';
 
-import { TreeNodeSelectItem } from '../../models/dot-edit-content-host-folder-field.interface';
 import { TruncatePathPipe } from '../../pipes/truncate-path.pipe';
 
 /**
@@ -60,6 +59,11 @@ export class DotEditContentHostFolderFieldComponent implements OnInit {
             const nodeSelected = this.store.nodeSelected();
             this.pathControl.setValue(nodeSelected);
         });
+
+        effect(() => {
+            const pathToSave = this.store.pathToSave();
+            this.formControl.setValue(pathToSave);
+        });
     }
 
     ngOnInit() {
@@ -73,15 +77,5 @@ export class DotEditContentHostFolderFieldComponent implements OnInit {
 
     get formControl(): FormControl {
         return this.#controlContainer.control.get(this.field.variable) as FormControl<string>;
-    }
-
-    onNodeSelect(event: TreeNodeSelectItem) {
-        const data = event.node.data;
-        if (!data) {
-            return;
-        }
-
-        const path = `${data.hostname}:${data.path ? data.path : '/'}`;
-        this.formControl.setValue(path);
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.ts
@@ -2,6 +2,7 @@ import { signalStore, withState, withComputed, withMethods } from '@ngrx/signals
 
 import { computed, inject } from '@angular/core';
 
+import { chooseNode } from './methods/chooseNode';
 import { loadChildren } from './methods/loadChildren';
 import { loadSites } from './methods/loadSites';
 
@@ -31,7 +32,7 @@ export const initialState: HostFolderFiledState = {
 
 export const HostFolderFiledStore = signalStore(
     withState(initialState),
-    withComputed(({ status }) => ({
+    withComputed(({ status, nodeSelected }) => ({
         iconClasses: computed(() => {
             const currentStatus = status();
 
@@ -39,6 +40,17 @@ export const HostFolderFiledStore = signalStore(
                 'pi-spin pi-spinner': currentStatus === 'LOADING',
                 'pi-chevron-down': currentStatus !== 'LOADING'
             };
+        }),
+        pathToSave: computed(() => {
+            const node = nodeSelected();
+
+            if (node && node.data) {
+                const { data } = node;
+
+                return `${data.hostname}:${data.path ? data.path : '/'}`;
+            }
+
+            return null;
         })
     })),
     withMethods((store) => {
@@ -46,7 +58,8 @@ export const HostFolderFiledStore = signalStore(
 
         return {
             loadSites: loadSites(store, dotEditContentService),
-            loadChildren: loadChildren(store, dotEditContentService)
+            loadChildren: loadChildren(store, dotEditContentService),
+            chooseNode: chooseNode(store)
         };
     })
 );

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.ts
@@ -44,7 +44,7 @@ export const HostFolderFiledStore = signalStore(
         pathToSave: computed(() => {
             const node = nodeSelected();
 
-            if (node && node.data) {
+            if (node?.data) {
                 const { data } = node;
 
                 return `${data.hostname}:${data.path ? data.path : '/'}`;

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/methods/chooseNode.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/methods/chooseNode.spec.ts
@@ -1,0 +1,60 @@
+import { createFakeEvent } from '@ngneat/spectator';
+import { mockProvider } from '@ngneat/spectator/jest';
+
+import { TestBed } from '@angular/core/testing';
+
+import { DotEditContentService } from '../../../../services/dot-edit-content.service';
+import { TREE_SELECT_MOCK } from '../../../../utils/mocks';
+import { HostFolderFiledStore } from '../host-folder-field.store';
+
+describe('StoreMethod: chooseNode', () => {
+    let store: InstanceType<typeof HostFolderFiledStore>;
+
+    beforeEach(() => {
+        store = TestBed.overrideProvider(
+            DotEditContentService,
+            mockProvider(DotEditContentService)
+        ).runInInjectionContext(() => new HostFolderFiledStore());
+    });
+
+    it('should update the form value with the correct format with root path', () => {
+        const mockItem = {
+            originalEvent: createFakeEvent('input'),
+            node: { ...TREE_SELECT_MOCK[0] }
+        };
+        store.chooseNode(mockItem);
+        const value = store.pathToSave();
+        expect(value).toBe('demo.dotcms.com:/');
+    });
+
+    it('should update the form value with the correct format with one level', () => {
+        const mockItem = {
+            originalEvent: createFakeEvent('input'),
+            node: { ...TREE_SELECT_MOCK[0].children[0] }
+        };
+        store.chooseNode(mockItem);
+        const value = store.pathToSave();
+        expect(value).toBe('demo.dotcms.com:/level1/');
+    });
+
+    it('should update the form value with the correct format with two level', () => {
+        const mockItem = {
+            originalEvent: createFakeEvent('input'),
+            node: { ...TREE_SELECT_MOCK[0].children[0].children[0] }
+        };
+        store.chooseNode(mockItem);
+        const value = store.pathToSave();
+        expect(value).toBe('demo.dotcms.com:/level1/child1/');
+    });
+
+    it('should be null when data is null', () => {
+        const mockItem = {
+            originalEvent: createFakeEvent('input'),
+            node: { ...TREE_SELECT_MOCK[0].children[0].children[0] }
+        };
+        delete mockItem.node.data;
+        store.chooseNode(mockItem);
+        const value = store.pathToSave();
+        expect(value).toBe(null);
+    });
+});

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/methods/chooseNode.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/methods/chooseNode.ts
@@ -1,0 +1,15 @@
+import { patchState } from '@ngrx/signals';
+
+import type { TreeNodeSelectItem } from './../../../../models/dot-edit-content-host-folder-field.interface';
+
+export const chooseNode = (store) => {
+    return (event: TreeNodeSelectItem) => {
+        const { node: nodeSelected } = event;
+        const data = nodeSelected.data;
+        if (!data) {
+            return;
+        }
+
+        patchState(store, { nodeSelected });
+    };
+};

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/methods/loadSites.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/methods/loadSites.spec.ts
@@ -1,47 +1,45 @@
-import { SpyObject, createSpyObject } from '@ngneat/spectator/jest';
-import { signalStore, withState } from '@ngrx/signals';
+import { SpyObject, mockProvider } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
 import { TestBed } from '@angular/core/testing';
 
-import { loadSites, SYSTEM_HOST_NAME } from './loadSites';
+import { SYSTEM_HOST_NAME } from './loadSites';
 
 import { DotEditContentService } from '../../../../services/dot-edit-content.service';
 import { TREE_SELECT_SITES_MOCK } from '../../../../utils/mocks';
-import { initialState } from '../host-folder-field.store';
+import { HostFolderFiledStore } from '../host-folder-field.store';
 
-describe('rxMethod: loadSites', () => {
-    let Store = signalStore(withState(initialState));
-    let store: InstanceType<typeof Store>;
+describe('StoreMethod: loadSites', () => {
+    let store: InstanceType<typeof HostFolderFiledStore>;
     let service: SpyObject<DotEditContentService>;
 
     beforeEach(() => {
-        service = createSpyObject(DotEditContentService);
-        Store = signalStore(withState(initialState));
-        store = new Store();
+        store = TestBed.overrideProvider(
+            DotEditContentService,
+            mockProvider(DotEditContentService)
+        ).runInInjectionContext(() => new HostFolderFiledStore());
+        service = TestBed.inject(DotEditContentService) as SpyObject<DotEditContentService>;
     });
 
     describe('System Host isRequired', () => {
         it('should include System Host when isRequired is false.', () => {
             service.getSitesTreePath.mockReturnValue(of(TREE_SELECT_SITES_MOCK));
-            const rxMethod = TestBed.runInInjectionContext(() => loadSites(store, service));
             const props = {
                 path: null,
                 isRequired: false
             };
-            rxMethod(props);
+            store.loadSites(props);
             const hasSystemHost = store.tree().some((item) => item.label === SYSTEM_HOST_NAME);
             expect(hasSystemHost).toBe(true);
         });
 
         it('should not include System Host when isRequired is true.', () => {
             service.getSitesTreePath.mockReturnValue(of(TREE_SELECT_SITES_MOCK));
-            const rxMethod = TestBed.runInInjectionContext(() => loadSites(store, service));
             const props = {
                 path: null,
                 isRequired: true
             };
-            rxMethod(props);
+            store.loadSites(props);
             const hasSystemHost = store.tree().some((item) => item.label === SYSTEM_HOST_NAME);
             expect(hasSystemHost).toBe(false);
         });
@@ -51,12 +49,11 @@ describe('rxMethod: loadSites', () => {
         it('should select the node if the path is not empty and not required', () => {
             const node = TREE_SELECT_SITES_MOCK[0];
             service.getSitesTreePath.mockReturnValue(of(TREE_SELECT_SITES_MOCK));
-            const rxMethod = TestBed.runInInjectionContext(() => loadSites(store, service));
             const props = {
                 path: node.label,
                 isRequired: false
             };
-            rxMethod(props);
+            store.loadSites(props);
             expect(service.getCurrentSiteAsTreeNodeItem).not.toHaveBeenCalled();
             expect(store.nodeSelected().key).toBe(node.key);
         });
@@ -64,12 +61,11 @@ describe('rxMethod: loadSites', () => {
         it('should select the node if the path is not empty and is required', () => {
             const node = TREE_SELECT_SITES_MOCK[0];
             service.getSitesTreePath.mockReturnValue(of(TREE_SELECT_SITES_MOCK));
-            const rxMethod = TestBed.runInInjectionContext(() => loadSites(store, service));
             const props = {
                 path: node.label,
                 isRequired: true
             };
-            rxMethod(props);
+            store.loadSites(props);
             expect(service.getCurrentSiteAsTreeNodeItem).not.toHaveBeenCalled();
             expect(store.nodeSelected().key).toBe(node.key);
         });
@@ -78,12 +74,11 @@ describe('rxMethod: loadSites', () => {
     describe('when path is empty', () => {
         it('should select System Host if the path is not empty and not required', () => {
             service.getSitesTreePath.mockReturnValue(of(TREE_SELECT_SITES_MOCK));
-            const rxMethod = TestBed.runInInjectionContext(() => loadSites(store, service));
             const props = {
                 path: null,
                 isRequired: false
             };
-            rxMethod(props);
+            store.loadSites(props);
             expect(service.getCurrentSiteAsTreeNodeItem).not.toHaveBeenCalled();
             expect(store.nodeSelected().label).toBe(SYSTEM_HOST_NAME);
         });
@@ -92,12 +87,11 @@ describe('rxMethod: loadSites', () => {
             const hostNode = TREE_SELECT_SITES_MOCK[1];
             service.getSitesTreePath.mockReturnValue(of(TREE_SELECT_SITES_MOCK));
             service.getCurrentSiteAsTreeNodeItem.mockReturnValue(of(hostNode));
-            const rxMethod = TestBed.runInInjectionContext(() => loadSites(store, service));
             const props = {
                 path: null,
                 isRequired: true
             };
-            rxMethod(props);
+            store.loadSites(props);
             expect(service.getCurrentSiteAsTreeNodeItem).toHaveBeenCalled();
             expect(store.nodeSelected().label).toBe(hostNode.label);
         });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/methods/loadSites.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/methods/loadSites.spec.ts
@@ -18,6 +18,7 @@ describe('StoreMethod: loadSites', () => {
             DotEditContentService,
             mockProvider(DotEditContentService)
         ).runInInjectionContext(() => new HostFolderFiledStore());
+
         service = TestBed.inject(DotEditContentService) as SpyObject<DotEditContentService>;
     });
 


### PR DESCRIPTION
If a field had a default value of System Host or CurrentSite, and the user saves that site/folder, the value is not in the form, so the form is invalid.

 ![Image](https://github.com/dotCMS/core/assets/1576794/869f1640-547a-4ee1-8d4e-a96082e6cec7)

### Proposed Changes
* Refactor unit test for signals store
* Create pathToSave computed signal

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Screenshots       
 Updated

 ![Screenshot 2024-06-19 at 4 19 14 PM](https://github.com/dotCMS/core/assets/7611944/d3622672-c0a0-47bd-a565-394bf2f706fb) 
Original

 ![Image](https://github.com/dotCMS/core/assets/1576794/869f1640-547a-4ee1-8d4e-a96082e6cec7)


This PR fixes: #28925