### PR TITLE
fix(backend):  Unnecessary additional Host caching in resolveHostName causing null return (#30108)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
@@ -121,23 +121,16 @@ public class HostAPIImpl implements HostAPI, Flushable<Host> {
     @Override
     @CloseDBIfOpened
     public Host resolveHostName(String serverName, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
-        Host host = hostCache.getHostByAlias(serverName);
         User systemUser = APILocator.systemUser();
-
-        if(host == null){
-
-            try {
-                final Optional<Host> optional = resolveHostNameWithoutDefault(serverName, systemUser, respectFrontendRoles);
-                host = optional.isPresent() ? optional.get() : findDefaultHost(systemUser, respectFrontendRoles);
-            } catch (Exception e) {
-                host = findDefaultHost(systemUser, respectFrontendRoles);
-            }
-
-            if(host != null){
-                hostCache.addHostAlias(serverName, host);
-            }
+        Host host;
+        try {
+            final Optional<Host> optional =
+                    resolveHostNameWithoutDefault(serverName, systemUser, respectFrontendRoles);
+            host = optional.isPresent() ? optional.get() : findDefaultHost(systemUser, respectFrontendRoles);
+        } catch (Exception e) {
+            Logger.debug(this, "Exception resolving host using default", e);
+            host = findDefaultHost(systemUser, respectFrontendRoles);
         }
-
         checkSitePermission(user, respectFrontendRoles, host);
         return host;
     }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostAPIImpl.java
@@ -121,15 +121,11 @@ public class HostAPIImpl implements HostAPI, Flushable<Host> {
     @Override
     @CloseDBIfOpened
     public Host resolveHostName(String serverName, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException {
-        Host host;
-        final Host cachedHostByAlias = hostCache.getHostByAlias(serverName);
-        if (UtilMethods.isSet(() -> cachedHostByAlias.getIdentifier())) {
-            if (HostCache.CACHE_404_HOST.equals(cachedHostByAlias.getIdentifier())) {
-                return null;
-            }
-            host = cachedHostByAlias;
-        } else {
-            final User systemUser = APILocator.systemUser();
+        Host host = hostCache.getHostByAlias(serverName);
+        User systemUser = APILocator.systemUser();
+
+        if(host == null){
+
             try {
                 final Optional<Host> optional = resolveHostNameWithoutDefault(serverName, systemUser, respectFrontendRoles);
                 host = optional.isPresent() ? optional.get() : findDefaultHost(systemUser, respectFrontendRoles);
@@ -137,15 +133,12 @@ public class HostAPIImpl implements HostAPI, Flushable<Host> {
                 host = findDefaultHost(systemUser, respectFrontendRoles);
             }
 
-            if (host != null) {
+            if(host != null){
                 hostCache.addHostAlias(serverName, host);
-            } else {
-                hostCache.addHostAlias(serverName, HostCache.cache404Contentlet);
             }
         }
-        if (host != null) {
-            checkSitePermission(user, respectFrontendRoles, host);
-        }
+
+        checkSitePermission(user, respectFrontendRoles, host);
         return host;
     }
 

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/api/client/files/PushServiceIT.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/api/client/files/PushServiceIT.java
@@ -200,8 +200,7 @@ class PushServiceIT {
      *
      * @throws IOException if an I/O error occurs
      */
-    // Temporarily ignore this test until the root cause of the problem is found
-    //@Test
+    @Test
     void Test_Push_New_Site() throws IOException {
 
         // Create a temporal folder for the pull


### PR DESCRIPTION

There is confusion in the code whether we should be caching the mapping between requested host and the backend host, or whether the mapping should cache the default entry returned.

The issue is occuring as a request for "localhost" that does not appear in the db hosts used to be mapped to the default host in com.dotmarketing.portlets.contentlet.business.HostAPIImpl#resolveHostName so null was not returned from this method.

With the change to this method in the original PR when it calls 

com.dotmarketing.portlets.contentlet.business.HostAPIImpl#resolveHostNameWithoutDefault it ends up with a 404 entry in the host cache for localhost.   A short time later it should replace this at the end of the method by adding a mapping to the resolved default host,  subsequent calls to localhost should then end up using this cached entry to the specific default host that was cached.

There is a short window of time though where the 404 entry was added, but the cache has not been updated to the default host where the current logic on finding the 404 entry is to just return null.  
This null was causing the ThreadNameFilter to throw a null pointer exception as it is using the result without null checking.

Caching the resolved default host may also cause issues if the default host is changed as it may not take this change into account.

There should actually be no reason to handle the caching logic in resolveHostName and only have it within resolveHostNameWithoutDefault that it calls.  This way even if there is a 404 entry for an unknown like "localhost" it will always return the current default value (that should itself be cached)  and not a null.

We can therefore revert the original changes to just this one method but still make use of the caching logic provided when it calls resolveHostNameWithoutDefault ensuring null is not returned by resolveHostName method.


This PR resolves #30108 (Flakey CLI Test PushServiceIT.Test_Push_New_Site).

This PR fixes: #30108