### PR TITLE
fix(Workflows): Show add divider button under FF in the workflow portlet

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/workflows/schemes/view_steps_filtered.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/workflows/schemes/view_steps_filtered.jsp
@@ -11,6 +11,7 @@
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <%@ page import="com.liferay.portal.model.User" %>
 <%@ page import="java.util.List" %>
+<%@page import="com.dotmarketing.util.Config"%>
 
 
 <%
@@ -110,9 +111,14 @@
             <%
                 }
             %>
+            <%
+                String newContentEditorEnabled = Config.getStringProperty("CONTENT_EDITOR2_ENABLED");
+                if (newContentEditorEnabled != null && newContentEditorEnabled.equalsIgnoreCase("true")) {
+            %>
             <div class="btn-flat btn-primary showPointer" onclick="addSeparator('<%=scheme.getId()%>', '<%=step.getId()%>');">
                 <i class="fa fa-plus" aria-hidden="true"></i> Divider
             </div>
+            <% } %>
             <div class="btn-flat btn-primary showPointer" onclick="actionAdmin.addOrAssociatedAction('<%=scheme.getId()%>', '<%=step.getId()%>', 'step-action-<%=step.getId()%>');">
                 <i class="fa fa-plus" aria-hidden="true"></i> Add
             </div>


### PR DESCRIPTION
### Proposed Changes
* Show the `add divider` button  under `DOT_CONTENT_EDITOR2_ENABLED` FF in the workflow portlet
 
### Screenshots

### `DOT_CONTENT_EDITOR2_ENABLED` off

![issue-28939-new-divider-button-under-workflows-should-be-under-ff-off](https://github.com/user-attachments/assets/25189550-48dc-468d-ab3d-362ae24fef30)

### `DOT_CONTENT_EDITOR2_ENABLED` on

![issue-28939-new-divider-button-under-workflows-should-be-under-ff-on](https://github.com/user-attachments/assets/48c227f1-4b9f-493f-9087-0d1a7c10159d)

This PR fixes: #28939