### PR TITLE
feat(editor-content): use new angular syntax in content types and templates

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-list/dot-template-list.component.html
@@ -53,18 +53,18 @@
                 size="14px"></dot-state-icon>
         </td>
         <td [ngStyle]="{ 'text-align': tableColumns[2].textAlign }" data-testId="theme-cell">
-            <ng-container *ngIf="rowData.themeInfo?.inode === 'SYSTEM_THEME'; else linkTemplate">
+            @if (rowData.themeInfo?.inode === 'SYSTEM_THEME') {
                 {{ rowData.themeInfo?.title }}
-            </ng-container>
-            <ng-template #linkTemplate>
-                <a
-                    *ngIf="rowData.themeInfo"
-                    (click)="goToFolder($event, rowData.themeInfo?.path)"
-                    data-testId="theme-folder-link"
-                    target="_self">
-                    {{ rowData.themeInfo?.title }}
-                </a>
-            </ng-template>
+            } @else {
+                @if (rowData.themeInfo) {
+                    <a
+                        (click)="goToFolder($event, rowData.themeInfo?.path)"
+                        data-testId="theme-folder-link"
+                        target="_self">
+                        {{ rowData.themeInfo?.title }}
+                    </a>
+                }
+            }
         </td>
         <td [ngStyle]="{ 'text-align': tableColumns[3].textAlign }">
             {{ rowData.friendlyName }}
@@ -73,17 +73,19 @@
             {{ rowData.modDate | dotRelativeDate }}
         </td>
         <td style="width: 5%">
-            <dot-action-menu-button
-                *ngIf="!rowData.disableInteraction"
-                [attr.data-testid]="rowData.identifier"
-                [actions]="setTemplateActions(rowData)"
-                [item]="rowData"
-                class="listing-datatable__action-button"></dot-action-menu-button>
+            @if (!rowData.disableInteraction) {
+                <dot-action-menu-button
+                    [attr.data-testid]="rowData.identifier"
+                    [actions]="setTemplateActions(rowData)"
+                    [item]="rowData"
+                    class="listing-datatable__action-button"></dot-action-menu-button>
+            }
         </td>
     </ng-template>
 </dot-listing-data-table>
 
