### PR TITLE
fix(backend): Sonar Quality Gate failure due to potential division by zero (#30337)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/jobs/business/processor/impl/LargeFileReader.java
+++ b/dotCMS/src/main/java/com/dotcms/jobs/business/processor/impl/LargeFileReader.java
@@ -56,7 +56,8 @@ public class LargeFileReader implements JobProcessor, Cancellable {
      */
     private void doReadLargeFile(DotTempFile dotTempFile, int nLines, int maxLines ,final Job job) {
         final Long totalCount = countLines(dotTempFile);
-        if (totalCount == null) {
+        if (totalCount == null || totalCount == 0 ) {
+            Logger.error(this.getClass(), "No lines in the file or unable to count lines: " + dotTempFile.file.getName());
             return;
         }
         Logger.info(this.getClass(), "Total lines in the file: " + totalCount);


### PR DESCRIPTION
### Proposed Changes
* To avoid division by zero in the LargeFileReader class, you should add a check before performing any division operation. In this class, the division operation is performed when calculating the progressPercentage.

### Additional Info
Related to #30337 (Sonar Quality Gate failure due to potential division by zero).

This PR fixes: #30337