### PR TITLE
fix(perf)  don't create session if it is not required

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/variant/business/web/CurrentVariantWebInterceptor.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/business/web/CurrentVariantWebInterceptor.java
@@ -56,7 +56,7 @@ public class CurrentVariantWebInterceptor implements WebInterceptor {
         }
 
         if (!UtilMethods.isSet(currentVariantName)) {
-            final HttpSession session = request.getSession();
+            final HttpSession session = request.getSession(false);
 
             if (session != null) {
                 final Object attribute = session.getAttribute(VariantAPI.VARIANT_KEY);

--- a/dotCMS/src/main/java/com/dotcms/variant/business/web/VariantWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/variant/business/web/VariantWebAPIImpl.java
@@ -66,19 +66,21 @@ public class VariantWebAPIImpl implements VariantWebAPI{
             }
         }
 
-        setSessionAttribute(request, currentVariantName);
+        setSessionAttributeIfNeeded(request, currentVariantName);
         return currentVariantName;
     }
 
-    private static void setSessionAttribute(final HttpServletRequest request,
+    private static void setSessionAttributeIfNeeded(final HttpServletRequest request,
             final String currentVariantName) {
 
-        final HttpSession session = request.getSession(true);
+        boolean buildSessionIfNeeded = !"DEFAULT".equals(currentVariantName);
+
+        final HttpSession session = request.getSession(buildSessionIfNeeded);
 
         if (!UtilMethods.isSet(session)) {
             return;
         }
-        
+
         final Object attribute = session.getAttribute(VariantAPI.VARIANT_KEY);
 
         if (mustOverwrite(attribute, currentVariantName)) {


### PR DESCRIPTION
This pull request includes changes to improve session handling in the `CurrentVariantWebInterceptor` and `VariantWebAPIImpl` classes. The main focus is on ensuring sessions are only created when necessary, which can help optimize resource usage and performance.

Session handling improvements:

* [`dotCMS/src/main/java/com/dotcms/variant/business/web/CurrentVariantWebInterceptor.java`](diffhunk://#diff-65fdb30fd885a08035709f661b6cd0e1e4f4354bde74a4f3e1f6464e765d0731L59-R59): Modified `getSession` to avoid creating a new session if one does not already exist by passing `false` to `getSession`.
* [`dotCMS/src/main/java/com/dotcms/variant/business/web/VariantWebAPIImpl.java`](diffhunk://#diff-c67db85ad5a8303546f73462e9074d4cf3f669295e99d9ca050c4bd8ce25e7f2L69-R78): Renamed `setSessionAttribute` to `setSessionAttributeIfNeeded` and updated the method to conditionally create a session based on the `currentVariantName`.

This PR fixes: #30321