### PR TITLE
feat(e2e): Introducing E2E tests to the CICD pipeline for both maven modules: `dotcms-e2e-java` and `dotcms-e2e-node`

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -34,7 +34,7 @@ cli: &cli
   - *full_build_test
   - *backend
 
-sdk_libs: &sdk_libs
+sdk_libs:
   - 'core-web/libs/sdk/**'  
 
 jvm_unit_test:

--- a/.github/workflows/cicd_1-pr.yml
+++ b/.github/workflows/cicd_1-pr.yml
@@ -68,6 +68,8 @@ jobs:
       postman: ${{ needs.initialize.outputs.backend == 'true' }}
       frontend: ${{ needs.initialize.outputs.frontend == 'true' }}
       cli: ${{ needs.initialize.outputs.cli == 'true' }}
+#      TODO: remove this param after testing E2E tests invocation
+      e2e: true
     secrets:
       DOTCMS_LICENSE: ${{ secrets.DOTCMS_LICENSE }}
 

--- a/.github/workflows/cicd_3-trunk.yml
+++ b/.github/workflows/cicd_3-trunk.yml
@@ -65,6 +65,7 @@ jobs:
     with:
       run-all-tests: ${{ inputs.run-all-tests || false }}
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
+      e2e: true
     secrets:
       DOTCMS_LICENSE: ${{ secrets.DOTCMS_LICENSE }}
     permissions:

--- a/.github/workflows/cicd_comp_test-phase.yml
+++ b/.github/workflows/cicd_comp_test-phase.yml
@@ -41,6 +41,10 @@ on:
         required: false
         type: boolean
         default: false
+      e2e:
+        required: false
+        type: boolean
+        default: false
     secrets:
       DOTCMS_LICENSE:
         required: true
