### PR TITLE
feat(block-editor): Avoid buttons to overlap at editor.

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.scss
@@ -98,7 +98,7 @@ dot-contentlet-thumbnail {
 }
 
 .preview-resource-links__actions {
-    position: absolute;
+    position: relative;
     top: 0;
     right: 0;
     display: flex;


### PR DESCRIPTION
Refs: #29966

This PR fixes: #29966