### PR TITLE
fix(deployment): Edit Page V2 Automate the deploy of the SDK librar (#28259)

### DIFF
--- a/.github/actions/core-cicd/notification/notify-slack/action.yaml
+++ b/.github/actions/core-cicd/notification/notify-slack/action.yaml
@@ -10,11 +10,16 @@ inputs:
   slack-bot-token:
     description: 'Slack Bot Token'
     required: true
+  json:
+    description: 'Boolean flag to indicate if the payload is already a JSON object'
+    required: false
+    default: 'false'    
 
 runs:
   using: "composite"
   steps:
     - name: Slack Notification
+      if: inputs.json == 'false'
       uses: slackapi/slack-github-action@v1.26.0
       with:
         channel-id: ${{ inputs.channel-id }}
@@ -32,3 +37,12 @@ runs:
           }
       env:
         SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }} 
+        
+    - name: Slack Notification with JSON
+      if: inputs.json == 'true'
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+        channel-id: ${{ inputs.channel-id }}
+        payload: ${{ inputs.payload }}
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}

--- a/.github/workflows/cicd_post-workflow-reporting.yml
+++ b/.github/workflows/cicd_post-workflow-reporting.yml
@@ -270,4 +270,5 @@ jobs:
         with:
           channel-id: ${{ vars.SLACK_REPORT_CHANNEL }}
           payload: ${{ steps.prepare-slack-message.outputs.payload }}
+          json: true
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }} 


### PR DESCRIPTION
### Proposed Changes
* This pull request updates the function sends Slack notifications using slackapi/slack-github-action@v1.27.0, handling both plain text messages and preformatted JSON payloads. It dynamically selects the appropriate format based on a boolean input (json), ensuring correct handling of Slack message formatting and maintaining compatibility with different notification types.

### Additional Info
Related to #28259 (Edit Page V2 Automate the deploy of the SDK librar).

This PR fixes: #28259