### PR TITLE
fix(UVE): Contentlet Controls Not Showing in Edit Mode When Back from Preview

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-ema-info-display/dot-ema-info-display.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-ema-info-display/dot-ema-info-display.component.spec.ts
@@ -121,7 +121,8 @@ describe('DotEmaInfoDisplayComponent', () => {
                 spectator.triggerEventHandler(infoAction, 'onClick', {});
 
                 expect(updateEditorDataSpy).toHaveBeenCalledWith({
-                    mode: EDITOR_MODE.EDIT
+                    mode: EDITOR_MODE.EDIT,
+                    device: null
                 });
             });
 
@@ -149,7 +150,8 @@ describe('DotEmaInfoDisplayComponent', () => {
                 spectator.triggerEventHandler(infoAction, 'onClick', {});
 
                 expect(updateEditorDataSpy).toHaveBeenCalledWith({
-                    mode: EDITOR_MODE.EDIT_VARIANT
+                    mode: EDITOR_MODE.EDIT_VARIANT,
+                    device: null
                 });
             });
 
@@ -177,7 +179,8 @@ describe('DotEmaInfoDisplayComponent', () => {
                 spectator.triggerEventHandler(infoAction, 'onClick', {});
 
                 expect(updateEditorDataSpy).toHaveBeenCalledWith({
-                    mode: EDITOR_MODE.PREVIEW_VARIANT
+                    mode: EDITOR_MODE.PREVIEW_VARIANT,
+                    device: null
                 });
             });
         });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-ema-info-display/dot-ema-info-display.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-ema-info-display/dot-ema-info-display.component.ts
@@ -146,12 +146,13 @@ export class DotEmaInfoDisplayComponent implements OnChanges {
 
         if (isNotDefaultVariant) {
             this.store.updateEditorData({
+                device: null,
                 mode: this.editorData.canEditVariant
                     ? this.editorMode.EDIT_VARIANT
                     : this.editorMode.PREVIEW_VARIANT
             });
         } else {
-            this.store.updateEditorData({ mode: this.editorMode.EDIT });
+            this.store.updateEditorData({ device: null, mode: this.editorMode.EDIT });
         }
     }
 }


### PR DESCRIPTION
### Proposed Changes
* Show `contentlet` controls after leaving `preview` mode
* Clear `device` object after leaving the `preview` mode

### Video



https://github.com/dotCMS/core/assets/72418962/975ebdbc-4236-4931-9502-e531be05b090


This PR fixes: #28960