### PR TITLE
#28947 fix shouldShow Unlock and InfoDisplay

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withEditorToolbar.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withEditorToolbar.ts
@@ -19,7 +19,8 @@ import {
     createPageApiUrlWithQueryParams,
     createPureURL,
     getIsDefaultVariant,
-    sanitizeURL
+    sanitizeURL,
+    computePageIsLocked
 } from '../../../../utils';
 import { UVEState } from '../../../models';
 import { EditorToolbarState, ToolbarProps } from '../models';
@@ -56,8 +57,11 @@ export function withEditorToolbar() {
                 }/${pageAPIQueryParams}`;
 
                 const isExperimentRunning = experiment?.status === DotExperimentStatus.RUNNING;
-                const shouldShowUnlock =
-                    pageAPIResponse?.page.locked && pageAPIResponse?.page.canLock;
+                const isPageLocked = computePageIsLocked(
+                    pageAPIResponse?.page,
+                    store.currentUser()
+                );
+                const shouldShowUnlock = isPageLocked && pageAPIResponse?.page.canLock;
 
                 const unlockButton = {
                     inode: pageAPIResponse?.page.inode,
@@ -67,7 +71,7 @@ export function withEditorToolbar() {
                 const shouldShowInfoDisplay =
                     !getIsDefaultVariant(pageAPIResponse?.viewAs.variantId) ||
                     !store.canEditPage() ||
-                    pageAPIResponse?.page.locked ||
+                    isPageLocked ||
                     !!store.device() ||
                     !!store.socialMedia();
 


### PR DESCRIPTION
### Proposed Changes
Incorporate the `computePageIsLocked()` function in the `shouldShowUnlock` and `shouldShowInfoDisplay` checks to determine if a page is locked by someone other than the current user.
This PR fixes https://github.com/dotCMS/core/issues/28947

This PR fixes: #28947