### PR TITLE
#30166 fixing cli build github runner references.

### DIFF
--- a/.github/workflows/cli-build-artifacts.yml
+++ b/.github/workflows/cli-build-artifacts.yml
@@ -38,9 +38,9 @@ jobs:
         id: set-os
         run: |
           if [[ "${{ inputs.buildNativeImage }}" == "true" ]]; then
-            RUNNERS='[{ "os": "ubuntu-latest", "label": "Linux" }, { "os": "macos-latest", "label": "macOS-Intel" }, { "os": "macos-13-xlarge", "label": "macOS-Silicon" }]'
+            RUNNERS='[{ "os": "ubuntu-22.04", "label": "Linux" }, { "os": "macos-13", "label": "macOS-Intel" }, { "os": "macos-14", "label": "macOS-Silicon" }]'
           else
-            RUNNERS='[{ "os": "ubuntu-latest", "label": "Linux" }]'
+            RUNNERS='[{ "os": "ubuntu-22.04", "label": "Linux" }]'
           fi
           echo "runners=$RUNNERS" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### Proposed Changes
* This PR resolves failures in the CLI native build for the Release LTS by replacing "latest" runner tags (`ubuntu-latest`, `macos-latest`, `macos-13-xlarge`) with specific nominal versions (`ubuntu-22.04`, `macos-13`, `macos-14`). This change ensures stable and repeatable builds by preventing disruptions from remote changes to runner environments.
### Additional Info
This PR resolves #30166 (Fix runner configuration in LTS Release Update CLI).