### PR TITLE
fix(FlakyTest) Tags Test fails sporadically in our merge Queue Refs: #29861

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/cache/provider/h22/H22CacheCleanupThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/cache/provider/h22/H22CacheCleanupThread.java
@@ -45,7 +45,7 @@ public class H22CacheCleanupThread extends Thread {
 						new TrashUtils().moveFileToTrash(folder, "h22");
 					}
 				} catch (IOException e) {
-					//Prevent Flakey tests
+					//Prevent Flaky tests from failing
 					Logger.warn(this.getClass(), "unable to delete folder:" + folder, e);
 				}
 			}

--- a/dotCMS/src/main/java/com/dotmarketing/business/cache/provider/h22/H22CacheCleanupThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/cache/provider/h22/H22CacheCleanupThread.java
@@ -45,11 +45,10 @@ public class H22CacheCleanupThread extends Thread {
 						new TrashUtils().moveFileToTrash(folder, "h22");
 					}
 				} catch (IOException e) {
-					throw new DotStateException("unable to delete folder:" + folder, e);
+					//Prevent Flakey tests
+					Logger.warn(this.getClass(), "unable to delete folder:" + folder, e);
 				}
-
 			}
-
 		}
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/tag/business/TagFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/tag/business/TagFactoryImpl.java
@@ -325,7 +325,7 @@ public class TagFactoryImpl implements TagFactory {
         } catch ( Exception e ) {
             Logger.warn(Tag.class, "getFilteredTags failed: " + e, e);
         }
-        return new java.util.ArrayList<>();
+        return List.of();
     }
 
     @Override
@@ -493,7 +493,7 @@ public class TagFactoryImpl implements TagFactory {
             tagInodeCache.putForTagId(tagId, tagInodes);
         }
 
-        return tagInodes;
+        return List.copyOf(tagInodes);
     }
 
     @Override
@@ -636,7 +636,7 @@ public class TagFactoryImpl implements TagFactory {
             tagCache.putForInode(inode, tags);
         }
 
-        return tags;
+        return List.copyOf(tags);
     }
 
     @Override
@@ -658,7 +658,7 @@ public class TagFactoryImpl implements TagFactory {
             }
         }
 
-        return tags;
+        return List.copyOf(tags);
     }
 
     @Override
