### PR TITLE
feat(CICD): Support for issue edited event to notify UI/UX

### DIFF
--- a/.github/data/github-teams.json
+++ b/.github/data/github-teams.json
@@ -1,0 +1,10 @@
+[
+  {
+    "team": "ui/ux",
+    "members": ["melissarojas-dotcms", "victoralfaro-dotcms"]
+  },
+  {
+    "team": "qa",
+    "members": ["bryanboza", "josemejias11"]
+  }
+]

--- a/.github/workflows/discover-issue-actions.yml
+++ b/.github/workflows/discover-issue-actions.yml
@@ -30,10 +30,6 @@ jobs:
           issue_number=$(cat $GITHUB_EVENT_PATH | jq '.issue.number')
           field_changed=$(cat $GITHUB_EVENT_PATH | jq '.changes.custom_fields.Technology.to')
 
-          # Remove me
-          field_changed='Front-end'
-          issue_number=29032
-               
           echo "field_changed=[${field_changed}]"
           if [[ -n "${issue_number}" && "${field_changed}" == 'Front-end' ]]; then
             [[ -n "${actions}" ]] && actions="${actions},"

--- a/.github/workflows/discover-issue-actions.yml
+++ b/.github/workflows/discover-issue-actions.yml
@@ -1,0 +1,47 @@
+# action.yml
+name: 'Discover actions after issue edited'
+on:
+  workflow_call:
+    outputs:
+      actions:
+        value: ${{ jobs.discover-actions.outputs.actions }}
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  discover-actions:
+    runs-on: ubuntu-20.04
+    outputs:
+      actions: ${{ steps.resolve-actions.outputs.actions }}
+    steps:
+      - run: echo 'GitHub context'
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+
+      - name: Resolve actions
+        id: resolve-actions
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "$GITHUB_EVENT_PATH"
+          
+          actions=
+          issue_number=$(cat $GITHUB_EVENT_PATH | jq '.issue.number')
+          field_changed=$(cat $GITHUB_EVENT_PATH | jq '.changes.custom_fields.Technology.to')
+
+          # Remove me
+          field_changed='Front-end'
+          issue_number=29032
+               
+          echo "field_changed=[${field_changed}]"
+          if [[ -n "${issue_number}" && "${field_changed}" == 'Front-end' ]]; then
+            [[ -n "${actions}" ]] && actions="${actions},"
+            action="{\"action\":\"FRONTEND_TECHNOLOGY_NOTIFY\",\"issue_number\":${issue_number}}"
+          fi
+               
+          actions="${actions}${action}"
+          [[ -n "${actions}" ]] && actions="[${actions}]"
+          
+          echo "actions: ${actions}"
+          echo "actions=${actions}" >> $GITHUB_OUTPUT

