### PR TITLE
Issue 30291 osgi actionlet reinit failure

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java
@@ -140,6 +140,7 @@ import com.liferay.util.StringPool;
 import io.vavr.control.Try;
 import org.apache.commons.lang.time.StopWatch;
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
+import org.apache.felix.framework.OSGIUtil;
 import org.elasticsearch.search.query.QueryPhaseExecutionException;
 import org.osgi.framework.BundleContext;
 
@@ -367,16 +368,23 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 	}
 
 	public void registerBundleService () {
-		if(System.getProperty(WebKeys.OSGI_ENABLED)!=null){
-			// Register main service
-			BundleContext context = HostActivator.instance().getBundleContext();
-			if (null != context) {
-				Hashtable<String, String> props = new Hashtable<>();
-				context.registerService(WorkflowAPIOsgiService.class.getName(), this, props);
-			} else {
-				Logger.error(this, "Bundle Context is null, WorkflowAPIOsgiService has been not registered");
-			}
+
+		// force init if not already done
+		OSGIUtil.getInstance().initializeFramework();
+		if (System.getProperty(WebKeys.OSGI_ENABLED) == null) {
+			// OSGI is not inited
+			throw new DotRuntimeException("Unable to register WorkflowAPIOsgiService as OSGI is not inited");
 		}
+
+		BundleContext context = HostActivator.instance().getBundleContext();
+		if (context == null) {
+			throw new DotRuntimeException("Bundle Context is null, WorkflowAPIOsgiService has been not registered");
+		}
+		if (context.getServiceReference(WorkflowAPIOsgiService.class.getName()) == null) {
+			Hashtable<String, String> props = new Hashtable<>();
+			context.registerService(WorkflowAPIOsgiService.class.getName(), this, props);
+		}
+
 	}
 
 	/**
@@ -1690,7 +1698,7 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 
         return this.findAvailableActions(contentlet, user, RenderMode.EDITING);
     }
-	
+
 	 /**
      * This method will return the list of workflows actions available to a user on any give
      * piece of content, based on how and who has the content locked and what workflow step the content
@@ -1703,7 +1711,7 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 
 		return this.findAvailableActions(contentlet, user, RenderMode.LISTING);
     }
-	
+
 	/**
 	 * This method will return the list of workflows actions available to a user on any give
 	 * piece of content, based on how and who has the content locked and what workflow step the content
@@ -2224,13 +2232,13 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 			// Delete action class
 			final int orderOfActionClassToDelete = actionClass.getOrder();
 			workFlowFactory.deleteActionClass(actionClass);
-			
-			// We don't need to get "complete" base action object from the database 
+
+			// We don't need to get "complete" base action object from the database
 			// to retrieve all action classes from him. So, we can create the base action object
 			// with the "action id" contain in actionClass parameter.
 			WorkflowAction baseAction = new WorkflowAction();
 			baseAction.setId(actionClass.getActionId());
-			
+
 			// Reorder the action classes in the database
 			final List<WorkflowActionClass> actionClasses = findActionClasses(baseAction);
 			if((actionClasses.size() > 1) && (actionClasses.size() != orderOfActionClassToDelete)) {
@@ -2273,12 +2281,12 @@ public class WorkflowAPIImpl implements WorkflowAPI, WorkflowAPIOsgiService {
 
 			List<WorkflowActionClass> actionClasses = null;
 			try {
-				// We don't need to get "complete" base action object from the database 
+				// We don't need to get "complete" base action object from the database
 				// to retrieve all action classes from him. So, we can create the base action object
 				// with the "action id" contain in actionClass parameter.
 				final WorkflowAction baseAction = new WorkflowAction();
 				baseAction.setId(actionClass.getActionId());
-				
+
 				actionClasses = findActionClasses(baseAction);
 			} catch (Exception e) {
 				throw new DotDataException(e.getLocalizedMessage());


### PR DESCRIPTION
This pull request forces OSGI to init BEFORE an actionlet is registered.  It changes to the `WorkflowAPIImpl` class to improve OSGI initialization and error handling. The most important changes include adding a new import for `OSGIUtil`, modifying the `registerBundleService` method to ensure OSGI is initialized, and adding error handling for null `BundleContext`.

### Improvements to OSGI Initialization and Error Handling:

* [`dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java`](diffhunk://#diff-5a5ef615df4ac7495073609cffd31eabd85513c4c81dd48cc82b5c6fd0523934R143): Added import for `org.apache.felix.framework.OSGIUtil`.
* [`dotCMS/src/main/java/com/dotmarketing/portlets/workflows/business/WorkflowAPIImpl.java`](diffhunk://#diff-5a5ef615df4ac7495073609cffd31eabd85513c4c81dd48cc82b5c6fd0523934L370-R387): Modified `registerBundleService` method to initialize OSGI framework and added error handling for cases where OSGI is not initialized or `BundleContext` is null.

This PR fixes: #30291