### PR TITLE
mplementation(PrimeNG-17): #29673 Alignment of pagination 

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_paginator.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_paginator.scss
@@ -7,7 +7,6 @@
     border-width: 0;
     padding: 0.375rem $spacing-2;
     border-radius: $border-radius-xs;
-    justify-content: flex-end;
 }
 
 .p-paginator .p-paginator-first,


### PR DESCRIPTION
### Proposed Changes
*  The `justify-content` rule has been overwritten by the PrimeNG theme, but because of the [CSS layer](https://primeng.org/guides/csslayer) implemented in V17, the custom styles now take precedence.


