### PR TITLE
feat(lts): notification message when LTS is reaching or reached EOL. ref: #30156

### DIFF
--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -860,3 +860,6 @@ LOCALIZATION_ENHANCEMENTS_ENABLED=false
 
 STARTER_BUILD_VERSION=${starter.deploy.version}
 
+##LTS properties to show EOL message
+show.lts.eol.message=false
+date.lts.eol=12/31/2099

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5798,3 +5798,7 @@ edit.content.category-field.search.empty.legend=To create a new category, naviga
 
 edit.content.wysiwyg.confirm.switch-editor.header=Confirm View Change
 edit.content.wysiwyg.confirm.switch-editor.message=Switching to the WYSIWYG view may change your code and cause code loss.<br> Are you sure you want to continue?
+
+lts.expired.message = This version of dotCMS already reached EOL. Please contact your CSM to schedule an upgrade.
+lts.expires.soon.message = Your dotCMS version will reach EOL in {0} days. Please contact your CSM to schedule an upgrade.
+


### PR DESCRIPTION
We are pleased to announce the addition of a notification feature to inform users about the upcoming end-of-life (EOL) or the already reached EOL status of a LTS or a dotCMS.

Notifications for products approaching EOL will be displayed exclusively to Admin Users.
<img width="395" alt="Message_Upcoming_EOL" src="https://github.com/user-attachments/assets/60f75a02-2c9c-4f25-9447-9b280e59f2e8">


Notifications for products that have already reached EOL will be made available to all users.
<img width="382" alt="Message_Already_EOL" src="https://github.com/user-attachments/assets/6e06ef53-57c7-4c68-8407-bbd7df239bed">

This PR fixes: #30156