### PR TITLE
ci: Fix SonarQube timeout property (#29886)

### DIFF
--- a/.github/workflows/cicd_comp_sonarqube-phase.yml
+++ b/.github/workflows/cicd_comp_sonarqube-phase.yml
@@ -55,10 +55,10 @@ jobs:
       # Check SonarQube Quality Gate status
       - name: SonarQube Quality Gate check
         id: sonarqube-quality-gate-check
-        uses: sonarsource/sonarqube-quality-gate-action@master
+        uses: sonarsource/sonarqube-quality-gate-action@dc2f7b0dd95544cd550de3028f89193576e958b9
         continue-on-error: ${{ github.repository != 'dotCMS/core' }}
-        timeout-minutes: 10 # Force step to fail after specific time
         with:
+          pollingTimeoutSec: 600 # 10 minutes
           scanMetadataReportFile: target/sonar/report-task.txt
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
### Proposed Changes
* Fix the action to the current commit  https://github.com/sonarsource/sonarqube-quality-gate-action/tree/dc2f7b0dd95544cd550de3028f89193576e958b9 for reproducability instead of auto updting any change to master branch. Includes the timeout change in this PR https://github.com/SonarSource/sonarqube-quality-gate-action/pull/50
*
* set the new pollingTimeoutSec to 600 (e.g. 10 minutes)

To test, check the logs of the build run in the sonarqube step and it should show the timeout passed in as "600" instead of "300"

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
This PR resolves #29886 (Fix SonarQube timeout property).


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #29886