### PR TITLE
fix (experimetns): #30045 Aligment not correct in A/B testing - Edit traffic split 

### DIFF
--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.html
@@ -10,7 +10,7 @@
                 class="p-fluid"
                 data-testId="add-traffic-split-form"
                 novalidate>
-                <div class="field">
+                <div class="experiment-traffic-split__radio">
                     <label>
                         {{ 'experiments.configure.traffic.split.name' | dm }}
                     </label>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.scss
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-traffic-split-add/dot-experiments-configuration-traffic-split-add.component.scss
@@ -10,16 +10,13 @@
 
     label {
         font-weight: $font-weight-bold;
-        margin-bottom: $spacing-3;
         font-size: $font-size-lmd;
     }
 
-    p-radioButton {
-        display: block;
-    }
-
-    p-radioButton:first-of-type {
-        margin-bottom: $spacing-3;
+    .experiment-traffic-split__radio {
+        display: flex;
+        flex-direction: column;
+        gap: $spacing-3;
     }
 
     .experiment-traffic-split__variants {


### PR DESCRIPTION
### Proposed Changes
* aligment fixes. 


### Screenshots
Before: 

<img width="645" alt="image" src="https://github.com/user-attachments/assets/fcfd6841-6cd2-45bd-a062-e3d4e61d30a5">


After: 

<img width="627" alt="image" src="https://github.com/user-attachments/assets/4d0490b1-8d35-4fd1-809c-37165b13ef2d">

