### PR TITLE
fix(uve): Enterprise features need to be disabled on community license

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.spec.ts
@@ -304,7 +304,22 @@ describe('UVEStore', () => {
 
                 expect(layoutItem.isDisabled).toBe(true);
             });
+            it('should return layout, rules and experiments as disabled when isEnterprise is false', () => {
+                jest.spyOn(dotPageApiService, 'get').mockImplementation(
+                    buildPageAPIResponseFromMock(MOCK_RESPONSE_VTL)
+                );
 
+                patchState(store, { isEnterprise: false });
+
+                const shellProps = store.$shellProps();
+                const layoutItem = shellProps.items.find((item) => item.id === 'layout');
+                const rulesItem = shellProps.items.find((item) => item.id === 'rules');
+                const experimentsItem = shellProps.items.find((item) => item.id === 'experiments');
+
+                expect(layoutItem.isDisabled).toBe(true);
+                expect(rulesItem.isDisabled).toBe(true);
+                expect(experimentsItem.isDisabled).toBe(true);
+            });
             it('should return item for layout as disable and with a tooltip', () => {
                 jest.spyOn(dotPageApiService, 'get').mockImplementation(
                     buildPageAPIResponseFromMock({

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
@@ -28,7 +28,15 @@ const initialState: UVEState = {
 export const UVEStore = signalStore(
     withState<UVEState>(initialState),
     withComputed(
-        ({ pageAPIResponse, isTraditionalPage, params, languages, errorCode: error, status }) => {
+        ({
+            pageAPIResponse,
+            isTraditionalPage,
+            params,
+            languages,
+            errorCode: error,
+            status,
+            isEnterprise
+        }) => {
             return {
                 $translateProps: computed<TranslateProps>(() => {
                     const response = pageAPIResponse();
@@ -58,6 +66,7 @@ export const UVEStore = signalStore(
 
                     const errorPayload = getErrorPayload(errorCode);
                     const isLoading = status() === UVE_STATUS.LOADING;
+                    const isEnterpriseLicense = isEnterprise();
 
                     return {
                         canRead: page?.canRead,
@@ -80,7 +89,7 @@ export const UVEStore = signalStore(
                                 label: 'editema.editor.navbar.layout',
                                 href: 'layout',
                                 id: 'layout',
-                                isDisabled: isLayoutDisabled,
+                                isDisabled: isLayoutDisabled || !isEnterpriseLicense,
                                 tooltip: templateDrawed
                                     ? null
                                     : 'editema.editor.navbar.layout.tooltip.cannot.edit.advanced.template'
@@ -90,14 +99,14 @@ export const UVEStore = signalStore(
                                 label: 'editema.editor.navbar.rules',
                                 id: 'rules',
                                 href: `rules/${page?.identifier}`,
-                                isDisabled: !page?.canEdit
+                                isDisabled: !page?.canEdit || !isEnterpriseLicense
                             },
                             {
                                 iconURL: 'experiments',
                                 label: 'editema.editor.navbar.experiments',
                                 href: `experiments/${page?.identifier}`,
                                 id: 'experiments',
-                                isDisabled: !page?.canEdit
+                                isDisabled: !page?.canEdit || !isEnterpriseLicense
                             },
                             {
                                 icon: 'pi-th-large',


### PR DESCRIPTION
### Proposed Changes
* Updated the logic to disable navigation items based on whether they require an enterprise license and the current license status.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
In this update, navigation items that are enterprise (layout, rules, experiments) will be disabled if the current license is not an enterprise license. This ensures that enterprise-only features are not accessible in the Community Edition, improving the user experience by preventing confusion and frustration.

### Screenshots
#### Editing a page in community edition
![image](https://github.com/user-attachments/assets/4e30c553-db35-40cd-bc34-686d34286d21)

#### Editing a page in enterprise edition
![image](https://github.com/user-attachments/assets/dfead069-95aa-4a6d-81b3-c736cef40556)

This pr fixes #29977

This PR fixes: #29977