### PR TITLE
refactor(backend): Refactor of ReindexThread (#30109)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
@@ -141,10 +141,9 @@ public class BulkProcessorListener implements BulkProcessor.Listener {
         return totalResponses.get() == 0 || ((double) successCount.get() / totalResponses.get() < 0.5);
     }
 
-    private void addSuccessToQueue(ReindexEntry bulkItemResponse) {
+    private void addSuccessToQueue(ReindexEntry idx) {
         successCount.incrementAndGet();
-        workingRecords.remove(bulkItemResponse.getId());
-        queue.add(new ReindexResult(bulkItemResponse));
+        queue.add(new ReindexResult(idx));
     }
 
     private void addErrorToQueue(ReindexEntry idx, String errorMessage) {

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -2,7 +2,6 @@ package com.dotmarketing.common.reindex;
 
 import com.dotmarketing.common.reindex.BulkProcessorListener.ReindexResult;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import com.dotcms.api.system.event.Visibility;

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -101,10 +101,6 @@ public class ReindexThread {
     public static final int ELASTICSEARCH_BULK_ACTIONS =
             Config.getIntProperty("REINDEX_THREAD_ELASTICSEARCH_BULK_ACTIONS", 10);
 
-    // How often should the bulk request processor should flush its request - default 3 seconds
-    public static final int ELASTICSEARCH_BULK_FLUSH_INTERVAL =
-            Config.getIntProperty("REINDEX_THREAD_ELASTICSEARCH_BULK_FLUSH_INTERVAL_MS", 3000);
-
     // Setting this to number > 0 makes each bulk request asynchronous,
     // If set to 0 the bulk requests will be performed synchronously
     public static final int ELASTICSEARCH_CONCURRENT_REQUESTS =


### PR DESCRIPTION
This pull request includes significant updates to the `BulkProcessorListener` class in the `dotCMS` project to improve concurrency handling and error logging. The most important changes involve replacing existing data structures with thread-safe alternatives, adding new atomic counters, and refactoring methods for better readability and functionality.

### Improvements to concurrency handling:

* Replaced `HashMap` with `ConcurrentHashMap` for `workingRecords` to ensure thread-safe operations. (`dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java`)
* Introduced `AtomicInteger` counters for tracking total responses, success, and failure counts. (`dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java`)
* Added a `BlockingQueue<ReindexResult>` to manage reindexing results in a thread-safe manner. (`dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java`)

### Refactoring for readability and functionality:

* Extracted logic for obtaining IDs from `BulkItemResponse` into a new method `getIdFromResponse`. (`dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java`)
* Refactored error handling and success logging into separate methods `addErrorToQueue` and `addSuccessToQueue`. (`dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java`)
* Replaced `handleFailure` and `handleSuccess` methods with new logic to add results to the queue and increment counters. (`dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java`)

Follows on from basic change in https://github.com/dotCMS/core/pull/30084


This PR resolves #30109 (Refactor of ReindexThread).