### PR TITLE
fix(gd): Visibility of delete button on content types portlet in community edition #29473

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.spec.ts
@@ -288,7 +288,7 @@ describe('DotContentTypesPortletComponent', () => {
         ).toEqual([
             {
                 label: 'Delete',
-                icon: 'delete'
+                icon: 'pi pi-trash'
             }
         ]);
     });

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.ts
@@ -174,7 +174,7 @@ export class DotContentTypesPortletComponent implements OnInit, OnDestroy {
                 menuItem: {
                     label: this.dotMessageService.get('contenttypes.action.delete'),
                     command: (item) => this.removeConfirmation(item),
-                    icon: 'delete'
+                    icon: 'pi pi-trash'
                 },
                 shouldShow: (item) => !item.fixed && !item.defaultType
             }
@@ -245,6 +245,7 @@ export class DotContentTypesPortletComponent implements OnInit, OnDestroy {
 
         return actions;
     }
+    f;
 
     private removeIconsFromMenuItem(action: DotActionMenuItem): DotActionMenuItem {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.ts
@@ -245,7 +245,6 @@ export class DotContentTypesPortletComponent implements OnInit, OnDestroy {
 
         return actions;
     }
-    f;
 
     private removeIconsFromMenuItem(action: DotActionMenuItem): DotActionMenuItem {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
### Proposed Changes
* Change Icon to work with PrimeNG Icons

### Screenshots


https://github.com/user-attachments/assets/fca825c7-84a9-46b1-9cbe-b7f8822e43cd


This PR fixes: #29473