### PR TITLE
Fix(#28847) CLI: push command no executing properly

### DIFF
--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/common/PushMixin.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/common/PushMixin.java
@@ -72,7 +72,7 @@ public class PushMixin {
         if (null == pushPath) {
             return Path.of("").toAbsolutePath();
         }
-        return pushPath.toPath().toAbsolutePath();
+        return pushPath.toPath().normalize().toAbsolutePath();
     }
 
     public boolean isWatchMode(){

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/common/PushMixin.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/common/PushMixin.java
@@ -72,7 +72,7 @@ public class PushMixin {
         if (null == pushPath) {
             return Path.of("").toAbsolutePath();
         }
-        return pushPath.toPath();
+        return pushPath.toPath().toAbsolutePath();
     }
 
     public boolean isWatchMode(){

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/PushCommandIT.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/PushCommandIT.java
@@ -99,6 +99,7 @@ class PushCommandIT extends CommandTest {
         var tempFolder = createTempFolder();
         // And a workspace for it
         workspaceManager.getOrCreate(tempFolder);
+        System.out.println(tempFolder.toAbsolutePath());
 
         try {
 
@@ -114,6 +115,39 @@ class PushCommandIT extends CommandTest {
             deleteTempDirectory(tempFolder);
         }
     }
+
+    /**
+     * This test checks for a simple push situation using a relative path where everything should work as expected.
+     *
+     * @throws IOException if there's a problem accessing the files and folders needed for the
+     *                     test.
+     */
+    @Test
+    void testPushWithRelativePath() throws IOException {
+
+        // Create a temporal folder for the push
+        var tempFolder = createTempFolder();
+        // And a workspace for it
+        workspaceManager.getOrCreate(tempFolder);
+
+        // Get the relative path of the temporal folder
+        var relativePath = Path.of("").toAbsolutePath().relativize(tempFolder.toAbsolutePath());
+
+        try {
+            final CommandLine commandLine = createCommand();
+            final StringWriter writer = new StringWriter();
+            try (PrintWriter out = new PrintWriter(writer)) {
+                commandLine.setOut(out);
+                final int status = commandLine.execute(PushCommand.NAME,
+                        relativePath.toString(), "--dry-run");
+                Assertions.assertEquals(CommandLine.ExitCode.OK, status);
+            }
+        } finally {
+            deleteTempDirectory(tempFolder);
+        }
+    }
+
+
 
     /**
      * This test checks for a situation where an incorrect option is passed to the push command.

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/PushCommandIT.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/PushCommandIT.java
@@ -99,7 +99,6 @@ class PushCommandIT extends CommandTest {
         var tempFolder = createTempFolder();
         // And a workspace for it
         workspaceManager.getOrCreate(tempFolder);
-        System.out.println(tempFolder.toAbsolutePath());
 
         try {
 

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/PushCommandIT.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/command/PushCommandIT.java
@@ -116,10 +116,9 @@ class PushCommandIT extends CommandTest {
     }
 
     /**
-     * This test checks for a simple push situation using a relative path where everything should work as expected.
-     *
-     * @throws IOException if there's a problem accessing the files and folders needed for the
-     *                     test.
+     * Given scenario: A push command is executed using a relative path.
+     * Expected result: The command should find the folder to push and complete successfully with an exit code 0 (OK).
+     * @throws IOException
      */
     @Test
     void testPushWithRelativePath() throws IOException {

--- a/tools/dotcms-cli/cli/test-workspace/languages/es-es.json
+++ b/tools/dotcms-cli/cli/test-workspace/languages/es-es.json
@@ -1,0 +1,4 @@
+{
+  "isoCode" : "es-es",
+  "dotCMSObjectType" : "Language"
+}

--- a/tools/dotcms-cli/cli/test-workspace/languages/es-es.json
+++ b/tools/dotcms-cli/cli/test-workspace/languages/es-es.json
@@ -1,4 +1,0 @@
-{
-  "isoCode" : "es-es",
-  "dotCMSObjectType" : "Language"
-}


### PR DESCRIPTION
### Proposed Changes
* Updated `PushMixin.path()` to ensure correct absolute path resolution.

### Screenshots
![screen-recording-cli-push-command-relative-path](https://github.com/dotCMS/core/assets/77643678/7573f4ad-40cc-4ad2-a9e4-ef668e37f625)

This PR fixes: https://github.com/dotCMS/core/issues/28847

This PR fixes: #28847