### PR TITLE
ci(api): Add logging of Github API limits before and after  (#30055)

### DIFF
--- a/.github/actions/core-cicd/api-limits-check/Readme.md
+++ b/.github/actions/core-cicd/api-limits-check/Readme.md
@@ -1,0 +1,32 @@
+# Check GitHub API Rate Limit Action
+
+This GitHub Action allows you to check the current API rate limits for your GitHub account by querying the `/rate_limit` endpoint of the GitHub API. The action outputs the full JSON response, including rate limits for core, search, GraphQL, and other GitHub API resources.
+
+## Inputs
+
+| Input  | Description | Required | Default |
+|--------|-------------|----------|---------|
+| `token` | The GitHub token to authenticate the API request. | true | `${{ github.token }}` |
+
+## Outputs
+
+The action outputs the full JSON response from the `/rate_limit` endpoint directly to the workflow log.
+
+## Usage
+
+Here’s an example of how to use this action in a GitHub workflow:
+
+```yaml
+name: Check GitHub API Rate Limits
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check-rate-limits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check API Rate Limit
+        uses: your-repo/check-rate-limit-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/actions/core-cicd/api-limits-check/action.yml
+++ b/.github/actions/core-cicd/api-limits-check/action.yml
@@ -1,0 +1,15 @@
+name: 'Check GitHub API Rate Limit'
+description: 'Outputs information on GitHub API /rate_limit endpoint'
+
+inputs:
+  token:
+    description: 'GitHub token to authenticate the API request'
+    required: true
+    default: ${{ github.token }}
+
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        curl -s -H "Authorization: token ${{ inputs.token }}" https://api.github.com/rate_limit
+      shell: bash

--- a/.github/workflows/cicd_comp_finalize-phase.yml
+++ b/.github/workflows/cicd_comp_finalize-phase.yml
@@ -184,3 +184,11 @@ jobs:
             echo "One or more jobs failed or cancelled!"
             exit 1
           fi
+
+      # Check can be removed if we have resolved root cause
+      # We cannot use a local github action for this as it is run before we checkout the repo
+      # secrets.GITHUB_TOKEN is not available in composite workflows so it needs to be passed in.
+      - name: Check API Rate Limit
+        shell: bash
+        run: |
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN}}" https://api.github.com/rate_limit || true

--- a/.github/workflows/cicd_comp_initialize-phase.yml
+++ b/.github/workflows/cicd_comp_initialize-phase.yml
@@ -64,6 +64,13 @@ jobs:
         shell: bash
         run: |
           echo "Initializing..."
+        # Check can be removed if we have resolved root cause
+        # We cannot use a local github action for this as it is run before we checkout the repo
+        # secrets.GITHUB_TOKEN is not available in composite workflows so it needs to be passed in.
+      - name: Check API Rate Limit
+        shell: bash
+        run: |
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit || true
 
   # This job checks for artifacts from previous builds and determines if they can be reused
   check-previous-build:

--- a/.github/workflows/cicd_comp_pr-notifier.yml
+++ b/.github/workflows/cicd_comp_pr-notifier.yml
@@ -89,3 +89,10 @@ jobs:
             -d "{ \"channel\":\"${channel}\",\"text\":\"${message}\"}" \
             -s \
             https://slack.com/api/chat.postMessage
+      # Check can be removed if we have resolved root cause
+      # We cannot use a local github action for this as it is run before we checkout the repo
+      # secrets.GITHUB_TOKEN is not available in composite workflows so it needs to be passed in.
+      - name: Check API Rate Limit
+        shell: bash
+        run: |
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit || true

--- a/.github/workflows/cicd_post-workflow-reporting.yml
+++ b/.github/workflows/cicd_post-workflow-reporting.yml
@@ -271,4 +271,11 @@ jobs:
           channel-id: ${{ vars.SLACK_REPORT_CHANNEL }}
           payload: ${{ steps.prepare-slack-message.outputs.payload }}
           json: true
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }} 
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+        # Check can be removed if we have resolved root cause
+        # We cannot use a local github action for this as it is run before we checkout the repo
+        # secrets.GITHUB_TOKEN is not available in composite workflows so it needs to be passed in.
+      - name: Check API Rate Limit
+        shell: bash
+        run: |
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit || true


### PR DESCRIPTION
Adding rate limit logging before and after workflows to identify root cause of Github API limits

This PR resolves #30055 (Add logging of Github API limits before and after ).

This PR fixes: #30055