### PR TITLE
Fix (CLI): Fixed flaky test ContentTypeCommandIT.Test_Command_Content_Type_Folder_Push

### DIFF
--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/common/ContentTypesTestHelperService.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/common/ContentTypesTestHelperService.java
@@ -63,9 +63,6 @@ public class ContentTypesTestHelperService {
 
         final ContentTypeAPI contentTypeAPI = clientFactory.getClient(ContentTypeAPI.class);
 
-        final long identifier = System.currentTimeMillis();
-        final String varName = "var_" + identifier;
-
         final ImmutableSimpleContentType contentType = buildContentType(
                 null, null, detailPage, urlMapPattern
         );
@@ -74,7 +71,12 @@ public class ContentTypesTestHelperService {
                 from(contentType).build();
         contentTypeAPI.createContentTypes(List.of(saveRequest));
 
-        return varName;
+        // Make sure the content type is created, and we are giving the server some time to process
+        findContentType(contentType.variable()).orElseThrow(() -> new RuntimeException(
+                "Content type not found after creation: " + contentType.variable()
+        ));
+
+        return contentType.variable();
     }
 
     /**


### PR DESCRIPTION
This pull request updates the `createContentTypeOnServer` method in the `ContentTypesTestHelperService` class to improve content type creation and validation. The most important changes include removing unused variables and adding a validation step to ensure the content type is created successfully.

Codebase simplification and validation improvement:

* [`tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/common/ContentTypesTestHelperService.java`](diffhunk://#diff-aec7feeb63a6f9ad6aa941eff561882f257837e0a706ad26fe2625b0355ee3d5L66-L68): Removed unused variables `identifier` and `varName` from the `createContentTypeOnServer` method.
* [`tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/common/ContentTypesTestHelperService.java`](diffhunk://#diff-aec7feeb63a6f9ad6aa941eff561882f257837e0a706ad26fe2625b0355ee3d5L77-R79): Added a validation step to check if the content type is created successfully and throw an exception if not found.

This PR fixes: #30280