### PR TITLE
task(dev) update dev docker image to use java 21

### DIFF
--- a/docker/dev-env/Dockerfile
+++ b/docker/dev-env/Dockerfile
@@ -5,7 +5,7 @@ ARG DOTCMS_DOCKER_TAG="latest"
 
 FROM dotcms/dotcms:${DOTCMS_DOCKER_TAG} AS dotcms
 
-FROM ubuntu:22.04
+FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu AS dev-env-builder
 
 # Defining default non-root user UID, GID, and name 
 ARG USER_UID="65001"
@@ -21,6 +21,7 @@ RUN groupadd -f -g $USER_GID $USER_GROUP
 RUN useradd -l -d /srv -g $USER_GID -u $USER_UID $USER_NAME
 
 COPY --from=dotcms --chown=$USER_NAME:$USER_GROUP /srv/ /srv/
+COPY --from=dotcms  /java /java
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_RELEASE=jammy
@@ -52,11 +53,16 @@ RUN apt-get autoremove -y && \
 
 COPY --from=opensearchproject/opensearch:1 --chown=$USER_NAME:$USER_GROUP /usr/share/opensearch /usr/share/opensearch
 
+
+
+
+
 RUN echo "discovery.type: single-node\nbootstrap.memory_lock: true\ncluster.routing.allocation.disk.threshold_enabled: true\ncluster.routing.allocation.disk.watermark.low: 1g\ncluster.routing.allocation.disk.watermark.high: 500m\ncluster.routing.allocation.disk.watermark.flood_stage: 400m\ncluster.info.update.interval: 5m" >> /usr/share/opensearch/config/opensearch.yml
 
 
 ENV PATH=$PATH:/usr/share/opensearch/bin
 RUN /usr/share/opensearch/opensearch-onetime-setup.sh
+RUN rm -rf /usr/share/opensearch/jdk
 RUN chown -R dotcms.dotcms /usr/share/opensearch/config
 COPY entrypoint.sh /
 RUN chmod 755 /entrypoint.sh
@@ -66,5 +72,8 @@ COPY license-request.sh /
 RUN chmod 755 /license-request.sh
 RUN bash -x /license-request.sh
 RUN rm /license-request.sh
+
+FROM scratch
+COPY --from=dev-env-builder  / /
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]

--- a/docker/dev-env/README.md
+++ b/docker/dev-env/README.md
@@ -120,12 +120,23 @@ By default, this image is built from the `dotcms/dotcms:latest` tagged version o
 `--build-arg DOTCMS_DOCKER_TAG=latest` or `--build-arg DOTCMS_DOCKER_TAG=23.07`
 
 ```
-docker build --pull --build-arg DOTCMS_DOCKER_TAG=latest  . -t dotcms/dotcms-dev
+docker build --pull --build-arg DOTCMS_DOCKER_TAG=latest --progress=plain --load . -t dotcms/dotcms-dev:testing
 ```
 or
 ```
-docker buildx build --build-arg DOTCMS_DOCKER_TAG=master_latest_SNAPSHOT --platform linux/amd64,linux/arm64 --pull --push -t dotcms/dotcms-dev:master_latest_SNAPSHOT .
+docker buildx build --build-arg DOTCMS_DOCKER_TAG=trunk --platform linux/amd64,linux/arm64 --pull --push -t dotcms/dotcms-dev:testing .
 ```
+
+then
+```
+
+docker run --rm \
+-p 8000:8000 \
+-p 8443:8443 \
+-v $PWD/data:/data 
+dotcms/dotcms-dev:testing
+```
+
 
 ### Included Database and Elasticsearch
 

--- a/docker/dev-env/entrypoint.sh
+++ b/docker/dev-env/entrypoint.sh
@@ -5,7 +5,7 @@ DB_BACKUP_FILE=/data/dotcms_db.sql.gz
 STARTER_ZIP=/data/starter.zip
 DEV_LICENSE_SRC=/srv/dev_licensepack.zip
 DEV_LICENSE_DEST=/data/shared/assets/licensepack.zip
-export JAVA_HOME=/usr/share/opensearch/jdk
+export JAVA_HOME=/java
 export ES_JAVA_OPTS=${ES_JAVA_OPTS:-"-Xmx512m"}
 export DOTCMS_CLONE_TYPE=${DOTCMS_CLONE_TYPE:-"dump"}
 export DOWNLOAD_ALL_ASSETS=${ALL_ASSETS:-"false"}
@@ -60,7 +60,8 @@ setup_opensearch () {
 
     echo "Starting OPENSEARCH"
     # Start up Elasticsearch
-    su -c "/usr/share/opensearch/bin/opensearch 1> /dev/null" dotcms &
+    #su -c "/usr/share/opensearch/bin/opensearch 1> /dev/null" dotcms &
+    su -c "OPENSEARCH_JAVA_HOME=/usr /usr/share/opensearch/bin/opensearch " dotcms &
 }
 
 

--- a/docker/dev-env/license-request.sh
+++ b/docker/dev-env/license-request.sh
@@ -12,7 +12,7 @@ request_license () {
   fi
 
 
-  EXPIRE_DATE=$(date +%Y-%m-%d -d "+90 day")
+  EXPIRE_DATE=$(date +%Y-%m-%d -d "+365 day")
 
   curl -H "Content-Type: application/json" -H "Authorization:Bearer $DEV_REQUEST_TOKEN" -XPUT https://license.dotcms.com/api/ext/license -d "
     {


### PR DESCRIPTION
ref: #29830


The dev image was unable to use the minified `/java` version that we ship with the dotcms image because it was missing some packages that are needed by opensearch to run.



This PR fixes: #29830