### PR TITLE
chore(design system): Fix large font-sizes inconsistencies #28724 

### DIFF
--- a/core-web/apps/dotcdn/src/app/app.component.scss
+++ b/core-web/apps/dotcdn/src/app/app.component.scss
@@ -83,7 +83,7 @@ h1 {
 
 .dot-cdn__tab-content-label {
     margin: 0;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }
 
 .dot-cdn__tab-content__row:first-child {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-form/dot-apps-configuration-detail-form.component.scss
@@ -35,7 +35,7 @@
 
     input,
     textarea {
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         width: 100%;
     }
 
@@ -52,7 +52,7 @@
         }
 
         p-checkbox label {
-            font-size: $font-size-lg;
+            font-size: $font-size-lmd;
         }
 
         p-checkbox.required label:before,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.scss
@@ -49,4 +49,5 @@
     flex-direction: column;
     overflow-y: auto;
     width: 100%;
+    font-size: $font-size-md;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail.component.scss
@@ -28,7 +28,7 @@
     color: $black;
     display: flex;
     justify-content: space-between;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: $font-weight-semi-bold;
     padding: $spacing-3;
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-header/dot-apps-configuration-header.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-header/dot-apps-configuration-header.component.scss
@@ -39,7 +39,7 @@
 .dot-apps-configuration__service-key {
     color: $color-palette-gray-700;
     display: inline-block;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     margin-left: $spacing-3;
     display: flex;
     align-items: center;
@@ -71,7 +71,7 @@
     .dot-apps-configuration__description__link_show-more {
         background-color: $white;
         cursor: pointer;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         padding-left: $spacing-1;
         position: absolute;
         bottom: 0;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-header/dot-apps-configuration-header.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-header/dot-apps-configuration-header.component.scss
@@ -31,7 +31,7 @@
     color: $black;
     cursor: pointer;
     display: inline-block;
-    font-size: $font-size-xxl;
+    font-size: $font-size-xl;
     font-weight: bold;
     margin: 0;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.component.scss
@@ -39,7 +39,7 @@
 }
 
 .dot-apps-configuration__add-configurations-title {
-    font-size: $font-size-xxl;
+    font-size: $font-size-xl;
     font-weight: bold;
 }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.component.scss
@@ -54,4 +54,5 @@
     box-shadow: $shadow-m;
     overflow-y: auto;
     width: 100%;
+    font-size: $font-size-md;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration.component.scss
@@ -44,7 +44,7 @@
 }
 
 .dot-apps-configuration__add-configurations-description {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     margin-bottom: $spacing-9;
     margin-top: $spacing-4;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-card/dot-apps-card.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-card/dot-apps-card.component.scss
@@ -91,7 +91,7 @@ p-avatar {
     color: $black;
     display: block;
     flex: 1;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: bold;
     text-overflow: ellipsis;
     transition: color $basic-speed ease;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.scss
@@ -15,6 +15,7 @@
     justify-content: space-between;
     padding: 0 $spacing-4 $spacing-4;
     width: 100%;
+    font-size: $font-size-md;
 
     input {
         width: 31.42rem;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list.component.scss
@@ -15,7 +15,6 @@
     justify-content: space-between;
     padding: 0 $spacing-4 $spacing-4;
     width: 100%;
-    font-size: $font-size-md;
 
     input {
         width: 31.42rem;
@@ -60,4 +59,5 @@
     background-color: $white;
     box-shadow: $shadow-m;
     padding-top: $spacing-4;
+    font-size: $font-size-md;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-categories/dot-categories-list/dot-categories-list.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-categories/dot-categories-list/dot-categories-list.component.scss
@@ -19,6 +19,6 @@ dot-portlet-base {
         display: flex;
         justify-content: center;
         font-size: $spacing-9;
-        font-size: $font-size-xxl;
+        font-size: $font-size-xl;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/container-list/container-list.component.scss
@@ -49,6 +49,6 @@ dot-content-type-selector {
 .listing-datatable__empty {
     display: flex;
     justify-content: center;
-    font-size: $font-size-xxl;
+    font-size: $font-size-xl;
     margin-top: $spacing-4;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/dot-container-properties.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-properties/dot-container-properties.component.scss
@@ -27,7 +27,7 @@
 .dot-container-properties__title-text {
     display: inline-block;
     padding-right: $spacing-2;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }
 
 .dot-container-properties__max-contents-input {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-edit-page-info/dot-edit-page-info.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-edit-page-info/dot-edit-page-info.component.scss
@@ -10,6 +10,6 @@ h2 {
     margin: 0 $spacing-3 0 0;
     align-self: center;
     color: $font-color-base;
-    font-size: $font-size-xxl;
+    font-size: $font-size-xl;
     font-weight: normal;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.scss
@@ -17,6 +17,6 @@
     .whats-changed__empty-state {
         text-align: center;
         margin-top: $spacing-9;
-        font-size: $font-size-xxl;
+        font-size: $font-size-xl;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-info-seo/dot-edit-page-info-seo.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-info-seo/dot-edit-page-info-seo.component.scss
@@ -10,6 +10,6 @@ h2 {
     margin: 0 $spacing-3 0 0;
     align-self: center;
     color: $font-color-base;
-    font-size: $font-size-xxl;
+    font-size: $font-size-xl;
     font-weight: normal;
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages-favorite-panel/dot-pages-favorite-panel.component.scss
@@ -61,7 +61,7 @@
 
         i.pi {
             color: $color-palette-primary;
-            font-size: $font-size-xxl;
+            font-size: $font-size-xl;
             margin-bottom: $spacing-3;
         }
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.scss
@@ -107,7 +107,7 @@ $number-link-icon-size: 2.28rem;
 
         h4 {
             color: $black;
-            font-size: $font-size-lg;
+            font-size: $font-size-lmd;
             font-weight: $font-weight-semi-bold;
             margin: 0;
         }
@@ -129,7 +129,7 @@ $number-link-icon-size: 2.28rem;
     }
 
     .dot-starter-top-main__title {
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         font-weight: $font-weight-semi-bold;
         margin: 0;
         border-bottom: 1px solid $color-palette-gray-300;
@@ -166,7 +166,7 @@ $number-link-icon-size: 2.28rem;
 
         h4 {
             color: $black;
-            font-size: $font-size-lg;
+            font-size: $font-size-lmd;
             margin: 0;
         }
         p {
@@ -180,7 +180,7 @@ $number-link-icon-size: 2.28rem;
 
         h4 {
             color: $color-palette-primary;
-            font-size: $font-size-lg;
+            font-size: $font-size-lmd;
             font-weight: 500;
             margin: 0;
             padding-bottom: $spacing-1;
@@ -228,7 +228,7 @@ $number-link-icon-size: 2.28rem;
 
         h4 {
             color: $black;
-            font-size: $font-size-lg;
+            font-size: $font-size-lmd;
             margin: 0;
         }
         p {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.scss
@@ -29,7 +29,7 @@ $number-link-icon-size: 2.28rem;
 
     .dot-starter-title {
         color: $black;
-        font-size: $font-size-xl;
+        font-size: $font-size-lg;
         margin: $spacing-5 $spacing-3 $spacing-1;
     }
 
@@ -123,7 +123,7 @@ $number-link-icon-size: 2.28rem;
 
         i {
             color: $color-palette-gray-500;
-            font-size: $font-size-xl;
+            font-size: $font-size-lg;
             margin-right: $spacing-3;
         }
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-convert-wysiwyg-to-block/dot-convert-wysiwyg-to-block.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-convert-wysiwyg-to-block/dot-convert-wysiwyg-to-block.component.scss
@@ -9,7 +9,7 @@
 }
 
 h3 {
-    font-size: $font-size-xl;
+    font-size: $font-size-lg;
     margin: $spacing-2 0;
 }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-convert-wysiwyg-to-block/dot-convert-wysiwyg-to-block.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-convert-wysiwyg-to-block/dot-convert-wysiwyg-to-block.component.scss
@@ -14,7 +14,7 @@ h3 {
 }
 
 h4 {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     margin: $spacing-2 0;
 }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-add-row/content-type-fields-add-row.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-add-row/content-type-fields-add-row.component.scss
@@ -40,7 +40,7 @@ $row-height: 70px;
     position: relative;
 
     .dot-add-rows-columns-list__title {
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
     }
 
     p-button {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.scss
@@ -145,7 +145,7 @@ $top-height: ($toolbar-height + $tabview-nav-height + $dot-secondary-toolbar-mai
     }
 
     .content-type__dot-separator {
-        font-size: $font-size-xl;
+        font-size: $font-size-lg;
         margin: 0 4px;
         vertical-align: middle;
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.scss
@@ -101,7 +101,7 @@ $top-height: ($toolbar-height + $tabview-nav-height + $dot-secondary-toolbar-mai
     }
 
     .content-type__title {
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         display: flex;
         flex-flow: column wrap;
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-bulk-information/dot-bulk-information.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-bulk-information/dot-bulk-information.component.scss
@@ -2,7 +2,7 @@
 
 .bulk-information__success-message {
     color: $color-palette-gray-700;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     text-align: center;
     padding-top: $spacing-3;
     padding-bottom: $spacing-5;
@@ -40,7 +40,7 @@
     }
     h5 {
         padding-bottom: $spacing-1;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
     }
     padding: $spacing-3;
     box-shadow: $shadow-xs;

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-empty-state/dot-empty-state.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-empty-state/dot-empty-state.component.scss
@@ -28,7 +28,7 @@
     }
 
     h3 {
-        font-size: $font-size-xl;
+        font-size: $font-size-lg;
         margin: $spacing-3 0 $spacing-2 0;
         font-weight: $font-weight-semi-bold;
     }

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-generate-secure-password/dot-generate-secure-password.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-generate-secure-password/dot-generate-secure-password.component.scss
@@ -12,7 +12,7 @@
     border: 0;
     background-color: transparent;
     color: $black;
-    font-size: $font-size-xl;
+    font-size: $font-size-lg;
     font-weight: bold;
     text-align: center;
 }

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-md-icon-selector/dot-md-icon-selector.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-md-icon-selector/dot-md-icon-selector.component.scss
@@ -32,7 +32,7 @@ dot-material-icon-picker {
         }
 
         .dot-material-icon__preview {
-            font-size: $font-size-xl;
+            font-size: $font-size-lg;
         }
 
         .dot-material-icon__button {
@@ -43,7 +43,7 @@ dot-material-icon-picker {
             justify-content: center;
 
             mwc-icon {
-                font-size: $font-size-xl;
+                font-size: $font-size-lg;
                 width: $field-height-md;
             }
         }

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-md-icon-selector/dot-md-icon-selector.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-md-icon-selector/dot-md-icon-selector.component.scss
@@ -69,7 +69,7 @@ dot-material-icon-picker {
             }
 
             mwc-icon {
-                font-size: $font-size-lg;
+                font-size: $font-size-lmd;
             }
         }
     }

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.scss
@@ -2,7 +2,7 @@
 @import "mixins";
 
 .site-selector__title {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }
 
 .site-selector__modal {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/dot-crumbtrail.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-crumbtrail/dot-crumbtrail.component.scss
@@ -3,17 +3,17 @@
 :host ::ng-deep .p-breadcrumb {
     ul li {
         &:first-child {
-            font-size: $font-size-lg;
+            font-size: $font-size-lmd;
             a span.p-menuitem-text {
                 color: $black;
-                font-size: $font-size-lg;
+                font-size: $font-size-lmd;
                 font-weight: $font-weight-regular-bold;
             }
         }
 
         .p-menuitem-link[href] {
             .p-menuitem-text {
-                font-size: $font-size-lg;
+                font-size: $font-size-lmd;
             }
         }
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-edit-layout-sidebar/dot-edit-layout-sidebar.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-edit-layout-sidebar/dot-edit-layout-sidebar.component.scss
@@ -29,7 +29,7 @@ h6 {
     align-items: center;
     background-color: $color-palette-gray-200;
     display: flex;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: normal;
     height: 48px;
     margin: 0;

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-layout-designer/dot-layout-designer.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-layout-designer/dot-layout-designer.component.scss
@@ -31,7 +31,7 @@
     color: $color-palette-gray-700;
     display: flex;
     flex-shrink: 0;
-    font-size: $font-size-xxl;
+    font-size: $font-size-xl;
     justify-content: center;
 }
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-edit-layout-designer/components/dot-theme-selector/dot-theme-selector.component.scss
@@ -9,7 +9,7 @@ $theme-item-dimension: 240px;
 
         dot-searchable-dropdown .p-button,
         .site-selector__title {
-            font-size: $font-size-lg;
+            font-size: $font-size-lmd;
             min-width: 200px;
         }
     }
@@ -39,7 +39,7 @@ $theme-item-dimension: 240px;
 
     .p-dataview-content .p-widget-content.p-g-12 {
         text-align: center;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         margin-top: $spacing-7;
     }
 
@@ -65,7 +65,7 @@ $theme-item-dimension: 240px;
     position: relative;
 
     input {
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
     }
 
     dot-icon {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/action-header/action-header.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/action-header/action-header.component.scss
@@ -10,6 +10,7 @@
     flex-direction: row-reverse;
     align-items: center;
     padding: $spacing-3 $spacing-5;
+    font-size: $font-size-md;
 
     &.selected {
         .action-header__primary-button {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.scss
@@ -69,7 +69,7 @@
     display: flex;
     justify-content: center;
     font-size: $spacing-9;
-    font-size: $font-size-xxl;
+    font-size: $font-size-xl;
     margin-top: $spacing-9;
 }
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-message-display/dot-message-display.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-message-display/dot-message-display.component.scss
@@ -11,7 +11,7 @@
             h4,
             h5,
             h6 {
-                font-size: $font-size-lg;
+                font-size: $font-size-lmd;
                 font-weight: bold;
             }
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/components/dot-portlet-toolbar/dot-portlet-toolbar.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/components/dot-portlet-toolbar/dot-portlet-toolbar.component.scss
@@ -8,7 +8,7 @@
 
 h3 {
     margin: 0 $spacing-2 0 0;
-    font-size: $font-size-xxl;
+    font-size: $font-size-xl;
     line-height: 1.6; // Default 39px height
 }
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-relationship-tree/dot-relationship-tree.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-relationship-tree/dot-relationship-tree.component.scss
@@ -41,7 +41,7 @@
         display: flex;
         justify-content: space-evenly;
         align-items: flex-end;
-        font-size: $font-size-xl;
+        font-size: $font-size-lg;
         line-height: 1px;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-secondary-toolbar/dot-secondary-toolbar.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-secondary-toolbar/dot-secondary-toolbar.component.scss
@@ -65,7 +65,7 @@
 
             h2 {
                 color: inherit;
-                font-size: $font-size-xxl;
+                font-size: $font-size-xl;
                 font-weight: normal;
             }
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-secondary-toolbar/dot-secondary-toolbar.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-secondary-toolbar/dot-secondary-toolbar.component.scss
@@ -85,7 +85,7 @@
         .main-toolbar-right {
             h2 {
                 margin: 0;
-                font-size: $font-size-lg;
+                font-size: $font-size-lmd;
             }
         }
     }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.scss
@@ -32,7 +32,7 @@
         background: $bg-highlight;
         width: 3.43rem;
         height: 3.43rem;
-        font-size: $font-size-xxl;
+        font-size: $font-size-xl;
         color: $color-palette-primary-400;
         text-transform: uppercase;
         text-align: center;

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-announcements/dot-toolbar-announcements.component.scss
@@ -56,7 +56,7 @@
     margin: 0;
     padding-bottom: $spacing-1;
     border-bottom: 1px solid $color-palette-gray-300;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }
 
 .announcements__content {
@@ -76,7 +76,7 @@
     background-color: var(--color-palette-secondary-200);
     color: var(--color-palette-secondary-500);
     border-radius: 50%;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }
 
 .announcements__label {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-notifications/dot-toolbar-notifications.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-notifications/dot-toolbar-notifications.component.scss
@@ -52,7 +52,7 @@ $notification-dot-badge-size: 0.625rem;
     }
 
     .toolbar-notifications__title {
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         margin: 0;
         padding-bottom: $spacing-0;
     }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.scss
@@ -20,7 +20,7 @@ p-avatar {
     .toolbar-user__user-name {
         margin: 0;
         white-space: nowrap;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         color: $black;
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/view/components/global-search/global-search.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/global-search/global-search.scss
@@ -11,7 +11,7 @@ $placeholder-color: $color-palette-white-op-50;
         background-color: $color-palette-white-op-20;
         border: none;
         color: $white;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         height: 36px;
         padding: 0 10px;
         width: 100%;

--- a/core-web/libs/block-editor/src/lib/extensions/asset-form/components/dot-upload-asset/dot-upload-asset.component.scss
+++ b/core-web/libs/block-editor/src/lib/extensions/asset-form/components/dot-upload-asset/dot-upload-asset.component.scss
@@ -12,7 +12,7 @@
 
     .error {
         color: $error;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         max-width: 100%;
         white-space: pre-wrap;
     }

--- a/core-web/libs/block-editor/src/lib/extensions/asset-uploader/components/upload-placeholder/upload-placeholder.component.scss
+++ b/core-web/libs/block-editor/src/lib/extensions/asset-uploader/components/upload-placeholder/upload-placeholder.component.scss
@@ -28,6 +28,6 @@
     background-color: $color-palette-gray-200;
     display: block;
     padding: $dot-editor-size;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     width: 100%;
 }

--- a/core-web/libs/block-editor/src/lib/nodes/contentlet-block/contentlet-block.component.scss
+++ b/core-web/libs/block-editor/src/lib/nodes/contentlet-block/contentlet-block.component.scss
@@ -58,7 +58,7 @@
                         padding: 0;
                         text-overflow: ellipsis;
                         white-space: nowrap;
-                        font-size: $font-size-xl;
+                        font-size: $font-size-lg;
                     }
                 }
             }

--- a/core-web/libs/dot-rules/src/lib/components/dot-unlicense/dot-unlicense.component.scss
+++ b/core-web/libs/dot-rules/src/lib/components/dot-unlicense/dot-unlicense.component.scss
@@ -16,7 +16,7 @@
     }
 
     h4 {
-        font-size: $font-size-xxl;
+        font-size: $font-size-xl;
         font-weight: 400;
         margin: $spacing-3 0;
     }

--- a/core-web/libs/dot-rules/src/lib/styles/rule-engine.scss
+++ b/core-web/libs/dot-rules/src/lib/styles/rule-engine.scss
@@ -576,7 +576,7 @@ $finder-s-input: ".ui.input input";
 
         i {
             color: $white;
-            font-size: $font-size-xl;
+            font-size: $font-size-lg;
         }
     }
 }

--- a/core-web/libs/dot-rules/src/lib/styles/rule-engine.scss
+++ b/core-web/libs/dot-rules/src/lib/styles/rule-engine.scss
@@ -538,7 +538,7 @@ $finder-s-input: ".ui.input input";
         }
 
         h2 {
-            font-size: $font-size-xxl;
+            font-size: $font-size-xl;
             margin: 0;
             color: $color-palette-gray-700;
         }

--- a/core-web/libs/dot-rules/src/lib/styles/rule-engine.scss
+++ b/core-web/libs/dot-rules/src/lib/styles/rule-engine.scss
@@ -244,6 +244,7 @@ $finder-s-input: ".ui.input input";
         border: 1px solid $background-primary;
         border-radius: 0.5em;
         background-color: #fff;
+        font-size: $font-size-md;
 
         .cw-header-actions {
             margin-right: 0.5em;

--- a/core-web/libs/dotcms-field-elements/src/components/dot-binary-file-preview/dot-binary-file-preview.scss
+++ b/core-web/libs/dotcms-field-elements/src/components/dot-binary-file-preview/dot-binary-file-preview.scss
@@ -37,7 +37,7 @@ dot-binary-file-preview {
             overflow: hidden;
             padding: 0.5rem;
             text-overflow: ellipsis;
-            font-size: $font-size-xxxl;
+            font-size: $font-size-xxl;
         }
     }
 }

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_accordion.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_accordion.scss
@@ -7,7 +7,7 @@
     font-weight: $font-weight-semi-bold;
     border-radius: $border-radius-md;
     transition: box-shadow 0.2s;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }
 .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     margin-right: $spacing-1;

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_card.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_card.scss
@@ -20,7 +20,7 @@
         padding: $spacing-4;
 
         .p-card-title {
-            font-size: $font-size-xl;
+            font-size: $font-size-lg;
             font-weight: 700;
             margin-bottom: $spacing-2;
         }

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_chip.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_chip.scss
@@ -204,10 +204,10 @@ p-chip .p-chip {
     &.p-chip-lg {
         height: $field-height-lg;
         border-radius: $border-radius-lg;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
 
         .p-chip-text {
-            font-size: $font-size-lg;
+            font-size: $font-size-lmd;
         }
     }
 

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_confirmpopup.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_confirmpopup.scss
@@ -14,7 +14,7 @@
     box-shadow: $shadow-xs;
 
     .p-confirm-popup-icon {
-        font-size: $font-size-xl;
+        font-size: $font-size-lg;
         color: $color-palette-primary-500;
     }
 

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_dataview.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_dataview.scss
@@ -43,7 +43,7 @@
 }
 
 .p-dataview .p-dataview-loading-icon {
-    font-size: $font-size-xxxl;
+    font-size: $font-size-xxl;
 }
 
 .p-dataview .p-dataview-emptymessage {

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_dialog.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_dialog.scss
@@ -85,7 +85,7 @@
 
 //TODO: This need to go to the confirm-dialog stylesheet when we update the look and feel
 .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
-    font-size: $font-size-xxl;
+    font-size: $font-size-xl;
     padding-right: $spacing-1;
     color: $color-palette-primary;
 }

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_image.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_image.scss
@@ -43,7 +43,7 @@
     }
 
     i {
-        font-size: $font-size-xl;
+        font-size: $font-size-lg;
     }
 
     .p-icon {

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_image.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_image.scss
@@ -9,7 +9,7 @@
     color: $white;
 
     .pi-window-maximize {
-        font-size: $font-size-xxl;
+        font-size: $font-size-xl;
     }
 }
 

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_panel.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_panel.scss
@@ -15,14 +15,14 @@ p-panel {
 }
 
 .p-panel-header {
-    font-size: $font-size-xl;
+    font-size: $font-size-lg;
     margin: $spacing-1 0;
     padding: $spacing-3 0;
     position: relative;
 
     .p-panel-icons span {
         color: $color-palette-primary;
-        font-size: $font-size-xl;
+        font-size: $font-size-lg;
         margin-left: $spacing-1;
         margin-right: $spacing-2;
     }

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/buttons/common.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/buttons/common.scss
@@ -4,7 +4,7 @@
 #large {
     height: $field-height-lg;
     border-radius: $border-radius-lg;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 
     .p-button-label {
         font-size: inherit;

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_calendar.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_calendar.scss
@@ -119,7 +119,7 @@
                 .p-datepicker-year,
                 .p-datepicker-month,
                 .p-datepicker-decade {
-                    font-size: $font-size-lg;
+                    font-size: $font-size-lmd;
                     font-family: $font-default;
                     font-weight: $font-weight-regular-bold;
                     color: inherit;

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/messages/_message.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/messages/_message.scss
@@ -143,7 +143,7 @@
     font-weight: $font-weight-semi-bold;
 }
 .p-message .p-message-icon {
-    font-size: $font-size-xl;
+    font-size: $font-size-lg;
     margin-right: $spacing-1;
 }
 .p-message .p-message-summary {

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/utils/_theme-variables.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/utils/_theme-variables.scss
@@ -195,7 +195,7 @@ $tabview-nav-height: 48px;
 $menu-link-color: $black;
 
 // DIALOG
-$dialog-title-font-size: $font-size-xxl;
+$dialog-title-font-size: $font-size-xl;
 $dialog-message-line-height: $line-height;
 $dialog-message-warning-color: $red;
 $dialog-close-button-normal-color: $color-palette-black-op-70;

--- a/core-web/libs/dotcms-scss/jsp/scss/backend/dot-admin/forms/_fields.scss
+++ b/core-web/libs/dotcms-scss/jsp/scss/backend/dot-admin/forms/_fields.scss
@@ -120,7 +120,7 @@ Styles for commons fields along the backend
 
 .lineDividerTitle {
     color: $color-palette-gray-700;
-    font-size: $font-size-xl;
+    font-size: $font-size-lg;
     border-bottom: 1px solid $color-palette-gray-400;
     padding-bottom: $spacing-1 * 2;
     margin: $spacing-1 * 6 0 $spacing-1 * 3;

--- a/core-web/libs/dotcms-scss/jsp/scss/backend/dot-admin/portlets/_calendar-events.scss
+++ b/core-web/libs/dotcms-scss/jsp/scss/backend/dot-admin/portlets/_calendar-events.scss
@@ -14,7 +14,7 @@
 
     .portlet-toolbar__info {
         flex: 1 0 auto;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         justify-content: center;
     }
 }

--- a/core-web/libs/dotcms-scss/jsp/scss/backend/dot-admin/portlets/_view-roles.scss
+++ b/core-web/libs/dotcms-scss/jsp/scss/backend/dot-admin/portlets/_view-roles.scss
@@ -70,7 +70,7 @@
 
 .nameText {
     align-self: center;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: normal;
 }
 

--- a/core-web/libs/dotcms-scss/jsp/scss/backend/dot-admin/portlets/_view-users.scss
+++ b/core-web/libs/dotcms-scss/jsp/scss/backend/dot-admin/portlets/_view-users.scss
@@ -129,7 +129,7 @@
 }
 
 .fullUserName {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: bold;
     margin-bottom: $spacing-1;
     padding-bottom: 0;

--- a/core-web/libs/dotcms-scss/jsp/scss/dijit/form/_button.scss
+++ b/core-web/libs/dotcms-scss/jsp/scss/dijit/form/_button.scss
@@ -419,7 +419,7 @@
             color: $white;
             line-height: $field-height-md;
             margin: 0;
-            font-size: $font-size-lg;
+            font-size: $font-size-lmd;
         }
 
         .dijitButtonNode {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-aside/dot-edit-content-aside.component.scss
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-aside/dot-edit-content-aside.component.scss
@@ -55,7 +55,7 @@
 
         h2 {
             color: $black;
-            font-size: $font-size-lmd;
+            font-size: $font-size-md;
             font-weight: $font-weight-bold;
             line-height: $line-height;
             margin: 0;

--- a/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.scss
+++ b/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.scss
@@ -17,7 +17,7 @@
     grid-area: topBar;
 
     .pi {
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         margin-right: $spacing-1;
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-category-list/dot-category-field-category-list.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-category-list/dot-category-field-category-list.component.scss
@@ -16,7 +16,7 @@
 
 .category-list__header {
     padding: $spacing-1 $spacing-4;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: $font-weight-medium-bold;
     border-bottom: 1px solid $color-palette-gray-400;
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-sidebar/dot-category-field-sidebar.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-sidebar/dot-category-field-sidebar.component.scss
@@ -20,7 +20,7 @@
 }
 
 .category-field__header-title {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: $font-weight-medium-bold;
     margin: 0;
 }

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-goals/dot-experiments-configuration-goals.component.scss
@@ -6,7 +6,7 @@ h3 {
 }
 
 h2 {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: $font-weight-bold;
     text-transform: uppercase;
     margin-bottom: $spacing-3;

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-scheduling/dot-experiments-configuration-scheduling.component.scss
@@ -2,7 +2,7 @@
 
 h2 {
     margin: 0;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: $font-weight-bold;
     text-transform: uppercase;
 }

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-targeting/dot-experiments-configuration-targeting.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-targeting/dot-experiments-configuration-targeting.component.scss
@@ -2,7 +2,7 @@
 
 h2 {
     margin: 0;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: $font-weight-bold;
     text-transform: uppercase;
 }

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-allocation-add/dot-experiments-configuration-traffic-allocation-add.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-allocation-add/dot-experiments-configuration-traffic-allocation-add.component.scss
@@ -3,7 +3,7 @@
 h5 {
     font-weight: $font-weight-bold;
     margin: 0;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }
 
 .experiment-traffic-allocation-add__form-wrapper {
@@ -11,7 +11,7 @@ h5 {
 
     label {
         font-weight: $font-weight-bold;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
     }
 
     p {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.scss
@@ -11,7 +11,7 @@
     label {
         font-weight: $font-weight-bold;
         margin-bottom: $spacing-3;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
     }
 
     p-radioButton {
@@ -33,7 +33,7 @@
             min-height: 2.7rem;
 
             &.experiment-traffic-split__variants-header {
-                font-size: $font-size-lg;
+                font-size: $font-size-lmd;
                 color: $color-palette-gray-700;
                 text-transform: uppercase;
                 font-weight: $font-weight-bold;

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic/dot-experiments-configuration-traffic.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic/dot-experiments-configuration-traffic.component.scss
@@ -2,7 +2,7 @@
 
 h2 {
     margin: 0;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: 500;
     text-transform: uppercase;
 }

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.scss
@@ -3,7 +3,7 @@
 .variant--title__wrapper {
     h2 {
         margin: 0;
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         font-weight: $font-weight-bold;
     }
 

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/components/dot-experiments-reports-chart/dot-experiments-reports-chart.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-reports/components/dot-experiments-reports-chart/dot-experiments-reports-chart.component.scss
@@ -21,7 +21,7 @@
 }
 
 .empty__message {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }
 
 .empty__description {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiment-options/dot-experiment-options.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiment-options/dot-experiment-options.component.scss
@@ -26,7 +26,7 @@
             }
 
             h2 {
-                font-size: $font-size-lg;
+                font-size: $font-size-lmd;
                 font-weight: $font-weight-bold;
             }
 

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-details-table/dot-experiments-details-table.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-details-table/dot-experiments-details-table.component.scss
@@ -38,7 +38,7 @@
 }
 
 .empty__message {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }
 
 .empty__description {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-goals-coming-soon/dot-experiments-goals-coming-soon.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-goals-coming-soon/dot-experiments-goals-coming-soon.component.scss
@@ -38,7 +38,7 @@
                 border-radius: $border-radius-sm $border-radius-sm 0 0;
 
                 i {
-                    font-size: $font-size-xl;
+                    font-size: $font-size-lg;
                     color: $color-palette-primary-500;
                 }
             }

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-header/dot-experiments-ui-header.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-header/dot-experiments-ui-header.component.scss
@@ -6,7 +6,7 @@
     min-height: $dot-secondary-toolbar-main-height;
     background-color: $white;
     color: $black;
-    font-size: $font-size-xl;
+    font-size: $font-size-lg;
     border-bottom: 1px solid $color-palette-gray-300;
 
     a {

--- a/core-web/libs/portlets/dot-locales/portlet/src/lib/share/ui/DotLocaleConfirmationDialog/DotLocaleConfirmationDialog.component.scss
+++ b/core-web/libs/portlets/dot-locales/portlet/src/lib/share/ui/DotLocaleConfirmationDialog/DotLocaleConfirmationDialog.component.scss
@@ -13,7 +13,7 @@
 
     i {
         color: $color-alert-yellow;
-        font-size: $font-size-lmd;
+        font-size: $font-size-md;
     }
 }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.scss
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.scss
@@ -29,7 +29,7 @@
     position: relative;
 
     .pi {
-        font-size: $font-size-xl;
+        font-size: $font-size-lg;
         color: $color-palette-primary-800;
     }
 

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.scss
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.scss
@@ -18,7 +18,7 @@
 
 .dot-content-compare-table__title {
     color: $black;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }
 
 :host ::ng-deep .p-datatable {

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-device-selector-seo/dot-device-selector-seo.component.scss
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-device-selector-seo/dot-device-selector-seo.component.scss
@@ -24,7 +24,7 @@ $device-selector-name-margin: 0.375rem;
 }
 
 .dot-device-selector__header-title {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-style: normal;
     line-height: 140%;
     color: $black;

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-results-seo-tool/dot-results-seo-tool.component.scss
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-results-seo-tool/dot-results-seo-tool.component.scss
@@ -52,7 +52,7 @@
 }
 
 .results-seo-tool__search-title {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     text-decoration: none;
 }
 
@@ -74,7 +74,7 @@
     display: flex;
     gap: $spacing-3;
     align-items: center;
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     color: $black;
 }
 

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-select-seo-tool/dot-select-seo-tool.component.scss
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-select-seo-tool/dot-select-seo-tool.component.scss
@@ -15,7 +15,7 @@
 }
 
 .dot-select-seo-tool__icon {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     color: $color-palette-primary-500;
 }
 
@@ -24,6 +24,6 @@
 }
 
 .dot-select-seo-tool__details {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     color: $color-palette-gray-700;
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-widget/add-widget.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-widget/add-widget.component.scss
@@ -13,7 +13,7 @@
     transition: transform 100ms ease-in;
 
     .material-icons {
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         color: $color-palette-gray-500;
     }
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/dot-layout-properties/dot-layout-properties.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/dot-layout-properties/dot-layout-properties.component.scss
@@ -7,5 +7,5 @@
 }
 
 .p-button-icon.material-icons {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-section/template-builder-section.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-section/template-builder-section.component.scss
@@ -8,7 +8,7 @@
     background: $color-palette-primary-200;
     height: 5rem;
     color: $color-palette-primary;
-    font-size: $font-size-xl;
+    font-size: $font-size-lg;
     border-radius: $spacing-1;
     padding: 0 $spacing-0;
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-sidebar/template-builder-sidebar.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-sidebar/template-builder-sidebar.component.scss
@@ -17,7 +17,7 @@
     align-items: center;
 
     .header__title {
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         margin: 0;
         line-height: 140%;
         font-weight: $font-weight-semi-bold;

--- a/core-web/libs/ui/src/lib/components/dot-empty-container/dot-empty-container.component.scss
+++ b/core-web/libs/ui/src/lib/components/dot-empty-container/dot-empty-container.component.scss
@@ -14,7 +14,7 @@
     line-height: 140%;
 }
 .message__title {
-    font-size: $font-size-lg;
+    font-size: $font-size-lmd;
     font-weight: $font-weight-semi-bold;
     color: $black;
 }

--- a/core-web/libs/ui/src/lib/components/dot-info-page/dot-info-page.component.scss
+++ b/core-web/libs/ui/src/lib/components/dot-info-page/dot-info-page.component.scss
@@ -27,7 +27,7 @@ i {
 }
 h4 {
     color: $black;
-    font-size: $font-size-xl;
+    font-size: $font-size-lg;
 }
 
 .actions {

--- a/core-web/libs/ui/src/lib/components/dot-not-license/dot-not-license.component.scss
+++ b/core-web/libs/ui/src/lib/components/dot-not-license/dot-not-license.component.scss
@@ -23,7 +23,7 @@ i {
 }
 h4 {
     color: $black;
-    font-size: $font-size-xl;
+    font-size: $font-size-lg;
 }
 p {
     color: $color-palette-gray-700;

--- a/core-web/libs/ui/src/lib/components/dot-sidebar-header/dot-sidebar-header.component.scss
+++ b/core-web/libs/ui/src/lib/components/dot-sidebar-header/dot-sidebar-header.component.scss
@@ -10,7 +10,7 @@
     margin-top: -$spacing-3;
 
     h2 {
-        font-size: $font-size-lg;
+        font-size: $font-size-lmd;
         margin: 0;
         margin-left: $spacing-1;
     }


### PR DESCRIPTION
### Proposed Changes
* Replaced `lmd` with `md`
* Replaced `lg` with `lmd`
* Replaced `xl` with `lg`
* Replaced `xxl` with `xl`
* Replaced `xxxl` with `xxl`
* Corrected font-size in `dot-apps`
* Adjusted font-size for "show archive" label in templates and containers portlets
* Updated `.cw-rule` font-size for rules portlet

### Additional Info
This PR fixes #28724. The previous pull request failed QA due to some inconsistencies.

This PR includes missing replacements, specifically for font sizes `$font-size-lmd`, `lg`, `xl`, `xxl`, and `xxxl`. The extensive changes to files are due to these replacements. *Care was taken to avoid modifying font sizes that were corrected in the previous PR*.

The replacement process followed this order to avoid collisions: `lmd` to `md`, `lg` to `lmd`, `xl` to `lg`, `xxl` to `xl`, and `xxxl` to `xxl`. Additionally, missing font size properties were added to portlets where they were previously omitted, including in `dot-apps`, templates, and containers portlets.

### Screenshots
Original (Header)            |  Updated
:-------------------------:|:-------------------------:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0bf2a535-f56f-4aac-b9c9-9195d1fda0ff">|<img width="1722" alt="image" src="https://github.com/user-attachments/assets/9c8056be-cbc5-4958-a915-492eaafe8aeb">
Original (show archive)|Updated
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/7750403f-51a8-4ca5-863d-a6e5ae02ea0b">|<img width="1724" alt="image" src="https://github.com/user-attachments/assets/7c9fb459-c2c8-4f67-9aaa-cdae981f7036">
Original  (apps cards)|Updated
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/37528738-fdff-498e-ac52-31e0051aa693">|<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f5c78cb7-3fa6-4886-a416-50d719cf1dc4">
Original (apps detail)|Updated
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/e914e4ed-83f9-4231-bfd1-59767b58c9fa">|<img width="1728" alt="image" src="https://github.com/user-attachments/assets/ad921103-1706-410f-aa3b-a0dd78d420d0">
Original (apps form)|Updated
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/fe06dd42-0c44-4f8b-aa96-a8cbfd7d1c4f">|<img width="1728" alt="image" src="https://github.com/user-attachments/assets/74bfee34-e918-47cf-8630-21bf69ce4a6b">
Original (rules "evaluate")|Updated
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a3fbf28c-6cf3-4c50-8bb8-dadf2dd8f9ec">|<img width="1728" alt="image" src="https://github.com/user-attachments/assets/c1d5ef38-e17e-46d2-a747-231ee4b192a5">
Original (overlaypanel titles)|Updated
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/640fb071-db51-45ed-acfd-3c444ee929c4">|<img width="1728" alt="image" src="https://github.com/user-attachments/assets/fdd90a5f-9dbb-49f1-a6c9-78682cf93598">
 

This PR fixes: #28724