### PR TITLE
ci: Fix workflow path issue introduced in #29506 (#28554)

### DIFF
--- a/.github/workflows/cicd_3-trunk.yml
+++ b/.github/workflows/cicd_3-trunk.yml
@@ -82,7 +82,7 @@ jobs:
     name: CLI Build
     needs: [ initialize,test ]
     if: always() && !failure() && !cancelled()
-    uses: ./.github/workflows/cicd_comp_build-phase.yml
+    uses: ./.github/workflows/cicd_comp_cli-native-build-phase.yml
     with:
       buildNativeImage: true
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}

--- a/.github/workflows/cicd_4-nightly.yml
+++ b/.github/workflows/cicd_4-nightly.yml
@@ -74,7 +74,7 @@ jobs:
     name: Nightly CLI Build
     needs: [ initialize, test ]
     if: always() && !failure() && !cancelled()
-    uses: ./.github/workflows/cicd_comp_build-phase.yml
+    uses: ./.github/workflows/cicd_comp_cli-native-build-phase.yml
     with:
       buildNativeImage: true
       branch: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Merge Queue](https://github.com/dotCMS/core/actions/workflows/cicd_2-merge-queue.yml/badge.svg)](https://github.com/dotCMS/core/actions/workflows/cicd_2-merge-queue.yml)
 
-[![Trunk](https://github.com/dotCMS/core/actions/workflows/cicd_3-trunk/badge.svg)](https://github.com/dotCMS/core/actions/workflows/cicd_3-trunk.yml)
+[![Trunk](https://github.com/dotCMS/core/actions/workflows/cicd_3-trunk.yml/badge.svg)](https://github.com/dotCMS/core/actions/workflows/cicd_3-trunk.yml)
 
 [![Nightly](https://github.com/dotCMS/core/actions/workflows/cicd_4-nightly.yml/badge.svg)](https://github.com/dotCMS/core/actions/workflows/cicd_4-nightly.yml)
 


### PR DESCRIPTION
Fix incorrect reusable workflow path in nightly and trunk workflow introduced in https://github.com/dotCMS/core/pull/29506
Also fix badge image for trunk in top level README.md

This PR resolves #28554 (Refactor github workflows to group key top level w).

This PR fixes: #28554