### PR TITLE
fix: developer builds fail on yarn install when run mul (#29406)

### DIFF
--- a/core-web/.eslintignore
+++ b/core-web/.eslintignore
@@ -1,2 +1,2 @@
-node_modules
 **/*.md
+/**/node_modules/*

--- a/core-web/.husky/pre-commit
+++ b/core-web/.husky/pre-commit
@@ -8,51 +8,90 @@ error_occurred=false
 
 # Perform fix operations on the staged files
 perform_fixes() {
-    local files="$1"         # Store files as a string
-    local add_to_index="$2"    # Should be 'true' or 'false'
-    local file               # Declare file variable for use in loop
+    local files="$1"
+    local add_to_index="$2"
+    local file
 
-    if ! npx nx format:write; then
+    YARN_EXEC="${root_dir}/installs/node/yarn/dist/bin/yarn"
+    NODE_EXEC="${root_dir}/installs/node/node"
+
+    echo "Yarn version: $($YARN_EXEC --version 2>/dev/null)"
+    echo "Node version: $($NODE_EXEC --version)"
+
+    if ! $YARN_EXEC nx affected -t lint --exclude='tag:skip:lint' --fix=true; then
         error_occurred=true
     fi
 
-    if ! npx nx affected -t lint --exclude='tag:skip:lint' --fix=true; then
-            error_occurred=true
+    if ! $YARN_EXEC nx format:write; then
+        error_occurred=true
     fi
 
     if [ "$add_to_index" = "true" ]; then
-        # Get a list of modified files in the working tree (excluding untracked/new files)
-        local modified_files=$(git diff --name-only)
+        local modified_files
+        modified_files=$( (git diff --name-only && git diff --name-only --cached) | sort | uniq)
 
-        # Loop through the list of files that were originally considered
+        local unmatched_files=()
+
         for file in $files; do
             if echo "$modified_files" | grep -Fxq "$file"; then
                 if ! git add -- "${root_dir}/${file}"; then
-                    error_occurred=true  # Record that an error occurred
+                    error_occurred=true
                 fi
+            else
+                unmatched_files+=("$file")
             fi
         done
+
+        if [ ${#unmatched_files[@]} -ne 0 ]; then
+            echo "==================================="
+            echo "Warning: The following unrelated files in the affected modules should be linted and/or formatted"
+            echo ""
+            for file in "${unmatched_files[@]}"; do
+                echo "    ${file}"
+                git restore "${file}"
+            done
+            echo ""
+            echo "You can fix these files by running the following commands:"
+            echo "nx affected -t lint --exclude='tag:skip:lint' --fix=true"
+            echo "nx format:write;"
+        fi
     fi
 }
 
+# Function to run yarn install with --frozen-lockfile and handle failure
+run_yarn_install_frozen_lockfile() {
+    if ! yarn install --frozen-lockfile; then
+        echo "Failed to install dependencies with --frozen-lockfile."
+        echo "Please run 'yarn install' to update the lockfile and make sure you commit this with any package.json changes."
+        exit 1
+    fi
+}
 
-# Backup current working directory
 original_pwd=${PWD}
+root_dir="$(git rev-parse --show-toplevel)"
 
-# Ensure we're in the correct directory
-root_dir="$(git rev-parse --show-toplevel)"  # Get the root directory of the Git repository
+# This will ensure that the correct version of node and yarn is installed
+# from core-web/pom.xml and .nvmrc files are updated
+if ! ./mvnw validate -pl :dotcms-core --am -q; then
+    echo "Failed to run './mvnw validate -pl :dotcms-core --am'"
+    echo "Please run the following command to see the detailed output:"
+    echo "./mvnw validate -pl :dotcms-core --am"
+    exit 1
+else
+    echo "Completed Maven init"
+fi
 
-# Define core-web directory relative to the Git root
+yarn config set registry https://dotcms-npm.b-cdn.net
+
+run_yarn_install_frozen_lockfile
+
+
 core_web_dir="${root_dir}/core-web"
+cd "${core_web_dir}" || exit
 
-# Moving to the core-web directory
-cd "${core_web_dir}" || exit  # Exit if the directory does not exist
+staged_files=$(git diff --cached --name-only)
+modified_files=$(git diff --name-only)
 
-# Find untracked files in core-web
-staged_files=$(git diff --cached --name-only)  # Get a list of staged files
-modified_files=$(git diff --name-only)  # Get a list of modified but unstaged files
-
-# Find common files which are both staged and modified but not staged
 untracked_files=$(printf "%s\n%s" "$staged_files" "$modified_files" | sort | uniq -d)
 
 
@@ -82,7 +121,6 @@ for file in $untracked_files; do
 done
 
 echo "Backed up workspace to ${temp_dir}"
-git status
 
 # Perform operations on staged files and capture the error count
 if [ -n "${staged_files}" ]; then
@@ -122,7 +160,9 @@ cd "${original_pwd}" || exit  # Exit if the directory does not exist
 
 # Final check before exiting
 if [ "$error_occurred" = true ]; then
+    echo "Checks failed.  force commit with --no-verify option if bypass required"
     exit 1  # Change the exit code to reflect that an error occurred
 else
+    echo "Commit checks completed OK"
     exit 0  # No errors, exit normally
 fi

--- a/core-web/.husky/pre-commit
+++ b/core-web/.husky/pre-commit
@@ -72,6 +72,7 @@ root_dir="$(git rev-parse --show-toplevel)"
 
 # This will ensure that the correct version of node and yarn is installed
 # from core-web/pom.xml and .nvmrc files are updated
+cd "${root_dir}" || exit
 if ! ./mvnw validate -pl :dotcms-core --am -q; then
     echo "Failed to run './mvnw validate -pl :dotcms-core --am'"
     echo "Please run the following command to see the detailed output:"
@@ -81,13 +82,12 @@ else
     echo "Completed Maven init"
 fi
 
-yarn config set registry https://dotcms-npm.b-cdn.net
-
-run_yarn_install_frozen_lockfile
-
 
 core_web_dir="${root_dir}/core-web"
 cd "${core_web_dir}" || exit
+
+yarn config set registry https://dotcms-npm.b-cdn.net
+run_yarn_install_frozen_lockfile
 
 staged_files=$(git diff --cached --name-only)
 modified_files=$(git diff --name-only)

--- a/core-web/.husky/pre-commit
+++ b/core-web/.husky/pre-commit
@@ -73,6 +73,7 @@ root_dir="$(git rev-parse --show-toplevel)"
 # This will ensure that the correct version of node and yarn is installed
 # from core-web/pom.xml and .nvmrc files are updated
 cd "${root_dir}" || exit
+echo "Initializing maven, node and yarn versions"
 if ! ./mvnw validate -pl :dotcms-core --am -q; then
     echo "Failed to run './mvnw validate -pl :dotcms-core --am'"
     echo "Please run the following command to see the detailed output:"

--- a/core-web/.nxignore
+++ b/core-web/.nxignore
@@ -1,2 +1,3 @@
 .nx
 dist
+node_modules

--- a/core-web/nx.json
+++ b/core-web/nx.json
@@ -166,5 +166,6 @@
             }
         }
     ],
-    "defaultBase": "master"
+    "defaultBase": "master",
+    "ignorePatterns": ["**/node_modules"]
 }