--- a/.github/workflows/frontend-notify.yml
+++ b/.github/workflows/frontend-notify.yml
@@ -1,0 +1,89 @@
+# action.yml
+name: 'Notification for Frontend'
+on:
+  workflow_call:
+    inputs:
+      actions:
+        description: 'Actions to perform'
+        type: string
+        required: true
+        default: '[]'
+    secrets:
+      CI_MACHINE_USER:
+        description: 'CI machine user'
+        required: true
+      CI_MACHINE_TOKEN:
+        description: 'CI machine token'
+        required: true
+      SLACK_BOT_TOKEN:
+        description: 'Slack bot token'
+        required: true
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  resolve-data:
+    runs-on: ubuntu-20.04
+    outputs:
+      issue_number: ${{ steps.evaluate-actions.outputs.issue_number }}
+    steps:
+      - name: Show detected actions
+        run: echo "${{ inputs.actions }}"
+
+      - name: Evaluate actions
+        id: evaluate-actions
+        run: |
+          action_json="${{ toJSON(inputs.actions) }}"
+          action_found=$(jq -r '.[] | select(.action == "FRONTEND_TECHNOLOGY_NOTIFY")' <<< ${action_json})
+          echo "action_found=[${action_found}]"
+          [[ -z "${action_found}" || ${action_found} == 'null' ]] && echo 'Action not found' && exit 1
+          
+          issue_number=$(jq -r '.issue_number' <<< ${action_found})
+          echo "issue_number=[${issue_number}]"
+          [[ -z "${issue_number}" ]] && echo 'Issue number not found' && exit 2
+          
+          echo "issue_number=${issue_number}" >> $GITHUB_OUTPUT
+
+  member-resolver:
+    name: Resolve members
+    needs: resolve-data
+    if: needs.resolve-data.outputs.issue_number
+    uses: ./.github/workflows/github-member-resolver.yml
+    with:
+      team: 'ui/ux'
+
+  slack-channel-resolver:
+    name: Resolve Slack Channel
+    needs: member-resolver
+    if: success() && needs.member-resolver.outputs.members
+    uses: ./.github/workflows/slack-channel-resolver.yml
+    with:
+      github_users: ${{ needs.member-resolver.outputs.members }}
+    secrets:
+      CI_MACHINE_USER: ${{ secrets.CI_MACHINE_USER }}
+      CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  frontend-notify:
+    name: Notify team member ${{ matrix.members }}
+    needs: [resolve-data, slack-channel-resolver]
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        member: ${{ fromJSON(needs.slack-channel-resolver.outputs.channel_ids) }}
+    env:
+      ISSUE_URL: https://github.com/${{ github.repository }}/issues/${{ needs.resolve-data.outputs.issue_number }}
+    steps:
+      - name: Notify member
+        shell: bash
+        run: |
+          channel=${{ matrix.member }}
+          message="The following github issue has been marked as a Front-end issue: ${{ env.ISSUE_URL }}"
+          
+          curl -X POST \
+            -H "Content-type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -d "{ \"channel\":\"${channel}\",\"text\":\"${message}\"}" \
+            -s \
+            https://slack.com/api/chat.postMessage

--- a/.github/workflows/github-member-resolver.yml
+++ b/.github/workflows/github-member-resolver.yml
@@ -1,0 +1,52 @@
+# action.yml
+name: 'Github Member Resolver'
+on:
+  workflow_call:
+    inputs:
+      team:
+        description: 'Team'
+        type: string
+        required: true
+      branch:
+        description: 'Branch'
+        type: string
+        required: false
+        default: master
+      continue_on_error:
+        description: 'Continue on error'
+        type: boolean
+        required: false
+        default: false
+    outputs:
+      members:
+        value: ${{ jobs.github-member-resolver.outputs.members }}
+
+jobs:
+  github-member-resolver:
+    runs-on: ubuntu-20.04
+    outputs:
+      members: ${{ steps.resolve-members.outputs.members }}
+    steps:
+      - name: Resolve Members
+        id: resolve-members
+        continue-on-error: ${{ inputs.continue_on_error }}
+        shell: bash
+        run: |
+          githack_host=raw.githack.com
+          githack_core_repo_url=https://${githack_host}/${{ github.repository }}
+          github_teams_url=${githack_core_repo_url}/${{ inputs.branch }}/.github/data/github-teams.json
+          
+          json=$(curl -s ${github_teams_url})
+          members=$(jq -r ".[] | select(.team == \"${{ inputs.team }}\") | .members[]" <<< "${json}" | tr '\n' ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          echo "Found members: [${members}]"
+          
+          declare -A deduped_array
+          for element in "${members[@]}"; do
+            deduped_array["$element"]=1
+          done
+          
+          deduped_members=("${!deduped_array[@]}")
+          members=$(echo "${deduped_members[@]}")
+          
+          echo "members=[${members}]"
+          echo "members=${members}" >> $GITHUB_OUTPUT

--- a/.github/workflows/post-issue-edited.yml
+++ b/.github/workflows/post-issue-edited.yml
@@ -1,0 +1,21 @@
+name: Post Issue Edited
+on:
+  issues:
+    types: [edited]
+
+jobs:
+  discover-actions:
+    name: Issue Resolve Actions
+    uses: ./.github/workflows/discover-issue-actions.yml
+
+  frontend-notify:
+    needs: discover-actions
+    name: Issue Resolve Actions
+    if: success() && needs.discover-actions.outputs.actions
+    uses: ./.github/workflows/frontend-notify.yml
+    with:
+      actions: ${{ needs.discover-actions.outputs.actions }}
+    secrets:
+      CI_MACHINE_USER: ${{ secrets.CI_MACHINE_USER }}
+      CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/pr-notifier.yml
+++ b/.github/workflows/pr-notifier.yml
@@ -7,12 +7,6 @@ on:
         description: 'PR status'
         type: string
         required: true
-      github_user:
-        description: 'Github user'
-        type: string
-        required: false
-        default: ${{ github.actor }}
-
     secrets:
       CI_MACHINE_USER:
         description: 'CI machine user'
@@ -25,129 +19,69 @@ on:
         required: true
 
 jobs:
-  pr-notifier:
+  message-resolver:
+    name: Resolve Message
     runs-on: ubuntu-20.04
-    if: always()
-    env:
-      SOURCE_REPOSITORY: ${{ github.repository }}
+    outputs:
+      message: ${{ steps.message-resolver.outputs.message }}
+    steps:
+      - name: Resolve Message
+        id: message-resolver
+        shell: bash
+        run: |
+          pr_status=${{ inputs.pr_status }}
+          run_id=${{ github.run_id }}
+          run_url=https://github.com/${{ github.repository }}/actions/runs/${run_id}
+          details_message="Please check ${run_url} for more details."
+          
+          case "${pr_status}" in
+          "SUCCESS")
+              message=":white_check_mark: PR passed all checks"
+              ;;
+          "FAILURE")
+              message=":x: PR failed checks"
+              ;;
+          "CANCELLED")
+              message=":warning: PR was cancelled"
+              ;;
+          *)
+              message=":question: PR status is unknown"
+              ;;
+          esac
+          
+          message="${message}. ${details_message}"
+          
+          echo "message: [${message}]"
+          echo "message=${message}" >> $GITHUB_OUTPUT
+
+  slack-channel-resolver:
+    name: Resolve Slack Channel
+    uses: ./.github/workflows/slack-channel-resolver.yml
+    with:
+      github_users: "${{ github.actor }}"
+      default_channel: eng
+      default_channel_id: C028Z3R2D
+      continue_on_error: true
+    secrets:
+      CI_MACHINE_USER: ${{ secrets.CI_MACHINE_USER }}
+      CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  pr-notifier:
+    needs: [message-resolver, slack-channel-resolver]
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        member: ${{ fromJSON(needs.slack-channel-resolver.outputs.channel_ids) }}
     continue-on-error: true
     steps:
