### PR TITLE
logs: more logging added to PP receiver classes. ref: #29668

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditAPIImpl.java
@@ -78,6 +78,8 @@ public class PublishAuditAPIImpl extends PublishAuditAPI {
 	@Override
 	public void insertPublishAuditStatus(PublishAuditStatus pa)
 			throws DotPublisherException {
+		Logger.debug(PublishAuditAPIImpl.class,"Inserting audit table for bundle: " + pa.getBundleId());
+		Logger.debug(PublishAuditAPIImpl.class,"Status: " + pa.getStatus().name());
 	    boolean localt=false;
 		if(getPublishAuditStatus(pa.getBundleId()) == null) {
 			try{
@@ -123,6 +125,8 @@ public class PublishAuditAPIImpl extends PublishAuditAPI {
 	@WrapInTransaction
 	@Override
 	public void updatePublishAuditStatus(String bundleId, Status newStatus, PublishAuditHistory history, Boolean updateDates ) throws DotPublisherException {
+		Logger.debug(PublishAuditAPIImpl.class,"Updating audit table for bundle: " + bundleId);
+		Logger.debug(PublishAuditAPIImpl.class,"Status: " + newStatus.name());
 	    boolean local=false;
 		try{
 			local = HibernateUtil.startLocalTransactionIfNeeded();
@@ -515,6 +519,8 @@ public class PublishAuditAPIImpl extends PublishAuditAPI {
 
 		//Status
 		PublishAuditStatus status =  new PublishAuditStatus(bundleFolder);
+		Logger.debug(PublishAuditAPIImpl.class,"Updating audit table for bundle: " + bundleFolder);
+		Logger.debug(PublishAuditAPIImpl.class,"Status: " + status.getStatus().name());
 		//History
 		PublishAuditHistory historyPojo = new PublishAuditHistory();
 		EndpointDetail detail = new EndpointDetail();

--- a/dotCMS/src/main/java/com/dotcms/publisher/receiver/BundlePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/receiver/BundlePublisher.java
@@ -105,6 +105,7 @@ public class BundlePublisher extends Publisher {
 
     @Override
     public PublisherConfig init(PublisherConfig config) throws DotPublishingException {
+        Logger.debug(BundlePublisher.class, "Initializing bundle publisher");
         if (LicenseUtil.getLevel() < LicenseLevel.STANDARD.level) {
             throw new RuntimeException("need an enterprise license to run this");
         }
@@ -148,6 +149,7 @@ public class BundlePublisher extends Publisher {
      */
     @Override
     public PublisherConfig process ( final PublishStatus status ) throws DotPublishingException {
+        Logger.debug(BundlePublisher.class, "Processing bundle");
         if ( LicenseUtil.getLevel() < LicenseLevel.PROFESSIONAL.level ) {
             throw new RuntimeException( "need an enterprise license to run this" );
         }
@@ -165,6 +167,7 @@ public class BundlePublisher extends Publisher {
 
         try {
             //Update audit
+            Logger.debug(BundlePublisher.class, "Updating audit table for bundle with ID '" + bundleName + "'");
             currentStatusHistory = config.getPublishAuditStatus().getStatusPojo();
             currentStatusHistory.setPublishStart(new Date());
 
@@ -209,6 +212,7 @@ public class BundlePublisher extends Publisher {
         BundleMetaDataFile bundleMetaDataFile = null;
 
         try {
+            Logger.debug(BundlePublisher.class, "Getting assets list from received bundle with ID '" + bundleName + "'");
             bundleMetaDataFile = new BundleMetaDataFile(finalBundlePath);
             assetsDetails = bundleMetaDataFile.getAssetsDetails();
         } catch (Exception e) {
@@ -219,6 +223,7 @@ public class BundlePublisher extends Publisher {
             HibernateUtil.startTransaction();
             // Execute the handlers
             for (IHandler handler : handlers) {
+                Logger.debug(BundlePublisher.class, "Start of Handler: " + handler.getName());
                 handler.handle(folderOut);
 
                 if (!handler.getWarnings().isEmpty()){
@@ -230,6 +235,7 @@ public class BundlePublisher extends Publisher {
                     }
                     hasWarnings = true;
                 }
+                Logger.debug(BundlePublisher.class, "End of Handler: " + handler.getName());
             }
             HibernateUtil.commitTransaction();
         } catch (Exception e) {
@@ -311,7 +317,8 @@ public class BundlePublisher extends Publisher {
      * @throws DotPublisherException 
      */
     private void untar(InputStream bundle, String path, String fileName) throws DotPublishingException {
-      TarArchiveEntry entry;
+        Logger.debug(BundlePublisher.class, "Untaring bundle: " + fileName);
+        TarArchiveEntry entry;
         TarArchiveInputStream inputStream = null;
         OutputStream outputStream = null;
         File baseBundlePath = new File(ConfigUtils.getBundlePath());
@@ -379,7 +386,7 @@ public class BundlePublisher extends Publisher {
                     Logger.warn(this.getClass(), "Error Closing Stream.", e);
                 }
             }// while
-
+            Logger.debug(BundlePublisher.class, "Untaring bundle finished");
         } catch (Exception e) {
             throw new DotPublishingException(e.getMessage(),e);
 
@@ -416,6 +423,7 @@ public class BundlePublisher extends Publisher {
         }
 
         private Map<String, Object> getAssetsDetailsFromBundleXML(final String finalBundlePath) {
+            Logger.debug(BundlePublisher.class, "Getting assets details from bundle.xml for bundle: " + finalBundlePath);
             File xml = new File(finalBundlePath + File.separator + "bundle.xml");
 
             PushPublisherConfig readConfig = (PushPublisherConfig) BundlerUtil.xmlToObject(xml);
@@ -429,6 +437,7 @@ public class BundlePublisher extends Publisher {
         }
 
         private Map<String, Object> getAssetsDetailsFromManifest(final File manifestFile) {
+            Logger.debug(BundlePublisher.class, "Getting assets details from manifest for bundle: " + manifestFile.getName());
             final Map<String, String> assetsDetails = new HashMap<>();
 
             Collection<ManifestInfo> bundlerAssets;

--- a/dotCMS/src/main/java/com/dotcms/rest/BundlePublisherResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/BundlePublisherResource.java
@@ -101,8 +101,13 @@ public class BundlePublisherResource {
 								 final HttpServletRequest request,
 								 final String remoteIP) throws Exception {
 
+		Logger.debug(BundlePublisherResource.class, "Publishing bundle from " + remoteIP);
+		Logger.debug(BundlePublisherResource.class, "Force Push: " + forcePush);
+
 		final String fileNameSent = getFileNameFromRequest(request);
 		final String fileName = UtilMethods.isSet(fileNameSent) ? fileNameSent : generatedBundleFileName();
+
+		Logger.debug(BundlePublisherResource.class, "Bundle file name: " + fileName);
 
 		Bundle bundle = null;
 
@@ -114,9 +119,10 @@ public class BundlePublisherResource {
 					remoteIP, remoteIP, bundleFolder, true);
 
 			// save bundle if it doesn't exists
+			Logger.debug(BundlePublisherResource.class, "Checking if bundle exists: " + bundleFolder);
 			bundle = APILocator.getBundleAPI().getBundleById(bundleFolder);
 			if (bundle == null || bundle.getId() == null) {
-
+				Logger.debug(BundlePublisherResource.class, "Saving bundle: " + bundleFolder);
 				bundle = new Bundle();
 				bundle.setId(bundleFolder);
 				bundle.setName(fileName.replace(".tar.gz", ""));
@@ -124,6 +130,7 @@ public class BundlePublisherResource {
 				bundle.setOwner(APILocator.getUserAPI().getSystemUser().getUserId());
 				bundle.setForcePush(forcePush);
 				APILocator.getBundleAPI().saveBundle(bundle);
+				Logger.debug(BundlePublisherResource.class, "Bundle saved: " + bundleFolder);
 			}
 
 			//Write file on FS
@@ -132,6 +139,7 @@ public class BundlePublisherResource {
 			//Start thread
 
 			if(!status.getStatus().equals(Status.PUBLISHING_BUNDLE)) {
+				Logger.debug(BundlePublisherResource.class, "Triggering Push Publisher Job for bundle: " + fileName);
 				PushPublisherJob.triggerPushPublisherJob(fileName, status);
 			}
 

--- a/dotCMS/src/main/java/com/dotcms/rest/PushPublisherJob.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/PushPublisherJob.java
@@ -56,6 +56,8 @@ public class PushPublisherJob extends DotStatefulJob {
 	 */
 	@Override
 	public void run(JobExecutionContext jobContext) throws JobExecutionException {
+		Logger.debug(PushPublisherJob.class, "Running Push Publisher Job");
+		Logger.debug(PushPublisherJob.class, "Job context: " + jobContext);
 		final Trigger trigger = jobContext.getTrigger();
 		final Map<String, Serializable> executionData = getExecutionData(trigger, PushPublisherJob.class);
 
@@ -73,14 +75,15 @@ public class PushPublisherJob extends DotStatefulJob {
 	 */
 	public static void triggerPushPublisherJob(final String bundleName,
 			final PublishAuditStatus status) {
-
+		Logger.debug(PushPublisherJob.class, "Triggering Push Publisher Job for bundle: " + bundleName);
+		Logger.debug(PushPublisherJob.class, "Status: " + status.getStatus().name());
 		final ImmutableMap<String, Serializable> nextExecutionData = ImmutableMap
 				.of("bundleName", bundleName, "status", status);
 
 		try {
 			DotStatefulJob.enqueueTrigger(nextExecutionData, PushPublisherJob.class);
 		} catch (Exception e) {
-			Logger.error(ResetPermissionsJob.class, "Error scheduling the Publishing of bundle. Bundle name: " + bundleName, e);
+			Logger.error(PushPublisherJob.class, "Error scheduling the Publishing of bundle. Bundle name: " + bundleName, e);
 			throw new DotRuntimeException("Error scheduling the reset of permissions", e);
 		}
 	}


### PR DESCRIPTION
More debug logs have been added for when the receiver processes a bundle. To enable these logs, please run the following:

```
let names = ['com.dotcms.publisher.receiver.BundlePublisher','com.dotcms.rest.BundlePublisherResource','com.dotcms.rest.PushPublisherJob','com.dotcms.publisher.business.PublishAuditAPIImpl'];

names.forEach(name => {
    fetch('/api/v1/logger/', {
        method: 'PUT',
        body: JSON.stringify({
            name: name,
            level: 'DEBUG'
        }),
        headers: {
            'Content-type': 'application/json; charset=UTF-8'
        }
    })
        .then(res => res.json())
        .then(console.log)
});
```

This PR fixes: #29668