### PR TITLE
fix ( Content Types ) :  #29736 Remove "Permissions" and "Relationships Legacy" fields from the field selections sidebar in the Content Type editor

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.html
@@ -5,7 +5,7 @@
     data-drag-type="source">
     @for (fieldType of $fieldTypes(); track fieldType.clazz) {
         <li [attr.data-clazz]="fieldType.clazz" class="content-types-fields-list__item">
-            <dot-icon name="{{ getIcon(fieldType.clazz) }}"></dot-icon>
+            <dot-icon name="{{ fieldIcons[fieldType.clazz] }}"></dot-icon>
             <span role="listitem">{{ fieldType.name }}</span>
         </li>
     }

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.html
@@ -1,13 +1,12 @@
 <ul
-    [dragulaModel]="fieldTypes"
+    [dragulaModel]="$fieldTypes()"
     class="content-types-fields-list"
     dragula="fields-bag"
     data-drag-type="source">
-    <li
-        *ngFor="let fieldType of fieldTypes"
-        [attr.data-clazz]="fieldType.clazz"
-        class="content-types-fields-list__item">
-        <dot-icon name="{{ fieldService.getIcon(fieldType.clazz) }}"></dot-icon>
-        <span role="listitem">{{ fieldType.name }}</span>
-    </li>
+    @for (fieldType of $fieldTypes(); track fieldType.clazz) {
+        <li [attr.data-clazz]="fieldType.clazz" class="content-types-fields-list__item">
+            <dot-icon name="{{ getIcon(fieldType.clazz) }}"></dot-icon>
+            <span role="listitem">{{ fieldType.name }}</span>
+        </li>
+    }
 </ul>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.spec.ts
@@ -42,8 +42,8 @@ const itemsData = [
     },
     {
         label: 'Permission',
-        id: 'permission_tab',
-        clazz: 'permission_tab'
+        id: 'permissions_tab',
+        clazz: 'permissions_tab'
     },
     {
         label: 'Line Divider',

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.spec.ts
@@ -36,6 +36,16 @@ const itemsData = [
         clazz: 'tab'
     },
     {
+        label: 'Relationships Legacy',
+        id: 'relationships_tab',
+        clazz: 'relationships_tab'
+    },
+    {
+        label: 'Permission',
+        id: 'permission_tab',
+        clazz: 'permission_tab'
+    },
+    {
         label: 'Line Divider',
         clazz: 'com.dotcms.contenttype.model.field.ImmutableLineDividerField'
     }
@@ -74,9 +84,11 @@ describe('ContentTypesFieldsListComponent', () => {
             items = de.queryAll(By.css('li span'));
         });
 
-        it('should filter our tab field', () => {
+        it('should filter black listed fields', () => {
+            const backListFields = ['relationships_tab', 'permissions_tab', 'tab_divider'];
+
             items.forEach((el: DebugElement) => {
-                expect(el.nativeElement.textContent).not.toBe('Tab Divider');
+                expect(backListFields).not.toContain(el.nativeElement.textContent);
             });
         });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.ts
@@ -3,6 +3,7 @@ import { Component, inject, Input, OnInit, signal } from '@angular/core';
 import { filter, mergeMap, take, toArray } from 'rxjs/operators';
 
 import { FieldUtil } from '@dotcms/utils-testing';
+import { FIELD_ICONS } from '@portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-icon-map';
 
 import { FieldType } from '..';
 import { FieldService } from '../service';
@@ -21,6 +22,7 @@ export class ContentTypesFieldsListComponent implements OnInit {
     @Input() baseType: string;
 
     $fieldTypes = signal<{ clazz: string; name: string }[]>([]);
+    fieldIcons = FIELD_ICONS;
 
     #dotFormFields = [
         'com.dotcms.contenttype.model.field.ImmutableBinaryField',
@@ -74,15 +76,6 @@ export class ContentTypesFieldsListComponent implements OnInit {
                 const COLUMN_BREAK_FIELD = FieldUtil.createColumnBreak();
                 this.$fieldTypes.set([COLUMN_BREAK_FIELD, LINE_DIVIDER, ...fieldsFiltered]);
             });
-    }
-
-    /**
-     * Get the icon based on the Field Type
-     *
-     * @param {string} clazz
-     */
-    getIcon(clazz: string): string {
-        return this.#fieldService.getIcon(clazz);
     }
 
     private isFormField(field: { clazz: string; name: string }): boolean {


### PR DESCRIPTION
### Proposed Changes
* The "Permissions" and "Relationships Legacy" fields are now deprecated, and will not be migrated to the new content edit screen.
