### PR TITLE
ci: Fix default runid for base and ci artifacts when running on master branch.

### DIFF
--- a/.github/actions/deploy-artifact-jfrog/action.yml
+++ b/.github/actions/deploy-artifact-jfrog/action.yml
@@ -31,15 +31,14 @@ inputs:
   github-token:
     description: 'GitHub Token'
     required: true
+  artifact-run-id:
+    default: ${{ github.run_id }}
+    description: 'The run id of the core artifacts'
 
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-
-    - name: Setup Java # Uses .sdkmanrc file
-      id: sdkman-java
-      uses: sdkman/sdkman-action@b1f9b696c79148b66d3d3a06f7ea801820318d0f
 
     - name: Install xmllint
       run: |
@@ -50,7 +49,7 @@ runs:
       with:
         stage-name: "Deploy Artifacts Validate"
         maven-args: "validate" # We don't need to build just get the repo and use validate to check everything exists
-
+        artifacts-from: ${{ inputs.artifact-run-id }}
 
     - uses: jfrog/setup-jfrog-cli@v4
 

--- a/.github/actions/publish-npm-cli/action.yml
+++ b/.github/actions/publish-npm-cli/action.yml
@@ -23,12 +23,9 @@ inputs:
     description: 'Node.js version'
     required: false
     default: '19'
-  artifact-id:
-    description: 'Artifact id'
-    required: false
-    default: 'cli-artifacts-*'
-  reuse-previous-build:
-    description: 'Indicates if the workflow should reuse the previous build'
+  cli-artifact-run-id:
+    default: ${{ github.run_id }}
+    description: 'The run id of the cli artifacts'
     required: false
 outputs:
   npm-package-version:
@@ -55,81 +52,16 @@ runs:
       run: pip install jinja2-cli
       shell: bash
 
-    - name: 'Download Build Artifact'
-      id: data-download
-      uses: dawidd6/action-download-artifact@v3.1.4
-      with:
-        github_token: ${{ inputs.github-token }}
-        #workflow: ${{ inputs.workflow-to-search }}
-        commit: ${{ github.sha }}
-        workflow_conclusion: success
-        search_artifacts: true
-        dry_run: true
-        name: ${{ inputs.artifact-id }}
-        name_is_regexp: true
-        path: .
-        if_no_artifact_found: warn
 
-    - name: 'Check if artifact exists'
-      id: check
-      run: |
-        build_artifact_exists=${{ steps.data-download.outputs.found_artifact }}
-        if [[ ${build_artifact_exists} == "true" ]]; then
-            run_id=`echo '${{ steps.data-download.outputs.artifacts }}' | jq -r '.[0].workflow_run.id'`
-            found_artifacts=true
-            echo "Artifact Run id: $run_id"
-        else
-           echo "No artifact found"
-           run_id="${{ github.run_id }}"
-           found_artifacts=false
-        fi
-        echo "run_id=$run_id" >> $GITHUB_OUTPUT
-        echo "found_artifacts=$found_artifacts" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Download Previous Build Artifact
-      id: data-download-previous
-      uses: dawidd6/action-download-artifact@v3.1.4
-      if: ${{ inputs.reuse-previous-build == true && steps.data-download.outputs.found_artifact == 'false' }}
-      with:
-        github_token: ${{ inputs.github-token }}
-        #workflow: build-test-merge_group.yml
-        workflow_search: true
-        #commit: ${{ github.sha }}
-        workflow_conclusion: success
-        search_artifacts: true
-        dry_run: true
-        name: ${{ inputs.artifact-id }}
-        path: .
-        if_no_artifact_found: warn
-
-    - name: 'Check if any previous artifact exists'
-      id: check-previous
-      if: ${{ inputs.reuse-previous-build == true && steps.data-download.outputs.found_artifact == 'false' }}
-      run: |
-        build_artifact_exists=${{ steps.data-download-previous.outputs.found_artifact }}
-        if [[ ${build_artifact_exists} == "true" ]]; then
-            run_id=`echo '${{ steps.data-download-previous.outputs.artifacts }}' | jq -r '.[0].workflow_run.id'`
-            found_artifacts=true
-            echo "Artifact Run id: $run_id"
-        else
-           echo "No artifact found"
-           run_id="${{ github.run_id }}"
-           found_artifacts=false
-        fi
-        echo "run_id=$run_id" >> $GITHUB_OUTPUT
-        echo "found_artifacts=$found_artifacts" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: 'Download all build artifacts'
+    - name: 'Download all cli build artifacts.'
       id: download-cli-artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: ${{ inputs.artifact-id }}
+        pattern: cli-artifacts-*
         path: ${{ github.workspace }}/artifacts
         github-token: ${{ inputs.github-token }} # token with actions:read permissions on target repo
         merge-multiple: true
-        run-id: ${{ steps.check.outputs.run_id }}
+        run-id: ${{ inputs.cli-artifact-run-id }} # CLI Artifacts currently always from the same run-id and never from merge queue
 
     - name: 'List CLI Artifacts'
       run: |
@@ -139,11 +71,6 @@ runs:
         echo "::endgroup::"
       shell: bash
 
-    - name: 'Extract run-id'
-      id: extract-metadata
-      run: |
-        echo "run-id=${{ github.run_id }}" >> $GITHUB_OUTPUT
-      shell: bash
 
     - name: 'Extract package version'
       id: project

--- a/.github/workflows/build-test-master.yml
+++ b/.github/workflows/build-test-master.yml
@@ -65,6 +65,7 @@ jobs:
     uses: ./.github/workflows/cli-build-artifacts.yml
     with:
       buildNativeImage: true
+      artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
       branch: ${{ github.ref }}
 
   deployment:

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -101,6 +101,7 @@ jobs:
           artifactory-password: ${{ secrets.EE_REPO_PASSWORD }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+
       - name: CLI Publish
         id: cli_publish
         if: inputs.publish-npm-package
@@ -108,7 +109,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_ORG_TOKEN }}
-          reuse-previous-build: ${{ inputs.reuse-previous-build }}
+          cli-artifact-run-id: ${{ github.run_id }} # currently cli artifacts are never from build queue
 
 
       # A Slack notification is sent using the 'slackapi/slack-github-action' action if the repository is 'dotcms/core'.

--- a/.github/workflows/reusable-sonarqube.yml
+++ b/.github/workflows/reusable-sonarqube.yml
@@ -26,6 +26,7 @@ jobs:
         uses: ./.github/actions/maven-job
         with:
           stage-name: "SonarQube Scan"
+          artifacts-from: ${{ inputs.artifact-run-id }}
           restore-classes: true
           require-master: true
           cache-sonar: true


### PR DESCRIPTION
### Proposed Changes
* When running on master branch we are either using maven artifacts built in the merge queue or from the current run id.   CLI artifacts are currently always generated in the current build and are not pulled from the merge queue.
* There was an issue that the correct run-id was not being passed for the sonarqube step or to pull maven repo for cli native builds.  
* This fix makes sure the correct run-id is consistently passed through and used by CLI and jobs requiring core artifacts.


### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #27998