### PR TITLE
chore(uve-ui): Update icon from add to edit on device selector

### DIFF
--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-device-selector-seo/dot-device-selector-seo.component.html
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-device-selector-seo/dot-device-selector-seo.component.html
@@ -20,7 +20,7 @@
                     [queryParams]="linkToEditDeviceQueryParams"
                     data-testId="dot-device-link-add">
                     <p-button
-                        icon="pi pi-plus"
+                        icon="pi pi-pencil"
                         styleClass="p-button-rounded p-button-text"></p-button>
                 </a>
             </div>


### PR DESCRIPTION
### Proposed Changes
* Changed icon from add to edit(pencil)

<img width="812" alt="Screenshot 2024-06-27 at 11 27 07 AM" src="https://github.com/dotCMS/core/assets/144152756/cf535059-3152-40b0-9e1c-36706ff25032">


This PR fixes: #28455