### PR TITLE
chore(authentication) #27069 : User login tries to access default host

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/cms/login/LoginServiceAPIFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/cms/login/LoginServiceAPIFactory.java
@@ -498,17 +498,20 @@ public class LoginServiceAPIFactory implements Serializable {
          * @return An {@link Optional} containing the Default Site if the User has permission to
          * access it. Otherwise, an Empty Optional is returned.
          *
-         * @throws DotDataException     If an error occurred when interacting with the data source.
-         * @throws DotSecurityException If a permission problem when accessing the dotCMS APIs has
-         *                              occurred.
+         * @throws DotDataException If an error occurred when interacting with the data source.
          */
-        private Optional<Host> findDefaultSite(final User user) throws DotDataException,
-                DotSecurityException {
-            final Host defaultSite = APILocator.getHostAPI().findDefaultHost(user, DONT_RESPECT_FRONT_END_ROLES);
-            final boolean hasPermission =
-                    APILocator.getPermissionAPI().doesUserHavePermission(defaultSite,
-                            PermissionAPI.PERMISSION_READ, user, DONT_RESPECT_FRONT_END_ROLES);
-            return hasPermission ? Optional.of(defaultSite) : Optional.empty();
+        private Optional<Host> findDefaultSite(final User user) throws DotDataException {
+            try {
+                final Host defaultSite = APILocator.getHostAPI().findDefaultHost(user, DONT_RESPECT_FRONT_END_ROLES);
+                final boolean hasPermission =
+                        APILocator.getPermissionAPI().doesUserHavePermission(defaultSite,
+                                PermissionAPI.PERMISSION_READ, user, DONT_RESPECT_FRONT_END_ROLES);
+                return hasPermission ? Optional.of(defaultSite) : Optional.empty();
+            } catch (final DotSecurityException e) {
+                Logger.debug(this, String.format("User '%s' does not have permission to retrieve the Default Site: %s",
+                        user, ExceptionUtil.getErrorMessage(e)));
+                return Optional.empty();
+            }
         }
 
         /**

--- a/dotCMS/src/main/java/com/dotmarketing/util/Constants.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Constants.java
@@ -174,4 +174,8 @@ public final class Constants {
 	 * Extension for the JSON file: .json
 	 */
 	public static final String JSON_FILE_EXTENSION = ".json";
+
+	public static final boolean RESPECT_FRONT_END_ROLES = Boolean.TRUE;
+	public static final boolean DONT_RESPECT_FRONT_END_ROLES = Boolean.FALSE;
+
 }


### PR DESCRIPTION
### Proposed Changes
* Suppresses the excessive logging when a User attempts to log in without having READ access to the Default Site.
* Adds a new configuration flag named `FIRST_AVAILABLE_SITE_FALLBACK` which allows you to specify whether Users that have no access to the Default Site can fall back to logging into their first available Site or not. This is enabled, by default.
* Here's an example of what the log looks like when attempting to log into the Default Site called `newsite.com`, but the User doesn't have access to it:
```
13:21:47.203  WARN  login.LoginServiceAPIFactory - User 'dotcms.org.2795' does not have read permissions on 'newsite.com'
13:21:47.203  WARN  login.LoginServiceAPIFactory - User 'dotcms.org.2795' does not have read permissions on 'newsite.com'
13:21:47.204  WARN  login.LoginServiceAPIFactory - com.dotmarketing.portlets.contentlet.business.HostAPIImpl.checkSitePermission(HostAPIImpl.java:188)
13:21:47.215  WARN  business.HostAPIImpl - An error occurred when checking permissions from User 'dotcms.org.2795' on Site '8fcb6608-6098-4386-91b3-ecdc931a7640': User 'dotcms.org.2795' does not have read permissions on 'newsite.com'
13:21:47.217  WARN  login.LoginServiceAPIFactory$LoginServiceImpl - User 'dotcms.org.2795' does not have READ permission to the Default Site. Setting the first available Site 'demo.dotcms.com' as current one
13:21:47.224  INFO  util.SecurityLogger - class com.dotcms.cms.login.LoginServiceAPIFactory$LoginServiceImpl : User dotcms.org.2795 has successfully login from IP: 127.0.0.1 -- ip:127.0.0.1,user:Chris Publisher [ID: dotcms.org.2795][email:chris@dotcms.com]
```
* Users won't be able to log into the dotCMS back-end at all if at least one of the following conditions is met:
  * They DON'T have READ access on ANY Site in the repository.
  * They DON'T have READ access to the Default Site, and the `FIRST_AVAILABLE_SITE_FALLBACK` flag is set to `false`.

This PR fixes: #27069