### PR TITLE
fix(QuarkusTest)  Quarkus Test were not getting executed #29933

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -44,6 +44,52 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.surefire.plugin}</version>
+                <configuration>
+                    <forkCount>${surefire.fork.count}</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <argLine>@{argLine} -Xmx1024m
+                        ${java.module.args}
+                    </argLine>
+
+                    <systemPropertyVariables/>
+                    <trimStackTrace>true</trimStackTrace>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${version.surefire.plugin}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${version.failsafe.plugin}</version>
+                <configuration>
+
+                    <!--
+                         NOTE: In case if you need to pass in special JVM argumengts for instance say, to enable Java language
+                     preview features, the following is how it MUST be done. The @{argLine} goes through late evaluattion that
+                     points to Jacoco agent JVM argument followed by any additional JVM arguments of your choice each separated
+                     by space. The expression @{argLine} retains Jacoco JVM agent argument. Without this any additional JVM
+                     arguments that you add will be taken but you lose Jacoco's argument causing to lose code coverage report
+                     files and hence the coverage report.
+                    -->
+                    <argLine>@{argLine} -Xmx1024m
+                        ${java.module.args}
+                    </argLine>
+
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${version.failsafe.plugin}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -1937,7 +1937,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
@@ -1956,6 +1955,56 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${version.failsafe.plugin}</version>
+                <configuration>
+
+                    <!--
+                         NOTE: In case if you need to pass in special JVM argumengts for instance say, to enable Java language
+                     preview features, the following is how it MUST be done. The @{argLine} goes through late evaluattion that
+                     points to Jacoco agent JVM argument followed by any additional JVM arguments of your choice each separated
+                     by space. The expression @{argLine} retains Jacoco JVM agent argument. Without this any additional JVM
+                     arguments that you add will be taken but you lose Jacoco's argument causing to lose code coverage report
+                     files and hence the coverage report.
+                    -->
+                    <argLine>@{argLine} -Xmx1024m
+                        ${java.module.args}
+                    </argLine>
+
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${version.failsafe.plugin}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.surefire.plugin}</version>
+                <configuration>
+                    <forkCount>${surefire.fork.count}</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <argLine>@{argLine} -Xmx1024m
+                        ${java.module.args}
+                    </argLine>
+
+                    <systemPropertyVariables/>
+                    <trimStackTrace>true</trimStackTrace>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${version.surefire.plugin}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -1956,56 +1956,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${version.failsafe.plugin}</version>
-                <configuration>
-
-                    <!--
-                         NOTE: In case if you need to pass in special JVM argumengts for instance say, to enable Java language
-                     preview features, the following is how it MUST be done. The @{argLine} goes through late evaluattion that
-                     points to Jacoco agent JVM argument followed by any additional JVM arguments of your choice each separated
-                     by space. The expression @{argLine} retains Jacoco JVM agent argument. Without this any additional JVM
-                     arguments that you add will be taken but you lose Jacoco's argument causing to lose code coverage report
-                     files and hence the coverage report.
-                    -->
-                    <argLine>@{argLine} -Xmx1024m
-                        ${java.module.args}
-                    </argLine>
-
-                    <trimStackTrace>false</trimStackTrace>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>${version.failsafe.plugin}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${version.surefire.plugin}</version>
-                <configuration>
-                    <forkCount>${surefire.fork.count}</forkCount>
-                    <reuseForks>true</reuseForks>
-                    <argLine>@{argLine} -Xmx1024m
-                        ${java.module.args}
-                    </argLine>
-
-                    <systemPropertyVariables/>
-                    <trimStackTrace>true</trimStackTrace>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>${version.surefire.plugin}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
         </plugins>
     </build>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -689,34 +689,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>${version.failsafe.plugin}</version>
-                    <configuration>
-
-                        <!--
-                             NOTE: In case if you need to pass in special JVM argumengts for instance say, to enable Java language
-                         preview features, the following is how it MUST be done. The @{argLine} goes through late evaluattion that
-                         points to Jacoco agent JVM argument followed by any additional JVM arguments of your choice each separated
-                         by space. The expression @{argLine} retains Jacoco JVM agent argument. Without this any additional JVM
-                         arguments that you add will be taken but you lose Jacoco's argument causing to lose code coverage report
-                         files and hence the coverage report.
-                        -->
-                        <argLine>@{argLine} -Xmx1024m
-                            ${java.module.args}
-                        </argLine>
-
-                        <trimStackTrace>false</trimStackTrace>
-                    </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.surefire</groupId>
-                            <artifactId>surefire-junit47</artifactId>
-                            <version>${version.failsafe.plugin}</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>${version.gpg.plugin}</version>
                 </plugin>
@@ -851,28 +823,6 @@
                             </manifestEntries>
                         </archive>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${version.surefire.plugin}</version>
-                    <configuration>
-                        <forkCount>${surefire.fork.count}</forkCount>
-                        <reuseForks>true</reuseForks>
-                        <argLine>@{argLine} -Xmx1024m
-                            ${java.module.args}
-                        </argLine>
-
-                        <systemPropertyVariables/>
-                        <trimStackTrace>true</trimStackTrace>
-                    </configuration>
-                   <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.surefire</groupId>
-                            <artifactId>surefire-junit47</artifactId>
-                            <version>${version.surefire.plugin}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Proposed Changes
I think it is due to the global fix to use junit 4 provider but quarkus uses junit5 so we need to override

Using configured provider org.apache.maven.surefire.junitcore.JUnitCoreProvider

in parent/pom.xml we have

```
<dependencies>
      <dependency>
          <groupId>org.apache.maven.surefire</groupId>
          <artifactId>surefire-junit47</artifactId>
          <version>${version.failsafe.plugin}</version>
      </dependency>
  </dependencies>
```
                    
 This overrides the auto-detection.  
 
We probably want to move this override into dotcms-build-parent which will only impact core and related modules like postman, integration tests and not quarkus modules. 
                    