### PR TITLE
fix(content edit) #23074 : Add units (seconds) to Page Properties Cache TTL label

### DIFF
--- a/docker/docker-compose-examples/cluster-mode/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/cluster-mode/docker-compose-node-1.yml
@@ -46,7 +46,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/cluster-mode/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/cluster-mode/docker-compose-node-2.yml
@@ -23,7 +23,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     volumes:
       #- {local_data_path}:/data/shared
       - {license_local_path}/license.zip:/data/shared/assets/license.zip

--- a/docker/docker-compose-examples/push-publish/docker-compose-receiver.yml
+++ b/docker/docker-compose-examples/push-publish/docker-compose-receiver.yml
@@ -45,7 +45,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch-receiver:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-receiver'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - opensearch-receiver
       - db-receiver

--- a/docker/docker-compose-examples/push-publish/docker-compose-sender.yml
+++ b/docker/docker-compose-examples/push-publish/docker-compose-sender.yml
@@ -45,7 +45,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch-sender:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-sender'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - opensearch-sender
       - db-sender

--- a/docker/docker-compose-examples/push-publish/receiver/docker-compose.yml
+++ b/docker/docker-compose-examples/push-publish/receiver/docker-compose.yml
@@ -45,7 +45,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch-sender:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-sender'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - opensearch-sender
       - db-sender

--- a/docker/docker-compose-examples/single-node-debug-mode/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-debug-mode/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
-        CUSTOM_STARTER_URL: https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip
+        CUSTOM_STARTER_URL: https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/single-node/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/with-opensearch-dashboard/docker-compose.yml
+++ b/docker/docker-compose-examples/with-opensearch-dashboard/docker-compose.yml
@@ -55,7 +55,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/with-redis-session/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/with-redis-session/docker-compose-node-1.yml
@@ -53,7 +53,7 @@ services:
         DOT_ES_AUTH_BASIC_PASSWORD: 'admin'
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/with-redis/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/with-redis/docker-compose-node-1.yml
@@ -50,7 +50,7 @@ services:
         DOT_DOT_PUBSUB_PROVIDER_OVERRIDE: 'com.dotcms.dotpubsub.RedisPubSubImpl'
         DOT_REDIS_LETTUCECLIENT_URLS: 'redis://MY_SECRET_P4SS@redis'
         DOT_CACHE_DEFAULT_CHAIN: 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/with-redis/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/with-redis/docker-compose-node-2.yml
@@ -28,7 +28,7 @@ services:
         DOT_DOT_PUBSUB_PROVIDER_OVERRIDE: 'com.dotcms.dotpubsub.RedisPubSubImpl'
         DOT_REDIS_LETTUCECLIENT_URLS: 'redis://MY_SECRET_P4SS@redis'
         DOT_CACHE_DEFAULT_CHAIN: 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     volumes:
       #- {local_data_path}:/data/shared
       - {license_local_path}/license.zip:/data/shared/assets/license.zip

--- a/dotCMS/src/docker-compose/local-run/docker-compose.yml
+++ b/dotCMS/src/docker-compose/local-run/docker-compose.yml
@@ -47,7 +47,7 @@ services:
 
             'CMS_HEAP_SIZE': '1g'
 
-            # "CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240709/starter-20240709.zip'
+            # "CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
         depends_on:
             - elasticsearch
             - db

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -77,7 +77,7 @@
         <docker.jacoco.skip>true</docker.jacoco.skip>
         <!-- starter -->
         <starter.download.folder>${project.build.directory}/starter</starter.download.folder>
-        <starter.deploy.version>empty_20240531</starter.deploy.version>
+        <starter.deploy.version>empty_20240719</starter.deploy.version>
         <starter.deploy.filename>starter.zip</starter.deploy.filename>
         <starter.run.version>${starter.deploy.version}</starter.run.version>
         <starter.run.filename>starter-${starter.run.version}.zip</starter.run.filename>


### PR DESCRIPTION
### Proposed Changes
* Adding units (seconds) to Page Properties Cache TTL label.
* New versions of both Full and Empty Starters were generated:
  * Empty Starter: https://repo.dotcms.com/ui/repos/tree/General/libs-release-local/com/dotcms/starter/empty_20240719
  * Full Starter: https://repo.dotcms.com/ui/repos/tree/General/libs-release-local/com/dotcms/starter/20240719

This PR fixes: #23074