### PR TITLE
fix(seo): title and description truncation with ellipsis #26531

### DIFF
--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-results-seo-tool/dot-results-seo-tool.component.ts
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-results-seo-tool/dot-results-seo-tool.component.ts
@@ -70,13 +70,29 @@ export class DotResultsSeoToolComponent implements OnInit, OnChanges {
     noFavicon = false;
 
     ngOnInit(): void {
+        const truncateText = (text: string, limit: number) => {
+            if (!text) {
+                return '';
+            }
+
+            if (text.length <= limit) {
+                return text;
+            }
+
+            const truncated = text.slice(0, limit);
+
+            return truncated.slice(0, truncated.lastIndexOf(' ')) + '...';
+        };
+
         const title =
-            this.seoOGTags?.['og:title']?.slice(0, SEO_LIMITS.MAX_OG_TITLE_LENGTH) ||
-            this.seoOGTags?.title?.slice(0, SEO_LIMITS.MAX_OG_TITLE_LENGTH);
+            truncateText(this.seoOGTags?.['og:title'], SEO_LIMITS.MAX_OG_TITLE_LENGTH) ||
+            truncateText(this.seoOGTags?.title, SEO_LIMITS.MAX_OG_TITLE_LENGTH);
 
         const description =
-            this.seoOGTags?.['og:description']?.slice(0, SEO_LIMITS.MAX_OG_DESCRIPTION_LENGTH) ||
-            this.seoOGTags?.description?.slice(0, SEO_LIMITS.MAX_OG_DESCRIPTION_LENGTH);
+            truncateText(
+                this.seoOGTags?.['og:description'],
+                SEO_LIMITS.MAX_OG_DESCRIPTION_LENGTH
+            ) || truncateText(this.seoOGTags?.description, SEO_LIMITS.MAX_OG_DESCRIPTION_LENGTH);
 
         const twitterDescriptionProperties = [
             'twitter:description',
@@ -87,15 +103,15 @@ export class DotResultsSeoToolComponent implements OnInit, OnChanges {
 
         const twitterDescription = twitterDescriptionProperties
             .map((property) =>
-                this.seoOGTags?.[property]?.slice(0, SEO_LIMITS.MAX_TWITTER_DESCRIPTION_LENGTH)
+                truncateText(this.seoOGTags?.[property], SEO_LIMITS.MAX_TWITTER_DESCRIPTION_LENGTH)
             )
-            .find((value) => value !== undefined);
+            .find((value) => value !== undefined && value.length > 0);
 
         const twitterTitle = twitterTitleProperties
             .map((property) =>
-                this.seoOGTags?.[property]?.slice(0, SEO_LIMITS.MAX_TWITTER_TITLE_LENGTH)
+                truncateText(this.seoOGTags?.[property], SEO_LIMITS.MAX_TWITTER_TITLE_LENGTH)
             )
-            .find((value) => value !== undefined);
+            .find((value) => value !== undefined && value.length > 0);
 
         this.allPreview = [
             {

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-results-seo-tool/dot-results-seo-tool.component.ts
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-results-seo-tool/dot-results-seo-tool.component.ts
@@ -70,15 +70,14 @@ export class DotResultsSeoToolComponent implements OnInit, OnChanges {
     noFavicon = false;
 
     ngOnInit(): void {
-        const title =
-            ellipsizeText(this.seoOGTags?.['og:title'], SEO_LIMITS.MAX_OG_TITLE_LENGTH) ||
-            ellipsizeText(this.seoOGTags?.title, SEO_LIMITS.MAX_OG_TITLE_LENGTH);
+        const title = this.seoOGTags?.['og:title'] || this.seoOGTags?.title;
+        const ellipsizedTitle = ellipsizeText(title, SEO_LIMITS.MAX_OG_TITLE_LENGTH);
 
-        const description =
-            ellipsizeText(
-                this.seoOGTags?.['og:description'],
-                SEO_LIMITS.MAX_OG_DESCRIPTION_LENGTH
-            ) || ellipsizeText(this.seoOGTags?.description, SEO_LIMITS.MAX_OG_DESCRIPTION_LENGTH);
+        const description = this.seoOGTags?.['og:description'] || this.seoOGTags?.description;
+        const ellipsizedDescription = ellipsizeText(
+            description,
+            SEO_LIMITS.MAX_OG_DESCRIPTION_LENGTH
+        );
 
         const twitterDescriptionProperties = [
             'twitter:description',
@@ -102,8 +101,8 @@ export class DotResultsSeoToolComponent implements OnInit, OnChanges {
         this.allPreview = [
             {
                 hostName: this.hostName,
-                title,
-                description,
+                title: ellipsizedTitle,
+                description: ellipsizedDescription,
                 type: 'Desktop',
                 isMobile: false,
                 image: this.seoOGTags?.['og:image'],
@@ -114,8 +113,8 @@ export class DotResultsSeoToolComponent implements OnInit, OnChanges {
             },
             {
                 hostName: this.hostName,
-                title,
-                description,
+                title: ellipsizedTitle,
+                description: ellipsizedDescription,
                 type: 'Mobile',
                 isMobile: true
             }

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-results-seo-tool/dot-results-seo-tool.component.ts
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-results-seo-tool/dot-results-seo-tool.component.ts
@@ -26,10 +26,10 @@ import {
     SEO_LIMITS
 } from '@dotcms/dotcms-models';
 import { DotMessagePipe, DotSafeHtmlPipe } from '@dotcms/ui';
+import { ellipsizeText } from '@dotcms/utils';
 
 import { DotSelectSeoToolComponent } from '../dot-select-seo-tool/dot-select-seo-tool.component';
 import { DotSeoImagePreviewComponent } from '../dot-seo-image-preview/dot-seo-image-preview.component';
-
 @Component({
     selector: 'dot-results-seo-tool',
     standalone: true,
@@ -70,29 +70,15 @@ export class DotResultsSeoToolComponent implements OnInit, OnChanges {
     noFavicon = false;
 
     ngOnInit(): void {
-        const truncateText = (text: string, limit: number) => {
-            if (!text) {
-                return '';
-            }
-
-            if (text.length <= limit) {
-                return text;
-            }
-
-            const truncated = text.slice(0, limit);
-
-            return truncated.slice(0, truncated.lastIndexOf(' ')) + '...';
-        };
-
         const title =
-            truncateText(this.seoOGTags?.['og:title'], SEO_LIMITS.MAX_OG_TITLE_LENGTH) ||
-            truncateText(this.seoOGTags?.title, SEO_LIMITS.MAX_OG_TITLE_LENGTH);
+            ellipsizeText(this.seoOGTags?.['og:title'], SEO_LIMITS.MAX_OG_TITLE_LENGTH) ||
+            ellipsizeText(this.seoOGTags?.title, SEO_LIMITS.MAX_OG_TITLE_LENGTH);
 
         const description =
-            truncateText(
+            ellipsizeText(
                 this.seoOGTags?.['og:description'],
                 SEO_LIMITS.MAX_OG_DESCRIPTION_LENGTH
-            ) || truncateText(this.seoOGTags?.description, SEO_LIMITS.MAX_OG_DESCRIPTION_LENGTH);
+            ) || ellipsizeText(this.seoOGTags?.description, SEO_LIMITS.MAX_OG_DESCRIPTION_LENGTH);
 
         const twitterDescriptionProperties = [
             'twitter:description',
@@ -103,13 +89,13 @@ export class DotResultsSeoToolComponent implements OnInit, OnChanges {
 
         const twitterDescription = twitterDescriptionProperties
             .map((property) =>
-                truncateText(this.seoOGTags?.[property], SEO_LIMITS.MAX_TWITTER_DESCRIPTION_LENGTH)
+                ellipsizeText(this.seoOGTags?.[property], SEO_LIMITS.MAX_TWITTER_DESCRIPTION_LENGTH)
             )
             .find((value) => value !== undefined && value.length > 0);
 
         const twitterTitle = twitterTitleProperties
             .map((property) =>
-                truncateText(this.seoOGTags?.[property], SEO_LIMITS.MAX_TWITTER_TITLE_LENGTH)
+                ellipsizeText(this.seoOGTags?.[property], SEO_LIMITS.MAX_TWITTER_TITLE_LENGTH)
             )
             .find((value) => value !== undefined && value.length > 0);
 

--- a/core-web/libs/utils/src/lib/dot-utils.spec.ts
+++ b/core-web/libs/utils/src/lib/dot-utils.spec.ts
@@ -73,6 +73,18 @@ describe('Ellipsize Text Utility', () => {
         expect(ellipsizeText(undefined, 10)).toEqual('');
     });
 
+    it('should return empty string when text is empty', () => {
+        expect(ellipsizeText('', 10)).toEqual('');
+    });
+
+    it('should return empty string when limit is 0', () => {
+        expect(ellipsizeText('Any text', 0)).toEqual('');
+    });
+
+    it('should return empty string when limit is negative', () => {
+        expect(ellipsizeText('Any text', -5)).toEqual('');
+    });
+
     it('should return the original text when it is shorter than the limit', () => {
         const text = 'Short text';
         expect(ellipsizeText(text, 20)).toEqual(text);
@@ -81,24 +93,32 @@ describe('Ellipsize Text Utility', () => {
     it('should truncate the text with ellipsis when it exceeds the limit', () => {
         const text = 'This is a longer text that needs truncation';
         const truncated = 'This is a longer...';
-        expect(ellipsizeText(text, 20)).toEqual(truncated);
+        expect(ellipsizeText(text, 18)).toEqual(truncated);
     });
 
-    it('should truncate the text at the nearest word boundary', () => {
+    it('should handle no spaces correctly and truncate at the limit', () => {
+        const text = 'Thisisaverylongwordthatneedstruncation';
+        const truncated = 'Thisisaverylongwo...';
+        expect(ellipsizeText(text, 18)).toEqual(truncated);
+    });
+    it('should return empty string when a non-string value is passed', () => {
+        expect(ellipsizeText(12345 as any, 10)).toEqual('');
+        expect(ellipsizeText({} as any, 10)).toEqual('');
+        expect(ellipsizeText([] as any, 10)).toEqual('');
+        expect(ellipsizeText(null, 10)).toEqual('');
+    });
+    it('should return empty string when limit is not a number', () => {
+        const text = 'Any text';
+        expect(ellipsizeText(text, NaN)).toEqual('');
+        expect(ellipsizeText(text, 'abc' as any)).toEqual('');
+        expect(ellipsizeText(text, {} as any)).toEqual('');
+        expect(ellipsizeText(text, [] as any)).toEqual('');
+        expect(ellipsizeText(text, null)).toEqual('');
+    });
+
+    it('should truncate text at word boundary if there is a space before the limit', () => {
         const text = 'This is a longer text that needs truncation';
         const truncated = 'This is a...';
         expect(ellipsizeText(text, 15)).toEqual(truncated);
-    });
-
-    it('should return the truncated text with ellipsis even if there is no space before the limit', () => {
-        const text = 'Thisisaverylongwordthatneedstruncation';
-        const truncated = 'Thisisaverylongw...';
-        expect(ellipsizeText(text, 17)).toEqual(truncated);
-    });
-
-    it('should handle edge cases where limit is 0', () => {
-        const text = 'Any text';
-        const truncated = '...';
-        expect(ellipsizeText(text, 0)).toEqual(truncated);
     });
 });

--- a/core-web/libs/utils/src/lib/dot-utils.spec.ts
+++ b/core-web/libs/utils/src/lib/dot-utils.spec.ts
@@ -1,7 +1,7 @@
 import { DotCMSBaseTypesContentTypes } from '@dotcms/dotcms-models';
 import { EMPTY_CONTENTLET } from '@dotcms/utils-testing';
 
-import { getImageAssetUrl } from './dot-utils';
+import { getImageAssetUrl, ellipsizeText } from './dot-utils';
 
 describe('Dot Utils', () => {
     describe('getImageAssetUrl', () => {
@@ -65,5 +65,40 @@ describe('Dot Utils', () => {
 
             expect(getImageAssetUrl(contentlet)).toEqual('');
         });
+    });
+});
+
+describe('Ellipsize Text Utility', () => {
+    it('should return empty string when text is undefined', () => {
+        expect(ellipsizeText(undefined, 10)).toEqual('');
+    });
+
+    it('should return the original text when it is shorter than the limit', () => {
+        const text = 'Short text';
+        expect(ellipsizeText(text, 20)).toEqual(text);
+    });
+
+    it('should truncate the text with ellipsis when it exceeds the limit', () => {
+        const text = 'This is a longer text that needs truncation';
+        const truncated = 'This is a longer...';
+        expect(ellipsizeText(text, 20)).toEqual(truncated);
+    });
+
+    it('should truncate the text at the nearest word boundary', () => {
+        const text = 'This is a longer text that needs truncation';
+        const truncated = 'This is a...';
+        expect(ellipsizeText(text, 15)).toEqual(truncated);
+    });
+
+    it('should return the truncated text with ellipsis even if there is no space before the limit', () => {
+        const text = 'Thisisaverylongwordthatneedstruncation';
+        const truncated = 'Thisisaverylongw...';
+        expect(ellipsizeText(text, 17)).toEqual(truncated);
+    });
+
+    it('should handle edge cases where limit is 0', () => {
+        const text = 'Any text';
+        const truncated = '...';
+        expect(ellipsizeText(text, 0)).toEqual(truncated);
     });
 });

--- a/core-web/libs/utils/src/lib/dot-utils.ts
+++ b/core-web/libs/utils/src/lib/dot-utils.ts
@@ -94,3 +94,24 @@ export function getImageAssetUrl(contentlet: DotCMSContentlet): string {
             return contentlet?.asset || '';
     }
 }
+
+/**
+ * This method is used to truncate a text with ellipsis.
+ * It ensures that the text is truncated at the nearest word boundary.
+ * @param text - The text to be truncated.
+ * @param limit - The maximum length of the truncated text.
+ * @returns The truncated text with ellipsis if it exceeds the limit, otherwise the original text.
+ */
+export function ellipsizeText(text: string, limit: number): string {
+    if (!text) {
+        return '';
+    }
+
+    if (text.length <= limit) {
+        return text;
+    }
+
+    const truncated = text.slice(0, limit);
+
+    return truncated.slice(0, truncated.lastIndexOf(' ')) + '...';
+}

--- a/core-web/libs/utils/src/lib/dot-utils.ts
+++ b/core-web/libs/utils/src/lib/dot-utils.ts
@@ -103,7 +103,7 @@ export function getImageAssetUrl(contentlet: DotCMSContentlet): string {
  * @returns The truncated text with ellipsis if it exceeds the limit, otherwise the original text.
  */
 export function ellipsizeText(text: string, limit: number): string {
-    if (!text) {
+    if (!text || typeof text !== 'string' || limit <= 0 || isNaN(limit)) {
         return '';
     }
 


### PR DESCRIPTION
Fix SEO title and description truncation with ellipsis

### Proposed Changes
* Truncate SEO titles and descriptions with ellipsis after specified character limits.
* Ensure consistent handling of SEO_LIMITS for title and description truncation.

This PR fixes #26531

### Screenshots
<img width="1728" alt="Captura de pantalla 2024-07-18 a la(s) 14 41 56" src="https://github.com/user-attachments/assets/45c0818e-901d-4897-808e-0c6944ec29c6">
<img width="1728" alt="Captura de pantalla 2024-07-18 a la(s) 14 42 10" src="https://github.com/user-attachments/assets/19fd9e83-75a7-4f35-84b8-a63bb4c15799">
<img width="1728" alt="Captura de pantalla 2024-07-18 a la(s) 14 42 22" src="https://github.com/user-attachments/assets/04f10393-c8e5-48fc-b7c1-499a3bbeb13a">
<img width="1728" alt="Captura de pantalla 2024-07-18 a la(s) 14 48 29" src="https://github.com/user-attachments/assets/32c0cd48-c590-4e40-84cf-febe2502d6ae">


This PR fixes: #26531