### PR TITLE
fix (binary-field) : #29939 Double preview on binary fields: displaying both old and new editors 

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -1050,7 +1050,7 @@
 
     </script>
 
-    <%} %>
+
     <%
 
         String bnFlag = Config.getStringProperty("FEATURE_FLAG_NEW_BINARY_FIELD");
@@ -1076,8 +1076,8 @@
             <% } %>
 
         <% } %>
-    <% } %>
-
+      <% } %>
+    <%} %>
     <!--  END display -->
     <!-- javascript -->
     <script type="text/javascript">


### PR DESCRIPTION
### Proposed Changes
* Cover the scenario of hide the legacy editor once the new Binary field is enable. 
