### PR TITLE
feat(Content Analytics) fixes #30191 : Support multiple values for the `filters` attribute in our Content Analytics Query

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/analytics/content/ContentAnalyticsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/content/ContentAnalyticsAPIImpl.java
@@ -26,16 +26,15 @@ public class ContentAnalyticsAPIImpl implements ContentAnalyticsAPI {
 
     @Override
     public ReportResponse runReport(final AnalyticsQuery query, final User user) {
-
         Logger.debug(this, ()-> "Running the report for the query: " + query);
-        // note: should check any permissions for an user.
+        // TODO: We should check for specific user permissions
         return this.contentAnalyticsFactory.getReport(query, user);
     }
 
     @Override
-    public ReportResponse runRawReport(CubeJSQuery cubeJSQuery, User user) {
+    public ReportResponse runRawReport(final CubeJSQuery cubeJSQuery, final User user) {
         Logger.debug(this, ()-> "Running the report for the raw query: " + cubeJSQuery);
-        // note: should check any permissions for an user.
+        // TODO: We should check for specific user permissions
         return this.contentAnalyticsFactory.getRawReport(cubeJSQuery, user);
     }
 

--- a/dotCMS/src/main/java/com/dotcms/analytics/query/AnalyticsQueryParser.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/query/AnalyticsQueryParser.java
@@ -204,7 +204,6 @@ public class AnalyticsQueryParser {
      * @return The value or values of a token as an array of strings.
      */
     private String[] parseTokenValues(final String values) {
-        //final String[] valueArray = values.split("\\s*,\\s*");
         final String[] valueArray = values.split(",");
         return Arrays.stream(valueArray).map(
                 value -> value.trim().replaceAll(APOSTROPHE, BLANK))

--- a/dotCMS/src/main/java/com/dotcms/analytics/query/AnalyticsQueryParser.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/query/AnalyticsQueryParser.java
@@ -13,15 +13,23 @@ import io.vavr.Tuple2;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.liferay.util.StringPool.APOSTROPHE;
+import static com.liferay.util.StringPool.BLANK;
+
 /**
- * Parser for the analytics query, it can parse a json string to a {@link AnalyticsQuery} or a {@link CubeJSQuery}
+ * This class exposes a parser for the {@link AnalyticsQuery} class. It can parse a JSON string
+ * into a {@link AnalyticsQuery} object or a {@link CubeJSQuery} object. The Analytics Query
+ * exposes a more readable and simple syntax compared to the CubeJS query
+ *
  * @author jsanca
+ * @since Sep 19th, 2024
  */
 @ApplicationScoped
 public class AnalyticsQueryParser {
@@ -44,14 +52,14 @@ public class AnalyticsQueryParser {
     public AnalyticsQuery parseJsonToQuery(final String json) {
 
         if (Objects.isNull(json)) {
-            throw new IllegalArgumentException("Json can not be null");
+            throw new IllegalArgumentException("JSON cannot be null");
         }
         try {
 
-            Logger.debug(this, ()-> "Parsing json to query: " + json);
+            Logger.debug(this, ()-> "Parsing json query: " + json);
             return DotObjectMapperProvider.getInstance().getDefaultObjectMapper()
                     .readValue(json, AnalyticsQuery.class);
-        } catch (JsonProcessingException e) {
+        } catch (final JsonProcessingException e) {
             Logger.error(this, e.getMessage(), e);
             throw new DotRuntimeException(e);
         }
@@ -80,18 +88,20 @@ public class AnalyticsQueryParser {
     }
 
     /**
-     * Parse an {@link AnalyticsQuery} to a {@link CubeJSQuery}
-     * @param query
-     * @return CubeJSQuery
+     * Parses an {@link AnalyticsQuery} object into a {@link CubeJSQuery} object, which represents
+     * the official CubeJS query.
+     *
+     * @param query The {@link AnalyticsQuery} object to be parsed.
+     *
+     * @return The {@link CubeJSQuery} object.
      */
     public CubeJSQuery parseQueryToCubeQuery(final AnalyticsQuery query) {
-
         if (Objects.isNull(query)) {
-            throw new IllegalArgumentException("Query can not be null");
+            throw new IllegalArgumentException("Query cannot be null");
         }
 
         final CubeJSQuery.Builder builder = new CubeJSQuery.Builder();
-        Logger.debug(this, ()-> "Parsing query to cube query: " + query);
+        Logger.debug(this, ()-> "Parsing query: " + query);
 
         if (UtilMethods.isSet(query.getDimensions())) {
             builder.dimensions(query.getDimensions());
@@ -136,6 +146,15 @@ public class AnalyticsQueryParser {
                 ).collect(Collectors.toList());
     }
 
+    /**
+     * Parses the value of the {@code filters} attribute of the {@link AnalyticsQuery} object. This
+     * filter can have several logical operators, and be able to compare a variable against multiple
+     * values.
+     *
+     * @param filters the value of the {@code filters} attribute.
+     *
+     * @return A collection of {@link Filter} objects.
+     */
     private Collection<Filter> parseFilters(final String filters) {
         final  Tuple2<List<FilterParser.Token>,List<FilterParser.LogicalOperator>> result =
                 FilterParser.parseFilterExpression(filters);
@@ -144,14 +163,13 @@ public class AnalyticsQueryParser {
         final List<SimpleFilter> simpleFilters = new ArrayList<>();
 
         for (final FilterParser.Token token : result._1) {
-
             simpleFilters.add(
                     new SimpleFilter(token.member,
-                            parseOperator(token.operator),
-                            new Object[]{token.values}));
+                    parseOperator(token.operator),
+                    this.parseTokenValues(token.values)));
         }
 
-        // if has operators
+        // Are there any operators?
         if (UtilMethods.isSet(result._2())) {
 
             FilterParser.LogicalOperator logicalOperator = result._2().get(0); // first one
@@ -177,6 +195,21 @@ public class AnalyticsQueryParser {
         return filterList;
     }
 
+    /**
+     * Takes the value of a token and parses its contents into an array of strings. A token can have
+     * both single and multiple values.
+     *
+     * @param values The value of the token.
+     *
+     * @return The value or values of a token as an array of strings.
+     */
+    private String[] parseTokenValues(final String values) {
+        final String[] valueArray = values.split("\\s*,\\s*");
+        return Arrays.stream(valueArray).map(
+                value -> value.replaceAll(APOSTROPHE, BLANK))
+                .toArray(String[]::new);
+    }
+
     private SimpleFilter.Operator parseOperator(final String operator) {
         switch (operator) {
             case "=":
@@ -191,4 +224,5 @@ public class AnalyticsQueryParser {
                 throw new DotRuntimeException("Operator not supported: " + operator);
         }
     }
+
 }

--- a/dotCMS/src/main/java/com/dotcms/analytics/query/AnalyticsQueryParser.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/query/AnalyticsQueryParser.java
@@ -204,9 +204,10 @@ public class AnalyticsQueryParser {
      * @return The value or values of a token as an array of strings.
      */
     private String[] parseTokenValues(final String values) {
-        final String[] valueArray = values.split("\\s*,\\s*");
+        //final String[] valueArray = values.split("\\s*,\\s*");
+        final String[] valueArray = values.split(",");
         return Arrays.stream(valueArray).map(
-                value -> value.replaceAll(APOSTROPHE, BLANK))
+                value -> value.trim().replaceAll(APOSTROPHE, BLANK))
                 .toArray(String[]::new);
     }
 

--- a/dotCMS/src/main/java/com/dotcms/cube/filters/Filter.java
+++ b/dotCMS/src/main/java/com/dotcms/cube/filters/Filter.java
@@ -6,6 +6,9 @@ import java.util.Map;
  * Represents a CubeJs Query Filter
  *
  * @see <a href="https://cube.dev/docs/query-format#filters-formate">Filters format</a>
+ *
+ * @author Freddy Rodriguez
+ * @since Jan 27th, 2023
  */
 public interface Filter {
 
@@ -15,7 +18,8 @@ public interface Filter {
 
     Map<String, Object> asMap();
 
-    public enum Order {
+    enum Order {
         ASC, DESC;
     }
+
 }

--- a/dotCMS/src/test/java/com/dotcms/analytics/query/FilterParserTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/query/FilterParserTest.java
@@ -1,14 +1,15 @@
 package com.dotcms.analytics.query;
 
-
 import io.vavr.Tuple2;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 /**
- * Test for {@link FilterParser}
+ * Tests for {@link FilterParser} class.
  *
  * @author jsanca
  */
@@ -20,23 +21,23 @@ public class FilterParserTest  {
      * should return 2 tokens and 1 logical operator
      */
     @Test
-    public void test_2_tokens_parseFilterExpression_should_be_OK() throws Exception {
+    public void test_2_tokens_parseFilterExpression_should_be_OK() {
         final Tuple2<List<FilterParser.Token>,List<FilterParser.LogicalOperator>> result =
                 FilterParser.parseFilterExpression("Events.variant = ['B'] or Events.experiments = ['C']");
 
-        Assert.assertNotNull(result);
-        Assert.assertEquals(2, result._1.size()); // two tokens
-        Assert.assertEquals(1, result._2.size()); // one operator
+        assertNotNull(result);
+        assertEquals(2, result._1.size()); // two tokens
+        assertEquals(1, result._2.size()); // one operator
         final FilterParser.Token token1 = result._1.get(0);
         final FilterParser.Token token2 = result._1.get(1);
-        Assert.assertEquals("Events.variant", token1.member);
-        Assert.assertEquals("=", token1.operator);
-        Assert.assertEquals("B", token1.values);
-        Assert.assertEquals("Events.experiments", token2.member);
-        Assert.assertEquals("=", token2.operator);
-        Assert.assertEquals("C", token2.values);
+        assertEquals("Events.variant", token1.member);
+        assertEquals("=", token1.operator);
+        assertEquals("'B'", token1.values);
+        assertEquals("Events.experiments", token2.member);
+        assertEquals("=", token2.operator);
+        assertEquals("'C'", token2.values);
 
-        Assert.assertEquals(FilterParser.LogicalOperator.OR, result._2.get(0));
+        assertEquals(FilterParser.LogicalOperator.OR, result._2.get(0));
     }
 
     /**
@@ -45,29 +46,88 @@ public class FilterParserTest  {
      * should return 3 tokens and 2 logical operator
      */
     @Test
-    public void test_3_tokens_parseFilterExpression_should_be_OK() throws Exception {
+    public void test_3_tokens_parseFilterExpression_should_be_OK() {
         final Tuple2<List<FilterParser.Token>,List<FilterParser.LogicalOperator>> result =
                 FilterParser.parseFilterExpression("Events.variant in ['B'] and Events.experiments != ['C'] or Events.goals !in ['C']");
 
-        Assert.assertNotNull(result);
-        Assert.assertEquals(3, result._1.size()); // two tokens
-        Assert.assertEquals(2, result._2.size()); // one operator
+        assertNotNull(result);
+        assertEquals(3, result._1.size()); // two tokens
+        assertEquals(2, result._2.size()); // one operator
         final FilterParser.Token token1 = result._1.get(0);
         final FilterParser.Token token2 = result._1.get(1);
         final FilterParser.Token token3 = result._1.get(2);
-        Assert.assertEquals("Events.variant", token1.member);
-        Assert.assertEquals("in", token1.operator);
-        Assert.assertEquals("B", token1.values);
-        Assert.assertEquals("Events.experiments", token2.member);
-        Assert.assertEquals("!=", token2.operator);
-        Assert.assertEquals("C", token2.values);
-        Assert.assertEquals("Events.goals", token3.member);
-        Assert.assertEquals("!in", token3.operator);
-        Assert.assertEquals("C", token3.values);
+        assertEquals("Events.variant", token1.member);
+        assertEquals("in", token1.operator);
+        assertEquals("'B'", token1.values);
+        assertEquals("Events.experiments", token2.member);
+        assertEquals("!=", token2.operator);
+        assertEquals("'C'", token2.values);
+        assertEquals("Events.goals", token3.member);
+        assertEquals("!in", token3.operator);
+        assertEquals("'C'", token3.values);
 
-        Assert.assertEquals(FilterParser.LogicalOperator.AND, result._2.get(0));
-        Assert.assertEquals(FilterParser.LogicalOperator.OR, result._2.get(1));
+        assertEquals(FilterParser.LogicalOperator.AND, result._2.get(0));
+        assertEquals(FilterParser.LogicalOperator.OR, result._2.get(1));
     }
 
+    /**
+     * <ul>
+     *     <li><b>Method to test: </b>{@link FilterParser#parseFilterExpression(String)}</li>
+     *     <li><b>Given Scenario: </b>Parse a filter that includes multiple values.</li>
+     *     <li><b>Expected Result: </b>All values should be returned.</li>
+     * </ul>
+     */
+    @Test
+    public void parseExpressionWithMultipleValues() {
+        // ╔════════════════════════╗
+        // ║  Generating Test Data  ║
+        // ╚════════════════════════╝
+        final Tuple2<List<FilterParser.Token>,List<FilterParser.LogicalOperator>> result =
+                FilterParser.parseFilterExpression("request.whatAmI = ['PAGE','FILE']");
+
+        // ╔══════════════╗
+        // ║  Assertions  ║
+        // ╚══════════════╝
+        assertNotNull(result);
+        assertEquals("Only one token is expected", 1, result._1.size());
+        assertEquals("No logical operators are expected", 0, result._2.size());
+        final FilterParser.Token token1 = result._1.get(0);
+        assertEquals("request.whatAmI", token1.member);
+        assertEquals("=", token1.operator);
+        assertEquals("'PAGE','FILE'", token1.values);
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test: </b>{@link FilterParser#parseFilterExpression(String)}</li>
+     *     <li><b>Given Scenario: </b>Parse a filter that includes multiple values and two logical
+     *     operators.</li>
+     *     <li><b>Expected Result: </b>All values and expressions should be returned.</li>
+     * </ul>
+     */
+    @Test
+    public void parseExpressionWithMultipleValuesAndTwoLogicalOperators() {
+        // ╔════════════════════════╗
+        // ║  Generating Test Data  ║
+        // ╚════════════════════════╝
+        final Tuple2<List<FilterParser.Token>,List<FilterParser.LogicalOperator>> result =
+                FilterParser.parseFilterExpression("request.whatAmI = ['PAGE','FILE'] and request.url in ['/blog']");
+
+        // ╔══════════════╗
+        // ║  Assertions  ║
+        // ╚══════════════╝
+        assertNotNull(result);
+        assertEquals("Two tokens are expected", 2, result._1.size());
+        assertEquals("Only one logical operator is expected", 1, result._2.size());
+        final FilterParser.Token token1 = result._1.get(0);
+        final FilterParser.Token token2 = result._1.get(1);
+        assertEquals("request.whatAmI", token1.member);
+        assertEquals("=", token1.operator);
+        assertEquals("'PAGE','FILE'", token1.values);
+        assertEquals("request.url", token2.member);
+        assertEquals("in", token2.operator);
+        assertEquals("'/blog'", token2.values);
+        assertEquals(FilterParser.LogicalOperator.AND, result._2.get(0));
+    }
 
 }


### PR DESCRIPTION
### Proposed Changes
* Supporting the comparison of an array of values for the `filters` attribute in our Content Analytics Query. This way, our custom filter parameter can work just like it does in a CubeJS Query.

This PR fixes: #30191