### PR TITLE
chore(edit content) fixes #29708: Page Properties Cache TTL label not showing units when creating a new Page Type

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/model/type/PageContentType.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/model/type/PageContentType.java
@@ -11,9 +11,10 @@ import com.dotcms.contenttype.model.field.ImmutableTextField;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableList;
+import org.immutables.value.Value;
+
 import java.util.ArrayList;
 import java.util.List;
-import org.immutables.value.Value;
 
 /**
  * Provides the basic definition and field layout of the Page Asset Base Type. By default, all contents of type Page
@@ -135,7 +136,7 @@ public abstract class PageContentType extends ContentType implements Expireable{
 		);
 		fields.add(
 				ImmutableCustomField.builder()
-				.name("Cache TTL")
+				.name("Cache TTL (seconds)")
 				.dataType(DataTypes.TEXT)
 				.variable(PAGE_CACHE_TTL_FIELD_VAR)
 				.indexed(true)


### PR DESCRIPTION
### Proposed Changes
* The `Cache TTL` field label was updated in both Empty and Full Starters. However, it was NOT changed in the `com.dotcms.contenttype.model.type.PageContentType` class.
* Now, when you create a new Content Type of type `Page`, you'll see the expected `Cache TTL (seconds)` label.

This PR fixes: #29708