### PR TITLE
Issue 28779 exception ss portlet

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/sitesearch/ESSiteSearchAPI.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/sitesearch/ESSiteSearchAPI.java
@@ -162,7 +162,9 @@ public class ESSiteSearchAPI implements SiteSearchAPI{
                 if (defaultIndice != null && !defaultIndice.isEmpty() && !list.isEmpty() ){
                     final int index = list.indexOf(defaultIndice);
                     //change the element defaultIndex to the first position of the arraylist if it is not yet
-                    if (index != 0) {
+                    if(index < 0){
+                        Logger.warn(this.getClass(), String.format("The default site search '%s' index was not found in the list of indices.", defaultIndice));
+                    } else {
                         list.remove(index);
                         list.add(indexPosition, defaultIndice);
                     }

--- a/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ESSiteSearchAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ESSiteSearchAPITest.java
@@ -194,6 +194,38 @@ public class ESSiteSearchAPITest {
         assertEquals(defIndex, indices.get(0));
     }
 
+    /**
+     * Method to test: {@link SiteSearchAPI#listIndices()}
+     * Given Scenario: Create a few SiteSearch, set one as default, delete it, Attempt to load the list.
+     * ExpectedResult: The list should load fine, a WARN message should be logged regarding Default Index not found.
+     */
+    @Test
+    public void test_listIndices_defaultIndexNotExist() throws IOException, DotDataException {
+        String timeStamp, indexName, aliasName;
+        String defIndex = "";
+
+        final int indicesAmount = 3;
+        for (int i = 0; i < indicesAmount; i++) {
+            timeStamp = String.valueOf(new Date().getTime());
+            indexName = ES_SITE_SEARCH_NAME + "_" + timeStamp;
+            aliasName = "indexAlias" + "_" + timeStamp;
+
+            siteSearchAPI.createSiteSearchIndex(indexName, aliasName, 1);
+
+            if (i == 2){
+                //sets as default
+                siteSearchAPI.activateIndex(indexName);
+                defIndex = indexName;
+            }
+        }
+
+        //delete the default index
+        indexAPI.delete(defIndex);
+
+        //get the list of indices (previously was throwing an IndexOutOfBoundsException)
+        siteSearchAPI.listIndices();
+    }
+
 
     /**
      * Method to test: {@link SiteSearchAPI#deleteOldSiteSearchIndices()}


### PR DESCRIPTION
I understand the frustration of dealing with the SS portlet becoming unusable when the default index is removed. I'm glad to share that with this change, even if the index does not exist, a warning will be logged and the portlet will render successfully. This means you'll be able to set another SS index as the default one without any issues.

A test was added.

This PR fixes: #28779