### PR TITLE
Issue 29293 cannot change folder url to uppercase

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -628,7 +628,7 @@ public class FolderAPIImpl implements FolderAPI  {
 
 		final boolean isNew = folder.getInode() == null;
 		//if the folder was renamed, we will need to create a new identifier
-		if (!folder.getName().equals(existingID.getAssetName())){
+		if (!folder.getName().equalsIgnoreCase(existingID.getAssetName())){
 			folderFactory.renameFolder(folder, folder.getName(), user, respectFrontEndPermissions);
 		} else{
 			folder.setModDate(new Date());

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderAPITest.java
@@ -1781,4 +1781,29 @@ public class FolderAPITest extends IntegrationTestBase {//24 contentlets
 		return htmlPage;
 	}
 
+	/**
+	 * Method to test
+	 * {@link FolderAPI#save(Folder, String, User, boolean)}
+	 * Given scenario: Create a folder, then change its name for the same name but in uppercase
+	 * Expected result: The folder name should be saved in uppercase without any exception
+	 */
+	@Test
+	public void testSave_Same_Name_UpperCase()
+			throws DotDataException, DotSecurityException {
+		Identifier newIdentifier=null;
+		try {
+			final Folder existingFolder = new FolderDataGen().name("test").next();
+			newIdentifier = identifierAPI.createNew(existingFolder, host);
+			existingFolder.setIdentifier(newIdentifier.getId());
+			folderAPI.save(existingFolder, APILocator.systemUser(), false);
+			existingFolder.setName("TEST");
+			folderAPI.save(existingFolder, APILocator.systemUser(), false);
+			final Folder checkFolder = folderAPI.findFolderByPath(StringPool.SLASH + existingFolder.getName(), host, user, false);
+			assertEquals("TEST", checkFolder.getName());
+		} finally {
+			if (newIdentifier!=null)
+				identifierAPI.delete(newIdentifier);
+		}
+	}
+
 }


### PR DESCRIPTION
When renaming a folder an insert statement was being executed to update the folder. But when the name is the same (lowercase or uppercase) that insert was throwing a _duplicate key value violates unique constraint "idx_ident_uniq_asset_name"_ 

Now the validation to check if it is renamed or not is _equalsIgnoreCase_ so in these cases the name will be considered as the same, and update the folder in a correct way.

This PR fixes: #29293