### PR TITLE
Fix 29084 cli add validation for column limit

### DIFF
--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/push/contenttype/ContentTypePushHandler.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/push/contenttype/ContentTypePushHandler.java
@@ -60,6 +60,8 @@ public class ContentTypePushHandler implements PushHandler<ContentType> {
     public ContentType add(File localFile, ContentType localContentType,
             Map<String, Object> customOptions) {
 
+        ContentTypeValidator.validate(localContentType);
+
         final ContentTypeAPI contentTypeAPI = clientFactory.getClient(ContentTypeAPI.class);
 
         final SaveContentTypeRequest saveRequest = new Builder().of(localContentType).build();
@@ -75,6 +77,8 @@ public class ContentTypePushHandler implements PushHandler<ContentType> {
     public ContentType edit(File localFile, ContentType localContentType,
             ContentType serverContentType,
             Map<String, Object> customOptions) {
+
+        ContentTypeValidator.validate(localContentType);
 
         final ContentTypeAPI contentTypeAPI = clientFactory.getClient(ContentTypeAPI.class);
 

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/push/contenttype/ContentTypeValidator.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/push/contenttype/ContentTypeValidator.java
@@ -1,0 +1,78 @@
+package com.dotcms.api.client.push.contenttype;
+
+import com.dotcms.contenttype.model.field.FieldLayoutRow;
+import com.dotcms.contenttype.model.type.ContentType;
+
+import java.util.List;
+import java.util.Objects;
+/**
+ * A utility class for validating {@link ContentType} instances.
+ * <p>
+ * This class provides static methods to validate various constraints on {@link ContentType} objects. Currently,
+ * it includes validation to ensure that no row in a {@link ContentType} has more than a specified number of columns.
+ * Additional validation methods can be added in the future to extend functionality.
+ * </p>
+ * <p>
+ * This class is not intended to be instantiated. All methods are static and can be accessed directly from the class.
+ * </p>
+ */
+public final class ContentTypeValidator {
+
+    private static final String CONTENT_TYPE_NOT_NULL_MESSAGE = "ContentType must not be null.";
+    private static final int COLUMNS_PER_ROW_LIMIT = 4;
+    private static final String COLUMNS_PER_ROW_LIMIT_MESSAGE =
+            "The maximum number of columns per row is limited to four.";
+
+    /**
+     * Private constructor to prevent instantiation.
+     * <p>
+     * This class is a utility class and should not be instantiated.
+     * </p>
+     */
+    private ContentTypeValidator() {
+    }
+
+    /**
+     * Validates the given {@link ContentType} to ensure it meets all defined constraints.
+     * <p>
+     * This method currently performs the following validation:
+     * <ul>
+     *     <li>Ensures that the {@link ContentType} is not {@code null}.</li>
+     *     <li>Ensures that no row in the {@link ContentType} has more columns than the allowed limit.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * Additional validation checks may be added in the future to handle other constraints. If any validation fails,
+     * an {@link IllegalArgumentException} is thrown with an appropriate error message.
+     * </p>
+     *
+     * @param contentType the {@link ContentType} to be validated
+     * @throws NullPointerException if {@code contentType} is {@code null}
+     * @throws IllegalArgumentException if any row has more than the allowed columns
+     */
+    public static void validate(ContentType contentType) {
+        Objects.requireNonNull(contentType, CONTENT_TYPE_NOT_NULL_MESSAGE);
+        if (!hasValidColumnCountPerRow(contentType.layout())) {
+            throw new IllegalArgumentException(COLUMNS_PER_ROW_LIMIT_MESSAGE);
+        }
+    }
+
+    /**
+     * Validates that no row in the given list of {@link FieldLayoutRow} has more than four columns.
+     *
+     * @param layoutRows the list of {@link FieldLayoutRow} to be validated
+     * @return {@code true} if all rows have four or fewer columns, {@code false} otherwise
+     */
+    private static boolean hasValidColumnCountPerRow( List<FieldLayoutRow> layoutRows) {
+        if (layoutRows == null) {
+            return true;
+        }
+        for (FieldLayoutRow row : layoutRows) {
+            if (row.columns().size() > COLUMNS_PER_ROW_LIMIT) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/api/client/push/contenttype/ContentTypeValidatorTest.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/api/client/push/contenttype/ContentTypeValidatorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.function.Executable;
 import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
+@TestProfile(DotCMSITProfile.class)
 class ContentTypeValidatorTest {
 
     @Inject

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/api/client/push/contenttype/ContentTypeValidatorTest.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/api/client/push/contenttype/ContentTypeValidatorTest.java
@@ -1,0 +1,99 @@
+package com.dotcms.api.client.push.contenttype;
+
+import com.dotcms.DotCMSITProfile;
+import com.dotcms.cli.common.ContentTypesTestHelperService;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class ContentTypeValidatorTest {
+
+    @Inject
+    ContentTypesTestHelperService contentTypesTestHelper;
+
+    private static final String TEST_IDENTIFIER = "bbe0293638b685eb422dab5766441b3b";
+    private static final String TEST_VARIABLE = "test";
+
+    /**
+     * Given scenario: The content type is null.
+     * Expected result: The validate method should throw a NullPointerException.
+     */
+    @Test
+    void validate_ShouldThrowException_WhenContentTypeIsNull() {
+        // Given a null content type
+        // When validating the content type
+        Executable executable = () -> ContentTypeValidator.validate(null);
+
+        // Then a NullPointerException should be thrown
+        assertThrows(NullPointerException.class, executable,
+                "ContentType must not be null.");
+    }
+
+    /**
+     * Given scenario: The content type has more than four columns.
+     * Expected result: The validate method should throw an IllegalArgumentException.
+     */
+    @Test
+    void validate_ShouldThrowException_WhenRowsExceedColumnLimit() {
+        // Given a content type with more than four columns
+        var contentType = contentTypesTestHelper.buildContentTypeWithColumns(
+                TEST_IDENTIFIER, TEST_VARIABLE, 5);
+
+        // When validating the content type
+        Executable executable = () -> ContentTypeValidator.validate(contentType);
+
+        // Then an IllegalArgumentException should be thrown
+        assertThrows(IllegalArgumentException.class, executable,
+                "The maximum number of columns per row is limited to four.");
+    }
+
+    /**
+     * Given scenario: The content type has four or fewer columns.
+     * Expected result: The validate method should not throw any exception.
+     */
+    @Test
+    void validate_ShouldNotThrowException_WhenRowsAreWithinColumnLimit() {
+        // Given a content type with four or fewer columns
+        var contentType = contentTypesTestHelper.buildContentTypeWithColumns(
+                TEST_IDENTIFIER, TEST_VARIABLE, 4);
+
+        // When validating the content type
+        // Then no exception should be thrown
+        assertDoesNotThrow(() -> ContentTypeValidator.validate(contentType));
+    }
+
+    /**
+     * Given scenario: The content type has zero columns.
+     * Expected result: The validate method should not throw any exception.
+     */
+    @Test
+    void validate_ShouldNotThrowException_WhenLayoutColumnsIsZero() {
+        // Given a content type with zero columns
+        var contentType = contentTypesTestHelper.buildContentTypeWithColumns(
+                TEST_IDENTIFIER, TEST_VARIABLE, 0);
+
+        // When validating the content type
+        // Then no exception should be thrown
+        assertDoesNotThrow(() -> ContentTypeValidator.validate(contentType));
+    }
+
+    /**
+     * Given scenario: The content type has no layout columns.
+     * Expected result: The validate method should not throw any exception.
+     */
+    @Test
+    void validate_ShouldNotThrowException_WhenLayoutIsNull() {
+        // Given a content type without layout columns
+        var contentType = contentTypesTestHelper.buildContentTypeWithColumnsWithoutLayout(
+                TEST_IDENTIFIER, TEST_VARIABLE, 4);
+
+        // When validating the content type
+        // Then no exception should be thrown
+        assertDoesNotThrow(() -> ContentTypeValidator.validate(contentType));
+    }
+}

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/common/ContentTypesTestHelperService.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/common/ContentTypesTestHelperService.java
@@ -5,9 +5,7 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 import com.dotcms.api.ContentTypeAPI;
 import com.dotcms.api.client.model.RestClientFactory;
 import com.dotcms.api.provider.ClientObjectMapper;
-import com.dotcms.contenttype.model.field.DataTypes;
-import com.dotcms.contenttype.model.field.ImmutableBinaryField;
-import com.dotcms.contenttype.model.field.ImmutableTextField;
+import com.dotcms.contenttype.model.field.*;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ImmutableSimpleContentType;
@@ -21,10 +19,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
@@ -308,6 +303,240 @@ public class ContentTypesTestHelperService {
         public Path path() {
             return path;
         }
+    }
+
+
+    /**
+     * Builds a content type with the specified identifier, variable, and number of columns.
+     *
+     * @param identifier      the identifier for the content type.
+     * @param variable        the variable name for the content type.
+     * @param numberOfColumns the number of columns to include in the content type.
+     * @return the built content type with the specified columns.
+     */
+    public ImmutableSimpleContentType buildContentTypeWithColumns(final String identifier, final String variable,
+                                                                  final int numberOfColumns) {
+        final long millis = System.currentTimeMillis();
+        final String contentTypeVariable = Objects.requireNonNullElseGet(variable,
+                () -> "var_" + millis);
+
+        var rowField = buildRowField(0);
+
+        var columnFieldList = buildColumnFields(numberOfColumns);
+        var layoutColumnFieldList = buildLayoutColumns(columnFieldList);
+
+        ImmutableFieldLayoutRow fieldLayoutRow = buildFieldLayoutRow(rowField, layoutColumnFieldList);
+
+        var builder = buildContentTypeBuilder(contentTypeVariable, rowField, columnFieldList, fieldLayoutRow);
+
+        if (identifier != null) {
+            builder.id(identifier);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Builds a content type with the specified identifier, variable, and number of columns, without a layout.
+     *
+     * @param identifier      the identifier for the content type.
+     * @param variable        the variable name for the content type.
+     * @param numberOfColumns the number of columns to include in the content type.
+     * @return the built content type with the specified columns but without a layout.
+     */
+    public ImmutableSimpleContentType buildContentTypeWithColumnsWithoutLayout(final String identifier, final String variable,
+                                                                               final int numberOfColumns) {
+        final long millis = System.currentTimeMillis();
+        final String contentTypeVariable = Objects.requireNonNullElseGet(variable,
+                () -> "var_" + millis);
+
+        var rowField = buildRowField(0);
+
+        var columnFieldList = buildColumnFields(numberOfColumns);
+
+        var builder = buildContentTypeBuilderWithoutLayout(contentTypeVariable, rowField, columnFieldList);
+
+        if (identifier != null) {
+            builder.id(identifier);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Builds a column field with the specified index.
+     *
+     * @param index the index of the column field.
+     * @return the built column field.
+     */
+    private ImmutableColumnField buildColumnField(int index) {
+        return ImmutableColumnField.builder()
+                .searchable(false)
+                .unique(false)
+                .indexed(false)
+                .listed(false)
+                .readOnly(false)
+                .forceIncludeInApi(false)
+                .name("fields-" + index)
+                .required(false)
+                .sortOrder(index)
+                .fixed(false)
+                .fieldType("Column")
+                .fieldTypeLabel("Column")
+                .variable("fields" + index)
+                .dataType(DataTypes.SYSTEM)
+                .build();
+    }
+
+    /**
+     * Builds a row field with the specified index.
+     *
+     * @param index the index of the row field.
+     * @return the built row field.
+     */
+    private RowField buildRowField(int index) {
+        return ImmutableRowField.builder()
+                .searchable(false)
+                .unique(false)
+                .indexed(false)
+                .listed(false)
+                .readOnly(false)
+                .forceIncludeInApi(false)
+                .name("fields-" + index)
+                .required(false)
+                .sortOrder(index)
+                .fixed(false)
+                .fieldType("Row")
+                .fieldTypeLabel("Row")
+                .variable("fields" + index)
+                .dataType(DataTypes.SYSTEM)
+                .build();
+    }
+
+    /**
+     * Builds a list of column fields for the specified number of columns.
+     *
+     * @param numberOfColumns the number of columns to build.
+     * @return the list of built column fields.
+     */
+    private List<ImmutableColumnField> buildColumnFields(int numberOfColumns) {
+        var columnFieldList = new ArrayList<ImmutableColumnField>();
+        for (int i = 1; i <= numberOfColumns; i++) {
+            var columnField = buildColumnField(i);
+            columnFieldList.add(columnField);
+        }
+        return columnFieldList;
+    }
+
+    /**
+     * Builds the content type builder with the specified parameters.
+     *
+     * @param contentTypeVariable the variable name for the content type.
+     * @param rowField            the row field for the content type.
+     * @param columnFieldList     the list of column fields for the content type.
+     * @param fieldLayoutRow      the layout row for the content type.
+     * @return the content type builder.
+     */
+    private ImmutableSimpleContentType.Builder buildContentTypeBuilder(String contentTypeVariable,
+                                                                       RowField rowField,
+                                                                       List<ImmutableColumnField> columnFieldList,
+                                                                       FieldLayoutRow fieldLayoutRow) {
+        return ImmutableSimpleContentType.builder()
+                .baseType(BaseContentType.CONTENT)
+                .description("ct for testing.")
+                .name("name-" + contentTypeVariable)
+                .variable(contentTypeVariable)
+                .modDate(new Date())
+                .fixed(false)
+                .iDate(new Date())
+                .host("SYSTEM_HOST")
+                .folder("SYSTEM_FOLDER")
+                .folderPath("/")
+                .icon("360")
+                .description("test")
+                .defaultType(false)
+                .system(false)
+                .addFields(rowField)
+                .addAllFields(columnFieldList)
+                .addLayout(fieldLayoutRow)
+                .workflows(
+                        List.of(
+                                ImmutableWorkflow.builder()
+                                        .id(SYSTEM_WORKFLOW_ID)
+                                        .variableName(SYSTEM_WORKFLOW_VARIABLE_NAME)
+                                        .build()
+                        )
+                );
+    }
+
+    /**
+     * Builds the content type builder without a layout with the specified parameters.
+     *
+     * @param contentTypeVariable the variable name for the content type.
+     * @param rowField            the row field for the content type.
+     * @param columnFieldList     the list of column fields for the content type.
+     * @return the content type builder without a layout.
+     */
+    private ImmutableSimpleContentType.Builder buildContentTypeBuilderWithoutLayout(String contentTypeVariable,
+                                                                                    RowField rowField,
+                                                                                    List<ImmutableColumnField> columnFieldList) {
+        return ImmutableSimpleContentType.builder()
+                .baseType(BaseContentType.CONTENT)
+                .description("ct for testing.")
+                .name("name-" + contentTypeVariable)
+                .variable(contentTypeVariable)
+                .modDate(new Date())
+                .fixed(false)
+                .iDate(new Date())
+                .host("SYSTEM_HOST")
+                .folder("SYSTEM_FOLDER")
+                .folderPath("/")
+                .icon("360")
+                .description("test")
+                .defaultType(false)
+                .system(false)
+                .addFields(rowField)
+                .addAllFields(columnFieldList)
+                .workflows(
+                        List.of(
+                                ImmutableWorkflow.builder()
+                                        .id(SYSTEM_WORKFLOW_ID)
+                                        .variableName(SYSTEM_WORKFLOW_VARIABLE_NAME)
+                                        .build()
+                        )
+                );
+    }
+
+    /**
+     * Builds a list of layout columns for the specified column fields.
+     *
+     * @param columnFieldList the list of column fields to include in the layout.
+     * @return the list of built layout columns.
+     */
+    private List<ImmutableFieldLayoutColumn> buildLayoutColumns(List<ImmutableColumnField> columnFieldList) {
+        var layoutColumnFieldList = new ArrayList<ImmutableFieldLayoutColumn>();
+        for (var columnField : columnFieldList) {
+            var layoutColumn = ImmutableFieldLayoutColumn.builder()
+                    .columnDivider(columnField)
+                    .fields(List.of())
+                    .build();
+            layoutColumnFieldList.add(layoutColumn);
+        }
+        return layoutColumnFieldList;
+    }
+
+    /**
+     * Builds a field layout row with the specified row field and layout columns.
+     *
+     * @param rowField             the row field for the layout row.
+     * @param layoutColumnFieldList the list of layout columns for the layout row.
+     * @return the built field layout row.
+     */
+    private ImmutableFieldLayoutRow buildFieldLayoutRow(RowField rowField, List<ImmutableFieldLayoutColumn> layoutColumnFieldList) {
+        return ImmutableFieldLayoutRow.builder()
+                .divider(rowField)
+                .addAllColumns(layoutColumnFieldList)
+                .build();
     }
 
 }


### PR DESCRIPTION
### Proposed Changes
* Added ContentTypeValidator class to validate that the number of columns per row does not exceed the allowed limit.
* Updated CLI commands to include validation checks before pushing a ContentType to the server.
* Added utility methods for creating ContentType objects with columns and layout for testing purposes.
* Implemented test cases for the ContentTypeValidator class to ensure correct validation behavior.

### Screenshots

![cli-columns-per-wor-validation-update](https://github.com/user-attachments/assets/3b3136f1-9ba3-4158-860c-cc5b49fcd358)

### Screenshots
![cli-columns-per-row-validation-add](https://github.com/user-attachments/assets/db655322-c1e3-4dac-a2d7-79cc78ffa6a6)
