### PR TITLE
fix(deployment): Pass SDKMAN_JAVA_VERSION when building deployment image  (#29685)

### DIFF
--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -70,6 +70,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get SDKMan Version
+        id: get-sdkman-version
+        shell: bash
+        run: |
+          if [ -f .sdkmanrc ]; then
+            SDKMAN_JAVA_VERSION=$(awk -F "=" '/^java=/ {print $2}' .sdkmanrc)
+            echo "using default Java version from .sdkmanrc: ${SDKMAN_JAVA_VERSION}"
+            echo "SDKMAN_JAVA_VERSION=${SDKMAN_JAVA_VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "No .sdkmanrc file found"
+            exit 1
+          fi
+
       # Clean up the runner to ensure a fresh environment
       - uses: ./.github/actions/core-cicd/cleanup-runner
 
@@ -88,6 +101,9 @@ jobs:
           docker_io_username: ${{ secrets.DOCKER_USERNAME }}
           docker_io_token: ${{ secrets.DOCKER_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          build_args: |
+            DOTCMS_DOCKER_TAG=${{ inputs.environment }}
+            SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
 
       # Build and push the dev Docker image (if required)
       - name: Build/Push Docker Dev Image
@@ -107,7 +123,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_args: |
             DOTCMS_DOCKER_TAG=${{ inputs.environment }}
-            DEV_REQUEST_TOKEN=${{ secrets.DEV_REQUEST_TOKEN }} 
+            DEV_REQUEST_TOKEN=${{ secrets.DEV_REQUEST_TOKEN }}
+            SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
 
       # Deploy CLI artifacts to JFrog Artifactory
       - name: CLI Deploy

--- a/dotCMS/src/main/docker/original/Dockerfile
+++ b/dotCMS/src/main/docker/original/Dockerfile
@@ -1,7 +1,9 @@
 # ----------------------------------------------
 # Stage 1: Construct our container using the minimal-java image and copying the prebuilt dotcms
 # ----------------------------------------------
-ARG SDKMAN_JAVA_VERSION="11.0.22-ms"
+# Need to specify the SDKMAN_JAVA_VERSION to a valid sdkman java version that is available in the dotcms/java-base image
+ARG SDKMAN_JAVA_VERSION="SDKMAN_JAVA_VERSION_ARG_NOT_SET"
+
 FROM dotcms/java-base:${SDKMAN_JAVA_VERSION} AS container-base
 WORKDIR /srv
 


### PR DESCRIPTION
### Proposed Changes
* Ensure that correct java version is used by passing SDKMAN_JAVA_VERSION build arg during deployment image build
* Remove confusion by replacing specific default for SDKMAN_JAVA_VERSION from Dockerfile requiring it to be set.

Change will only have impact in deployment step in trunk workflow. 



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
Related to #29685 (Update Project Java Version to 21.04ms and Ensure ).


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #29685