### PR TITLE
chore(uve): fix reset contentletArea when scrolling #28947

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.spec.ts
@@ -1356,6 +1356,13 @@ describe('UVEStore', () => {
 
                     expect(store.state()).toEqual(EDITOR_STATE.OUT_OF_BOUNDS);
                 });
+                it('should set the contentletArea to null when we are scrolling', () => {
+                    store.setEditorState(EDITOR_STATE.SCROLLING);
+
+                    store.updateEditorScrollState();
+
+                    expect(store.contentletArea()).toBe(null);
+                });
             });
 
             describe('updateEditorOnScrollEnd', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -187,7 +187,8 @@ export function withEditor() {
                     }
 
                     patchState(store, {
-                        state: store.dragItem() ? EDITOR_STATE.SCROLL_DRAG : EDITOR_STATE.SCROLLING
+                        state: store.dragItem() ? EDITOR_STATE.SCROLL_DRAG : EDITOR_STATE.SCROLLING,
+                        contentletArea: null
                     });
                 },
                 updateEditorOnScrollEnd() {


### PR DESCRIPTION
### Proposed Changes
* Set contentletArea  to null when scrolling

### Screenshots
Before:

https://github.com/user-attachments/assets/11052d73-5e7d-4111-9c76-364a74674ba9

After:

https://github.com/user-attachments/assets/b9e32b87-1b85-4b8e-bc6a-5edd381a60f0

This PR fixes: https://github.com/dotCMS/core/issues/28947