### PR TITLE
fix: CLI  deployed cli jar getting corrupted (#28917)

### DIFF
--- a/tools/dotcms-cli/jreleaser.yml
+++ b/tools/dotcms-cli/jreleaser.yml
@@ -47,15 +47,15 @@ distributions:
     active: ALWAYS
     stereotype: CLI
     artifacts:
-      - path: '{{artifactsDir}}/osx-aarch_64/dotcms-cli-{{projectVersion}}-runner.jar'
+      - path: '{{artifactsDir}}/{{artifactsDir}}-osx-aarch_64/dotcms-cli-{{projectVersion}}-runner.jar'
         platform: 'osx-aarch_64'
         extraProperties:
           optional: 'true'
-      - path: '{{artifactsDir}}/osx-x86_64/dotcms-cli-{{projectVersion}}-runner.jar'
+      - path: '{{artifactsDir}}/{{artifactsDir}}-osx-x86_64/dotcms-cli-{{projectVersion}}-runner.jar'
         platform: 'osx-x86_64'
         extraProperties:
           optional: 'true'
-      - path: '{{artifactsDir}}/linux-x86_64/dotcms-cli-{{projectVersion}}-runner.jar'
+      - path: '{{artifactsDir}}/{{artifactsDir}}-linux-x86_64/dotcms-cli-{{projectVersion}}-runner.jar'
         platform: 'linux-x86_64'
         extraProperties:
           optional: 'true'
@@ -63,15 +63,15 @@ distributions:
   dotcms-cli-native:
     type: BINARY
     artifacts:
-      - path: '{{artifactsDir}}/osx-aarch_64/distributions/dotcms-cli-{{projectVersion}}-osx-aarch_64.zip'
+      - path: '{{artifactsDir}}/{{artifactsDir}}-osx-aarch_64/distributions/dotcms-cli-{{projectVersion}}-osx-aarch_64.zip'
         platform: 'osx-aarch_64'
         extraProperties:
           optional: 'true'
-      - path: '{{artifactsDir}}/osx-x86_64/distributions/dotcms-cli-{{projectVersion}}-osx-x86_64.zip'
+      - path: '{{artifactsDir}}/{{artifactsDir}}-osx-x86_64/distributions/dotcms-cli-{{projectVersion}}-osx-x86_64.zip'
         platform: 'osx-x86_64'
         extraProperties:
           optional: 'true'
-      - path: '{{artifactsDir}}/linux-x86_64/distributions/dotcms-cli-{{projectVersion}}-linux-x86_64.zip'
+      - path: '{{artifactsDir}}/{{artifactsDir}}-linux-x86_64/distributions/dotcms-cli-{{projectVersion}}-linux-x86_64.zip'
         platform: 'linux-x86_64'
         extraProperties:
           optional: 'true'

--- a/tools/dotcms-cli/jreleaser.yml
+++ b/tools/dotcms-cli/jreleaser.yml
@@ -51,14 +51,6 @@ distributions:
         platform: 'linux-x86_64'
         extraProperties:
           optional: 'true'
-      # - path: '{{artifactsDir}}/{{artifactsDir}}-osx-aarch_64/dotcms-cli-{{projectVersion}}-runner.jar'
-      #   platform: 'osx-aarch_64'
-      #   extraProperties:
-      #     optional: 'true'
-      # - path: '{{artifactsDir}}/{{artifactsDir}}-osx-x86_64/dotcms-cli-{{projectVersion}}-runner.jar'
-      #   platform: 'osx-x86_64'
-      #   extraProperties:
-      #     optional: 'true'
 
   dotcms-cli-native:
     type: BINARY

--- a/tools/dotcms-cli/jreleaser.yml
+++ b/tools/dotcms-cli/jreleaser.yml
@@ -47,18 +47,18 @@ distributions:
     active: ALWAYS
     stereotype: CLI
     artifacts:
-      - path: '{{artifactsDir}}/{{artifactsDir}}-osx-aarch_64/dotcms-cli-{{projectVersion}}-runner.jar'
-        platform: 'osx-aarch_64'
-        extraProperties:
-          optional: 'true'
-      - path: '{{artifactsDir}}/{{artifactsDir}}-osx-x86_64/dotcms-cli-{{projectVersion}}-runner.jar'
-        platform: 'osx-x86_64'
-        extraProperties:
-          optional: 'true'
       - path: '{{artifactsDir}}/{{artifactsDir}}-linux-x86_64/dotcms-cli-{{projectVersion}}-runner.jar'
         platform: 'linux-x86_64'
         extraProperties:
           optional: 'true'
+      # - path: '{{artifactsDir}}/{{artifactsDir}}-osx-aarch_64/dotcms-cli-{{projectVersion}}-runner.jar'
+      #   platform: 'osx-aarch_64'
+      #   extraProperties:
+      #     optional: 'true'
+      # - path: '{{artifactsDir}}/{{artifactsDir}}-osx-x86_64/dotcms-cli-{{projectVersion}}-runner.jar'
+      #   platform: 'osx-x86_64'
+      #   extraProperties:
+      #     optional: 'true'
 
   dotcms-cli-native:
     type: BINARY


### PR DESCRIPTION
### Proposed Changes
* Fixing artifact path to be published on CLI release.

### Additional Info
Related to #28917 (CLI  deployed cli jar getting corrupted).

This PR fixes: #28917