### PR TITLE
 #29281: returning available models as object that includes 'name' and 'type' instead of just a list os strings

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIAppUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIAppUtil.java
@@ -1,6 +1,8 @@
 package com.dotcms.ai.app;
 
+import com.dotcms.security.apps.AppsUtil;
 import com.dotcms.security.apps.Secret;
+import com.dotmarketing.util.UtilMethods;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
@@ -139,6 +141,24 @@ public class AIAppUtil {
      */
     public boolean discoverBooleanSecret(final Map<String, Secret> secrets, final AppKeys key) {
         return Boolean.parseBoolean(discoverSecret(secrets, key));
+    }
+
+    /**
+     * Resolves a secret value from the provided secrets map using the specified key and environment variable.
+     * If the secret is not found in the secrets map, it attempts to discover the value from the environment variable.
+     *
+     * @param secrets the map of secrets
+     * @param key the key to look up the secret
+     * @param envVar the environment variable name to look up if the secret is not found in the secrets map
+     * @return the resolved secret value or the value from the environment variable if the secret is not found
+     */
+    public String discoverEnvSecret(final Map<String, Secret> secrets, final AppKeys key, final String envVar) {
+        final String secret = discoverSecret(secrets, key);
+        if (UtilMethods.isSet(secret)) {
+            return secret;
+        }
+
+        return AppsUtil.discoverEnvVarValue(AppKeys.APP_KEY, key.key, envVar);
     }
 
     private int toInt(final String value) {

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIModel.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIModel.java
@@ -113,11 +113,14 @@ public class AIModel {
     @Override
     public String toString() {
         return "AIModel{" +
-                "name='" + names + '\'' +
+                "type=" + type +
+                ", names=" + names +
                 ", tokensPerMinute=" + tokensPerMinute +
                 ", apiPerMinute=" + apiPerMinute +
                 ", maxTokens=" + maxTokens +
                 ", isCompletion=" + isCompletion +
+                ", current=" + current +
+                ", decommissioned=" + decommissioned +
                 '}';
     }
 

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIModels.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIModels.java
@@ -2,6 +2,7 @@ package com.dotcms.ai.app;
 
 import com.dotcms.ai.model.OpenAIModel;
 import com.dotcms.ai.model.OpenAIModels;
+import com.dotcms.ai.model.SimpleModel;
 import com.dotcms.http.CircuitBreakerUrl;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
@@ -15,7 +16,7 @@ import io.vavr.control.Try;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.time.Duration;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -177,18 +178,23 @@ public class AIModels {
      *
      * @return a list of available model names
      */
-    public List<String> getAvailableModels() {
-        final Set<String> configured = internalModels.entrySet().stream().flatMap(entry -> entry.getValue().stream())
+    public List<SimpleModel> getAvailableModels() {
+        final Set<SimpleModel> configured = internalModels.entrySet()
+                .stream()
+                .flatMap(entry -> entry.getValue().stream())
                 .map(Tuple2::_2)
-                .flatMap(model -> model.getNames().stream())
+                .flatMap(model -> model.getNames().stream().map(name -> new SimpleModel(name, model.getType())))
                 .collect(Collectors.toSet());
-        final Set<String> supported = new HashSet<>(getOrPullSupportedModels());
+        final Set<SimpleModel> supported = getOrPullSupportedModels()
+                .stream()
+                .map(SimpleModel::new)
+                .collect(Collectors.toSet());
         configured.retainAll(supported);
-        return configured.stream().sorted().collect(Collectors.toList());
+
+        return new ArrayList<>(configured);
     }
 
     private static CircuitBreakerUrl.Response<OpenAIModels> fetchOpenAIModels(final AppConfig appConfig) {
-
         final CircuitBreakerUrl.Response<OpenAIModels> response = CircuitBreakerUrl.builder()
                 .setMethod(CircuitBreakerUrl.Method.GET)
                 .setUrl(OPEN_AI_MODELS_URL)

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The AppConfig class provides a configuration for the AI application.
@@ -294,8 +295,13 @@ public class AppConfig implements Serializable {
         }
     }
 
+    /**
+     * Checks if the configuration is enabled.
+     *
+     * @return true if the configuration is enabled, false otherwise
+     */
     public boolean isEnabled() {
-        return StringUtils.isNotBlank(apiKey);
+        return Stream.of(apiUrl, apiImageUrl, apiEmbeddingsUrl, apiKey).allMatch(StringUtils::isNotBlank);
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
@@ -4,12 +4,16 @@ import com.dotcms.security.apps.Secret;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
+import com.liferay.util.StringPool;
 import io.vavr.control.Try;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -25,8 +29,10 @@ public class AppConfig implements Serializable {
     private static final String AI_API_URL_KEY = "AI_API_URL";
     private static final String AI_IMAGE_API_URL_KEY = "AI_IMAGE_API_URL";
     private static final String AI_EMBEDDINGS_API_URL_KEY = "AI_EMBEDDINGS_API_URL";
-
+    private static final String SYSTEM_HOST = "System Host";
     public static final Pattern SPLITTER = Pattern.compile("\\s?,\\s?");
+
+    private static final AtomicReference<AppConfig> SYSTEM_HOST_CONFIG = new AtomicReference<>();
 
     private final String host;
     private final String apiKey;
@@ -45,6 +51,9 @@ public class AppConfig implements Serializable {
 
     public AppConfig(final String host, final Map<String, Secret> secrets) {
         this.host = host;
+        if (SYSTEM_HOST.equalsIgnoreCase(host)) {
+            setSystemHostConfig(this);
+        }
 
         final AIAppUtil aiAppUtil = AIAppUtil.get();
         apiKey = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_KEY, AI_API_KEY_KEY);
@@ -73,18 +82,36 @@ public class AppConfig implements Serializable {
 
         configValues = secrets.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        Logger.debug(getClass(), () -> "apiKey: " + apiKey);
-        Logger.debug(getClass(), () -> "apiUrl: " + apiUrl);
-        Logger.debug(getClass(), () -> "apiImageUrl: " + apiImageUrl);
-        Logger.debug(getClass(), () -> "embeddingsUrl: " + apiEmbeddingsUrl);
-        Logger.debug(getClass(), () -> "rolePrompt: " + rolePrompt);
-        Logger.debug(getClass(), () -> "textPrompt: " + textPrompt);
-        Logger.debug(getClass(), () -> "model: " + model);
-        Logger.debug(getClass(), () -> "imagePrompt: " + imagePrompt);
-        Logger.debug(getClass(), () -> "imageModel: " + imageModel);
-        Logger.debug(getClass(), () -> "imageSize: " + imageSize);
-        Logger.debug(getClass(), () -> "embeddingsModel: " + embeddingsModel);
-        Logger.debug(getClass(), () -> "listerIndexer: " + listenerIndexer);
+        Logger.debug(this, this::toString);
+    }
+
+    /**
+     * Retrieves the system host configuration.
+     *
+     * @return the system host configuration
+     */
+    public static AppConfig getSystemHostConfig() {
+        if (Objects.isNull(SYSTEM_HOST_CONFIG.get())) {
+            setSystemHostConfig(ConfigService.INSTANCE.config());
+        }
+        return SYSTEM_HOST_CONFIG.get();
+    }
+
+    /**
+     * Prints a specific error message to the log, based on the {@link AppKeys#DEBUG_LOGGING}
+     * property instead of the usual Log4j configuration.
+     *
+     * @param clazz   The {@link Class} to log the message for.
+     * @param message The {@link Supplier} with the message to log.
+     */
+    public static void debugLogger(final Class<?> clazz, final Supplier<String> message) {
+        if (getSystemHostConfig().getConfigBoolean(AppKeys.DEBUG_LOGGING)) {
+            Logger.info(clazz, message.get());
+        }
+    }
+
+    public static void setSystemHostConfig(final AppConfig systemHostConfig) {
+        AppConfig.SYSTEM_HOST_CONFIG.set(systemHostConfig);
     }
 
     /**
@@ -288,25 +315,31 @@ public class AppConfig implements Serializable {
     }
 
     /**
-     * Prints a specific error message to the log, based on the {@link AppKeys#DEBUG_LOGGING}
-     * property instead of the usual Log4j configuration.
-     *
-     * @param clazz   The {@link Class} to log the message for.
-     * @param message The {@link Supplier} with the message to log.
-     */
-    public static void debugLogger(final Class<?> clazz, final Supplier<String> message) {
-        if (ConfigService.INSTANCE.config().getConfigBoolean(AppKeys.DEBUG_LOGGING)) {
-            Logger.info(clazz, message.get());
-        }
-    }
-
-    /**
      * Checks if the configuration is enabled.
      *
      * @return true if the configuration is enabled, false otherwise
      */
     public boolean isEnabled() {
         return Stream.of(apiUrl, apiImageUrl, apiEmbeddingsUrl, apiKey).allMatch(StringUtils::isNotBlank);
+    }
+
+    @Override
+    public String toString() {
+        return "AppConfig{\n" +
+                "  host='" + host + "',\n" +
+                "  apiKey='" + Optional.ofNullable(apiKey).map(key -> "*****").orElse(StringPool.BLANK) + "',\n" +
+                "  model=" + model + "',\n" +
+                "  imageModel=" + imageModel + "',\n" +
+                "  embeddingsModel=" + embeddingsModel + "',\n" +
+                "  apiUrl='" + apiUrl + "',\n" +
+                "  apiImageUrl='" + apiImageUrl + "',\n" +
+                "  apiEmbeddingsUrl='" + apiEmbeddingsUrl + "',\n" +
+                "  rolePrompt='" + rolePrompt + "',\n" +
+                "  textPrompt='" + textPrompt + "',\n" +
+                "  imagePrompt='" + imagePrompt + "',\n" +
+                "  imageSize='" + imageSize + "',\n" +
+                "  listenerIndexer='" + listenerIndexer + "'\n" +
+                '}';
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
@@ -21,6 +21,11 @@ import java.util.stream.Stream;
  */
 public class AppConfig implements Serializable {
 
+    private static final String AI_API_KEY_KEY = "AI_API_KEY";
+    private static final String AI_API_URL_KEY = "AI_API_URL";
+    private static final String AI_IMAGE_API_URL_KEY = "AI_IMAGE_API_URL";
+    private static final String AI_EMBEDDINGS_API_URL_KEY = "AI_EMBEDDINGS_API_URL";
+
     public static final Pattern SPLITTER = Pattern.compile("\\s?,\\s?");
 
     private final String host;
@@ -42,10 +47,10 @@ public class AppConfig implements Serializable {
         this.host = host;
 
         final AIAppUtil aiAppUtil = AIAppUtil.get();
-        apiKey = aiAppUtil.discoverSecret(secrets, AppKeys.API_KEY);
-        apiUrl = aiAppUtil.discoverSecret(secrets, AppKeys.API_URL);
-        apiImageUrl = aiAppUtil.discoverSecret(secrets, AppKeys.API_IMAGE_URL);
-        apiEmbeddingsUrl = aiAppUtil.discoverSecret(secrets, AppKeys.API_EMBEDDINGS_URL);
+        apiKey = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_KEY, AI_API_KEY_KEY);
+        apiUrl = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_URL, AI_API_URL_KEY);
+        apiImageUrl = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_IMAGE_URL, AI_IMAGE_API_URL_KEY);
+        apiEmbeddingsUrl = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_EMBEDDINGS_URL, AI_EMBEDDINGS_API_URL_KEY);
 
         if (!secrets.isEmpty() || isEnabled()) {
             AIModels.get().loadModels(

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppKeys.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppKeys.java
@@ -2,10 +2,10 @@ package com.dotcms.ai.app;
 
 public enum AppKeys {
 
+    API_KEY("apiKey", null),
     API_URL("apiUrl", "https://api.openai.com/v1/chat/completions"),
     API_IMAGE_URL("apiImageUrl", "https://api.openai.com/v1/images/generations"),
     API_EMBEDDINGS_URL("apiEmbeddingsUrl", "https://api.openai.com/v1/embeddings"),
-    API_KEY("apiKey", null),
     ROLE_PROMPT(
             "rolePrompt",
             "You are dotCMSbot, and AI assistant to help content" +

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppKeys.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppKeys.java
@@ -1,5 +1,7 @@
 package com.dotcms.ai.app;
 
+import com.liferay.util.StringPool;
+
 public enum AppKeys {
 
     API_KEY("apiKey", null),
@@ -22,12 +24,12 @@ public enum AppKeys {
     IMAGE_MODEL_TOKENS_PER_MINUTE("imageModelTokensPerMinute", "0"),
     IMAGE_MODEL_API_PER_MINUTE("imageModelApiPerMinute", "50"),
     IMAGE_MODEL_MAX_TOKENS("imageModelMaxTokens", "0"),
-    IMAGE_MODEL_COMPLETION("imageModelCompletion",  AppKeys.FALSE),
+    IMAGE_MODEL_COMPLETION("imageModelCompletion",  StringPool.FALSE),
     EMBEDDINGS_MODEL_NAMES("embeddingsModelNames", null),
     EMBEDDINGS_MODEL_TOKENS_PER_MINUTE("embeddingsModelTokensPerMinute", "1000000"),
     EMBEDDINGS_MODEL_API_PER_MINUTE("embeddingsModelApiPerMinute", "3000"),
     EMBEDDINGS_MODEL_MAX_TOKENS("embeddingsModelMaxTokens", "8191"),
-    EMBEDDINGS_MODEL_COMPLETION("embeddingsModelCompletion",  AppKeys.FALSE),
+    EMBEDDINGS_MODEL_COMPLETION("embeddingsModelCompletion",  StringPool.FALSE),
     EMBEDDINGS_SPLIT_AT_TOKENS("com.dotcms.ai.embeddings.split.at.tokens", "512"),
     EMBEDDINGS_MINIMUM_TEXT_LENGTH_TO_INDEX("com.dotcms.ai.embeddings.minimum.text.length", "64"),
     EMBEDDINGS_MINIMUM_FILE_SIZE_TO_INDEX("com.dotcms.ai.embeddings.minimum.file.size", "1024"),
@@ -39,7 +41,7 @@ public enum AppKeys {
     EMBEDDINGS_CACHE_TTL_SECONDS("com.dotcms.ai.embeddings.cache.ttl.seconds", "600"),
     EMBEDDINGS_CACHE_SIZE("com.dotcms.ai.embeddings.cache.size", "1000"),
     EMBEDDINGS_DB_DELETE_OLD_ON_UPDATE("com.dotcms.ai.embeddings.delete.old.on.update", "true"),
-    DEBUG_LOGGING("com.dotcms.ai.debug.logging", AppKeys.FALSE),
+    DEBUG_LOGGING("com.dotcms.ai.debug.logging", StringPool.FALSE),
     COMPLETION_TEMPERATURE("com.dotcms.ai.completion.default.temperature", "1"),
     COMPLETION_ROLE_PROMPT(
             "com.dotcms.ai.completion.role.prompt",
@@ -51,8 +53,6 @@ public enum AppKeys {
     LISTENER_INDEXER("listenerIndexer", "{}"),
     AI_MODELS_CACHE_TTL("com.dotcms.ai.models.supported.ttl", "28800"),
     AI_MODELS_CACHE_SIZE("com.dotcms.ai.models.supported.size", "64");
-
-    private static final String FALSE = "false";
 
     public static final String APP_KEY = "dotAI";
 

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppKeys.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppKeys.java
@@ -22,12 +22,12 @@ public enum AppKeys {
     IMAGE_MODEL_TOKENS_PER_MINUTE("imageModelTokensPerMinute", "0"),
     IMAGE_MODEL_API_PER_MINUTE("imageModelApiPerMinute", "50"),
     IMAGE_MODEL_MAX_TOKENS("imageModelMaxTokens", "0"),
-    IMAGE_MODEL_COMPLETION("imageModelCompletion", "false"),
+    IMAGE_MODEL_COMPLETION("imageModelCompletion",  AppKeys.FALSE),
     EMBEDDINGS_MODEL_NAMES("embeddingsModelNames", null),
     EMBEDDINGS_MODEL_TOKENS_PER_MINUTE("embeddingsModelTokensPerMinute", "1000000"),
     EMBEDDINGS_MODEL_API_PER_MINUTE("embeddingsModelApiPerMinute", "3000"),
     EMBEDDINGS_MODEL_MAX_TOKENS("embeddingsModelMaxTokens", "8191"),
-    EMBEDDINGS_MODEL_COMPLETION("embeddingsModelCompletion", "false"),
+    EMBEDDINGS_MODEL_COMPLETION("embeddingsModelCompletion",  AppKeys.FALSE),
     EMBEDDINGS_SPLIT_AT_TOKENS("com.dotcms.ai.embeddings.split.at.tokens", "512"),
     EMBEDDINGS_MINIMUM_TEXT_LENGTH_TO_INDEX("com.dotcms.ai.embeddings.minimum.text.length", "64"),
     EMBEDDINGS_MINIMUM_FILE_SIZE_TO_INDEX("com.dotcms.ai.embeddings.minimum.file.size", "1024"),
@@ -39,7 +39,7 @@ public enum AppKeys {
     EMBEDDINGS_CACHE_TTL_SECONDS("com.dotcms.ai.embeddings.cache.ttl.seconds", "600"),
     EMBEDDINGS_CACHE_SIZE("com.dotcms.ai.embeddings.cache.size", "1000"),
     EMBEDDINGS_DB_DELETE_OLD_ON_UPDATE("com.dotcms.ai.embeddings.delete.old.on.update", "true"),
-    DEBUG_LOGGING("com.dotcms.ai.debug.logging", "false"),
+    DEBUG_LOGGING("com.dotcms.ai.debug.logging", AppKeys.FALSE),
     COMPLETION_TEMPERATURE("com.dotcms.ai.completion.default.temperature", "1"),
     COMPLETION_ROLE_PROMPT(
             "com.dotcms.ai.completion.role.prompt",
@@ -51,6 +51,8 @@ public enum AppKeys {
     LISTENER_INDEXER("listenerIndexer", "{}"),
     AI_MODELS_CACHE_TTL("com.dotcms.ai.models.supported.ttl", "28800"),
     AI_MODELS_CACHE_SIZE("com.dotcms.ai.models.supported.size", "64");
+
+    private static final String FALSE = "false";
 
     public static final String APP_KEY = "dotAI";
 

--- a/dotCMS/src/main/java/com/dotcms/ai/listener/EmbeddingContentListener.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/listener/EmbeddingContentListener.java
@@ -83,7 +83,10 @@ public class EmbeddingContentListener implements ContentletListener<Contentlet> 
 
         final AppConfig appConfig = ConfigService.INSTANCE.config(host);
         if (!appConfig.isEnabled()) {
-            throw new DotRuntimeException("No API urls or API key found in app config");
+            AppConfig.debugLogger(
+                    getClass(),
+                    () -> "dotAI is not enabled since no API urls or API key found in app config");
+            throw new DotRuntimeException("App dotAI config without API urls or API key");
         }
 
         return appConfig;

--- a/dotCMS/src/main/java/com/dotcms/ai/listener/EmbeddingContentListener.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/listener/EmbeddingContentListener.java
@@ -83,7 +83,7 @@ public class EmbeddingContentListener implements ContentletListener<Contentlet> 
 
         final AppConfig appConfig = ConfigService.INSTANCE.config(host);
         if (!appConfig.isEnabled()) {
-            throw new DotRuntimeException("No API key found in app config");
+            throw new DotRuntimeException("No API urls or API key found in app config");
         }
 
         return appConfig;

--- a/dotCMS/src/main/java/com/dotcms/ai/model/SimpleModel.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/model/SimpleModel.java
@@ -1,0 +1,53 @@
+package com.dotcms.ai.model;
+
+import com.dotcms.ai.app.AIModelType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Represents a simple model with a name and type.
+ * This class is immutable and uses Jackson annotations for JSON serialization and deserialization.
+ *
+ * @author vico
+ */
+public class SimpleModel implements Serializable {
+
+    private final String name;
+    private final AIModelType type;
+
+    @JsonCreator
+    public SimpleModel(@JsonProperty("name") final String name, @JsonProperty("type") final AIModelType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    @JsonCreator
+    public SimpleModel(@JsonProperty("name") final String name) {
+        this(name, null);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public AIModelType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SimpleModel that = (SimpleModel) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/ai/rest/CompletionsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/rest/CompletionsResource.java
@@ -5,6 +5,7 @@ import com.dotcms.ai.app.AIModels;
 import com.dotcms.ai.app.AppConfig;
 import com.dotcms.ai.app.AppKeys;
 import com.dotcms.ai.app.ConfigService;
+import com.dotcms.ai.model.SimpleModel;
 import com.dotcms.ai.rest.forms.CompletionsForm;
 import com.dotcms.ai.util.LineReadingOutputStream;
 import com.dotcms.rest.WebResource;
@@ -118,7 +119,7 @@ public class CompletionsResource {
         final String apiKey = UtilMethods.isSet(app.getApiKey()) ? "*****" : "NOT SET";
         map.put(AppKeys.API_KEY.key, apiKey);
 
-        final List<String> models = AIModels.get().getAvailableModels();
+        final List<SimpleModel> models = AIModels.get().getAvailableModels();
         map.put(AiKeys.AVAILABLE_MODELS, models);
 
         return Response.ok(map).build();

--- a/dotCMS/src/main/java/com/dotcms/ai/util/OpenAIRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/util/OpenAIRequest.java
@@ -54,8 +54,7 @@ public class OpenAIRequest {
                                  final OutputStream out) {
 
         if (!appConfig.isEnabled()) {
-            Logger.debug(OpenAIRequest.class, "OpenAI is not enabled and will not send request.");
-            return;
+            throw new DotRuntimeException("OpenAI is not enabled and will not send request.");
         }
 
         final AIModel model = appConfig.resolveModelOrThrow(json.optString(AiKeys.MODEL));

--- a/dotCMS/src/main/java/com/dotcms/ai/util/OpenAIRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/util/OpenAIRequest.java
@@ -52,18 +52,23 @@ public class OpenAIRequest {
                                  final AppConfig appConfig,
                                  final JSONObject json,
                                  final OutputStream out) {
+        AppConfig.debugLogger(
+                OpenAIRequest.class,
+                () -> String.format(
+                        "Posting to [%s] with method [%s]%s  with app config:%s%s  the payload: %s",
+                        urlIn,
+                        method,
+                        System.lineSeparator(),
+                        appConfig.toString(),
+                        System.lineSeparator(),
+                        json.toString(2)));
 
         if (!appConfig.isEnabled()) {
-            AppConfig.debugLogger(OpenAIRequest.class, () -> "dotAI is not enabled and will not send request.");
+            AppConfig.debugLogger(OpenAIRequest.class, () -> "App dotAI is not enabled and will not send request.");
             throw new DotRuntimeException("App dotAI config without API urls or API key");
         }
 
         final AIModel model = appConfig.resolveModelOrThrow(json.optString(AiKeys.MODEL));
-
-        if (appConfig.getConfigBoolean(AppKeys.DEBUG_LOGGING)) {
-            Logger.debug(OpenAIRequest.class, "posting: " + json);
-        }
-
         final long sleep = lastRestCall.computeIfAbsent(model, m -> 0L)
                 + model.minIntervalBetweenCalls()
                 - System.currentTimeMillis();

--- a/dotCMS/src/main/java/com/dotcms/ai/util/OpenAIRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/util/OpenAIRequest.java
@@ -54,7 +54,8 @@ public class OpenAIRequest {
                                  final OutputStream out) {
 
         if (!appConfig.isEnabled()) {
-            throw new DotRuntimeException("OpenAI is not enabled and will not send request.");
+            AppConfig.debugLogger(OpenAIRequest.class, () -> "dotAI is not enabled and will not send request.");
+            throw new DotRuntimeException("App dotAI config without API urls or API key");
         }
 
         final AIModel model = appConfig.resolveModelOrThrow(json.optString(AiKeys.MODEL));

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsUtil.java
@@ -676,7 +676,8 @@ public class AppsUtil {
     private static String discoverEnvVarValue(final Supplier<String> envVarSupplier, final String envVar) {
         return Optional
                 .ofNullable(envVarSupplier.get())
-                .map(discovered -> Config.getStringProperty(discovered, null))
+                .map(supplied -> Config.getStringProperty(supplied, null))
+                .or(() -> Optional.ofNullable(envVar).map(ev -> Config.getStringProperty(ev, null)))
                 .or(() -> Optional.ofNullable(envVar).map(System::getenv))
                 .orElse(null);
     }

--- a/dotCMS/src/main/java/com/liferay/util/StringPool.java
+++ b/dotCMS/src/main/java/com/liferay/util/StringPool.java
@@ -89,4 +89,6 @@ public class StringPool {
 
 	public static final String TRUE = Boolean.TRUE.toString();
 
+	public static final String FALSE = Boolean.FALSE.toString();
+
 }

--- a/dotCMS/src/main/resources/apps/dotAI.yml
+++ b/dotCMS/src/main/resources/apps/dotAI.yml
@@ -14,6 +14,13 @@ params:
     label: "API Key"
     hint: "Your ChatGPT API key"
     required: true
+  textModelNames:
+    value: ""
+    hidden: false
+    type: "STRING"
+    label: "Model Names"
+    hint: "Comma delimited list of models used to generate OpenAI API response (e.g. gpt-3.5-turbo-16k)"
+    required: true
   rolePrompt:
     value: "You are dotCMSbot, and AI assistant to help content creators generate and rewrite content in their content management system."
     hidden: false
@@ -28,13 +35,6 @@ params:
     label: "Text Prompt"
     hint: "A prompt describing writing style."
     required: false
-  textModelNames:
-    value: "gpt-3.5-turbo-16k"
-    hidden: false
-    type: "STRING"
-    label: "Model Names"
-    hint: "Comma delimited list of models used to generate OpenAI API response."
-    required: true
   textModelTokensPerMinute:
     value: "180000"
     hidden: false
@@ -63,6 +63,13 @@ params:
     label: "Completion model enabled"
     hint: "Enable completion model used to generate OpenAI API response."
     required: false
+  imageModelNames:
+    value: ""
+    hidden: false
+    type: "STRING"
+    label: "Image Model Names"
+    hint: "Comma delimited list of image models used to generate OpenAI API response(e.g. dall-e-3)."
+    required: true
   imagePrompt:
     value: "Use 16:9 aspect ratio."
     hidden: false
@@ -96,13 +103,6 @@ params:
         value: "1920x1080"
       - label: "256x256 (Small Square 1:1)"
         value: "256x256"
-  imageModelNames:
-    value: "dall-e-3"
-    hidden: false
-    type: "STRING"
-    label: "Image Model Names"
-    hint: "Comma delimited list of image models used to generate OpenAI API response."
-    required: true
   imageModelTokensPerMinute:
     value: "0"
     hidden: false
@@ -132,11 +132,11 @@ params:
     hint: "Enable completion model used to generate OpenAI API response."
     required: false
   embeddingsModelNames:
-    value: "text-embedding-ada-002"
+    value: ""
     hidden: false
     type: "STRING"
     label: "Embeddings Model Names"
-    hint: "Comma delimited list of embeddings models used to generate OpenAI API response."
+    hint: "Comma delimited list of embeddings models used to generate OpenAI API response (e.g. text-embedding-ada-002)."
     required: true
   embeddingsModelTokensPerMinute:
     value: "1000000"

--- a/dotCMS/src/main/webapp/html/portlet/ext/dotai/dotai.js
+++ b/dotCMS/src/main/webapp/html/portlet/ext/dotai/dotai.js
@@ -131,10 +131,13 @@ const writeModelToDropdown = async () => {
     }
 
     for (i = 0; i < dotAiState.config.availableModels.length; i++) {
+        if (dotAiState.config.availableModels[i].type !== 'TEXT') {
+            continue;
+        }
 
         const newOption = document.createElement("option");
-        newOption.value = dotAiState.config.availableModels[i];
-        newOption.text = `${dotAiState.config.availableModels[i]}`
+        newOption.value = dotAiState.config.availableModels[i].name;
+        newOption.text = `${dotAiState.config.availableModels[i].name}`
         if (dotAiState.config.availableModels[i] === dotAiState.config.model) {
             newOption.selected = true;
             newOption.text = `${dotAiState.config.availableModels[i]} (default)`

--- a/dotCMS/src/test/java/com/dotcms/ai/app/AIAppUtilTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/app/AIAppUtilTest.java
@@ -162,4 +162,17 @@ public class AIAppUtilTest {
         assertTrue(model.getNames().contains("embeddingsmodel"));
     }
 
+    @Test
+    public void testDiscoverEnvSecret() {
+        // Mock the secret value in the secrets map
+        when(secrets.get("apiKey")).thenReturn(secret);
+        when(secret.getString()).thenReturn("secretValue");
+
+        // Call the method with the key and environment variable
+        String result = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_KEY, "ENV_API_KEY");
+
+        // Assert the expected outcome
+        assertEquals("secretValue", result);
+    }
+
 }

--- a/dotcms-integration/src/test/java/com/dotcms/ai/AiTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/ai/AiTest.java
@@ -78,4 +78,8 @@ public interface AiTest {
         return aiAppSecrets(wireMockServer, host, MODEL, IMAGE_MODEL, EMBEDDINGS_MODEL);
     }
 
+    static void removeSecrets(final Host host) throws DotDataException, DotSecurityException {
+        APILocator.getAppsAPI().removeSecretsForSite(host, APILocator.systemUser());
+    }
+
 }

--- a/dotcms-integration/src/test/resources/mappings/openai-models.json
+++ b/dotcms-integration/src/test/resources/mappings/openai-models.json
@@ -9,6 +9,36 @@
       "object": "list",
       "data": [
         {
+          "id": "text-model-1",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
+          "id": "text-model-2",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
+          "id": "image-model-3",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
+          "id": "image-model-4",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
+          "id": "embeddings-model-5",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
+          "id": "embeddings-model-6",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
           "id": "dall-e-3",
           "object": "model",
           "created": 1698785189,


### PR DESCRIPTION
Instead of a `List<String>` we now return a `List<SimpleModel>` which, for now, contains `name` and `type` so this information can be consumed by other components such as the UI.