### PR TITLE
fix: revert session manager jar location change from PR #29694 (#23631)

### DIFF
--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -26,7 +26,7 @@
         <tomcat-dist-folder>dotserver/tomcat-${tomcat.version}</tomcat-dist-folder>
         <tomcat-lib-folder>${assembly-directory}/${tomcat-dist-folder}/lib</tomcat-lib-folder>
         <tomcat-log4j-lib-folder>${assembly-directory}/${tomcat-dist-folder}/log4j2/lib</tomcat-log4j-lib-folder>
-        <session-manager-lib-folder>${assembly-directory}/${tomcat-dist-folder}/session-manager/lib</session-manager-lib-folder>
+        <session-manager-lib-folder>${tomcat-lib-folder}</session-manager-lib-folder>
         <tomcat9-overrides>${project.basedir}/src/main/resources/container/tomcat9</tomcat9-overrides>
         <exploded-webapp-dir>${assembly-directory}/${tomcat-dist-folder}/webapps/ROOT</exploded-webapp-dir>
         <war.output.file>${project.build.directory}/${project.build.finalName}-war.war</war.output.file>

--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.bat
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.bat
@@ -33,8 +33,8 @@ set "CATALINA_OPTS=%CATALINA_OPTS% -Dorg.apache.tomcat.util.digester.PROPERTY_SO
 rem Check if log4j2.configurationFile is already set
 echo %CATALINA_OPTS% | findstr /C:"-Dlog4j2.configurationFile" >nul
 if %errorlevel% neq 0 (
-  echo Setting log4j2.configurationFile=%TOMCAT_HOME%\webapps\ROOT\WEB-INF\log4j\log4j2.xml
-  set "CATALINA_OPTS=%CATALINA_OPTS% -Dlog4j2.configurationFile=%TOMCAT_HOME%\webapps\ROOT\WEB-INF\log4j\log4j2.xml"
+  echo Setting log4j2.configurationFile=%CATALINA_HOME%\webapps\ROOT\WEB-INF\log4j\log4j2.xml
+  set "CATALINA_OPTS=%CATALINA_OPTS% -Dlog4j2.configurationFile=%CATALINA_HOME%\webapps\ROOT\WEB-INF\log4j\log4j2.xml"
 ) else (
   echo Log4j configuration already set
 )
@@ -49,7 +49,7 @@ if %errorlevel% neq 0 (
 )
 
 rem Set the CLASSPATH
-set "ADDITIONAL_CLASSPATH=%CATALINA_HOME%\log4j2\lib\*;%CATALINA_HOME%\session-manager\lib\*"
+set "ADDITIONAL_CLASSPATH=%CATALINA_HOME%\log4j2\lib\*"
 if "%CLASSPATH%" neq "" (
   set "CLASSPATH=%CLASSPATH%;%ADDITIONAL_CLASSPATH%"
 ) else (

--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -34,8 +34,8 @@ export CATALINA_OPTS="$CATALINA_OPTS -Dorg.apache.tomcat.util.digester.PROPERTY_
 if echo "$CATALINA_OPTS" | grep -q '\-Dlog4j2\.configurationFile'; then
   echo "Log4j configuration already set"
 else
-  echo "Setting log4j2.configurationFile=$TOMCAT_HOME/webapps/ROOT/WEB-INF/log4j/log4j2.xml"
-  export CATALINA_OPTS="$CATALINA_OPTS -Dlog4j2.configurationFile=$TOMCAT_HOME/webapps/ROOT/WEB-INF/log4j/log4j2.xml"
+  echo "Setting log4j2.configurationFile=$CATALINA_HOME/webapps/ROOT/WEB-INF/log4j/log4j2.xml"
+  export CATALINA_OPTS="$CATALINA_OPTS -Dlog4j2.configurationFile=$CATALINA_HOME/webapps/ROOT/WEB-INF/log4j/log4j2.xml"
 fi
 
 if echo "$CATALINA_OPTS" | grep -q '\-DLog4jContextSelector'; then
@@ -45,7 +45,7 @@ else
   export CATALINA_OPTS="$CATALINA_OPTS -DLog4jContextSelector=org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector"
 fi
 
-ADDITIONAL_CLASSPATH="$CATALINA_HOME/log4j2/lib/*:$CATALINA_HOME/session-manager/lib/*"
+ADDITIONAL_CLASSPATH="$CATALINA_HOME/log4j2/lib/*"
 
 if [ -n "$CLASSPATH" ]; then
   CLASSPATH="$CLASSPATH:$ADDITIONAL_CLASSPATH"


### PR DESCRIPTION
### Proposed Changes
* Fix classloader issue with session manager introduced in PR #29694
* Use CATALINA_HOME in setenv scripts instead of TOMCAT_HOME.  The first is always available, the second is only set within the docker startup scripts

Instructions for Log4j require the classes to be added to the system classloader when tomcat loads by adding to the main java CLASSPATH.  These logging jars do not need to reference any of the tomcat jars
the session manager jars do need to reference the tomcat jars e.g. catalina.jar in the main lib folder.  This is what is called the common.loader and is defined in catalina.properties file.
the session manager jars either need to be in a folder referenced in this common.loader property or as before dropped into the existing lib folder.  There is no need to change the old behaviour at this time so we can just change the install location back.

This PR fixes: #23631