### PR TITLE
Change icon to use primeng icon #26327

### DIFF
--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/dot-layout-properties/dot-layout-properties.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/dot-layout-properties/dot-layout-properties.component.html
@@ -21,7 +21,7 @@
     class="p-button-text p-button-vertical"
     pButton
     type="button"
+    icon="pi pi-objects-column"
     label="{{ 'Layout' | dm }}"
     data-testId="btn-select-layout">
-    <span class="p-button-icon material-icons">view_quilt</span>
 </button>

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/dot-layout-properties/dot-layout-properties.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/dot-layout-properties/dot-layout-properties.component.html
@@ -23,5 +23,4 @@
     type="button"
     icon="pi pi-objects-column"
     label="{{ 'Layout' | dm }}"
-    data-testId="btn-select-layout">
-</button>
+    data-testId="btn-select-layout"></button>


### PR DESCRIPTION
### Proposed Changes
* Remove the Material Icon
* Use PrimeNG icon for the layout icon
* Align name and icon with the icon of Theme

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original  
<img width="487" alt="Screenshot 2024-09-20 at 11 10 33 AM" src="https://github.com/user-attachments/assets/061baf22-0c07-47e5-949a-6491a30ede0a">


Updated
<img width="222" alt="Screenshot 2024-09-20 at 11 10 43 AM" src="https://github.com/user-attachments/assets/effbe629-7d6b-4eae-9dff-aa1c584daf35">