@@ -691,7 +691,7 @@ public class TagFactoryImpl implements TagFactory {
                 .addParam(siteId)
                 .loadObjectResults();
 
-        return results.stream().map(row -> row.get(TAG_COLUMN_TAGNAME).toString()).collect(Collectors.toSet());
+        return results.stream().map(row -> row.get(TAG_COLUMN_TAGNAME).toString()).collect(Collectors.toUnmodifiableSet());
     }
 
     /**
@@ -724,7 +724,7 @@ public class TagFactoryImpl implements TagFactory {
             }
         }
 
-        return new ArrayList<>(tagsMap.values());
+        return List.copyOf(tagsMap.values());
     }
 
     /**
@@ -744,7 +744,7 @@ public class TagFactoryImpl implements TagFactory {
             }
         }
 
-        return tags;
+        return List.copyOf(tags);
     }
 
     /**
@@ -764,7 +764,7 @@ public class TagFactoryImpl implements TagFactory {
             }
         }
 
-        return tagInodes;
+        return List.copyOf(tagInodes);
     }
 
 	/**

--- a/dotcms-integration/src/test/java/com/dotmarketing/tag/business/TagAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/tag/business/TagAPITest.java
@@ -145,7 +145,7 @@ public class TagAPITest extends IntegrationTestBase {
 
 		List<Tag> tags = tagAPI.getTagsForUserByUserId(testUser.getUserId());
 		assertNotNull(tags);
-		assertTrue(tags.size() > 0);
+        assertFalse(tags.isEmpty());
 
 		String tagName = "testapi"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss");
 		Tag createdTag = tagAPI.saveTag(tagName, testUser.getUserId(), defaultHostId, false);
@@ -153,7 +153,7 @@ public class TagAPITest extends IntegrationTestBase {
 
 		tags = tagAPI.getTagsForUserByUserId(testUser.getUserId());
 		assertNotNull(tags);
-		assertTrue(tags.size() > 0);
+        assertFalse(tags.isEmpty());
 		assertTrue(tags.contains(createdTag));
 	}
 
@@ -189,7 +189,7 @@ public class TagAPITest extends IntegrationTestBase {
 		List<Tag> tags = tagAPI.getFilteredTags (tagName, defaultHost.getIdentifier(), true, "tagname", 0, 10 );
 		assertTrue(tags.size() > 1);
 		for(Tag tag : tags){
-			assertTrue(tag.getTagName().indexOf(tagName) != -1);
+			assertTrue(tag.getTagName().contains(tagName));
 		}
 	}
 
@@ -203,7 +203,7 @@ public class TagAPITest extends IntegrationTestBase {
 		Tag newTag = tagAPI.getTagAndCreate ( tagName, testUser.getUserId(), defaultHostId );
 		Tag tag = tagAPI.getTagByNameAndHost(tagName, defaultHostId);
 		assertNotNull(tag);
-		assertTrue(tag.equals(newTag));
+        assertEquals(tag, newTag);
 	}
 
 	/**
@@ -219,7 +219,7 @@ public class TagAPITest extends IntegrationTestBase {
 		Tag tag = tagAPI.getTagByTagId(tagId); 
 
 		assertNotNull(tag);
-		assertTrue(tag.getTagId().equals(tagId));
+        assertEquals(tag.getTagId(), tagId);
 	}
 
 	/**
@@ -267,7 +267,7 @@ public class TagAPITest extends IntegrationTestBase {
 
 		Tag tag = tagAPI.getTagByNameAndHost(tagName, hostAPI.findSystemHost().getIdentifier());
 		assertNotNull(tag);
-		assertTrue(tag.getTagName().equals(tagName));
+        assertEquals(tag.getTagName(), tagName);
 	}
 
 	/**
@@ -285,7 +285,7 @@ public class TagAPITest extends IntegrationTestBase {
 		tagAPI.updateTag(newTag.getTagId(), tagName2 );
 
 		Tag tag = tagAPI.getTagByTagId(newTag.getTagId());
-		assertTrue(tag.getTagName().equals(tagName2));
+        assertEquals(tag.getTagName(), tagName2);
 
 		//testing update tag second implementation ( String tagId, String tagName, boolean updateTagReference, String hostId )
 		String tagName3 ="testapi9"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss"); 
@@ -293,8 +293,8 @@ public class TagAPITest extends IntegrationTestBase {
 		tagAPI.updateTag(newTag.getTagId(), tagName3, true, host.getIdentifier() );
 
 		tag = tagAPI.getTagByTagId(newTag.getTagId());
-		assertTrue(tag.getTagName().equals(tagName3));
-		assertTrue(tag.getHostId().equals(host.getIdentifier()));
+        assertEquals(tag.getTagName(), tagName3);
+        assertEquals(tag.getHostId(), host.getIdentifier());
 	}
 
 	/**
@@ -346,7 +346,7 @@ public class TagAPITest extends IntegrationTestBase {
 
 		Contentlet contentAsset=new Contentlet();
 		ContentType contentType = TestDataUtils.getWikiLikeContentType();
-		contentAsset.setStructureInode(contentType.id());
+		contentAsset.setContentTypeId(contentType.id());
 		contentAsset.setHost(defaultHostId);
 		contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());
 		String name="testtagapi"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss");
@@ -386,7 +386,7 @@ public class TagAPITest extends IntegrationTestBase {
 
 		Contentlet contentAsset=new Contentlet();
 		ContentType contentType = TestDataUtils.getWikiLikeContentType();
-		contentAsset.setStructureInode(contentType.id());
+		contentAsset.setContentTypeId(contentType.id());
 		contentAsset.setHost(defaultHostId);
 		contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());
 		String name="testtagapi15"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss");
@@ -425,7 +425,7 @@ public class TagAPITest extends IntegrationTestBase {
 	public void getTagInodesByTagId() throws Exception{
 		Contentlet contentAsset=new Contentlet();
 		ContentType contentType = TestDataUtils.getWikiLikeContentType();
-		contentAsset.setStructureInode(contentType.id());
+		contentAsset.setContentTypeId(contentType.id());
 		contentAsset.setHost(defaultHostId);
 		contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());
 		String name="testtagapi16"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss");
@@ -465,7 +465,7 @@ public class TagAPITest extends IntegrationTestBase {
 
 		Contentlet contentAsset=new Contentlet();
 		ContentType contentType = TestDataUtils.getWikiLikeContentType();
-		contentAsset.setStructureInode(contentType.id());
+		contentAsset.setContentTypeId(contentType.id());
 		contentAsset.setHost(defaultHostId);
 		contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());
 		String name="testtagapi17"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss");
@@ -487,8 +487,8 @@ public class TagAPITest extends IntegrationTestBase {
 		assertNotNull(tagInode2);
 		assertTrue(UtilMethods.isSet(tagInode.getTagId()));
 		assertTrue(UtilMethods.isSet(tagInode2.getTagId()));
-		assertTrue(tagInode.getTagId().equals(tagInode2.getTagId()));
-		assertTrue(tagInode.getInode().equals(tagInode2.getInode()));
+        assertEquals(tagInode.getTagId(), tagInode2.getTagId());
+        assertEquals(tagInode.getInode(), tagInode2.getInode());
 
 		conAPI.destroy(contentAsset, testUser, false);
 	}
@@ -501,7 +501,7 @@ public class TagAPITest extends IntegrationTestBase {
 	public void deleteTagInode() throws Exception {
 		Contentlet contentAsset=new Contentlet();
 		ContentType contentType = TestDataUtils.getWikiLikeContentType();
-		contentAsset.setStructureInode(contentType.id());
+		contentAsset.setContentTypeId(contentType.id());
 		contentAsset.setHost(defaultHostId);
 		contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());
 		String name="testtagapi18"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss");
@@ -558,7 +558,7 @@ public class TagAPITest extends IntegrationTestBase {
 
 		Contentlet contentAsset=new Contentlet();
 		ContentType contentType = TestDataUtils.getWikiLikeContentType();
-		contentAsset.setStructureInode(contentType.id());
+		contentAsset.setContentTypeId(contentType.id());
 		contentAsset.setHost(defaultHostId);
 		contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());
 		String name="testtagapi21"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss");
@@ -599,14 +599,14 @@ public class TagAPITest extends IntegrationTestBase {
 		int tagSize = tags.size();
 		assertTrue(tagSize > 1);
 		for(Tag tag : tags){
-			assertTrue(tag.getTagName().indexOf(tagName) != -1);
+			assertTrue(tag.getTagName().contains(tagName));
 		}
 
 		tagName="testing";
 		tags = tagAPI.getSuggestedTag (tagName, defaultHostId);
-		assertTrue(tags.size() >= 1);
+        assertFalse(tags.isEmpty());
 		for(Tag tag : tags){
-			assertTrue(tag.getTagName().indexOf(tagName) != -1);
+			assertTrue(tag.getTagName().contains(tagName));
 		}
 
 		assertTrue(tags.size() < tagSize);
@@ -624,8 +624,8 @@ public class TagAPITest extends IntegrationTestBase {
 			//Creates a new Host
 			Contentlet host = new Contentlet();
 			Structure st = structureAPI.findByVarName("Host", systemUser);
-			host.setStructureInode(st.getInode());
-			String hostName = "testtagapiHost_" + System.currentTimeMillis();
+			host.setContentTypeId(st.getInode());
+			String hostName = "testtagapiHost" + System.currentTimeMillis() + ".com";
 			host.setProperty(Host.HOST_NAME_KEY, hostName);
 			host.setLanguageId(langAPI.getDefaultLanguage().getId());
 			host.setIndexPolicy(IndexPolicy.FORCE);
@@ -645,15 +645,15 @@ public class TagAPITest extends IntegrationTestBase {
 
 			//Gets the default Host Tags
 			List<Tag> tags = tagAPI.getTagsByHostId(defaultHostId);
-			int defaultHostInitialNumberOfTags = tags.size();
 			assertNotNull(tags);
+			int defaultHostInitialNumberOfTags = tags.size();
 			assertTrue(defaultHostInitialNumberOfTags > 0);
 
 			//Gets the new Host Tags
 			tags = tagAPI.getTagsByHostId(newHost.getIdentifier());
-			int newHostinitialNumberOfTags = tags.size();
 			assertNotNull(tags);
-			assertTrue(newHostinitialNumberOfTags == 0);
+			int newHostinitialNumberOfTags = tags.size();
+            assertEquals(0, newHostinitialNumberOfTags);
 
 			//Move the Tags to the new Host
 			tagAPI.updateTagReferences(defaultHostId, defaultHostId, newHost.getIdentifier());
@@ -673,21 +673,21 @@ public class TagAPITest extends IntegrationTestBase {
 			tagCache.clearCache();
 
 			defaultHostTagsAfterUpdate = tagAPI.getTagsByHostId(defaultHostId);
-			assertTrue(defaultHostTagsAfterUpdate.size() == defaultHostInitialNumberOfTags);
+            assertEquals(defaultHostTagsAfterUpdate.size(), defaultHostInitialNumberOfTags);
 
 			/*here the amount is not 0 because is entering in the condition
 			 * if((hostIdentifier.equals(newTagStorageId) && hostTagList.size() == 0) && !newTagStorageId.equals(Host.SYSTEM_HOST)) {
 			 * saveTag(tag.getTagName(), "", hostIdentifier);
 			 */
 			newHostTagsAfterUpdate = tagAPI.getTagsByHostId(newHost.getIdentifier());
