### PR TITLE
Issue 29321 asset considered as image when its name starts with specific pattern

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
@@ -65,21 +65,21 @@ public class ShortyServlet extends HttpServlet {
   private static final String  WEBP                        = "webp";
   private static final String  FILE_ASSET_DEFAULT          = FileAssetAPI.BINARY_FIELD;
   public  static final String  SHORTY_SERVLET_FORWARD_PATH = "shorty.servlet.forward.path";
-  private static final Pattern widthPattern                = Pattern.compile("/(\\d+)w");
-  private static final Pattern heightPattern               = Pattern.compile("/(\\d+)h");
-  private static final Pattern cropWidthPattern                = Pattern.compile("/(\\d+)cw");
-  private static final Pattern cropHeightPattern               = Pattern.compile("/(\\d+)ch");
+  private static final Pattern widthPattern                = Pattern.compile("/(\\d+)w\\b");
+  private static final Pattern heightPattern               = Pattern.compile("/(\\d+)h\\b");
+  private static final Pattern cropWidthPattern                = Pattern.compile("/(\\d+)cw\\b");
+  private static final Pattern cropHeightPattern               = Pattern.compile("/(\\d+)ch\\b");
   
-  private static final Pattern focalPointPattern               = Pattern.compile("/(\\.\\d+,\\.\\d+)fp");
+  private static final Pattern focalPointPattern               = Pattern.compile("/(\\.\\d+,\\.\\d+)fp\\b");
   
-  private static final Pattern qualityPattern               = Pattern.compile("/(\\d+)q");
+  private static final Pattern qualityPattern               = Pattern.compile("/(\\d+)q\\b");
   
-  private static final Pattern resampleOptsPattern               = Pattern.compile("/(\\d+)ro");
+  private static final Pattern resampleOptsPattern               = Pattern.compile("/(\\d+)ro\\b");
   
-  private static final Pattern maxWidthPattern                = Pattern.compile("/(\\d+)maxw");
-  private static final Pattern maxHeightPattern               = Pattern.compile("/(\\d+)maxh");
-  private static final Pattern minWidthPattern                = Pattern.compile("/(\\d+)minw");
-  private static final Pattern minHeightPattern               = Pattern.compile("/(\\d+)minh");
+  private static final Pattern maxWidthPattern                = Pattern.compile("/(\\d+)maxw\\b");
+  private static final Pattern maxHeightPattern               = Pattern.compile("/(\\d+)maxh\\b");
+  private static final Pattern minWidthPattern                = Pattern.compile("/(\\d+)minw\\b");
+  private static final Pattern minHeightPattern               = Pattern.compile("/(\\d+)minh\\b");
   
   
   
@@ -109,7 +109,7 @@ public class ShortyServlet extends HttpServlet {
   
   
 
-  private int getWidth(final String uri, final int defaultWidth) {
+  protected int getWidth(final String uri, final int defaultWidth) {
 
     int width = 0;
 
@@ -130,7 +130,7 @@ public class ShortyServlet extends HttpServlet {
     return width;
   }
 
-    private int cropWidth(final String uri) {
+    protected int cropWidth(final String uri) {
 
         int cropWidth=0;
         try {
@@ -148,7 +148,7 @@ public class ShortyServlet extends HttpServlet {
         return cropWidth;
     }
   
-    private int cropHeight(final String uri) {
+    protected int cropHeight(final String uri) {
         int cropHeight=0;
         try {
             final Matcher heightMatcher = cropHeightPattern.matcher(uri);
@@ -177,7 +177,7 @@ public class ShortyServlet extends HttpServlet {
     }
   
   
-  private int getHeight (final String uri, final int defaultHeight) {
+  protected int getHeight (final String uri, final int defaultHeight) {
 
     int height = 0;
 
@@ -199,27 +199,27 @@ public class ShortyServlet extends HttpServlet {
     return height;
   }
   
-  private int getMaxHeight(final String uri) {
+  protected int getMaxHeight(final String uri) {
       final Matcher matcher = maxHeightPattern.matcher(uri);
       return matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
   }
   
-  private int getMaxWidth(final String uri) {
+  protected int getMaxWidth(final String uri) {
       final Matcher matcher = maxWidthPattern.matcher(uri);
       return matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
   }
   
-  private int getMinHeight(final String uri) {
+  protected int getMinHeight(final String uri) {
       final Matcher matcher = minHeightPattern.matcher(uri);
       return matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
   }
   
-  private int getMinWidth(final String uri) {
+  protected int getMinWidth(final String uri) {
       final Matcher matcher = minWidthPattern.matcher(uri);
       return matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
   }
   
-  private int getQuality (final String uri, final int defaultQuality) {
+  protected int getQuality (final String uri, final int defaultQuality) {
 
     int quality = 0;
 
@@ -316,7 +316,7 @@ public class ShortyServlet extends HttpServlet {
     final boolean  jpeg    = lowerUri.contains(JPEG);
     final boolean  jpegp   = jpeg && lowerUri.contains(JPEGP);
     final boolean  webp    = lowerUri.contains(WEBP);
-    final boolean  isImage = (webp || jpeg) && (width+height+maxWidth+maxHeight +minHeight+minWidth> 0 || quality>0 || cropHeight>0 || cropWidth>0);
+    final boolean  isImage = webp || jpeg || width+height+maxWidth+maxHeight +minHeight+minWidth> 0 || quality>0 || cropHeight>0 || cropWidth>0;
     final ShortyId shorty  = shortOpt.get();
     final String   path    = isImage? "/contentAsset/image" : "/contentAsset/raw-data";
     final User systemUser  = APILocator.systemUser();

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
@@ -316,7 +316,7 @@ public class ShortyServlet extends HttpServlet {
     final boolean  jpeg    = lowerUri.contains(JPEG);
     final boolean  jpegp   = jpeg && lowerUri.contains(JPEGP);
     final boolean  webp    = lowerUri.contains(WEBP);
-    final boolean  isImage = webp || jpeg || width+height+maxWidth+maxHeight +minHeight+minWidth> 0 || quality>0 || cropHeight>0 || cropWidth>0;
+    final boolean  isImage = (webp || jpeg) && (width+height+maxWidth+maxHeight +minHeight+minWidth> 0 || quality>0 || cropHeight>0 || cropWidth>0);
     final ShortyId shorty  = shortOpt.get();
     final String   path    = isImage? "/contentAsset/image" : "/contentAsset/raw-data";
     final User systemUser  = APILocator.systemUser();


### PR DESCRIPTION
Modified the regex. If a file has some name that could match the previous pattern (1q, 300w, etc) now it won't match as it is the name and not a filter.  

This PR fixes: #29321