### PR TITLE
feat(dotAI): Adding fallback mechanism when it comes to send models

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIAppUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIAppUtil.java
@@ -6,6 +6,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -40,9 +41,14 @@ public class AIAppUtil {
      * @return the created text model instance
      */
     public AIModel createTextModel(final Map<String, Secret> secrets) {
+        final List<String> modelNames = splitDiscoveredSecret(secrets, AppKeys.TEXT_MODEL_NAMES);
+        if (CollectionUtils.isEmpty(modelNames)) {
+            return AIModel.NOOP_MODEL;
+        }
+
         return AIModel.builder()
                 .withType(AIModelType.TEXT)
-                .withNames(splitDiscoveredSecret(secrets, AppKeys.TEXT_MODEL_NAMES))
+                .withModelNames(modelNames)
                 .withTokensPerMinute(discoverIntSecret(secrets, AppKeys.TEXT_MODEL_TOKENS_PER_MINUTE))
                 .withApiPerMinute(discoverIntSecret(secrets, AppKeys.TEXT_MODEL_API_PER_MINUTE))
                 .withMaxTokens(discoverIntSecret(secrets, AppKeys.TEXT_MODEL_MAX_TOKENS))
@@ -57,9 +63,14 @@ public class AIAppUtil {
      * @return the created image model instance
      */
     public AIModel createImageModel(final Map<String, Secret> secrets) {
+        final List<String> modelNames = splitDiscoveredSecret(secrets, AppKeys.IMAGE_MODEL_NAMES);
+        if (CollectionUtils.isEmpty(modelNames)) {
+            return AIModel.NOOP_MODEL;
+        }
+
         return AIModel.builder()
                 .withType(AIModelType.IMAGE)
-                .withNames(splitDiscoveredSecret(secrets, AppKeys.IMAGE_MODEL_NAMES))
+                .withModelNames(modelNames)
                 .withTokensPerMinute(discoverIntSecret(secrets, AppKeys.IMAGE_MODEL_TOKENS_PER_MINUTE))
                 .withApiPerMinute(discoverIntSecret(secrets, AppKeys.IMAGE_MODEL_API_PER_MINUTE))
                 .withMaxTokens(discoverIntSecret(secrets, AppKeys.IMAGE_MODEL_MAX_TOKENS))
@@ -74,9 +85,14 @@ public class AIAppUtil {
      * @return the created embeddings model instance
      */
     public AIModel createEmbeddingsModel(final Map<String, Secret> secrets) {
+        final List<String> modelNames = splitDiscoveredSecret(secrets, AppKeys.EMBEDDINGS_MODEL_NAMES);
+        if (CollectionUtils.isEmpty(modelNames)) {
+            return AIModel.NOOP_MODEL;
+        }
+
         return AIModel.builder()
                 .withType(AIModelType.EMBEDDINGS)
-                .withNames(splitDiscoveredSecret(secrets, AppKeys.EMBEDDINGS_MODEL_NAMES))
+                .withModelNames(modelNames)
                 .withTokensPerMinute(discoverIntSecret(secrets, AppKeys.EMBEDDINGS_MODEL_TOKENS_PER_MINUTE))
                 .withApiPerMinute(discoverIntSecret(secrets, AppKeys.EMBEDDINGS_MODEL_API_PER_MINUTE))
                 .withMaxTokens(discoverIntSecret(secrets, AppKeys.EMBEDDINGS_MODEL_MAX_TOKENS))
@@ -117,9 +133,11 @@ public class AIAppUtil {
      * @return the list of split secret values
      */
     public List<String> splitDiscoveredSecret(final Map<String, Secret> secrets, final AppKeys key) {
-        return Arrays.stream(Optional.ofNullable(discoverSecret(secrets, key)).orElse(StringPool.BLANK).split(","))
-                .map(String::trim)
-                .map(String::toLowerCase)
+        return Arrays
+                .stream(Optional
+                        .ofNullable(discoverSecret(secrets, key))
+                        .map(secret -> secret.split(StringPool.COMMA))
+                        .orElse(new String[0]))
                 .collect(Collectors.toList());
     }
 

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIModels.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIModels.java
@@ -81,22 +81,22 @@ public class AIModels {
                                 loading.stream()
                                         .map(model -> Tuple.of(model.getType(), model))
                                         .collect(Collectors.toList())));
-        loading.forEach(model -> model
-                .getNames()
-                .forEach(name -> {
+        loading.forEach(aiModel -> aiModel
+                .getModels()
+                .forEach(model -> {
                     final Tuple2<String, String> key = Tuple.of(
                             host,
-                            name.toLowerCase().trim());
+                            model.getName().toLowerCase().trim());
                     if (modelsByName.containsKey(key)) {
                         Logger.debug(
                                 this,
                                 String.format(
                                         "Model [%s] already exists for host [%s], ignoring it",
-                                        name,
+                                        model.getName(),
                                         host));
                         return;
                     }
-                    modelsByName.putIfAbsent(key, model);
+                    modelsByName.putIfAbsent(key, aiModel);
                 }));
     }
 
@@ -192,7 +192,9 @@ public class AIModels {
                 .stream()
                 .flatMap(entry -> entry.getValue().stream())
                 .map(Tuple2::_2)
-                .flatMap(model -> model.getNames().stream().map(name -> new SimpleModel(name, model.getType())))
+                .flatMap(aiModel -> aiModel.getModels()
+                        .stream()
+                        .map(model -> new SimpleModel(model.getName(), aiModel.getType())))
                 .collect(Collectors.toSet());
         final Set<SimpleModel> supported = getOrPullSupportedModels()
                 .stream()

--- a/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AppConfig.java
@@ -1,5 +1,6 @@
 package com.dotcms.ai.app;
 
+import com.dotcms.ai.exception.DotAIModelNotFoundException;
 import com.dotcms.security.apps.Secret;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Logger;
@@ -114,6 +115,15 @@ public class AppConfig implements Serializable {
     }
 
     /**
+     * Retrieves the host.
+     *
+     * @return the host
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
      * Retrieves the API URL.
      *
      * @return the API URL
@@ -134,7 +144,7 @@ public class AppConfig implements Serializable {
     /**
      * Retrieves the API Embeddings URL.
      *
-     * @return
+     * @return the API Embeddings URL
      */
     public String getApiEmbeddingsUrl() {
         return UtilMethods.isEmpty(apiEmbeddingsUrl) ? AppKeys.API_EMBEDDINGS_URL.defaultValue : apiEmbeddingsUrl;
@@ -293,24 +303,10 @@ public class AppConfig implements Serializable {
      * @param modelName the name of the model to find
      */
     public AIModel resolveModelOrThrow(final String modelName) {
-        final AIModel aiModel = AIModels.get()
+        return AIModels.get()
                 .findModel(host, modelName)
-                .orElseThrow(() -> {
-                    final String supported = String.join(", ", AIModels.get().getOrPullSupportedModels());
-                    return new DotRuntimeException(
-                            "Unable to find model: [" + modelName + "]. Only [" + supported + "] are supported ");
-                });
-
-        if (!aiModel.isOperational()) {
-            debugLogger(
-                    AppConfig.class,
-                    () -> String.format(
-                            "Resolved model [%s] is not operational, avoiding its usage",
-                            aiModel.getCurrentModel()));
-            throw new DotRuntimeException(String.format("Model [%s] is not operational", aiModel.getCurrentModel()));
-        }
-
-        return aiModel;
+                .orElseThrow(() ->
+                        new DotAIModelNotFoundException(String.format("Unable to find model: [%s].", modelName)));
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/ai/app/ConfigService.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/ConfigService.java
@@ -7,6 +7,7 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.util.Logger;
+import com.google.common.annotations.VisibleForTesting;
 import com.liferay.portal.model.User;
 import io.vavr.control.Try;
 
@@ -23,7 +24,12 @@ public class ConfigService {
     private final LicenseValiditySupplier licenseValiditySupplier;
 
     private ConfigService() {
-        licenseValiditySupplier = new LicenseValiditySupplier() {};
+        this(new LicenseValiditySupplier() {});
+    }
+
+    @VisibleForTesting
+    ConfigService(final LicenseValiditySupplier licenseValiditySupplier) {
+        this.licenseValiditySupplier = licenseValiditySupplier;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/ai/client/AIClientStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/AIClientStrategy.java
@@ -1,5 +1,7 @@
 package com.dotcms.ai.client;
 
+import com.dotcms.ai.domain.AIResponse;
+
 import java.io.OutputStream;
 import java.io.Serializable;
 

--- a/dotCMS/src/main/java/com/dotcms/ai/client/AIProxiedClient.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/AIProxiedClient.java
@@ -1,5 +1,7 @@
 package com.dotcms.ai.client;
 
+import com.dotcms.ai.domain.AIResponse;
+
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;

--- a/dotCMS/src/main/java/com/dotcms/ai/client/AIProxyClient.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/AIProxyClient.java
@@ -3,6 +3,7 @@ package com.dotcms.ai.client;
 import com.dotcms.ai.client.openai.OpenAIClient;
 import com.dotcms.ai.client.openai.OpenAIResponseEvaluator;
 import com.dotcms.ai.domain.AIProvider;
+import com.dotcms.ai.domain.AIResponse;
 import io.vavr.Lazy;
 
 import java.io.OutputStream;

--- a/dotCMS/src/main/java/com/dotcms/ai/client/README.md
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/README.md
@@ -1,0 +1,61 @@
+# AI Clients
+
+This initiative that is introduced to dotCMS in several commits but the main idea is to provide a way to interact with AI services in a more generic way.
+
+## From OpenAIRequest to AIClient
+Basically we use to have a class called `OpenAIRequest` that was used to interact with OpenAI services. This class was a bit coupled with OpenAI services and we decided to create a more generic way to interact with AI services.
+So we created the `AIClient` interface which will be implemented by any component that needs to interact with an AI Provider.
+Since OpenAI is the first AI provider we are integrating with, we created the `OpenAIClient` class that implements the `AIClient` interface.
+
+Usually, the `AIClient` will have a method called `sendRequest` that will receive a `Request` object and return a `Response` object.
+That's it. You should not have to worry about instantiating the `AIClient` implementation, since this is managed by a higher level component called `AIClientProxy`. 
+
+## AIClientProxy
+This class will hold an internal structure that maps the AI provider identification to something called `AIProxiedClient`. 
+
+The `AIClientProxy` is a class that will manage the instantiation of the `AIClient` implementation.
+
+### AIProxiedClient
+The mere purpose of this class it to hold the `AIClient` implementation, an `AIClientStrategy` implementation and a `AIResponseEvaluator` implementation. 
+It's like a intersection point between these three classes and to keep decoupled enough the concepts of a AI client and the strategy used to send requests to the AI provider and finally how to interpret/evaluate the response from the AI provider.
+It provides the flexibility of decouple a strategy from the client and from the response evaluator.
+
+### AIClientStrategy
+This class is responsible for defining the strategy that the `AIClient` will use to interact with the AI provider.
+Currently there are 2 strategies:
+- `AIDefaultStrategy`: This strategy will be used when the desired behaviour is to just try to send a request.
+- `AIModelFallbackStrategy`: This strategy will be used when the desired behaviour is to try to send a request to a model and if it fails, try to send the request to another model and so on until options are exhausted.
+
+### AIResponseEvaluator
+This class is responsible for defining how the response from the AI provider will be evaluated. We will look for specific contents in the response to resolve (if any) the type of error and how to handle it. 
+
+## How to use the whole thing
+`AIClientProxy` is a singleton class that is the entrypoint for any other dotCMS component which needs to consume AI output.
+It used to be the `OpenAIRequest` class but now it should be the `AIClientProxy` class since it provides multi-provider and multi-strategy support.
+
+Given a `AIRequest` instance (which will be built before calling this entrypoint and that for the sake of this example it will be built inline) and an `OutputStream` subclass, this is how you use it in your code:
+
+```java
+final AIReponse response = AIProxyClient.get()
+        .sendRequest(
+                AIProvider.OPEN_AI.name(),
+                OpenAIRequest.builder()
+                        .model("gpt-3.5-turbo")
+                        .prompt("Once upon a time")
+                        .build(),
+                output);
+```
+Based on the provider name, behind curtains, the `AIClientProxy` will look for the `AIProxiedClient` instance that is registered with the provider name and will use the strategy and response evaluator that are registered with the `AIProxiedClient` instance.
+
+You can register instances of `AIProxiedClient` that will be used by the `AIClientProxy` like this:
+
+```java
+AIProxyClient.get().addClient(
+        AIProvider.OPEN_AI.name(),
+        AIProxiedClient.of(
+                OpenAIClient.get(),
+                AIProxyStrategy.MODEL_FALLBACK,
+                OpenAIResponseEvaluator.get()));
+```
+Here we can see how the three main elements are conjugated in a single `AIProxiedClient` instance.
+Here we are registering an `OpenAIClient` instance with the `MODEL_FALLBACK` strategy and the `OpenAIResponseEvaluator` instance and it means that whenvever 

--- a/dotCMS/src/main/java/com/dotcms/ai/db/EmbeddingsDTO.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/db/EmbeddingsDTO.java
@@ -87,7 +87,8 @@ public class EmbeddingsDTO implements Serializable {
                 .withOperator(form.operator)
                 .withThreshold(form.threshold)
                 .withTemperature(form.temperature)
-                .withTokenCount(form.responseLengthTokens);
+                .withTokenCount(form.responseLengthTokens)
+                .withUser(form.user);
     }
 
     public static Builder from(final Map<String, Object> form) {

--- a/dotCMS/src/main/java/com/dotcms/ai/domain/AIResponse.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/domain/AIResponse.java
@@ -1,4 +1,4 @@
-package com.dotcms.ai.client;
+package com.dotcms.ai.domain;
 
 /**
  * Represents a response from an AI service.

--- a/dotCMS/src/main/java/com/dotcms/ai/rest/forms/CompletionsForm.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/rest/forms/CompletionsForm.java
@@ -8,6 +8,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.liferay.portal.model.User;
 import io.vavr.control.Try;
 
 import javax.validation.constraints.Max;
@@ -49,6 +50,7 @@ public class CompletionsForm {
     public final String model;
     public final String operator;
     public final String site;
+    public final User user;
 
     @Override
     public boolean equals(final Object o) {
@@ -88,6 +90,7 @@ public class CompletionsForm {
                 ", operator='" + operator + '\'' +
                 ", site='" + site + '\'' +
                 ", contentType=" + Arrays.toString(contentType) +
+                ", user=" + user +
                 '}';
     }
 
@@ -118,6 +121,7 @@ public class CompletionsForm {
             this.temperature = builder.temperature >= 2 ? 2 : builder.temperature;
         }
         this.model = UtilMethods.isSet(builder.model) ? builder.model : ConfigService.INSTANCE.config().getModel().getCurrentModel();
+        this.user = builder.user;
     }
 
     private String validateBuilderQuery(final String query) {
@@ -131,7 +135,6 @@ public class CompletionsForm {
         return Try.of(() -> Long.parseLong(language))
                 .recover(x -> APILocator.getLanguageAPI().getLanguage(language).getId())
                 .getOrElseTry(() -> APILocator.getLanguageAPI().getDefaultLanguage().getId());
-
     }
 
     public static Builder copy(final CompletionsForm form) {
@@ -149,7 +152,8 @@ public class CompletionsForm {
                 .operator(form.operator)
                 .indexName(form.indexName)
                 .threshold(form.threshold)
-                .stream(form.stream);
+                .stream(form.stream)
+                .user(form.user);
     }
 
     public static final class Builder {
@@ -182,6 +186,8 @@ public class CompletionsForm {
         private String operator = "cosine";
         @JsonSetter(nulls = Nulls.SKIP)
         private String site;
+        @JsonSetter(nulls = Nulls.SKIP)
+        private User user;
 
         public Builder prompt(String queryOrPrompt) {
             this.prompt = queryOrPrompt;
@@ -224,7 +230,7 @@ public class CompletionsForm {
         }
 
         public Builder model(String model) {
-            this.model =model;
+            this.model = model;
             return this;
         }
 
@@ -254,7 +260,12 @@ public class CompletionsForm {
         }
 
         public Builder site(String site) {
-            this.site =site;
+            this.site = site;
+            return this;
+        }
+
+        public Builder user(User user) {
+            this.user = user;
             return this;
         }
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
@@ -3678,4 +3678,15 @@ public class UtilMethods {
     public static <T extends CharSequence> boolean exceedsMaxLength(final T value, final int maxLength) {
         return value != null && value.length() > maxLength;
     }
+
+    /**
+     * Extracts the user id from a User object or returns null if the object is null
+     *
+     * @param user User object
+     * @return User id or null
+     */
+    public static String extractUserIdOrNull(final User user) {
+        return Optional.ofNullable(user).map(User::getUserId).orElse(null);
+    }
+
 }

--- a/dotCMS/src/test/java/com/dotcms/ai/app/AIAppUtilTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/app/AIAppUtilTest.java
@@ -1,10 +1,12 @@
 package com.dotcms.ai.app;
 
+import com.dotcms.ai.domain.Model;
 import com.dotcms.security.apps.Secret;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -127,7 +129,7 @@ public class AIAppUtilTest {
         AIModel model = aiAppUtil.createTextModel(secrets);
         assertNotNull(model);
         assertEquals(AIModelType.TEXT, model.getType());
-        assertTrue(model.getNames().contains("textmodel"));
+        assertTrue(model.getModels().stream().map(Model::getName).collect(Collectors.toList()).contains("textmodel"));
     }
 
     /**
@@ -143,7 +145,7 @@ public class AIAppUtilTest {
         AIModel model = aiAppUtil.createImageModel(secrets);
         assertNotNull(model);
         assertEquals(AIModelType.IMAGE, model.getType());
-        assertTrue(model.getNames().contains("imagemodel"));
+        assertTrue(model.getModels().stream().map(Model::getName).collect(Collectors.toList()).contains("imagemodel"));
     }
 
     /**
@@ -159,7 +161,8 @@ public class AIAppUtilTest {
         AIModel model = aiAppUtil.createEmbeddingsModel(secrets);
         assertNotNull(model);
         assertEquals(AIModelType.EMBEDDINGS, model.getType());
-        assertTrue(model.getNames().contains("embeddingsmodel"));
+        assertTrue(model.getModels().stream().map(Model::getName).collect(Collectors.toList())
+                .contains("embeddingsmodel"));
     }
 
     @Test

--- a/dotCMS/src/test/java/com/dotcms/ai/client/openai/AIProxiedClientTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/client/openai/AIProxiedClientTest.java
@@ -1,0 +1,102 @@
+package com.dotcms.ai.client.openai;
+
+import com.dotcms.ai.client.AIClient;
+import com.dotcms.ai.client.AIClientStrategy;
+import com.dotcms.ai.client.AIProxiedClient;
+import com.dotcms.ai.client.AIProxyStrategy;
+import com.dotcms.ai.client.AIRequest;
+import com.dotcms.ai.domain.AIResponse;
+import com.dotcms.ai.client.AIResponseEvaluator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the AIProxiedClient class.
+ *
+ * @author vico
+ */
+public class AIProxiedClientTest {
+
+    private AIClient mockClient;
+    private AIProxyStrategy mockProxyStrategy;
+    private AIClientStrategy mockClientStrategy;
+    private AIResponseEvaluator mockResponseEvaluator;
+    private AIProxiedClient proxiedClient;
+
+    @Before
+    public void setUp() {
+        mockClient = mock(AIClient.class);
+        mockProxyStrategy = mock(AIProxyStrategy.class);
+        mockClientStrategy = mock(AIClientStrategy.class);
+        when(mockProxyStrategy.getStrategy()).thenReturn(mockClientStrategy);
+        mockResponseEvaluator = mock(AIResponseEvaluator.class);
+        proxiedClient = AIProxiedClient.of(mockClient, mockProxyStrategy, mockResponseEvaluator);
+    }
+
+    /**
+     * Scenario: Sending a valid AI request
+     * Given a valid AI request
+     * When the request is sent to the AI service
+     * Then the strategy should be applied
+     * And the response should be written to the output stream
+     */
+    @Test
+    public void testSendToAI_withValidRequest() {
+        AIRequest<Serializable> request = mock(AIRequest.class);
+        OutputStream output = mock(OutputStream.class);
+
+        AIResponse response = proxiedClient.sendToAI(request, output);
+
+        verify(mockClientStrategy).applyStrategy(mockClient, mockResponseEvaluator, request, output);
+        assertEquals(AIResponse.EMPTY, response);
+    }
+
+    /**
+     * Scenario: Sending an AI request with null output stream
+     * Given a valid AI request and a null output stream
+     * When the request is sent to the AI service
+     * Then the strategy should be applied
+     * And the response should be returned as a string
+     */
+    @Test
+    public void testSendToAI_withNullOutput() {
+        AIRequest<Serializable> request = mock(AIRequest.class);
+        AIResponse response = proxiedClient.sendToAI(request, null);
+
+        verify(mockClientStrategy).applyStrategy(
+                eq(mockClient),
+                eq(mockResponseEvaluator),
+                eq(request),
+                any(OutputStream.class));
+        assertEquals("", response.getResponse());
+    }
+
+    /**
+     * Scenario: Sending an AI request with NOOP client
+     * Given a valid AI request and a NOOP client
+     * When the request is sent to the AI service
+     * Then no operations should be performed
+     * And the response should be empty
+     */
+    @Test
+    public void testSendToAI_withNoopClient() {
+        proxiedClient = AIProxiedClient.NOOP;
+        AIRequest<Serializable> request = AIRequest.builder().build();
+        OutputStream output = new ByteArrayOutputStream();
+
+        AIResponse response = proxiedClient.sendToAI(request, output);
+
+        assertEquals(AIResponse.EMPTY, response);
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/ai/client/openai/OpenAIResponseEvaluatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/client/openai/OpenAIResponseEvaluatorTest.java
@@ -1,0 +1,143 @@
+package com.dotcms.ai.client.openai;
+
+import com.dotcms.ai.domain.AIResponseData;
+import com.dotcms.ai.domain.ModelStatus;
+import com.dotcms.ai.exception.DotAIModelNotFoundException;
+import com.dotmarketing.exception.DotRuntimeException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for the OpenAIResponseEvaluator class.
+ *
+ * @author vico
+ */
+public class OpenAIResponseEvaluatorTest {
+
+    private OpenAIResponseEvaluator evaluator;
+
+    @Before
+    public void setUp() {
+        evaluator = OpenAIResponseEvaluator.get();
+    }
+
+    /**
+     * Scenario: Processing a response with an error
+     * Given a response with an error message "Model has been deprecated"
+     * When the response is processed
+     * Then the metadata should contain the error message "Model has been deprecated"
+     * And the status should be set to DECOMMISSIONED
+     */
+    @Test
+    public void testFromResponse_withError() {
+        String response = new JSONObject()
+                .put("error", new JSONObject().put("message", "Model has been deprecated"))
+                .toString();
+        AIResponseData metadata = new AIResponseData();
+
+        evaluator.fromResponse(response, metadata, true);
+
+        assertEquals("Model has been deprecated", metadata.getError());
+        assertEquals(ModelStatus.DECOMMISSIONED, metadata.getStatus());
+    }
+
+    /**
+     * Scenario: Processing a response with an error
+     * Given a response with an error message "Model has been deprecated"
+     * When the response is processed as no JSON
+     * Then the metadata should contain the error message "Model has been deprecated"
+     * And the status should be set to DECOMMISSIONED
+     */
+    @Test
+    public void testFromResponse_withErrorNoJson() {
+        String response = new JSONObject()
+                .put("error", new JSONObject().put("message", "Model has been deprecated"))
+                .toString();
+        AIResponseData metadata = new AIResponseData();
+
+        evaluator.fromResponse(response, metadata, false);
+
+        assertEquals("Model has been deprecated", metadata.getError());
+        assertEquals(ModelStatus.DECOMMISSIONED, metadata.getStatus());
+    }
+
+    /**
+     * Scenario: Processing a response with an error
+     * Given a response with an error message "Model has been deprecated"
+     * When the response is processed as no JSON
+     * Then the metadata should contain the error message "Model has been deprecated"
+     * And the status should be set to DECOMMISSIONED
+     */
+    @Test
+    public void testFromResponse_withoutErrorNoJson() {
+        String response = "not a json response";
+        AIResponseData metadata = new AIResponseData();
+
+        evaluator.fromResponse(response, metadata, false);
+
+        assertNull(metadata.getError());
+        assertNull(metadata.getStatus());
+    }
+
+    /**
+     * Scenario: Processing a response without an error
+     * Given a response without an error message
+     * When the response is processed
+     * Then the metadata should not contain any error message
+     * And the status should be null
+     */
+    @Test
+    public void testFromResponse_withoutError() {
+        String response = new JSONObject().put("data", "some data").toString();
+        AIResponseData metadata = new AIResponseData();
+
+        evaluator.fromResponse(response, metadata, true);
+
+        assertNull(metadata.getError());
+        assertNull(metadata.getStatus());
+    }
+
+    /**
+     * Scenario: Processing an exception of type DotRuntimeException
+     * Given an exception of type DotAIModelNotFoundException with message "Model not found"
+     * When the exception is processed
+     * Then the metadata should contain the error message "Model not found"
+     * And the status should be set to INVALID
+     * And the exception should be set to the given DotRuntimeException
+     */
+    @Test
+    public void testFromException_withDotRuntimeException() {
+        DotRuntimeException exception = new DotAIModelNotFoundException("Model not found");
+        AIResponseData metadata = new AIResponseData();
+
+        evaluator.fromException(exception, metadata);
+
+        assertEquals("Model not found", metadata.getError());
+        assertEquals(ModelStatus.INVALID, metadata.getStatus());
+        assertEquals(exception, metadata.getException());
+    }
+
+    /**
+     * Scenario: Processing a general exception
+     * Given a general exception with message "General error"
+     * When the exception is processed
+     * Then the metadata should contain the error message "General error"
+     * And the status should be set to UNKNOWN
+     * And the exception should be wrapped in a DotRuntimeException
+     */
+    @Test
+    public void testFromException_withOtherException() {
+        Exception exception = new Exception("General error");
+        AIResponseData metadata = new AIResponseData();
+
+        evaluator.fromException(exception, metadata);
+
+        assertEquals("General error", metadata.getError());
+        assertEquals(ModelStatus.UNKNOWN, metadata.getStatus());
+        assertEquals(DotRuntimeException.class, metadata.getException().getClass());
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/ai/service/OpenAIChatServiceImplTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/service/OpenAIChatServiceImplTest.java
@@ -66,7 +66,7 @@ public class OpenAIChatServiceImplTest {
 
     private JSONObject prepareJsonObject(final String prompt) {
         when(config.getModel())
-                .thenReturn(AIModel.builder().withType(AIModelType.TEXT).withNames("some-model").build());
+                .thenReturn(AIModel.builder().withType(AIModelType.TEXT).withModelNames("some-model").build());
         when(config.getConfigFloat(AppKeys.COMPLETION_TEMPERATURE)).thenReturn(123.321F);
         when(config.getRolePrompt()).thenReturn("some-role-prompt");
 

--- a/dotCMS/src/test/java/com/dotcms/ai/service/OpenAIImageServiceImplTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/service/OpenAIImageServiceImplTest.java
@@ -220,7 +220,8 @@ public class OpenAIImageServiceImplTest {
     }
 
     private JSONObject prepareJsonObject(final String prompt, final boolean tempFileError) throws Exception {
-        when(config.getImageModel()).thenReturn(AIModel.builder().withType(AIModelType.IMAGE).withNames("some-image-model").build());
+        when(config.getImageModel())
+                .thenReturn(AIModel.builder().withType(AIModelType.IMAGE).withModelNames("some-image-model").build());
         when(config.getImageSize()).thenReturn("some-image-size");
         final File file = mock(File.class);
         when(file.getName()).thenReturn(UUIDGenerator.shorty());

--- a/dotCMS/src/test/java/com/dotmarketing/util/UtilMethodsTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/UtilMethodsTest.java
@@ -5,9 +5,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.dotcms.UnitTestBase;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.liferay.portal.model.User;
 import org.junit.Test;
 
 /**
@@ -206,6 +209,31 @@ public class UtilMethodsTest extends UnitTestBase {
 		for(String imageName:badImageNames){
 			assertFalse(UtilMethods.isImage(imageName));
 		}
+	}
+
+	/**
+	 * Scenario: Extracting user ID from a User object
+	 * Given a null User object
+	 * When the user ID is extracted
+	 * Then the result should be null
+	 *
+	 * Given a mocked User object with no user ID
+	 * When the user ID is extracted
+	 * Then the result should be null
+	 *
+	 * Given a mocked User object with a user ID "userId"
+	 * When the user ID is extracted
+	 * Then the result should be "userId"
+	 */
+	@Test
+	public void test_extractUserIdOrNull(){
+		assertNull(UtilMethods.extractUserIdOrNull(null));
+
+		final User user = mock(User.class);
+		assertNull(UtilMethods.extractUserIdOrNull(user));
+
+		when(user.getUserId()).thenReturn("userId");
+		assertEquals("userId", UtilMethods.extractUserIdOrNull(user));
 	}
 
 }

--- a/dotcms-integration/src/test/java/com/dotcms/ai/AiTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/ai/AiTest.java
@@ -11,6 +11,8 @@ import com.dotmarketing.exception.DotSecurityException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 public interface AiTest {
 
@@ -81,5 +83,63 @@ public interface AiTest {
     static void removeSecrets(final Host host) throws DotDataException, DotSecurityException {
         APILocator.getAppsAPI().removeSecretsForSite(host, APILocator.systemUser());
     }
+
+
+
+
+    // TODO: pr-split -> remove methods below
+    static Map<String, Secret> aiAppSecrets(final Host host,
+                                            final String apiKey,
+                                            final String textModels,
+                                            final String imageModels,
+                                            final String embeddingsModel) throws Exception {
+        final AppSecrets.Builder builder = new AppSecrets.Builder()
+                .withKey(AppKeys.APP_KEY)
+                .withSecret(AppKeys.API_URL.key, String.format(API_URL, PORT))
+                .withSecret(AppKeys.API_IMAGE_URL.key, String.format(API_IMAGE_URL, PORT))
+                .withSecret(AppKeys.API_EMBEDDINGS_URL.key, String.format(API_EMBEDDINGS_URL, PORT))
+                .withHiddenSecret(AppKeys.API_KEY.key, apiKey)
+                .withSecret(AppKeys.IMAGE_SIZE.key, IMAGE_SIZE)
+                .withSecret(AppKeys.LISTENER_INDEXER.key, "{\"default\":\"blog\"}")
+                .withSecret(AppKeys.COMPLETION_ROLE_PROMPT.key, AppKeys.COMPLETION_ROLE_PROMPT.defaultValue)
+                .withSecret(AppKeys.COMPLETION_TEXT_PROMPT.key, AppKeys.COMPLETION_TEXT_PROMPT.defaultValue);
+
+        if (Objects.nonNull(textModels)) {
+            builder.withSecret(AppKeys.TEXT_MODEL_NAMES.key, textModels);
+        }
+        if (Objects.nonNull(imageModels)) {
+            builder.withSecret(AppKeys.IMAGE_MODEL_NAMES.key, imageModels);
+        }
+        if (Objects.nonNull(embeddingsModel)) {
+            builder.withSecret(AppKeys.EMBEDDINGS_MODEL_NAMES.key, embeddingsModel);
+        }
+
+        final AppSecrets appSecrets = builder.build();
+        APILocator.getAppsAPI().saveSecrets(appSecrets, host, APILocator.systemUser());
+        TimeUnit.SECONDS.sleep(1);
+        return appSecrets.getSecrets();
+    }
+
+    static Map<String, Secret> aiAppSecrets(final Host host, final String apiKey) throws Exception {
+        return aiAppSecrets(host, apiKey, MODEL, IMAGE_MODEL, EMBEDDINGS_MODEL);
+    }
+
+    static Map<String, Secret> aiAppSecrets(final Host host,
+                                            final String textModels,
+                                            final String imageModels,
+                                            final String embeddingsModel) throws Exception {
+        return aiAppSecrets(host, API_KEY, textModels, imageModels, embeddingsModel);
+    }
+
+    static Map<String, Secret> aiAppSecrets(final Host host) throws Exception {
+
+        return aiAppSecrets(host, MODEL, IMAGE_MODEL, EMBEDDINGS_MODEL);
+    }
+
+    static void removeAiAppSecrets(final Host host) throws Exception {
+        APILocator.getAppsAPI().deleteSecrets(AppKeys.APP_KEY, host, APILocator.systemUser());
+    }
+
+
 
 }

--- a/dotcms-integration/src/test/java/com/dotcms/ai/app/ConfigServiceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/ai/app/ConfigServiceTest.java
@@ -1,0 +1,101 @@
+package com.dotcms.ai.app;
+
+import com.dotcms.ai.AiTest;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotcms.util.LicenseValiditySupplier;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the ConfigService class.
+ *
+ * <p>
+ * This class contains tests to verify the behavior of the ConfigService,
+ * including scenarios with valid and invalid licenses, and configurations
+ * with and without secrets.
+ * </p>
+ *
+ * <p>
+ * The tests ensure that the ConfigService correctly initializes and
+ * configures the AppConfig based on the provided Host and license validity.
+ * </p>
+ *
+ * @author vico
+ */
+public class ConfigServiceTest {
+
+    private Host host;
+    private ConfigService configService;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    @Before
+    public void before() {
+        host = new SiteDataGen().nextPersisted();
+        configService = ConfigService.INSTANCE;
+    }
+
+    /**
+     * Given a ConfigService with an invalid license
+     * When the config method is called with a host
+     * Then the models should not be operational.
+     */
+    @Test
+    public void test_invalidLicense() {
+        configService = new ConfigService(new LicenseValiditySupplier() {
+            @Override
+            public boolean hasValidLicense() {
+                return false;
+            }
+        });
+        final AppConfig appConfig = configService.config(host);
+
+        assertFalse(appConfig.getModel().isOperational());
+        assertFalse(appConfig.getImageModel().isOperational());
+        assertFalse(appConfig.getEmbeddingsModel().isOperational());
+    }
+
+    /**
+     * Given a host with secrets and a ConfigService
+     * When the config method is called with the host
+     * Then the models should be operational and the host should be correctly set in the AppConfig.
+     */
+    @Test
+    public void test_config_hostWithSecrets() throws Exception {
+        AiTest.aiAppSecrets(host, "text-model-0", "image-model-1", "embeddings-model-2");
+        final AppConfig appConfig = configService.config(host);
+
+        assertTrue(appConfig.getModel().isOperational());
+        assertTrue(appConfig.getImageModel().isOperational());
+        assertTrue(appConfig.getEmbeddingsModel().isOperational());
+        assertEquals(host.getHostname(), appConfig.getHost());
+    }
+
+    /**
+     * Given a host without secrets and a ConfigService
+     * When the config method is called with the host
+     * Then the models should be operational and the host should be set to "System Host" in the AppConfig.
+     */
+    @Test
+    public void test_config_hostWithoutSecrets() throws Exception {
+        AiTest.aiAppSecrets(APILocator.systemHost(), "text-model-10", "image-model-11", "embeddings-model-12");
+        final AppConfig appConfig = configService.config(host);
+
+        assertTrue(appConfig.getModel().isOperational());
+        assertTrue(appConfig.getImageModel().isOperational());
+        assertTrue(appConfig.getEmbeddingsModel().isOperational());
+        assertEquals("System Host", appConfig.getHost());
+    }
+
+}

--- a/dotcms-integration/src/test/resources/mappings/apollo-space-program.json
+++ b/dotcms-integration/src/test/resources/mappings/apollo-space-program.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/c",
+    "headers": {
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
+      "Authorization": {
+        "equalTo": "Bearer some-api-key-1a2bc3"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matches": ".*\"model\":\"gpt-4o-mini\".*\"content\":\"What are the major achievements of the Apollo space program.*"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "cmpl-11",
+      "object": "text_completion",
+      "created": 1699999999,
+      "model": "gpt-4o-mini",
+      "choices": [
+        {
+          "text": "The Apollo space program, conducted by NASA, achieved several major milestones in space exploration. Its most significant achievement was the successful landing of humans on the Moon. Apollo 11, in 1969, saw astronauts Neil Armstrong and Buzz Aldrin become the first humans to set foot on the lunar surface. The program also provided extensive scientific data and technological advancements.",
+          "index": 0,
+          "logprobs": null,
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": {
+        "prompt_tokens": 10,
+        "completion_tokens": 57,
+        "total_tokens": 67
+      }
+    }
+  }
+}

--- a/dotcms-integration/src/test/resources/mappings/decommissioned-model.json
+++ b/dotcms-integration/src/test/resources/mappings/decommissioned-model.json
@@ -1,0 +1,30 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/c",
+    "headers": {
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
+      "Authorization": {
+        "equalTo": "Bearer some-api-key-1a2bc3"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matches": ".*\"model\":\"some-decommissioned-model-..\".*"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "error": {
+        "message": "The model `some-decommissioned-model` has been deprecated, learn more here: https://platform.openai.com/docs/deprecations",
+        "type": "invalid_request_error",
+        "param": null,
+        "code": "model_not_found"
+      }
+    }
+  }
+}

--- a/dotcms-integration/src/test/resources/mappings/invalid-model.json
+++ b/dotcms-integration/src/test/resources/mappings/invalid-model.json
@@ -1,0 +1,30 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/c",
+    "headers": {
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
+      "Authorization": {
+        "equalTo": "Bearer some-api-key-1a2bc3"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matches": ".*\"model\":\"some-made-up-model-..\".*"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "error": {
+        "message": "The model `some-made-up-mode` does not exist or you do not have access to it.",
+        "type": "invalid_request_error",
+        "param": null,
+        "code": "model_not_found"
+      }
+    }
+  }
+}

--- a/dotcms-postman/src/main/resources/postman/AI.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/AI.postman_collection.json
@@ -60,7 +60,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"apiKey\": {\n    \"value\": \"some-api-key-1a2bc3\"\n  },\n  \"textModelNames\": {\n    \"value\": \"gpt-4o\"\n  },\n  \"textModelMaxTokens\": {\n    \"value\":\"16384\"\n  },\n  \"imageModelNames\": {\n    \"value\": \"dall-e-3\"\n  },\n  \"imageSize\": {\n    \"value\": \"1024x1024\"\n  },\n  \"imageModelMaxTokens\": {\n    \"value\":\"0\"\n  },\n  \"embeddingsModelNames\": {\n    \"value\": \"text-embedding-ada-002\"\n  },\n  \"embeddingsModelMaxTokens\": {\n    \"value\":\"8191\"\n  },\n  \"listenerIndexer\": {\n    \"value\": \"{\\\"default\\\":\\\"blog,dotcmsdocumentation,feature,ProductBriefs,news,report.file,builds,casestudy\\\",\\\"documentation\\\":\\\"dotcmsdocumentation\\\"}\"\n  }\n}\n"
+							"raw": "{\n  \"apiKey\": {\n    \"value\": \"some-api-key-1a2bc3\"\n  },\n  \"textModelNames\": {\n    \"value\": \"gpt-4o-mini\"\n  },\n  \"textModelMaxTokens\": {\n    \"value\":\"16384\"\n  },\n  \"imageModelNames\": {\n    \"value\": \"dall-e-3\"\n  },\n  \"imageSize\": {\n    \"value\": \"1024x1024\"\n  },\n  \"imageModelMaxTokens\": {\n    \"value\":\"0\"\n  },\n  \"embeddingsModelNames\": {\n    \"value\": \"text-embedding-ada-002\"\n  },\n  \"embeddingsModelMaxTokens\": {\n    \"value\":\"8191\"\n  },\n  \"listenerIndexer\": {\n    \"value\": \"{\\\"default\\\":\\\"blog,dotcmsdocumentation,feature,ProductBriefs,news,report.file,builds,casestudy\\\",\\\"documentation\\\":\\\"dotcmsdocumentation\\\"}\"\n  }\n}\n"
 						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/apps/dotAI/SYSTEM_HOST",
@@ -3035,7 +3035,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"prompt\": \"{{seoText}}\",\n    \"model\": \"text-embedding-ada-002\",\n    \"responseLengthTokens\": 1\n}",
+							"raw": "{\n    \"prompt\": \"{{seoText}}\",\n    \"responseLengthTokens\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3111,7 +3111,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"prompt\": \"{{seoText}}\",\n    \"responseLengthTokens\": 1,\n    \"model\": \"text-embedding-ada-002\",\n    \"stream\": true\n}",
+							"raw": "{\n    \"prompt\": \"{{seoText}}\",\n    \"responseLengthTokens\": 1,\n    \"stream\": true\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3140,7 +3140,7 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test('Status code should be ok 200', function () {",
+									"pm.test('Status code should be ok 20', function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									"",
@@ -3431,11 +3431,19 @@
 	],
 	"variable": [
 		{
+			"key": "seoId",
+			"value": ""
+		},
+		{
+			"key": "seoText",
+			"value": ""
+		},
+		{
 			"key": "seoIndex",
 			"value": ""
 		},
 		{
-			"key": "seoId",
+			"key": "seos",
 			"value": ""
 		},
 		{
@@ -3444,18 +3452,6 @@
 		},
 		{
 			"key": "seoContentTypeVar",
-			"value": ""
-		},
-		{
-			"key": "seos",
-			"value": ""
-		},
-		{
-			"key": "seoText",
-			"value": ""
-		},
-		{
-			"key": "key",
 			"value": ""
 		}
 	]

--- a/dotcms-postman/src/test/resources/mappings/apollo-space-program.json
+++ b/dotcms-postman/src/test/resources/mappings/apollo-space-program.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/c",
+    "headers": {
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
+      "Authorization": {
+        "equalTo": "Bearer some-api-key-1a2bc3"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matches": ".*\"content\":\"What are the major achievements of the Apollo space program.*"
+      }
+    ]
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "id": "cmpl-11",
+      "object": "text_completion",
+      "created": 1699999999,
+      "model": "gpt-3.5-turbo-16k",
+      "choices": [
+        {
+          "text": "The Apollo space program, conducted by NASA, achieved several major milestones in space exploration. Its most significant achievement was the successful landing of humans on the Moon. Apollo 11, in 1969, saw astronauts Neil Armstrong and Buzz Aldrin become the first humans to set foot on the lunar surface. The program also provided extensive scientific data and technological advancements.",
+          "index": 0,
+          "logprobs": null,
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": {
+        "prompt_tokens": 10,
+        "completion_tokens": 57,
+        "total_tokens": 67
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adding multi model support with a more robust class thans just String to AIModel class. Introducing README file to document new usage of AIClient instead of OpenAIRequest class. Adding AI testing utils as well as necessary Wiremock templates for IT and postman tests.

Refs: #29284

This PR fixes: #29284