### PR TITLE
fix: make @dotcms/angular support versioning 17 and up better

### DIFF
--- a/core-web/libs/sdk/angular/package.json
+++ b/core-web/libs/sdk/angular/package.json
@@ -2,12 +2,12 @@
   "name": "@dotcms/angular",
   "version": "0.0.1-alpha.38",
   "peerDependencies": {
-    "@angular/common": "^17.1.0",
-    "@angular/core": "^17.1.0",
-    "@angular/router": "^17.1.0",
-    "@dotcms/client": "0.0.1-alpha.38",
+    "@angular/common": ">=17.0.0",
+    "@angular/core": "=>17.0.0",
+    "@angular/router": "=>17.0.0",
+    "@dotcms/client": "latest",
     "@tinymce/tinymce-angular": "^8.0.0",
-    "rxjs": "^7.8.0"
+    "rxjs": ">=7.0.0"
   },
   "description": "Official Angular Components library to render a dotCMS page.",
   "repository": {


### PR DESCRIPTION
### Proposed Changes
* Make the library support angular `>=17.0.0`

This fix the error where you init a clean ng 18 project and if you try to `npm install @dotcms/angular@latest` you get this error:

```
npm i @dotcms/angular
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: test-dotcms-angular-sdk@0.0.0
npm error Found: @angular/common@18.2.7
npm error node_modules/@angular/common
npm error   @angular/common@"^18.2.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @angular/common@"^17.1.0" from @dotcms/angular@0.0.1-alpha.41
npm error node_modules/@dotcms/angular
npm error   @dotcms/angular@"*" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/fmontes/.npm/_logs/2024-10-07T21_55_21_800Z-eresolve-report.txt
npm error A complete log of this run can be found in: /Users/fmontes/.npm/_logs/2024-10-07T21_55_21_800Z-debug-0.log
```

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
