### PR TITLE
fix: Unable to deploy portlet plugins  (#29276)

### DIFF
--- a/config/user/logging/log4j2.xml
+++ b/config/user/logging/log4j2.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration monitorInterval="10">
+    <Properties>
+        <Property name="DEFAULT_CONSOLE_PATTERN">%d{HH:mm:ss.SSS} hello5 [%X] %highlight{%-5level} [%tn] %c{1.}.%M(%F:%L) - %m%n%ex{filters(${stack.filter})}</Property>
+        <Property name="DOTCMS_LOGGING_INCLUDE_LOCATION">false</Property>
+    </Properties>
+    <Loggers>
+        <Logger name="com.dotcms" level="info" additivity="true">
+        </Logger>
+    </Loggers>
+
+    <Loggers>
+        <Logger name="com.dotcms.concurrent.DotConcurrentFactory" level="info" additivity="true">
+        </Logger>
+    </Loggers>
+    <Loggers>
+        <Logger name="com.dotmarketing.filters.ThreadNameFilter" level="warn" additivity="true">
+        </Logger>
+    </Loggers>
+
+
+</Configuration>

--- a/dotCMS/src/main/java/com/dotmarketing/business/portal/PortletFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/portal/PortletFactoryImpl.java
@@ -26,10 +26,7 @@ import java.io.InputStream;
 import java.util.*;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
 
 /**
  * Implementation class for the {@link PortletFactory} interface. This class uses JAXB to map XML

--- a/dotCMS/src/main/java/com/dotmarketing/business/portal/PortletSaxHandler.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/portal/PortletSaxHandler.java
@@ -1,0 +1,86 @@
+package com.dotmarketing.business.portal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class PortletSaxHandler<T> extends DefaultHandler {
+
+    private final StringBuilder currentValue = new StringBuilder();
+    private final Function<String,Optional<T>> valueMapper;
+    private final Map<String, T> valueMap;
+    private String portletName;
+    private String portletClass;
+    private final StringBuilder portletElement = new StringBuilder();
+    private boolean isPortlet = false;
+
+    PortletSaxHandler(Function<String,Optional<T>>  valueMapper) {
+        this.valueMap = new HashMap<>();
+        this.valueMapper = valueMapper;
+    }
+
+    public Map<String, T> getValueMap() {
+        return valueMap;
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) {
+        currentValue.setLength(0);
+        if (qName.equalsIgnoreCase("portlet")) {
+            portletElement.setLength(0);
+            isPortlet = true;
+        }
+        if (isPortlet) {
+            appendStartElement(qName, attributes);
+        }
+    }
+
+    @Override
+    public void characters(char[] ch, int start, int length) {
+        currentValue.append(ch, start, length);
+        if (isPortlet) {
+            portletElement.append(ch, start, length);
+        }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) {
+        handleEndElement(qName);
+    }
+
+    private void appendStartElement(String qName, Attributes attributes) {
+        portletElement.append("<").append(qName);
+        for (int i = 0; i < attributes.getLength(); i++) {
+            portletElement.append(" ").append(attributes.getQName(i)).append("=\"").append(attributes.getValue(i)).append("\"");
+        }
+        portletElement.append(">");
+    }
+
+    private void handleEndElement(String qName) {
+        if (qName.equalsIgnoreCase("portlet-name")) {
+            portletName = currentValue.toString().trim();
+        } else if (qName.equalsIgnoreCase("portlet-class")) {
+            portletClass = currentValue.toString().trim();
+        } else if (qName.equalsIgnoreCase("portlet")) {
+            processPortletEndElement();
+        }
+        if (isPortlet) {
+            portletElement.append("</").append(qName).append(">");
+        }
+    }
+
+    private void processPortletEndElement() {
+        if (portletName != null && !portletName.isEmpty() && portletClass != null && !portletClass.isEmpty()) {
+            String portletXML = portletElement.toString();
+            valueMapper.apply(portletXML).ifPresent(value -> valueMap.put(portletName, value));
+        }
+        portletName = null;
+        portletClass = null;
+        isPortlet = false;
+    }
+
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/business/portal/PortletSaxHandler.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/portal/PortletSaxHandler.java
@@ -10,14 +10,14 @@ import org.xml.sax.helpers.DefaultHandler;
 public class PortletSaxHandler<T> extends DefaultHandler {
 
     private final StringBuilder currentValue = new StringBuilder();
-    private final Function<String,Optional<T>> valueMapper;
+    private final Function<String, Optional<T>> valueMapper;
     private final Map<String, T> valueMap;
     private String portletName;
     private String portletClass;
     private final StringBuilder portletElement = new StringBuilder();
     private boolean isPortlet = false;
 
-    PortletSaxHandler(Function<String,Optional<T>>  valueMapper) {
+    PortletSaxHandler(Function<String, Optional<T>> valueMapper) {
         this.valueMap = new HashMap<>();
         this.valueMapper = valueMapper;
     }
@@ -48,6 +48,9 @@ public class PortletSaxHandler<T> extends DefaultHandler {
 
     @Override
     public void endElement(String uri, String localName, String qName) {
+        if (isPortlet) {
+            portletElement.append("</").append(qName).append(">");
+        }
         handleEndElement(qName);
     }
 
@@ -67,9 +70,6 @@ public class PortletSaxHandler<T> extends DefaultHandler {
         } else if (qName.equalsIgnoreCase("portlet")) {
             processPortletEndElement();
         }
-        if (isPortlet) {
-            portletElement.append("</").append(qName).append(">");
-        }
     }
 
     private void processPortletEndElement() {
@@ -81,6 +81,4 @@ public class PortletSaxHandler<T> extends DefaultHandler {
         portletClass = null;
         isPortlet = false;
     }
-
-
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/portal/ThreadLocalSaxParserFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/portal/ThreadLocalSaxParserFactory.java
@@ -1,6 +1,8 @@
 package com.dotmarketing.business.portal;
 
 import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.util.Logger;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -19,9 +21,22 @@ public class ThreadLocalSaxParserFactory {
                             SAXParserFactory factory = SAXParserFactory.newInstance();
                             // https://rules.sonarsource.com/java/RSPEC-2755
                             // prevent XXE, completely disable DOCTYPE declaration:
-                            factory.setFeature(
-                                    "http://apache.org/xml/features/disallow-doctype-decl", true);
+                            // may not be able to use for backwards compatibility
+                            //factory.setFeature(
+                            //        "http://apache.org/xml/features/disallow-doctype-decl", true);
+
+                            factory.setFeature("http://xml.org/sax/features/external-general-entities",false);
+                            factory.setFeature("http://xml.org/sax/features/external-parameter-entities",false);
+                            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",false);
+                            factory.setXIncludeAware(false);
+                            factory.setValidating(false);
+                            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
                             return factory;
+                        } catch (ParserConfigurationException e) {
+                            Logger.error(ThreadLocalSaxParserFactory.class,"ParserConfigurationException was thrown. The feature 'XMLConstants.FEATURE_SECURE_PROCESSING'"
+                                    + " is probably not supported by your XML processor.",e);
+                            throw new DotRuntimeException(e);
                         } catch (Exception e) {
                             throw new DotRuntimeException(e);
                         }

--- a/dotCMS/src/main/java/com/dotmarketing/business/portal/ThreadLocalSaxParserFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/portal/ThreadLocalSaxParserFactory.java
@@ -1,0 +1,38 @@
+package com.dotmarketing.business.portal;
+
+import com.dotmarketing.exception.DotRuntimeException;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import org.xml.sax.SAXException;
+
+public class ThreadLocalSaxParserFactory {
+
+    private ThreadLocalSaxParserFactory() {
+        // utility class, do not instantiate
+    }
+
+    private static final ThreadLocal<SAXParserFactory> saxParserFactoryThreadLocal =
+            ThreadLocal.withInitial(
+                    () -> {
+                        try {
+                            SAXParserFactory factory = SAXParserFactory.newInstance();
+                            // https://rules.sonarsource.com/java/RSPEC-2755
+                            // prevent XXE, completely disable DOCTYPE declaration:
+                            factory.setFeature(
+                                    "http://apache.org/xml/features/disallow-doctype-decl", true);
+                            return factory;
+                        } catch (Exception e) {
+                            throw new DotRuntimeException(e);
+                        }
+                    });
+
+    public static SAXParser getSaxParser() throws ParserConfigurationException, SAXException {
+        // you could catch and re-throw the RuntimeException if the caller should handle it
+        return saxParserFactoryThreadLocal.get().newSAXParser();
+    }
+
+    public static void cleanup() {
+        saxParserFactoryThreadLocal.remove();
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotmarketing/business/portal/PortletAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/business/portal/PortletAPIImplTest.java
@@ -23,13 +23,20 @@ import com.liferay.portlet.StrutsPortlet;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import javax.xml.parsers.ParserConfigurationException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
 
 @RunWith(DataProviderRunner.class)
 public class PortletAPIImplTest {
@@ -73,6 +80,24 @@ public class PortletAPIImplTest {
                 .build();
 
         return portletApi.savePortlet(newPortlet.toPortlet(), systemUser);
+    }
+
+    /**
+     * Test case to ensure no portlets are returned from the mixed-portlets-test.xml file
+     * It should handle without error  but ignore portlet elements within the portlets element
+     * that do not contain a portlet-name and portlet-class
+     */
+    @Test
+    public void test_portletsFromMixedPortletXml() throws Exception {
+        String resourcePath = "/com/dotmarketing/business/portal/mixed-portlets-test.xml";
+        try (InputStream stream = getClass().getResourceAsStream(resourcePath)) {
+            assertNotNull("Resource not found: " + resourcePath, stream);
+            Map<String, Portlet> portlets = new PortletFactoryImpl().xmlToPortlets(stream);
+            assertTrue("Expecting exactly 1 valid portlet",portlets.size() == 1);
+        } catch (IOException | ParserConfigurationException | SAXException e) {
+            Logger.error(this, "Error loading portlets from liferay-portlet.xml", e);
+            Assert.fail("Exception occurred: " + e.getMessage());
+        }
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotmarketing/business/portal/PortletAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/business/portal/PortletAPIImplTest.java
@@ -93,7 +93,7 @@ public class PortletAPIImplTest {
         try (InputStream stream = getClass().getResourceAsStream(resourcePath)) {
             assertNotNull("Resource not found: " + resourcePath, stream);
             Map<String, Portlet> portlets = new PortletFactoryImpl().xmlToPortlets(stream);
-            assertTrue("Expecting exactly 1 valid portlet",portlets.size() == 1);
+            assertEquals("Expecting exactly 1 valid portlet", 1, portlets.size());
         } catch (IOException | ParserConfigurationException | SAXException e) {
             Logger.error(this, "Error loading portlets from liferay-portlet.xml", e);
             Assert.fail("Exception occurred: " + e.getMessage());

--- a/dotcms-integration/src/test/resources/com/dotmarketing/business/portal/mixed-portlets-test.xml
+++ b/dotcms-integration/src/test/resources/com/dotmarketing/business/portal/mixed-portlets-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE portlets>
+
+<portlets>
+    <portlet id="EXT_HELLO_WORLD" narrow="true"/>
+    <portlet id="EXT_STRUTS_HELLO_WORLD" struts-path="ext/strutshello" narrow="true"/>
+    <!-- Add one valid portlet to check that others are ignored -->
+    <portlet>
+        <portlet-name>files-legacy</portlet-name>
+        <display-name>File Manager</display-name>
+        <portlet-class>com.liferay.portlet.StrutsPortlet</portlet-class>
+        <init-param>
+            <name>view-action</name>
+            <value>/ext/files/view_files</value>
+        </init-param>
+        <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
+    </portlet>
+    <portlet id="EXT_JSP_HELLO_WORLD" narrow="true"/>
+</portlets>

--- a/justfile
+++ b/justfile
@@ -59,7 +59,7 @@ build-select-module-deps module=":dotcms-core":
 
 # Starts the dotCMS application in a Docker container on a dynamic port, running in the foreground
 dev-run:
-    ./mvnw -pl :dotcms-core -Pdocker-start
+    ./mvnw -pl :dotcms-core -Pdocker-start,debug-suspend
 
 # Maps paths in the docker container to local paths, useful for development
 dev-run-map-dev-paths:


### PR DESCRIPTION
### Proposed Changes
* Changes to use generkc java Sax to handle the list of <portlet> within <portlets> and only process with DotPortlet the ones that contain a <portlet-name> and <portlet-class> elements


### Checklist

- Tested with the cdn plugin, osgi-portlets-example (which has a liferay-portlet.xml file that triggers the issue) and rest-endpoint-example
- Added a test case with a resource containing a mix of portlets

### Additional Info
Related to #29276 (Unable to deploy portlet plugins ).


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #29276