### PR TITLE
#29742 apitoken doc IQA fixes & more

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenForm.java
@@ -5,14 +5,16 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableMap;
+import io.swagger.v3.oas.annotations.Hidden;
 
 @JsonDeserialize(builder = ApiTokenForm.Builder.class)
 public class ApiTokenForm  {
 
 
     public final String userId;
-
+    @Hidden
     public final String tokenId;
+    @Hidden
     public final boolean showRevoked;
     public final int expirationSeconds;
     public final String network;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
@@ -74,9 +74,9 @@ import static java.util.Collections.EMPTY_MAP;
  * Endpoint to handle Api Tokens
  */
 @Path("/v1/apitoken")
-@Tag(name = "Api Token",
-        description = "Endpoints that handle operations related to Api Tokens",
-        externalDocs = @ExternalDocumentation(description = "Additional Api Token information",
+@Tag(name = "API Token",
+        description = "Endpoints that handle operations related to API tokens",
+        externalDocs = @ExternalDocumentation(description = "Additional API token information",
                 url = "https://www.dotcms.com/docs/latest/rest-api-authentication#APIToken"))
 
 public class ApiTokenResource implements Serializable {
@@ -104,44 +104,46 @@ public class ApiTokenResource implements Serializable {
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Consumes({MediaType.APPLICATION_JSON})
-    @Operation(operationId = "getApiTokens",
-            summary = "Gets api tokens from a user's ID",
-            description = "Takes a user ID and returns a list of Api Tokens associated with the ID.\n\n" +
-                    "The list of tokens also includes any tokens that have been revoked.\n\n",
-            tags = {"Api Token"},
+    @Operation(operationId = "getApiTokensByUserId",
+            summary = "Retrieves API tokens based on a user ID",
+            description = "Accepts a user identifier and returns a list of API tokens associated with that user.\n\n" +
+                    "The returned list may optionally include or exclude tokens that have been revoked.\n\n",
+            tags = {"API Token"},
             responses = {
-                    @ApiResponse(responseCode = "200", description = "User Api tokens successfully retrieved",
+                    @ApiResponse(responseCode = "200", description = "User's API tokens successfully retrieved",
                             content = @Content(mediaType = "application/json",
                                     examples = {
                                             @ExampleObject(
                                                     value = "{\n" +
                                                             "  \"entity\": {\n" +
-                                                            "    \"jwt\": \"string\",\n" +
-                                                            "    \"token\": {\n" +
-                                                            "      \"allowNetwork\": \"0.0.0.0/0\",\n" +
-                                                            "      \"claims\": {\n" +
-                                                            "        \"label\": \"string\"\n" +
-                                                            "      },\n" +
-                                                            "      \"expired\": false,\n" +
-                                                            "      \"expiresDate\": 0 \n," +
-                                                            "      \"id\": \"string\",\n" +
-                                                            "      \"issueDate\": 0,\n" +
-                                                            "      \"issuer\": \"string\",\n" +
-                                                            "      \"modificationDate\": 0,\n" +
-                                                            "      \"notBeforeDate\": false,\n" +
-                                                            "      \"requestingIp\": \"string\",\n" +
-                                                            "      \"requestingUserId\": \"string\",\n" +
-                                                            "      \"revoked\": false,\n" +
-                                                            "      \"revokedDate\": 0,\n" +
-                                                            "      \"subject\": \"string\",\n" +
-                                                            "      \"tokenType\": \"string\",\n" +
-                                                            "      \"userId\": \"string\",\n" +
-                                                            "      \"valid\": true\n" +
-                                                            "    }\n" +
+                                                            "    \"tokens\": [\n" +
+                                                            "      {\n" +
+                                                            "        \"allowNetwork\": null,\n" +
+                                                            "        \"claims\": {\n" +
+                                                            "          \"label\": \"string\"\n" +
+                                                            "        },\n" +
+                                                            "        \"expired\": false,\n" +
+                                                            "        \"expiresDate\": 1822623941000,\n" +
+                                                            "        \"id\": \"string\",\n" +
+                                                            "        \"issueDate\": 1728061510000,\n" +
+                                                            "        \"issuer\": \"string\",\n" +
+                                                            "        \"modificationDate\": 1728061510000,\n" +
+                                                            "        \"notBeforeDate\": false,\n" +
+                                                            "        \"requestingIp\": \"string\",\n" +
+                                                            "        \"requestingUserId\": \"string\",\n" +
+                                                            "        \"revoked\": false,\n" +
+                                                            "        \"revokedDate\": null,\n" +
+                                                            "        \"subject\": \"string\",\n" +
+                                                            "        \"tokenType\": \"string\",\n" +
+                                                            "        \"userId\": \"string\",\n" +
+                                                            "        \"valid\": true\n" +
+                                                            "      }\n" +
+                                                            "    ]\n" +
                                                             "  },\n" +
                                                             "  \"errors\": [],\n" +
                                                             "  \"i18nMessagesMap\": {},\n" +
                                                             "  \"messages\": [],\n" +
+                                                            "  \"pagination\": null,\n" +
                                                             "  \"permissions\": []\n" +
                                                             "}"
                                             )
@@ -149,7 +151,9 @@ public class ApiTokenResource implements Serializable {
                             )
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad request"),
+                    @ApiResponse(responseCode = "401", description = "Invalid user"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "404", description = "Invalid user"),
                     @ApiResponse(responseCode = "500", description = "Unexpected server error")
 
             }
@@ -159,11 +163,11 @@ public class ApiTokenResource implements Serializable {
             @Context final HttpServletResponse response,
             @PathParam("userId") @Parameter(
                     required = true,
-                    description = "ID for user getting api tokens.",
+                    description = "Identifier of user to check for tokens.",
                     schema = @Schema(type = "string")
             ) final String userId,
             @QueryParam("showRevoked") @Parameter(
-                    description = "Determines whether revokes tokens are shown.",
+                    description = "Determines whether revoked tokens are shown. Defaults to `false` if omitted.",
                     schema = @Schema(type = "boolean")
             )final boolean showRevoked) {
 
@@ -180,44 +184,44 @@ public class ApiTokenResource implements Serializable {
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Consumes({MediaType.APPLICATION_JSON})
-    @Operation(operationId = "putTokenIdRevoke",
-            summary = "Revokes an api token from user(s)",
-            description = "Takes a token ID and revokes it from any specified users.\n\n" +
-                    "If the token attempmting to be revoked is expired the request will fail.\n\n",
-            tags = {"Api Token"},
+    @Operation(operationId = "putRevokeTokenById",
+            summary = "Revokes an API token",
+            description = "Revokes a token by its identifier.\n\n Returned entity contains the " +
+                    "property `revoked`, whose value is an object representing the revoked token.",
+            tags = {"API Token"},
             responses = {
-                    @ApiResponse(responseCode = "200", description = "Tokens revoked successfully",
+                    @ApiResponse(responseCode = "200", description = "Token revoked successfully",
                             content = @Content(mediaType = "application/json",
                                     examples = {
                                             @ExampleObject(
                                                     value = "{\n" +
                                                             "  \"entity\": {\n" +
-                                                            "    \"jwt\": \"string\",\n" +
-                                                            "    \"token\": {\n" +
-                                                            "      \"allowNetwork\": \"0.0.0.0/0\",\n" +
+                                                            "    \"revoked\": {\n" +
+                                                            "      \"allowNetwork\": null,\n" +
                                                             "      \"claims\": {\n" +
                                                             "        \"label\": \"string\"\n" +
                                                             "      },\n" +
                                                             "      \"expired\": false,\n" +
-                                                            "      \"expiresDate\": 0 \n," +
+                                                            "      \"expiresDate\": 1822623941000,\n" +
                                                             "      \"id\": \"string\",\n" +
-                                                            "      \"issueDate\": 0,\n" +
+                                                            "      \"issueDate\": 1728061510000,\n" +
                                                             "      \"issuer\": \"string\",\n" +
-                                                            "      \"modificationDate\": 0,\n" +
+                                                            "      \"modificationDate\": 1728069870000,\n" +
                                                             "      \"notBeforeDate\": false,\n" +
                                                             "      \"requestingIp\": \"string\",\n" +
                                                             "      \"requestingUserId\": \"string\",\n" +
-                                                            "      \"revoked\": false,\n" +
-                                                            "      \"revokedDate\": 0,\n" +
+                                                            "      \"revoked\": true,\n" +
+                                                            "      \"revokedDate\": 1728069870000,\n" +
                                                             "      \"subject\": \"string\",\n" +
                                                             "      \"tokenType\": \"string\",\n" +
                                                             "      \"userId\": \"string\",\n" +
-                                                            "      \"valid\": true\n" +
+                                                            "      \"valid\": false\n" +
                                                             "    }\n" +
                                                             "  },\n" +
                                                             "  \"errors\": [],\n" +
                                                             "  \"i18nMessagesMap\": {},\n" +
                                                             "  \"messages\": [],\n" +
+                                                            "  \"pagination\": null,\n" +
                                                             "  \"permissions\": []\n" +
                                                             "}"
                                             )
@@ -225,7 +229,9 @@ public class ApiTokenResource implements Serializable {
                             )
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad request"),
+                    @ApiResponse(responseCode = "401", description = "Invalid user"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "404", description = "Token not found"),
                     @ApiResponse(responseCode = "500", description = "Unexpected server error")
             }
     )
@@ -234,15 +240,8 @@ public class ApiTokenResource implements Serializable {
             @Context final HttpServletResponse response,
             @PathParam("tokenId") @Parameter(
                     required = true,
-                    description = "ID of Api token being revoked",
-                    schema = @Schema(type = "string"))
-            @RequestBody(description = "This method takes an api-token ID and revokes it from the IP address where the request was made.\n\n" +
-                    "If the token is expired then the system will return a message stating the token is expire.\n\n",
-                    required = true,
-                    content = @Content(
-                            schema = @Schema(type = "String")
-                    ))
-            final String tokenId) {
+                    description = "Identifier of API token to be revoked",
+                    schema = @Schema(type = "string")) final String tokenId) {
 
         final InitDataObject initDataObject = this.webResource.init(null, true, request, true, "users");
         final User user                     = initDataObject.getUser();
@@ -272,10 +271,11 @@ public class ApiTokenResource implements Serializable {
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(operationId = "deleteApiToken",
-            summary = "Deletes an api-token",
-            description = "Takes an api-token ID and deletes from the device connected to the IP address from the request.",
-            tags = {"Api Token"},
+    @Operation(operationId = "deleteApiTokenById",
+            summary = "Deletes an API token",
+            description = "Deletes an API token by identifier. May be performed on either active, expired, or revoked.\n\n" +
+                    "Returned entity contains the property `deleted`, the value of which is the deleted token object.",
+            tags = {"API Token"},
             responses = {
                     @ApiResponse(responseCode = "200", description = "Token successfully deleted",
                             content = @Content(mediaType = "application/json",
@@ -283,32 +283,32 @@ public class ApiTokenResource implements Serializable {
                                             @ExampleObject(
                                                     value = "{\n" +
                                                             "  \"entity\": {\n" +
-                                                            "    \"jwt\": \"string\",\n" +
-                                                            "    \"token\": {\n" +
-                                                            "      \"allowNetwork\": \"0.0.0.0/0\",\n" +
+                                                            "    \"deleted\": {\n" +
+                                                            "      \"allowNetwork\": null,\n" +
                                                             "      \"claims\": {\n" +
                                                             "        \"label\": \"string\"\n" +
                                                             "      },\n" +
                                                             "      \"expired\": false,\n" +
-                                                            "      \"expiresDate\": 0 \n," +
+                                                            "      \"expiresDate\": 1822623941000,\n" +
                                                             "      \"id\": \"string\",\n" +
-                                                            "      \"issueDate\": 0,\n" +
+                                                            "      \"issueDate\": 1728061510000,\n" +
                                                             "      \"issuer\": \"string\",\n" +
-                                                            "      \"modificationDate\": 0,\n" +
+                                                            "      \"modificationDate\": 1728069870000,\n" +
                                                             "      \"notBeforeDate\": false,\n" +
                                                             "      \"requestingIp\": \"string\",\n" +
                                                             "      \"requestingUserId\": \"string\",\n" +
-                                                            "      \"revoked\": false,\n" +
-                                                            "      \"revokedDate\": 0,\n" +
+                                                            "      \"revoked\": true,\n" +
+                                                            "      \"revokedDate\": 1728069870000,\n" +
                                                             "      \"subject\": \"string\",\n" +
                                                             "      \"tokenType\": \"string\",\n" +
                                                             "      \"userId\": \"string\",\n" +
-                                                            "      \"valid\": true\n" +
+                                                            "      \"valid\": false\n" +
                                                             "    }\n" +
                                                             "  },\n" +
                                                             "  \"errors\": [],\n" +
                                                             "  \"i18nMessagesMap\": {},\n" +
                                                             "  \"messages\": [],\n" +
+                                                            "  \"pagination\": null,\n" +
                                                             "  \"permissions\": []\n" +
                                                             "}"
                                             )
@@ -316,6 +316,8 @@ public class ApiTokenResource implements Serializable {
                             )
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad request"),
+                    @ApiResponse(responseCode = "401", description = "Invalid user"),
+                    @ApiResponse(responseCode = "404", description = "Token not found"),
                     @ApiResponse(responseCode = "500", description = "Unexpected server error")
             }
     )
@@ -324,7 +326,7 @@ public class ApiTokenResource implements Serializable {
             @Context final HttpServletResponse response,
             @PathParam("tokenId") @Parameter(
                     required = true,
-                    description = "ID of Api token being revoked",
+                    description = "Identifier of API token to be deleted.",
                     schema = @Schema(type = "string"))
             final String tokenId) {
 
@@ -359,15 +361,16 @@ public class ApiTokenResource implements Serializable {
      * @return Response
      */
     @POST
-    @Path("/")
+    //@Path("/") testing before full deletion
     @JSONP
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Operation(operationId = "postIssueApiToken",
-            summary = "Issues api token to authorized user",
-            description = "Issues an api token to an admin user who has requested the token, no other user can request a token.",
-            tags = {"Api Token"},
+            summary = "Issues an API token",
+            description = "Issues an API token to an authorized user account.\n\n" +
+                    "Returns an object representing the issued token.",
+            tags = {"API Token"},
             responses = {
                     @ApiResponse(responseCode = "200", description = "Token successfully issued to user",
                             content = @Content(mediaType = "application/json",
@@ -401,6 +404,7 @@ public class ApiTokenResource implements Serializable {
                                                             "  \"errors\": [],\n" +
                                                             "  \"i18nMessagesMap\": {},\n" +
                                                             "  \"messages\": [],\n" +
+                                                            "  \"pagination\": null," +
                                                             "  \"permissions\": []\n" +
                                                             "}"
                                             )
@@ -408,6 +412,7 @@ public class ApiTokenResource implements Serializable {
                             )
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad request"),
+                    @ApiResponse(responseCode = "401", description = "Invalid user"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
                     @ApiResponse(responseCode = "500", description = "Unexpected server error")
             }
@@ -416,15 +421,30 @@ public class ApiTokenResource implements Serializable {
             @Context final HttpServletRequest request,
             @Context final HttpServletResponse response,
             @RequestBody(description = "This method requires a POST body of a JSON object containing the following properties.\n\n" +
-                    "| **Property**    | **Value** | **Description**                               |\n" +
+                    "| Property        | Value     | Description                                   |\n" +
                     "|-----------------|-----------|-----------------------------------------------|\n" +
-                    "| `userId`        | String    | **Required.** ID of user attempting receiving |\n" +
-                    "| `tokenId`       | String    | ID of api token being issued                  |\n" +
-                    "| `network`       | String    | User IP address                               |\n" +
-                    "| `shouldBeAdmin` | Boolean   | Must be `true` to receive token               |",
+                    "| `userId`             | String    | **Required.** ID of user attempting receiving |\n" +
+                    "| `expirationSeconds`  | Integer    | **Required.** TTL of token in seconds. |\n" +
+                    "| `network`            | String    | Network mask in which token is valid. Defaults to `0.0.0.0/0`, " +
+                                                            "or any local network.  |\n" +
+                    "| `claims`             | Object    | Contains `label` property. |\n" +
+                    "| `claims.label`       | String    | Sets a user-defined name for token. |\n" +
+                    "| `shouldBeAdmin`      | Boolean   | If `true`, the call only succeeds if the token is being issued " +
+                                                            "to an admin account. Defaults to `false` if omitted. |\n",
                     required = true,
                     content = @Content(
-                            schema = @Schema(implementation = ApiTokenForm.class))
+                            schema = @Schema(implementation = ApiTokenForm.class),
+                            examples = @ExampleObject(
+                                    value = "{\n" +
+                                    "  \"userId\": \"string\",\n" +
+                                    "  \"expirationSeconds\": 0,\n" +
+                                    "  \"network\": \"string\",\n" +
+                                    "  \"claims\": {\n" +
+                                    "    \"label\": \"string\"\n" +
+                                    "  },\n" +
+                                    "  \"shouldBeAdmin\": false\n" +
+                                    "}")
+                    )
             )
             final ApiTokenForm formData) throws DotDataException, DotSecurityException {
 
@@ -437,7 +457,7 @@ public class ApiTokenResource implements Serializable {
         }
 
         if (requestingUser != forUser && !requestingUser.isAdmin()) {
-            throw new DotDataException("Just Admin user can request a Token for another user");
+            throw new DotDataException("Only Admin user can request a token for another user");
         }
 
         if (!forUser.isAdmin() && formData.shouldBeAdmin) {
@@ -451,7 +471,7 @@ public class ApiTokenResource implements Serializable {
 
         if(expirationSeconds < 0) {
 
-            return ExceptionMapperUtil.createResponse(new DotStateException("invalid expirationDays"), Response.Status.BAD_REQUEST);
+            return ExceptionMapperUtil.createResponse(new DotStateException("Invalid expirationSeconds"), Response.Status.BAD_REQUEST);
         }
 
         ApiToken token = ApiToken.builder()
@@ -484,20 +504,20 @@ public class ApiTokenResource implements Serializable {
      * <pre>
      * {
      *    token: {
-     *      netmask:'192.168.1.0/24',
-     *      expirationDays:1000,
-     *      userId:'dotcms.org.1'
+     *      network: '192.168.1.0/24',
+     *      expirationSeconds: 1000,
      *      claims: {
      *          label: 'Push Publish'
      *      }
      *    },
      * 	  remote: {
-     * 	    host: localhost,
-     * 		port: 8090
+     * 	    host: 'localhost',
+     * 		port: 8090,
+     * 	    protocol: 'http'
      * 	  },
      * 	  auth: {
      * 	    login: admin@dotcms.com,
-     * 		pasword: [password in Base64]
+     * 		password: [password in Base64]
      * 	  }
      * }
      * </pre>
@@ -510,12 +530,15 @@ public class ApiTokenResource implements Serializable {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Operation(operationId = "putGetRemoteToken",
-            summary = "Gets a remote api token",
-            description = "Returns a remote token to the user who requested the token.\n\n" +
-                    "Users must be an admin to request a token.",
-            tags = {"Api Token"},
+            summary = "Generates a remote API token",
+            description = "This endpoint takes as part of its payload authentication credentials for a user account " +
+                    "on a remote dotCMS instance. It returns a token object that can be used to permit remote operation " +
+                    "according to the role and permissions of the authenticated account.\n\nThis is used, for example, " +
+                    "in configuring a [push publishing](https://www.dotcms.com/docs/latest/push-publishing) endpoint.\n\n" +
+                    "Usable only by administrators.",
+            tags = {"API Token"},
             responses = {
-                    @ApiResponse(responseCode = "200", description = "Remote token retrieved successfully",
+                    @ApiResponse(responseCode = "200", description = "Remote token generated successfully",
                             content = @Content(mediaType = "application/json",
                                     examples = {
                                             @ExampleObject(
@@ -554,51 +577,50 @@ public class ApiTokenResource implements Serializable {
                             )
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad request"),
+                    @ApiResponse(responseCode = "401", description = "Invalid user"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
                     @ApiResponse(responseCode = "500", description = "Unexpected server error")
             }
     )
     public final Response getRemoteToken(
             @Context final HttpServletRequest httpRequest,
-            @RequestBody(description = "PUT body consists of a JSON object containing the following properties, values are separated by their parent properites:\n\n" +
-                    "| **Token Properties**  | **Value** | **Description**                                       |\n" +
-                    "|-----------------------|-----------|-------------------------------------------------------|\n" +
-                    "| `network`             | String    | IP address where token can be used                    |\n" +
-                    "| `expirationSeconds`   | String    | Seconds until token expires                           |\n" +
-                    "| `userId`              | String    | ID of user receiving remote token                     |\n" +
-                    "| `tokenId`             | String    | ID of api token user is getting                       |\n" +
-                    "| `label`               | String    | **Subsection of `claims`** Name of remote token       |\n\n" +
-                    "| **Remote Properties** | **Value** | **Description**                                       |\n" +
-                    "|-----------------------|-----------|-------------------------------------------------------|\n" +
-                    "| `host`                | String    | Current host user is logged into; such as `localhost` |\n" +
-                    "| `port`                | String    | Port number for host                                  |\n" +
-                    "| `protocol`            | String    | Type of web protocol where the token resides          |\n\n" +
-                    "| **Auth Properties**   | **Value** | **Description**                                       |\n" +
-                    "|-----------------------|-----------|-------------------------------------------------------|\n" +
-                    "| `login`               | String    | Username for login                                    |\n" +
-                    "| `password`            | String    | User password                                         |",
+            @RequestBody(description = "PUT body consists of a JSON object containing three properties: `token`, concerning the token's " +
+                    "direct properties; `remote`, defining the remote host, and `auth`, specifying remote user authentication.\n\n" +
+                    "Each of these three top-level properties is itself an object containing further properties, listed fully below:\n\n" +
+                    "| Properties                 | Value   | Description                                                            |\n" +
+                    "|----------------------------|---------|------------------------------------------------------------------------|\n" +
+                    "| `token.network`            | String  | Network mask in which the token is active.                             |\n" +
+                    "| `token.expirationSeconds`  | String  | Seconds until the token expires.                                       |\n" +
+                    "| `token.claims`             | Object  | Object containing the property `label`, defined below.                 |\n" +
+                    "| `token.claims.label`       | String  | The name of the token generated.                                       |\n" +
+                    "|             |   |  |\n" +
+                    "| `remote.host`              | String  | Remote host for which to generate a token.                             |\n" +
+                    "| `remote.port`              | String  | Port number for the remote host.                                       |\n" +
+                    "| `remote.protocol`          | String  | Web protocol used to connect to the remote host.                       |\n" +
+                    "|             |   |  |\n" +
+                    "| `auth.login`               | String  | Email of account from which the remote token will derive permissions.  |\n" +
+                    "| `auth.password`            | String  | A string representing a base64-encoded password.                       |\n",
                     required = true,
                     content = @Content(
-                            schema = @Schema(implementation = RemoteAPITokenForm.class),
+                            schema = @Schema(implementation = RemoteAPITokenForm.class), // can't get this to introspect properly >:(
                             examples = {
                                     @ExampleObject(
                                             value = "{\n" +
                                                     "  \"token\": {\n" +
                                                     "    \"network\": \"0.0.0.0/0\",\n" +
-                                                    "    \"expirationSeconds\": \"string\",\n" +
-                                                    "    \"userId\": \"string\",\n" +
+                                                    "    \"expirationSeconds\": \"1000\",\n" +
                                                     "    \"claims\": {\n" +
-                                                    "      \"label\": \"string\"\n" +
+                                                    "      \"label\": \"Example\"\n" +
                                                     "    }\n" +
                                                     "  },\n" +
                                                     "  \"remote\": {\n" +
-                                                    "    \"host\": \"string\",\n" +
-                                                    "    \"port\": \"string\",\n" +
-                                                    "    \"protocol\": \"string\"\n" +
+                                                    "    \"host\": \"dotcms-receiver.local\",\n" +
+                                                    "    \"port\": \"8082\",\n" +
+                                                    "    \"protocol\": \"http\"\n" +
                                                     "  },\n" +
                                                     "  \"auth\": {\n" +
-                                                    "    \"login\": \"string\",\n" +
-                                                    "    \"password\": \"string\"\n" +
+                                                    "    \"login\": \"admin@dotcms.com\",\n" +
+                                                    "    \"password\": \"YWRtaW4=\"\n" +
                                                     "  }\n" +
                                                     "}"
                                     )
@@ -684,50 +706,33 @@ public class ApiTokenResource implements Serializable {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Operation(operationId = "getGetJwtFromApiToken",
-            summary = "Retrieves JSON web token from api token",
-            description = "Returns a JSON web token associated with an api token ID requested by a user, this token will then be included in a message to the user.",
-            tags = {"Api Token"},
+            summary = "Generates a new JWT for an existing token",
+            description = "Returns a JSON web token. This overwrites the JWT value associated with the " +
+                    "specified token object.",
+            tags = {"API Token"},
             responses = {
-                    @ApiResponse(responseCode = "200", description = "JSON web token successfully retrieved",
+                    @ApiResponse(responseCode = "200", description = "JSON web token successfully created",
                             content = @Content(mediaType = "application/json",
                                     examples = {
                                             @ExampleObject(
                                                     value = "{\n" +
-                                                            "  \"entity\": {\n" +
-                                                            "    \"jwt\": \"string\",\n" +
-                                                            "    \"token\": {\n" +
-                                                            "      \"allowNetwork\": \"0.0.0.0/0\",\n" +
-                                                            "      \"claims\": {\n" +
-                                                            "        \"label\": \"string\"\n" +
-                                                            "      },\n" +
-                                                            "      \"expired\": false,\n" +
-                                                            "      \"expiresDate\": 0 \n," +
-                                                            "      \"id\": \"string\",\n" +
-                                                            "      \"issueDate\": 0,\n" +
-                                                            "      \"issuer\": \"string\",\n" +
-                                                            "      \"modificationDate\": 0,\n" +
-                                                            "      \"notBeforeDate\": false,\n" +
-                                                            "      \"requestingIp\": \"string\",\n" +
-                                                            "      \"requestingUserId\": \"string\",\n" +
-                                                            "      \"revoked\": false,\n" +
-                                                            "      \"revokedDate\": 0,\n" +
-                                                            "      \"subject\": \"string\",\n" +
-                                                            "      \"tokenType\": \"string\",\n" +
-                                                            "      \"userId\": \"string\",\n" +
-                                                            "      \"valid\": true\n" +
-                                                            "    }\n" +
-                                                            "  },\n" +
-                                                            "  \"errors\": [],\n" +
-                                                            "  \"i18nMessagesMap\": {},\n" +
-                                                            "  \"messages\": [],\n" +
-                                                            "  \"permissions\": []\n" +
+                                                            "    \"entity\": {\n" +
+                                                            "        \"jwt\": \"string\"\n" +
+                                                            "    },\n" +
+                                                            "    \"errors\": [],\n" +
+                                                            "    \"i18nMessagesMap\": {},\n" +
+                                                            "    \"messages\": [],\n" +
+                                                            "    \"pagination\": null,\n" +
+                                                            "    \"permissions\": []\n" +
                                                             "}"
                                             )
                                     }
                             )
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad request"),
+                    @ApiResponse(responseCode = "401", description = "Invalid user"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "404", description = "Token not found"),
                     @ApiResponse(responseCode = "500", description = "Unexpected server error")
             }
     )
@@ -735,7 +740,7 @@ public class ApiTokenResource implements Serializable {
             @Context final HttpServletResponse response,
             @PathParam("tokenId") @Parameter(
                     required = true,
-                    description = "Identifier for the api token getting its json web token retrieved.",
+                    description = "Identifier of API token to receive a new JWT.",
                     schema = @Schema(type = "string")
             )final String tokenId) {
 
@@ -762,52 +767,35 @@ public class ApiTokenResource implements Serializable {
 
 
     @PUT
-    @Path("/users/{userid}/revoke")
+    @Path("/users/{userId}/revoke")
     @JSONP
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
+    @Hidden // This one doesn't seem to work; on 200 response, no token is revoked.
     @Operation(operationId = "putRevokeUserToken",
             summary = "Revokes specified token from user",
-            description = "This operation takes in a user id and retrieves any tokens associated to the user.\n\n" +
-                    "If the user token is not null, then this token will be invalidated and revoked.",
-            tags = {"Api Token"},
+            description = "This operation revokes all API tokens associated with a user. Usable only by administrators.",
+            tags = {"API Token"},
             responses = {
-                    @ApiResponse(responseCode = "200", description = "Token revoked successfully",
+                    @ApiResponse(responseCode = "200", description = "Tokens revoked successfully",
                             content = @Content(mediaType = "application/json",
                                     schema = @Schema(implementation = RemoteAPITokenForm.class)
                             )
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad request"),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized to remove tokens"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
                     @ApiResponse(responseCode = "404", description = "User not found"),
                     @ApiResponse(responseCode = "500", description = "Unexpected server error")
             })
     public final Response revokeUserToken(@Context final HttpServletRequest request,
             @Context final HttpServletResponse response,
-            @PathParam("userid") @Parameter(
+            @PathParam("userId") @Parameter(
                     required = true,
-                    description = "Identification of the user whose user token is being revoked.",
+                    description = "Identifier of user to have all tokens revoked.",
                     schema = @Schema(type = "string")
-            )
-            @RequestBody(description = "PUT body conists of a JSON object containing the `userID` of the user whose tokens are being revoked.",
-                    required = true,
-                    content = @Content(
-                            examples = {
-                                    @ExampleObject(
-                                            value = "{\n" +
-                                                    "  \"entity\": {\n" +
-                                                    "    \"revoked\": \"string\"\n" +
-                                                    "  },\n" +
-                                                    "  \"errors\": [],\n" +
-                                                    "  \"i18nMessagesMap\": {},\n" +
-                                                    "  \"messages\": [],\n" +
-                                                    "  \"permissions\": []\n" +
-                                                    "}"
-                                    )
-                            }
-                    ))
-            final String userid) throws DotSecurityException, DotDataException {
+            ) final String userId) throws DotSecurityException, DotDataException {
 
         final InitDataObject initDataObject = new WebResource.InitBuilder(this.webResource).rejectWhenNoUser(true)
                 .requestAndResponse(request, response).requiredPortlet("users")
@@ -817,14 +805,14 @@ public class ApiTokenResource implements Serializable {
         if (APILocator.getRoleAPI().doesUserHaveRole(initDataObject.getUser(), APILocator.getRoleAPI().loadCMSAdminRole())) {
 
             final User user      = initDataObject.getUser();
-            final User userToken = APILocator.getUserAPI().loadUserById(userid);
+            final User userToken = APILocator.getUserAPI().loadUserById(userId);
 
             if (null != userToken) {
 
-                SecurityLogger.logInfo(this.getClass(), "Revoking token " + userid + " from " + request.getRemoteAddr() + " ");
+                SecurityLogger.logInfo(this.getClass(), "Revoking token " + userId + " from " + request.getRemoteAddr() + " ");
                 userToken.setSkinId(UUIDGenerator.generateUuid()); // setting a new id will invalidate the token
                 APILocator.getUserAPI().save(userToken, user, PageMode.get(request).respectAnonPerms); // this will invalidate
-                return Response.ok(new ResponseEntityView(Map.of("revoked", userid), EMPTY_MAP)).build(); // 200
+                return Response.ok(new ResponseEntityView(Map.of("revoked", userId), EMPTY_MAP)).build(); // 200
             }
         } else {
 
@@ -844,11 +832,11 @@ public class ApiTokenResource implements Serializable {
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
-    @Operation(operationId = "putRevokeUsersToken",
-            summary = "Revokes users' tokens from list of tokens",
-            description = "This operation checks if user has an admin role and retrieves all user tokens.\n\n" +
-                    "Once all user tokens are received, each are invalidated and returned as a list of revoked tokens.",
-            tags = {"Api Token"},
+    @Hidden // This one doesn't seem to work; revokes no tokens for any user.
+    @Operation(operationId = "putRevokeAllUsersTokens",
+            summary = "Revokes all users' tokens",
+            description = "This operation revokes all tokens for all users. Usable only by administrators.",
+            tags = {"API Token"},
             responses = {
                     @ApiResponse(responseCode = "200", description = "User tokens successfully revoked",
                             content = @Content(mediaType = "application/json",
@@ -868,6 +856,7 @@ public class ApiTokenResource implements Serializable {
                             )
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad request"),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized to remove tokens"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
                     @ApiResponse(responseCode = "500", description = "Unexpected server error")
             })

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
@@ -103,7 +103,6 @@ public class ApiTokenResource implements Serializable {
     @JSONP
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
-    @Consumes({MediaType.APPLICATION_JSON})
     @Operation(operationId = "getApiTokensByUserId",
             summary = "Retrieves API tokens based on a user ID",
             description = "Accepts a user identifier and returns a list of API tokens associated with that user.\n\n" +
@@ -169,7 +168,7 @@ public class ApiTokenResource implements Serializable {
             @QueryParam("showRevoked") @Parameter(
                     description = "Determines whether revoked tokens are shown. Defaults to `false` if omitted.",
                     schema = @Schema(type = "boolean")
-            )final boolean showRevoked) {
+            ) final boolean showRevoked) {
 
 
         final InitDataObject initDataObject = this.webResource.init(null, true, request, true, "users");
@@ -183,7 +182,6 @@ public class ApiTokenResource implements Serializable {
     @JSONP
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
-    @Consumes({MediaType.APPLICATION_JSON})
     @Operation(operationId = "putRevokeTokenById",
             summary = "Revokes an API token",
             description = "Revokes a token by its identifier.\n\n Returned entity contains the " +
@@ -270,7 +268,6 @@ public class ApiTokenResource implements Serializable {
     @JSONP
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
-    @Consumes(MediaType.APPLICATION_JSON)
     @Operation(operationId = "deleteApiTokenById",
             summary = "Deletes an API token",
             description = "Deletes an API token by identifier. May be performed on either active, expired, or revoked.\n\n" +
@@ -361,7 +358,6 @@ public class ApiTokenResource implements Serializable {
      * @return Response
      */
     @POST
-    //@Path("/") testing before full deletion
     @JSONP
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
@@ -703,7 +699,6 @@ public class ApiTokenResource implements Serializable {
     @Path("/{tokenId}/jwt")
     @JSONP
     @NoCache
-    @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Operation(operationId = "getGetJwtFromApiToken",
             summary = "Generates a new JWT for an existing token",
@@ -742,7 +737,7 @@ public class ApiTokenResource implements Serializable {
                     required = true,
                     description = "Identifier of API token to receive a new JWT.",
                     schema = @Schema(type = "string")
-            )final String tokenId) {
+            ) final String tokenId) {
 
         final InitDataObject initDataObject = this.webResource.init(null, true, request, true, "users");
         final User user = initDataObject.getUser();
@@ -770,7 +765,6 @@ public class ApiTokenResource implements Serializable {
     @Path("/users/{userId}/revoke")
     @JSONP
     @NoCache
-    @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Hidden // This one doesn't seem to work; on 200 response, no token is revoked.
     @Operation(operationId = "putRevokeUserToken",
@@ -830,7 +824,6 @@ public class ApiTokenResource implements Serializable {
     @Path("/users/revoke")
     @JSONP
     @NoCache
-    @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Hidden // This one doesn't seem to work; revokes no tokens for any user.
     @Operation(operationId = "putRevokeAllUsersTokens",

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/RemoteAPITokenForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/RemoteAPITokenForm.java
@@ -8,33 +8,33 @@ import java.util.Map;
 @JsonDeserialize(builder = RemoteAPITokenForm.Builder.class)
 public class RemoteAPITokenForm {
     private TokenInfo token;
-    private RemoteHostInfo remoteHostInfo;
-    private AuthInfo authInfo;
+    private RemoteHostInfo remote;
+    private AuthInfo auth;
 
     private RemoteAPITokenForm(Builder builder) {
         this.token = builder.getToken();
-        this.remoteHostInfo = builder.getRemoteHostInfo();
-        this.authInfo = builder.getAuthInfo();
+        this.remote = builder.getRemote();
+        this.auth = builder.getAuth();
     }
 
     public String host(){
-        return remoteHostInfo.host;
+        return remote.host;
     }
 
     public String protocol(){
-        return remoteHostInfo.protocol;
+        return remote.protocol;
     }
 
     public int port(){
-        return remoteHostInfo.port;
+        return remote.port;
     }
 
     public String login(){
-        return authInfo.login;
+        return auth.login;
     }
 
     public String password(){
-        return authInfo.password;
+        return auth.password;
     }
 
     public Map<String, Object> getTokenInfo(){
@@ -64,11 +64,11 @@ public class RemoteAPITokenForm {
             return token;
         }
 
-        public RemoteAPITokenForm.RemoteHostInfo getRemoteHostInfo() {
+        public RemoteHostInfo getRemote() {
             return remote;
         }
 
-        public RemoteAPITokenForm.AuthInfo getAuthInfo() {
+        public AuthInfo getAuth() {
             return auth;
         }
     }


### PR DESCRIPTION
This addresses everything raised in [this IQA doc](https://docs.google.com/document/d/1_z7j9sRbIlZv-aIjj1eBlOY8TU014cTCDsej6W6MF-A/edit), and then further issues I found while working on that initial batch. I won't go point by point on this in the bullets below, because it's quite a lot and I've completely lost track of them all. But I'll list the biggest ones I can remember.

### Proposed Changes
* All concerns in document addressed
* Both forms edited
    * ApiTokenForm got a couple of `@Hidden` annotations for unnecessary props
    * RemoteApiTokenForm had a bunch of variables renamed so error messages make more sense if a key property is omitted.
* Both user-based revocation endpoints have been `@Hidden`, as neither of them appears to work.
    * (Also found another unrelated bug in the API token UI; separate issue forthcoming. )
        * EDIT: https://github.com/dotCMS/core/issues/30268 is the issue, and it turns out not to be unrelated at all. Removing unnecessary `@Consumes` annotations fixes it, so the current PR will resolve it. Shoutout to @valentinogiardino for his sharp eye!
* Various text fixes
* Various schema fixes
* Various response example fixes
* Several endpoint descriptions corrected
* Various request body description and/or example fixes
* Tag adjustment



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

This PR fixes: #29742