### PR TITLE
fix(deployment): Edit Page V2 Automate the deploy of the SDK librar (#28259)

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -196,7 +196,6 @@ runs:
       shell: bash               
 
     - name: 'Publishing sdk into NPM registry'
-      if: ${{ steps.validate_version.outputs.publish == 'true' }}
       working-directory: ${{ github.workspace }}/core-web/libs/sdk/
       env:
         NEXT_VERSION: ${{ steps.next_version.outputs.next_version }}

--- a/.github/workflows/cicd_comp_initialize-phase.yml
+++ b/.github/workflows/cicd_comp_initialize-phase.yml
@@ -136,6 +136,7 @@ jobs:
       
       # 1. Attempt to download the existing artifact using the BASE_SHA
       - name: Download Existing SDK Status Artifact
+        if: ${{ github.event_name != 'pull_request' }}
         id: download-artifact
         uses: dawidd6/action-download-artifact@v3.1.4
         with:

--- a/.github/workflows/cicd_comp_initialize-phase.yml
+++ b/.github/workflows/cicd_comp_initialize-phase.yml
@@ -123,29 +123,97 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: ${{ inputs.validation-level != 'none' }}
+
+      - name: Determine BASE_SHA
+        id: determine-base-sha
+        run: |
+          echo "::group::Determine BASE_SHA"
+          # 1 - PULL REQUEST || 2 - MERGE GROUP || 3 - PUSH || 4 - DEFAULT
+          BASE_SHA=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || github.sha }}
+          echo "::notice::BASE SHA: ${BASE_SHA}"
+          echo "BASE_SHA=${BASE_SHA}" >> $GITHUB_ENV
+          echo "::endgroup::"
+      
+      # 1. Attempt to download the existing artifact using the BASE_SHA
+      - name: Download Existing SDK Status Artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v3.1.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow_search: true
+          search_artifacts: true
+          name: sdk-status-sha-${{ env.BASE_SHA }}  # Name of the artifact using BASE_SHA
+          path: .
+          if_no_artifact_found: warn
+        continue-on-error: true  # Do not fail if the artifact does not exist
+
+      # 2. Check if the artifact was downloaded
+      - name: Check if SDK Status exists
+        id: check-artifact
+        run: |
+          echo "::group::Check if SDK Status exists"
+          if [ -f sdk_status_sha_${{ env.BASE_SHA }}.txt ]; then
+            echo "Artifact found. Using existing sdk_status."
+            sdk_libs=$(cat sdk_status_sha_${{ env.BASE_SHA }}.txt | grep 'sdk_libs' | cut -d'=' -f2)
+            echo "sdk_libs=$sdk_libs"
+            echo "sdk_libs=$sdk_libs" >> $GITHUB_ENV
+          else
+            echo "Artifact not found. Calculating sdk_status..."
+            echo "sdk_status_not_found=true"
+            echo "sdk_status_not_found=true" >> $GITHUB_ENV
+          fi  
+          # Correctly closing the if statement
+          echo "::endgroup::"
+
+      # Execute the paths-filter step to determine changes
       - uses: dorny/paths-filter@v3.0.1
         if: ${{ inputs.validation-level != 'none' }}
         id: filter
         with:
           filters: .github/filters.yaml
           list-files: 'escape'
