### PR TITLE
fix(CICD): Changing the order of execution of the setup git config in the cicd_post_sync-main-with-master.yml workflow

### DIFF
--- a/.github/workflows/cicd_post_sync-main-with-master.yml
+++ b/.github/workflows/cicd_post_sync-main-with-master.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 'Setup git config'
-        run: |
-          git config user.name "${{ secrets.CI_MACHINE_USER }}"
-          git config user.email "dotCMS-Machine-User@dotcms.com"
-          
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches
+
+      - name: 'Setup git config'
+        run: |
+          git config user.name "${{ secrets.CI_MACHINE_USER }}"
+          git config user.email "dotCMS-Machine-User@dotcms.com"
 
       - name: Create or update main branch
         run: |


### PR DESCRIPTION
### Proposed Changes
* The order of execution of the steps was changed to avoid failures
Refs: #29840

This PR fixes: #29840