-      - name: Resolve User
-        id: resolve-user
-        continue-on-error: true
-        shell: bash
-        env:
-          DEFAULT_CHANNEL: eng
-        run: |
-          github_user=${{ inputs.github_user }}
-          [[ -z "${github_user}" ]] && github_user=${{ env.DEFAULT_CHANNEL }}
-          
-          echo "github_user=${github_user}"
-          echo "github_user=${github_user}" >> $GITHUB_OUTPUT
-
-      - name: Resolve Channel
-        id: resolve-channel
-        continue-on-error: true
-        shell: bash
-        env:
-          DEFAULT_CHANNEL_ID: C028Z3R2D # eng channel id
-        run: |
-          github_user=${{ steps.resolve-user.outputs.github_user }}
-          
-          githack_host=raw.githack.com
-          githack_core_repo_url=https://${githack_host}/${{ env.SOURCE_REPOSITORY }}
-          
-          branch=/${{ github.head_ref }}
-          slack_mappings_file=slack-mappings.json
-          slack_mappings_path=.github/data/${slack_mappings_file}
-          slack_mapping_url=${githack_core_repo_url}${branch}/${slack_mappings_path}
-          
-          if [[ -n "${github_user}" ]]; then
-            json=$(curl -s ${slack_mapping_url})
-          
-            channel_id=$( \
-              jq ".[] | select(.github_user == \"${github_user}\")" <<< "${json}" | \
-              jq -r '.slack_id' \
-            )
-        
-            echo "Resolved channel id [${channel_id}] from [${slack_mappings_file}]"
-          
-            if [[ -z "${channel_id}" ]]; then
-              echo "Channel id could not be resolved from [${slack_mappings_file}]. Attempting to resolve from Github user email."
-              user_email=$( \
-                curl \
-                  -u ${{ secrets.CI_MACHINE_USER }}:${{ secrets.CI_MACHINE_TOKEN }} \
-                  --request GET \
-                  -s \
-                  https://api.github.com/users/${github_user} | \
-                grep "\"email\":" | \
-                sed "s/\"email\"://g" | \
-                tr -d '",[:space:]' \
-              )
-              echo "Resolved user email: [${user_email}]"
-            
-              if [[ -n "${user_email}" ]]; then
-                channel_id=$( \
-                  curl \
-                    --request GET \
-                    --header "Content-type: application/json" \
-                    --header "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-                    -s \
-                    "https://slack.com/api/users.lookupByEmail?email=${user_email}" | \
-                  python3 -m json.tool | \
-                  grep "\"id\":" | \
-                  sed "s/\"id\"://g" | \
-                  tr -d '",[:space:]' \
-                )
-          
-                echo "Resolved channel id [${channel_id}] from email [${user_email}]"
-              fi
-            fi
-          fi
-            
-          [[ -z "${channel_id}" ]] \
-            && echo "Channel id could not be resolved, defaulting to eng's [${{ env.DEFAULT_CHANNEL_ID }}]" \
-            && channel_id=${{ env.DEFAULT_CHANNEL_ID }}
-          echo "channel_id=${channel_id}" >> $GITHUB_OUTPUT
-          echo "channel_id=${channel_id}"
-
-      - name: Resolve Message
-        id: resolve-message
-        continue-on-error: true
-        shell: bash
-        run: |
-            pr_status=${{ inputs.pr_status }}
-            channel_id=${{ steps.resolve-channel.outputs.channel_id }}
-            run_id=${{ github.run_id }}
-            run_url=https://github.com/${{ env.SOURCE_REPOSITORY }}/actions/runs/${run_id}
-            details_message="Please check ${run_url} for more details."
-            
-            case "${pr_status}" in
-            "SUCCESS")
-                message=":white_check_mark: PR passed all checks"
-                ;;
-            "FAILURE")
-                message=":x: PR failed checks"
-                ;;
-            "CANCELLED")
-                message=":warning: PR was cancelled"
-                ;;
-            *)
-                message=":question: PR status is unknown"
-                ;;
-            esac
-          
-            message="${message}. ${details_message}"
-            
-            echo "message=${message}" >> $GITHUB_OUTPUT
-            echo "message=${message}"
-
       - name: Notify PR Status
         continue-on-error: true
         shell: bash
         run: |
