### PR TITLE
#29281: adding a centralized OpenAI api-key validation procedure

### DIFF
--- a/core-web/yarn.lock
+++ b/core-web/yarn.lock
@@ -22128,7 +22128,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22145,6 +22145,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
@@ -22242,7 +22251,7 @@ stringify-package@^1.0.0, stringify-package@^1.0.1:
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22269,6 +22278,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -24269,7 +24285,7 @@ worker-farm@^1.6.0, worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -24299,6 +24315,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/dotCMS/src/main/java/com/dotcms/ai/api/CompletionsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/api/CompletionsAPIImpl.java
@@ -204,7 +204,7 @@ public class CompletionsAPIImpl implements CompletionsAPI {
     }
 
     private int countTokens(final String testString) {
-        return EncodingUtil.REGISTRY
+        return EncodingUtil.get().registry
                 .getEncodingForModel(config.get().getModel().getCurrentModel())
                 .map(enc -> enc.countTokens(testString))
                 .orElseThrow(() -> new DotRuntimeException("Encoder not found"));

--- a/dotCMS/src/main/java/com/dotcms/ai/api/CompletionsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/api/CompletionsAPIImpl.java
@@ -256,7 +256,7 @@ public class CompletionsAPIImpl implements CompletionsAPI {
 
         final JSONObject json = new JSONObject();
         json.put(AiKeys.MESSAGES, messages);
-        json.putIfAbsent(AiKeys.MODEL, config.get().getConfig(AppKeys.TEXT_MODEL_NAMES));
+        json.putIfAbsent(AiKeys.MODEL, config.get().getModel().getCurrentModel());
         json.put(AiKeys.TEMPERATURE, form.temperature);
         json.put(AiKeys.MAX_TOKENS, form.responseLengthTokens);
         json.put(AiKeys.STREAM, form.stream);

--- a/dotCMS/src/main/java/com/dotcms/ai/api/EmbeddingsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/api/EmbeddingsAPIImpl.java
@@ -328,7 +328,10 @@ class EmbeddingsAPIImpl implements EmbeddingsAPI {
             return cachedEmbeddings;
         }
 
-        final List<Integer> tokens = EncodingUtil.ENCODING.get().encode(content);
+        final List<Integer> tokens = EncodingUtil.get()
+                .getEncoding()
+                .map(encoding -> encoding.encode(content))
+                .orElse(List.of());
         if (tokens.isEmpty()) {
             debugLogger(this.getClass(), () -> String.format("No tokens for content ID '%s' were encoded: %s", contentId, content));
             return Tuple.of(0, List.of());

--- a/dotCMS/src/main/java/com/dotcms/ai/api/EmbeddingsRunner.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/api/EmbeddingsRunner.java
@@ -68,7 +68,10 @@ class EmbeddingsRunner implements Runnable {
             int totalTokens = 0;
             for (int end = iterator.next(); end != BreakIterator.DONE; start = end, end = iterator.next()) {
                 final String sentence = cleanContent.substring(start, end);
-                final int tokenCount = EncodingUtil.ENCODING.get().countTokens(sentence);
+                final int tokenCount = EncodingUtil.get()
+                        .getEncoding()
+                        .map(encoding -> encoding.countTokens(sentence))
+                        .orElse(0);
                 totalTokens += tokenCount;
 
                 if (totalTokens < splitAtTokens) {

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIAppUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIAppUtil.java
@@ -117,7 +117,7 @@ public class AIAppUtil {
      * @return the list of split secret values
      */
     public List<String> splitDiscoveredSecret(final Map<String, Secret> secrets, final AppKeys key) {
-        return Arrays.stream(discoverSecret(secrets, key).split(","))
+        return Arrays.stream(Optional.ofNullable(discoverSecret(secrets, key)).orElse(StringPool.BLANK).split(","))
                 .map(String::trim)
                 .map(String::toLowerCase)
                 .collect(Collectors.toList());

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIAppUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIAppUtil.java
@@ -42,7 +42,7 @@ public class AIAppUtil {
     public AIModel createTextModel(final Map<String, Secret> secrets) {
         return AIModel.builder()
                 .withType(AIModelType.TEXT)
-                .withNames(discoverSecret(secrets, AppKeys.TEXT_MODEL_NAMES))
+                .withNames(splitDiscoveredSecret(secrets, AppKeys.TEXT_MODEL_NAMES))
                 .withTokensPerMinute(discoverIntSecret(secrets, AppKeys.TEXT_MODEL_TOKENS_PER_MINUTE))
                 .withApiPerMinute(discoverIntSecret(secrets, AppKeys.TEXT_MODEL_API_PER_MINUTE))
                 .withMaxTokens(discoverIntSecret(secrets, AppKeys.TEXT_MODEL_MAX_TOKENS))
@@ -59,7 +59,7 @@ public class AIAppUtil {
     public AIModel createImageModel(final Map<String, Secret> secrets) {
         return AIModel.builder()
                 .withType(AIModelType.IMAGE)
-                .withNames(discoverSecret(secrets, AppKeys.IMAGE_MODEL_NAMES))
+                .withNames(splitDiscoveredSecret(secrets, AppKeys.IMAGE_MODEL_NAMES))
                 .withTokensPerMinute(discoverIntSecret(secrets, AppKeys.IMAGE_MODEL_TOKENS_PER_MINUTE))
                 .withApiPerMinute(discoverIntSecret(secrets, AppKeys.IMAGE_MODEL_API_PER_MINUTE))
                 .withMaxTokens(discoverIntSecret(secrets, AppKeys.IMAGE_MODEL_MAX_TOKENS))

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIModel.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIModel.java
@@ -18,6 +18,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class AIModel {
 
+    public static final AIModel NOOP_MODEL = AIModel.builder()
+            .withType(AIModelType.UNKNOWN)
+            .withNames(List.of())
+            .build();
+
     private final AIModelType type;
     private final List<String> names;
     private final int tokensPerMinute;
@@ -86,6 +91,10 @@ public class AIModel {
 
     public void setDecommissioned(final boolean decommissioned) {
         this.decommissioned.set(decommissioned);
+    }
+
+    public boolean isOperational() {
+        return this != NOOP_MODEL;
     }
 
     public String getCurrentModel() {

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIModels.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIModels.java
@@ -131,18 +131,16 @@ public class AIModels {
      */
     public void resetModels(final Host host) {
         final String hostKey = host.getHostname();
-        synchronized (AIModels.class) {
-            Optional.ofNullable(internalModels.get(hostKey)).ifPresent(models -> {
-                models.clear();
-                internalModels.remove(hostKey);
-            });
-            modelsByName.keySet()
-                    .stream()
-                    .filter(key -> key._1.equals(hostKey))
-                    .collect(Collectors.toSet())
-                    .forEach(modelsByName::remove);
-            ConfigService.INSTANCE.config(host);
-        }
+        Optional.ofNullable(internalModels.get(hostKey)).ifPresent(models -> {
+            models.clear();
+            internalModels.remove(hostKey);
+        });
+        modelsByName.keySet()
+                .stream()
+                .filter(key -> key._1.equals(hostKey))
+                .collect(Collectors.toSet())
+                .forEach(modelsByName::remove);
+        ConfigService.INSTANCE.config(host);
     }
 
     /**
@@ -152,31 +150,29 @@ public class AIModels {
      * @return a list of supported model names
      */
     public List<String> getOrPullSupportedModels() {
-        synchronized (supportedModelsCache) {
-            final List<String> cached = supportedModelsCache.getIfPresent(SUPPORTED_MODELS_KEY);
-            if (CollectionUtils.isNotEmpty(cached)) {
-                return cached;
-            }
-
-            final AppConfig appConfig = appConfigSupplier.get();
-            if (!appConfig.isEnabled()) {
-                Logger.debug(this, "OpenAI is not enabled, returning empty list of supported models");
-                return List.of();
-            }
-
-            final List<String> supported = Try.of(() ->
-                            fetchOpenAIModels(appConfig)
-                                    .getResponse()
-                                    .getData()
-                                    .stream()
-                                    .map(OpenAIModel::getId)
-                                    .map(String::toLowerCase)
-                                    .collect(Collectors.toList()))
-                    .getOrElse(Optional.ofNullable(cached).orElse(List.of()));
-            supportedModelsCache.put(SUPPORTED_MODELS_KEY, supported);
-
-            return supported;
+        final List<String> cached = supportedModelsCache.getIfPresent(SUPPORTED_MODELS_KEY);
+        if (CollectionUtils.isNotEmpty(cached)) {
+            return cached;
         }
+
+        final AppConfig appConfig = appConfigSupplier.get();
+        if (!appConfig.isEnabled()) {
+            Logger.debug(this, "OpenAI is not enabled, returning empty list of supported models");
+            return List.of();
+        }
+
+        final List<String> supported = Try.of(() ->
+                        fetchOpenAIModels(appConfig)
+                                .getResponse()
+                                .getData()
+                                .stream()
+                                .map(OpenAIModel::getId)
+                                .map(String::toLowerCase)
+                                .collect(Collectors.toList()))
+                .getOrElse(Optional.ofNullable(cached).orElse(List.of()));
+        supportedModelsCache.put(SUPPORTED_MODELS_KEY, supported);
+
+        return supported;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
@@ -1,5 +1,6 @@
 package com.dotcms.ai.app;
 
+import com.dotcms.ai.util.OpenAIRequest;
 import com.dotcms.security.apps.Secret;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
@@ -25,13 +26,13 @@ public class AppConfig implements Serializable {
     public static final Pattern SPLITTER = Pattern.compile("\\s?,\\s?");
 
     private final String host;
+    private final String apiKey;
     private final transient AIModel model;
     private final transient AIModel imageModel;
     private final transient AIModel embeddingsModel;
     private final String apiUrl;
     private final String apiImageUrl;
     private final String apiEmbeddingsUrl;
-    private final String apiKey;
     private final String rolePrompt;
     private final String textPrompt;
     private final String imagePrompt;
@@ -43,6 +44,8 @@ public class AppConfig implements Serializable {
         this.host = host;
 
         final AIAppUtil aiAppUtil = AIAppUtil.get();
+        apiKey = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_KEY);
+
         AIModels.get().loadModels(
                 this.host,
                 List.of(
@@ -57,7 +60,7 @@ public class AppConfig implements Serializable {
         apiUrl = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_URL);
         apiImageUrl = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_IMAGE_URL);
         apiEmbeddingsUrl = discoverEmbeddingsApiUrl(secrets);
-        apiKey = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_KEY);
+
         rolePrompt = aiAppUtil.discoverSecret(secrets, AppKeys.ROLE_PROMPT);
         textPrompt = aiAppUtil.discoverSecret(secrets, AppKeys.TEXT_PROMPT);
         imagePrompt = aiAppUtil.discoverSecret(secrets, AppKeys.IMAGE_PROMPT);
@@ -66,10 +69,10 @@ public class AppConfig implements Serializable {
 
         configValues = secrets.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+        Logger.debug(getClass(), () -> "apiKey: " + apiKey);
         Logger.debug(getClass(), () -> "apiUrl: " + apiUrl);
         Logger.debug(getClass(), () -> "apiImageUrl: " + apiImageUrl);
         Logger.debug(getClass(), () -> "embeddingsUrl: " + apiEmbeddingsUrl);
-        Logger.debug(getClass(), () -> "apiKey: " + apiKey);
         Logger.debug(getClass(), () -> "model: " + model);
         Logger.debug(getClass(), () -> "imageModel: " + imageModel);
         Logger.debug(getClass(), () -> "embeddingsModel: " + embeddingsModel);
@@ -251,7 +254,7 @@ public class AppConfig implements Serializable {
      * @param type the type of the model to find
      */
     public AIModel resolveModel(final AIModelType type) {
-        return AIModels.get().findModel(host, type).orElse(AIModels.NOOP_MODEL);
+        return AIModels.get().findModel(host, type).orElse(AIModel.NOOP_MODEL);
     }
 
     /**
@@ -260,13 +263,24 @@ public class AppConfig implements Serializable {
      * @param modelName the name of the model to find
      */
     public AIModel resolveModelOrThrow(final String modelName) {
-        return AIModels.get()
+        final AIModel model = AIModels.get()
                 .findModel(host, modelName)
                 .orElseThrow(() -> {
                     final String supported = String.join(", ", AIModels.get().getOrPullSupportedModels());
                     return new DotRuntimeException(
                             "Unable to find model: [" + modelName + "]. Only [" + supported + "] are supported ");
                 });
+
+        if (!model.isOperational()) {
+            Logger.debug(
+                    OpenAIRequest.class,
+                    String.format(
+                            "Resolved model [%s] is not operational, avoiding its usage",
+                            model.getCurrentModel()));
+            throw new DotRuntimeException(String.format("Model [%s] is not operational", model.getCurrentModel()));
+        }
+
+        return model;
     }
 
     /**
@@ -280,6 +294,10 @@ public class AppConfig implements Serializable {
         if (ConfigService.INSTANCE.config().getConfigBoolean(AppKeys.DEBUG_LOGGING)) {
             Logger.info(clazz, message.get());
         }
+    }
+
+    public boolean isEnabled() {
+        return StringUtils.isNotBlank(apiKey);
     }
 
     private String discoverEmbeddingsApiUrl(final Map<String, Secret> secrets) {

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppKeys.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppKeys.java
@@ -14,20 +14,20 @@ public enum AppKeys {
     IMAGE_PROMPT("imagePrompt", "Use 16:9 aspect ratio."),
     IMAGE_SIZE("imageSize", "1024x1024"),
     TEXT_MODEL_NAMES("textModelNames", "gpt-3.5-turbo-16k"),
-    TEXT_MODEL_TOKENS_PER_MINUTE("textModelTokensPerMinute", "1000"),
-    TEXT_MODEL_API_PER_MINUTE("textModelApiPerMinute", "1000"),
-    TEXT_MODEL_MAX_TOKENS("textModelMaxTokens", "1000"),
+    TEXT_MODEL_TOKENS_PER_MINUTE("textModelTokensPerMinute", "180000"),
+    TEXT_MODEL_API_PER_MINUTE("textModelApiPerMinute", "3500"),
+    TEXT_MODEL_MAX_TOKENS("textModelMaxTokens", "16384"),
     TEXT_MODEL_COMPLETION("textModelCompletion", "true"),
     IMAGE_MODEL_NAMES("imageModelNames", "dall-e-3"),
-    IMAGE_MODEL_TOKENS_PER_MINUTE("imageModelTokensPerMinute", "1000"),
-    IMAGE_MODEL_API_PER_MINUTE("imageModelApiPerMinute", "1000"),
-    IMAGE_MODEL_MAX_TOKENS("imageModelMaxTokens", "1000"),
-    IMAGE_MODEL_COMPLETION("imageModelCompletion", "true"),
+    IMAGE_MODEL_TOKENS_PER_MINUTE("imageModelTokensPerMinute", "0"),
+    IMAGE_MODEL_API_PER_MINUTE("imageModelApiPerMinute", "50"),
+    IMAGE_MODEL_MAX_TOKENS("imageModelMaxTokens", "0"),
+    IMAGE_MODEL_COMPLETION("imageModelCompletion", "false"),
     EMBEDDINGS_MODEL_NAMES("embeddingsModelNames", "text-embedding-ada-002"),
-    EMBEDDINGS_MODEL_TOKENS_PER_MINUTE("embeddingsModelTokensPerMinute", "1000"),
-    EMBEDDINGS_MODEL_API_PER_MINUTE("embeddingsModelApiPerMinute", "1000"),
-    EMBEDDINGS_MODEL_MAX_TOKENS("embeddingsModelMaxTokens", "1000"),
-    EMBEDDINGS_MODEL_COMPLETION("embeddingsModelCompletion", "true"),
+    EMBEDDINGS_MODEL_TOKENS_PER_MINUTE("embeddingsModelTokensPerMinute", "1000000"),
+    EMBEDDINGS_MODEL_API_PER_MINUTE("embeddingsModelApiPerMinute", "3000"),
+    EMBEDDINGS_MODEL_MAX_TOKENS("embeddingsModelMaxTokens", "8191"),
+    EMBEDDINGS_MODEL_COMPLETION("embeddingsModelCompletion", "false"),
     EMBEDDINGS_SPLIT_AT_TOKENS("com.dotcms.ai.embeddings.split.at.tokens", "512"),
     EMBEDDINGS_MINIMUM_TEXT_LENGTH_TO_INDEX("com.dotcms.ai.embeddings.minimum.text.length", "64"),
     EMBEDDINGS_MINIMUM_FILE_SIZE_TO_INDEX("com.dotcms.ai.embeddings.minimum.file.size", "1024"),
@@ -57,7 +57,7 @@ public enum AppKeys {
     public final String key;
     public final String defaultValue;
 
-    AppKeys(String key, String defaultValue) {
+    AppKeys(final String key, final String defaultValue) {
         this.key = key;
         this.defaultValue = defaultValue;
     }

--- a/dotCMS/src/main/java/com/dotcms/ai/listener/AIAppListener.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/listener/AIAppListener.java
@@ -49,7 +49,7 @@ public final class AIAppListener implements EventSubscriber<AppSecretSavedEvent>
         final String hostId = event.getHostIdentifier();
         final Host host = Try.of(() -> hostAPI.find(hostId, APILocator.systemUser(), false)).getOrNull();
 
-        Optional.ofNullable(host).ifPresent(found ->  AIModels.get().resetModels(found));
+        Optional.ofNullable(host).ifPresent(found -> AIModels.get().resetModels(found));
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/ai/listener/EmbeddingContentListener.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/listener/EmbeddingContentListener.java
@@ -2,7 +2,6 @@ package com.dotcms.ai.listener;
 
 import com.dotcms.ai.api.EmbeddingsAPI;
 import com.dotcms.ai.app.AppConfig;
-import com.dotcms.ai.app.AppKeys;
 import com.dotcms.ai.app.ConfigService;
 import com.dotcms.ai.db.EmbeddingsDTO;
 import com.dotcms.content.elasticsearch.business.event.ContentletArchiveEvent;
@@ -18,7 +17,6 @@ import com.dotmarketing.portlets.contentlet.model.ContentletListener;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.json.JSONObject;
 import io.vavr.control.Try;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -85,7 +83,7 @@ public class EmbeddingContentListener implements ContentletListener<Contentlet> 
                 .getOrElse(APILocator.systemHost());
 
         final AppConfig appConfig = ConfigService.INSTANCE.config(host);
-        if (StringUtils.isBlank(appConfig.getApiKey())) {
+        if (!appConfig.isEnabled()) {
             throw new DotRuntimeException("No API key found in app config");
         }
 
@@ -127,10 +125,7 @@ public class EmbeddingContentListener implements ContentletListener<Contentlet> 
                     .stream()
                     .filter(typeFields -> contentType.equalsIgnoreCase(typeFields.getKey()))
                     .forEach(e -> EmbeddingsAPI.impl()
-                            .generateEmbeddingsForContent(
-                                    contentlet,
-                                    e.getValue(),
-                                    indexName));
+                            .generateEmbeddingsForContent(contentlet, e.getValue(), indexName));
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/ai/listener/EmbeddingContentListener.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/listener/EmbeddingContentListener.java
@@ -100,7 +100,7 @@ public class EmbeddingContentListener implements ContentletListener<Contentlet> 
      */
     private JSONObject getConfigJson(final String hostId) {
         return Try
-                .of(() -> new JSONObject(getAppConfig(hostId).getConfig(AppKeys.LISTENER_INDEXER)))
+                .of(() -> new JSONObject(getAppConfig(hostId).getListenerIndexer()))
                 .onFailure(e -> Logger.debug(getClass(), "error in json config from app: " + e.getMessage()))
                 .getOrElse(new JSONObject());
     }

--- a/dotCMS/src/main/java/com/dotcms/ai/model/OpenAIModels.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/model/OpenAIModels.java
@@ -16,12 +16,15 @@ public class OpenAIModels implements Serializable {
 
     private final String object;
     private final List<OpenAIModel> data;
+    private final OpenAIError error;
 
     @JsonCreator
     public OpenAIModels(@JsonProperty("object") final String object,
-                        @JsonProperty("data") final List<OpenAIModel> data) {
+                        @JsonProperty("data") final List<OpenAIModel> data,
+                        @JsonProperty("error") final OpenAIError error) {
         this.object = object;
         this.data = data;
+        this.error = error;
     }
 
     public String getObject() {
@@ -30,6 +33,45 @@ public class OpenAIModels implements Serializable {
 
     public List<OpenAIModel> getData() {
         return data;
+    }
+
+    public OpenAIError getError() {
+        return error;
+    }
+
+    public static class OpenAIError {
+
+        private final String message;
+        private final String type;
+        private final String param;
+        private final String code;
+
+        @JsonCreator
+        public OpenAIError(@JsonProperty("object") final String message,
+                           @JsonProperty("type") final String type,
+                           @JsonProperty("param") final String param,
+                           @JsonProperty("code") final String code) {
+            this.message = message;
+            this.type = type;
+            this.param = param;
+            this.code = code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getParam() {
+            return param;
+        }
+
+        public String getCode() {
+            return code;
+        }
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/ai/rest/forms/CompletionsForm.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/rest/forms/CompletionsForm.java
@@ -117,7 +117,7 @@ public class CompletionsForm {
         } else {
             this.temperature = builder.temperature >= 2 ? 2 : builder.temperature;
         }
-        this.model = UtilMethods.isSet(builder.model) ? builder.model : ConfigService.INSTANCE.config().getConfig(AppKeys.TEXT_MODEL_NAMES);
+        this.model = UtilMethods.isSet(builder.model) ? builder.model : ConfigService.INSTANCE.config().getModel().getCurrentModel();
     }
 
     private String validateBuilderQuery(final String query) {

--- a/dotCMS/src/main/java/com/dotcms/ai/util/EncodingUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/util/EncodingUtil.java
@@ -6,6 +6,8 @@ import com.knuddels.jtokkit.api.Encoding;
 import com.knuddels.jtokkit.api.EncodingRegistry;
 import io.vavr.Lazy;
 
+import java.util.Optional;
+
 /**
  * Utility class for handling encoding operations related to AI models.
  * It provides a registry for encoding and a lazy-loaded encoding instance based on the current model.
@@ -13,11 +15,21 @@ import io.vavr.Lazy;
  */
 public class EncodingUtil {
 
-    public static final EncodingRegistry REGISTRY = Encodings.newDefaultEncodingRegistry();
-    public static final String MODEL = ConfigService.INSTANCE.config().getEmbeddingsModel().getCurrentModel();
-    public static final Lazy<Encoding> ENCODING = Lazy.of(() -> REGISTRY.getEncodingForModel(MODEL).get());
+    private static final Lazy<EncodingUtil> INSTANCE = Lazy.of(EncodingUtil::new);
+
+    public final EncodingRegistry registry = Encodings.newDefaultEncodingRegistry();
 
     private EncodingUtil() {
+    }
+
+    public static EncodingUtil get() {
+        return INSTANCE.get();
+    }
+
+    public Optional<Encoding> getEncoding() {
+        return Optional
+                .ofNullable(ConfigService.INSTANCE.config().getEmbeddingsModel().getCurrentModel())
+                .flatMap(registry::getEncodingForModel);
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/ai/viewtool/AIViewTool.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/viewtool/AIViewTool.java
@@ -14,7 +14,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.PortalUtil;
 import io.vavr.control.Try;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.tools.view.context.ViewContext;
 import org.apache.velocity.tools.view.tools.ViewTool;
 
@@ -46,9 +45,7 @@ public class AIViewTool implements ViewTool {
      * @return true if AI is enabled, false otherwise
      */
     public boolean isAiEnabled() {
-        return Optional.ofNullable(config)
-                .map(appConfig -> StringUtils.isNotBlank(appConfig.getApiKey()))
-                .orElse(false);
+        return Optional.ofNullable(config).map(AppConfig::isEnabled).orElse(false);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/ai/viewtool/EmbeddingsTool.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/viewtool/EmbeddingsTool.java
@@ -51,7 +51,7 @@ public class EmbeddingsTool implements ViewTool {
      * @return The number of tokens in the prompt, or -1 if no encoding is found for the model.
      */
     public int countTokens(final String prompt) {
-        return EncodingUtil.REGISTRY
+        return EncodingUtil.get().registry
                 .getEncodingForModel(appConfig.getModel().getCurrentModel())
                 .map(encoding -> encoding.countTokens(prompt))
                 .orElse(-1);

--- a/dotCMS/src/main/java/com/dotcms/ai/workflow/OpenAIAutoTagActionlet.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/workflow/OpenAIAutoTagActionlet.java
@@ -1,6 +1,5 @@
 package com.dotcms.ai.workflow;
 
-import com.dotcms.ai.app.AppKeys;
 import com.dotcms.ai.app.ConfigService;
 import com.dotmarketing.portlets.workflows.actionlet.Actionlet;
 import com.dotmarketing.portlets.workflows.actionlet.WorkFlowActionlet;
@@ -41,7 +40,7 @@ public class OpenAIAutoTagActionlet extends WorkFlowActionlet {
         return List.of(
                 overwriteParameter,
                 limitTagsToHost,
-                new WorkflowActionletParameter(OpenAIParams.MODEL.key, "The AI model to use, defaults to " + ConfigService.INSTANCE.config().getConfig(AppKeys.TEXT_MODEL_NAMES), ConfigService.INSTANCE.config().getConfig(AppKeys.TEXT_MODEL_NAMES), false),
+                new WorkflowActionletParameter(OpenAIParams.MODEL.key, "The AI model to use, defaults to " + ConfigService.INSTANCE.config().getModel().getCurrentModel(), ConfigService.INSTANCE.config().getModel().getCurrentModel(), false),
                 new WorkflowActionletParameter(OpenAIParams.TEMPERATURE.key, "The AI temperature for the response.  Between .1 and 2.0.", ".1", false)
         );
     }

--- a/dotCMS/src/main/java/com/dotcms/ai/workflow/OpenAIContentPromptActionlet.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/workflow/OpenAIContentPromptActionlet.java
@@ -37,7 +37,7 @@ public class OpenAIContentPromptActionlet extends WorkFlowActionlet {
                         "<br>and the keys of the json object will be used to update the content fields.", "", false),
                 overwriteParameter,
                 new WorkflowActionletParameter(OpenAIParams.OPEN_AI_PROMPT.key, "The prompt that will be sent to the AI", "We need an attractive search result in Google. Return a json object that includes the fields \"pageTitle\" for a meta title of less than 55 characters and \"metaDescription\" for the meta description of less than 300 characters using this content:\\n\\n${fieldContent}\\n\\n", true),
-                new WorkflowActionletParameter(OpenAIParams.MODEL.key, "The AI model to use, defaults to " + ConfigService.INSTANCE.config().getConfig(AppKeys.TEXT_MODEL_NAMES), ConfigService.INSTANCE.config().getConfig(AppKeys.TEXT_MODEL_NAMES), false),
+                new WorkflowActionletParameter(OpenAIParams.MODEL.key, "The AI model to use, defaults to " + ConfigService.INSTANCE.config().getModel().getCurrentModel(), ConfigService.INSTANCE.config().getModel().getCurrentModel(), false),
                 new WorkflowActionletParameter(OpenAIParams.TEMPERATURE.key, "The AI temperature for the response.  Between .1 and 2.0.  Defaults to " + ConfigService.INSTANCE.config().getConfig(AppKeys.COMPLETION_TEMPERATURE), ConfigService.INSTANCE.config().getConfig(AppKeys.COMPLETION_TEMPERATURE), false)
         );
     }

--- a/dotCMS/src/main/resources/apps/dotAI.yml
+++ b/dotCMS/src/main/resources/apps/dotAI.yml
@@ -28,6 +28,41 @@ params:
     label: "Text Prompt"
     hint: "A prompt describing writing style."
     required: false
+  textModelNames:
+    value: "gpt-3.5-turbo-16k"
+    hidden: false
+    type: "STRING"
+    label: "Model Names"
+    hint: "Comma delimited list of models used to generate OpenAI API response."
+    required: true
+  textModelTokensPerMinute:
+    value: "180000"
+    hidden: false
+    type: "STRING"
+    label: "Tokens per Minute"
+    hint: "Tokens per minute used to generate OpenAI API response."
+    required: false
+  textModelApiPerMinute:
+    value: "3500"
+    hidden: false
+    type: "STRING"
+    label: "API per Minute"
+    hint: "API per minute used to generate OpenAI API response."
+    required: false
+  textModelMaxTokens:
+    value: "16384"
+    hidden: false
+    type: "STRING"
+    label: "Max Tokens"
+    hint: "Maximum number of tokens used to generate OpenAI API response."
+    required: false
+  textModelCompletion:
+    value: "true"
+    hidden: false
+    type: "BOOL"
+    label: "Completion model enabled"
+    hint: "Enable completion model used to generate OpenAI API response."
+    required: false
   imagePrompt:
     value: "Use 16:9 aspect ratio."
     hidden: false
@@ -61,43 +96,8 @@ params:
         value: "1920x1080"
       - label: "256x256 (Small Square 1:1)"
         value: "256x256"
-  textModelNames:
-    value: ""
-    hidden: false
-    type: "STRING"
-    label: "Model Names"
-    hint: "Comma delimited list of models used to generate OpenAI API response."
-    required: true
-  textModelTokensPerMinute:
-    value: "180000"
-    hidden: false
-    type: "STRING"
-    label: "Tokens per Minute"
-    hint: "Tokens per minute used to generate OpenAI API response."
-    required: false
-  textModelApiPerMinute:
-    value: "3500"
-    hidden: false
-    type: "STRING"
-    label: "API per Minute"
-    hint: "API per minute used to generate OpenAI API response."
-    required: false
-  textModelMaxTokens:
-    value: "16384"
-    hidden: false
-    type: "STRING"
-    label: "Max Tokens"
-    hint: "Maximum number of tokens used to generate OpenAI API response."
-    required: false
-  textModelCompletion:
-    value: "false"
-    hidden: false
-    type: "BOOL"
-    label: "Completion model enabled"
-    hint: "Enable completion model used to generate OpenAI API response."
-    required: false
   imageModelNames:
-    value: ""
+    value: "dall-e-3"
     hidden: false
     type: "STRING"
     label: "Image Model Names"
@@ -132,12 +132,40 @@ params:
     hint: "Enable completion model used to generate OpenAI API response."
     required: false
   embeddingsModelNames:
-    value: ""
+    value: "text-embedding-ada-002"
     hidden: false
     type: "STRING"
     label: "Embeddings Model Names"
     hint: "Comma delimited list of embeddings models used to generate OpenAI API response."
     required: true
+  embeddingsModelTokensPerMinute:
+    value: "1000000"
+    hidden: false
+    type: "STRING"
+    label: "Embeddings Tokens per Minute"
+    hint: "Tokens per minute used to generate OpenAI API response."
+    required: false
+  embeddingsModelApiPerMinute:
+    value: "3000"
+    hidden: false
+    type: "STRING"
+    label: "Embeddings API per Minute"
+    hint: "API per minute used to generate OpenAI API response."
+    required: false
+  embeddingsModelMaxTokens:
+    value: "8191"
+    hidden: false
+    type: "STRING"
+    label: "Embeddings Max Tokens"
+    hint: "Maximum number of tokens used to generate OpenAI API response."
+    required: false
+  embeddingsModelCompletion:
+    value: "false"
+    hidden: false
+    type: "BOOL"
+    label: "Embeddings Completion model enabled"
+    hint: "Enable completion model used to generate OpenAI API response."
+    required: false
   listenerIndexer:
     value: ""
     hidden: false

--- a/dotCMS/src/test/java/com/dotcms/ai/app/AIAppUtilTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/app/AIAppUtilTest.java
@@ -98,6 +98,20 @@ public class AIAppUtilTest {
     }
 
     /**
+     * Given a map of secrets containing a key with an environment secret value
+     * When the discoverEnvSecret method is called with the key
+     * Then the environment secret value should be returned.
+     */
+    @Test
+    public void testDiscoverNotFoundEnvSecret() {
+        when(secrets.get("something-else")).thenReturn(secret);
+        when(secret.getString()).thenReturn("envSecretValue");
+
+        String result = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_KEY);
+        assertEquals("", result);
+    }
+
+    /**
      * Given a map of secrets containing a key with an integer secret value
      * When the discoverIntSecret method is called with the key
      * Then the integer secret value should be returned.
@@ -138,7 +152,7 @@ public class AIAppUtilTest {
         AIModel model = aiAppUtil.createTextModel(secrets);
         assertNotNull(model);
         assertEquals(AIModelType.TEXT, model.getType());
-        assertTrue(model.getNames().contains("textModel"));
+        assertTrue(model.getNames().contains("textmodel"));
     }
 
     /**
@@ -154,7 +168,7 @@ public class AIAppUtilTest {
         AIModel model = aiAppUtil.createImageModel(secrets);
         assertNotNull(model);
         assertEquals(AIModelType.IMAGE, model.getType());
-        assertTrue(model.getNames().contains("imageModel"));
+        assertTrue(model.getNames().contains("imagemodel"));
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotcms/ai/AiTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/ai/AiTest.java
@@ -79,10 +79,10 @@ public interface AiTest {
                 Secret.builder().withType(Type.STRING).withValue(API_KEY.toCharArray()).build(),
 
                 AppKeys.TEXT_MODEL_NAMES.key,
-                Secret.builder().withType(Type.STRING).withValue(MODEL.toCharArray()).build(),
+                Secret.builder().withType(Type.STRING).withValue(AppKeys.TEXT_MODEL_NAMES.defaultValue.toCharArray()).build(),
 
                 AppKeys.IMAGE_MODEL_NAMES.key,
-                Secret.builder().withType(Type.STRING).withValue(IMAGE_MODEL.toCharArray()).build(),
+                Secret.builder().withType(Type.STRING).withValue(AppKeys.IMAGE_MODEL_NAMES.defaultValue.toCharArray()).build(),
 
                 AppKeys.IMAGE_SIZE.key,
                 Secret.builder().withType(Type.SELECT).withValue(IMAGE_SIZE.toCharArray()).build(),

--- a/dotcms-integration/src/test/java/com/dotcms/ai/AiTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/ai/AiTest.java
@@ -1,33 +1,28 @@
 package com.dotcms.ai;
 
-import com.dotcms.ai.app.AppConfig;
 import com.dotcms.ai.app.AppKeys;
+import com.dotcms.security.apps.AppSecrets;
 import com.dotcms.security.apps.Secret;
-import com.dotcms.security.apps.Type;
 import com.dotcms.util.WireMockTestHelper;
 import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public interface AiTest {
 
     String API_URL = "http://localhost:%d/c";
     String API_IMAGE_URL = "http://localhost:%d/i";
+    String API_EMBEDDINGS_URL = "http://localhost:%d/e";
     String API_KEY = "some-api-key-1a2bc3";
     String MODEL = "gpt-3.5-turbo-16k";
     String IMAGE_MODEL = "dall-e-3";
+    String EMBEDDINGS_MODEL = "text-embedding-ada-002";
     String IMAGE_SIZE = "1024x1024";
     int PORT = 50505;
-
-    static AppConfig prepareConfig(final Host host, final WireMockServer wireMockServer) {
-        return new AppConfig(host.getHostname(), appConfigMap(wireMockServer));
-    }
-
-    static AppConfig prepareCompletionConfig(final Host host, final WireMockServer wireMockServer) {
-        return new AppConfig(host.getHostname(), completionAppConfigMap(appConfigMap(wireMockServer)));
-    }
 
     static WireMockServer prepareWireMock() {
         final WireMockServer wireMockServer = WireMockTestHelper.wireMockServer(PORT);
@@ -36,61 +31,51 @@ public interface AiTest {
         return wireMockServer;
     }
 
-    private static Map<String, Secret> completionAppConfigMap(final Map<String, Secret> configMap) {
-        final Map<String, Secret> completionValues = Map.of(
-                AppKeys.COMPLETION_ROLE_PROMPT.key,
-                Secret.builder()
-                        .withType(Type.STRING)
-                        .withValue(AppKeys.COMPLETION_ROLE_PROMPT.defaultValue.toCharArray())
-                        .build(),
-
-                AppKeys.COMPLETION_TEXT_PROMPT.key,
-                Secret.builder()
-                        .withType(Type.STRING)
-                        .withValue(AppKeys.COMPLETION_TEXT_PROMPT.defaultValue.toCharArray())
-                        .build(),
-
-                AppKeys.TEXT_MODEL_NAMES.key,
-                Secret.builder()
-                        .withType(Type.STRING)
-                        .withValue(AppKeys.TEXT_MODEL_NAMES.defaultValue.toCharArray())
-                        .build()
-        );
-        final Map<String, Secret> all = new HashMap<>(configMap);
-        all.putAll(completionValues);
-        return Map.copyOf(all);
+    static Map<String, Secret> aiAppSecrets(final WireMockServer wireMockServer,
+                                            final Host host,
+                                            final String apiKey,
+                                            final String textModels,
+                                            final String imageModels,
+                                            final String embeddingsModel)
+            throws DotDataException, DotSecurityException {
+        final AppSecrets appSecrets = new AppSecrets.Builder()
+                .withKey(AppKeys.APP_KEY)
+                .withSecret(AppKeys.API_URL.key, String.format(API_URL, wireMockServer.port()))
+                .withSecret(AppKeys.API_IMAGE_URL.key, String.format(API_IMAGE_URL, wireMockServer.port()))
+                .withSecret(AppKeys.API_EMBEDDINGS_URL.key, String.format(API_EMBEDDINGS_URL, wireMockServer.port()))
+                .withHiddenSecret(AppKeys.API_KEY.key, apiKey)
+                .withSecret(AppKeys.TEXT_MODEL_NAMES.key, textModels)
+                .withSecret(AppKeys.IMAGE_MODEL_NAMES.key, imageModels)
+                .withSecret(AppKeys.EMBEDDINGS_MODEL_NAMES.key, embeddingsModel)
+                .withSecret(AppKeys.IMAGE_SIZE.key, IMAGE_SIZE)
+                .withSecret(AppKeys.LISTENER_INDEXER.key, "{\"default\":\"blog\"}")
+                .withSecret(AppKeys.COMPLETION_ROLE_PROMPT.key, AppKeys.COMPLETION_ROLE_PROMPT.defaultValue)
+                .withSecret(AppKeys.COMPLETION_TEXT_PROMPT.key, AppKeys.COMPLETION_TEXT_PROMPT.defaultValue)
+                .build();
+        APILocator.getAppsAPI().saveSecrets(appSecrets, host, APILocator.systemUser());
+        return appSecrets.getSecrets();
     }
 
-    static Map<String, Secret> appConfigMap(final WireMockServer wireMockServer) {
-        return Map.of(
-                AppKeys.API_URL.key,
-                Secret.builder()
-                        .withType(Type.STRING)
-                        .withValue(String.format(API_URL, wireMockServer.port()).toCharArray())
-                        .build(),
-
-                AppKeys.API_IMAGE_URL.key,
-                Secret.builder()
-                        .withType(Type.STRING)
-                        .withValue(String.format(API_IMAGE_URL, wireMockServer.port()).toCharArray())
-                        .build(),
-
-                AppKeys.API_KEY.key,
-                Secret.builder().withType(Type.STRING).withValue(API_KEY.toCharArray()).build(),
-
-                AppKeys.TEXT_MODEL_NAMES.key,
-                Secret.builder().withType(Type.STRING).withValue(AppKeys.TEXT_MODEL_NAMES.defaultValue.toCharArray()).build(),
-
-                AppKeys.IMAGE_MODEL_NAMES.key,
-                Secret.builder().withType(Type.STRING).withValue(AppKeys.IMAGE_MODEL_NAMES.defaultValue.toCharArray()).build(),
-
-                AppKeys.IMAGE_SIZE.key,
-                Secret.builder().withType(Type.SELECT).withValue(IMAGE_SIZE.toCharArray()).build(),
-
-                AppKeys.LISTENER_INDEXER.key,
-                Secret.builder()
-                        .withType(Type.STRING)
-                        .withValue("{\"default\":\"blog\"}".toCharArray())
-                        .build());
+    static Map<String, Secret> aiAppSecrets(final WireMockServer wireMockServer,
+                                            final Host host,
+                                            final String apiKey)
+            throws DotDataException, DotSecurityException {
+        return aiAppSecrets(wireMockServer, host, apiKey, MODEL, IMAGE_MODEL, EMBEDDINGS_MODEL);
     }
+
+    static Map<String, Secret> aiAppSecrets(final WireMockServer wireMockServer,
+                                            final Host host,
+                                            final String textModels,
+                                            final String imageModels,
+                                            final String embeddingsModel)
+            throws DotDataException, DotSecurityException {
+        return aiAppSecrets(wireMockServer, host, API_KEY, textModels, imageModels, embeddingsModel);
+    }
+
+    static Map<String, Secret> aiAppSecrets(final WireMockServer wireMockServer, final Host host)
+            throws DotDataException, DotSecurityException {
+
+        return aiAppSecrets(wireMockServer, host, MODEL, IMAGE_MODEL, EMBEDDINGS_MODEL);
+    }
+
 }

--- a/dotcms-integration/src/test/java/com/dotcms/ai/app/AIModelsTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/ai/app/AIModelsTest.java
@@ -6,7 +6,11 @@ import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.util.network.IPUtils;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.util.DateUtil;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import io.vavr.control.Try;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -32,8 +36,6 @@ import static org.junit.Assert.assertTrue;
 public class AIModelsTest {
 
     private static WireMockServer wireMockServer;
-    private static AppConfig config;
-
     private final AIModels aiModels = AIModels.get();
     private Host host;
     private Host otherHost;
@@ -43,7 +45,6 @@ public class AIModelsTest {
         IntegrationTestInitService.getInstance().init();
         IPUtils.disabledIpPrivateSubnet(true);
         wireMockServer = AiTest.prepareWireMock();
-        config = AiTest.prepareConfig(APILocator.systemHost(), wireMockServer);
     }
 
     @AfterClass
@@ -56,6 +57,7 @@ public class AIModelsTest {
     public void before() {
         host = new SiteDataGen().nextPersisted();
         otherHost = new SiteDataGen().nextPersisted();
+        List.of(host, otherHost).forEach(h -> Try.of(() -> AiTest.aiAppSecrets(wireMockServer, host)).get());
     }
 
     /**
@@ -64,10 +66,16 @@ public class AIModelsTest {
      * Then the correct models should be found and returned.
      */
     @Test
-    public void test_loadModels_andFindThem() {
-        loadModels();
+    public void test_loadModels_andFindThem() throws DotDataException, DotSecurityException {
+        saveSecrets(
+                    host,
+                    "text-model-1,text-model-2",
+                    "image-model-3,image-model-4",
+                    "embeddings-model-5,embeddings-model-6");
+        saveSecrets(otherHost, "text-model-1", null, null);
 
         final String hostId = host.getHostname();
+
         final Optional<AIModel> notFound = aiModels.findModel(hostId, "some-invalid-model-name");
         assertTrue(notFound.isEmpty());
 
@@ -80,7 +88,6 @@ public class AIModelsTest {
         assertModels(image1, image2, AIModelType.IMAGE);
 
         final Optional<AIModel> embeddings1 = aiModels.findModel(hostId, "embeddings-model-5");
-        assertTrue(embeddings1.isPresent());
         final Optional<AIModel> embeddings2 = aiModels.findModel(hostId, "embeddings-model-6");
         assertModels(embeddings1, embeddings2, AIModelType.EMBEDDINGS);
 
@@ -100,22 +107,25 @@ public class AIModelsTest {
         final Optional<AIModel> text4 = aiModels.findModel(otherHost.getHostname(), "text-model-1");
         assertTrue(text3.isPresent());
         assertNotSame(text1.get(), text4.get());
-    }
 
-    /**
-     * Given a set of models loaded into the AIModels instance
-     * When the resetModels method is called with a specific host
-     * Then the models for that host should be reset and no longer found.
-     */
-    @Test
-    public void test_resetModels() {
-        loadModels();
-        final Optional<AIModel> aiModel = aiModels.findModel(host.getHostname(), AIModelType.TEXT);
+        saveSecrets(
+                host,
+                "text-model-7,text-model-8",
+                "image-model-9,image-model-10",
+                "embeddings-model-11, embeddings-model-12");
 
-        aiModels.resetModels(host);
+        final Optional<AIModel> text7 = aiModels.findModel(hostId, "text-model-7");
+        final Optional<AIModel> text8 = aiModels.findModel(hostId, "text-model-8");
+        assertModels(text7, text8, AIModelType.TEXT);
 
-        assertNotSame(aiModel.get(), aiModels.findModel(host.getHostname(), AIModelType.TEXT));
-        assertTrue(aiModels.findModel(host.getHostname(), "text-model-1").isEmpty());
+        final Optional<AIModel> image9 = aiModels.findModel(hostId, "image-model-9");
+        final Optional<AIModel> image10 = aiModels.findModel(hostId, "image-model-10");
+        assertModels(image9, image10, AIModelType.IMAGE);
+
+        final Optional<AIModel> embeddings11 = aiModels.findModel(hostId, "embeddings-model-11");
+        assertTrue(embeddings11.isPresent());
+        final Optional<AIModel> embeddings12 = aiModels.findModel(hostId, "embeddings-model-12");
+        assertModels(embeddings11, embeddings12, AIModelType.EMBEDDINGS);
     }
 
     /**
@@ -124,9 +134,9 @@ public class AIModelsTest {
      * Then a list of supported models should be returned.
      */
     @Test
-    public void test_getOrPullSupportedModules() {
+    public void test_getOrPullSupportedModules() throws DotDataException, DotSecurityException {
+        AiTest.aiAppSecrets(wireMockServer, APILocator.systemHost());
         AIModels.get().cleanSupportedModelsCache();
-        AIModels.get().setAppConfigSupplier(() -> config);
 
         List<String> supported = aiModels.getOrPullSupportedModels();
         assertNotNull(supported);
@@ -147,7 +157,6 @@ public class AIModelsTest {
     @Test
     public void test_getOrPullSupportedModules_invalidEndpoint() {
         AIModels.get().cleanSupportedModelsCache();
-        AIModels.get().setAppConfigSupplier(() -> config);
         IPUtils.disabledIpPrivateSubnet(false);
 
         final List<String> supported = aiModels.getOrPullSupportedModels();
@@ -164,52 +173,21 @@ public class AIModelsTest {
      * Then an empty list of supported models should be returned.
      */
     @Test
-    public void test_getOrPullSupportedModules_noApiKey() {
+    public void test_getOrPullSupportedModules_noApiKey() throws DotDataException, DotSecurityException {
+        AiTest.aiAppSecrets(wireMockServer, APILocator.systemHost(), null);
+
         AIModels.get().cleanSupportedModelsCache();
         final List<String> supported = aiModels.getOrPullSupportedModels();
         assertNotNull(supported);
         assertTrue(supported.isEmpty());
     }
 
-    private void loadModels() {
-        aiModels.loadModels(
-                host.getHostname(),
-                List.of(
-                        AIModel.builder()
-                                .withType(AIModelType.TEXT)
-                                .withNames("text-model-1", "text-model-2")
-                                .withTokensPerMinute(123)
-                                .withApiPerMinute(321)
-                                .withMaxTokens(555)
-                                .withIsCompletion(true)
-                                .build(),
-                        AIModel.builder()
-                                .withType(AIModelType.IMAGE)
-                                .withNames("image-model-3", "image-model-4")
-                                .withTokensPerMinute(111)
-                                .withApiPerMinute(222)
-                                .withMaxTokens(333)
-                                .withIsCompletion(false)
-                                .build(),
-                        AIModel.builder()
-                                .withType(AIModelType.EMBEDDINGS)
-                                .withNames("embeddings-model-5", "embeddings-model-6")
-                                .withTokensPerMinute(999)
-                                .withApiPerMinute(888)
-                                .withMaxTokens(777)
-                                .withIsCompletion(false)
-                                .build()));
-        aiModels.loadModels(
-                otherHost.getHostname(),
-                List.of(
-                        AIModel.builder()
-                                .withType(AIModelType.TEXT)
-                                .withNames("text-model-1")
-                                .withTokensPerMinute(123)
-                                .withApiPerMinute(321)
-                                .withMaxTokens(555)
-                                .withIsCompletion(true)
-                                .build()));
+    private void saveSecrets(final Host host,
+                             final String textModels,
+                             final String imageModels,
+                             final String embeddingsModels) throws DotDataException, DotSecurityException {
+        AiTest.aiAppSecrets(wireMockServer, host, textModels, imageModels, embeddingsModels);
+        DateUtil.sleep(1000);
     }
 
     private static void assertSameModels(Optional<AIModel> text3, Optional<AIModel> text1, Optional<AIModel> text2) {

--- a/dotcms-integration/src/test/java/com/dotcms/ai/viewtool/AIViewToolTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/ai/viewtool/AIViewToolTest.java
@@ -2,6 +2,7 @@ package com.dotcms.ai.viewtool;
 
 import com.dotcms.ai.AiTest;
 import com.dotcms.ai.app.AppConfig;
+import com.dotcms.ai.app.ConfigService;
 import com.dotcms.datagen.UserDataGen;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.util.network.IPUtils;
@@ -45,7 +46,8 @@ public class AIViewToolTest {
         IntegrationTestInitService.getInstance().init();
         IPUtils.disabledIpPrivateSubnet(true);
         wireMockServer = AiTest.prepareWireMock();
-        config = AiTest.prepareConfig(APILocator.systemHost(), wireMockServer);
+        AiTest.aiAppSecrets(wireMockServer, APILocator.systemHost());
+        config = ConfigService.INSTANCE.config();
     }
 
     @AfterClass

--- a/dotcms-integration/src/test/java/com/dotcms/ai/viewtool/CompletionsToolTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/ai/viewtool/CompletionsToolTest.java
@@ -3,11 +3,13 @@ package com.dotcms.ai.viewtool;
 import com.dotcms.ai.AiTest;
 import com.dotcms.ai.app.AppConfig;
 import com.dotcms.ai.app.AppKeys;
+import com.dotcms.ai.app.ConfigService;
 import com.dotcms.datagen.EmbeddingsDTODataGen;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.util.network.IPUtils;
 import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
 import com.dotmarketing.util.json.JSONArray;
 import com.dotmarketing.util.json.JSONObject;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -38,7 +40,7 @@ import static org.mockito.Mockito.when;
  */
 public class CompletionsToolTest {
 
-    private static AppConfig config;
+    private static AppConfig appConfig;
     private static WireMockServer wireMockServer;
     private static Host host;
 
@@ -50,7 +52,9 @@ public class CompletionsToolTest {
         IPUtils.disabledIpPrivateSubnet(true);
         host = new SiteDataGen().nextPersisted();
         wireMockServer = AiTest.prepareWireMock();
-        config = AiTest.prepareCompletionConfig(host, wireMockServer);
+        AiTest.aiAppSecrets(wireMockServer, APILocator.systemHost());
+        AiTest.aiAppSecrets(wireMockServer, host);
+        appConfig = ConfigService.INSTANCE.config(host);
     }
 
     @AfterClass
@@ -82,7 +86,7 @@ public class CompletionsToolTest {
         assertNotNull(config);
         assertEquals(AppKeys.COMPLETION_ROLE_PROMPT.defaultValue, config.get(AppKeys.COMPLETION_ROLE_PROMPT.key));
         assertEquals(AppKeys.COMPLETION_TEXT_PROMPT.defaultValue, config.get(AppKeys.COMPLETION_TEXT_PROMPT.key));
-        assertEquals(AppKeys.TEXT_MODEL_NAMES.defaultValue, config.get(AppKeys.TEXT_MODEL_NAMES.key));
+        assertEquals("gpt-3.5-turbo-16k", config.get(AppKeys.TEXT_MODEL_NAMES.key));
     }
 
     /**
@@ -173,7 +177,7 @@ public class CompletionsToolTest {
 
             @Override
             AppConfig config() {
-                return config;
+                return appConfig;
             }
         };
     }

--- a/dotcms-integration/src/test/java/com/dotcms/datagen/TestDataUtils.java
+++ b/dotcms-integration/src/test/java/com/dotcms/datagen/TestDataUtils.java
@@ -1260,6 +1260,7 @@ public class TestDataUtils {
     }
 
     public static Contentlet withEmbeddings(final boolean persist,
+                                            final Host host,
                                             final long languageId,
                                             final String contentTypeId,
                                             final String text) {
@@ -1273,7 +1274,7 @@ public class TestDataUtils {
                 .setProperty("body", "blogBody")
                 .setProperty("seo", text);
 
-        return getBlogContent(persist, null, contentletDataGen);
+        return getBlogContent(persist, host, contentletDataGen);
     }
 
     public static Contentlet getBlogContent(Boolean persist, long languageId,

--- a/dotcms-integration/src/test/java/com/dotcms/util/ConfigTestHelper.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ConfigTestHelper.java
@@ -93,8 +93,7 @@ public class ConfigTestHelper extends Config {
     }
 
 
-    private static Path getTestFilePath(String contextPath,String[] contextRoots)
-            throws MalformedURLException {
+    private static Path getTestFilePath(String contextPath,String[] contextRoots){
         if (!contextPath.startsWith("/"))
             throw new IllegalArgumentException("Resource path must start with a / and is relative to context root");
         else


### PR DESCRIPTION
Avoiding sending requests when there is no OpenAI API key to use. Putting it in a centralized place.
Adjusting a couple of tests to reflect this logic change.
Also since from the provided logs there was an Jackson parsing error, new fields were added to "DTO" class to consider the error field.
Initially when implementing IT for AI classes, I took the approach of mocking or building an `AppConfig` class on the flight instead of creating an `dotAI` app secrets so config classes can be created out of them. Just as it happens at production code. I'm introducing some changes to correct this as well.

This PR fixes: #29281