### PR TITLE
fix (GraphQL) Remove duplicated fields in Schema

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLFieldsProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/ContentAPIGraphQLFieldsProvider.java
@@ -49,7 +49,6 @@ enum ContentAPIGraphQLFieldsProvider implements GraphQLFieldsProvider {
 
             Logger.debug(this, ()-> "Creating collection field for type: " + type.variable());
             fieldDefinitions.add(createCollectionField(type, TypeUtil.collectionizedName(type.variable())));
-            fieldDefinitions.add(createCollectionField(type, TypeUtil.oldCollectionizedName(type.variable())));
         });
 
         // Each BaseType as query'able collection field

--- a/dotCMS/src/main/java/com/dotcms/graphql/util/TypeUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/util/TypeUtil.java
@@ -1,22 +1,16 @@
 package com.dotcms.graphql.util;
 
-import com.dotcms.graphql.InterfaceType;
-import com.dotcms.graphql.datafetcher.FieldDataFetcher;
+import static graphql.Scalars.GraphQLBoolean;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 
-import com.dotcms.util.DotPreconditions;
+import com.dotcms.graphql.datafetcher.FieldDataFetcher;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import graphql.GraphQLException;
+import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldDefinition.Builder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNamedSchemaElement;
@@ -25,12 +19,12 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLType;
 import graphql.schema.PropertyDataFetcher;
 import graphql.schema.TypeResolver;
-import java.util.Map.Entry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
-import org.jetbrains.annotations.NotNull;
-
-import static graphql.Scalars.GraphQLBoolean;
-import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 
 public class TypeUtil {
 
@@ -133,10 +127,6 @@ public class TypeUtil {
 
     public static String collectionizedName(final String typeName) {
         return typeName + "Collection";
-    }
-
-    public static String oldCollectionizedName(final String typeName) {
-        return typeName.substring(0, 1).toLowerCase() + typeName.substring(1) + "Collection";
     }
 
     public static String singularizeCollectionName(final String collectionName) {

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/business/GraphqlAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/business/GraphqlAPITest.java
@@ -89,6 +89,7 @@ import graphql.schema.GraphQLSchema;
 import io.vavr.Tuple2;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.function.BiFunction;
@@ -533,6 +534,29 @@ public class GraphqlAPITest extends IntegrationTestBase {
         }
     }
 
+    /**
+     * Given Scenario: Generate a graphQL Schema and validate the field definitions.
+     * <p>
+     * ExpectedResult: Field definitions are not duplicated.
+     */
+    @Test
+    public void testGetSchema_Validate_No_Duplicated_Fields() throws DotDataException {
+
+        final GraphqlAPI api = APILocator.getGraphqlAPI();
+
+        final GraphQLSchema schema = api.getSchema();
+        final var fieldDefinitions = schema.getQueryType().getFieldDefinitions();
+
+        var fieldNames = new HashSet<String>();
+        for (GraphQLFieldDefinition fieldDefinition : fieldDefinitions) {
+            assertFalse(
+                    String.format("Found duplicated field in graphQL Scheme [%s]",
+                            fieldDefinition.getName()),
+                    fieldNames.contains(fieldDefinition.getName().toLowerCase())
+            );
+            fieldNames.add(fieldDefinition.getName().toLowerCase());
+        }
+    }
 
     @UseDataProvider("fieldTestCases")
     @Test


### PR DESCRIPTION
This PR includes a fix to avoid duplicated field definitions in the graphQL Schema.

Refs: #29269

This PR fixes: #29269