--- a/core-web/pom.xml
+++ b/core-web/pom.xml
@@ -132,7 +132,7 @@
                         <phase>compile</phase>
 
                         <configuration>
-                            <arguments>run nx build dotcms-ui -- ${nx.build.options}</arguments>
+                            <arguments>run nx build dotcms-ui ${nx.build.options}</arguments>
                         </configuration>
                     </execution>
 
@@ -277,7 +277,7 @@
             </activation>
             <properties>
                 <nx.build.options>--prod</nx.build.options>
-                <yarn.install.cmd>--frozen-lockfile --silent</yarn.install.cmd>
+                <yarn.install.cmd>--frozen-lockfile</yarn.install.cmd>
             </properties>
             <build/>
         </profile>

--- a/nodejs-parent/pom.xml
+++ b/nodejs-parent/pom.xml
@@ -34,13 +34,14 @@
                             <goal>install-node-and-yarn</goal>
                         </goals>
                         <!-- optional: default phase is "generate-resources" -->
-                        <phase>generate-resources</phase>
+                        <phase>validate</phase>
                     </execution>
                     <execution>
                         <id>config yarn timeout</id>
                         <goals>
                             <goal>yarn</goal>
                         </goals>
+                        <phase>validate</phase>
                         <configuration>
                             <arguments>config set network-timeout 6000000</arguments>
                         </configuration>
@@ -50,6 +51,7 @@
                         <goals>
                             <goal>yarn</goal>
                         </goals>
+                        <phase>validate</phase>
                         <configuration>
                             <arguments>config set registry https://dotcms-npm.b-cdn.net</arguments>
                         </configuration>


### PR DESCRIPTION
This change updates the commit hook and ensures that node_modules is not processed by nx or eslint. 

Related to #29406 (developer builds fail on yarn install when run mul).

We could have the maven command also run the yarn install and even the lint and format to keep it totally consistent, but pulling out these subsequent steps makes these node commands more visible in the developer's console

### Testing

To test the commit hook without creating a commit you can modify the exit code to ensure it always returns a non-zero code, also you can create a test commit and then revert it with "git reset HEAD~1".  or "git reset --hard HEAD~1" if you do not want to keep any of the changes in the test commit.  Make sure you do not push with these changes

This change may run slower the first time if maven or yarn install has not already been run to download the dependencies the first time.  

This PR fixes: #29406