### PR TITLE
Issue #29730 Fixing introspected schema and error messages

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/workflow/form/WorkflowSchemeImportObjectForm.java
+++ b/dotCMS/src/main/java/com/dotcms/workflow/form/WorkflowSchemeImportObjectForm.java
@@ -6,6 +6,7 @@ import com.dotcms.repackage.javax.validation.constraints.NotNull;
 import com.dotcms.rest.api.Validated;
 import com.dotcms.rest.api.v1.workflow.WorkflowSchemeImportExportObjectView;
 import com.dotmarketing.beans.Permission;
+import io.swagger.v3.oas.annotations.Hidden;
 
 import java.util.List;
 
@@ -13,21 +14,22 @@ import java.util.List;
 public class WorkflowSchemeImportObjectForm extends Validated {
 
     @NotNull
-    private final WorkflowSchemeImportExportObjectView workflowImportObject;
+    private final WorkflowSchemeImportExportObjectView workflowObject;
     private final List<Permission>                 permissions;
 
     @JsonCreator
     public WorkflowSchemeImportObjectForm(
-            @JsonProperty("workflowObject") final WorkflowSchemeImportExportObjectView workflowImportObject,
+            @JsonProperty("workflowObject") final WorkflowSchemeImportExportObjectView workflowObject,
             @JsonProperty("permissions")          final List<Permission> permissions) {
 
-        this.workflowImportObject = workflowImportObject;
+        this.workflowObject = workflowObject;
         this.permissions          = permissions;
         this.checkValid();
     }
 
+    @Hidden // hides method from Swagger UI on the API Playground, to avoid cluttering its schema
     public WorkflowSchemeImportExportObjectView getWorkflowImportObject() {
-        return workflowImportObject;
+        return workflowObject;
     }
 
     public List<Permission> getPermissions() {


### PR DESCRIPTION
Builds beautifully on local. Schema and error messages both look normal and expected now:

![image](https://github.com/user-attachments/assets/20abf7da-a7b1-4ed0-a891-5ea5b6d5522a)
![image](https://github.com/user-attachments/assets/a9ae5d93-c3f3-4b69-9827-2f008baea6b7)


### Proposed Changes
* Renamed several properties
* Added one tactical `@Hidden` Swagger UI annotation

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

This PR fixes: #29730