-			assertTrue(newHostTagsAfterUpdate.size() == defaultHostInitialNumberOfTags);
+            assertEquals(newHostTagsAfterUpdate.size(), defaultHostInitialNumberOfTags);
 		} finally {
 
 			if (null != newHost) {
 				//delete host
 				hostAPI.archive(newHost,systemUser,false);
 				hostAPI.delete(newHost,systemUser,false);
-				assertTrue(tagAPI.getTagsByHostId(newHost.getIdentifier()).size()==0);
+                assertEquals(0, tagAPI.getTagsByHostId(newHost.getIdentifier()).size());
 			}
 
 		}
@@ -713,7 +713,7 @@ public class TagAPITest extends IntegrationTestBase {
 	public void getTagsByInode() throws Exception{
 		Contentlet contentAsset=new Contentlet();
 		ContentType contentType = TestDataUtils.getWikiLikeContentType();
-		contentAsset.setStructureInode(contentType.id());
+		contentAsset.setContentTypeId(contentType.id());
 		contentAsset.setHost(defaultHostId);
 		contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());
 		String name="testtagapi22"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss");
@@ -751,7 +751,7 @@ public class TagAPITest extends IntegrationTestBase {
 		String text="test1, test 2, test number three,another\n testing\t to'do\r now"; 
 		List<Tag> tags = tagAPI.getTagsInText (text, testUser.getUserId(), defaultHostId);
 		assertNotNull(tags);
-		assertTrue(tags.size()==7);
+        assertEquals(7, tags.size());
 	}
 
 	/**
@@ -762,7 +762,7 @@ public class TagAPITest extends IntegrationTestBase {
 	public void validatePersonaTags() throws Exception {
 
 		Contentlet persona = new Contentlet();
-		persona.setStructureInode(PersonaAPI.DEFAULT_PERSONAS_STRUCTURE_INODE);
+		persona.setContentTypeId(PersonaAPI.DEFAULT_PERSONAS_STRUCTURE_INODE);
 		persona.setHost(defaultHostId);
 		persona.setLanguageId(langAPI.getDefaultLanguage().getId());
 		String name="testtagapipersona1"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss");
@@ -885,7 +885,7 @@ public class TagAPITest extends IntegrationTestBase {
 		 */
 		Contentlet contentAsset=new Contentlet();
 		ContentType contentType = TestDataUtils.getWikiLikeContentType();
-		contentAsset.setStructureInode(contentType.id());
+		contentAsset.setContentTypeId(contentType.id());
 		contentAsset.setHost(defaultHostId);
 		contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());
 		String name="testtagapi27"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss");
