### PR TITLE
ci: pass github-secret to maven-job artifact so it can load artifacts fro…

### DIFF
--- a/.github/actions/deploy-artifact-jfrog/action.yml
+++ b/.github/actions/deploy-artifact-jfrog/action.yml
@@ -47,6 +47,7 @@ runs:
 
     - uses: ./.github/actions/maven-job
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         stage-name: "Deploy Artifacts Validate"
         maven-args: "validate" # We don't need to build just get the repo and use validate to check everything exists
         artifacts-from: ${{ inputs.artifact-run-id }}

--- a/.github/workflows/cli-build-artifacts.yml
+++ b/.github/workflows/cli-build-artifacts.yml
@@ -74,6 +74,7 @@ jobs:
           generates-test-results: false
           artifacts-from: ${{ env.ARTIFACT_RUN_ID }}
           version: ${{ inputs.version }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Upload built distribution'
         id: upload-artifact

--- a/.github/workflows/cli-release-process.yml
+++ b/.github/workflows/cli-release-process.yml
@@ -151,6 +151,7 @@ jobs:
           JRELEASER_ARTIFACTORY_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}
           JRELEASER_DRY_RUN: ${{ github.event.inputs.dry-run || 'false' }}
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           stage-name: "JReleaser"
           maven-args: "-Prelease validate -DartifactsDir=artifacts -Dm2Dir=$HOME/.m2/repository -Djreleaser.git.root.search=true -pl :dotcms-cli-parent -Dmaven.plugin.validation=VERBOSE"
           artifacts-from: ${{ env.ARTIFACT_RUN_ID }}

--- a/.github/workflows/reusable-sonarqube.yml
+++ b/.github/workflows/reusable-sonarqube.yml
@@ -29,6 +29,7 @@ jobs:
           artifacts-from: ${{ inputs.artifact-run-id }}
           restore-classes: true
           require-master: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           cache-sonar: true
           java-version: 21.0.3-ms # does not work with java 11, remove once we are on java 21
           maven-args: -Dsonar.ws.timeout=180 -Dsonar.log.level=DEBUG org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=dotCMS_core_AYSbIemxK43eThAXTlt- -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }} -Dsonar.token=${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
…m merge-queue

### Proposed Changes
* Should fix issue where artifacts from merge queue build are not being found by Master build.   The current github-secret needs to be explicitly passed to the maven-job action for it to find the artifact.  This does not effect other workflows where the build was done with the same run-id as the current job.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #27998