### PR TITLE
ci(tests): Fix test reports archives not generated on maven f (#29348)

### DIFF
--- a/.github/actions/maven-job/action.yml
+++ b/.github/actions/maven-job/action.yml
@@ -291,7 +291,7 @@ runs:
     - id: create-test-reports-artifact
       name: Create Test Reports Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ inputs.generates-test-results == 'true' }}
+      if: always() && inputs.generates-test-results == 'true'
       with:
         name: "build-reports-test-${{ inputs.stage-name }}"
         path: |


### PR DESCRIPTION
### Proposed Changes
* Force test archives to upload even when maven fails

To test
Will Test to success in PR, then will force a postman failure to force generation of the archive and  report, then fix the failure before merging.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
Related to #29348 (Fix test reports archives not generated on maven f).


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #29348