### PR TITLE
fix(UVE): make changes to layout you lose container editable areas

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -90,7 +90,8 @@ describe('EditEmaLayoutComponent', () => {
                 save: jest.fn(() => of(PAGE_RESPONSE))
             }),
             mockProvider(DotPageApiService, {
-                get: jest.fn(() => of(PAGE_RESPONSE))
+                get: jest.fn(() => of(PAGE_RESPONSE)),
+                getClientPage: jest.fn(() => of(PAGE_RESPONSE))
             }),
             MockProvider(DotExperimentsService, DotExperimentsServiceMock, 'useValue'),
             MockProvider(DotRouterService, new MockDotRouterJestService(jest), 'useValue'),
@@ -148,14 +149,14 @@ describe('EditEmaLayoutComponent', () => {
         });
 
         it('should trigger a save after 5 secs', fakeAsync(() => {
-            const updatePageResponseSpy = jest.spyOn(store, 'updatePageResponse');
             const setUveStatusSpy = jest.spyOn(store, 'setUveStatus');
+            const reloadSpy = jest.spyOn(store, 'reload');
 
             templateBuilder.templateChange.emit();
             tick(5000);
 
             expect(dotPageLayoutService.save).toHaveBeenCalled();
-            expect(updatePageResponseSpy).toHaveBeenCalledWith(PAGE_RESPONSE);
+            expect(reloadSpy).toHaveBeenCalled();
             expect(setUveStatusSpy).toHaveBeenCalledWith(UVE_STATUS.LOADING);
 
             expect(messageService.add).toHaveBeenNthCalledWith(1, {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
@@ -17,10 +17,9 @@ import {
 } from 'rxjs/operators';
 
 import { DotMessageService, DotPageLayoutService, DotRouterService } from '@dotcms/data-access';
-import { DotPageRender, DotTemplateDesigner } from '@dotcms/dotcms-models';
+import { DotTemplateDesigner } from '@dotcms/dotcms-models';
 import { TemplateBuilderModule } from '@dotcms/template-builder';
 
-import { DotPageApiResponse } from '../services/dot-page-api.service';
 import { UVE_STATUS } from '../shared/enums';
 import { UVEStore } from '../store/dot-uve.store';
 
@@ -90,7 +89,7 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
             .save(this.uveStore.$layoutProps().pageId, { ...template, title: null })
             .pipe(take(1))
             .subscribe(
-                (updatedPage: DotPageRender) => this.handleSuccessSaveTemplate(updatedPage),
+                () => this.handleSuccessSaveTemplate(),
                 (err: HttpErrorResponse) => this.handleErrorSaveTemplate(err),
                 () => this.dotRouterService.allowRouteDeactivation()
             );
@@ -133,7 +132,7 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
                 })
             )
             .subscribe(
-                (updatedPage: DotPageRender) => this.handleSuccessSaveTemplate(updatedPage),
+                () => this.handleSuccessSaveTemplate(),
                 (err: HttpErrorResponse) => this.handleErrorSaveTemplate(err)
             );
     }
@@ -143,16 +142,15 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
      *
      * @private
      * @template T
-     * @param {T=unkonwm} page // To avoid getting type error with DotPageRender and DotPageApiResponse
      * @memberof EditEmaLayoutComponent
      */
-    private handleSuccessSaveTemplate<T = unknown>(page: T): void {
+    private handleSuccessSaveTemplate(): void {
         this.messageService.add({
             severity: 'success',
             summary: 'Success',
             detail: this.dotMessageService.get('dot.common.message.saved')
         });
-        this.uveStore.updatePageResponse(page as DotPageApiResponse);
+        this.uveStore.reload();
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes
* Replaced `updatePageResponse` with the `reload` method in `EditEmaLayoutComponent` to trigger a page reload after saving.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
Issue #30116 was identified due to an issue with the response from the backend when making a POST request to `api/v1/page/{pageId}/layout`. The response contains the `page.rendered` object, which is used to patch the UVE page state. However, this `page.rendered` HTML comes in **preview mode**, causing empty layout containers to disappear, making it impossible to edit the page correctly.  

### Screenshots
https://github.com/user-attachments/assets/86e03108-308d-40c4-bea2-bafe8b787a15

This pr fixes #30116

This PR fixes: #30116