### PR TITLE
chore(binary-field): fix error with font size

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.scss
@@ -39,6 +39,7 @@
 
     .label-ai {
         text-transform: none;
+        font-size: $font-size-sm;
     }
 
     .p-button {


### PR DESCRIPTION
### Parent Issue

#29859 

### Proposed Changes
* Fix error with font size on AI button

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)



### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
![Screenshot 2024-09-04 at 9 26 20 AM](https://github.com/user-attachments/assets/8470e1ee-2274-44ed-bb99-2261dbb73f86)  |  ![Screenshot 2024-09-06 at 12 53 37 PM](https://github.com/user-attachments/assets/4c9dfedd-3c39-4195-b2cf-5398a8a664ef)

This PR fixes: #29859