### PR TITLE
feat(edit-content): fixed alignment in add persona form

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-autocomplete-tags/dot-autocomplete-tags.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-autocomplete-tags/dot-autocomplete-tags.component.scss
@@ -10,7 +10,7 @@
         font-size: $font-size-sm;
         text-transform: uppercase;
         position: absolute;
-        top: 15px;
+        top: $spacing-4;
         right: $spacing-1;
         color: $color-palette-gray-700;
         display: flex;


### PR DESCRIPTION
### Proposed Changes
* Update top of helper text

The truncated text was already fixed in a previous PR

![Screenshot 2024-07-10 at 1 05 57 PM](https://github.com/dotCMS/core/assets/144152756/8b406c2d-77b7-410c-9fed-a02ed90302d5)

This PR fixes: #26081