-<dot-add-to-bundle
-    *ngIf="addToBundleIdentifier"
-    (cancel)="addToBundleIdentifier = null"
-    [assetIdentifier]="addToBundleIdentifier"></dot-add-to-bundle>
+@if (addToBundleIdentifier) {
+    <dot-add-to-bundle
+        (cancel)="addToBundleIdentifier = null"
+        [assetIdentifier]="addToBundleIdentifier"></dot-add-to-bundle>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-listing/dot-content-types.component.html
@@ -1,29 +1,32 @@
 <dot-portlet-base>
-    <dot-listing-data-table
-        *ngIf="showTable"
-        (rowWasClicked)="editContentType($event)"
-        [actionHeaderOptions]="actionHeaderOptions"
-        [actions]="rowActions"
-        [columns]="contentTypeColumns"
-        [paginatorExtraParams]="paginatorExtraParams"
-        #listing
-        sortField="modDate"
-        sortOrder="DESC"
-        url="v1/contenttype">
-        <dot-base-type-selector
-            *ngIf="!filterBy"
-            (selected)="changeBaseTypeSelector($event)"></dot-base-type-selector>
-    </dot-listing-data-table>
+    @if (showTable) {
+        <dot-listing-data-table
+            (rowWasClicked)="editContentType($event)"
+            [actionHeaderOptions]="actionHeaderOptions"
+            [actions]="rowActions"
+            [columns]="contentTypeColumns"
+            [paginatorExtraParams]="paginatorExtraParams"
+            #listing
+            sortField="modDate"
+            sortOrder="DESC"
+            url="v1/contenttype">
+            @if (!filterBy) {
+                <dot-base-type-selector (selected)="changeBaseTypeSelector($event)" />
+            }
+        </dot-listing-data-table>
+    }
 
-    <dot-add-to-bundle
-        *ngIf="addToBundleIdentifier"
-        (cancel)="addToBundleIdentifier = null"
-        [assetIdentifier]="addToBundleIdentifier"></dot-add-to-bundle>
+    @if (addToBundleIdentifier) {
+        <dot-add-to-bundle
+            (cancel)="addToBundleIdentifier = null"
+            [assetIdentifier]="addToBundleIdentifier" />
+    }
 
-    <dot-add-to-menu
-        *ngIf="addToMenuContentType"
-        (cancel)="addToMenuContentType = null"
-        [contentType]="addToMenuContentType"></dot-add-to-menu>
+    @if (addToMenuContentType) {
+        <dot-add-to-menu
+            (cancel)="addToMenuContentType = null"
+            [contentType]="addToMenuContentType" />
+    }
 
     <ng-template #dotDynamicDialog></ng-template>
 </dot-portlet-base>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/action-header/action-header.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/action-header/action-header.component.html
@@ -1,29 +1,30 @@
 <div [class.selected]="selectedItems.length" class="action-header">
-    <ng-container *ngIf="options && options.primary">
+    @if (options && options.primary) {
         <dot-action-button
             (press)="handlePrimaryAction()"
             [model]="options.primary.model"
             class="action-header__primary-button"></dot-action-button>
-    </ng-container>
+    }
     <div [style.overflow]="dynamicOverflow" class="action-header__container">
         <div class="action-header__global-search">
             <ng-content></ng-content>
         </div>
-        <div
-            *ngIf="(options && options.secondary) || selectedItems.length"
-            class="action-header__group-actions">
-            <span class="action-header__selected-items-counter">
-                {{ selectedItems.length }} {{ 'selected' | dm }}
-            </span>
-            <ng-container *ngIf="options && options.secondary">
-                <p-splitButton
-                    *ngFor="let action of options.secondary"
-                    [model]="action.model"
-                    class="action-header__secondary-button"
-                    secondary
-                    label="{{ action.label }}"
-                    class="inverted"></p-splitButton>
-            </ng-container>
-        </div>
+        @if ((options && options.secondary) || selectedItems.length) {
+            <div class="action-header__group-actions">
+                <span class="action-header__selected-items-counter">
+                    {{ selectedItems.length }} {{ 'selected' | dm }}
+                </span>
+                @if (options && options.secondary) {
+                    @for (action of options.secondary; track action) {
+                        <p-splitButton
+                            [model]="action.model"
+                            class="action-header__secondary-button"
+                            secondary
+                            label="{{ action.label }}"
+                            class="inverted" />
+                    }
+                }
+            </div>
+        }
     </div>
 </div>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
@@ -34,14 +34,18 @@
     #dataTable
     loadingIcon="pi pi-spin pi-spinner">
     <ng-template let-columns pTemplate="header">
-        <tr *ngIf="items?.length" data-testClass="testHeadTableRow">
-            <th *ngIf="checkbox" style="width: 5%">
-                <p-tableHeaderCheckbox></p-tableHeaderCheckbox>
-            </th>
-            <ng-container
-                [ngTemplateOutletContext]="{ columns: columns }"
-                [ngTemplateOutlet]="headerTemplate || defaultHeaderTemplate"></ng-container>
-        </tr>
+        @if (items?.length) {
+            <tr data-testClass="testHeadTableRow">
+                @if (checkbox) {
+                    <th style="width: 5%">
+                        <p-tableHeaderCheckbox />
+                    </th>
+                }
+                <ng-container
+                    [ngTemplateOutletContext]="{ columns: columns }"
+                    [ngTemplateOutlet]="headerTemplate || defaultHeaderTemplate"></ng-container>
+            </tr>
+        }
     </ng-template>
 
     <ng-template let-columns="columns" let-rowData pTemplate="body">
@@ -56,75 +60,88 @@
             [pSelectableRow]="rowData"
             [attr.data-testId]="rowData?.variable ? 'row-' + rowData.variable : null"
             data-testClass="testTableRow">
-            <td *ngIf="checkbox">
-                <p-tableCheckbox
-                    *ngIf="!rowData.disableInteraction"
-                    (click)="$event.stopPropagation()"
-                    [value]="rowData"
-                    [attr.test-id]="rowData.friendlyName"></p-tableCheckbox>
-            </td>
+            @if (checkbox) {
+                <td>
+                    @if (!rowData.disableInteraction) {
+                        <p-tableCheckbox
+                            (click)="$event.stopPropagation()"
+                            [value]="rowData"
+                            [attr.test-id]="rowData.friendlyName" />
+                    }
+                </td>
+            }
             <ng-container
                 [ngTemplateOutletContext]="{ rowData: rowData }"
                 [ngTemplateOutlet]="rowTemplate || defaultRowTemplate"></ng-container>
         </tr>
     </ng-template>
     <ng-template pTemplate="emptymessage">
-        <div
-            *ngIf="isContentFiltered; else emptyState"
-            class="listing-datatable__empty"
-            data-testId="listing-datatable__empty">
-            {{ 'No-Results-Found' | dm }}
-        </div>
-        <ng-template #emptyState>
+        @if (isContentFiltered) {
+            <div class="listing-datatable__empty" data-testId="listing-datatable__empty">
+                {{ 'No-Results-Found' | dm }}
+            </div>
+        } @else {
             <ng-content select="dot-empty-state"></ng-content>
-        </ng-template>
+        }
     </ng-template>
 </p-table>
 <p-contextMenu [model]="contextMenuItems" #cm appendTo="body"></p-contextMenu>
 <ng-template #defaultHeaderTemplate let-columns="columns" pTemplate="header">
-    <th
-        *ngFor="let col of columns"
-        [ngStyle]="{ width: col.width, 'text-align': getAlign(col) }"
-        [pSortableColumnDisabled]="!col.sortable"
-        [pSortableColumn]="col.fieldName">
-        {{ col.header }}
-        <p-sortIcon *ngIf="col.sortable" [field]="col.fieldName"></p-sortIcon>
-    </th>
+    @for (col of columns; track col) {
+        <th
+            [ngStyle]="{ width: col.width, 'text-align': getAlign(col) }"
+            [pSortableColumnDisabled]="!col.sortable"
+            [pSortableColumn]="col.fieldName">
+            {{ col.header }}
+            @if (col.sortable) {
+                <p-sortIcon [field]="col.fieldName" />
+            }
+        </th>
+    }
     <th style="width: 5%"></th>
 </ng-template>
 
 <ng-template #defaultRowTemplate let-rowData="rowData">
-    <td
-        *ngFor="let col of columns"
-        [ngStyle]="{ width: col.width, 'text-align': getAlign(col) }"
-        [attr.data-testId]="col.fieldName">
-        <div *ngIf="col.icon" class="listing-datatable__column-icon">
-            <dot-icon name="{{ col.icon(rowData) }}"></dot-icon>
-            <span>{{ col.textContent || rowData[col.fieldName] }}</span>
-        </div>
-        <span *ngIf="!col.icon && col.fieldName !== 'nEntries' && col.format !== 'date'">
-            {{ rowData[col.fieldName] }}
-        </span>
-        <span *ngIf="!col.icon && col.fieldName !== 'nEntries' && col.format === 'date'">
-            {{ rowData[col.fieldName] | dotRelativeDate }}
-        </span>
-        <a
-            *ngIf="col.fieldName === 'nEntries' && !rowData?.system"
-            (click)="$event.stopPropagation()"
-            [queryParams]="rowData.variable === 'Host' ? {} : { filter: rowData.variable }"
-            [routerLink]="rowData.variable === 'Host' ? '/c/sites' : '/c/content'">
-            {{
-                col.textContent
-                    ? (col.textContent | dotStringFormat: [rowData[col.fieldName]])
-                    : rowData[col.fieldName]
-            }}
-        </a>
-    </td>
+    @for (col of columns; track col) {
+        <td
+            [ngStyle]="{ width: col.width, 'text-align': getAlign(col) }"
+            [attr.data-testId]="col.fieldName">
+            @if (col.icon) {
+                <div class="listing-datatable__column-icon">
+                    <dot-icon name="{{ col.icon(rowData) }}" />
+                    <span>{{ col.textContent || rowData[col.fieldName] }}</span>
+                </div>
+            }
+            @if (!col.icon && col.fieldName !== 'nEntries' && col.format !== 'date') {
+                <span>
+                    {{ rowData[col.fieldName] }}
+                </span>
+            }
+            @if (!col.icon && col.fieldName !== 'nEntries' && col.format === 'date') {
+                <span>
+                    {{ rowData[col.fieldName] | dotRelativeDate }}
+                </span>
+            }
+            @if (col.fieldName === 'nEntries' && !rowData?.system) {
+                <a
+                    (click)="$event.stopPropagation()"
+                    [queryParams]="rowData.variable === 'Host' ? {} : { filter: rowData.variable }"
+                    [routerLink]="rowData.variable === 'Host' ? '/c/sites' : '/c/content'">
+                    {{
+                        col.textContent
+                            ? (col.textContent | dotStringFormat: [rowData[col.fieldName]])
+                            : rowData[col.fieldName]
+                    }}
+                </a>
+            }
+        </td>
+    }
     <td class="listing-datatable__action-column" style="width: 5%">
-        <dot-action-menu-button
-            *ngIf="actions"
-            [actions]="actions"
-            [item]="rowData"
-            class="listing-datatable__action-button"></dot-action-menu-button>
+        @if (actions) {
+            <dot-action-menu-button
+                [actions]="actions"
+                [item]="rowData"
+                class="listing-datatable__action-button" />
+        }
     </td>
 </ng-template>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-listing-data-table/dot-listing-data-table.component.html
@@ -37,7 +37,7 @@
         @if (items?.length) {
             <tr data-testClass="testHeadTableRow">
                 @if (checkbox) {
-                    <th style="width: 5%">
+                    <th scope="col" style="width: 5%">
                         <p-tableHeaderCheckbox />
                     </th>
                 }


### PR DESCRIPTION
### Parent Issue

#30085 

### Proposed Changes
* Use the new Angular syntax in `/content-types-angular` `/templates`
* Use the new Angular syntax in `dot-listing-data-table` component

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Videos

Manual tests in  `/templates`

https://github.com/user-attachments/assets/85fa0477-0218-4038-9687-0b11d7c73280

Manual tests in  `/content-types-angular`

https://github.com/user-attachments/assets/f88ac9ed-6d32-4cf5-a4f9-80dde63ee78f


This PR fixes: #30085