### PR TITLE
fix(Logging) : Log less page details when making an unauthorized GraphQL request #29651

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java
@@ -377,9 +377,9 @@ public class HTMLPageAssetRenderedAPIImpl implements HTMLPageAssetRenderedAPI {
                 context.getPageMode().respectAnonPerms);
 
         if (!doesUserHavePermission) {
-            final String message = String.format("User: %s does not have permissions %s for object %s",
+            final String message = String.format("User: %s does not have permissions %s for page %s",
                     context.getUser(),
-                    PermissionLevel.READ, htmlPageAsset);
+                    PermissionLevel.READ, htmlPageAsset.getURI());
             throw new DotSecurityException(message);
         }
     }


### PR DESCRIPTION
### Proposed Changes
* Change log to only display `htmlPageAsset.getURI()`

### Screenshots
### Before:
![image](https://github.com/user-attachments/assets/bb3ea6cd-cadf-45fb-9234-4706563928b7)
### After:
![image](https://github.com/user-attachments/assets/fe5b293d-0239-4b3a-af71-77b08cc7589a)

This PR fixes: #29651

This PR fixes: #29651