### PR TITLE
#29828 IQA Followup Fixes

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/ResponseEntityWorkflowActionView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/ResponseEntityWorkflowActionView.java
@@ -1,9 +1,10 @@
 package com.dotcms.rest.api.v1.workflow;
 
 import com.dotcms.rest.ResponseEntityView;
+import com.dotmarketing.portlets.workflows.model.WorkflowAction;
 
-public class ResponseEntityWorkflowActionView extends ResponseEntityView<WorkflowActionView> {
-    public ResponseEntityWorkflowActionView(WorkflowActionView entity) {
+public class ResponseEntityWorkflowActionView extends ResponseEntityView<WorkflowAction> {
+    public ResponseEntityWorkflowActionView(WorkflowAction entity) {
         super(entity);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
@@ -335,7 +335,7 @@ public class WorkflowResource {
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Operation(operationId = "getWorkflowActionlets", summary = "Find all workflow actionlets",
-            description = "Returns a list of all workflow actionlets, a.k.a. [workflow sub-actions]" +
+            description = "Returns a list of all workflow actionlets — a.k.a. [workflow sub-actions]" +
                             "(https://www.dotcms.com/docs/latest/workflow-sub-actions). " +
                           "The returned list is complete and does not use pagination.",
             tags = {"Workflow"},
@@ -380,13 +380,47 @@ public class WorkflowResource {
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Operation(operationId = "getWorkflowActionletsByActionId", summary = "Find workflow actionlets by workflow action",
-            description = "Returns a list of the workflow actionlets, a.k.a. [workflow sub-actions](https://www.dotcms." +
-                            "com/docs/latest/workflow-sub-actions), associated with a specified workflow action.",
+            description = "Returns a list of the workflow actionlets — a.k.a. [workflow sub-actions](https://www.dotcms." +
+                            "com/docs/latest/workflow-sub-actions) — associated with a specified workflow action.",
             tags = {"Workflow"},
             responses = {
                     @ApiResponse(responseCode = "200", description = "Workflow actionlets returned successfully",
                             content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = ResponseEntityWorkflowActionClassesView.class)
+                                    schema = @Schema(implementation = ResponseEntityWorkflowActionClassesView.class),
+                                    examples = @ExampleObject(
+                                            value = "{\n" +
+                                                    "  \"entity\": [\n" +
+                                                    "    {\n" +
+                                                    "      \"actionId\": \"string\",\n" +
+                                                    "      \"actionlet\": {\n" +
+                                                    "        \"actionClass\": \"string\",\n" +
+                                                    "        \"howTo\": \"string\",\n" +
+                                                    "        \"localizedHowto\": \"string\",\n" +
+                                                    "        \"localizedName\": \"string\",\n" +
+                                                    "        \"name\": \"string\",\n" +
+                                                    "        \"nextStep\": null,\n" +
+                                                    "        \"parameters\": [\n" +
+                                                    "          {\n" +
+                                                    "            \"displayName\": \"string\",\n" +
+                                                    "            \"key\": \"string\",\n" +
+                                                    "            \"defaultValue\": \"string\",\n" +
+                                                    "            \"required\": true\n" +
+                                                    "          }\n" +
+                                                    "        ]\n" +
+                                                    "      },\n" +
+                                                    "      \"clazz\": \"string\",\n" +
+                                                    "      \"id\": \"string\",\n" +
+                                                    "      \"name\": \"string\",\n" +
+                                                    "      \"order\": 0\n" +
+                                                    "    }\n" +
+                                                    "  ],\n" +
+                                                    "  \"errors\": [],\n" +
+                                                    "  \"i18nMessagesMap\": {},\n" +
+                                                    "  \"messages\": [],\n" +
+                                                    "  \"pagination\": null,\n" +
+                                                    "  \"permissions\": []\n" +
+                                                    "}"
+                                    )
                             )
                     ),
                     @ApiResponse(responseCode = "401", description = "Invalid User"),
@@ -398,8 +432,7 @@ public class WorkflowResource {
     public final Response findActionletsByAction(@Context final HttpServletRequest request,
                                                  @PathParam("actionId") @Parameter(
                                                          required = true,
-                                                         description = "Identifier of workflow action to examine for " +
-                                                                       "actionlets.\n\n" +
+                                                         description = "Identifier of workflow action to examine for actionlets.\n\n" +
                                                                        "Example value: `b9d89c80-3d88-4311-8365-187323c96436` " +
                                                                        "(Default system workflow \"Publish\" action)",
                                                          schema = @Schema(type = "string")
@@ -1649,7 +1682,8 @@ public class WorkflowResource {
                                                                                                         "(https://www.dotcms.com/docs/latest/managing-workflows#ActionShow) the " +
                                                                                                         "action is visible. States must be specified uppercase, such as `NEW` or " +
                                                                                                         "`LOCKED`. There is no single state for ALL; each state must be listed. |\n" +
-                                                                              "| `actionNextStep` | String | The identifier of the step to enter after performing the action. |\n" +
+                                                                              "| `actionNextStep` | String | The identifier of the step to enter after performing the action; " +
+                                                                                                            "`currentstep` is also a valid value. |\n" +
                                                                               "| `actionNextAssign` | String | A user identifier or role key (such as `CMS Anonymous`) to serve as the " +
                                                                                                         " default entry in the assignment dropdown. |\n" +
                                                                               "| `actionCondition` | String | [Custom Velocity code](https://www.dotcms.com/docs/latest/managing-workflows#" +
@@ -1723,24 +1757,19 @@ public class WorkflowResource {
                                        ) final String actionId,
                                        @RequestBody(
                                                description = "Body consists of a JSON object containing " +
-                                                       "a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions) " +
-                                                       "form. This includes the following properties:\n\n" +
+                                                       "the same form data as used above in `POST /v1/workflow/actions`. However, " +
+                                                       "this endpoint uses the form's properties differently, as noted below:\n\n" +
                                                        "| Property | Type | Description |\n" +
                                                        "|-|-|-|\n" +
-                                                       "| `actionId` | String | The identifier of the workflow action to be updated. " +
-                                                       "If left blank, a new workflow action will be created. |\n" +
                                                        "| `schemeId` | String | The [workflow scheme](https://www.dotcms.com/docs/latest" +
                                                        "/managing-workflows#Schemes) under which the action will be created. |\n" +
-                                                       "| `stepId` | String |  The [workflow step](https://www.dotcms.com/docs/latest" +
-                                                       "/managing-workflows#Steps) with which to associate the action. |\n" +
                                                        "| `actionName` | String | The name of the workflow action. Multiple actions of the " +
                                                        "same name can coexist with different identifiers.  |\n" +
                                                        "| `whoCanUse` | List of Strings | A list of identifiers representing [users]" +
                                                        "(https://www.dotcms.com/docs/latest/user-management), " +
                                                        "[role keys](https://www.dotcms.com/docs/latest/adding-roles), " +
                                                        "or [other user categories](https://www.dotcms.com" +
-                                                       "                             /docs/latest/managing-workflows#ActionWho)  " +
-                                                       "allowed to use this action. This list can be empty. |\n" +
+                                                       "/docs/latest/managing-workflows#ActionWho) allowed to use this action. This list can be empty. |\n" +
                                                        "| `actionIcon` | String | The icon to associate with the action. Example: `workflowIcon`.  |\n" +
                                                        "| `actionCommentable` | Boolean | Whether this action supports comments.  |\n" +
                                                        /* "| `requiresCheckout` | Boolean |   |\n" + // This is a deprecated, unnecessary, and broadly unused property. */
@@ -1748,14 +1777,17 @@ public class WorkflowResource {
                                                        "(https://www.dotcms.com/docs/latest/managing-workflows#ActionShow) the " +
                                                        "action is visible. States must be specified uppercase, such as `NEW` or " +
                                                        "`LOCKED`. There is no single state for ALL; each state must be listed. |\n" +
-                                                       "| `actionNextStep` | String | The identifier of the step to enter after performing the action. |\n" +
+                                                       "| `actionNextStep` | String | The identifier of the step to enter after performing the action; " +
+                                                                                    "`currentstep` is also a valid value. |\n" +
                                                        "| `actionNextAssign` | String | A user identifier or role key (such as `CMS Anonymous`) to serve as the " +
                                                        " default entry in the assignment dropdown. |\n" +
                                                        "| `actionCondition` | String | [Custom Velocity code](https://www.dotcms.com/docs/latest/managing-workflows#" +
                                                        "ActionAssign) to be executed along with the action. |\n" +
                                                        "| `actionAssignable` | Boolean | Whether this action can be assigned.  |\n" +
                                                        "| `actionRoleHierarchyForAssign` | Boolean | If true, non-administrators cannot assign tasks to administrators.  |\n" +
-                                                       "| `metadata` | Object | Additional metadata to include in the action definition. |\n\n",
+                                                       "| `metadata` | Object | Optional. Additional metadata to include in the action definition. |\n" +
+                                                       "| `actionId` | String | Omit; not used in this endpoint. |\n" +
+                                                       "| `stepId` | String | Omit; not used in this endpoint. |\n\n",
                                                required = true,
                                                content = @Content(schema = @Schema(implementation = WorkflowActionForm.class))
                                        ) final WorkflowActionForm workflowActionForm) {
@@ -1892,7 +1924,7 @@ public class WorkflowResource {
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Consumes({MediaType.APPLICATION_JSON})
     @Operation(operationId = "postAddActionletToActionById", summary = "Adds an actionlet to a workflow action",
-            description = "Adds an actionlet — also known as a [workflow sub-action]" +
+            description = "Adds an actionlet — a.k.a. a [workflow sub-action]" +
                     "(https://www.dotcms.com/docs/latest/workflow-sub-actions) — to a [workflow action]" +
                     "(https://www.dotcms.com/docs/latest/managing-workflows#Actions).\n\n" +
                     "Returns \"Ok\" on success.",
@@ -2164,7 +2196,7 @@ public class WorkflowResource {
             description = "Removes an [actionlet](https://www.dotcms.com/docs/latest/workflow-sub-actions), or sub-action, " +
                     "from a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions). This deletes " +
                     "only the actionlet's binding to the action utilizing it, and leaves the actionlet category intact.\n\n" +
-                    "To find the identifier, you can call `GET /workflow/actions/{actionId}/actionlets`." +
+                    "To find the identifier, you can call `GET /workflow/actions/{actionId}/actionlets`.\n\n" +
                     "Returns \"Ok\" on success.\n\n",
             tags = {"Workflow"},
             responses = {
@@ -2322,7 +2354,7 @@ public class WorkflowResource {
                                                                                 "with `0` being the first. |\n" +
                                                      "| `stepName` | String | The name of the workflow step. |\n" +
                                                      "| `enableEscalation` | Boolean | Determines whether a step is capable of automatic escalation " +
-                                                                                    "to the next step.\n\n(Read more about [schedule-enabled workflows]" +
+                                                                                    "to the next step. (Read more about [schedule-enabled workflows]" +
                                                                                     "(https://www.dotcms.com/docs/latest/schedule-enabled-workflow).) |\n" +
                                                      "| `escalationAction` | String | The identifier of the workflow action to execute on automatic escalation. |\n" +
                                                      "| `escalationTime` | String | The time, in seconds, before the workflow automatically escalates. |\n" +
@@ -2386,12 +2418,12 @@ public class WorkflowResource {
                                                                             "/latest/managing-workflows#Schemes) to which the step will be added. |\n" +
                                                   "| `stepName` | String | The name of the workflow step. |\n" +
                                                   "| `enableEscalation` | Boolean | Determines whether a step is capable of automatic escalation " +
-                                                  "to the next step.\n\n(Read more about [schedule-enabled workflows]" +
-                                                  "(https://www.dotcms.com/docs/latest/schedule-enabled-workflow).) |\n" +
+                                                                            "to the next step. (Read more about [schedule-enabled workflows]" +
+                                                                            "(https://www.dotcms.com/docs/latest/schedule-enabled-workflow).) |\n" +
                                                   "| `escalationAction` | String | The identifier of the workflow action to execute on automatic escalation. |\n" +
                                                   "| `escalationTime` | String | The time, in seconds, before the workflow automatically escalates. |\n" +
                                                   "| `stepResolved` | Boolean | If true, any content which enters this workflow step will be considered resolved.\n" +
-                                                  "Content in a resolved step will not appear in the workflow queues of any users.\n |\n\n",
+                                                                            "Content in a resolved step will not appear in the workflow queues of any users.\n |\n\n",
                                           required = true,
                                           content = @Content(
                                                   schema = @Schema(implementation = WorkflowStepAddForm.class)
@@ -5346,7 +5378,7 @@ public class WorkflowResource {
     public final Response saveScheme(@Context final HttpServletRequest request,
                                      @Context final HttpServletResponse response,
                                      @RequestBody(
-                                             description = "The request body consists of the following three properties:" +
+                                             description = "The request body consists of the following three properties:\n\n" +
                                                      "| Property | Type | Description |\n" +
                                                      "|-|-|-|\n" +
                                                      "| `schemeName` | String | The workflow scheme's name. |\n" +
@@ -5409,7 +5441,7 @@ public class WorkflowResource {
                                                schema = @Schema(type = "string")
                                        ) final String schemeId,
                                        @RequestBody(
-                                               description = "The request body consists of the following three properties:" +
+                                               description = "The request body consists of the following three properties:\n\n" +
                                                        "| Property | Type | Description |\n" +
                                                        "|-|-|-|\n" +
                                                        "| `schemeName` | String | The workflow scheme's name. |\n" +

--- a/dotCMS/src/main/java/com/dotcms/workflow/form/WorkflowActionForm.java
+++ b/dotCMS/src/main/java/com/dotcms/workflow/form/WorkflowActionForm.java
@@ -9,6 +9,7 @@ import com.dotmarketing.portlets.workflows.model.WorkflowAction;
 import com.dotmarketing.portlets.workflows.model.WorkflowState;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.vavr.control.Try;
 
 import java.util.Arrays;
@@ -45,11 +46,13 @@ public class WorkflowActionForm extends Validated {
     @NotNull
     private final boolean       actionCommentable;
     @NotNull
+    @Hidden
     private final boolean       requiresCheckout;
     @NotNull
     private final Set<WorkflowState> showOn;
     @NotNull
     private final boolean       actionRoleHierarchyForAssign;
+    @Hidden
     private final boolean       roleHierarchyForAssign;
     @NotNull
     private final String        actionNextStep;


### PR DESCRIPTION
This PR addresses various small and sundry changes raised in the IQA pass, visible [here](https://docs.google.com/document/d/1Q4iSSVtbPVMGjGrKP8MyJ8g2X1Dl0rWZAopKK7Lcq78/edit). 

Point by point below:

### Proposed Changes
* Fixed spacing on `DELETE /workflow/actionlets/{actionletId}` return statement.
* Fixed rendering of link on `PUT /workflow/actions/{actionId}` description
* Fixed "a.k.a." consistency throughout (plus em-dashes)
* Adjusted `WorkflowActionForm` to add Swagger's `@Hidden` annotation, thereby removing deprecated or erroneous properties from display in `POST /api/v1/workflow/actions` and `PUT /workflow/actions/{actionId}`
* Adjusted `ResponseEntityWorkflowActionView` class to prototype with WorkflowAction instead of WorkflowActionView class, removing unnecessary `actionInputs` from example.
* Found the source of missing `actionlet.nextStep` property, but it's a very deep-set issue that involves a mix of code from 2012 and various actionlet subclasses that add `getNextStep{ return null }` methods. Might eventually make for an interesting project to determine whether these methods are necessary, but for now it was safer to just add a manual example response string.
* **No action needed** on nextStepCurrentStep property; it was present in the response description, but it was farther down in the object than it appears in the typical response.
* Fixed table formatting by adding newlines to request body description in `POST /workflow/schemes` and `PUT /workflow/schemes/{schemeId}`
* Fixed table formatting by REMOVING newlines in `POST /workflow/steps` and `PUT /workflow/steps/{stepId}`

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

This PR fixes: #29828