### PR TITLE
fix(edit-content): Angular Observable Destruction Error

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/dot-edit-content-file-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/dot-edit-content-file-field.component.ts
@@ -8,7 +8,6 @@ import {
     OnInit,
     OnDestroy
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
@@ -234,14 +233,9 @@ export class DotEditContentFileFieldComponent implements ControlValueAccessor, O
             }
         });
 
-        this.#dialogRef.onClose
-            .pipe(
-                filter((file) => !!file),
-                takeUntilDestroyed()
-            )
-            .subscribe((file) => {
-                this.store.setPreviewFile(file);
-            });
+        this.#dialogRef.onClose.pipe(filter((file) => !!file)).subscribe((file) => {
+            this.store.setPreviewFile(file);
+        });
     }
 
     /**


### PR DESCRIPTION
### Error

![Screenshot 2024-10-08 at 4 23 49 PM](https://github.com/user-attachments/assets/4b3f2014-762d-4234-b21c-843356f7af86)


### Proposed Changes
* Remove the unnecessary `takeUntilDestroyed` because `this.#dialogRef.close();` [completes](https://github.com/primefaces/primeng/blob/d6c7ffcfc5cb9a8ed355399ddae276c279836ccf/src/app/components/dynamicdialog/dynamicdialog-ref.ts#L13) the observable.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Ref

https://github.com/primefaces/primeng/blob/d6c7ffcfc5cb9a8ed355399ddae276c279836ccf/src/app/components/dynamicdialog/dynamicdialog-ref.ts#L13