### PR TITLE
Empty and error message for category field in `search` mode

### DIFF
--- a/core-web/libs/dotcms-models/src/lib/shared-models.ts
+++ b/core-web/libs/dotcms-models/src/lib/shared-models.ts
@@ -6,13 +6,15 @@
  *      |-> IDLE = Finished Loading or Saving
  * SAVING = Status of an action of the component loaded (delete, saving, editing)
  *      |-> IDLE = Finished delete, saving, editing
+ * ERROR = Error state for the component
  **/
 export enum ComponentStatus {
     INIT = 'INIT',
     LOADING = 'LOADING',
     LOADED = 'LOADED',
     SAVING = 'SAVING',
-    IDLE = 'IDLE'
+    IDLE = 'IDLE',
+    ERROR = 'ERROR'
 }
 
 export const enum FeaturedFlags {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.html
@@ -4,7 +4,7 @@
             data-testId="categories-table"
             [scrollHeight]="$scrollHeight()"
             [scrollable]="true"
-            [value]="categories()"
+            [value]="$categories()"
             dataKey="key"
             selectionMode="multiple"
             [(selection)]="itemsSelected"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.html
@@ -1,5 +1,5 @@
 <div #tableContainer class="category-field__search-list">
-    @if (!isLoading()) {
+    @if (!$isLoading()) {
         <p-table
             data-testId="categories-table"
             [scrollHeight]="$scrollHeight()"
@@ -11,7 +11,7 @@
             (onHeaderCheckboxToggle)="onHeaderCheckboxToggle($event)"
             (onRowSelect)="onSelectItem($event)"
             (onRowUnselect)="onRemoveItem($event)"
-            styleClass="dotTable ">
+            styleClass="dotTable">
             <ng-template pTemplate="header">
                 <tr data-testId="table-header">
                     <th id="checkbox" scope="col" data-testId="table-header-checkbox">
@@ -39,6 +39,16 @@
                                     | dm
                             }}
                         </span>
+                    </td>
+                </tr>
+            </ng-template>
+
+            <ng-template pTemplate="emptymessage">
+                <tr>
+                    <td colspan="3">
+                        <dot-empty-container
+                            [configuration]="$emptyOrErrorMessage()"
+                            [hideContactUsLink]="true" />
                     </td>
                 </tr>
             </ng-template>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 .category-field__search-list {
     display: flex;
     flex-direction: column;
@@ -5,7 +7,25 @@
     overflow: hidden;
 }
 
-:host ::ng-deep .dotTable.p-datatable > .p-datatable-wrapper {
-    border-radius: 0;
-    border: none;
+:host {
+    ::ng-deep {
+        .dotTable.p-datatable > .p-datatable-wrapper {
+            border-radius: 0;
+            border: none;
+        }
+    }
+
+    &.category-field__search-list--empty ::ng-deep {
+        p-table,
+        .dotTable.p-datatable,
+        .p-datatable-wrapper,
+        table {
+            height: 100%;
+
+            tr:not(.p-highlight):hover {
+                background: $white;
+                cursor: auto;
+            }
+        }
+    }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.spec.ts
@@ -88,4 +88,57 @@ describe('DotCategoryFieldSearchListComponent', () => {
         expect(spectator.query(DotEmptyContainerComponent)).not.toBeNull();
         expect(spectator.component.$emptyOrErrorMessage()).toEqual(expectedConfig);
     });
+
+    it('should emit $itemChecked event when an item is selected', () => {
+        const itemCheckedSpy = jest.spyOn(spectator.component.$itemChecked, 'emit');
+        const firstCategoryRow = spectator.query(byTestId('table-row'));
+        const checkboxInput = firstCategoryRow.querySelector(
+            'input[type="checkbox"]'
+        ) as HTMLInputElement;
+
+        spectator.click(checkboxInput);
+        spectator.detectChanges();
+
+        expect(itemCheckedSpy).toHaveBeenCalledWith(CATEGORY_MOCK_TRANSFORMED[0]);
+    });
+
+    it('should emit $removeItem event when an item is unselected', () => {
+        const removeItemSpy = jest.spyOn(spectator.component.$removeItem, 'emit');
+        const firstCategoryRow = spectator.query(byTestId('table-row'));
+        const checkboxInput = firstCategoryRow.querySelector(
+            'input[type="checkbox"]'
+        ) as HTMLInputElement;
+
+        spectator.click(checkboxInput); // Select
+        spectator.click(checkboxInput); // Unselect
+        spectator.detectChanges();
+
+        expect(removeItemSpy).toHaveBeenCalledWith(CATEGORY_MOCK_TRANSFORMED[0].key);
+    });
+
+    it('should emit $itemChecked event with all items when header checkbox is selected', () => {
+        const itemCheckedSpy = jest.spyOn(spectator.component.$itemChecked, 'emit');
+        const headerCheckbox = spectator
+            .query(byTestId('table-header-checkbox'))
+            .querySelector('input[type="checkbox"]') as HTMLInputElement;
+
+        spectator.click(headerCheckbox);
+        spectator.detectChanges();
+
+        expect(itemCheckedSpy).toHaveBeenCalledWith(CATEGORY_MOCK_TRANSFORMED);
+    });
+
+    it('should emit $removeItem event with all keys when header checkbox is unselected', () => {
+        const removeItemSpy = jest.spyOn(spectator.component.$removeItem, 'emit');
+        const headerCheckbox = spectator
+            .query(byTestId('table-header-checkbox'))
+            .querySelector('input[type="checkbox"]') as HTMLInputElement;
+
+        spectator.click(headerCheckbox); // select all
+        spectator.click(headerCheckbox); // unselect all
+        spectator.detectChanges();
+
+        const allKeys = CATEGORY_MOCK_TRANSFORMED.map((category) => category.key);
+        expect(removeItemSpy).toHaveBeenCalledWith(allKeys);
+    });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.spec.ts
@@ -1,5 +1,7 @@
 import { byTestId, createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 
+import { Table, TableModule } from 'primeng/table';
+
 import { DotMessageService } from '@dotcms/data-access';
 import { ComponentStatus } from '@dotcms/dotcms-models';
 import { DotEmptyContainerComponent } from '@dotcms/ui';
@@ -19,20 +21,19 @@ describe('DotCategoryFieldSearchListComponent', () => {
 
     const createComponent = createComponentFactory({
         component: DotCategoryFieldSearchListComponent,
-        providers: [{ provide: DotMessageService, useValue: mockMessageService }]
+        providers: [{ provide: DotMessageService, useValue: mockMessageService }],
+        imports: [TableModule]
     });
 
     beforeEach(() => {
         spectator = createComponent({
             detectChanges: false,
             props: {
-                categories: CATEGORY_MOCK_TRANSFORMED,
                 selected: CATEGORY_MOCK_TRANSFORMED,
+                categories: CATEGORY_MOCK_TRANSFORMED,
                 status: ComponentStatus.LOADED
-            }
+            } as unknown
         });
-
-        spectator.detectChanges();
     });
 
     beforeAll(() => {
@@ -54,17 +55,20 @@ describe('DotCategoryFieldSearchListComponent', () => {
     });
 
     it('should render table header', () => {
+        spectator.detectChanges();
         const rows = spectator.queryAll(byTestId('table-header'));
         expect(rows.length).toBe(1);
     });
 
     it('should render table header with 3 columns, checkbox, name of  category and parent path', () => {
+        spectator.detectChanges();
         expect(spectator.query(byTestId('table-header-checkbox'))).not.toBeNull();
         expect(spectator.query(byTestId('table-header-category-name'))).not.toBeNull();
         expect(spectator.query(byTestId('table-header-parents'))).not.toBeNull();
     });
 
     it('should render table with categories', () => {
+        spectator.detectChanges();
         const rows = spectator.queryAll(byTestId('table-row'));
         expect(rows.length).toBe(CATEGORY_MOCK_TRANSFORMED.length);
     });
@@ -89,54 +93,36 @@ describe('DotCategoryFieldSearchListComponent', () => {
         expect(spectator.component.$emptyOrErrorMessage()).toEqual(expectedConfig);
     });
 
-    it('should emit $itemChecked event when an item is selected', () => {
-        const itemCheckedSpy = jest.spyOn(spectator.component.$itemChecked, 'emit');
-        const firstCategoryRow = spectator.query(byTestId('table-row'));
-        const checkboxInput = firstCategoryRow.querySelector(
-            'input[type="checkbox"]'
-        ) as HTMLInputElement;
-
-        spectator.click(checkboxInput);
+    it('should emit $itemChecked event when an item is selected', async () => {
+        const itemCheckedSpy = jest.spyOn(spectator.component.itemChecked, 'emit');
         spectator.detectChanges();
-
+        spectator.triggerEventHandler(Table, 'onRowSelect', { data: CATEGORY_MOCK_TRANSFORMED[0] });
         expect(itemCheckedSpy).toHaveBeenCalledWith(CATEGORY_MOCK_TRANSFORMED[0]);
     });
 
     it('should emit $removeItem event when an item is unselected', () => {
-        const removeItemSpy = jest.spyOn(spectator.component.$removeItem, 'emit');
-        const firstCategoryRow = spectator.query(byTestId('table-row'));
-        const checkboxInput = firstCategoryRow.querySelector(
-            'input[type="checkbox"]'
-        ) as HTMLInputElement;
-
-        spectator.click(checkboxInput); // Select
-        spectator.click(checkboxInput); // Unselect
+        const removeItemSpy = jest.spyOn(spectator.component.removeItem, 'emit');
         spectator.detectChanges();
-
+        spectator.triggerEventHandler(Table, 'onRowUnselect', {
+            data: CATEGORY_MOCK_TRANSFORMED[0]
+        });
         expect(removeItemSpy).toHaveBeenCalledWith(CATEGORY_MOCK_TRANSFORMED[0].key);
     });
 
     it('should emit $itemChecked event with all items when header checkbox is selected', () => {
-        const itemCheckedSpy = jest.spyOn(spectator.component.$itemChecked, 'emit');
-        const headerCheckbox = spectator
-            .query(byTestId('table-header-checkbox'))
-            .querySelector('input[type="checkbox"]') as HTMLInputElement;
+        const itemCheckedSpy = jest.spyOn(spectator.component.itemChecked, 'emit');
 
-        spectator.click(headerCheckbox);
         spectator.detectChanges();
+        spectator.triggerEventHandler(Table, 'onHeaderCheckboxToggle', { checked: true });
 
         expect(itemCheckedSpy).toHaveBeenCalledWith(CATEGORY_MOCK_TRANSFORMED);
     });
 
     it('should emit $removeItem event with all keys when header checkbox is unselected', () => {
-        const removeItemSpy = jest.spyOn(spectator.component.$removeItem, 'emit');
-        const headerCheckbox = spectator
-            .query(byTestId('table-header-checkbox'))
-            .querySelector('input[type="checkbox"]') as HTMLInputElement;
-
-        spectator.click(headerCheckbox); // select all
-        spectator.click(headerCheckbox); // unselect all
+        const removeItemSpy = jest.spyOn(spectator.component.removeItem, 'emit');
         spectator.detectChanges();
+        spectator.triggerEventHandler(Table, 'onHeaderCheckboxToggle', { checked: true });
+        spectator.triggerEventHandler(Table, 'onHeaderCheckboxToggle', { checked: false });
 
         const allKeys = CATEGORY_MOCK_TRANSFORMED.map((category) => category.key);
         expect(removeItemSpy).toHaveBeenCalledWith(allKeys);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-search-list/dot-category-field-search-list.component.ts
@@ -73,29 +73,27 @@ export class DotCategoryFieldSearchListComponent implements AfterViewInit, OnDes
     /**
      * Represents the categories found with the filter
      */
-    categories = input.required<DotCategoryFieldKeyValueObj[]>();
+    $categories = input.required<DotCategoryFieldKeyValueObj[]>({ alias: 'categories' });
 
     /**
      * Represent the selected items in the store
      */
-    selected = input.required<DotCategoryFieldKeyValueObj[]>();
+    $selected = input.required<DotCategoryFieldKeyValueObj[]>({ alias: 'selected' });
 
     /**
      * Represents the current state of the component.
      */
-    status = input.required<ComponentStatus>();
+    $status = input.required<ComponentStatus>({ alias: 'status' });
 
     /**
      * Output for emit the selected category(ies).
      */
-    $itemChecked = output<DotCategoryFieldKeyValueObj | DotCategoryFieldKeyValueObj[]>({
-        alias: 'itemChecked'
-    });
+    itemChecked = output<DotCategoryFieldKeyValueObj | DotCategoryFieldKeyValueObj[]>();
 
     /**
      * Output that emits events to remove a selected item(s).
      */
-    $removeItem = output<string | string[]>({ alias: 'removeItem' });
+    removeItem = output<string | string[]>();
 
     /**
      * Model of the items selected
@@ -110,12 +108,12 @@ export class DotCategoryFieldSearchListComponent implements AfterViewInit, OnDes
     /**
      * Flag indicating whether the table is empty.
      */
-    $tableIsEmpty = computed(() => !this.$isLoading() && this.categories().length === 0);
+    $tableIsEmpty = computed(() => !this.$isLoading() && this.$categories().length === 0);
 
     /**
      * A computed variable that represents the loading status of a component.
      */
-    $isLoading = computed(() => this.status() === ComponentStatus.LOADING);
+    $isLoading = computed(() => this.$status() === ComponentStatus.LOADING);
 
     /**
      * Gets the computed value of $emptyOrErrorMessage.
@@ -126,7 +124,7 @@ export class DotCategoryFieldSearchListComponent implements AfterViewInit, OnDes
 
     readonly #effectRef = effect(() => {
         // Todo: find a better way to update this
-        this.itemsSelected = this.selected();
+        this.itemsSelected = this.$selected();
     });
     readonly #resize$ = new Subject<ResizeObserverEntry>();
     readonly #resizeObserver = new ResizeObserver((entries) => this.#resize$.next(entries[0]));
@@ -144,7 +142,7 @@ export class DotCategoryFieldSearchListComponent implements AfterViewInit, OnDes
      * @return {void}
      */
     onSelectItem({ data }: DotTableRowSelectEvent<DotCategoryFieldKeyValueObj>): void {
-        this.$itemChecked.emit(data);
+        this.itemChecked.emit(data);
     }
 
     /**
@@ -154,7 +152,7 @@ export class DotCategoryFieldSearchListComponent implements AfterViewInit, OnDes
      * @return {void}
      */
     onRemoveItem({ data: { key } }: DotTableRowSelectEvent<DotCategoryFieldKeyValueObj>): void {
-        this.$removeItem.emit(key);
+        this.removeItem.emit(key);
     }
 
     /**
@@ -166,11 +164,11 @@ export class DotCategoryFieldSearchListComponent implements AfterViewInit, OnDes
      */
     onHeaderCheckboxToggle({ checked }: DotTableHeaderCheckboxSelectEvent): void {
         if (checked) {
-            const values = this.categories().map((item) => item.key);
-            this.$itemChecked.emit(this.categories());
+            const values = this.$categories().map((item) => item.key);
+            this.itemChecked.emit(this.$categories());
             this.temporarySelectedAll = [...values];
         } else {
-            this.$removeItem.emit(this.temporarySelectedAll);
+            this.removeItem.emit(this.temporarySelectedAll);
             this.temporarySelectedAll = [];
         }
     }
@@ -203,7 +201,8 @@ export class DotCategoryFieldSearchListComponent implements AfterViewInit, OnDes
      * @returns {PrincipalConfiguration | null} Returns the message configuration, or null if no configuration is found.
      */
     private getMessageConfig(): PrincipalConfiguration | null {
-        const configKey = this.status() === ComponentStatus.ERROR ? ComponentStatus.ERROR : 'empty';
+        const configKey =
+            this.$status() === ComponentStatus.ERROR ? ComponentStatus.ERROR : 'empty';
         const { title, icon, subtitle } = CATEGORY_FIELD_EMPTY_MESSAGES[configKey];
 
         return {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-sidebar/dot-category-field-sidebar.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-sidebar/dot-category-field-sidebar.component.html
@@ -44,7 +44,7 @@
                         @fadeAnimation
                         (itemChecked)="store.addSelected($event)"
                         (removeItem)="store.removeSelected($event)"
-                        [isLoading]="store.isSearchLoading()"
+                        [status]="store.searchStatus()"
                         [categories]="store.searchCategoryList()"
                         [selected]="store.selected()" />
                 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-sidebar/dot-category-field-sidebar.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-sidebar/dot-category-field-sidebar.component.ts
@@ -68,16 +68,19 @@ export class DotCategoryFieldSidebarComponent implements OnInit, OnDestroy {
      * @memberof DotCategoryFieldSidebarComponent
      */
     @Input() visible = false;
+
     /**
      * Output that emit if the sidebar is closed
      */
     @Output() closedSidebar = new EventEmitter<void>();
+
     /**
      * Store based on the `CategoryFieldStore`.
      *
      * @memberof DotCategoryFieldSidebarComponent
      */
     readonly store = inject(CategoryFieldStore);
+
     /**
      * Computed property for retrieving all category keys.
      */

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
@@ -101,7 +101,10 @@ export class DotEditContentCategoryFieldComponent implements OnInit {
         effect(
             () => {
                 const categoryValues = this.store.selectedCategoriesValues();
-                this.categoryFieldControl.setValue(categoryValues);
+
+                if (this.categoryFieldControl) {
+                    this.categoryFieldControl.setValue(categoryValues);
+                }
             },
             {
                 injector: this.#injector
@@ -117,7 +120,7 @@ export class DotEditContentCategoryFieldComponent implements OnInit {
         this.$showCategoriesSidebar.set(true);
     }
     /**
-     * Close the categories sidebar.
+     * Close the categories' sidebar.
      *
      * @memberof DotEditContentCategoryFieldComponent
      */

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.ts
@@ -103,6 +103,13 @@ export const CategoryFieldStore = signalStore(
         ),
 
         /**
+         * Status of the Search Component
+         */
+        searchStatus: computed(() =>
+            store.mode() === 'search' ? store.state() : ComponentStatus.INIT
+        ),
+
+        /**
          * Categories for render with added properties
          */
         searchCategoryList: computed(() =>
@@ -141,13 +148,13 @@ export const CategoryFieldStore = signalStore(
                                     patchState(store, {
                                         field,
                                         selected,
-                                        state: ComponentStatus.IDLE
+                                        state: ComponentStatus.LOADED
                                     });
                                 },
                                 error: (error: HttpErrorResponse) => {
                                     patchState(store, {
                                         field,
-                                        state: ComponentStatus.IDLE
+                                        state: ComponentStatus.ERROR
                                     });
 
                                     dotHttpErrorManagerService.handle(error);
@@ -285,7 +292,7 @@ export const CategoryFieldStore = signalStore(
                                 },
                                 error: () => {
                                     // TODO: Add Error Handler
-                                    patchState(store, { state: ComponentStatus.IDLE });
+                                    patchState(store, { state: ComponentStatus.ERROR });
                                 }
                             })
                         );
@@ -315,8 +322,10 @@ export const CategoryFieldStore = signalStore(
                                         });
                                     },
                                     error: () => {
-                                        // TODO: Add Error Handler
-                                        patchState(store, { state: ComponentStatus.IDLE });
+                                        patchState(store, {
+                                            state: ComponentStatus.ERROR,
+                                            searchCategories: []
+                                        });
                                     }
                                 })
                             );

--- a/core-web/libs/edit-content/src/lib/models/dot-edit-content-field.constant.ts
+++ b/core-web/libs/edit-content/src/lib/models/dot-edit-content-field.constant.ts
@@ -1,5 +1,8 @@
 import { MonacoEditorConstructionOptions } from '@materia-ui/ngx-monaco-editor';
 
+import { ComponentStatus } from '@dotcms/dotcms-models';
+import { PrincipalConfiguration } from '@dotcms/ui';
+
 import { FIELD_TYPES } from './dot-edit-content-field.enum';
 
 export const CALENDAR_FIELD_TYPES = [FIELD_TYPES.DATE, FIELD_TYPES.DATE_AND_TIME, FIELD_TYPES.TIME];
@@ -28,4 +31,23 @@ export const DEFAULT_MONACO_CONFIG: MonacoEditorConstructionOptions = {
     fixedOverflowWidgets: true,
     language: 'text',
     fontSize: 14
+};
+
+/**
+ * Represent the able messages to use in the component DotEmptyContainerComponent
+ */
+export const CATEGORY_FIELD_EMPTY_MESSAGES: Record<
+    ComponentStatus.ERROR | 'empty',
+    PrincipalConfiguration
+> = {
+    empty: {
+        title: 'edit.content.category-field.search.not-found.title',
+        icon: 'pi-exclamation-circle',
+        subtitle: 'edit.content.category-field.search.not-found.legend'
+    },
+    [ComponentStatus.ERROR]: {
+        title: 'edit.content.category-field.search.error.title',
+        icon: 'pi-exclamation-triangle',
+        subtitle: 'edit.content.category-field.search.error.legend'
+    }
 };

--- a/core-web/libs/ui/src/lib/components/dot-empty-container/dot-empty-container.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-empty-container/dot-empty-container.component.html
@@ -28,14 +28,14 @@
 
             @if (!hideContactUsLink) {
                 @if (buttonLabel) {
-                    <span>{{ 'dot.common.or.text' }}</span>
+                    <span>{{ 'dot.common.or.text' | dm }}</span>
                 }
                 <a
                     class="message__external-link"
                     data-testid="message-contact-link"
                     href="https://dotcms.com/contact-us/"
                     target="_blank">
-                    {{ 'Contact-Us-for-more-Information' }}
+                    {{ 'Contact-Us-for-more-Information' | dm }}
                 </a>
             }
         </div>

--- a/core-web/libs/ui/src/lib/components/dot-empty-container/dot-empty-container.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-empty-container/dot-empty-container.component.html
@@ -1,17 +1,14 @@
 <div class="message__wrapper flex gap-4 flex-column w-30rem">
     <div
         class="message__principal-wrapper flex align-items-center flex-column gap-2"
-        data-Testid="message-principal">
-        @if (configuration?.icon) {
-            <i
-                [ngClass]="[configuration.icon]"
-                class="message__icon pi"
-                data-Testid="message-icon"></i>
+        data-testid="message-principal">
+        @if (configuration.icon) {
+            <i [class]="'message__icon pi ' + configuration.icon" data-testid="message-icon"></i>
         }
-        <h1 class="message__title" data-Testid="message-title">{{ configuration?.title }}</h1>
-        @if (configuration?.subtitle) {
-            <h2 class="message__subtitle" data-Testid="message-subtitle">
-                {{ configuration?.subtitle }}
+        <h1 class="message__title" data-testid="message-title">{{ configuration.title }}</h1>
+        @if (configuration.subtitle) {
+            <h2 class="message__subtitle" data-testid="message-subtitle">
+                {{ configuration.subtitle }}
             </h2>
         }
     </div>
@@ -19,25 +16,26 @@
     @if (!hideContactUsLink || buttonLabel) {
         <div
             class="message__extra-wrapper flex align-items-center flex-column gap-2"
-            data-Testid="message-extra">
+            data-testid="message-extra">
             @if (buttonLabel) {
                 <button
-                    (click)="buttonAction.emit()"
+                    pButton
                     [label]="buttonLabel"
                     [class.p-button-outlined]="secondaryButton"
-                    pButton
-                    data-Testid="message-button"></button>
+                    (click)="buttonAction.emit()"
+                    data-testid="message-button"></button>
             }
+
             @if (!hideContactUsLink) {
-                @if (!hideContactUsLink && buttonLabel) {
-                    <span>{{ 'dot.common.or.text' | dm }}</span>
+                @if (buttonLabel) {
+                    <span>{{ 'dot.common.or.text' }}</span>
                 }
                 <a
                     class="message__external-link"
-                    data-Testid="message-contact-link"
+                    data-testid="message-contact-link"
                     href="https://dotcms.com/contact-us/"
                     target="_blank">
-                    {{ 'Contact-Us-for-more-Information' | dm }}
+                    {{ 'Contact-Us-for-more-Information' }}
                 </a>
             }
         </div>

--- a/core-web/libs/ui/src/lib/components/dot-empty-container/dot-empty-container.component.spec.ts
+++ b/core-web/libs/ui/src/lib/components/dot-empty-container/dot-empty-container.component.spec.ts
@@ -21,8 +21,12 @@ describe('DotEmptyContainerComponent', () => {
     });
 
     beforeEach(() => {
-        spectator = createComponent();
-        spectator.setInput('configuration', BASIC_CONFIGURATION);
+        spectator = createComponent({
+            props: {
+                configuration: BASIC_CONFIGURATION
+            }
+        });
+        spectator.detectChanges();
     });
 
     describe('Only Principal message', () => {

--- a/core-web/libs/ui/src/lib/components/dot-empty-container/dot-empty-container.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-empty-container/dot-empty-container.component.ts
@@ -24,7 +24,7 @@ export interface PrincipalConfiguration {
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotEmptyContainerComponent {
-    //Todo: make required when Angular 16 updated
+    //Todo: change to input signal when ui migrated to jest
     /**
      * Principal configuration of the component
      */

--- a/core-web/yarn.lock
+++ b/core-web/yarn.lock
@@ -3336,27 +3336,27 @@
     "@types/mdx" "^2.0.0"
     "@types/react" ">=16"
 
-"@microsoft/api-extractor-model@7.29.3":
-  version "7.29.3"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.29.3.tgz#886d9f495b494ce601052d476c98f00280dcc432"
-  integrity sha512-kEWjLr2ygL3ku9EGyjeTnL2S5IxyH9NaF1k1UoI0Nzwr4xEJBSWCVsWuF2+0lPUrRPA6mTY95fR264SJ5ETKQA==
+"@microsoft/api-extractor-model@7.29.4":
+  version "7.29.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.29.4.tgz#098f94f304db98f3cea8618fd1107946e212eaf5"
+  integrity sha512-LHOMxmT8/tU1IiiiHOdHFF83Qsi+V8d0kLfscG4EvQE9cafiR8blOYr8SfkQKWB1wgEilQgXJX3MIA4vetDLZw==
   dependencies:
     "@microsoft/tsdoc" "~0.15.0"
     "@microsoft/tsdoc-config" "~0.17.0"
-    "@rushstack/node-core-library" "5.5.0"
+    "@rushstack/node-core-library" "5.5.1"
 
 "@microsoft/api-extractor@^7.34.4":
-  version "7.47.3"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.47.3.tgz#e4c7727a36f9d4c25b422fd84ccb00e08861b5a6"
-  integrity sha512-WKPcmg0vcBnuAX0vArXMbCtCwyN0xuyH1zoRBhuU//X0gP35KA7QInRSeuN0nFV/AKI5NGXapr8dS2lwlCDmgQ==
+  version "7.47.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.47.4.tgz#1a66dc9d6f316fe86eef336e7f8004ab9222499b"
+  integrity sha512-HKm+P4VNzWwvq1Ey+Jfhhj/3MjsD+ka2hbt8L5AcRM95lu1MFOYnz3XlU7Gr79Q/ZhOb7W/imAKeYrOI0bFydg==
   dependencies:
-    "@microsoft/api-extractor-model" "7.29.3"
+    "@microsoft/api-extractor-model" "7.29.4"
     "@microsoft/tsdoc" "~0.15.0"
     "@microsoft/tsdoc-config" "~0.17.0"
-    "@rushstack/node-core-library" "5.5.0"
-    "@rushstack/rig-package" "0.5.2"
-    "@rushstack/terminal" "0.13.2"
-    "@rushstack/ts-command-line" "4.22.2"
+    "@rushstack/node-core-library" "5.5.1"
+    "@rushstack/rig-package" "0.5.3"
+    "@rushstack/terminal" "0.13.3"
+    "@rushstack/ts-command-line" "4.22.3"
     lodash "~4.17.15"
     minimatch "~3.0.3"
     resolve "~1.22.1"
@@ -5230,10 +5230,10 @@
   optionalDependencies:
     fsevents "~2.3.2"
 
-"@rushstack/node-core-library@5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-5.5.0.tgz#59a7e0e333847ceaf870be47fba0eaceb9e39d20"
-  integrity sha512-Cl3MYQ74Je5Y/EngMxcA3SpHjGZ/022nKbAO1aycGfQ+7eKyNCBu0oywj5B1f367GCzuHBgy+3BlVLKysHkXZw==
+"@rushstack/node-core-library@5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-5.5.1.tgz#890db37eafaab582c79eb6bf421447b82b3a964b"
+  integrity sha512-ZutW56qIzH8xIOlfyaLQJFx+8IBqdbVCZdnj+XT1MorQ1JqqxHse8vbCpEM+2MjsrqcbxcgDIbfggB1ZSQ2A3g==
   dependencies:
     ajv "~8.13.0"
     ajv-draft-04 "~1.0.0"
@@ -5257,28 +5257,28 @@
     semver "~7.5.4"
     z-schema "~5.0.2"
 
-"@rushstack/rig-package@0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@rushstack/rig-package/-/rig-package-0.5.2.tgz#0e23a115904678717a74049661931c0b37dd5495"
-  integrity sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==
+"@rushstack/rig-package@0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@rushstack/rig-package/-/rig-package-0.5.3.tgz#ea4d8a3458540b1295500149c04e645f23134e5d"
+  integrity sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==
   dependencies:
     resolve "~1.22.1"
     strip-json-comments "~3.1.1"
 
-"@rushstack/terminal@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@rushstack/terminal/-/terminal-0.13.2.tgz#755b419039002ade346f410bcce23856f10be1f2"
-  integrity sha512-t8i0PsGvBHmFBY8pryO3badqFlxQsm2rw3KYrzjcmVkG/WGklKg1qVkr9beAS1Oe8XWDRgj6SkoHkpNjs7aaNw==
+"@rushstack/terminal@0.13.3":
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/@rushstack/terminal/-/terminal-0.13.3.tgz#9a05b8cf759f14161a49d3ccb09d556e4161caca"
+  integrity sha512-fc3zjXOw8E0pXS5t9vTiIPx9gHA0fIdTXsu9mT4WbH+P3mYvnrX0iAQ5a6NvyK1+CqYWBTw/wVNx7SDJkI+WYQ==
   dependencies:
-    "@rushstack/node-core-library" "5.5.0"
+    "@rushstack/node-core-library" "5.5.1"
     supports-color "~8.1.1"
 
-"@rushstack/ts-command-line@4.22.2":
-  version "4.22.2"
-  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.22.2.tgz#21e26b7320d09e904ae479c0586cb5ddf68ce652"
-  integrity sha512-xkvrGd6D9dPlI3I401Thc640WNsEPB1sGEmy12a2VJaPQPwhE6Ik0gEVPZJ/2G1w213eaCAdxUY1xpiTulsmpA==
+"@rushstack/ts-command-line@4.22.3":
+  version "4.22.3"
+  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.22.3.tgz#dcc75bd25b21031b32b2758ee3f2f4973b112572"
+  integrity sha512-edMpWB3QhFFZ4KtSzS8WNjBgR4PXPPOVrOHMbb7kNpmQ1UFS9HdVtjCXg1H5fG+xYAbeE+TMPcVPUyX2p84STA==
   dependencies:
-    "@rushstack/terminal" "0.13.2"
+    "@rushstack/terminal" "0.13.3"
     "@types/argparse" "1.0.38"
     argparse "~1.0.9"
     string-argv "~0.3.1"

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5759,5 +5759,10 @@ edit.content.category-field.list.show.less=Less
 edit.content.category-field.search.name=Name
 edit.content.category-field.search.assignee=Category Path
 edit.content.category-field.search.input.placeholder=Search
+edit.content.category-field.search.not-found.title=No categories found
+edit.content.category-field.search.not-found.legend=Your search does not match any of the categories, please try again.
+edit.content.category-field.search.error.title=Something went wrong
+edit.content.category-field.search.error.legend=Oops! Something went wrong. Please try again later.
 edit.content.category-field.category.root-name=Root
+
 


### PR DESCRIPTION
### Proposed Changes
* Add empty and error message for edit content in `search` mode

### Checklist
- [x] Tests
- [x] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Ok
<img width="1492" alt="Screenshot 2024-07-23 at 12 50 58 PM" src="https://github.com/user-attachments/assets/937d16ab-7654-4f05-9560-7b06af458afe">

### Error
<img width="1486" alt="Screenshot 2024-07-23 at 12 50 19 PM" src="https://github.com/user-attachments/assets/4ef22762-7b11-494a-ac05-54e30f03f1bb">

### Empty
<img width="1487" alt="Screenshot 2024-07-23 at 12 50 51 PM" src="https://github.com/user-attachments/assets/2cddecb6-dc2f-4237-9f11-3f01d7dab6c1">

This PR fixes: #29185