### PR TITLE
fix(encoding) : set default character encoding for requests

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/web.xml
+++ b/dotCMS/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0"?>
 <web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-                      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-		 version="3.0" metadata-complete="true">
+                      http://java.sun.com/xml/ns/javaee/web-app_4_0.xsd"
+		 version="4.0" metadata-complete="true">
     <display-name>dotCMS</display-name>
+
+	<request-character-encoding>UTF-8</request-character-encoding>
+	<response-character-encoding>UTF-8</response-character-encoding>
 
 	<!-- Don't ever delete the following comment tags, it will break the build -->
 	<!-- BEGIN JSPS --> <!-- END JSPS -->


### PR DESCRIPTION
Closes #29392

### Proposed Changes
* Upgrade `web.xml` deployment descriptor to use Servlet 4 specification
* With Servlet 4, these 2 elements can be added to the `web.xml` configuration file:
```
	<request-character-encoding>UTF-8</request-character-encoding>
	<response-character-encoding>UTF-8</response-character-encoding>
```
To set. UTF-8 as the default character encoding for requests and responses.

This PR fixes: #29392