### PR TITLE
Issue 28983 dotcms dev latest broken

### DIFF
--- a/docker/dev-env/README.md
+++ b/docker/dev-env/README.md
@@ -138,7 +138,7 @@ Running https on
 - data stored in /data/opensearch 
 
 
-#### Postgres 15
+#### Postgres 16
 Running on port 5432 and using the dotCMS defaults:
 - db: dotcms
 - user: dotcmsdbuser

--- a/docker/dev-env/entrypoint.sh
+++ b/docker/dev-env/entrypoint.sh
@@ -205,7 +205,7 @@ start_dotcms () {
     echo " - DOT_ES_ENDPOINTS: $DOT_ES_ENDPOINTS"
     echo " - DOT_DOTCMS_CLUSTER_ID: $DOT_DOTCMS_CLUSTER_ID"
     echo " - DOT_STARTER_DATA_LOAD: $DOT_STARTER_DATA_LOAD"
-    . /srv/entrypoint.sh
+    . /srv/entrypoint.sh dotcms
 }
 
 ## Moves the dev license to the correct location

--- a/dotCMS/src/main/docker/original/ROOT/srv/entrypoint.sh
+++ b/dotCMS/src/main/docker/original/ROOT/srv/entrypoint.sh
@@ -15,7 +15,7 @@ source /srv/40-custom-starter-zip.sh
 if [[ "$#" -eq 0 || "$1" == "dotcms" ]]; then
   shift
   echo ""
-  echo "Starting dotCMS ..."s
+  echo "Starting dotCMS ..."
   echo "-------------------"
   echo ""
   exec -- ${TOMCAT_HOME}/bin/catalina.sh run dotcms

--- a/dotCMS/src/main/docker/original/ROOT/srv/entrypoint.sh
+++ b/dotCMS/src/main/docker/original/ROOT/srv/entrypoint.sh
@@ -18,7 +18,7 @@ if [[ "$#" -eq 0 || "$1" == "dotcms" ]]; then
   echo "Starting dotCMS ..."
   echo "-------------------"
   echo ""
-  exec -- ${TOMCAT_HOME}/bin/catalina.sh run dotcms
+  exec -- ${TOMCAT_HOME}/bin/catalina.sh run
 else
   echo starting "$@"
   exec -- "$@"

--- a/dotCMS/src/main/docker/original/ROOT/srv/entrypoint.sh
+++ b/dotCMS/src/main/docker/original/ROOT/srv/entrypoint.sh
@@ -18,7 +18,7 @@ if [[ "$#" -eq 0 || "$1" == "dotcms" ]]; then
   echo "Starting dotCMS ..."s
   echo "-------------------"
   echo ""
-  exec -- ${TOMCAT_HOME}/bin/catalina.sh run "$@"
+  exec -- ${TOMCAT_HOME}/bin/catalina.sh run dotcms
 else
   echo starting "$@"
   exec -- "$@"

--- a/dotCMS/src/main/docker/original/ROOT/srv/entrypoint.sh
+++ b/dotCMS/src/main/docker/original/ROOT/srv/entrypoint.sh
@@ -12,7 +12,7 @@ source /srv/40-custom-starter-zip.sh
 
 [[ -n "${WAIT_FOR_DEPS}" ]] && echo "Waiting ${WAIT_FOR_DEPS} seconds for DotCMS dependencies to load..." && sleep ${WAIT_FOR_DEPS}
 
-if [[ "$1" == "dotcms" ]]; then
+if [[ "$#" -eq 0 || "$1" == "dotcms" ]]; then
   shift
   echo ""
   echo "Starting dotCMS ..."s


### PR DESCRIPTION
### Proposed Changes
* update readme for dotcms-dev to reflect postgres 16 
* removes hanging `s` typo outside of quoted string in console echoing
* update /srv/entrypoint.sh to start dotCMS server when no args are provided to it
* update /srv/entrypoint.sh to use `dotcms` as the arg if no args are provided or if dotcms is the arg provided
* update dev-env /entrypoint.sh to add `dotcms` as arg when invoking /srv/entrypoint.sh 

### Checklist
- [ x ] Tests
Tested locally but not in fork
- [ N/A ] Translations
- [ X ] Security Implications Contemplated (add notes if applicable)

### Additional Notes
This doesn't include the addition of test coverage.  That will come in an additional PR once this is merged and working as expected.

### Screenshots
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmk1bXNqYmU1a3llMHQzMThtNXZkdTF0cjN2bHM4cm83eTBmcmFnYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3ohc18sHy1xW3UEHD2/giphy.webp)

REFS #28983

This PR fixes: #28983