### PR TITLE
Issue 28489 respect language when creating new content

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
@@ -1583,6 +1583,7 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
     }
 
     function createContentlet(url, contentType) {
+        url = url + "&lang=" + selectedLang;
         var customEvent = document.createEvent("CustomEvent");
         customEvent.initCustomEvent("ng-event", false, false,  {
             name: "create-contentlet",


### PR DESCRIPTION
Added _lang_ property when sending the request to create new content from **site browser**, so now when changing to a language different from default and opening create content tab we can see the selected language.

Fix: #28489 

This PR fixes: #28489