### PR TITLE
fix: CICD Automate Generation and Deployment of Full St (#29160)

### DIFF
--- a/.github/workflows/publish-starter.yml
+++ b/.github/workflows/publish-starter.yml
@@ -73,8 +73,9 @@ jobs:
       - uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ vars.ARTIFACTORY_URL }}
-          JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}      
-          
+          JF_USER: ${{ secrets.EE_REPO_USERNAME }}
+          JF_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}          
+                    
       - name: 'JFrog CLI context'
         run: |
           echo "::group::JFrog CLI context"


### PR DESCRIPTION
### Proposed Changes
* In order to use the existing vars. `EE_REPO_USERNAME` and `EE_REPO_PASSWORD` vars are set instead of `ARTIFACTORY_ACCESS_TOKEN`.

### Additional Info
Related to #29160 (CICD Automate Generation and Deployment of Full St).

This PR fixes: #29160