### PR TITLE
Fix missed references in host cache after importing content types and relationships

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/starter/ImportStarterUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/starter/ImportStarterUtil.java
@@ -16,6 +16,7 @@ import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.beans.MultiTree;
 import com.dotmarketing.beans.Tree;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.DuplicateUserException;
 import com.dotmarketing.business.FactoryLocator;
@@ -214,6 +215,12 @@ public class ImportStarterUtil {
                 }
 
                 doJSONFileImport(file, entity.type());
+
+                if (entity.fileName().startsWith(Contentlet.class.getCanonicalName())) {
+                    // content types and relationships are imported before sites
+                    // so we need to clear the host cache to avoid missed hosts references
+                    CacheLocator.getHostCache().clearCache();
+                }
 
                 if (Contentlet.class.getCanonicalName().equals(entity.fileName())){
                     updateContentletToNewDefaultLang();


### PR DESCRIPTION
Closes #30173

### Proposed Changes
* When importing a starter, content types and relationships are imported before sites. With this change, the host cache is cleared after importing contentlets, to avoid missed host references in the cache when importing other objects like rules.

This PR fixes: #30173