### PR TITLE
Fix (CLI/Core) Fixed flakey test

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeResource.java
@@ -714,8 +714,7 @@ public class ContentTypeResource implements Serializable {
 							contentTypeAPI, false);
 			final ImmutableMap.Builder<Object, Object> builderMap =
 					ImmutableMap.builder()
-							.putAll(contentTypeHelper.contentTypeToMap(
-									contentTypeAPI.find(tuple2._1.variable()), user))
+							.putAll(contentTypeHelper.contentTypeToMap(tuple2._1, user))
 							.put(MAP_KEY_WORKFLOWS,
 									this.workflowHelper.findSchemesByContentType(
 											contentType.id(), initData.getUser()))


### PR DESCRIPTION
In this PR, we removed an unnecessary lookup that, under very rare circumstances, was returning an outdated cached version of the Content Type. I believe this happened because the cache invalidation process was still in progress. My theory is that the invalidation process isn’t always immediate, and the lookup occurred before it was completed, leading to the retrieval of an outdated version of the Content Type.

I managed to isolate the issue, and in the few instances where it was reproduced, allowing enough time before calling `contentTypeAPI.find` resulted in the correct version being returned. This observation led me to conclude that the issue was indeed related to cache invalidation timing.

This PR fixes: #29654