### PR TITLE
Update legacy-release_sbom-generator.yaml

### DIFF
--- a/.github/workflows/legacy-release_sbom-generator.yaml
+++ b/.github/workflows/legacy-release_sbom-generator.yaml
@@ -16,12 +16,12 @@ jobs:
       contents: write  # Ensure write access to contents
 
     steps:
-      - name: Checkout core-test-results repository
+      - name: Checkout core repository
         uses: actions/checkout@v3
         with:
-          repository: dotCMS/core-test-results
+          repository: dotCMS/core
           token: ${{ secrets.GITHUB_TOKEN }}
-          path: core-test-results
+          path: core
 
       - name: Get dotCMS release version
         id: get_version
@@ -51,12 +51,12 @@ jobs:
 
       - name: Scan Docker Image with Syft
         run: |
-          pipx run anchore_syft dotcms/dotcms:${{ env.DOTCMS_VERSION }} -o cyclonedx-xml > core-test-results/sbom/cyclonedx.json
+          pipx run anchore_syft dotcms/dotcms:${{ env.DOTCMS_VERSION }} -o cyclonedx-xml > core/sbom/cyclonedx.json
 
       - name: Rename SBOM file with dotCMS version
         run: |
-          mkdir -p core-test-results/sbom
-          mv core-test-results/sbom/cyclonedx.json core-test-results/sbom/dotcms-${{ env.DOTCMS_VERSION }}.json
+          mkdir -p core/sbom
+          mv core/sbom/cyclonedx.json core/sbom/dotcms-${{ env.DOTCMS_VERSION }}.json
 
       - name: Configure Git
         run: |
@@ -65,7 +65,7 @@ jobs:
 
       - name: Commit and push results to core-test-results repository
         run: |
-          cd core-test-results
+          cd core
           git add sbom/dotcms-${{ env.DOTCMS_VERSION }}.json
           git commit -m "Add SBOM for dotCMS version ${{ env.DOTCMS_VERSION }}" || echo "No changes to commit"
           git push origin master


### PR DESCRIPTION
Changed the SBOM destination to core repo instead of Core-test-results as GITHUB_TOKEN do not have permission to write on core-test-results
