### PR TITLE
ci: cleanup-runner option required for postman tests (#29608)

### DIFF
--- a/.github/workflows/cicd_comp_test-phase.yml
+++ b/.github/workflows/cicd_comp_test-phase.yml
@@ -173,3 +173,4 @@ jobs:
           needs-docker-image: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           artifacts-from: ${{ env.ARTIFACT_RUN_ID }}
+          cleanup-runner: true


### PR DESCRIPTION

Make sure that cleanup is done on the runner.
Test elastic search does not run out of space in GraphQl tests

This PR resolves #29608 (Flakey graphql postman tests due to opensearch dis).

This PR fixes: #29608