### PR TITLE
 #29281: Several dotAI enhancements

### DIFF
--- a/.github/workflows/cicd_comp_test-phase.yml
+++ b/.github/workflows/cicd_comp_test-phase.yml
@@ -157,7 +157,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        collection_group: [ 'category-content', 'container', 'experiment', 'graphql', 'page', 'pp', 'template', 'workflow', 'default-split', 'default' ]
+        collection_group: [ 'ai', 'category-content', 'container', 'experiment', 'graphql', 'page', 'pp', 'template', 'workflow', 'default-split', 'default' ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIAppUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIAppUtil.java
@@ -1,6 +1,8 @@
 package com.dotcms.ai.app;
 
+import com.dotcms.security.apps.AppsUtil;
 import com.dotcms.security.apps.Secret;
+import com.dotmarketing.util.UtilMethods;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
@@ -139,6 +141,24 @@ public class AIAppUtil {
      */
     public boolean discoverBooleanSecret(final Map<String, Secret> secrets, final AppKeys key) {
         return Boolean.parseBoolean(discoverSecret(secrets, key));
+    }
+
+    /**
+     * Resolves a secret value from the provided secrets map using the specified key and environment variable.
+     * If the secret is not found in the secrets map, it attempts to discover the value from the environment variable.
+     *
+     * @param secrets the map of secrets
+     * @param key the key to look up the secret
+     * @param envVar the environment variable name to look up if the secret is not found in the secrets map
+     * @return the resolved secret value or the value from the environment variable if the secret is not found
+     */
+    public String discoverEnvSecret(final Map<String, Secret> secrets, final AppKeys key, final String envVar) {
+        return Optional
+                .ofNullable(AppsUtil.discoverEnvVarValue(AppKeys.APP_KEY, key.key, envVar))
+                .orElseGet(() -> {
+                    final String secret = discoverSecret(secrets, key);
+                    return UtilMethods.isSet(secret) ? secret : null;
+                });
     }
 
     private int toInt(final String value) {

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIModel.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIModel.java
@@ -103,6 +103,7 @@ public class AIModel {
             logInvalidModelMessage();
             return null;
         }
+
         return names.get(currentIndex);
     }
 
@@ -113,11 +114,14 @@ public class AIModel {
     @Override
     public String toString() {
         return "AIModel{" +
-                "name='" + names + '\'' +
+                "type=" + type +
+                ", names=" + names +
                 ", tokensPerMinute=" + tokensPerMinute +
                 ", apiPerMinute=" + apiPerMinute +
                 ", maxTokens=" + maxTokens +
                 ", isCompletion=" + isCompletion +
+                ", current=" + current +
+                ", decommissioned=" + decommissioned +
                 '}';
     }
 

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIModels.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIModels.java
@@ -2,7 +2,9 @@ package com.dotcms.ai.app;
 
 import com.dotcms.ai.model.OpenAIModel;
 import com.dotcms.ai.model.OpenAIModels;
+import com.dotcms.ai.model.SimpleModel;
 import com.dotcms.http.CircuitBreakerUrl;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.github.benmanes.caffeine.cache.Cache;
@@ -11,12 +13,12 @@ import com.google.common.annotations.VisibleForTesting;
 import io.vavr.Lazy;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
-import io.vavr.control.Try;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.time.Duration;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,15 +41,16 @@ public class AIModels {
     private static final String AI_MODELS_FETCH_TIMEOUT_KEY = "ai.models.fetch.timeout";
     private static final int AI_MODELS_FETCH_TIMEOUT = Config.getIntProperty(AI_MODELS_FETCH_TIMEOUT_KEY, 4000);
     private static final Lazy<AIModels> INSTANCE = Lazy.of(AIModels::new);
-    private static final String OPEN_AI_MODELS_URL = Config.getStringProperty(
-            "OPEN_AI_MODELS_URL",
+    private static final String AI_MODELS_API_URL_KEY = "DOT_AI_MODELS_API_URL";
+    private static final String AI_MODELS_API_URL = Config.getStringProperty(
+            AI_MODELS_API_URL_KEY,
             "https://api.openai.com/v1/models");
     private static final int AI_MODELS_CACHE_TTL = 28800;  // 8 hours
     private static final int AI_MODELS_CACHE_SIZE = 128;
 
     private final ConcurrentMap<String, List<Tuple2<AIModelType, AIModel>>> internalModels = new ConcurrentHashMap<>();
     private final ConcurrentMap<Tuple2<String, String>, AIModel> modelsByName = new ConcurrentHashMap<>();
-    private final Cache<String, List<String>> supportedModelsCache =
+    private final Cache<String, Set<String>> supportedModelsCache =
             Caffeine.newBuilder()
                     .expireAfterWrite(Duration.ofSeconds(AI_MODELS_CACHE_TTL))
                     .maximumSize(AI_MODELS_CACHE_SIZE)
@@ -105,7 +108,11 @@ public class AIModels {
      * @return an Optional containing the found AIModel, or an empty Optional if not found
      */
     public Optional<AIModel> findModel(final String host, final String modelName) {
-        return Optional.ofNullable(modelsByName.get(Tuple.of(host, modelName.toLowerCase())));
+        final String lowered = modelName.toLowerCase();
+        final Set<String> supported = getOrPullSupportedModels();
+        return supported.contains(lowered)
+                ? Optional.ofNullable(modelsByName.get(Tuple.of(host, lowered)))
+                : Optional.empty();
     }
 
     /**
@@ -144,29 +151,32 @@ public class AIModels {
      * Retrieves the list of supported models, either from the cache or by fetching them
      * from an external source if the cache is empty or expired.
      *
-     * @return a list of supported model names
+     * @return a set of supported model names
      */
-    public List<String> getOrPullSupportedModels() {
-        final List<String> cached = supportedModelsCache.getIfPresent(SUPPORTED_MODELS_KEY);
+    public Set<String> getOrPullSupportedModels() {
+        final Set<String> cached = supportedModelsCache.getIfPresent(SUPPORTED_MODELS_KEY);
         if (CollectionUtils.isNotEmpty(cached)) {
             return cached;
         }
 
         final AppConfig appConfig = appConfigSupplier.get();
         if (!appConfig.isEnabled()) {
-            Logger.debug(this, "OpenAI is not enabled, returning empty list of supported models");
-            return List.of();
+            AppConfig.debugLogger(getClass(), () -> "dotAI is not enabled, returning empty list of supported models");
+            throw new DotRuntimeException("App dotAI config without API urls or API key");
         }
 
-        final List<String> supported = Try.of(() ->
-                        fetchOpenAIModels(appConfig)
-                                .getResponse()
-                                .getData()
-                                .stream()
-                                .map(OpenAIModel::getId)
-                                .map(String::toLowerCase)
-                                .collect(Collectors.toList()))
-                .getOrElse(Optional.ofNullable(cached).orElse(List.of()));
+        final CircuitBreakerUrl.Response<OpenAIModels> response = fetchOpenAIModels(appConfig);
+        if (Objects.nonNull(response.getResponse().getError())) {
+            throw new DotRuntimeException("Found error in AI response: " + response.getResponse().getError().getMessage());
+        }
+
+        final Set<String> supported = response
+                .getResponse()
+                .getData()
+                .stream()
+                .map(OpenAIModel::getId)
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
         supportedModelsCache.put(SUPPORTED_MODELS_KEY, supported);
 
         return supported;
@@ -177,25 +187,30 @@ public class AIModels {
      *
      * @return a list of available model names
      */
-    public List<String> getAvailableModels() {
-        final Set<String> configured = internalModels.entrySet().stream().flatMap(entry -> entry.getValue().stream())
+    public List<SimpleModel> getAvailableModels() {
+        final Set<SimpleModel> configured = internalModels.entrySet()
+                .stream()
+                .flatMap(entry -> entry.getValue().stream())
                 .map(Tuple2::_2)
-                .flatMap(model -> model.getNames().stream())
+                .flatMap(model -> model.getNames().stream().map(name -> new SimpleModel(name, model.getType())))
                 .collect(Collectors.toSet());
-        final Set<String> supported = new HashSet<>(getOrPullSupportedModels());
+        final Set<SimpleModel> supported = getOrPullSupportedModels()
+                .stream()
+                .map(SimpleModel::new)
+                .collect(Collectors.toSet());
         configured.retainAll(supported);
-        return configured.stream().sorted().collect(Collectors.toList());
+
+        return new ArrayList<>(configured);
     }
 
     private static CircuitBreakerUrl.Response<OpenAIModels> fetchOpenAIModels(final AppConfig appConfig) {
-
         final CircuitBreakerUrl.Response<OpenAIModels> response = CircuitBreakerUrl.builder()
                 .setMethod(CircuitBreakerUrl.Method.GET)
-                .setUrl(OPEN_AI_MODELS_URL)
+                .setUrl(AI_MODELS_API_URL)
                 .setTimeout(AI_MODELS_FETCH_TIMEOUT)
                 .setTryAgainAttempts(AI_MODELS_FETCH_ATTEMPTS)
                 .setHeaders(CircuitBreakerUrl.authHeaders("Bearer " + appConfig.getApiKey()))
-                .setThrowWhenNot2xx(false)
+                .setThrowWhenNot2xx(true)
                 .build()
                 .doResponse(OpenAIModels.class);
 
@@ -204,8 +219,9 @@ public class AIModels {
                     AIModels.class,
                     String.format(
                             "Error fetching OpenAI supported models from [%s] (status code: [%d])",
-                            OPEN_AI_MODELS_URL,
+                            AI_MODELS_API_URL,
                             response.getStatusCode()));
+            throw new DotRuntimeException("Error fetching OpenAI supported models");
         }
 
         return response;

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
@@ -2,23 +2,37 @@ package com.dotcms.ai.app;
 
 import com.dotcms.security.apps.Secret;
 import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
+import com.liferay.util.StringPool;
 import io.vavr.control.Try;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The AppConfig class provides a configuration for the AI application.
  * It includes methods for retrieving configuration values based on given keys.
  */
 public class AppConfig implements Serializable {
+
+    private static final String AI_API_URL_KEY = "AI_API_URL";
+    private static final String AI_IMAGE_API_URL_KEY = "AI_IMAGE_API_URL";
+    private static final String AI_EMBEDDINGS_API_URL_KEY = "AI_EMBEDDINGS_API_URL";
+    private static final String AI_DEBUG_LOGGER_KEY = "AI_DEBUG_LOGGER";
+    private static final String SYSTEM_HOST = "System Host";
+    private static final AtomicReference<AppConfig> SYSTEM_HOST_CONFIG = new AtomicReference<>();
+    private static final boolean DEBUG_LOGGING = Config.getBooleanProperty(AI_DEBUG_LOGGER_KEY, false);
 
     public static final Pattern SPLITTER = Pattern.compile("\\s?,\\s?");
 
@@ -39,12 +53,15 @@ public class AppConfig implements Serializable {
 
     public AppConfig(final String host, final Map<String, Secret> secrets) {
         this.host = host;
+        if (SYSTEM_HOST.equalsIgnoreCase(host)) {
+            setSystemHostConfig(this);
+        }
 
         final AIAppUtil aiAppUtil = AIAppUtil.get();
         apiKey = aiAppUtil.discoverSecret(secrets, AppKeys.API_KEY);
-        apiUrl = aiAppUtil.discoverSecret(secrets, AppKeys.API_URL);
-        apiImageUrl = aiAppUtil.discoverSecret(secrets, AppKeys.API_IMAGE_URL);
-        apiEmbeddingsUrl = aiAppUtil.discoverSecret(secrets, AppKeys.API_EMBEDDINGS_URL);
+        apiUrl = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_URL, AI_API_URL_KEY);
+        apiImageUrl = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_IMAGE_URL, AI_IMAGE_API_URL_KEY);
+        apiEmbeddingsUrl = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_EMBEDDINGS_URL, AI_EMBEDDINGS_API_URL_KEY);
 
         if (!secrets.isEmpty() || isEnabled()) {
             AIModels.get().loadModels(
@@ -67,18 +84,36 @@ public class AppConfig implements Serializable {
 
         configValues = secrets.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        Logger.debug(getClass(), () -> "apiKey: " + apiKey);
-        Logger.debug(getClass(), () -> "apiUrl: " + apiUrl);
-        Logger.debug(getClass(), () -> "apiImageUrl: " + apiImageUrl);
-        Logger.debug(getClass(), () -> "embeddingsUrl: " + apiEmbeddingsUrl);
-        Logger.debug(getClass(), () -> "rolePrompt: " + rolePrompt);
-        Logger.debug(getClass(), () -> "textPrompt: " + textPrompt);
-        Logger.debug(getClass(), () -> "model: " + model);
-        Logger.debug(getClass(), () -> "imagePrompt: " + imagePrompt);
-        Logger.debug(getClass(), () -> "imageModel: " + imageModel);
-        Logger.debug(getClass(), () -> "imageSize: " + imageSize);
-        Logger.debug(getClass(), () -> "embeddingsModel: " + embeddingsModel);
-        Logger.debug(getClass(), () -> "listerIndexer: " + listenerIndexer);
+        Logger.debug(this, this::toString);
+    }
+
+    /**
+     * Retrieves the system host configuration.
+     *
+     * @return the system host configuration
+     */
+    public static AppConfig getSystemHostConfig() {
+        if (Objects.isNull(SYSTEM_HOST_CONFIG.get())) {
+            setSystemHostConfig(ConfigService.INSTANCE.config());
+        }
+        return SYSTEM_HOST_CONFIG.get();
+    }
+
+    /**
+     * Prints a specific error message to the log, based on the {@link AppKeys#DEBUG_LOGGING}
+     * property instead of the usual Log4j configuration.
+     *
+     * @param clazz   The {@link Class} to log the message for.
+     * @param message The {@link Supplier} with the message to log.
+     */
+    public static void debugLogger(final Class<?> clazz, final Supplier<String> message) {
+        if (getSystemHostConfig().getConfigBoolean(AppKeys.DEBUG_LOGGING) || DEBUG_LOGGING) {
+            Logger.info(clazz, message.get());
+        }
+    }
+
+    public static void setSystemHostConfig(final AppConfig systemHostConfig) {
+        AppConfig.SYSTEM_HOST_CONFIG.set(systemHostConfig);
     }
 
     /**
@@ -282,20 +317,31 @@ public class AppConfig implements Serializable {
     }
 
     /**
-     * Prints a specific error message to the log, based on the {@link AppKeys#DEBUG_LOGGING}
-     * property instead of the usual Log4j configuration.
+     * Checks if the configuration is enabled.
      *
-     * @param clazz   The {@link Class} to log the message for.
-     * @param message The {@link Supplier} with the message to log.
+     * @return true if the configuration is enabled, false otherwise
      */
-    public static void debugLogger(final Class<?> clazz, final Supplier<String> message) {
-        if (ConfigService.INSTANCE.config().getConfigBoolean(AppKeys.DEBUG_LOGGING)) {
-            Logger.info(clazz, message.get());
-        }
+    public boolean isEnabled() {
+        return Stream.of(apiUrl, apiImageUrl, apiEmbeddingsUrl, apiKey).allMatch(StringUtils::isNotBlank);
     }
 
-    public boolean isEnabled() {
-        return StringUtils.isNotBlank(apiKey);
+    @Override
+    public String toString() {
+        return "AppConfig{\n" +
+                "  host='" + host + "',\n" +
+                "  apiKey='" + Optional.ofNullable(apiKey).map(key -> "*****").orElse(StringPool.BLANK) + "',\n" +
+                "  model=" + model + "',\n" +
+                "  imageModel=" + imageModel + "',\n" +
+                "  embeddingsModel=" + embeddingsModel + "',\n" +
+                "  apiUrl='" + apiUrl + "',\n" +
+                "  apiImageUrl='" + apiImageUrl + "',\n" +
+                "  apiEmbeddingsUrl='" + apiEmbeddingsUrl + "',\n" +
+                "  rolePrompt='" + rolePrompt + "',\n" +
+                "  textPrompt='" + textPrompt + "',\n" +
+                "  imagePrompt='" + imagePrompt + "',\n" +
+                "  imageSize='" + imageSize + "',\n" +
+                "  listenerIndexer='" + listenerIndexer + "'\n" +
+                '}';
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppKeys.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppKeys.java
@@ -1,11 +1,13 @@
 package com.dotcms.ai.app;
 
+import com.liferay.util.StringPool;
+
 public enum AppKeys {
 
+    API_KEY("apiKey", null),
     API_URL("apiUrl", "https://api.openai.com/v1/chat/completions"),
     API_IMAGE_URL("apiImageUrl", "https://api.openai.com/v1/images/generations"),
     API_EMBEDDINGS_URL("apiEmbeddingsUrl", "https://api.openai.com/v1/embeddings"),
-    API_KEY("apiKey", null),
     ROLE_PROMPT(
             "rolePrompt",
             "You are dotCMSbot, and AI assistant to help content" +
@@ -22,12 +24,12 @@ public enum AppKeys {
     IMAGE_MODEL_TOKENS_PER_MINUTE("imageModelTokensPerMinute", "0"),
     IMAGE_MODEL_API_PER_MINUTE("imageModelApiPerMinute", "50"),
     IMAGE_MODEL_MAX_TOKENS("imageModelMaxTokens", "0"),
-    IMAGE_MODEL_COMPLETION("imageModelCompletion", "false"),
+    IMAGE_MODEL_COMPLETION("imageModelCompletion",  StringPool.FALSE),
     EMBEDDINGS_MODEL_NAMES("embeddingsModelNames", null),
     EMBEDDINGS_MODEL_TOKENS_PER_MINUTE("embeddingsModelTokensPerMinute", "1000000"),
     EMBEDDINGS_MODEL_API_PER_MINUTE("embeddingsModelApiPerMinute", "3000"),
     EMBEDDINGS_MODEL_MAX_TOKENS("embeddingsModelMaxTokens", "8191"),
-    EMBEDDINGS_MODEL_COMPLETION("embeddingsModelCompletion", "false"),
+    EMBEDDINGS_MODEL_COMPLETION("embeddingsModelCompletion",  StringPool.FALSE),
     EMBEDDINGS_SPLIT_AT_TOKENS("com.dotcms.ai.embeddings.split.at.tokens", "512"),
     EMBEDDINGS_MINIMUM_TEXT_LENGTH_TO_INDEX("com.dotcms.ai.embeddings.minimum.text.length", "64"),
     EMBEDDINGS_MINIMUM_FILE_SIZE_TO_INDEX("com.dotcms.ai.embeddings.minimum.file.size", "1024"),
@@ -39,7 +41,7 @@ public enum AppKeys {
     EMBEDDINGS_CACHE_TTL_SECONDS("com.dotcms.ai.embeddings.cache.ttl.seconds", "600"),
     EMBEDDINGS_CACHE_SIZE("com.dotcms.ai.embeddings.cache.size", "1000"),
     EMBEDDINGS_DB_DELETE_OLD_ON_UPDATE("com.dotcms.ai.embeddings.delete.old.on.update", "true"),
-    DEBUG_LOGGING("com.dotcms.ai.debug.logging", "false"),
+    DEBUG_LOGGING("com.dotcms.ai.debug.logging", StringPool.FALSE),
     COMPLETION_TEMPERATURE("com.dotcms.ai.completion.default.temperature", "1"),
     COMPLETION_ROLE_PROMPT(
             "com.dotcms.ai.completion.role.prompt",

--- a/dotCMS/src/main/java/com/dotcms/ai/listener/EmbeddingContentListener.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/listener/EmbeddingContentListener.java
@@ -83,7 +83,10 @@ public class EmbeddingContentListener implements ContentletListener<Contentlet> 
 
         final AppConfig appConfig = ConfigService.INSTANCE.config(host);
         if (!appConfig.isEnabled()) {
-            throw new DotRuntimeException("No API key found in app config");
+            AppConfig.debugLogger(
+                    getClass(),
+                    () -> "dotAI is not enabled since no API urls or API key found in app config");
+            throw new DotRuntimeException("App dotAI config without API urls or API key");
         }
 
         return appConfig;

--- a/dotCMS/src/main/java/com/dotcms/ai/model/SimpleModel.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/model/SimpleModel.java
@@ -1,0 +1,53 @@
+package com.dotcms.ai.model;
+
+import com.dotcms.ai.app.AIModelType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Represents a simple model with a name and type.
+ * This class is immutable and uses Jackson annotations for JSON serialization and deserialization.
+ *
+ * @author vico
+ */
+public class SimpleModel implements Serializable {
+
+    private final String name;
+    private final AIModelType type;
+
+    @JsonCreator
+    public SimpleModel(@JsonProperty("name") final String name, @JsonProperty("type") final AIModelType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    @JsonCreator
+    public SimpleModel(@JsonProperty("name") final String name) {
+        this(name, null);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public AIModelType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SimpleModel that = (SimpleModel) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/ai/rest/CompletionsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/rest/CompletionsResource.java
@@ -5,6 +5,7 @@ import com.dotcms.ai.app.AIModels;
 import com.dotcms.ai.app.AppConfig;
 import com.dotcms.ai.app.AppKeys;
 import com.dotcms.ai.app.ConfigService;
+import com.dotcms.ai.model.SimpleModel;
 import com.dotcms.ai.rest.forms.CompletionsForm;
 import com.dotcms.ai.util.LineReadingOutputStream;
 import com.dotcms.rest.WebResource;
@@ -118,7 +119,7 @@ public class CompletionsResource {
         final String apiKey = UtilMethods.isSet(app.getApiKey()) ? "*****" : "NOT SET";
         map.put(AppKeys.API_KEY.key, apiKey);
 
-        final List<String> models = AIModels.get().getAvailableModels();
+        final List<SimpleModel> models = AIModels.get().getAvailableModels();
         map.put(AiKeys.AVAILABLE_MODELS, models);
 
         return Response.ok(map).build();

--- a/dotCMS/src/main/java/com/dotcms/ai/util/OpenAIRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/util/OpenAIRequest.java
@@ -52,18 +52,23 @@ public class OpenAIRequest {
                                  final AppConfig appConfig,
                                  final JSONObject json,
                                  final OutputStream out) {
+        AppConfig.debugLogger(
+                OpenAIRequest.class,
+                () -> String.format(
+                        "Posting to [%s] with method [%s]%s  with app config:%s%s  the payload: %s",
+                        urlIn,
+                        method,
+                        System.lineSeparator(),
+                        appConfig.toString(),
+                        System.lineSeparator(),
+                        json.toString(2)));
 
         if (!appConfig.isEnabled()) {
-            Logger.debug(OpenAIRequest.class, "OpenAI is not enabled and will not send request.");
-            return;
+            AppConfig.debugLogger(OpenAIRequest.class, () -> "App dotAI is not enabled and will not send request.");
+            throw new DotRuntimeException("App dotAI config without API urls or API key");
         }
 
         final AIModel model = appConfig.resolveModelOrThrow(json.optString(AiKeys.MODEL));
-
-        if (appConfig.getConfigBoolean(AppKeys.DEBUG_LOGGING)) {
-            Logger.debug(OpenAIRequest.class, "posting: " + json);
-        }
-
         final long sleep = lastRestCall.computeIfAbsent(model, m -> 0L)
                 + model.minIntervalBetweenCalls()
                 - System.currentTimeMillis();

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsUtil.java
@@ -676,7 +676,8 @@ public class AppsUtil {
     private static String discoverEnvVarValue(final Supplier<String> envVarSupplier, final String envVar) {
         return Optional
                 .ofNullable(envVarSupplier.get())
-                .map(discovered -> Config.getStringProperty(discovered, null))
+                .map(supplied -> Config.getStringProperty(supplied, null))
+                .or(() -> Optional.ofNullable(envVar).map(ev -> Config.getStringProperty(ev, null)))
                 .or(() -> Optional.ofNullable(envVar).map(System::getenv))
                 .orElse(null);
     }

--- a/dotCMS/src/main/java/com/liferay/util/StringPool.java
+++ b/dotCMS/src/main/java/com/liferay/util/StringPool.java
@@ -89,4 +89,6 @@ public class StringPool {
 
 	public static final String TRUE = Boolean.TRUE.toString();
 
+	public static final String FALSE = Boolean.FALSE.toString();
+
 }

--- a/dotCMS/src/main/resources/apps/dotAI.yml
+++ b/dotCMS/src/main/resources/apps/dotAI.yml
@@ -15,7 +15,7 @@ params:
     hint: "Your ChatGPT API key"
     required: true
   textModelNames:
-    value: ""
+    value: "gpt-4o"
     hidden: false
     type: "STRING"
     label: "Model Names"
@@ -64,7 +64,7 @@ params:
     hint: "Enable completion model used to generate OpenAI API response."
     required: false
   imageModelNames:
-    value: ""
+    value: "dall-e-3"
     hidden: false
     type: "STRING"
     label: "Image Model Names"
@@ -132,7 +132,7 @@ params:
     hint: "Enable completion model used to generate OpenAI API response."
     required: false
   embeddingsModelNames:
-    value: ""
+    value: "text-embedding-ada-002"
     hidden: false
     type: "STRING"
     label: "Embeddings Model Names"

--- a/dotCMS/src/main/resources/apps/dotAI.yml
+++ b/dotCMS/src/main/resources/apps/dotAI.yml
@@ -14,6 +14,13 @@ params:
     label: "API Key"
     hint: "Your ChatGPT API key"
     required: true
+  textModelNames:
+    value: ""
+    hidden: false
+    type: "STRING"
+    label: "Model Names"
+    hint: "Comma delimited list of models used to generate OpenAI API response (e.g. gpt-3.5-turbo-16k)"
+    required: true
   rolePrompt:
     value: "You are dotCMSbot, and AI assistant to help content creators generate and rewrite content in their content management system."
     hidden: false
@@ -28,13 +35,6 @@ params:
     label: "Text Prompt"
     hint: "A prompt describing writing style."
     required: false
-  textModelNames:
-    value: "gpt-3.5-turbo-16k"
-    hidden: false
-    type: "STRING"
-    label: "Model Names"
-    hint: "Comma delimited list of models used to generate OpenAI API response."
-    required: true
   textModelTokensPerMinute:
     value: "180000"
     hidden: false
@@ -63,6 +63,13 @@ params:
     label: "Completion model enabled"
     hint: "Enable completion model used to generate OpenAI API response."
     required: false
+  imageModelNames:
+    value: ""
+    hidden: false
+    type: "STRING"
+    label: "Image Model Names"
+    hint: "Comma delimited list of image models used to generate OpenAI API response(e.g. dall-e-3)."
+    required: true
   imagePrompt:
     value: "Use 16:9 aspect ratio."
     hidden: false
@@ -96,13 +103,6 @@ params:
         value: "1920x1080"
       - label: "256x256 (Small Square 1:1)"
         value: "256x256"
-  imageModelNames:
-    value: "dall-e-3"
-    hidden: false
-    type: "STRING"
-    label: "Image Model Names"
-    hint: "Comma delimited list of image models used to generate OpenAI API response."
-    required: true
   imageModelTokensPerMinute:
     value: "0"
     hidden: false
@@ -132,11 +132,11 @@ params:
     hint: "Enable completion model used to generate OpenAI API response."
     required: false
   embeddingsModelNames:
-    value: "text-embedding-ada-002"
+    value: ""
     hidden: false
     type: "STRING"
     label: "Embeddings Model Names"
-    hint: "Comma delimited list of embeddings models used to generate OpenAI API response."
+    hint: "Comma delimited list of embeddings models used to generate OpenAI API response (e.g. text-embedding-ada-002)."
     required: true
   embeddingsModelTokensPerMinute:
     value: "1000000"

--- a/dotCMS/src/main/webapp/html/portlet/ext/dotai/dotai.js
+++ b/dotCMS/src/main/webapp/html/portlet/ext/dotai/dotai.js
@@ -131,10 +131,13 @@ const writeModelToDropdown = async () => {
     }
 
     for (i = 0; i < dotAiState.config.availableModels.length; i++) {
+        if (dotAiState.config.availableModels[i].type !== 'TEXT') {
+            continue;
+        }
 
         const newOption = document.createElement("option");
-        newOption.value = dotAiState.config.availableModels[i];
-        newOption.text = `${dotAiState.config.availableModels[i]}`
+        newOption.value = dotAiState.config.availableModels[i].name;
+        newOption.text = `${dotAiState.config.availableModels[i].name}`
         if (dotAiState.config.availableModels[i] === dotAiState.config.model) {
             newOption.selected = true;
             newOption.text = `${dotAiState.config.availableModels[i]} (default)`

--- a/dotCMS/src/test/java/com/dotcms/ai/app/AIAppUtilTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/app/AIAppUtilTest.java
@@ -162,4 +162,17 @@ public class AIAppUtilTest {
         assertTrue(model.getNames().contains("embeddingsmodel"));
     }
 
+    @Test
+    public void testDiscoverEnvSecret() {
+        // Mock the secret value in the secrets map
+        when(secrets.get("apiKey")).thenReturn(secret);
+        when(secret.getString()).thenReturn("secretValue");
+
+        // Call the method with the key and environment variable
+        String result = aiAppUtil.discoverEnvSecret(secrets, AppKeys.API_KEY, "ENV_API_KEY");
+
+        // Assert the expected outcome
+        assertEquals("secretValue", result);
+    }
+
 }

--- a/dotcms-integration/pom.xml
+++ b/dotcms-integration/pom.xml
@@ -411,9 +411,9 @@
                                 <DOT_VELOCITY_ROOT>${test.webapp.root}/WEB-INF/velocity</DOT_VELOCITY_ROOT>
                                 <DOT_GEOIP2_CITY_DATABASE_PATH_OVERRIDE>${test.webapp.root}/WEB-INF/geoip2/GeoLite2-City.mmdb</DOT_GEOIP2_CITY_DATABASE_PATH_OVERRIDE>
                                 <DOT_DARTSASS_COMPILER_LOCATION>${test.webapp.root}/WEB-INF/bin</DOT_DARTSASS_COMPILER_LOCATION>
-                                <DOT_APP_AI_PARAM_API_EMBEDDINGS_URL>http://localhost:50505/e</DOT_APP_AI_PARAM_API_EMBEDDINGS_URL>
-                                <DOT_OPEN_AI_EMBEDDINGS_URL>http://localhost:50505/e</DOT_OPEN_AI_EMBEDDINGS_URL>
-                                <DOT_OPEN_AI_MODELS_URL>http://localhost:50505/m</DOT_OPEN_AI_MODELS_URL>
+                                <DOT_AI_EMBEDDINGS_API_URL>http://localhost:50505/e</DOT_AI_EMBEDDINGS_API_URL>
+                                <DOT_AI_MODELS_API_URL>http://localhost:50505/m</DOT_AI_MODELS_API_URL>
+                                <DOT_AI_DEBUG_LOGGER>true</DOT_AI_DEBUG_LOGGER>
                                 <!--suppress UnresolvedMavenProperty -->
                                 <java.io.tmpdir>${it.test.fork-folder}${surefire.forkNumber}/${test.temp.folder}</java.io.tmpdir>
                                 <!--suppress UnresolvedMavenProperty -->

--- a/dotcms-integration/src/test/java/com/dotcms/ai/AiTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/ai/AiTest.java
@@ -78,4 +78,8 @@ public interface AiTest {
         return aiAppSecrets(wireMockServer, host, MODEL, IMAGE_MODEL, EMBEDDINGS_MODEL);
     }
 
+    static void removeSecrets(final Host host) throws DotDataException, DotSecurityException {
+        APILocator.getAppsAPI().removeSecretsForSite(host, APILocator.systemUser());
+    }
+
 }

--- a/dotcms-integration/src/test/resources/mappings/openai-models.json
+++ b/dotcms-integration/src/test/resources/mappings/openai-models.json
@@ -9,6 +9,36 @@
       "object": "list",
       "data": [
         {
+          "id": "text-model-1",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
+          "id": "text-model-2",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
+          "id": "image-model-3",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
+          "id": "image-model-4",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
+          "id": "embeddings-model-5",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
+          "id": "embeddings-model-6",
+          "object": "model",
+          "created": 1698785189,
+          "owned_by": "system"
+        },{
           "id": "dall-e-3",
           "object": "model",
           "created": 1698785189,

--- a/dotcms-postman/config.json
+++ b/dotcms-postman/config.json
@@ -1,5 +1,9 @@
 [
     {
+        "name": "ai",
+        "collections": ["AI.postman_collection"]
+    },
+    {
         "name": "category-content",
         "collections": [
             "Category.postman_collection",

--- a/dotcms-postman/pom.xml
+++ b/dotcms-postman/pom.xml
@@ -134,8 +134,12 @@
                                     <DOT_ENABLE_SCRIPTING>true</DOT_ENABLE_SCRIPTING>
                                     <DOT_ANNOUNCEMENTS_BASE_URL>http://localhost:8080</DOT_ANNOUNCEMENTS_BASE_URL>
                                     <DOT_ALLOW_ACCESS_TO_PRIVATE_SUBNETS>true</DOT_ALLOW_ACCESS_TO_PRIVATE_SUBNETS>
-                                    <DOT_OPEN_AI_MODELS_URL>http://wm:8080/m</DOT_OPEN_AI_MODELS_URL>
                                     <DOT_DOTCMS_DEV_MODE>true</DOT_DOTCMS_DEV_MODE>
+                                    <DOT_AI_API_URL>http://wm:8080/c</DOT_AI_API_URL>
+                                    <DOT_AI_IMAGE_API_URL>http://wm:8080/i</DOT_AI_IMAGE_API_URL>
+                                    <DOT_AI_EMBEDDINGS_API_URL>http://wm:8080/e</DOT_AI_EMBEDDINGS_API_URL>
+                                    <DOT_AI_MODELS_API_URL>http://wm:8080/m</DOT_AI_MODELS_API_URL>
+                                    <DOT_AI_DEBUG_LOGGER>true</DOT_AI_DEBUG_LOGGER>
                                 </env>
                                 <links combine.children="append">
                                     <link>wiremock:wm</link>

--- a/dotcms-postman/src/main/resources/postman/AI.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/AI.postman_collection.json
@@ -60,7 +60,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"apiKey\": {\n    \"value\": \"some-api-key-1a2bc3\"\n  },\n  \"textModelNames\": {\n    \"value\": \"gpt-3.5-turbo-16k\"\n  },\n  \"textModelMaxTokens\": {\n    \"value\":\"16384\"\n  },\n  \"imageModelNames\": {\n    \"value\": \"dall-e-3\"\n  },\n  \"imageSize\": {\n    \"value\": \"1024x1024\"\n  },\n  \"imageModelMaxTokens\": {\n    \"value\":\"0\"\n  },\n  \"embeddingsModelNames\": {\n    \"value\": \"text-embedding-ada-002\"\n  },\n  \"embeddingsModelMaxTokens\": {\n    \"value\":\"8191\"\n  },\n  \"listenerIndexer\": {\n    \"value\": \"{\\\"default\\\":\\\"blog,dotcmsdocumentation,feature,ProductBriefs,news,report.file,builds,casestudy\\\",\\\"documentation\\\":\\\"dotcmsdocumentation\\\"}\"\n  }\n}\n"
+							"raw": "{\n  \"apiKey\": {\n    \"value\": \"some-api-key-1a2bc3\"\n  },\n  \"textModelNames\": {\n    \"value\": \"gpt-4o\"\n  },\n  \"textModelMaxTokens\": {\n    \"value\":\"16384\"\n  },\n  \"imageModelNames\": {\n    \"value\": \"dall-e-3\"\n  },\n  \"imageSize\": {\n    \"value\": \"1024x1024\"\n  },\n  \"imageModelMaxTokens\": {\n    \"value\":\"0\"\n  },\n  \"embeddingsModelNames\": {\n    \"value\": \"text-embedding-ada-002\"\n  },\n  \"embeddingsModelMaxTokens\": {\n    \"value\":\"8191\"\n  },\n  \"listenerIndexer\": {\n    \"value\": \"{\\\"default\\\":\\\"blog,dotcmsdocumentation,feature,ProductBriefs,news,report.file,builds,casestudy\\\",\\\"documentation\\\":\\\"dotcmsdocumentation\\\"}\"\n  }\n}\n"
 						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/apps/dotAI/SYSTEM_HOST",
@@ -3140,7 +3140,7 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test('Status code should be ok 20', function () {",
+									"pm.test('Status code should be ok 200', function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									"",

--- a/dotcms-postman/src/main/resources/postman/AI.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/AI.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "914f967b-8219-4118-aece-005e7212e0d7",
+		"_postman_id": "45540605-95ba-4b50-adba-254915172f48",
 		"name": "AI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "11174695"
@@ -60,7 +60,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"apiUrl\": {\n    \"value\": \"http://wm:8080/c\"\n  },\n  \"apiEmbeddingsUrl\": {\n    \"value\": \"http://wm:8080/e\"\n  },\n  \"apiImageUrl\": {\n    \"value\": \"http://wm:8080/i\"\n  },\n  \"apiKey\": {\n    \"value\": \"some-api-key-1a2bc3\"\n  },\n  \"textModelNames\": {\n    \"value\": \"gpt-3.5-turbo-16k\"\n  },\n  \"imageModelNames\": {\n    \"value\": \"dall-e-3\"\n  },\n  \"embeddingsModelNames\": {\n    \"value\": \"text-embedding-ada-002\"\n  },\n  \"imageSize\": {\n    \"value\": \"1024x1024\"\n  }\n}\n"
+							"raw": "{\n  \"apiKey\": {\n    \"value\": \"some-api-key-1a2bc3\"\n  },\n  \"textModelNames\": {\n    \"value\": \"gpt-3.5-turbo-16k\"\n  },\n  \"textModelMaxTokens\": {\n    \"value\":\"16384\"\n  },\n  \"imageModelNames\": {\n    \"value\": \"dall-e-3\"\n  },\n  \"imageSize\": {\n    \"value\": \"1024x1024\"\n  },\n  \"imageModelMaxTokens\": {\n    \"value\":\"0\"\n  },\n  \"embeddingsModelNames\": {\n    \"value\": \"text-embedding-ada-002\"\n  },\n  \"embeddingsModelMaxTokens\": {\n    \"value\":\"8191\"\n  },\n  \"listenerIndexer\": {\n    \"value\": \"{\\\"default\\\":\\\"blog,dotcmsdocumentation,feature,ProductBriefs,news,report.file,builds,casestudy\\\",\\\"documentation\\\":\\\"dotcmsdocumentation\\\"}\"\n  }\n}\n"
 						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/apps/dotAI/SYSTEM_HOST",
@@ -3345,7 +3345,10 @@
 									"    pm.expect(jsonData).to.have.property(\"apiUrl\");",
 									"    pm.expect(jsonData).to.have.property(\"availableModels\");",
 									"    pm.expect(jsonData.availableModels).to.be.an(\"array\");",
-									"    pm.expect(jsonData.availableModels.length).is.greaterThan(0);",
+									"    pm.expect(jsonData.availableModels.length).equals(3);",
+									"    pm.expect(jsonData.availableModels.find(model => model.type === 'TEXT')).is.not.undefined",
+									"    pm.expect(jsonData.availableModels.find(model => model.type === 'IMAGE')).is.not.undefined",
+									"    pm.expect(jsonData.availableModels.find(model => model.type === 'EMBEDDINGS')).is.not.undefined",
 									"    pm.expect(jsonData[\"com.dotcms.ai.completion.default.temperature\"]).to.equal(\"1\");",
 									"    pm.expect(jsonData[\"com.dotcms.ai.debug.logging\"]).to.equal(\"false\");",
 									"    pm.expect(jsonData.embeddingsModelNames).to.equal(\"text-embedding-ada-002\");",
@@ -3449,6 +3452,10 @@
 		},
 		{
 			"key": "seoText",
+			"value": ""
+		},
+		{
+			"key": "key",
 			"value": ""
 		}
 	]


### PR DESCRIPTION
Returning available models as object that includes 'name' and 'type' instead of just a list os strings. Throwing exceptions when AppConfig.isEnabled() is false to break the tests when any of AI API url or AI API key are missing. Clean the default values for model names. Added better logging at key places when interacting with OpenAI provider. Tests were added/updated.

This PR fixes: #29587