### PR TITLE
fix(edit-content): Bad colors in binary field

### DIFF
--- a/core-web/apps/dotcms-binary-field-builder/src/app/app.module.ts
+++ b/core-web/apps/dotcms-binary-field-builder/src/app/app.module.ts
@@ -13,7 +13,7 @@ import { AppComponent } from './app.component';
 
 interface ContenttypeFieldElement {
     tag: string;
-    component: Type<unknown>; // Expected to be a component
+    component: Type<DotEditContentBinaryFieldComponent>;
 }
 
 const CONTENTTYPE_FIELDS: ContenttypeFieldElement[] = [

--- a/core-web/libs/dotcms-scss/shared/_colors.scss
+++ b/core-web/libs/dotcms-scss/shared/_colors.scss
@@ -21,9 +21,9 @@ $color-palette-primary-op-70: var(--color-palette-primary-op-70);
 $color-palette-primary-op-80: var(--color-palette-primary-op-80);
 $color-palette-primary-op-90: var(--color-palette-primary-op-90);
 
-$color-palette-primary-shade: var(--color-palette-primary-shade);
-$color-palette-primary: var(--color-palette-primary);
-$color-palette-primary-tint: var(--color-palette-primary-tint);
+$color-palette-primary-shade: $color-palette-primary-600;
+$color-palette-primary: $color-palette-primary-500;
+$color-palette-primary-tint: $color-palette-primary-200;
 
 $color-palette-secondary-100: var(--color-palette-secondary-100);
 $color-palette-secondary-200: var(--color-palette-secondary-200);
@@ -45,9 +45,9 @@ $color-palette-secondary-op-70: var(--color-palette-secondary-op-70);
 $color-palette-secondary-op-80: var(--color-palette-secondary-op-80);
 $color-palette-secondary-op-90: var(--color-palette-secondary-op-90);
 
-$color-palette-secondary-shade: var(--color-palette-secondary-shade);
-$color-palette-secondary: var(--color-palette-secondary);
-$color-palette-secondary-tint: var(--color-palette-secondary-tint);
+$color-palette-secondary-shade: $color-palette-secondary-600;
+$color-palette-secondary: $color-palette-secondary-500;
+$color-palette-secondary-tint: $color-palette-secondary-200;
 
 $color-palette-black-op-10: var(--color-palette-black-op-10);
 $color-palette-black-op-20: var(--color-palette-black-op-20);


### PR DESCRIPTION
### Parent Issue

https://github.com/dotCMS/core/issues/29316

### Proposed Changes
* Fix problem with primary and secondary color
* New variables tiny, shade and base don't exist in runtime calculations.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
Problem primary color

https://github.com/user-attachments/assets/6b4a3958-a616-49ad-a221-cf61bf3dceab

### Screenshots

<img width="634" alt="Screenshot 2024-07-22 at 8 33 57 AM" src="https://github.com/user-attachments/assets/289e5319-72d8-4cd3-8215-6a66d0cd6f38">

<img width="1433" alt="Screenshot 2024-07-22 at 8 33 50 AM" src="https://github.com/user-attachments/assets/4d72bed0-0f55-4d98-b545-1530be80c2e0">

<img width="1490" alt="Screenshot 2024-07-22 at 8 33 44 AM" src="https://github.com/user-attachments/assets/f047461e-1441-464b-ba98-c2c4d33dbe72">

This PR fixes: #29316