### PR TITLE
fix(CLI): Updating the CLI version used by our CICD integration

### DIFF
--- a/tools/dotcms-cli/action/.github/workflows/main.yml
+++ b/tools/dotcms-cli/action/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       # This is how we instruct the cli to create the workspace if it does not exist
       DOT_CREATE_WORKSPACE: ${{ vars.DOT_CREATE_WORKSPACE || 'true' }}
       # This is the CLI version to use, but we can always override this value
-      DOT_CLI_JAR_DOWNLOAD_URL: ${{ vars.DOT_CLI_JAR_DOWNLOAD_URL || 'https://repo.dotcms.com/artifactory/libs-snapshot-local/com/dotcms/dotcms-cli/1.0.0-SNAPSHOT/dotcms-cli-1.0.0-20231002.205953-1.jar' }}
+      DOT_CLI_JAR_DOWNLOAD_URL: ${{ vars.DOT_CLI_JAR_DOWNLOAD_URL || 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/dotcms-cli/24.10.02/dotcms-cli-24.10.02-runner.jar' }}
       # In case we want to force the download of the CLI jar
       DOT_FORCE_DOWNLOAD: ${{ vars.DOT_FORCE_DOWNLOAD || 'false' }}
     steps:


### PR DESCRIPTION
### Proposed Changes
* The version of the CLI runner jar was outdated. It made the CICD integration failed.

I have manually updated the version as a temporary fix. However, this process will be automated [here](https://github.com/dotCMS/core/issues/30276) 
