### PR TITLE
chore(dotcms-ui): Fix error with autocomplete #30249

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/common.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/common.scss
@@ -65,8 +65,8 @@ $select-border-size: 2px;
     background: $color-palette-gray-200;
     color: $color-palette-primary;
     width: $field-height-md;
-    border-top-right-radius: $border-radius-md;
-    border-bottom-right-radius: $border-radius-md;
+    border-top-left-radius: $border-radius-md;
+    border-bottom-left-radius: $border-radius-md;
     height: 100%;
 }
 

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/common.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/common.scss
@@ -65,8 +65,8 @@ $select-border-size: 2px;
     background: $color-palette-gray-200;
     color: $color-palette-primary;
     width: $field-height-md;
-    border-top-left-radius: $border-radius-md;
-    border-bottom-left-radius: $border-radius-md;
+    border-top-right-radius: $border-radius-md;
+    border-bottom-right-radius: $border-radius-md;
     height: 100%;
 }
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.html
@@ -13,8 +13,7 @@
         data-testId="autocomplete"
         inputId="auto-complete-input"
         appendTo="body"
-        dotSelectItem
-        />
+        dotSelectItem />
     @if (hasClasses) {
         <ul data-testId="list">
             <li>

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.html
@@ -1,20 +1,21 @@
 <div class="dialog__auto-complete-container field">
-    @let isJsonClasses = $isJsonClasses();
+    @let hasClasses = $hasClasses();
     <p-autoComplete
         (completeMethod)="filterClasses($event)"
         [(ngModel)]="$selectedClasses"
         [unique]="true"
         [suggestions]="$filteredSuggestions()"
-        [size]="446"
         [multiple]="true"
-        [dropdown]="isJsonClasses"
+        [dropdown]="hasClasses"
         [autofocus]="true"
+        dropdownMode="blank"
         class="p-fluid"
-        dotSelectItem
         data-testId="autocomplete"
         inputId="auto-complete-input"
-        appendTo="body" />
-    @if (isJsonClasses) {
+        appendTo="body"
+        dotSelectItem
+        />
+    @if (hasClasses) {
         <ul data-testId="list">
             <li>
                 <i class="pi pi-info-circle"></i>

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.scss
@@ -10,7 +10,7 @@
     justify-content: flex-end;
 }
 
-:host ::ng-deep p-autoComplete {
+:host ::ng-deep p-autocomplete {
     margin-bottom: $spacing-3;
     display: block;
     .p-autocomplete-dropdown.p-element.p-button {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.scss
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.scss
@@ -10,9 +10,13 @@
     justify-content: flex-end;
 }
 
-p-autoComplete {
+:host ::ng-deep p-autoComplete {
     margin-bottom: $spacing-3;
     display: block;
+    .p-autocomplete-dropdown.p-element.p-button {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
 }
 
 ul {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.spec.ts
@@ -84,7 +84,6 @@ describe('AddStyleClassesDialogComponent', () => {
             expect(autocomplete.unique).toBe(true);
             expect(autocomplete.autofocus).toBe(true);
             expect(autocomplete.multiple).toBe(true);
-            expect(autocomplete.size).toBe(446);
             expect(autocomplete.inputId).toBe('auto-complete-input');
             expect(autocomplete.appendTo).toBe('body');
             expect(autocomplete.dropdown).toBe(true);

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it } from '@jest/globals';
 import { createFakeEvent } from '@ngneat/spectator';
 import { Spectator, byTestId, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
-import { of, throwError } from 'rxjs';
+import { of } from 'rxjs';
 
 import { provideHttpClient } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
@@ -68,7 +68,7 @@ describe('AddStyleClassesDialogComponent', () => {
                         }
                     }),
                     mockProvider(JsonClassesService, {
-                        getClasses: jest.fn().mockReturnValue(of({ classes: ['class1', 'class2'] }))
+                        getClasses: jest.fn().mockReturnValue(of(['class1', 'class2']))
                     })
                 ]
             });
@@ -169,7 +169,7 @@ describe('AddStyleClassesDialogComponent', () => {
                         provide: JsonClassesService,
                         useValue: {
                             getClasses() {
-                                return of({ classes: [] });
+                                return of([]);
                             }
                         }
                     }
@@ -200,94 +200,4 @@ describe('AddStyleClassesDialogComponent', () => {
         });
     });
 
-    describe('bad format json', () => {
-        beforeEach(() => {
-            spectator = createComponent({
-                providers: [
-                    ...providers,
-                    {
-                        provide: DynamicDialogConfig,
-                        useValue: {
-                            data: {
-                                selectedClasses: []
-                            }
-                        }
-                    },
-                    {
-                        provide: JsonClassesService,
-                        useValue: {
-                            getClasses() {
-                                return of({ badFormat: ['class1'] });
-                            }
-                        }
-                    }
-                ]
-            });
-
-            jsonClassesService = spectator.inject(JsonClassesService, true);
-            dialogRef = spectator.inject(DynamicDialogRef);
-            autocomplete = spectator.query(AutoComplete);
-        });
-
-        it('should set dropdown to false in autocomplete', () => {
-            spectator.detectChanges();
-            expect(autocomplete.dropdown).toBe(false);
-        });
-
-        it('should set component.classes empty', () => {
-            spectator.detectChanges();
-
-            expect(spectator.component.$classes()).toEqual([]);
-        });
-
-        it('should have multiples help message', () => {
-            spectator.detectChanges();
-            const list = spectator.query(byTestId('list'));
-
-            expect(list.textContent).toContain('no suggestions setup suggestions');
-        });
-    });
-
-    describe('error', () => {
-        beforeEach(() => {
-            spectator = createComponent({
-                providers: [
-                    ...providers,
-                    {
-                        provide: DynamicDialogConfig,
-                        useValue: {
-                            data: {
-                                selectedClasses: []
-                            }
-                        }
-                    },
-                    {
-                        provide: JsonClassesService,
-                        useValue: {
-                            getClasses() {
-                                return throwError(
-                                    new Error('An error occurred while fetching classes')
-                                );
-                            }
-                        }
-                    }
-                ]
-            });
-
-            jsonClassesService = spectator.inject(JsonClassesService, true);
-            dialogRef = spectator.inject(DynamicDialogRef);
-            autocomplete = spectator.query(AutoComplete);
-        });
-
-        it('should set dropdown to false in autocomplete', () => {
-            spectator.detectChanges();
-            expect(autocomplete.dropdown).toBe(false);
-        });
-
-        it('should set component.classes empty', () => {
-            spectator.detectChanges();
-
-            expect(spectator.component.$classes()).toEqual([]);
-        });
-    });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.spec.ts
@@ -199,5 +199,4 @@ describe('AddStyleClassesDialogComponent', () => {
             expect(list.textContent).toContain('no suggestions setup suggestions');
         });
     });
-
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.stories.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.stories.ts
@@ -1,7 +1,7 @@
 import { Meta, moduleMetadata, StoryObj, applicationConfig } from '@storybook/angular';
 import { of } from 'rxjs';
 
-import { HttpClient, provideHttpClient } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -47,17 +47,16 @@ const meta: Meta<AddStyleClassesDialogComponent> = {
                     }
                 },
                 {
-                    provide: HttpClient,
-                    useValue: {
-                        get: (_: string) => of(MOCK_STYLE_CLASSES_FILE)
-                    }
-                },
-                {
                     provide: DotMessageService,
                     useValue: DOT_MESSAGE_SERVICE_TB_MOCK
                 },
                 DynamicDialogRef,
-                JsonClassesService
+                {
+                    provide: JsonClassesService,
+                    useValue: {
+                        getClasses: () => of(MOCK_STYLE_CLASSES_FILE.classes)
+                    }
+                }
             ]
         })
     ]

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
@@ -1,5 +1,3 @@
-import { of } from 'rxjs';
-
 import {
     ChangeDetectionStrategy,
     Component,
@@ -11,15 +9,14 @@ import {
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 
-import { AutoCompleteModule } from 'primeng/autocomplete';
+import { AutoCompleteCompleteEvent, AutoCompleteModule } from 'primeng/autocomplete';
 import { ButtonModule } from 'primeng/button';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-
-import { catchError, map, shareReplay, tap } from 'rxjs/operators';
 
 import { DotMessagePipe, DotSelectItemDirective } from '@dotcms/ui';
 
 import { JsonClassesService } from './services/json-classes.service';
+
 
 @Component({
     selector: 'dotcms-add-style-classes-dialog',
@@ -49,17 +46,12 @@ export class AddStyleClassesDialogComponent implements OnInit {
      * @memberof AddStyleClassesDialogComponent
      */
     readonly #dialogRef = inject(DynamicDialogRef);
+    readonly #dynamicDialogConfig = inject(DynamicDialogConfig<{selectedClasses: string[]}>);
     /**
      * Selected classes to be added
      * @memberof AddStyleClassesDialogComponent
      */
     $selectedClasses = signal<string[]>([]);
-    /**
-     * Classes to be displayed
-     *
-     * @memberof AddStyleClassesDialogComponent
-     */
-    $classes = signal<string[]>([]);
     /**
      * Query to filter the classes
      *
@@ -67,55 +59,23 @@ export class AddStyleClassesDialogComponent implements OnInit {
      */
     $query = signal<string | null>(null);
     /**
-     * Filtered suggestions based on the query
-     *
-     * @memberof AddStyleClassesDialogComponent
-     */
-    $filteredSuggestions = computed(() => {
-        const classes = this.$classes();
-        const query = this.$query();
-
-        if (!query) {
-            return classes;
-        }
-
-        return classes.filter((item) => item.includes(query));
-    });
-    /**
-     * Check if there are classes in the JSON file
-     *
-     * @memberof AddStyleClassesDialogComponent
-     */
-    isJsonClasses$ = this.#jsonClassesService.getClasses().pipe(
-        tap(({ classes }) => {
-            if (classes?.length) {
-                this.$classes.set(classes);
-            } else {
-                this.$classes.set([]);
-            }
-        }),
-        map(({ classes }) => !!classes?.length),
-        catchError(() => {
-            this.$classes.set([]);
-
-            return of(false);
-        }),
-        shareReplay(1)
-    );
-    /**
      * Check if the JSON file has classes
      *
      * @memberof AddStyleClassesDialogComponent
      */
-    $isJsonClasses = toSignal(this.isJsonClasses$, {
-        initialValue: false
+    $classes = toSignal(this.#jsonClassesService.getClasses(), {
+        initialValue: []
     });
+    /**
+     * Filtered suggestions based on the query
+     *
+     * @memberof AddStyleClassesDialogComponent
+     */
+    $filteredSuggestions = signal<string[]>(this.$classes());
 
-    constructor(
-        public dynamicDialogConfig: DynamicDialogConfig<{
-            selectedClasses: string[];
-        }>
-    ) {}
+    $hasClasses = computed(() => this.$classes().length > 0);
+
+
 
     /**
      * Set the selected classes
@@ -123,10 +83,7 @@ export class AddStyleClassesDialogComponent implements OnInit {
      * @memberof AddStyleClassesDialogComponent
      */
     ngOnInit() {
-        const data = this.dynamicDialogConfig.data;
-        if (data) {
-            this.$selectedClasses.set(data.selectedClasses);
-        }
+        this.$selectedClasses.set(this.#dynamicDialogConfig?.data?.selectedClasses || []);
     }
 
     /**
@@ -136,15 +93,10 @@ export class AddStyleClassesDialogComponent implements OnInit {
      * @return {*}
      * @memberof AddStyleClassesDialogComponent
      */
-    filterClasses({ query }: { query: string }): void {
-        /*
-            https://github.com/primefaces/primeng/blob/master/src/app/components/autocomplete/autocomplete.ts#L739
-
-            Sadly we need to pass suggestions all the time, even if they are empty because on the set is where the primeng remove the loading icon
-        */
-
-        // PrimeNG autocomplete doesn't support async pipe in the suggestions
-        this.$query.set(query);
+    filterClasses({ query }: AutoCompleteCompleteEvent): void {
+        const classes = this.$classes();
+        const filteredClasses = query ? classes.filter((item) => item.includes(query)) : classes;
+        this.$filteredSuggestions.set([...filteredClasses]);
     }
 
     /**

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
@@ -17,7 +17,6 @@ import { DotMessagePipe, DotSelectItemDirective } from '@dotcms/ui';
 
 import { JsonClassesService } from './services/json-classes.service';
 
-
 @Component({
     selector: 'dotcms-add-style-classes-dialog',
     standalone: true,
@@ -46,7 +45,7 @@ export class AddStyleClassesDialogComponent implements OnInit {
      * @memberof AddStyleClassesDialogComponent
      */
     readonly #dialogRef = inject(DynamicDialogRef);
-    readonly #dynamicDialogConfig = inject(DynamicDialogConfig<{selectedClasses: string[]}>);
+    readonly #dynamicDialogConfig = inject(DynamicDialogConfig<{ selectedClasses: string[] }>);
     /**
      * Selected classes to be added
      * @memberof AddStyleClassesDialogComponent
@@ -74,8 +73,6 @@ export class AddStyleClassesDialogComponent implements OnInit {
     $filteredSuggestions = signal<string[]>(this.$classes());
 
     $hasClasses = computed(() => this.$classes().length > 0);
-
-
 
     /**
      * Set the selected classes

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
@@ -91,6 +91,10 @@ export class AddStyleClassesDialogComponent implements OnInit {
      * @memberof AddStyleClassesDialogComponent
      */
     filterClasses({ query }: AutoCompleteCompleteEvent): void {
+        /*
+            https://github.com/primefaces/primeng/blob/master/src/app/components/autocomplete/autocomplete.ts#L541
+            Sadly we need to pass suggestions all the time, even if they are empty because on the set is where the primeng remove the loading icon
+        */
         const classes = this.$classes();
         const filteredClasses = query ? classes.filter((item) => item.includes(query)) : classes;
         this.$filteredSuggestions.set([...filteredClasses]);

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/add-style-classes-dialog.component.ts
@@ -52,12 +52,6 @@ export class AddStyleClassesDialogComponent implements OnInit {
      */
     $selectedClasses = signal<string[]>([]);
     /**
-     * Query to filter the classes
-     *
-     * @memberof AddStyleClassesDialogComponent
-     */
-    $query = signal<string | null>(null);
-    /**
      * Check if the JSON file has classes
      *
      * @memberof AddStyleClassesDialogComponent

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.spec.ts
@@ -5,31 +5,31 @@ import { JsonClassesService, STYLE_CLASSES_FILE_URL } from './json-classes.servi
 import { MOCK_STYLE_CLASSES_FILE } from '../../../utils/mocks';
 
 describe('JsonClassesService', () => {
-  let spectator: SpectatorHttp<JsonClassesService>;
-  const createHttp = createHttpFactory(JsonClassesService);
+    let spectator: SpectatorHttp<JsonClassesService>;
+    const createHttp = createHttpFactory(JsonClassesService);
 
-  beforeEach(() => spectator = createHttp());
+    beforeEach(() => (spectator = createHttp()));
 
-  it('should be requested to the expected URL', () => {
-    spectator.service.getClasses().subscribe();
-    spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
-  });
+    it('should be requested to the expected URL', () => {
+        spectator.service.getClasses().subscribe();
+        spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
+    });
 
-  it('should return all classes', () => {
-    spectator.service.getClasses().subscribe();
+    it('should return all classes', () => {
+        spectator.service.getClasses().subscribe();
 
-    const req = spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
-    expect(req.request.body).toEqual(MOCK_STYLE_CLASSES_FILE.classes);
+        const req = spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
+        expect(req.request.body).toEqual(MOCK_STYLE_CLASSES_FILE.classes);
 
-    req.flush(MOCK_STYLE_CLASSES_FILE);
-  });
+        req.flush(MOCK_STYLE_CLASSES_FILE);
+    });
 
-  it('should return an empty array with a error', () => {
-    spectator.service.getClasses().subscribe();
+    it('should return an empty array with a error', () => {
+        spectator.service.getClasses().subscribe();
 
-    const req = spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
-    expect(req.request.body).toEqual([]);
+        const req = spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
+        expect(req.request.body).toEqual([]);
 
-    req.flush('', { status: 404 });
-  });
+        req.flush('', { status: 404 });
+    });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.spec.ts
@@ -16,20 +16,32 @@ describe('JsonClassesService', () => {
     });
 
     it('should return all classes', () => {
-        spectator.service.getClasses().subscribe();
+        spectator.service.getClasses().subscribe((res) => {
+            expect(res).toEqual(MOCK_STYLE_CLASSES_FILE.classes);
+        });
 
         const req = spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
-        expect(req.request.body).toEqual(MOCK_STYLE_CLASSES_FILE.classes);
 
         req.flush(MOCK_STYLE_CLASSES_FILE);
     });
 
     it('should return an empty array with a error', () => {
-        spectator.service.getClasses().subscribe();
+        spectator.service.getClasses().subscribe((res) => {
+            expect(res).toEqual([]);
+        });
 
         const req = spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
-        expect(req.request.body).toEqual([]);
 
-        req.flush('', { status: 404 });
+        req.flush('', { status: 404, statusText: 'Not Found' });
+    });
+
+    it('should return an empty array with a bad format', () => {
+        spectator.service.getClasses().subscribe((res) => {
+            expect(res).toEqual([]);
+        });
+
+        const req = spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
+
+        req.flush({ bad: 'format' });
     });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.spec.ts
@@ -1,38 +1,35 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { TestBed, getTestBed } from '@angular/core/testing';
+import { createHttpFactory, HttpMethod, SpectatorHttp } from '@ngneat/spectator';
 
 import { JsonClassesService, STYLE_CLASSES_FILE_URL } from './json-classes.service';
 
+import { MOCK_STYLE_CLASSES_FILE } from '../../../utils/mocks';
+
 describe('JsonClassesService', () => {
-    let injector: TestBed;
-    let service: JsonClassesService;
-    let httpMock: HttpTestingController;
+  let spectator: SpectatorHttp<JsonClassesService>;
+  const createHttp = createHttpFactory(JsonClassesService);
 
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [JsonClassesService]
-        });
+  beforeEach(() => spectator = createHttp());
 
-        injector = getTestBed();
-        service = injector.inject(JsonClassesService);
-        httpMock = injector.inject(HttpTestingController);
-    });
+  it('should be requested to the expected URL', () => {
+    spectator.service.getClasses().subscribe();
+    spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
+  });
 
-    afterEach(() => {
-        httpMock.verify();
-    });
+  it('should return all classes', () => {
+    spectator.service.getClasses().subscribe();
 
-    it('should return an Observable with classes', () => {
-        const expectedClasses = { classes: ['class1', 'class2', 'class3'] };
-        // httpClientSpy.get.and.returnValue(of(expectedClasses));
+    const req = spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
+    expect(req.request.body).toEqual(MOCK_STYLE_CLASSES_FILE.classes);
 
-        service.getClasses().subscribe((classes) => {
-            expect(classes).toEqual(expectedClasses);
-        });
+    req.flush(MOCK_STYLE_CLASSES_FILE);
+  });
 
-        const req = httpMock.expectOne(STYLE_CLASSES_FILE_URL);
-        expect(req.request.method).toBe('GET');
-        req.flush(expectedClasses);
-    });
+  it('should return an empty array with a error', () => {
+    spectator.service.getClasses().subscribe();
+
+    const req = spectator.expectOne(STYLE_CLASSES_FILE_URL, HttpMethod.GET);
+    expect(req.request.body).toEqual([]);
+
+    req.flush('', { status: 404 });
+  });
 });

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.ts
@@ -1,15 +1,22 @@
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
+
+import { catchError, map } from 'rxjs/operators';
+
+import { MOCK_STYLE_CLASSES_FILE } from '../../../utils/mocks';
 
 export const STYLE_CLASSES_FILE_URL = '/application/templates/classes.json';
 
 @Injectable()
 export class JsonClassesService {
-    constructor(private http: HttpClient) {}
+    readonly #http = inject(HttpClient);
 
-    getClasses(): Observable<{ classes: string[] }> {
-        return this.http.get<{ classes: string[] }>(STYLE_CLASSES_FILE_URL);
+    getClasses(): Observable<string[]> {
+        return this.#http.get<{ classes: string[] }>(STYLE_CLASSES_FILE_URL).pipe(
+            map((res) => res.classes),
+            catchError(() => of(MOCK_STYLE_CLASSES_FILE.classes))
+        );
     }
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.ts
@@ -5,8 +5,6 @@ import { inject, Injectable } from '@angular/core';
 
 import { catchError, map } from 'rxjs/operators';
 
-import { MOCK_STYLE_CLASSES_FILE } from '../../../utils/mocks';
-
 export const STYLE_CLASSES_FILE_URL = '/application/templates/classes.json';
 
 @Injectable()
@@ -16,7 +14,7 @@ export class JsonClassesService {
     getClasses(): Observable<string[]> {
         return this.#http.get<{ classes: string[] }>(STYLE_CLASSES_FILE_URL).pipe(
             map((res) => res.classes),
-            catchError(() => of(MOCK_STYLE_CLASSES_FILE.classes))
+            catchError(() => of([]))
         );
     }
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-style-classes-dialog/services/json-classes.service.ts
@@ -13,7 +13,7 @@ export class JsonClassesService {
 
     getClasses(): Observable<string[]> {
         return this.#http.get<{ classes: string[] }>(STYLE_CLASSES_FILE_URL).pipe(
-            map((res) => res.classes),
+            map((res) => res?.classes || []),
             catchError(() => of([]))
         );
     }


### PR DESCRIPTION
### Parent Issue
#30249 

### Proposed Changes
* Change singal approach

### The problem

This computed signal caused the error:

```ts
$filteredSuggestions = computed(() => {
    const classes = this.$classes();
    const query = this.$query();

    if (!query) {
        return classes;
    }

    return classes.filter((item) => item.includes(query));
});

filterClasses({ query }: AutoCompleteCompleteEvent): void {
    this.$query.set(query);
}
```

The signals functionality in PrimeNg doesn't works very well. In the previous signal, `$filteredSuggestions` doesn't trigger a change if the classes or query are the same as the current state. This is desirable. However, PrimeNg [waits](https://github.com/primefaces/primeng/blob/d6c7ffcfc5cb9a8ed355399ddae276c279836ccf/src/app/components/autocomplete/autocomplete.ts#L541) for a change in the `suggestions` input after the `completeMethod` is called to turn off the loading. This is why the loading indicator remains active but never deactivates.

To address this, we manually forced a change in `$filteredSuggestions` and used `[...filteredClasses]` to create a new array.

```ts
filterClasses({ query }: AutoCompleteCompleteEvent): void {
      const classes = this.$classes();
      const filteredClasses = query ? classes.filter((item) => item.includes(query)) : classes;
      this.$filteredSuggestions.set([...filteredClasses]);
  }
```

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Screenshots


https://github.com/user-attachments/assets/5a199569-9192-4acb-89bd-3fb6530aefce



This PR fixes: #30249