### PR TITLE
Issue 28366 image doesn't inherit permissions when creating from a non default language 

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_permissions_tab_inc_wrapper.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_permissions_tab_inc_wrapper.jsp
@@ -13,6 +13,7 @@ This jsp gets called in the edit content screen (edit_content_js_inc.jsp) to pai
 	<% Contentlet contentlet = APILocator.getContentletAPI().findContentletByIdentifier(id, false, lang, user, false);%>
 	<%if(contentlet !=null && UtilMethods.isSet(contentlet.getIdentifier())){ %>
 		<% request.setAttribute(com.dotmarketing.util.WebKeys.PERMISSIONABLE_EDIT, contentlet);%>
+		<% request.setAttribute(com.dotmarketing.util.WebKeys.CONTENTLET_EDIT, contentlet);%>
 		<% APILocator.getPermissionAPI().checkPermission(contentlet, PermissionLevel.EDIT_PERMISSIONS, user);%>
 		
 		<%@ include file="/html/portlet/ext/common/edit_permissions_tab_inc.jsp" %>


### PR DESCRIPTION
Set the contentlet value to the attribute _CONTENTLET_EDIT_ to the request, because where it should be used the value of it was null. 

This PR fixes: #28366