### PR TITLE
fix(uve) enterprise features need to be disabled on community edition

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.html
@@ -8,8 +8,8 @@
 
 <ng-template #anchor let-item="item">
     <a
-        [routerLink]="item.isDisabled ? null : item.href"
-        [ngClass]="{ 'edit-ema-nav-bar__item--disabled': item.isDisabled }"
+        [routerLink]="isItemDisabled(item) ? null : item.href"
+        [ngClass]="{ 'edit-ema-nav-bar__item--disabled': isItemDisabled(item) }"
         [pTooltip]="item.tooltip | dm"
         class="edit-ema-nav-bar__item"
         data-testId="nav-bar-item"
@@ -28,9 +28,9 @@
 
 <ng-template #button let-item="item">
     <button
-        (click)="item.isDisabled ? null : itemAction(item)"
-        [ngClass]="{ 'edit-ema-nav-bar__item--disabled': item.isDisabled }"
-        [disabled]="item.isDisabled"
+        (click)="isItemDisabled(item) ? null : itemAction(item)"
+        [ngClass]="{ 'edit-ema-nav-bar__item--disabled': isItemDisabled(item) }"
+        [disabled]="isItemDisabled(item)"
         class="edit-ema-nav-bar__item edit-ema-nav-bar__item--button"
         data-testId="nav-bar-item">
         <ng-container
@@ -45,6 +45,7 @@
 <ng-template #icon let-item="item">
     <i [class]="'pi ' + item.icon" data-testId="nav-bar-item-icon"></i>
 </ng-template>
+
 <ng-template #iconURL let-item="item">
     <svg class="item__image" fill="currentColor" viewBox="0 0 24 24" width="24px" height="24px">
         <use

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.ts
@@ -7,6 +7,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { DotMessagePipe } from '@dotcms/ui';
 
 import { NavigationBarItem } from '../../../shared/models';
