### PR TITLE
Fix `clear all` button in Category Field Dialog

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-category-list/dot-category-field-category-list.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-category-list/dot-category-field-category-list.component.spec.ts
@@ -14,7 +14,7 @@ import {
     CATEGORY_LIST_MOCK,
     CATEGORY_LIST_MOCK_TRANSFORMED_MATRIX,
     CATEGORY_MOCK_TRANSFORMED,
-    SELECTED_LIST_MOCK
+    MOCK_SELECTED_CATEGORIES_KEYS
 } from '../../mocks/category-field.mocks';
 import { DotCategoryFieldListSkeletonComponent } from '../dot-category-field-list-skeleton/dot-category-field-list-skeleton.component';
 
@@ -29,7 +29,7 @@ describe('DotCategoryFieldCategoryListComponent', () => {
     beforeEach(() => {
         spectator = createComponent();
         spectator.setInput('categories', CATEGORY_LIST_MOCK_TRANSFORMED_MATRIX);
-        spectator.setInput('selected', SELECTED_LIST_MOCK);
+        spectator.setInput('selected', MOCK_SELECTED_CATEGORIES_KEYS);
         spectator.setInput('state', ComponentStatus.INIT);
         spectator.setInput('breadcrumbs', []);
 
@@ -81,7 +81,7 @@ describe('DotCategoryFieldCategoryListComponent', () => {
 
     it('should apply selected class to the correct item', () => {
         spectator.setInput('categories', [CATEGORY_MOCK_TRANSFORMED]);
-        spectator.setInput('selected', SELECTED_LIST_MOCK);
+        spectator.setInput('selected', MOCK_SELECTED_CATEGORIES_KEYS);
         spectator.setInput('state', ComponentStatus.LOADED);
 
         spectator.detectChanges();
@@ -97,7 +97,7 @@ describe('DotCategoryFieldCategoryListComponent', () => {
         const testCategories = Array(minColumns).fill(CATEGORY_LIST_MOCK_TRANSFORMED_MATRIX[0]);
 
         spectator.setInput('categories', testCategories);
-        spectator.setInput('selected', SELECTED_LIST_MOCK);
+        spectator.setInput('selected', MOCK_SELECTED_CATEGORIES_KEYS);
         spectator.setInput('state', ComponentStatus.LOADED);
 
         spectator.detectChanges();
@@ -107,7 +107,7 @@ describe('DotCategoryFieldCategoryListComponent', () => {
 
     it('should render the skeleton component if is loading', () => {
         spectator.setInput('categories', [CATEGORY_MOCK_TRANSFORMED]);
-        spectator.setInput('selected', SELECTED_LIST_MOCK);
+        spectator.setInput('selected', MOCK_SELECTED_CATEGORIES_KEYS);
         spectator.setInput('state', ComponentStatus.LOADING);
 
         spectator.detectChanges();

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.html
@@ -18,7 +18,6 @@
             </div>
             <div class="flex-grow-1 category-field__categories">
                 @if (store.mode() === 'list') {
-
                     <dot-category-field-category-list
                         (itemChecked)="store.updateSelected($event.selected, $event.item)"
                         (rowClicked)="store.getCategories($event)"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.html
@@ -18,12 +18,13 @@
             </div>
             <div class="flex-grow-1 category-field__categories">
                 @if (store.mode() === 'list') {
+
                     <dot-category-field-category-list
                         (itemChecked)="store.updateSelected($event.selected, $event.item)"
                         (rowClicked)="store.getCategories($event)"
                         [categories]="store.categoryList()"
                         [state]="store.listState()"
-                        [selected]="store.confirmedCategoriesValues()"
+                        [selected]="store.dialogSelectedKeys()"
                         [breadcrumbs]="store.breadcrumbMenu()" />
                 } @else {
                     <dot-category-field-search-list
@@ -31,23 +32,23 @@
                         (removeItem)="store.removeSelected($event)"
                         [state]="store.searchState()"
                         [categories]="store.searchCategoryList()"
-                        [selected]="store.selected()" />
+                        [selected]="store.dialog.selected()" />
                 }
             </div>
         </div>
 
         <div
             class="category-field__right-pane flex flex-column"
-            [ngClass]="{ empty: !store.selected().length }">
-            @if (store.selected().length) {
+            [ngClass]="{ empty: !store.dialog.selected().length }">
+            @if (store.dialog.selected().length) {
                 <div class="category-field__selected-categories-list flex-1">
                     <dot-category-field-selected
                         (removeItem)="store.removeSelected($event)"
-                        [categories]="store.selected()" />
+                        [categories]="store.dialog.selected()" />
                 </div>
                 <div class="category-field__actions flex justify-content-end">
                     <button
-                        (click)="store.removeSelected($allCategoryKeys())"
+                        (click)="store.removeSelected(store.dialogSelectedKeys())"
                         class="p-button p-button-link"
                         data-testId="clear_all-btn"
                         pButton>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.spec.ts
@@ -85,17 +85,11 @@ describe('DotCategoryFieldDialogComponent', () => {
 
     it('should save the changes and apply the categories when the apply button is clicked', () => {
         const closedDialogSpy = jest.spyOn(spectator.component.closedDialog, 'emit');
-        const addConfirmedCategoriesSky = jest.spyOn(store, 'addConfirmedCategories');
-        const categories = { key: '1234', value: 'test' };
-        store.addSelected({ key: '1234', value: 'test' });
+        const addConfirmedCategoriesSky = jest.spyOn(store, 'applyDialogSelection');
         spectator.detectChanges();
-
-        expect(store.selected()).toEqual([categories]);
-        expect(store.confirmedCategories()).toEqual([]);
 
         spectator.click(byTestId('dialog-apply'));
 
-        expect(store.confirmedCategories()).toEqual([categories]);
         expect(closedDialogSpy).toHaveBeenCalled();
         expect(addConfirmedCategoriesSky).toHaveBeenCalled();
     });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.ts
@@ -2,7 +2,6 @@ import { NgClass } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
-    computed,
     inject,
     model,
     OnDestroy,
@@ -68,11 +67,6 @@ export class DotCategoryFieldDialogComponent implements OnInit, OnDestroy {
      */
     readonly store = inject(CategoryFieldStore);
 
-    /**
-     * Computed property for retrieving all category keys.
-     */
-    $allCategoryKeys = computed(() => this.store.selected().map((category) => category.key));
-
     ngOnInit(): void {
         this.store.getCategories();
     }
@@ -82,7 +76,7 @@ export class DotCategoryFieldDialogComponent implements OnInit, OnDestroy {
     }
 
     confirmCategories(): void {
-        this.store.addConfirmedCategories();
+        this.store.applyDialogSelection();
         this.closedDialog.emit();
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.html
@@ -2,7 +2,7 @@
     <dot-category-field-chips
         data-testId="category-chip-list"
         [categories]="store.selected()"
-        (remove)="store.removeSelected($event)" />
+        (remove)="store.removeRootSelected($event)" />
 }
 
 <div class="dot-category-field__select">

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.html
@@ -1,26 +1,26 @@
-@if (store.confirmedCategories().length) {
+@if (store.selected().length) {
     <dot-category-field-chips
         data-testId="category-chip-list"
-        [categories]="store.confirmedCategories()"
-        (remove)="store.removeConfirmedCategories($event)" />
+        [categories]="store.selected()"
+        (remove)="store.removeSelected($event)" />
 }
 
 <div class="dot-category-field__select">
     <button
         type="button"
         (click)="openCategoriesDialog()"
-        [disabled]="$showCategoriesDialog()"
+        [disabled]="store.isDialogOpen()"
         [label]="'edit.content.category-field.show-categories-dialog' | dm"
         class="p-button-sm p-button-text p-button-secondary"
         data-testId="show-dialog-btn"
         pButton></button>
 </div>
 
-@if ($showCategoriesDialog()) {
-    @defer (when $showCategoriesDialog()) {
+@if (store.isDialogOpen()) {
+    @defer (when store.isDialogOpen()) {
         <dot-category-field-dialog
-            [isVisible]="$showCategoriesDialog()"
-            (closedDialog)="closeCategoriesDialog()"
+            [isVisible]="store.isDialogOpen()"
+            (closedDialog)="store.closeDialog()"
             data-testId="dialog-placeholder" />
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.spec.ts
@@ -16,8 +16,10 @@ import {
     CATEGORY_FIELD_MOCK,
     CATEGORY_FIELD_VARIABLE_NAME,
     CATEGORY_HIERARCHY_MOCK,
-    SELECTED_LIST_MOCK
+    CATEGORY_LEVEL_2,
+    MOCK_SELECTED_CATEGORIES_OBJECT
 } from './mocks/category-field.mocks';
+import { DotCategoryFieldKeyValueObj } from './models/dot-category-field.models';
 import { CategoriesService } from './services/categories.service';
 import { CategoryFieldStore } from './store/content-category-field.store';
 
@@ -86,7 +88,7 @@ describe('DotEditContentCategoryFieldComponent', () => {
             it('should categoryFieldControl has the values loaded on the store', () => {
                 const categoryValue = spectator.component.categoryFieldControl.value;
 
-                expect(categoryValue).toEqual(SELECTED_LIST_MOCK);
+                expect(categoryValue).toEqual(MOCK_SELECTED_CATEGORIES_OBJECT);
             });
         });
 
@@ -186,30 +188,50 @@ describe('DotEditContentCategoryFieldComponent', () => {
             // Check if the form has the correct value
             const categoryValue = spectator.component.categoryFieldControl.value;
 
-            expect(categoryValue).toEqual(SELECTED_LIST_MOCK);
+            expect(categoryValue).toEqual(MOCK_SELECTED_CATEGORIES_OBJECT);
         }));
 
         it('should set categoryFieldControl value when adding a new category', () => {
-            store.addSelected({
-                key: '1234',
-                value: 'test'
-            });
-            store.addConfirmedCategories();
-            spectator.flushEffects();
+            const newItem: DotCategoryFieldKeyValueObj = {
+                key: CATEGORY_LEVEL_2[0].key,
+                value: CATEGORY_LEVEL_2[0].categoryName,
+                inode: CATEGORY_LEVEL_2[0].inode,
+                path: CATEGORY_LEVEL_2[0].categoryName
+            };
 
-            const categoryValue = spectator.component.categoryFieldControl.value;
+            // this apply selected to the dialog
+            store.openDialog();
 
-            expect(categoryValue).toEqual([...SELECTED_LIST_MOCK, '1234']);
+            // Add the new category
+            store.addSelected(newItem);
+            // Apply the selected to the field
+            store.applyDialogSelection();
+
+            spectator.detectChanges();
+
+            const categoryValues = spectator.component.categoryFieldControl.value;
+
+            expect(categoryValues).toEqual([...MOCK_SELECTED_CATEGORIES_OBJECT, newItem]);
         });
 
         it('should set categoryFieldControl value when removing a category', () => {
-            store.removeConfirmedCategories(SELECTED_LIST_MOCK[0]);
+            const categoryValue: DotCategoryFieldKeyValueObj[] =
+                spectator.component.categoryFieldControl.value;
 
-            spectator.flushEffects();
+            const expectedSelected = [categoryValue[0]];
 
-            const categoryValue = spectator.component.categoryFieldControl.value;
+            expect(categoryValue.length).toBe(2);
+            store.openDialog(); // this apply selected to the dialog
 
-            expect(categoryValue).toEqual([SELECTED_LIST_MOCK[1]]);
+            store.removeSelected(categoryValue[1].key);
+            store.applyDialogSelection(); // this apply the selected in the dialog to the final selected
+
+            spectator.detectChanges();
+
+            const newCategoryValue = spectator.component.categoryFieldControl.value;
+
+            expect(newCategoryValue).toEqual(expectedSelected);
+            expect(newCategoryValue.length).toBe(1);
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
@@ -7,8 +7,7 @@ import {
     inject,
     Injector,
     input,
-    OnInit,
-    signal
+    OnInit
 } from '@angular/core';
 import { ControlContainer, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
@@ -45,8 +44,8 @@ import { CategoryFieldStore } from './store/content-category-field.store';
     styleUrl: './dot-edit-content-category-field.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
-        '[class.dot-category-field__container--has-categories]': '$hasConfirmedCategories()',
-        '[class.dot-category-field__container]': '!$hasConfirmedCategories()'
+        '[class.dot-category-field__container--has-categories]': '$hasSelectedCategories()',
+        '[class.dot-category-field__container]': '!$hasSelectedCategories()'
     },
     viewProviders: [
         {
@@ -60,10 +59,7 @@ export class DotEditContentCategoryFieldComponent implements OnInit {
     readonly store = inject(CategoryFieldStore);
     readonly #form = inject(ControlContainer).control as FormGroup;
     readonly #injector = inject(Injector);
-    /**
-     * Disable the button to open the dialog
-     */
-    $showCategoriesDialog = signal(false);
+
     /**
      * The `field` variable is of type `DotCMSContentTypeField` and is a required input.
      * @description The variable represents a field of a DotCMS content type and is a required input.
@@ -79,7 +75,7 @@ export class DotEditContentCategoryFieldComponent implements OnInit {
      *
      * @returns {Boolean} - True if there are selected categories, false otherwise.
      */
-    $hasConfirmedCategories = computed(() => !!this.store.hasConfirmedCategories());
+    $hasSelectedCategories = computed(() => !!this.store.selected());
     /**
      * Getter to retrieve the category field control.
      *
@@ -100,7 +96,7 @@ export class DotEditContentCategoryFieldComponent implements OnInit {
         });
         effect(
             () => {
-                const categoryValues = this.store.confirmedCategoriesValues();
+                const categoryValues = this.store.selected();
 
                 if (this.categoryFieldControl) {
                     this.categoryFieldControl.setValue(categoryValues);
@@ -117,15 +113,6 @@ export class DotEditContentCategoryFieldComponent implements OnInit {
      * @memberof DotEditContentCategoryFieldComponent
      */
     openCategoriesDialog(): void {
-        this.store.setSelectedCategories();
-        this.$showCategoriesDialog.set(true);
-    }
-    /**
-     * Close the categories dialog.
-     *
-     * @memberof DotEditContentCategoryFieldComponent
-     */
-    closeCategoriesDialog() {
-        this.$showCategoriesDialog.set(false);
+        this.store.openDialog();
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/mocks/category-field.mocks.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/mocks/category-field.mocks.ts
@@ -15,7 +15,7 @@ export const CATEGORY_FIELD_CONTENTLET_MOCK: DotCMSContentlet = {
     baseType: 'CONTENT',
     [CATEGORY_FIELD_VARIABLE_NAME]: [
         {
-            '1f208488057007cedda0e0b5d52ee3b3': 'Electrical'
+            '1f208488057007cedda0e0b5d52ee3b3': 'Cleaning Supplies'
         },
         {
             cb83dc32c0a198fd0ca427b3b587f4ce: 'Doors & Windows'
@@ -197,14 +197,32 @@ export const CATEGORY_LEVEL_2: DotCategory[] = [
 export const CATEGORY_LIST_MOCK: DotCategory[][] = [[...CATEGORY_LEVEL_1], [...CATEGORY_LEVEL_2]];
 
 /**
- * Represent the selected categories
+ * Represent the selected categories keys
  */
-export const SELECTED_LIST_MOCK = [CATEGORY_LEVEL_1[0].key, CATEGORY_LEVEL_1[1].key];
+export const MOCK_SELECTED_CATEGORIES_KEYS = [CATEGORY_LEVEL_1[0].key, CATEGORY_LEVEL_1[1].key];
+
+/**
+ * Represent the selected categories as an object
+ */
+export const MOCK_SELECTED_CATEGORIES_OBJECT: DotCategoryFieldKeyValueObj[] = [
+    {
+        key: CATEGORY_LEVEL_1[0].key,
+        value: CATEGORY_LEVEL_1[0].categoryName,
+        inode: CATEGORY_LEVEL_1[0].inode,
+        path: CATEGORY_LEVEL_1[0].categoryName // root categories is the categoryName
+    },
+    {
+        key: CATEGORY_LEVEL_1[1].key,
+        value: CATEGORY_LEVEL_1[1].categoryName,
+        inode: CATEGORY_LEVEL_1[1].inode,
+        path: CATEGORY_LEVEL_1[1].categoryName // root categories is the categoryName
+    }
+];
 
 export const CATEGORY_LIST_MOCK_TRANSFORMED_MATRIX: DotCategoryFieldKeyValueObj[][] =
     CATEGORY_LIST_MOCK.map(
         (categoryLevel) => transformCategories(categoryLevel) as DotCategoryFieldKeyValueObj[],
-        SELECTED_LIST_MOCK
+        MOCK_SELECTED_CATEGORIES_KEYS
     );
 
 export const CATEGORY_MOCK_TRANSFORMED: DotCategoryFieldKeyValueObj[] = [
@@ -295,9 +313,9 @@ export const CATEGORY_HIERARCHY_MOCK: HierarchyParent[] = [
                 name: CATEGORY_FIELD_MOCK.categories.categoryName
             },
             {
-                inode: CATEGORY_LEVEL_1[0].inode,
-                key: CATEGORY_LEVEL_1[0].key,
-                name: CATEGORY_LEVEL_1[0].categoryName
+                inode: CATEGORY_LEVEL_1[1].inode,
+                key: CATEGORY_LEVEL_1[1].key,
+                name: CATEGORY_LEVEL_1[1].categoryName
             }
         ]
     }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.spec.ts
@@ -64,7 +64,6 @@ describe('CategoryFieldStore', () => {
             ];
 
             store.load({ field: CATEGORY_FIELD_MOCK, contentlet: CATEGORY_FIELD_CONTENTLET_MOCK });
-            console.log(store.selected());
             expect(store.selected()).toEqual(expectedCategoryValues);
             expect(store.rootCategoryInode()).toEqual(CATEGORY_FIELD_MOCK.values);
         });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.spec.ts
@@ -16,14 +16,27 @@ import {
     CATEGORY_FIELD_MOCK,
     CATEGORY_HIERARCHY_MOCK,
     CATEGORY_LEVEL_1,
-    CATEGORY_LEVEL_2,
-    SELECTED_LIST_MOCK
+    CATEGORY_LEVEL_2
 } from '../mocks/category-field.mocks';
 import { DotCategoryFieldKeyValueObj } from '../models/dot-category-field.models';
 import { CategoriesService } from '../services/categories.service';
 import { transformCategories } from '../utils/category-field.utils';
 
 const EMPTY_ARRAY = [];
+const MOCK_SELECTED_CATEGORIES: DotCategoryFieldKeyValueObj[] = [
+    {
+        key: '1f208488057007cedda0e0b5d52ee3b3',
+        value: 'Cleaning Supplies',
+        inode: '111111',
+        path: 'Cleaning Supplies'
+    },
+    {
+        key: 'cb83dc32c0a198fd0ca427b3b587f4ce',
+        value: 'Doors & Windows',
+        inode: '22222',
+        path: 'Cleaning Supplies'
+    }
+];
 
 describe('CategoryFieldStore', () => {
     let spectator: SpectatorService<InstanceType<typeof CategoryFieldStore>>;
@@ -52,25 +65,15 @@ describe('CategoryFieldStore', () => {
         expect(store.keyParentPath()).toEqual(EMPTY_ARRAY);
         expect(store.state()).toEqual(ComponentStatus.INIT);
         expect(store.selected()).toEqual(EMPTY_ARRAY);
-        expect(store.confirmedCategories()).toEqual(EMPTY_ARRAY);
+        expect(store.dialog.selected()).toEqual(EMPTY_ARRAY);
+        expect(store.dialog.state()).toEqual('closed');
         expect(store.mode()).toEqual('list');
     });
 
     describe('withMethods', () => {
         it('should set the correct rootCategoryInode and categoriesValue', () => {
             const expectedCategoryValues: DotCategoryFieldKeyValueObj[] = [
-                {
-                    key: '1f208488057007cedda0e0b5d52ee3b3',
-                    value: 'Cleaning Supplies',
-                    inode: '111111',
-                    path: 'Cleaning Supplies'
-                },
-                {
-                    key: 'cb83dc32c0a198fd0ca427b3b587f4ce',
-                    value: 'Doors & Windows',
-                    inode: '22222',
-                    path: 'Cleaning Supplies'
-                }
+                ...MOCK_SELECTED_CATEGORIES
             ];
 
             store.load({ field: CATEGORY_FIELD_MOCK, contentlet: CATEGORY_FIELD_CONTENTLET_MOCK });
@@ -124,43 +127,89 @@ describe('CategoryFieldStore', () => {
                 expect(store.categories().length).toBe(2);
             });
         });
-
-        it('should remove confirmed categories with given key', () => {
-            store.addSelected([{ key: '1234', value: 'test' }]);
-            store.addConfirmedCategories();
-
-            store.removeConfirmedCategories('1234');
-            expect(store.confirmedCategories().length).toEqual(0);
-        });
-
-        it('should add selected categories to confirmed categories', () => {
-            store.addSelected([{ key: '1234', value: 'test' }]);
-            store.addConfirmedCategories();
-
-            expect(store.confirmedCategories()).toEqual(store.selected());
-        });
-
-        it('should set selected categories based on confirmed categories', () => {
-            store.addSelected([{ key: '1234', value: 'test' }]);
-            store.addConfirmedCategories();
-
-            store.removeSelected('1234');
-
-            expect(store.selected()).toEqual(EMPTY_ARRAY);
-
-            store.setSelectedCategories();
-
-            expect(store.selected()).toEqual(store.confirmedCategories());
-        });
     });
 
-    describe('withComputed', () => {
-        it('should show item after load the values', () => {
-            const expectedSelectedValues = SELECTED_LIST_MOCK;
+    describe('Dialog', () => {
+        beforeEach(() => {
             store.load({ field: CATEGORY_FIELD_MOCK, contentlet: CATEGORY_FIELD_CONTENTLET_MOCK });
-            expect(store.confirmedCategoriesValues().sort()).toEqual(expectedSelectedValues.sort());
+            store.openDialog();
+        });
 
-            expect(store.categoryList()).toEqual(EMPTY_ARRAY);
+        describe('openDialog', () => {
+            it('should set the dialog state to open and copy selected items', () => {
+                expect(store.dialog.state()).toBe('open');
+                expect(store.dialog.selected()).toEqual(MOCK_SELECTED_CATEGORIES);
+            });
+        });
+
+        describe('closeDialog', () => {
+            it('should set the dialog state to closed and clear selected items', () => {
+                store.closeDialog();
+                expect(store.dialog.state()).toBe('closed');
+                expect(store.dialog.selected()).toEqual(EMPTY_ARRAY);
+                expect(store.dialog.selected()).toEqual(EMPTY_ARRAY);
+            });
+        });
+
+        describe('updateSelected', () => {
+            it('should add a new item to the dialog selected items', () => {
+                expect(store.dialog.selected().length).toBe(MOCK_SELECTED_CATEGORIES.length);
+
+                const newItem: DotCategoryFieldKeyValueObj = {
+                    key: CATEGORY_LEVEL_2[0].key,
+                    value: CATEGORY_LEVEL_2[0].categoryName,
+                    inode: CATEGORY_LEVEL_2[0].inode,
+                    path: CATEGORY_LEVEL_2[0].categoryName
+                };
+                const selectedKeys = [
+                    ...MOCK_SELECTED_CATEGORIES.map((item) => item.key),
+                    newItem.key
+                ];
+                store.updateSelected(selectedKeys, newItem);
+
+                const expectedItems = [...MOCK_SELECTED_CATEGORIES, newItem];
+
+                expect(store.dialog.selected()).toEqual(expectedItems);
+                expect(store.dialog.selected().length).toBe(MOCK_SELECTED_CATEGORIES.length + 1);
+            });
+        });
+
+        describe('applyDialogSelection', () => {
+            it("should update the store's selected items with the dialog's selected items", () => {
+                const newItem: DotCategoryFieldKeyValueObj = {
+                    key: CATEGORY_LEVEL_2[0].key,
+                    value: CATEGORY_LEVEL_2[0].categoryName,
+                    inode: CATEGORY_LEVEL_2[0].inode,
+                    path: CATEGORY_LEVEL_2[0].categoryName
+                };
+
+                store.updateSelected(
+                    [...MOCK_SELECTED_CATEGORIES.map((item) => item.key), newItem.key],
+                    newItem
+                );
+                store.applyDialogSelection();
+
+                expect(store.selected()).toEqual([...MOCK_SELECTED_CATEGORIES, newItem]);
+            });
+        });
+
+        describe('removeSelected', () => {
+            it('should remove a single item by key from the dialog selected items', () => {
+                store.removeSelected(MOCK_SELECTED_CATEGORIES[0].key);
+
+                expect(store.dialog.selected().length).toBe(MOCK_SELECTED_CATEGORIES.length - 1);
+                expect(
+                    store.dialog
+                        .selected()
+                        .find((item) => item.key === MOCK_SELECTED_CATEGORIES[0].key)
+                ).toBeUndefined();
+            });
+
+            it('should remove multiple items by keys from the dialog selected items', () => {
+                store.removeSelected(MOCK_SELECTED_CATEGORIES.map((item) => item.key));
+
+                expect(store.dialog.selected()).toEqual(EMPTY_ARRAY);
+            });
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.spec.ts
@@ -16,27 +16,14 @@ import {
     CATEGORY_FIELD_MOCK,
     CATEGORY_HIERARCHY_MOCK,
     CATEGORY_LEVEL_1,
-    CATEGORY_LEVEL_2
+    CATEGORY_LEVEL_2,
+    MOCK_SELECTED_CATEGORIES_OBJECT
 } from '../mocks/category-field.mocks';
 import { DotCategoryFieldKeyValueObj } from '../models/dot-category-field.models';
 import { CategoriesService } from '../services/categories.service';
 import { transformCategories } from '../utils/category-field.utils';
 
 const EMPTY_ARRAY = [];
-const MOCK_SELECTED_CATEGORIES: DotCategoryFieldKeyValueObj[] = [
-    {
-        key: '1f208488057007cedda0e0b5d52ee3b3',
-        value: 'Cleaning Supplies',
-        inode: '111111',
-        path: 'Cleaning Supplies'
-    },
-    {
-        key: 'cb83dc32c0a198fd0ca427b3b587f4ce',
-        value: 'Doors & Windows',
-        inode: '22222',
-        path: 'Cleaning Supplies'
-    }
-];
 
 describe('CategoryFieldStore', () => {
     let spectator: SpectatorService<InstanceType<typeof CategoryFieldStore>>;
@@ -73,11 +60,11 @@ describe('CategoryFieldStore', () => {
     describe('withMethods', () => {
         it('should set the correct rootCategoryInode and categoriesValue', () => {
             const expectedCategoryValues: DotCategoryFieldKeyValueObj[] = [
-                ...MOCK_SELECTED_CATEGORIES
+                ...MOCK_SELECTED_CATEGORIES_OBJECT
             ];
 
             store.load({ field: CATEGORY_FIELD_MOCK, contentlet: CATEGORY_FIELD_CONTENTLET_MOCK });
-
+            console.log(store.selected());
             expect(store.selected()).toEqual(expectedCategoryValues);
             expect(store.rootCategoryInode()).toEqual(CATEGORY_FIELD_MOCK.values);
         });
@@ -138,7 +125,7 @@ describe('CategoryFieldStore', () => {
         describe('openDialog', () => {
             it('should set the dialog state to open and copy selected items', () => {
                 expect(store.dialog.state()).toBe('open');
-                expect(store.dialog.selected()).toEqual(MOCK_SELECTED_CATEGORIES);
+                expect(store.dialog.selected()).toEqual(MOCK_SELECTED_CATEGORIES_OBJECT);
             });
         });
 
@@ -153,7 +140,7 @@ describe('CategoryFieldStore', () => {
 
         describe('updateSelected', () => {
             it('should add a new item to the dialog selected items', () => {
-                expect(store.dialog.selected().length).toBe(MOCK_SELECTED_CATEGORIES.length);
+                expect(store.dialog.selected().length).toBe(MOCK_SELECTED_CATEGORIES_OBJECT.length);
 
                 const newItem: DotCategoryFieldKeyValueObj = {
                     key: CATEGORY_LEVEL_2[0].key,
@@ -162,15 +149,17 @@ describe('CategoryFieldStore', () => {
                     path: CATEGORY_LEVEL_2[0].categoryName
                 };
                 const selectedKeys = [
-                    ...MOCK_SELECTED_CATEGORIES.map((item) => item.key),
+                    ...MOCK_SELECTED_CATEGORIES_OBJECT.map((item) => item.key),
                     newItem.key
                 ];
                 store.updateSelected(selectedKeys, newItem);
 
-                const expectedItems = [...MOCK_SELECTED_CATEGORIES, newItem];
+                const expectedItems = [...MOCK_SELECTED_CATEGORIES_OBJECT, newItem];
 
                 expect(store.dialog.selected()).toEqual(expectedItems);
-                expect(store.dialog.selected().length).toBe(MOCK_SELECTED_CATEGORIES.length + 1);
+                expect(store.dialog.selected().length).toBe(
+                    MOCK_SELECTED_CATEGORIES_OBJECT.length + 1
+                );
             });
         });
 
@@ -184,29 +173,31 @@ describe('CategoryFieldStore', () => {
                 };
 
                 store.updateSelected(
-                    [...MOCK_SELECTED_CATEGORIES.map((item) => item.key), newItem.key],
+                    [...MOCK_SELECTED_CATEGORIES_OBJECT.map((item) => item.key), newItem.key],
                     newItem
                 );
                 store.applyDialogSelection();
 
-                expect(store.selected()).toEqual([...MOCK_SELECTED_CATEGORIES, newItem]);
+                expect(store.selected()).toEqual([...MOCK_SELECTED_CATEGORIES_OBJECT, newItem]);
             });
         });
 
         describe('removeSelected', () => {
             it('should remove a single item by key from the dialog selected items', () => {
-                store.removeSelected(MOCK_SELECTED_CATEGORIES[0].key);
+                store.removeSelected(MOCK_SELECTED_CATEGORIES_OBJECT[0].key);
 
-                expect(store.dialog.selected().length).toBe(MOCK_SELECTED_CATEGORIES.length - 1);
+                expect(store.dialog.selected().length).toBe(
+                    MOCK_SELECTED_CATEGORIES_OBJECT.length - 1
+                );
                 expect(
                     store.dialog
                         .selected()
-                        .find((item) => item.key === MOCK_SELECTED_CATEGORIES[0].key)
+                        .find((item) => item.key === MOCK_SELECTED_CATEGORIES_OBJECT[0].key)
                 ).toBeUndefined();
             });
 
             it('should remove multiple items by keys from the dialog selected items', () => {
-                store.removeSelected(MOCK_SELECTED_CATEGORIES.map((item) => item.key));
+                store.removeSelected(MOCK_SELECTED_CATEGORIES_OBJECT.map((item) => item.key));
 
                 expect(store.dialog.selected()).toEqual(EMPTY_ARRAY);
             });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.ts
@@ -1,17 +1,10 @@
 import { tapResponse } from '@ngrx/component-store';
-import {
-    getState,
-    patchState,
-    signalStore,
-    withComputed,
-    withMethods,
-    withState
-} from '@ngrx/signals';
+import { patchState, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { pipe } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { computed, effect, inject } from '@angular/core';
+import { computed, inject } from '@angular/core';
 
 import { filter, switchMap, tap } from 'rxjs/operators';
 
@@ -148,8 +141,17 @@ export const CategoryFieldStore = signalStore(
         }),
 
         // Dialog
+        /**
+         * Computed property that checks if a dialog is open.
+         */
         isDialogOpen: computed(() => store.dialog.state() === 'open'),
 
+        /**
+         * A computed property that retrieves the keys of selected dialog items.
+         * This function accesses the store's dialog and maps each selected item's key.
+         *
+         * @returns {Array} An array of keys of selected dialog items.
+         */
         dialogSelectedKeys: computed(() => store.dialog.selected().map((item) => item.key))
     })),
     withMethods(
@@ -210,6 +212,9 @@ export const CategoryFieldStore = signalStore(
                 });
             },
 
+            /**
+             * Opens the dialog with the current selected items and sets the state to 'open'.
+             */
             openDialog(): void {
                 patchState(store, {
                     dialog: {
@@ -219,6 +224,9 @@ export const CategoryFieldStore = signalStore(
                 });
             },
 
+            /**
+             * Closes the dialog and resets the selected items.
+             */
             closeDialog(): void {
                 patchState(store, {
                     dialog: {
@@ -263,6 +271,9 @@ export const CategoryFieldStore = signalStore(
                 });
             },
 
+            /**
+             * Applies the selected items from the dialog to the store.
+             */
             applyDialogSelection(): void {
                 const { selected } = store.dialog();
                 patchState(store, {
@@ -280,12 +291,12 @@ export const CategoryFieldStore = signalStore(
                 const selected = removeItemByKey(store.dialog.selected(), key);
 
                 patchState(store, {
-                    dialog: { state: store.dialog.state(), selected }
+                    dialog: { ...store.dialog(), selected }
                 });
             },
 
             /**
-             * Clears all categories from the store, effectively resetting state related to categories and their parent paths.
+             * Resets the store to its initial state.
              */
             clean() {
                 patchState(store, {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.ts
@@ -282,7 +282,7 @@ export const CategoryFieldStore = signalStore(
             },
 
             /**
-             * Removes the selected items with the given key(s).
+             * Removes the selected at the dialog items with the given key(s).
              *
              * @param {string | string[]} key - The key(s) of the item(s) to be removed.
              * @return {void}
@@ -293,6 +293,18 @@ export const CategoryFieldStore = signalStore(
                 patchState(store, {
                     dialog: { ...store.dialog(), selected }
                 });
+            },
+
+            /**
+             * Removes the selected items with the given key(s).
+             *
+             * @param {string | string[]} key - The key(s) of the item(s) to be removed.
+             * @return {void}
+             */
+            removeRootSelected(key: string | string[]): void {
+                const selected = removeItemByKey(store.selected(), key);
+
+                patchState(store, { selected });
             },
 
             /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.spec.ts
@@ -21,6 +21,10 @@ import {
 } from '../mocks/category-field.mocks';
 import { DotCategoryFieldKeyValueObj } from '../models/dot-category-field.models';
 
+const MOCK_SELECTED_OBJECT: DotCategoryFieldKeyValueObj[] = [
+    { key: '1f208488057007cedda0e0b5d52ee3b3', value: 'Cleaning Supplies' },
+    { key: 'cb83dc32c0a198fd0ca427b3b587f4ce', value: 'Doors & Windows' }
+];
 describe('CategoryFieldUtils', () => {
     describe('getSelectedCategories', () => {
         it('should return an empty array if contentlet is null', () => {
@@ -29,10 +33,7 @@ describe('CategoryFieldUtils', () => {
         });
 
         it('should return parsed the values', () => {
-            const expected: DotCategoryFieldKeyValueObj[] = [
-                { key: '1f208488057007cedda0e0b5d52ee3b3', value: 'Cleaning Supplies' },
-                { key: 'cb83dc32c0a198fd0ca427b3b587f4ce', value: 'Doors & Windows' }
-            ];
+            const expected: DotCategoryFieldKeyValueObj[] = MOCK_SELECTED_OBJECT;
             const result = getSelectedFromContentlet(
                 CATEGORY_FIELD_MOCK,
                 CATEGORY_FIELD_CONTENTLET_MOCK
@@ -605,10 +606,7 @@ describe('CategoryFieldUtils', () => {
                 CATEGORY_FIELD_MOCK,
                 CATEGORY_FIELD_CONTENTLET_MOCK
             );
-            expect(result).toEqual([
-                { key: '1f208488057007cedda0e0b5d52ee3b3', value: 'Cleaning Supplies' },
-                { key: 'cb83dc32c0a198fd0ca427b3b587f4ce', value: 'Doors & Windows' }
-            ]);
+            expect(result).toEqual(MOCK_SELECTED_OBJECT);
         });
 
         it('should handle empty selected categories in contentlet', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.spec.ts
@@ -30,7 +30,7 @@ describe('CategoryFieldUtils', () => {
 
         it('should return parsed the values', () => {
             const expected: DotCategoryFieldKeyValueObj[] = [
-                { key: '1f208488057007cedda0e0b5d52ee3b3', value: 'Electrical' },
+                { key: '1f208488057007cedda0e0b5d52ee3b3', value: 'Cleaning Supplies' },
                 { key: 'cb83dc32c0a198fd0ca427b3b587f4ce', value: 'Doors & Windows' }
             ];
             const result = getSelectedFromContentlet(
@@ -606,7 +606,7 @@ describe('CategoryFieldUtils', () => {
                 CATEGORY_FIELD_CONTENTLET_MOCK
             );
             expect(result).toEqual([
-                { key: '1f208488057007cedda0e0b5d52ee3b3', value: 'Electrical' },
+                { key: '1f208488057007cedda0e0b5d52ee3b3', value: 'Cleaning Supplies' },
                 { key: 'cb83dc32c0a198fd0ca427b3b587f4ce', value: 'Doors & Windows' }
             ]);
         });


### PR DESCRIPTION
### Proposed Changes
* Fix clear all button in Category Field Dialog


### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
No visual changes

This PR fixes: #30008