### PR TITLE
implementation(PrimeNG-17): #29664 Fix p-dropdown issues and breaking change 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
@@ -97,7 +97,6 @@
                 [options]="dateVarOptions"
                 [tabindex]="7"
                 [placeholder]="'contenttypes.form.date.field.placeholder' | dm"
-                [autoDisplayFirst]="false"
                 [showClear]="true"
                 id="content-type-form-publish-date-field"
                 appendTo="body"
@@ -111,7 +110,6 @@
             <p-dropdown
                 (onChange)="handleDateVarChange($event, 'expireDateVar')"
                 [showClear]="true"
-                [autoDisplayFirst]="false"
                 [options]="dateVarOptions"
                 [tabindex]="8"
                 [placeholder]="'contenttypes.form.date.field.placeholder' | dm"

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/dot-workflows-actions-selector-field.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/dot-workflows-actions-selector-field.component.html
@@ -2,7 +2,6 @@
     *ngIf="actions$ | async as actions"
     (onChange)="handleChange($event)"
     [(ngModel)]="value"
-    [autoDisplayFirst]="false"
     [disabled]="disabled || actions.length === 0"
     [group]="true"
     [options]="actions"

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/dot-workflows-actions-selector-field.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/dot-workflows-actions-selector-field.component.spec.ts
@@ -149,7 +149,6 @@ describe('DotWorkflowsActionsSelectorFieldComponent', () => {
                     expect(dropdown.group).toBe(true);
                     expect(dropdown.placeholder).toBe('Select an action');
                     expect(dropdown.style).toEqual({ width: '100%' });
-                    expect(dropdown.autoDisplayFirst).toBe(false);
                 });
             });
 

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_dropdown.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_dropdown.scss
@@ -41,6 +41,12 @@ p-dropdown.ng-dirty.ng-invalid > .p-dropdown {
     .p-dropdown-label {
         padding-right: $spacing-1;
         @include truncate-text;
+
+        &:focus,
+        &:enabled:focus {
+            outline: 0 none;
+            box-shadow: none;
+        }
     }
 
     &:has(.p-dropdown-clear-icon) {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.html
@@ -33,7 +33,6 @@
                 [filter]="true"
                 [placeholder]="dropdownLabel"
                 [formControl]="formControl"
-                [autoDisplayFirst]="false"
                 scrollHeight="18.75rem"
                 dotContainerOptions
                 data-testId="btn-plus"


### PR DESCRIPTION
### Proposed Changes
* remove attr `autoDisplayFirst ` since will be deprecated; we have placeholders on all the cases actually don't make any difference based on the description: `Whether to display the first item as the label if no placeholder is defined and value is null.`
* adding styles to remove the outline in the dropdown label / placeholder. 


### Screenshots

Before

<img width="382" alt="image" src="https://github.com/user-attachments/assets/b0bdaeee-b6a8-4f0a-9dff-7127bbaf7086">



After 

<img width="379" alt="image" src="https://github.com/user-attachments/assets/216d8416-1d9a-4276-8395-b1ef453b3eb8">