+      
+      # 3. Calculate sdk_status if it does not exist
+      - name: Calculate SDK Status
+        if: env.sdk_status_not_found == 'true'
+        run: |
+          echo "::group::Calculating sdk_status"
+          # Logic to determine sdk_status
+          sdk_libs=${{ steps.filter.outputs.sdk_libs || 'false' }}  # Default value in case of failure
+          echo "sdk_libs=$sdk_libs" > sdk_status_sha_${{ env.BASE_SHA }}.txt
+          echo "sdk_libs=$sdk_libs"
+          echo "$(cat sdk_status_sha_${{ env.BASE_SHA }}.txt)"
+          echo "sdk_libs=$sdk_libs" >> $GITHUB_ENV
+          echo "::endgroup::"
+
+      # 4. Upload the sdk_status as an artifact if it was calculated
+      - name: Upload SDK Status Artifact
+        if: env.sdk_status_not_found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-status-sha-${{ env.BASE_SHA }}  # Name of the artifact using BASE_SHA
+          path: sdk_status_sha_${{ env.BASE_SHA }}.txt
+          retention-days: 30  # Configure retention period as needed
+          
       - name: Rewrite Filter
         id: filter-rewrite
         env:
           CICD_SKIP_TESTS: ${{ vars.CICD_SKIP_TESTS }}
+          SDK_LIBS: ${{ env.sdk_libs }}
         run: |
+          echo "::group::Rewrite Fiter"
           # Default action outcomes based on paths-filter action outputs
           frontend=${{ steps.filter.outputs.frontend || 'true'}}
           cli=${{ steps.filter.outputs.cli || 'true' }}
           backend=${{ steps.filter.outputs.backend || 'true' }}
           build=${{ steps.filter.outputs.build || 'true' }}
           jvm_unit_test=${{ steps.filter.outputs.jvm_unit_test || 'true' }}
-          sdk_libs=${{ steps.filter.outputs.sdk_libs || 'false' }}
+          sdk_libs=${{ env.SDK_LIBS || steps.filter.outputs.sdk_libs }}  # Use the recovered or calculated value
 
           # Check if the commit is to the master branch
           skip_tests=${CICD_SKIP_TESTS:-false}  # Use environment variable, default to 'false'
 
-          # The below line ensures that if skip_tests is true, all tests are set to false.
+          # If skip_tests is true, set all tests to false
           if [ "$skip_tests" == "true" ]; then
             echo "Skipping tests as per CICD_SKIP_TESTS flag."
             frontend=false
@@ -175,7 +243,7 @@ jobs:
               elif [ "${module}" == "jvm_unit_test" ]; then
                 jvm_unit_test=${{ steps.filter.outputs.jvm_unit_test }}
               elif [ "${module}" == "sdk_libs" ]; then
-                sdk=${{ steps.filter.outputs.sdk_libs }}
+                sdk_libs=${{ env.SDK_LIBS }}  # Use the recovered or calculated value
               fi
             done
           fi          
@@ -194,3 +262,4 @@ jobs:
           echo "build=${build}" >> $GITHUB_OUTPUT
           echo "jvm_unit_test=${jvm_unit_test}" >> $GITHUB_OUTPUT
           echo "sdk_libs=${sdk_libs}" >> $GITHUB_OUTPUT
+          echo "::endgroup::"


### PR DESCRIPTION
### Proposed Changes
This pull request introduces a solution to persist and propagate the sdk_libs state across multiple phases of the CI/CD workflow in GitHub Actions, ensuring consistent state management during PR Checks, Merge Queue Checks, and Master Checks.

Key Steps
1. Use of a Consistent Identifier (BASE_SHA):

A unique identifier (`BASE_SHA`) is determined based on the available context: `base.sha` for `pull requests`, `merge_group.base_sha` for `merge queues`, or the `before SHA` for `push` events. This identifier is consistent across all phases and is used to reference the correct commit state.

2. Download Existing State Artifact:

In each workflow phase, an attempt is made to download an artifact named `sdk-status-${BASE_SHA}`. If the artifact exists, its content is used to define the `sdk_libs` state. If not found, the state is recalculated.

3. Calculate and Upload the Artifact if Necessary:

If no previous artifact is found, the `sdk_libs` state is recalculated using the `dorny/paths-filter` action. A new artifact named `sdk-status-${BASE_SHA}` is uploaded with the calculated state if needed.

### Additional Info
Related to #28259 (Edit Page V2 Automate the deploy of the SDK libraries).

This PR fixes: #28259