@@ -898,7 +898,7 @@ public class TagAPITest extends IntegrationTestBase {
 		APILocator.getContentletAPI().publish(contentAsset, testUser, false);
 
 		tagName ="testapi27"+UtilMethods.dateToHTMLDate(new Date(),"MMddyyyyHHmmss"); 
-		tag = tagAPI.saveTag(tagName, testUser.getUserId(), defaultHostId);
+		tagAPI.saveTag(tagName, testUser.getUserId(), defaultHostId);
 		tagAPI.addContentletTagInode(tagName, contentAsset.getInode(), defaultHostId, WIKI_TAG_VARNAME);
 
 		//Verify the cache -> THE SAVE SHOULD ADD NOTHING TO CACHE, JUST THE LOAD
@@ -991,12 +991,12 @@ public class TagAPITest extends IntegrationTestBase {
 		final String tagvalue1 = "mytesttag1";
 
 		final Tag tag1 = Try.of(()->APILocator.getTagAPI().saveTag(tagvalue1, testUser.getUserId(), defaultHostId)).getOrNull();
-		IntStream.range(0, 100).forEach($ -> {
+		IntStream.range(0, 100).forEach(r -> {
 
 			try {
 				final Contentlet contentAsset = new Contentlet();
 				ContentType contentType = TestDataUtils.getWikiLikeContentType();
-				contentAsset.setStructureInode(contentType.id());
+				contentAsset.setContentTypeId(contentType.id());
 				contentAsset.setHost(defaultHostId);
 				contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());
 				String name = "testtagapi" + UtilMethods.dateToHTMLDate(new Date(), "MMddyyyyHHmmss");


### PR DESCRIPTION
### Proposed Changes
* Folder clean-up operation was breaking tests sporadically
* a few improvements on the Test-itself 
* Changes to make Tag's cache return an immutable list

This PR fixes: #29861