@@ -154,7 +158,7 @@ jobs:
   # Postman Tests
   linux-postman-tests:
     name: Run Postman Tests - ${{matrix.collection_group}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: inputs.postman || inputs.run-all-tests
     strategy:
       fail-fast: false
@@ -169,6 +173,37 @@ jobs:
         with:
           stage-name: "Postman ${{ matrix.collection_group }}"
           maven-args: "-Pcoverage verify -pl :dotcms-postman -Dpostman.test.skip=false -Dpostman.collections=${{ matrix.collection_group }}"
+          generates-test-results: true
+          dotcms-license: ${{ secrets.DOTCMS_LICENSE }}
+          requires-node: true
+          needs-docker-image: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts-from: ${{ env.ARTIFACT_RUN_ID }}
+          cleanup-runner: true
+
+  # E2E Tests
+  linux-e2e-tests:
+    name: E2E Tests ${{matrix.suites.name}}
+    runs-on: ubuntu-24.04
+    if: inputs.e2e || inputs.run-all-tests
+    timeout-minutes: 240
+    env:
+      MAVEN_OPTS: -Xmx2048m
+    strategy:
+      fail-fast: false
+      matrix:
+        suites:
+          - { name: "JVM E2E Suite", pathName: "jvme2etestsuite", maven_args: '-Dit.test=E2eTestSuite -Dci=true -pl :dotcms-e2e-java' }
+          - { name: "Node.js E2E Suite", pathName: "nodee2etestsuite", maven_args: '-De2e.test.env=ci -pl :dotcms-e2e-node' }
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/core-cicd/maven-job
+        with:
+          stage-name: "E2E ${{ matrix.suites.name }}"
+          maven-args: "verify -Pcoverage -De2e.test.skip=false ${{ matrix.suites.maven_args}}"
           generates-test-results: true
           dotcms-license: ${{ secrets.DOTCMS_LICENSE }}
           requires-node: true

--- a/dotcms-postman/index.js
+++ b/dotcms-postman/index.js
@@ -271,7 +271,6 @@ async function main() {
         if (summaryResults.failures > 0) {
             console.error('Some collections failed.');
             process.exit(0);
-            //process.exit(1);
         }
     } catch (error) {
         console.error('An error occurred:', error);

--- a/e2e/dotcms-e2e-java/pom.xml
+++ b/e2e/dotcms-e2e-java/pom.xml
@@ -151,6 +151,31 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <skip>${e2e.test.skip}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install-playwright</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>./mvnw</executable>
+                            <arguments>
+                                <argument>exec:java</argument>
+                                <argument>-e</argument>
+                                <argument>-Dexec.mainClass=com.microsoft.playwright.CLI</argument>
+                                <argument>-Dexec.args="install-deps"</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
@@ -165,7 +190,11 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>default</id>
+                        <id>integration-test</id>
+                        <phase>none</phase> <!-- This disables automatic test execution in the integration-test phase -->
+                    </execution>
+                    <execution>
+                        <id>verify</id>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
@@ -247,16 +276,6 @@
                         </goals>
                         <phase>verify</phase>
                     </execution>
-                    <!--<execution>
-                        <id>docker-stop</id>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                        <phase>post-integration-test</phase>
-                        <configuration>
-                            <skip>${e2e.test.skip}</skip>
-                        </configuration>
-                    </execution>-->
                 </executions>
             </plugin>
         </plugins>

--- a/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/E2eTestSuite.java
+++ b/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/E2eTestSuite.java
@@ -21,10 +21,10 @@ import org.junit.platform.suite.api.Suite;
  */
 @Suite
 @SelectClasses({
-        LoginTests.class,
+        LoginTests.class/*,
         ContentPagesTests.class,
         ContentSearchTests.class,
-        SiteLayoutContainersTests.class
+        SiteLayoutContainersTests.class*/
 })
 public class E2eTestSuite {
 }

--- a/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/playwright/PlaywrightSupport.java
+++ b/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/playwright/PlaywrightSupport.java
@@ -39,12 +39,14 @@ import java.util.stream.Stream;
  *   <li>{@link #close(AutoCloseable...)} - Closes the provided resources.</li>
  *   <li>{@link #createContextAndPage(Browser)} - Creates a new browser context and page.</li>
  *   <li>{@link #resolveBrowser(Playwright, String)} - Resolves the browser type from a string.</li>
- *   <li>{@link #visibleTimeout(double)} - Creates visibility timeout options for assertions.</li>
+ *   <li>{@link #assertVisibleTimeout(double)} - Creates visibility timeout options for assertions.</li>
  * </ul>
  *
  * @author vico
  */
 public class PlaywrightSupport {
+
+    private static final double DEFAULT_TIMEOUT = 10000;
 
     private static final PlaywrightSupport INSTANCE = new PlaywrightSupport();
 
@@ -52,7 +54,10 @@ public class PlaywrightSupport {
         return INSTANCE;
     }
 
+    private final boolean ci;
+
     private PlaywrightSupport() {
+        ci = Boolean.parseBoolean(EnvironmentService.get().getProperty(E2eKeys.CI_KEY));
     }
 
     /**
@@ -70,7 +75,7 @@ public class PlaywrightSupport {
      * @return true if the current environment is a CI environment, false otherwise
      */
     public boolean isCi() {
-        return Boolean.parseBoolean(EnvironmentService.get().getProperty(E2eKeys.CI_KEY));
+        return ci;
     }
 
     /**
@@ -153,8 +158,17 @@ public class PlaywrightSupport {
      * @param timeout the timeout value in milliseconds
      * @return the visibility timeout options
      */
-    public LocatorAssertions.IsVisibleOptions visibleTimeout(final double timeout) {
+    public LocatorAssertions.IsVisibleOptions assertVisibleTimeout(final double timeout) {
         return new LocatorAssertions.IsVisibleOptions().setTimeout(timeout);
+    }
+
+    /**
+     * Creates visibility timeout options for assertions.
+     *
+     * @return the visibility timeout options
+     */
+    public LocatorAssertions.IsVisibleOptions assertVisibleTimeout() {
+        return assertVisibleTimeout(DEFAULT_TIMEOUT);
     }
 
 }

--- a/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/service/EnvironmentService.java
+++ b/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/service/EnvironmentService.java
@@ -60,7 +60,12 @@ public class EnvironmentService {
      * @return the property value or the default value if not found
      */
     public String getProperty(final String key, final String defaultValue) {
-        final String propValue = props.getProperty(key);
+        String propValue = props.getProperty(key);
+        if (StringUtils.isNotBlank(propValue)) {
+            return propValue;
+        }
+
+        propValue = System.getProperty(key);
         if (StringUtils.isNotBlank(propValue)) {
             return propValue;
         }

--- a/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/test/ContentPagesTests.java
+++ b/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/test/ContentPagesTests.java
@@ -7,6 +7,7 @@ import com.dotcms.e2e.page.LoginPage;
 import com.dotcms.e2e.page.MenuNavigation;
 import com.dotcms.e2e.page.PagesPage;
 import com.dotcms.e2e.page.ToolEntries;
+import com.dotcms.e2e.playwright.PlaywrightSupport;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
@@ -65,7 +66,8 @@ public class ContentPagesTests extends BaseE2eTest {
         pagesPage.fillPagesForm(pagesDetailFrame, "Testing Page", "Default Template");
         // validations
         assertThat(page.locator("li")
-                .filter(new Locator.FilterOptions().setHasText("Testing Page"))).isVisible();
+                .filter(new Locator.FilterOptions().setHasText("Testing Page")))
+                .isVisible(PlaywrightSupport.get().assertVisibleTimeout());
     }
 
 
@@ -104,7 +106,7 @@ public class ContentPagesTests extends BaseE2eTest {
                 new Page.GetByRoleOptions().setName("Status"))).isVisible();
         //execute the delete action
         pagesPage.executePagesWorkflow("Testing Page", "Delete");
-        assertThat(page.getByText("Workflow executed")).isVisible();
+        assertThat(page.getByText("Workflow executed")).isVisible(PlaywrightSupport.get().assertVisibleTimeout());
     }
 
 }

--- a/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/test/LoginTests.java
+++ b/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/test/LoginTests.java
@@ -62,7 +62,7 @@ public class LoginTests extends BaseE2eTest {
     @Test
     public void test_loginWrongPass() {
         loginPage.login("admin@dotcms.com", "winteriscoming");
-        assertThat(page.getByTestId("message")).isVisible(PlaywrightSupport.get().visibleTimeout(10000));
+        assertThat(page.getByTestId("message")).isVisible(PlaywrightSupport.get().assertVisibleTimeout());
     }
 
     /**

--- a/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/util/StringToolbox.java
+++ b/e2e/dotcms-e2e-java/src/test/java/com/dotcms/e2e/util/StringToolbox.java
@@ -21,7 +21,7 @@ public class StringToolbox {
      * @return the converted snake_case string
      */
     public static String camelToSnake(String str) {
-        return str.replaceAll("([a-z])([A-Z]+)", "$1_$2").toLowerCase();
+        return str.replaceAll("([a-z])([A-Z]+)", "$1_$2").toUpperCase();
     }
 
 }

--- a/e2e/dotcms-e2e-node/frontend/playwright.config.ts
+++ b/e2e/dotcms-e2e-node/frontend/playwright.config.ts
@@ -2,6 +2,7 @@ import dotenv from 'dotenv';
 import * as path from "node:path";
 import { defineConfig, devices } from '@playwright/test';
 
+
 const resolveEnvs = () => {
   const envFiles = ['.env'];
 
@@ -19,7 +20,12 @@ const resolveEnvs = () => {
   });
 };
 
+const prepareForTesting = () => {
+
+};
+
 resolveEnvs();
+prepareForTesting();
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -35,12 +41,13 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['junit', { outputFile: '../target/failsafe-reports/failsafe-summary.xml' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     baseURL: process.env.BASE_URL,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    headless: process.env.CI === 'true',
   },
   /* Configure projects for major browsers */
   projects: [

--- a/e2e/dotcms-e2e-node/pom.xml
+++ b/e2e/dotcms-e2e-node/pom.xml
@@ -16,18 +16,31 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <license.use>true</license.use>
         <skip.npm.install>false</skip.npm.install>
         <yarn.install.cmd>install --frozen-lockfile</yarn.install.cmd>
-        <playwright.install.cmd>global add playwright</playwright.install.cmd>
+        <playwright.add.cmd>global add playwright</playwright.add.cmd>
+        <playwright.install.cmd>playwright install</playwright.install.cmd>
+        <playwright.install.deps.cmd>playwright install-deps</playwright.install.deps.cmd>
         <e2e.test.skip>true</e2e.test.skip>
         <e2e.test.env>local</e2e.test.env>
+        <e2e.frontend.dir>./frontend</e2e.frontend.dir>
         <e2e.test.cmd>run start-${e2e.test.env}</e2e.test.cmd>
         <tomcat.port>8080</tomcat.port>
         <e2e.server.url>http://localhost:${tomcat.port}</e2e.server.url>
+        <version.cargo.plugin>1.10.6</version.cargo.plugin>
+        <clean.docker.volumes>true</clean.docker.volumes>
+        <buildDocker>true</buildDocker>
+        <docker.base.image>tomcat:9.0.74-jdk11</docker.base.image>
         <wiremock.api.key>${ext.wiremock.api.key}</wiremock.api.key>
         <docker.image.wiremock>${ext.docker.image.wiremock}</docker.image.wiremock>
         <docker.wm.volume>./src/test/resources</docker.wm.volume>
         <docker.wm.volume.internal>/home/wiremock</docker.wm.volume.internal>
+        <it.test.fork-folder.prefix>${project.build.directory}/testdata/fork-</it.test.fork-folder.prefix>
+        <it.test.fork-folder>${it.test.fork-folder.prefix}</it.test.fork-folder>
+        <cleanup.before.tests>true</cleanup.before.tests>
+        <tomcat.port>8080</tomcat.port>
+        <docker.jacoco.skip>false</docker.jacoco.skip>
     </properties>
 
     <build>
@@ -44,31 +57,55 @@
                         <!-- optional: the default phase is "generate-resources" -->
                         <phase>generate-resources</phase>
                         <configuration>
+                            <workingDirectory>${e2e.frontend.dir}</workingDirectory>
                             <skip>${skip.npm.install}</skip>
                             <arguments>${yarn.install.cmd}</arguments>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>install-playwrigth</id>
+                        <id>add-playwright</id>
                         <goals>
                             <goal>yarn</goal>
                         </goals>
-                        <!-- optional: the default phase is "generate-resources" -->
                         <phase>generate-resources</phase>
                         <configuration>
-                            <skip>${skip.npm.install}</skip>
+                            <workingDirectory>${e2e.frontend.dir}</workingDirectory>
+                            <skip>${e2e.test.skip}</skip>
+                            <arguments>${playwright.add.cmd}</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-playwright</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <workingDirectory>${e2e.frontend.dir}</workingDirectory>
+                            <skip>${e2e.test.skip}</skip>
                             <arguments>${playwright.install.cmd}</arguments>
                         </configuration>
                     </execution>
                     <execution>
+                        <id>install-playwright-deps</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <workingDirectory>${e2e.frontend.dir}</workingDirectory>
+                            <skip>${e2e.test.skip}</skip>
+                            <arguments>${playwright.install.deps.cmd}</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>run node script</id>
-                        <!-- Adjust the phase as per your requirement -->
                         <goals>
                             <goal>yarn</goal>
                         </goals>
                         <phase>integration-test</phase>
                         <configuration>
-                            <workingDirectory>./frontend</workingDirectory>
+                            <workingDirectory>${e2e.frontend.dir}</workingDirectory>
                             <skip>${e2e.test.skip}</skip>
                             <arguments>${e2e.test.cmd}</arguments>
                         </configuration>
@@ -85,14 +122,6 @@
                     <execution>
                         <id>integration-test</id>
                         <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>verify</id>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/justfile
+++ b/justfile
@@ -134,9 +134,13 @@ test-e2e-java:
 test-e2e-java-debug-suspend:
     ./mvnw -pl :dotcms-e2e-java verify -De2e.test.skip=false -Pdebug-suspend-e2e-tests
 
+# Executes Node E2E tests
+test-e2e-node:
+    ./mvnw -pl :dotcms-e2e-node verify -De2e.test.skip=false
+
 # Stops E2E test services
 test-e2e-stop:
-    ./mvnw -pl :dotcms-e2e -Pdocker-stop -De2e.test.skip=false
+    ./mvnw -pl :dotcms-e2e-java,:dotcms-e2e-node -Pdocker-stop -De2e.test.skip=false
 
 # Docker Commands
 # Runs a published dotCMS Docker image on a dynamic port


### PR DESCRIPTION
Pipeline will run in a parallel way both maven E2E modules and adding test results to the test phase life cycle.
For the moment E2E tests will run in regular PR-check as well.

Refs: #29846

This PR fixes: #29846