### PR TITLE
fix(edit-content): Image AI modal on large screens

### DIFF
--- a/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.component.html
@@ -9,7 +9,7 @@
         [maskStyleClass]="'p-dialog-mask-transparent'"
         [modal]="true"
         [resizable]="false"
-        [style]="{ height: '90%', width: '90%' }"
+        [style]="{ width: '1040px' }"
         (onHide)="store.hideDialog()">
         <div class="dialog-prompt__wrapper">
             @if (vm.showDialog) {
@@ -55,8 +55,7 @@
                 key="ai-image-prompt"
                 rejectButtonStyleClass="p-button-outlined"
                 acceptIcon="null"
-                rejectIcon="null">
-            </p-confirmDialog>
+                rejectIcon="null"></p-confirmDialog>
         </div>
     </p-dialog>
 }

--- a/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.component.html
@@ -9,7 +9,7 @@
         [maskStyleClass]="'p-dialog-mask-transparent'"
         [modal]="true"
         [resizable]="false"
-        [style]="{ width: '1040px' }"
+        [style]="{ width: '90%', maxWidth: '1040px' }"
         (onHide)="store.hideDialog()">
         <div class="dialog-prompt__wrapper">
             @if (vm.showDialog) {

--- a/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.component.html
@@ -1,61 +1,61 @@
 @if (vm$ | async; as vm) {
-    <p-dialog
-        [(visible)]="vm.showDialog"
-        [appendTo]="'body'"
-        [closeOnEscape]="false"
-        [draggable]="false"
-        [header]="'block-editor.extension.ai-image.dialog-title' | dm"
-        [keepInViewport]="false"
-        [maskStyleClass]="'p-dialog-mask-transparent'"
-        [modal]="true"
-        [resizable]="false"
-        [style]="{ width: '90%', maxWidth: '1040px' }"
-        (onHide)="store.hideDialog()">
-        <div class="dialog-prompt__wrapper">
-            @if (vm.showDialog) {
-                <dot-ai-image-prompt-form
-                    (valueChange)="store.setFormValue($event)"
-                    (generate)="store.generateImage()"
-                    [value]="vm.images[vm.galleryActiveIndex]"
-                    [isLoading]="vm.isLoading"
-                    [hasEditorContent]="vm.hasEditorContent" />
-            }
+<p-dialog
+    [(visible)]="vm.showDialog"
+    [appendTo]="'body'"
+    [closeOnEscape]="false"
+    [draggable]="false"
+    [header]="'block-editor.extension.ai-image.dialog-title' | dm"
+    [keepInViewport]="false"
+    [maskStyleClass]="'p-dialog-mask-transparent'"
+    [modal]="true"
+    [resizable]="false"
+    [style]="{ width: '90%', maxWidth: '1040px' }"
+    (onHide)="store.hideDialog()">
+    <div class="dialog-prompt__wrapper">
+        @if (vm.showDialog) {
+        <dot-ai-image-prompt-form
+            (valueChange)="store.setFormValue($event)"
+            (generate)="store.generateImage()"
+            [value]="vm.images[vm.galleryActiveIndex]"
+            [isLoading]="vm.isLoading"
+            [hasEditorContent]="vm.hasEditorContent" />
+        }
 
-            <div [class.dialog-prompt_gallery]="vm.images.length || vm.isLoading">
-                <dot-ai-image-prompt-gallery
-                    (activeIndexChange)="store.setGalleryActiveIndex($event)"
-                    (regenerate)="store.generateImage()"
-                    [isLoading]="vm.isLoading"
-                    [images]="vm.images"
-                    [activeImageIndex]="vm.galleryActiveIndex"
-                    [orientation]="vm.formValue?.size" />
-                @if (vm.images.length || vm.isLoading) {
-                    <div class="dot-ai-image__buttons">
-                        <button
-                            (click)="closeDialog()"
-                            [label]="'Cancel' | dm"
-                            class="p-button-text"
-                            data-testid="close-btn"
-                            type="button"
-                            pButton></button>
-                        <button
-                            (click)="store.setSelectedImage(vm.images[vm.galleryActiveIndex])"
-                            [disabled]="vm.isLoading || vm.images[vm.galleryActiveIndex].error"
-                            [label]="'block-editor.extension.ai-image.insert' | dm"
-                            class="align-self-end"
-                            data-testid="submit-btn"
-                            pButton
-                            type="submit"
-                            icon="pi pi-check"></button>
-                    </div>
-                }
+        <div [class.dialog-prompt_gallery]="vm.images.length || vm.isLoading">
+            <dot-ai-image-prompt-gallery
+                (activeIndexChange)="store.setGalleryActiveIndex($event)"
+                (regenerate)="store.generateImage()"
+                [isLoading]="vm.isLoading"
+                [images]="vm.images"
+                [activeImageIndex]="vm.galleryActiveIndex"
+                [orientation]="vm.formValue?.size" />
+            @if (vm.images.length || vm.isLoading) {
+            <div class="dot-ai-image__buttons">
+                <button
+                    (click)="closeDialog()"
+                    [label]="'Cancel' | dm"
+                    class="p-button-text"
+                    data-testid="close-btn"
+                    type="button"
+                    pButton></button>
+                <button
+                    (click)="store.setSelectedImage(vm.images[vm.galleryActiveIndex])"
+                    [disabled]="vm.isLoading || vm.images[vm.galleryActiveIndex].error"
+                    [label]="'block-editor.extension.ai-image.insert' | dm"
+                    class="align-self-end"
+                    data-testid="submit-btn"
+                    pButton
+                    type="submit"
+                    icon="pi pi-check"></button>
             </div>
-            <p-confirmDialog
-                [style]="{ width: '500px' }"
-                key="ai-image-prompt"
-                rejectButtonStyleClass="p-button-outlined"
-                acceptIcon="null"
-                rejectIcon="null"></p-confirmDialog>
+            }
         </div>
-    </p-dialog>
+        <p-confirmDialog
+            [style]="{ width: '500px' }"
+            key="ai-image-prompt"
+            rejectButtonStyleClass="p-button-outlined"
+            acceptIcon="null"
+            rejectIcon="null"></p-confirmDialog>
+    </div>
+</p-dialog>
 }

--- a/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.component.spec.ts
+++ b/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.component.spec.ts
@@ -63,6 +63,13 @@ describe('DotAIImagePromptComponent', () => {
         expect(store.hideDialog).toHaveBeenCalled();
     });
 
+    it('should the modal have 1040px in width', () => {
+        spectator.detectChanges();
+        const dialog = spectator.query(Dialog);
+        const width = dialog.style.width;
+        expect(width).toBe('1040px');
+    });
+
     it('should generate image', () => {
         const promptForm = spectator.query(AiImagePromptFormComponent);
         const formMock: AIImagePrompt = {

--- a/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.component.spec.ts
+++ b/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.component.spec.ts
@@ -63,11 +63,13 @@ describe('DotAIImagePromptComponent', () => {
         expect(store.hideDialog).toHaveBeenCalled();
     });
 
-    it('should the modal have 1040px in width', () => {
+    it('should the modal have 1040px in maxWidth', () => {
         spectator.detectChanges();
         const dialog = spectator.query(Dialog);
         const width = dialog.style.width;
-        expect(width).toBe('1040px');
+        const maxWidth = dialog.style.maxWidth;
+        expect(width).toBe('90%');
+        expect(maxWidth).toBe('1040px');
     });
 
     it('should generate image', () => {


### PR DESCRIPTION
### Parent Issue

https://github.com/dotCMS/core/issues/29301

### Problem Statement

Pop up do not resize correctly in tall screens. 

### Proposed Changes
* Define maxWidth and width for the AI Modal
* Add unit test

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Screenshots

Before

<img width="1582" alt="image" src="https://github.com/dotCMS/core/assets/31667212/a1760bda-3e0e-4afb-a23b-1bdf75f047cb">

After

<img width="1728" alt="Screenshot 2024-07-22 at 9 11 39 AM" src="https://github.com/user-attachments/assets/f19612a5-3011-445f-8a0d-33e492806f04">




This PR fixes: #29301