-          channel=${{ steps.resolve-channel.outputs.channel_id }}
-          message="${{ steps.resolve-message.outputs.message }}"
+          channel=${{ matrix.member }}
+          message="${{ needs.message-resolver.outputs.message }}"
           
           curl -X POST \
             -H "Content-type: application/json" \

--- a/.github/workflows/slack-channel-resolver.yml
+++ b/.github/workflows/slack-channel-resolver.yml
@@ -1,0 +1,136 @@
+# action.yml
+name: 'Slack Channel Resolver'
+on:
+  workflow_call:
+    inputs:
+      github_users:
+        description: 'Github users space delimited list'
+        type: string
+        required: false
+        default: ''
+      default_channel:
+        description: 'Default channel'
+        type: string
+        required: false
+      default_channel_id:
+        description: 'Default channel ID'
+        type: string
+        required: false
+      branch:
+        description: 'Branch'
+        type: string
+        required: false
+        default: master
+      continue_on_error:
+        description: 'Continue on error'
+        type: boolean
+        required: false
+        default: false
+    outputs:
+      channel_ids:
+        value: ${{ jobs.slack-channel-resolver.outputs.channel_ids }}
+    secrets:
+      CI_MACHINE_USER:
+        description: 'CI machine user'
+        required: true
+      CI_MACHINE_TOKEN:
+        description: 'CI machine token'
+        required: true
+      SLACK_BOT_TOKEN:
+        description: 'Slack bot token'
+        required: true
+
+jobs:
+  slack-channel-resolver:
+    runs-on: ubuntu-20.04
+    outputs:
+      channel_ids: ${{ steps.resolve-channels.outputs.channel_ids }}
+    steps:
+      - name: Resolve Users
+        id: resolve-users
+        shell: bash
+        run: |
+          github_users="${{ inputs.github_users }}"
+          default_channel=${{ inputs.default_channel }}
+          [[ -z "${github_users}" && -n "${default_channel}" ]] && github_users=${default_channel}
+          
+          echo "github_users: [${github_users}]"
+          echo "github_users=${github_users}" >> $GITHUB_OUTPUT
+
+      - name: Resolve Channels
+        id: resolve-channels
+        continue-on-error: ${{ inputs.continue_on_error }}
+        shell: bash
+        run: |
+          github_users="${{ steps.resolve-users.outputs.github_users }}"
+          echo "Found github users: [${github_users}]"
+          github_users_array=(${github_users})
+          
+          githack_host=raw.githack.com
+          githack_core_repo_url=https://${githack_host}/${{ github.repository }}
+          slack_mappings_file=slack-mappings.json
+          slack_mapping_url=${githack_core_repo_url}/${{ inputs.branch }}/.github/data/${slack_mappings_file}
+          json=$(curl -s ${slack_mapping_url})
+          
+          channel_ids=
+          for github_user in "${github_users_array[@]}"; do
+            channel_id=$( \
+              jq ".[] | select(.github_user == \"${github_user}\")" <<< "${json}" | \
+              jq -r '.slack_id' \
+            )
+            echo "Resolved channel id [${channel_id}] from [${slack_mappings_file}]"
+          
+            if [[ -z "${channel_id}" ]]; then
+              echo "Channel id could not be resolved from [${slack_mappings_file}]. Attempting to resolve from Github user email."
+              user_email=$( \
+                curl \
+                  -u ${{ secrets.CI_MACHINE_USER }}:${{ secrets.CI_MACHINE_TOKEN }} \
+                  --request GET \
+                  -s \
+                  https://api.github.com/users/${github_user} | \
+                grep "\"email\":" | \
+                sed "s/\"email\"://g" | \
+                tr -d '",[:space:]' \
+              )
+              echo "Resolved user email: [${user_email}]"
+            
+              if [[ -n "${user_email}" ]]; then
+                channel_id=$( \
+                  curl \
+                    --request GET \
+                    --header "Content-type: application/json" \
+                    --header "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+                    -s \
+                    "https://slack.com/api/users.lookupByEmail?email=${user_email}" | \
+                  python3 -m json.tool | \
+                  grep "\"id\":" | \
+                  sed "s/\"id\"://g" | \
+                  tr -d '",[:space:]' \
+                )
+          
+                echo "Resolved channel id [${channel_id}] from email [${user_email}]"
+              fi
+            fi
+
+            [[ -n "${channel_id}" ]] && channel_ids="${channel_ids} ${channel_id}"
+          done
+          
+          default_channel_id=${{ inputs.default_channel_id }}
+          [[ -z "${channel_ids}" && -n "${default_channel_id}" ]] \
+            && echo "Channel id could not be resolved, defaulting to channel id: [${default_channel_id}]" \
+            && channel_ids=${default_channel_id}
+          
+          channel_ids=$(echo "${channel_ids}" | tr '\n' ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          if [[ -n "${channel_ids}" ]]; then
+            channel_ids_array=(${channel_ids})
+            declare -A deduped_array
+            for element in "${channel_ids_array[@]}"; do
+              deduped_array["$element"]=1
+            done
+            
+            deduped_channel_ids=("${!deduped_array[@]}")
+            channel_ids=$(printf '%s\n' "${deduped_channel_ids[@]}" | jq -R . | jq -s . | tr -d '\n' | tr -d ' ')
+          fi
+          
+          echo "channel_ids: ${channel_ids}"
+          echo "channel_ids=${channel_ids}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Introducing handling of `Issue edition` event specifically for when the `Technology` field is set to `Font-end`.
Also, not including an entry point just for this. Instead I'm providing a general purpose workflow for when an issue is changed and from there evaluate the actions it needs to execute. Also identified some logic that was extracted in order to be reused instead of copy-paste for resolving slack user ids from github accounts and the creation of teams where github  accounts are grouped under a team.

This PR fixes: #29032