+
 @Component({
     selector: 'dot-edit-ema-navigation-bar',
     standalone: true,
@@ -25,6 +26,17 @@ export class EditEmaNavigationBarComponent {
     @Input() items: NavigationBarItem[];
 
     /**
+     * Indicates whether the current license is an enterprise license.
+     *
+     * This flag is used to determine if enterprise-only features should be enabled.
+     * When false, items marked as needsEnterpriseLicense will be disabled in the navigation bar.
+     *
+     * @type {boolean}
+     * @default false
+     */
+    @Input() isEnterpriseLicense = false;
+
+    /**
      * Emits the id of the clicked item
      *
      * @type {EventEmitter<string>}
@@ -40,5 +52,19 @@ export class EditEmaNavigationBarComponent {
      */
     itemAction(item: NavigationBarItem): void {
         this.action.emit(item.id);
+    }
+
+    /**
+     * Determines if a navigation bar item should be disabled.
+     *
+     * An item is considered disabled if:
+     * 1. It is explicitly marked as disabled (item.isDisabled is true), or
+     * 2. It needs an enterprise license (item.needsEnterpriseLicense is true) and the current license is not an enterprise license.
+     *
+     * @param {NavigationBarItem} item - The navigation bar item to check.
+     * @returns {boolean} True if the item should be disabled, false otherwise.
+     */
+    isItemDisabled(item: NavigationBarItem): boolean {
+        return item.isDisabled || (item.needsEnterpriseLicense && !this.isEnterpriseLicense);
     }
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.html
@@ -2,6 +2,7 @@
     <router-outlet></router-outlet>
     <dot-edit-ema-navigation-bar
         [items]="$shellProps().items"
+        [isEnterpriseLicense]="isEnterpriseLicense$ | async"
         (action)="handleItemAction($event)"
         data-testId="ema-nav-bar"></dot-edit-ema-navigation-bar>
     <p-toast position="top-center" data-testId="ema-toast"></p-toast>

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -1,4 +1,4 @@
-import { Subject } from 'rxjs';
+import { Observable, of, Subject } from 'rxjs';
 
 import { CommonModule } from '@angular/common';
 import { Component, effect, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
@@ -9,13 +9,14 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogService } from 'primeng/dynamicdialog';
 import { ToastModule } from 'primeng/toast';
 
-import { skip, takeUntil } from 'rxjs/operators';
+import { skip, take, takeUntil } from 'rxjs/operators';
 
 import {
     DotESContentService,
     DotExperimentsService,
     DotFavoritePageService,
     DotLanguagesService,
+    DotLicenseService,
     DotMessageService,
     DotPageLayoutService,
     DotPageRenderService,
@@ -89,7 +90,7 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
     readonly #confirmationService = inject(ConfirmationService);
 
     protected readonly $shellProps = this.uveStore.$shellProps;
-
+    readonly #dotLicenseService = inject(DotLicenseService);
     readonly #destroy$ = new Subject<boolean>();
 
     readonly translatePageEffect = effect(() => {
@@ -99,8 +100,10 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
             this.createNewTranslation(currentLanguage, page);
         }
     });
+    isEnterpriseLicense$: Observable<boolean> = of(false);
 
     ngOnInit(): void {
+        this.isEnterpriseLicense$ = this.#dotLicenseService.isEnterprise().pipe(take(1));
         this.#activatedRoute.queryParams
             .pipe(takeUntil(this.#destroy$))
             .subscribe((queryParams) => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
@@ -87,6 +87,7 @@ export interface NavigationBarItem {
     id: string;
     isDisabled?: boolean;
     tooltip?: string;
+    needsEnterpriseLicense?: boolean;
 }
 
 export interface MessageInfo {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
@@ -73,7 +73,8 @@ export const UVEStore = signalStore(
                                 icon: 'pi-file',
                                 label: 'editema.editor.navbar.content',
                                 href: 'content',
-                                id: 'content'
+                                id: 'content',
+                                needsEnterpriseLicense: false
                             },
                             {
                                 icon: 'pi-table',
@@ -81,6 +82,7 @@ export const UVEStore = signalStore(
                                 href: 'layout',
                                 id: 'layout',
                                 isDisabled: isLayoutDisabled,
+                                needsEnterpriseLicense: true,
                                 tooltip: templateDrawed
                                     ? null
                                     : 'editema.editor.navbar.layout.tooltip.cannot.edit.advanced.template'
@@ -90,25 +92,29 @@ export const UVEStore = signalStore(
                                 label: 'editema.editor.navbar.rules',
                                 id: 'rules',
                                 href: `rules/${page?.identifier}`,
-                                isDisabled: !page?.canEdit
+                                isDisabled: !page?.canEdit,
+                                needsEnterpriseLicense: true
                             },
                             {
                                 iconURL: 'experiments',
                                 label: 'editema.editor.navbar.experiments',
                                 href: `experiments/${page?.identifier}`,
                                 id: 'experiments',
-                                isDisabled: !page?.canEdit
+                                isDisabled: !page?.canEdit,
+                                needsEnterpriseLicense: true
                             },
                             {
                                 icon: 'pi-th-large',
                                 label: 'editema.editor.navbar.page-tools',
-                                id: 'page-tools'
+                                id: 'page-tools',
+                                needsEnterpriseLicense: false
                             },
                             {
                                 icon: 'pi-ellipsis-v',
                                 label: 'editema.editor.navbar.properties',
                                 id: 'properties',
-                                isDisabled: isLoading
+                                isDisabled: isLoading,
+                                needsEnterpriseLicense: false
                             }
                         ]
                     };


### PR DESCRIPTION
### Proposed Changes
* Added `needsEnterpriseLicense` flag to `NavigationBarItem`.
* Updated the logic to disable navigation items based on whether they require an enterprise license and the current license status.

### Checklist
- [ ] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
In this update, navigation items that are marked as `needsEnterpriseLicense` will be disabled if the current license is not an enterprise license. This ensures that enterprise-only features are not accessible in the Community Edition, improving the user experience by preventing confusion and frustration.

### Screenshots
![image](https://github.com/user-attachments/assets/4e30c553-db35-40cd-bc34-686d34286d21)

This pr fixes #29977
