### PR TITLE
ci:  base image build tag needs prefix for push (27998)

### DIFF
--- a/.github/workflows/build-java-base.yml
+++ b/.github/workflows/build-java-base.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           context: ./docker/java-base
           push: ${{ github.event.inputs.push }}
-          tags: ${{ github.event.inputs.sdkman_java_version }}
+          tags: dotcms/java-base:${{ github.event.inputs.sdkman_java_version }}
           platforms: ${{ env.PLATFORMS }}
           build-args:
             SDKMAN_JAVA_VERSION=${{ github.event.inputs.sdkman_java_version }}


### PR DESCRIPTION
### Proposed Changes
* The base image needs to use the sdkman version as its tag, but the github action requires the image name to be prefixed to be able to push e.g. dotcms/java-base:11.0.22-ms and not just 11.0.22-ms

Relates to #27998 and found after this previous PR https://github.com/dotCMS/core/pull/28938

This PR fixes: #27998