### PR TITLE
fix(indexer): Fix concurrency issues in ReindexThread (#30083)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -340,8 +340,8 @@ public class ReindexThread {
                                             new ThreadPoolExecutor.DiscardOldestPolicy())
                                     .build()
                     );
-            submitter.submit(thread);
             getInstance().state(ThreadState.RUNNING);
+            submitter.submit(thread);
         }
 
     }

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -327,8 +327,6 @@ public class ReindexThread {
             OSGISystem.getInstance().initializeFramework();
             Logger.infoEvery(ReindexThread.class, "--- ReindexThread Running", 60000);
             cache.get().remove(REINDEX_THREAD_PAUSED);
-            final Thread thread = new Thread(getInstance().ReindexThreadRunnable,
-                    "ReindexThreadRunnable");
 
             final DotSubmitter submitter = DotConcurrentFactory.getInstance()
                     .getSubmitter("ReindexThreadSubmitter",
@@ -341,7 +339,7 @@ public class ReindexThread {
                                     .build()
                     );
             getInstance().state(ThreadState.RUNNING);
-            submitter.submit(thread);
+            submitter.submit(getInstance().ReindexThreadRunnable);
         }
 
     }


### PR DESCRIPTION
Fixes concurrency issues and prevents race conditions that cause the indexer from hanging or shutting down immediately after startup.

This PR resolves #30083 (Startup timeouts due to indexer concurrency issues).

This PR fixes: #30083