### PR TITLE
Issue 28365 add host column to reference tab

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_references.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_references.jsp
@@ -20,6 +20,7 @@
 		</td>
 	</tr>
 	<tr class="header">
+		<th><%= LanguageUtil.get(pageContext, "Host") %></th>
 		<th><%= LanguageUtil.get(pageContext, "Page") %></th>
 		<th><%= LanguageUtil.get(pageContext, "Container") %></th>
 		<th><%= LanguageUtil.get(pageContext, "Page-Owner") %></th>
@@ -43,7 +44,8 @@
 		Cmod++;
 %>
 	<tr <%= str_style2 %> >
-		<td>			
+		<td><%= host.getName() %></td>
+		<td>
 			<a href="/dotAdmin/#/edit-page/content?url=<%=htmlpageRef.getURI()%>" class="beta" target="_top">
 				<%= UtilMethods.escapeHTMLSpecialChars(htmlpageRef.getTitle()) %>
 			</a>


### PR DESCRIPTION
Feat: #28365 

Added a new table header (column) "Host" in the table on the references tab with the corresponding  host value in each row

This PR fixes: #28365