### PR TITLE
Fix iqa comments

### DIFF
--- a/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.html
+++ b/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.html
@@ -78,3 +78,4 @@
 }
 
 <p-toast></p-toast>
+<p-confirmDialog />

--- a/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.ts
+++ b/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.ts
@@ -14,6 +14,7 @@ import { ActivatedRoute, RouterLink } from '@angular/router';
 
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { MessagesModule } from 'primeng/messages';
 import { ToastModule } from 'primeng/toast';
 
@@ -47,7 +48,8 @@ import { DotEditContentService } from '../../services/dot-edit-content.service';
         RouterLink,
         DotEditContentFormComponent,
         DotEditContentAsideComponent,
-        DotEditContentToolbarComponent
+        DotEditContentToolbarComponent,
+        ConfirmDialogModule
     ],
     templateUrl: './edit-content.layout.component.html',
     styleUrls: ['./edit-content.layout.component.scss'],

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.html
@@ -21,5 +21,3 @@
             data-testId="language-selector" />
     }
 </div>
-
-<p-confirmDialog />

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.ts
@@ -184,7 +184,7 @@ export class DotEditContentWYSIWYGFieldComponent implements AfterViewInit {
         const currentDisplayedEditor = this.$displayedEditor();
         const content = this.$fieldContent();
 
-        if (content.length > 0) {
+        if (content.length > 0 && this.$displayedEditor() !== AvailableEditor.TinyMCE) {
             this.#confirmationService.confirm({
                 header: this.#dotMessageService.get(
                     'edit.content.wysiwyg.confirm.switch-editor.header'

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5797,4 +5797,4 @@ edit.content.category-field.search.empty.title=There are no categories yet
 edit.content.category-field.search.empty.legend=To create a new category, navigate to: Content model > Categories > Click the "+" Plus Button > Add.
 
 edit.content.wysiwyg.confirm.switch-editor.header=Confirm View Change
-edit.content.wysiwyg.confirm.switch-editor.message=Switching to the WYSIWYG view may change your HTML code and cause code loss.<br> Are you sure you want to continue?
+edit.content.wysiwyg.confirm.switch-editor.message=Switching to the WYSIWYG view may change your code and cause code loss.<br> Are you sure you want to continue?


### PR DESCRIPTION
### Proposed Changes
* When you have multiple Wysiwyg fields and switch between Wysiwyg and Code, the popup is displayed three times, one for each of the fields instead only for the field being modified ✅
* We should not show the popup when switching from Wysiwyg to Code but only from Code to Wysiwyg. ✅
* Remove the "HTML" word from the message in the popup ✅

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #28186