### PR TITLE
fix(UVE): Page Preview Top Bar Cut Off

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.scss
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.scss
@@ -21,7 +21,7 @@ dot-ema-page-dropzone {
 }
 
 dot-edit-ema-toolbar {
-    grid-column: 1 / -1;
+    grid-column: 1 / 3;
 }
 
 dot-ema-device-display {
@@ -42,7 +42,7 @@ dot-results-seo-tool {
     overflow: auto;
 }
 .editor-content--device {
-    grid-column: 1 / -1;
+    grid-column: 1 / 3;
 }
 
 .editor-content--hidden {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.scss
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.scss
@@ -21,7 +21,7 @@ dot-ema-page-dropzone {
 }
 
 dot-edit-ema-toolbar {
-    grid-column: 1 / 3;
+    grid-column: 1 / -1;
 }
 
 dot-ema-device-display {
@@ -29,7 +29,7 @@ dot-ema-device-display {
 }
 
 dot-results-seo-tool {
-    grid-column: 1 / 3;
+    grid-column: 1 / -1;
 }
 
 .editor-content {
@@ -42,7 +42,7 @@ dot-results-seo-tool {
     overflow: auto;
 }
 .editor-content--device {
-    grid-column: 1 / 3;
+    grid-column: 1 / -1;
 }
 
 .editor-content--hidden {


### PR DESCRIPTION
### Proposed Changes
* Adjusted grid-column for dot-edit-ema-toolbar and .editor-content--device in edit-ema-editor.component.scss to ensure proper display of the top bar in RRSS page preview.

### Screenshots

Original

https://github.com/dotCMS/core/assets/77643678/adc32a58-ebd8-470b-9cad-6d717cfc14ff 


Updated

https://github.com/dotCMS/core/assets/77643678/93f414d7-f368-40f1-933e-521f11982bbe

This PR fixes: https://github.com/dotCMS/core/issues/28959

This PR fixes: #28959