### PR TITLE
fix (ace editor): #29733 WYSIWYG code view styles messed up 

### DIFF
--- a/dotCMS/src/main/webapp/html/js/ace-builds-1.2.3/src-noconflict/ace.js
+++ b/dotCMS/src/main/webapp/html/js/ace-builds-1.2.3/src-noconflict/ace.js
@@ -14752,7 +14752,7 @@ var VScrollBar = require("./scrollbar").VScrollBar;
 var RenderLoop = require("./renderloop").RenderLoop;
 var FontMetrics = require("./layer/font_metrics").FontMetrics;
 var EventEmitter = require("./lib/event_emitter").EventEmitter;
-var editorCss = ".ace_editor {\
+var editorCss = ".ace_editor, .ace_editor * {\
 position: relative;\
 overflow: hidden;\
 font: 12px/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;\


### PR DESCRIPTION
### Proposed Changes
* Force the editor font size to be consistent at 12px to avoid cursor odd behavior. 

