### PR TITLE
fix(seo) fix misalignment list at Read More section

### DIFF
--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-results-seo-tool/dot-results-seo-tool.component.scss
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-results-seo-tool/dot-results-seo-tool.component.scss
@@ -164,7 +164,6 @@
         span {
             display: flex;
             align-items: center;
-            padding-left: $spacing-0;
         }
     }
 


### PR DESCRIPTION
### Proposed Changes
* fix the misalignment list in the `Read More` section

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original        
![image](https://github.com/user-attachments/assets/0cb76eb8-8e43-4070-b109-9d5fbb77bfd1)


Updated
![Screenshot 2024-08-02 at 1 02 45 PM](https://github.com/user-attachments/assets/65747612-b21a-4580-9e44-eaa59c053d17)

This PR fixes: #26497