### PR TITLE
 fix(chore) Unable to revoke tokens in dotCMS #30142

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
@@ -1391,6 +1391,9 @@
 		    var xhrArgs = {
 		        url : "/api/v1/apitoken/" + keyId + "/revoke" ,
 		        handleAs : "json",
+				headers: {
+					'Content-Type': 'application/json',
+				},
 		        load : function(data){
 		        	loadApiKeys()
 		        },


### PR DESCRIPTION
### Proposed Changes
* Added the `'Content-Type': 'application/json'` header to the API call for revoking tokens.

### Checklist
- [x] Tests
- [x] Translations: No changes needed.
- [x] Security Implications Contemplated: Fix ensures that API token revocation works as expected, reducing the security risk of lingering active tokens.

### Additional Info
This fix resolved the issue where users were receiving a `415 Unsupported Media Type` error when attempting to revoke tokens via the `/api/v1/apitoken/{keyId}/revoke` endpoint due to the absence of the `Content-Type` header in the request. By explicitly setting `'Content-Type': 'application/json'`, the server can now properly handle the request.

### Screenshots

https://github.com/user-attachments/assets/94f70c12-b932-4548-af2d-f15f31d10469

This PR fixes: #30142