### PR TITLE
chore(sdk): removed entity wrapper from `page.get` response #28962

### DIFF
--- a/core-web/libs/sdk/angular/package.json
+++ b/core-web/libs/sdk/angular/package.json
@@ -1,11 +1,11 @@
 {
     "name": "@dotcms/angular",
-    "version": "0.0.1-alpha.24",
+    "version": "0.0.1-alpha.25",
     "peerDependencies": {
         "@angular/common": "^17.1.0",
         "@angular/core": "^17.1.0",
         "@angular/router": "^17.1.0",
-        "@dotcms/client": "0.0.1-alpha.24",
+        "@dotcms/client": "0.0.1-alpha.25",
         "rxjs": "^7.8.0"
     },
     "description": "Official Angular Components library to render a dotCMS page.",

--- a/core-web/libs/sdk/client/package.json
+++ b/core-web/libs/sdk/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dotcms/client",
-    "version": "0.0.1-alpha.24",
+    "version": "0.0.1-alpha.25",
     "type": "module",
     "description": "Official JavaScript library for interacting with DotCMS REST APIs.",
     "repository": {

--- a/core-web/libs/sdk/client/src/lib/client/sdk-js-client.spec.ts
+++ b/core-web/libs/sdk/client/src/lib/client/sdk-js-client.spec.ts
@@ -176,7 +176,7 @@ describe('DotCmsClient', () => {
         describe('page.get', () => {
             it('should fetch page data successfully', async () => {
                 const mockResponse = { content: 'Page data' };
-                mockFetchResponse(mockResponse);
+                mockFetchResponse({ entity: mockResponse });
 
                 const data = await client.page.get({ path: '/home' });
 
@@ -397,7 +397,7 @@ describe('DotCmsClient', () => {
 
         it('should fetch page data with extra headers and cache', async () => {
             const mockResponse = { content: 'Page data' };
-            mockFetchResponse(mockResponse);
+            mockFetchResponse({ entity: mockResponse });
 
             const data = await client.page.get({ path: '/home' });
 

--- a/core-web/libs/sdk/client/src/lib/client/sdk-js-client.ts
+++ b/core-web/libs/sdk/client/src/lib/client/sdk-js-client.ts
@@ -243,7 +243,7 @@ export class DotCmsClient {
                 throw error;
             }
 
-            return response.json();
+            return response.json().then((data) => data.entity);
         }
     };
 

--- a/core-web/libs/sdk/experiments/package.json
+++ b/core-web/libs/sdk/experiments/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dotcms/experiments",
-    "version": "0.0.1-alpha.24",
+    "version": "0.0.1-alpha.25",
     "description": "Official JavaScript library to use Experiments with DotCMS.",
     "repository": {
         "type": "git",
@@ -25,6 +25,6 @@
     "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18",
-        "@dotcms/client": "0.0.1-alpha.24"
+        "@dotcms/client": "0.0.1-alpha.25"
     }
 }

--- a/core-web/libs/sdk/react/package.json
+++ b/core-web/libs/sdk/react/package.json
@@ -1,10 +1,10 @@
 {
     "name": "@dotcms/react",
-    "version": "0.0.1-alpha.24",
+    "version": "0.0.1-alpha.25",
     "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18",
-        "@dotcms/client": "0.0.1-alpha.24"
+        "@dotcms/client": "0.0.1-alpha.25"
     },
     "description": "Official React Components library to render a dotCMS page.",
     "repository": {

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -21,8 +21,8 @@
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.2",
-    "@dotcms/client": "0.0.1-alpha.24",
-    "@dotcms/angular": "0.0.1-alpha.24"
+    "@dotcms/client": "0.0.1-alpha.25",
+    "@dotcms/angular": "0.0.1-alpha.25"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.0.7",

--- a/examples/angular/src/app/guards/can-match-page.guard.ts
+++ b/examples/angular/src/app/guards/can-match-page.guard.ts
@@ -21,11 +21,8 @@ export const canMatchPage: CanMatchFn = async (
       params: queryParams,
     });
 
-    const { entity } = (await client.page.get(pageProps)) as {
-      entity: DotCMSPageAsset;
-    };
-
-    const { vanityUrl } = entity;
+    const pageAsset = (await client.page.get(pageProps)) as DotCMSPageAsset;
+    const { vanityUrl } = pageAsset;
 
     if (vanityUrl?.permanentRedirect || vanityUrl?.temporaryRedirect) {
       return router.createUrlTree([vanityUrl.forwardTo]);
@@ -33,7 +30,7 @@ export const canMatchPage: CanMatchFn = async (
 
     // Add the page asset to the route data
     // so it can be used by the DotCMSPageResolver and avoid fetching it again.
-    route.data = { ...route.data, pageAsset: entity };
+    route.data = { ...route.data, pageAsset };
 
     if (vanityUrl) {
       const vanityPagePros = { ...pageProps, path: vanityUrl.forwardTo };
@@ -45,7 +42,7 @@ export const canMatchPage: CanMatchFn = async (
       route.data = { ...route.data, pageAsset: pageResponse.entity };
     }
 
-    return !!entity;
+    return !!pageAsset;
   } catch (error: any) {
     console.error(error); // Log the error
     route.data = { ...route.data, pageAsset: { layout: {} } }; // Add the page asset to the route data

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,9 +9,9 @@
         "lint": "next lint"
     },
     "dependencies": {
-        "@dotcms/client": "0.0.1-alpha.24",
-        "@dotcms/react": "0.0.1-alpha.24",
-        "@dotcms/experiments": "0.0.1-alpha.24",
+        "@dotcms/client": "0.0.1-alpha.25",
+        "@dotcms/react": "0.0.1-alpha.25",
+        "@dotcms/experiments": "0.0.1-alpha.25",
         "next": "14.1.1",
         "react": "^18",
         "react-dom": "^18"

--- a/examples/nextjs/src/app/[[...slug]]/page.js
+++ b/examples/nextjs/src/app/[[...slug]]/page.js
@@ -21,7 +21,7 @@ export async function generateMetadata({ params, searchParams }) {
 
     try {
         const data = await client.page.get(pageRequestParams);
-        const page = data.entity?.page;
+        const page = data.page;
         const title = page?.friendlyName || page?.title;
 
         return {
@@ -42,29 +42,29 @@ export default async function Home({ searchParams, params }) {
                 path,
                 params: searchParams,
             });
-            const data = await client.page.get(pageRequestParams);
+            const pageAsset = await client.page.get(pageRequestParams);
             const nav = await client.nav.get({
                 path: "/",
                 depth: 2,
                 languageId: searchParams.language_id,
             });
 
-            return { data, nav };
+            return { pageAsset, nav };
         } catch (error) {
-            return { data: null, nav: null, error };
+            return { pageAsset: null, nav: null, error };
         }
     };
-    const { data, nav, error } = await getPageData();
+    const { pageAsset, nav, error } = await getPageData();
 
     if (error) {
         return <ErrorPage error={error} />;
     }
 
-    const { vanityUrl } = data?.entity;
+    const { vanityUrl } = pageAsset;
 
     if (vanityUrl) {
         handleVanityUrlRedirect(vanityUrl);
     }
 
-    return <MyPage nav={nav.entity.children} pageAsset={data.entity}></MyPage>;
+    return <MyPage nav={nav.entity.children} pageAsset={pageAsset}></MyPage>;
 }

--- a/examples/vuejs/package.json
+++ b/examples/vuejs/package.json
@@ -11,7 +11,7 @@
         "format": "prettier --write src/"
     },
     "dependencies": {
-        "@dotcms/client": "^0.0.1-alpha.24",
+        "@dotcms/client": "^0.0.1-alpha.25",
         "vue": "^3.4.15",
         "vue-router": "^4.2.5"
     },


### PR DESCRIPTION
### Proposed Changes
* Removed entity wrapper in page.get responses
* Updated Angular/NextJS examples

This PR fixes: #28962