### PR TITLE
fix(UVE): UrlContentMap Redirection to Correct Page After Save or Publish #29896

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -54,7 +54,11 @@ import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.s
 import { DotPageApiService } from '../services/dot-page-api.service';
 import { DEFAULT_PERSONA, WINDOW } from '../shared/consts';
 import { FormStatus, NG_CUSTOM_EVENTS } from '../shared/enums';
-import { PAGE_RESPONSE_BY_LANGUAGE_ID, PAYLOAD_MOCK } from '../shared/mocks';
+import {
+    PAGE_RESPONSE_BY_LANGUAGE_ID,
+    PAGE_RESPONSE_URL_CONTENT_MAP,
+    PAYLOAD_MOCK
+} from '../shared/mocks';
 import { UVEStore } from '../store/dot-uve.store';
 
 describe('DotEmaShellComponent', () => {
@@ -961,7 +965,7 @@ describe('DotEmaShellComponent', () => {
 
                 expect(navigate).toHaveBeenCalledWith([], {
                     queryParams: {
-                        url: 'my-awesome-page'
+                        url: '/my-awesome-page'
                     },
                     queryParamsHandling: 'merge'
                 });
@@ -999,6 +1003,40 @@ describe('DotEmaShellComponent', () => {
                 spectator.triggerEventHandler(DotEmaDialogComponent, 'reloadFromDialog', null);
 
                 expect(reloadSpy).toHaveBeenCalled();
+            });
+
+            it('should trigger a store reload if the URL from urlContentMap is the same as the current URL', () => {
+                const reloadSpy = jest.spyOn(store, 'reload');
+                // Mocking the uveStore to return a urlContentMap with the same URL as the current one
+                jest.spyOn(store, 'pageAPIResponse').mockReturnValue(PAGE_RESPONSE_URL_CONTENT_MAP);
+                jest.spyOn(store, 'params').mockReturnValue({
+                    url: '/test-url',
+                    language_id: '1',
+                    'com.dotmarketing.persona.id': '1'
+                });
+
+                spectator.detectChanges();
+
+                spectator.triggerEventHandler(DotEmaDialogComponent, 'action', {
+                    event: new CustomEvent('ng-event', {
+                        detail: {
+                            name: NG_CUSTOM_EVENTS.SAVE_PAGE,
+                            payload: {
+                                htmlPageReferer: '/test-url'
+                            }
+                        }
+                    }),
+                    payload: PAYLOAD_MOCK,
+                    form: {
+                        status: FormStatus.SAVED,
+                        isTranslation: false
+                    }
+                });
+
+                spectator.detectChanges();
+
+                expect(reloadSpy).toHaveBeenCalled();
+                expect(router.navigate).not.toHaveBeenCalled();
             });
         });
     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -37,6 +37,7 @@ import { WINDOW } from '../shared/consts';
 import { FormStatus, NG_CUSTOM_EVENTS } from '../shared/enums';
 import { DialogAction, DotPage } from '../shared/models';
 import { UVEStore } from '../store/dot-uve.store';
+import { compareUrlPaths } from '../utils';
 
 @Component({
     selector: 'dot-ema-shell',
@@ -179,7 +180,7 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
      * @return {void}
      */
     private handleSavePageEvent(event: CustomEvent): void {
-        const url = this.extractUrl(event);
+        const url = this.extractPageRefererUrl(event);
         const targetUrl = this.getTargetUrl(url);
 
         if (this.shouldNavigate(targetUrl)) {
@@ -192,14 +193,13 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
         this.uveStore.reload();
     }
     /**
-     * Extracts the URL from the event payload.
+     * Extracts the htmlPageReferer url from the event payload.
      *
      * @param {CustomEvent} event - The event object containing the payload with the URL.
      * @return {string | undefined} - The extracted URL or undefined if not found.
      */
-    private extractUrl(event: CustomEvent): string | undefined {
-        // Remove leading slash and extract URL without query parameters
-        return event.detail.payload?.htmlPageReferer?.split('?')[0].replace('/', '');
+    private extractPageRefererUrl(event: CustomEvent): string | undefined {
+        return event.detail.payload?.htmlPageReferer;
     }
 
     /**
@@ -228,7 +228,7 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
         const currentUrl = this.uveStore.params().url;
 
         // Navigate if the target URL is defined and different from the current URL
-        return targetUrl !== undefined && currentUrl !== targetUrl;
+        return targetUrl !== undefined && !compareUrlPaths(targetUrl, currentUrl);
     }
 
     /**

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-toolbar/edit-ema-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-toolbar/edit-ema-toolbar.component.spec.ts
@@ -39,7 +39,9 @@ import { DEFAULT_PERSONA } from '../../../shared/consts';
 import {
     HEADLESS_BASE_QUERY_PARAMS,
     MOCK_RESPONSE_HEADLESS,
+    MOCK_RESPONSE_VTL,
     PAGE_RESPONSE_BY_LANGUAGE_ID,
+    PAGE_RESPONSE_URL_CONTENT_MAP,
     URL_CONTENT_MAP_MOCK
 } from '../../../shared/mocks';
 import { UVEStore } from '../../../store/dot-uve.store';
@@ -179,7 +181,9 @@ describe('EditEmaToolbarComponent', () => {
                         }),
                         setDevice: jest.fn(),
                         setSocialMedia: jest.fn(),
-                        params: signal(params)
+                        params: signal(params),
+                        pageAPIResponse: signal(MOCK_RESPONSE_VTL),
+                        reload: jest.fn()
                     })
                 ]
             });
@@ -445,6 +449,21 @@ describe('EditEmaToolbarComponent', () => {
                     },
                     queryParamsHandling: 'merge'
                 });
+            });
+
+            it('should trigger a store reload if the URL from urlContentMap is the same as the current URL', () => {
+                jest.spyOn(store, 'pageAPIResponse').mockReturnValue(PAGE_RESPONSE_URL_CONTENT_MAP);
+
+                spectator.triggerEventHandler(DotEditEmaWorkflowActionsComponent, 'newPage', {
+                    pageURI: '/test-url',
+                    url: '/test-url',
+                    languageId: 1
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                } as any);
+
+                spectator.detectChanges();
+                expect(store.reload).toHaveBeenCalled();
+                expect(router.navigate).not.toHaveBeenCalled();
             });
         });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-toolbar/edit-ema-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-toolbar/edit-ema-toolbar.component.ts
@@ -253,10 +253,21 @@ export class EditEmaToolbarComponent {
         });
     }
 
+    /**
+     * Determines whether navigation to a new page is necessary based on URL and language changes.
+     *
+     * @param {Params} params - The incoming parameters, including a new URL and language ID.
+     * @returns {boolean} - True if navigation to a new page is needed.
+     */
     private shouldNavigateToNewPage(params: Params): boolean {
         const { url: newUrl, language_id: newLanguageId } = params;
-        const { url, language_id } = this.uveStore.params();
+        const { url: currentUrl, language_id: currentLanguageId } = this.uveStore.params();
 
-        return !compareUrlPaths(newUrl, url) || newLanguageId != language_id;
+        // Determine the target URL, prioritizing the content map URL if available
+        const urlContentMap = this.uveStore.pageAPIResponse().urlContentMap;
+        const targetUrl = urlContentMap?.URL_MAP_FOR_CONTENT || newUrl;
+
+        // Return true if the URL paths are different or the language has changed
+        return !compareUrlPaths(currentUrl, targetUrl) || newLanguageId != currentLanguageId;
     }
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/mocks.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/mocks.ts
@@ -203,44 +203,6 @@ export const URL_CONTENT_MAP_MOCK = {
     URL_MAP_FOR_CONTENT: '/test-url'
 };
 
-export const PAGE_RESPONSE_URL_CONTENT_MAP = {
-    page: {
-        pageURI: 'test-url',
-        title: 'Test Page',
-        identifier: '123',
-        inode: '123-i',
-        canEdit: true,
-        canRead: true,
-        rendered: '<html><body><h1>Hello, World!</h1></body></html>',
-        contentType: 'htmlpageasset',
-        canLock: true,
-        locked: false,
-        lockedBy: '',
-        lockedByName: '',
-        live: true,
-        liveInode: '1234',
-        stInode: '12345'
-    },
-    viewAs: {
-        language: {
-            id: 1,
-            language: 'English',
-            countryCode: 'US',
-            languageCode: '1',
-            country: 'United States'
-        },
-
-        persona: {
-            ...DEFAULT_PERSONA
-        }
-    },
-    site: mockSites[0],
-    layout: mockDotLayout(),
-    template: mockDotTemplate(),
-    containers: mockDotContainers(),
-    urlContentMap: URL_CONTENT_MAP_MOCK
-};
-
 export const MOCK_RESPONSE_VTL: DotPageApiResponse = {
     page: {
         pageURI: 'test-url',
@@ -276,6 +238,11 @@ export const MOCK_RESPONSE_VTL: DotPageApiResponse = {
     layout: mockDotLayout(),
     template: mockDotTemplate(),
     containers: mockDotContainers()
+};
+
+export const PAGE_RESPONSE_URL_CONTENT_MAP = {
+    ...MOCK_RESPONSE_VTL,
+    urlContentMap: URL_CONTENT_MAP_MOCK
 };
 
 export const dotPageContainerStructureMock: DotPageContainerStructure = {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/mocks.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/mocks.ts
@@ -177,6 +177,70 @@ export const MOCK_RESPONSE_HEADLESS: DotPageApiResponse = {
     containers: mockDotContainers()
 };
 
+export const URL_CONTENT_MAP_MOCK = {
+    contentType: 'Blog',
+    identifier: '123',
+    inode: '1234',
+    title: 'hello world',
+    baseType: 'CONTENT',
+    folder: 'SYSTEM_FOLDER',
+    host: '123',
+    languageId: 1,
+    live: true,
+    modDate: '1722992210315',
+    modUser: 'dotcms.org.1',
+    owner: 'dotcms.org.1',
+    url: '/content.ec123',
+    working: true,
+    archived: false,
+    hasTitleImage: true,
+    hostName: 'demo.dotcms.com',
+    locked: false,
+    modUserName: 'Admin User',
+    sortOrder: 0,
+    stInode: '799f176a-d32e-4844-a07c-1b5fcd107578',
+    titleImage: 'image',
+    URL_MAP_FOR_CONTENT: '/test-url'
+};
+
+export const PAGE_RESPONSE_URL_CONTENT_MAP = {
+    page: {
+        pageURI: 'test-url',
+        title: 'Test Page',
+        identifier: '123',
+        inode: '123-i',
+        canEdit: true,
+        canRead: true,
+        rendered: '<html><body><h1>Hello, World!</h1></body></html>',
+        contentType: 'htmlpageasset',
+        canLock: true,
+        locked: false,
+        lockedBy: '',
+        lockedByName: '',
+        live: true,
+        liveInode: '1234',
+        stInode: '12345'
+    },
+    viewAs: {
+        language: {
+            id: 1,
+            language: 'English',
+            countryCode: 'US',
+            languageCode: '1',
+            country: 'United States'
+        },
+
+        persona: {
+            ...DEFAULT_PERSONA
+        }
+    },
+    site: mockSites[0],
+    layout: mockDotLayout(),
+    template: mockDotTemplate(),
+    containers: mockDotContainers(),
+    urlContentMap: URL_CONTENT_MAP_MOCK
+};
+
 export const MOCK_RESPONSE_VTL: DotPageApiResponse = {
     page: {
         pageURI: 'test-url',
@@ -385,13 +449,6 @@ export const EDIT_ACTION_PAYLOAD_MOCK: ActionPayload = {
     },
     pageId: 'test',
     position: 'before'
-};
-
-export const URL_CONTENT_MAP_MOCK = {
-    contentType: 'Blog',
-    identifier: '123',
-    inode: '1234',
-    title: 'hello world'
 };
 
 export const PAGE_RESPONSE_BY_LANGUAGE_ID = {


### PR DESCRIPTION
### Proposed Changes
* Refactored the logic to handle URL redirection after saving a UrlContentMap.
* Added methods to extract and determine the target URL for redirection, ensuring the correct URL is used when publishing content.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
This fix addresses the issue where, after saving or publishing a UrlContentMap, the system incorrectly redirects to the content type’s detail page instead of the expected URL. The changes ensure that the correct URL is detected and used, preventing unwanted redirection after the save or publish action.

### Screenshots
#### Before:

https://github.com/user-attachments/assets/1b4f74fa-f0b7-46f4-b389-a1bc63f52f7b

#### After:

https://github.com/user-attachments/assets/84ea8aa1-a434-4c17-a4b3-b4f391a58d14



This PR fixes: #29896