### PR TITLE
#29255 also set siteName to CT

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentTypeHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentTypeHandler.java
@@ -301,11 +301,14 @@ public class ContentTypeHandler implements IHandler {
 					.toJavaOptional()
 					.orElse(Host.SYSTEM_HOST);
 
+		final Host host = APILocator.getHostAPI().find(hostId, APILocator.systemUser(), false);
 
 		// update host so that it works locally
 		final ContentType typeToSave = hostId.equals(contentTypeIn.host())
 				? contentTypeIn
-				: ContentTypeBuilder.builder(contentTypeIn).from(contentTypeIn).host(hostId).build();
+				: ContentTypeBuilder.builder(contentTypeIn).from(contentTypeIn)
+				.host(host.getIdentifier())
+				.siteName(host.getHostname()).build();
 
 
 		final List<Field> deferredFields = fields.stream()


### PR DESCRIPTION
The siteName is also needed to be set to the CT because otherwise the host it gets looked up by siteName first if it does not exist on the receiver it will fallback to defaultHost, which is *not* the desired behavior here, which is fallback to system_host. 

This PR fixes: #29255