### PR TITLE
fix(deployment): Issue 30166 fix runner configuration in lts release

### DIFF
--- a/.github/workflows/cli-build-artifacts.yml
+++ b/.github/workflows/cli-build-artifacts.yml
@@ -30,7 +30,7 @@ defaults:
 jobs:
   os-runners:
     name: 'Get OS matrix'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       runners: ${{ steps.set-os.outputs.runners }}
     steps:
@@ -63,7 +63,7 @@ jobs:
           ref: ${{ env.BRANCH }}
 
       - name: 'Cleanup Ubuntu Runner'
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ contains(matrix.os, 'ubuntu-') }}
         uses: ./.github/actions/cleanup-runner
 
       - name: 'Cleanup MacOS Runner'
@@ -82,7 +82,7 @@ jobs:
       - name: 'Set up GRAALVM for ${{ matrix.label }}'
         if: ${{ inputs.buildNativeImage == true && matrix.os != 'windows-latest' }}
         run: |
-          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+          if [ "${{ matrix.os }}" == "ubuntu-22.04" ]; then
             echo "GRAALVM on Linux (AMD64)"
 
             ARCH=amd64
@@ -111,7 +111,7 @@ jobs:
           tar -xzf graalvm-ce-java11-${PLATFORM}-${ARCH}-${{ env.GRAALVM_VERSION }}.tar.gz
           sudo mv graalvm-ce-java11-${{ env.GRAALVM_VERSION }} $INSTALLATION_PATH
 
-          if [ "${{ matrix.os }}" != "ubuntu-latest" ]; then
+          if [ "${{ matrix.os }}" != "ubuntu-22.04" ]; then
             sudo xattr -r -d com.apple.quarantine /Library/Java/JavaVirtualMachines/graalvm-ce-java11-${{ env.GRAALVM_VERSION }}/Contents/Home
             GRAALVM_HOME="${INSTALLATION_PATH}/graalvm-ce-java11-${{ env.GRAALVM_VERSION }}/Contents/Home"
           else

--- a/.github/workflows/cli-build-artifacts.yml
+++ b/.github/workflows/cli-build-artifacts.yml
@@ -38,9 +38,9 @@ jobs:
         id: set-os
         run: |
           if [[ "${{ inputs.buildNativeImage }}" == "true" ]]; then
-            RUNNERS='[{ "os": "ubuntu-latest", "label": "Linux" }, { "os": "macos-latest", "label": "macOS-Intel" }, { "os": "macos-13-xlarge", "label": "macOS-Silicon" }]'
+            RUNNERS='[{ "os": "ubuntu-22.04", "label": "Linux" }, { "os": "macos-13", "label": "macOS-Intel" }, { "os": "macos-14", "label": "macOS-Silicon" }]'
           else
-            RUNNERS='[{ "os": "ubuntu-latest", "label": "Linux" }]'
+            RUNNERS='[{ "os": "ubuntu-22.04", "label": "Linux" }]'
           fi
           echo "runners=$RUNNERS" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### Proposed Changes
* This PR resolves failures in the CLI native build for the Release LTS by replacing "latest" runner tags (`ubuntu-latest`, `macos-latest`, `macos-13-xlarge`) with specific nominal versions (`ubuntu-22.04`, `macos-13`, `macos-14`). This change ensures stable and repeatable builds by preventing disruptions from remote changes to runner environments.

Some ubuntu reference had to be updated.

### Additional Info
This PR resolves #30166 (Fix runner configuration in LTS Release Update CLI).
