### PR TITLE
fix(deployment): Runtime error in CICD PR Checks due to data type incompatibility (#30164)

### DIFF
--- a/.github/workflows/cicd_1-pr.yml
+++ b/.github/workflows/cicd_1-pr.yml
@@ -69,7 +69,7 @@ jobs:
       postman: ${{ needs.initialize.outputs.backend == 'true' }}
       frontend: ${{ needs.initialize.outputs.frontend == 'true' }}
       cli: ${{ needs.initialize.outputs.cli == 'true' }}
-      e2e: ${{ needs.initialize.outputs.build }}
+      e2e: ${{ needs.initialize.outputs.build == 'true' }}
     secrets:
       DOTCMS_LICENSE: ${{ secrets.DOTCMS_LICENSE }}
 


### PR DESCRIPTION
### Proposed Changes
* This PR fixes a runtime error in the CICD PR verification phase caused by an incorrect logical expression. The expression `${{ needs.initialize.outputs.build }}` has been updated to `${{ needs.initialize.outputs.build == 'true' }}` to ensure correct type handling. This change explicitly compares the value to 'true', resolving potential failures when dealing with boolean, empty, or null values.

### Additional Info
This PR resolves #30164 (Runtime error in CICD PR Checks due to incompatible data type).

This PR fixes: #30164