### PR TITLE
fix(UVE): unable to execute sub-action on pages

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-toolbar/dot-edit-content-toolbar.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-toolbar/dot-edit-content-toolbar.component.html
@@ -4,6 +4,6 @@
         <dot-workflow-actions
             (actionFired)="actionFired.emit($event)"
             [actions]="actions"
-            [groupAction]="true" />
+            [groupActions]="true" />
     </div>
 </p-toolbar>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-toolbar/dot-edit-content-toolbar.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-toolbar/dot-edit-content-toolbar.component.spec.ts
@@ -31,7 +31,7 @@ describe('DotEditContentToolbarComponent', () => {
         const component = spectator.query(DotWorkflowActionsComponent);
         expect(component).toBeTruthy();
         expect(component.actions).toEqual(WORKFLOW_ACTIONS_MOCK);
-        expect(component.groupAction).toBeTruthy();
+        expect(component.groupActions).toBeTruthy();
         expect(component.size).toBe('normal');
     });
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-toolbar/dot-edit-content-toolbar.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-toolbar/dot-edit-content-toolbar.component.spec.ts
@@ -30,9 +30,9 @@ describe('DotEditContentToolbarComponent', () => {
     it('should dot-workflow-actions component with the correct input', () => {
         const component = spectator.query(DotWorkflowActionsComponent);
         expect(component).toBeTruthy();
-        expect(component.actions).toEqual(WORKFLOW_ACTIONS_MOCK);
-        expect(component.groupActions).toBeTruthy();
-        expect(component.size).toBe('normal');
+        expect(component.actions()).toEqual(WORKFLOW_ACTIONS_MOCK);
+        expect(component.groupActions()).toBeTruthy();
+        expect(component.size()).toBe('normal');
     });
 
     it('should emit the action dot-workflow-actions emits the fired action', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-edit-ema-workflow-actions/dot-edit-ema-workflow-actions.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-edit-ema-workflow-actions/dot-edit-ema-workflow-actions.component.spec.ts
@@ -135,9 +135,9 @@ describe('DotEditEmaWorkflowActionsComponent', () => {
 
         it('should set action as an empty array and loading to true', () => {
             const dotWorkflowActionsComponent = spectator.query(DotWorkflowActionsComponent);
-            expect(dotWorkflowActionsComponent.actions).toEqual([]);
-            expect(dotWorkflowActionsComponent.loading).toBeTruthy();
-            expect(dotWorkflowActionsComponent.size).toBe('small');
+            expect(dotWorkflowActionsComponent.actions()).toEqual([]);
+            expect(dotWorkflowActionsComponent.loading()).toBeTruthy();
+            expect(dotWorkflowActionsComponent.size()).toBe('small');
         });
     });
 
@@ -155,7 +155,7 @@ describe('DotEditEmaWorkflowActionsComponent', () => {
             const dotWorkflowActionsComponent = spectator.query(DotWorkflowActionsComponent);
 
             expect(dotWorkflowsActionsService.getByInode).toHaveBeenCalledWith('123');
-            expect(dotWorkflowActionsComponent.actions).toEqual(mockWorkflowsActions);
+            expect(dotWorkflowActionsComponent.actions()).toEqual(mockWorkflowsActions);
         });
 
         it('should fire workflow actions when it does not have inputs', () => {

--- a/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.html
@@ -1,4 +1,4 @@
-@for (action of groupedActions(); track $index) {
+@for (action of $groupedActions(); track $index) {
     @let mainAction = action.mainAction;
     @let subActions = action.subActions;
     @if (subActions.length) {

--- a/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.html
@@ -3,24 +3,24 @@
     @let subActions = action.subActions;
     @if (subActions.length) {
         <p-splitButton
-            (onClick)="mainAction.command({ originalEvent: $event })"
-            [disabled]="loading"
+            (onClick)="mainAction?.command({ originalEvent: $event })"
+            [disabled]="loading()"
             [styleClass]="sizeClass"
             [model]="subActions"
             [outlined]="!$first"
             [label]="mainAction.label" />
     } @else {
         <p-button
-            (onClick)="mainAction.command({ originalEvent: $event })"
-            [loading]="loading"
+            (onClick)="mainAction?.command({ originalEvent: $event })"
+            [loading]="loading()"
             [styleClass]="sizeClass + (!$first ? ' p-button-outlined' : '')"
             [label]="mainAction.label" />
     }
 } @empty {
     <p-button
-        [loading]="loading"
-        [disabled]="!loading"
+        [loading]="loading()"
+        [disabled]="!loading()"
         [styleClass]="sizeClass"
-        [label]="(loading ? 'Loading' : 'edit.ema.page.no.workflow.action') | dm"
+        [label]="(loading() ? 'Loading' : 'edit.ema.page.no.workflow.action') | dm"
         data-testId="empty-button" />
 }

--- a/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.html
@@ -1,18 +1,20 @@
 @for (action of groupedActions(); track $index) {
-    @if (action.length > 1) {
+    @let mainAction = action.mainAction;
+    @let subActions = action.subActions;
+    @if (subActions.length) {
         <p-splitButton
-            (onClick)="action[0].command({ originalEvent: $event })"
+            (onClick)="mainAction.command({ originalEvent: $event })"
             [disabled]="loading"
             [styleClass]="sizeClass"
-            [model]="action | slice: 1"
+            [model]="subActions"
             [outlined]="!$first"
-            [label]="action[0].label" />
+            [label]="mainAction.label" />
     } @else {
         <p-button
-            (onClick)="action[0].command({ originalEvent: $event })"
+            (onClick)="mainAction.command({ originalEvent: $event })"
             [loading]="loading"
             [styleClass]="sizeClass + (!$first ? ' p-button-outlined' : '')"
-            [label]="action[0].label" />
+            [label]="mainAction.label" />
     }
 } @empty {
     <p-button

--- a/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.spec.ts
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.spec.ts
@@ -82,7 +82,7 @@ describe('DotWorkflowActionsComponent', () => {
         spectator = createComponent({
             props: {
                 actions: WORKFLOW_ACTIONS_MOCK,
-                groupAction: true,
+                groupActions: true,
                 loading: false,
                 size: 'normal'
             }
@@ -146,7 +146,7 @@ describe('DotWorkflowActionsComponent', () => {
 
     describe('not group action', () => {
         beforeEach(() => {
-            spectator.setInput('groupAction', false);
+            spectator.setInput('groupActions', false);
             spectator.detectComponentChanges();
         });
 

--- a/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.ts
@@ -2,10 +2,9 @@ import { CommonModule } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
-    EventEmitter,
     input,
     OnChanges,
-    Output,
+    output,
     signal
 } from '@angular/core';
 
@@ -70,7 +69,7 @@ export class DotWorkflowActionsComponent implements OnChanges {
      *
      * @memberof DotWorkflowActionsComponent
      */
-    @Output() actionFired = new EventEmitter<DotCMSWorkflowAction>();
+    actionFired = output<DotCMSWorkflowAction>();
 
     protected $groupedActions = signal<WorkflowActionsGroup[]>([]);
     protected sizeClass!: string;

--- a/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.ts
@@ -3,7 +3,7 @@ import {
     ChangeDetectionStrategy,
     Component,
     EventEmitter,
-    Input,
+    input,
     OnChanges,
     Output,
     signal
@@ -45,26 +45,26 @@ export class DotWorkflowActionsComponent implements OnChanges {
      * @type {DotCMSWorkflowAction[]}
      * @memberof DotWorkflowActionsComponent
      */
-    @Input({ required: true }) actions: DotCMSWorkflowAction[];
+    actions = input.required<DotCMSWorkflowAction[]>();
     /**
      * Show a loading button spinner
      *
      * @memberof DotWorkflowActionsComponent
      */
-    @Input() loading = false;
+    loading = input<boolean>(false);
     /**
      * Group the actions by separator
      *
      * @memberof DotWorkflowActionsComponent
      */
-    @Input() groupActions = false;
+    groupActions = input<boolean>(false);
     /**
      * Button size
      *
      * @type {ButtonSize}
      * @memberof DotWorkflowActionsComponent
      */
-    @Input() size: ButtonSize = 'normal';
+    size = input<ButtonSize>('normal');
     /**
      * Emits when an action is selected
      *
@@ -73,12 +73,12 @@ export class DotWorkflowActionsComponent implements OnChanges {
     @Output() actionFired = new EventEmitter<DotCMSWorkflowAction>();
 
     protected $groupedActions = signal<WorkflowActionsGroup[]>([]);
-    protected sizeClass: string;
+    protected sizeClass!: string;
 
     ngOnChanges(): void {
-        this.sizeClass = InplaceButtonSizePrimeNg[this.size];
+        this.sizeClass = InplaceButtonSizePrimeNg[this.size()];
 
-        if (!this.actions.length) {
+        if (!this.actions().length) {
             this.$groupedActions.set([]);
 
             return;
@@ -94,7 +94,7 @@ export class DotWorkflowActionsComponent implements OnChanges {
      * @memberof DotWorkflowActionsComponent
      */
     private setActions(): void {
-        const groups = this.createGroups(this.actions);
+        const groups = this.createGroups(this.actions());
         const actions = groups.map((group) => {
             const [first, ...rest] = group;
             const mainAction = this.createActions(first);
@@ -116,7 +116,7 @@ export class DotWorkflowActionsComponent implements OnChanges {
      * @memberof DotWorkflowActionsComponent
      */
     private createGroups(actions: DotCMSWorkflowAction[]): DotCMSWorkflowAction[][] {
-        if (!this.groupActions) {
+        if (!this.groupActions()) {
             // Remove the separator from the actions and return the actions grouped
             const formatActions = actions.filter(
                 (action) => action?.metadata?.subtype !== DotCMSActionSubtype.SEPARATOR
@@ -127,7 +127,7 @@ export class DotWorkflowActionsComponent implements OnChanges {
 
         // Create a new group every time we find a separator
         return actions
-            .reduce(
+            .reduce<DotCMSWorkflowAction[][]>(
                 (acc, action) => {
                     if (action?.metadata?.subtype === DotCMSActionSubtype.SEPARATOR) {
                         acc.push([]);

--- a/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.ts
@@ -72,14 +72,14 @@ export class DotWorkflowActionsComponent implements OnChanges {
      */
     @Output() actionFired = new EventEmitter<DotCMSWorkflowAction>();
 
-    protected groupedActions = signal<WorkflowActionsGroup[]>([]);
+    protected $groupedActions = signal<WorkflowActionsGroup[]>([]);
     protected sizeClass: string;
 
     ngOnChanges(): void {
         this.sizeClass = InplaceButtonSizePrimeNg[this.size];
 
         if (!this.actions.length) {
-            this.groupedActions.set([]);
+            this.$groupedActions.set([]);
 
             return;
         }
@@ -103,7 +103,7 @@ export class DotWorkflowActionsComponent implements OnChanges {
             return { mainAction, subActions };
         });
 
-        this.groupedActions.set(actions);
+        this.$groupedActions.set(actions);
     }
 
     /**

--- a/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.ts
@@ -13,7 +13,7 @@ import { MenuItem } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { SplitButtonModule } from 'primeng/splitbutton';
 
-import { CustomMenuItem, DotCMSActionSubtype, DotCMSWorkflowAction } from '@dotcms/dotcms-models';
+import { DotCMSActionSubtype, DotCMSWorkflowAction } from '@dotcms/dotcms-models';
 
 import { DotMessagePipe } from '../../dot-message/dot-message.pipe';
 
@@ -25,6 +25,11 @@ const InplaceButtonSizePrimeNg: Record<ButtonSize, string> = {
     large: 'p-button-lg'
 };
 
+interface WorkflowActionsGroup {
+    mainAction: MenuItem;
+    subActions: MenuItem[];
+}
+
 @Component({
     selector: 'dot-workflow-actions',
     standalone: true,
@@ -34,71 +39,121 @@ const InplaceButtonSizePrimeNg: Record<ButtonSize, string> = {
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotWorkflowActionsComponent implements OnChanges {
+    /**
+     * List of actions to display
+     *
+     * @type {DotCMSWorkflowAction[]}
+     * @memberof DotWorkflowActionsComponent
+     */
     @Input({ required: true }) actions: DotCMSWorkflowAction[];
+    /**
+     * Show a loading button spinner
+     *
+     * @memberof DotWorkflowActionsComponent
+     */
     @Input() loading = false;
-    @Input() groupAction = false;
+    /**
+     * Group the actions by separator
+     *
+     * @memberof DotWorkflowActionsComponent
+     */
+    @Input() groupActions = false;
+    /**
+     * Button size
+     *
+     * @type {ButtonSize}
+     * @memberof DotWorkflowActionsComponent
+     */
     @Input() size: ButtonSize = 'normal';
+    /**
+     * Emits when an action is selected
+     *
+     * @memberof DotWorkflowActionsComponent
+     */
     @Output() actionFired = new EventEmitter<DotCMSWorkflowAction>();
 
-    protected groupedActions = signal<MenuItem[][]>([]);
+    protected groupedActions = signal<WorkflowActionsGroup[]>([]);
     protected sizeClass: string;
 
     ngOnChanges(): void {
-        this.groupedActions.set(
-            this.groupAction ? this.groupActions(this.actions) : this.formatActions(this.actions)
-        );
         this.sizeClass = InplaceButtonSizePrimeNg[this.size];
+
+        if (!this.actions.length) {
+            this.groupedActions.set([]);
+
+            return;
+        }
+
+        this.setActions();
     }
 
     /**
-     * Group actions by separator
+     * Set the actions to display
      *
      * @private
-     * @param {DotCMSWorkflowAction[]} [actions=[]]
-     * @return {*}  {MenuItem[][]}
      * @memberof DotWorkflowActionsComponent
      */
-    private groupActions(actions: DotCMSWorkflowAction[] = []): MenuItem[][] {
+    private setActions(): void {
+        const groups = this.createGroups(this.actions);
+        const actions = groups.map((group) => {
+            const [first, ...rest] = group;
+            const mainAction = this.createActions(first);
+            const subActions = rest.map((action) => this.createActions(action));
+
+            return { mainAction, subActions };
+        });
+
+        this.groupedActions.set(actions);
+    }
+
+    /**
+     * Create the groups of actions
+     * Each group is create when a separator is found
+     *
+     * @private
+     * @param {DotCMSWorkflowAction[]} actions
+     * @return {*}  {DotCMSWorkflowAction[][]}
+     * @memberof DotWorkflowActionsComponent
+     */
+    private createGroups(actions: DotCMSWorkflowAction[]): DotCMSWorkflowAction[][] {
+        if (!this.groupActions) {
+            // Remove the separator from the actions and return the actions grouped
+            const formatActions = actions.filter(
+                (action) => action?.metadata?.subtype !== DotCMSActionSubtype.SEPARATOR
+            );
+
+            return [formatActions].filter((group) => !!group.length);
+        }
+
+        // Create a new group every time we find a separator
         return actions
-            ?.reduce(
+            .reduce(
                 (acc, action) => {
                     if (action?.metadata?.subtype === DotCMSActionSubtype.SEPARATOR) {
                         acc.push([]);
                     } else {
-                        acc[acc.length - 1].push({
-                            label: action.name,
-                            command: () => this.actionFired.emit(action)
-                        });
+                        acc[acc.length - 1].push(action);
                     }
 
                     return acc;
                 },
                 [[]]
             )
-            .filter((group) => group.length);
+            .filter((group) => !!group.length);
     }
 
     /**
-     * Remove the separator from the actions and return the actions grouped
-     * in a single group.
+     * Create the action menu item
      *
      * @private
-     * @param {DotCMSWorkflowAction[]} [actions=[]]
-     * @return {*}  {MenuItem[][]}
+     * @param {DotCMSWorkflowAction} action
+     * @return {*}  {MenuItem}
      * @memberof DotWorkflowActionsComponent
      */
-    private formatActions(actions: DotCMSWorkflowAction[] = []): CustomMenuItem[][] {
-        const formatedActions = actions?.reduce((acc, action) => {
-            if (action?.metadata?.subtype !== DotCMSActionSubtype.SEPARATOR) {
-                acc.push({
-                    label: action.name,
-                    command: () => this.actionFired.emit(action)
-                });
-            }
-
-            return acc;
-        }, []);
-
-        return [formatedActions].filter((group) => group.length);
+    private createActions(action: DotCMSWorkflowAction): MenuItem {
+        return {
+            label: action.name,
+            command: () => this.actionFired.emit(action)
+        };
     }
 }


### PR DESCRIPTION
### Proposed Changes
*  Let users execute `sub-actions` on pages

### Checklist
- [x] Tests

### Why was this error happening?
It seems like an incompatibility between Angular's `SlicePipe` and PrimeNg v17

A general guess, `SlicePipe` is not a Pure Pipe and has Angular's own logic implemented inside that doesn't work like a native slice, which makes it inconsistent with what one would expect it to work like by @zJaaal 

#### Test the `Slice` pipe with PrimeNg `v15` and `v17`

- PrimeNG v15 - slice [demo](https://stackblitz.com/edit/xad6jf?file=src%2Fapp%2Fdemo%2Fsplit-button-basic-demo.ts,src%2Fapp%2Fdemo%2Fsplit-button-basic-demo.html)
- PrimeNG v17 - slice [demo](https://stackblitz.com/edit/ixjqxa?file=src%2Fapp%2Fsplit-button-basic-demo.ts)

### Video

https://github.com/user-attachments/assets/2ae68864-155c-4c53-903f-7f233d8021af

