### PR TITLE
feat(CICD): avoiding steps failures to stop email notificacion

### DIFF
--- a/.github/workflows/frontend-notify.yml
+++ b/.github/workflows/frontend-notify.yml
@@ -115,23 +115,24 @@ jobs:
 
       - name: Evaluate actions
         id: evaluate-actions
+        if: steps.resolve-actions.outputs.actions != '[]'
         shell: bash
         run: |
           actions_json="${{ toJSON(steps.resolve-actions.outputs.actions) }}"
           action_found=$(jq -r '.[] | select(.action == "FRONTEND_TECHNOLOGY_NOTIFY")' <<< ${actions_json})
           echo "action_found=[${action_found}]"
-          [[ -z "${action_found}" || ${action_found} == 'null' ]] && echo 'Action not found' && exit 1
+          [[ -z "${action_found}" || ${action_found} == 'null' ]] && echo 'Action not found'
           
           issue_number=$(jq -r '.issue_number' <<< ${action_found})
           echo "issue_number=[${issue_number}]"
-          [[ -z "${issue_number}" ]] && echo 'Issue number not found' && exit 2
+          [[ -z "${issue_number}" || "${issue_number}" == 'null' ]] && echo 'Issue number not found'
           
           echo "issue_number=${issue_number}" >> $GITHUB_OUTPUT
 
   member-resolver:
     name: Resolve members
     needs: resolve-data
-    if: needs.resolve-data.outputs.issue_number
+    if: success() && needs.resolve-data.outputs.issue_number
     uses: ./.github/workflows/github-member-resolver.yml
     with:
       team: 'ui/ux'
@@ -152,6 +153,7 @@ jobs:
     name: Notify team member ${{ matrix.members }}
     needs: [resolve-data, slack-channel-resolver]
     runs-on: ubuntu-20.04
+    if: success() && needs.resolve-data.outputs.issue_number && needs.slack-channel-resolver.outputs.channel_ids
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/slack-channel-resolver.yml
+++ b/.github/workflows/slack-channel-resolver.yml
@@ -132,5 +132,5 @@ jobs:
             channel_ids=$(printf '%s\n' "${deduped_channel_ids[@]}" | jq -R . | jq -s . | tr -d '\n' | tr -d ' ')
           fi
           
-          echo "channel_ids: ${channel_ids}"
+          echo "channel_ids: [${channel_ids}]"
           echo "channel_ids=${channel_ids}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
When Post issue changed workflow fail it usually sends anonoying emails.
This fix is to avoid failures and if they exist they will be ignored.

This PR fixes: #29032