### PR TITLE
feat(backend): Need to ship with the updated glowroot.jar (#30024)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -22,7 +22,6 @@
         <bouncy-castle.version>1.70</bouncy-castle.version>
         <awaitility.version>4.0.0</awaitility.version>
         <shedlock.version>4.33.0</shedlock.version>
-        <glowroot.version>0.14.1</glowroot.version>
         <jackson.version>2.17.2</jackson.version>
         <jersey.version>2.28</jersey.version>
         <graalvm.version>22.3.3</graalvm.version>
@@ -1506,10 +1505,8 @@
                 <groupId>org.glowroot</groupId>
                 <artifactId>glowroot-agent</artifactId>
                 <version>${glowroot.version}</version>
-                <!-- TODO: May need zip
-                <type>zip</type>
                 <classifier>dist</classifier>
-                -->
+                <type>zip</type>
             </dependency>
 
 

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -15,7 +15,6 @@
         <palantirJavaFormat.version>2.29.0</palantirJavaFormat.version>
         <src.dir>${project.basedir}/src/main/java</src.dir>
         <test.src.dir>${project.basedir}/src/test/java</test.src.dir>
-        <glowroot.version>0.14.1</glowroot.version>
         <version.cargo.plugin>1.10.6</version.cargo.plugin>
         <assembly-directory>${basedir}/target/dist</assembly-directory>
         <docker.skip.build>${docker.skip}</docker.skip.build>
@@ -26,6 +25,7 @@
         <tomcat-dist-folder>dotserver/tomcat-${tomcat.version}</tomcat-dist-folder>
         <tomcat-lib-folder>${assembly-directory}/${tomcat-dist-folder}/lib</tomcat-lib-folder>
         <tomcat-log4j-lib-folder>${assembly-directory}/${tomcat-dist-folder}/log4j2/lib</tomcat-log4j-lib-folder>
+        <tomcat-glowroot-parent-folder>${assembly-directory}/${tomcat-dist-folder}</tomcat-glowroot-parent-folder>
         <session-manager-lib-folder>${tomcat-lib-folder}</session-manager-lib-folder>
         <tomcat9-overrides>${project.basedir}/src/main/resources/container/tomcat9</tomcat9-overrides>
         <exploded-webapp-dir>${assembly-directory}/${tomcat-dist-folder}/webapps/ROOT</exploded-webapp-dir>
@@ -1269,15 +1269,6 @@
             <scope>test</scope>
         </dependency>
 
-
-        <!--
-                <dependency>
-                    <groupId>org.glowroot</groupId>
-                    <artifactId>glowroot-agent</artifactId>
-                </dependency>
-        -->
-
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -1511,6 +1502,17 @@
                         </goals>
                         <configuration>
                             <artifactItems>
+                              <artifactItem>
+                                    <groupId>org.glowroot</groupId>
+                                    <artifactId>glowroot-agent</artifactId>
+                                    <classifier>dist</classifier>
+                                    <type>zip</type>
+                                    <version>${glowroot.version}</version>
+                                    <overWrite>true</overWrite>
+                                    <!-- the inner "glowroot" folder gets created under this -->
+                                    <outputDirectory>${tomcat-glowroot-parent-folder}</outputDirectory>
+                                </artifactItem>
+
                                 <artifactItem>
                                     <groupId>com.dotcms</groupId>
                                     <artifactId>dotcms-core-web</artifactId>
@@ -1976,6 +1978,10 @@
                                 <configuration>
                                     <type>standalone</type>
                                     <configfiles>
+                                        <configfile>
+                                            <file>${tomcat9-overrides}/glowroot/local-web/admin.json</file>
+                                            <todir>glowroot/local-web</todir>
+                                        </configfile>
                                         <configfile>
                                             <file>${tomcat9-overrides}/bin/build.conf</file>
                                             <todir>bin</todir>

--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -21,15 +21,14 @@ export CATALINA_OPTS="$CATALINA_OPTS --add-opens java.management/javax.managemen
 export CATALINA_OPTS="$CATALINA_OPTS --add-opens java.base/sun.nio.cs=ALL-UNNAMED"
 export CATALINA_OPTS="$CATALINA_OPTS --add-opens java.base/sun.util.calendar=ALL-UNNAMED"
 export CATALINA_OPTS="$CATALINA_OPTS --add-opens java.base/sun.util.locale=ALL-UNNAMED"
-
-
+export CATALINA_OPTS="$CATALINA_OPTS --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
 
 export CATALINA_OPTS="$CATALINA_OPTS -Djavax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl"
 export CATALINA_OPTS="$CATALINA_OPTS -Djavax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"
 export CATALINA_OPTS="$CATALINA_OPTS -Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl"
 export CATALINA_OPTS="$CATALINA_OPTS -Dorg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource"
 
-
+# Set Log4j properties if not already set
 if echo "$CATALINA_OPTS" | grep -q '\-Dlog4j2\.configurationFile'; then
   echo "Log4j configuration already set"
 else
@@ -46,11 +45,52 @@ fi
 
 ADDITIONAL_CLASSPATH="$CATALINA_HOME/log4j2/lib/*"
 
+# Set CLASSPATH with additional path if necessary
 if [ -n "$CLASSPATH" ]; then
   CLASSPATH="$CLASSPATH:$ADDITIONAL_CLASSPATH"
 else
   CLASSPATH="$ADDITIONAL_CLASSPATH"
 fi
 
-export CLASSPATH
 
+# CATALINA_OPTS: Used to pass options to the JVM running Tomcat. This script appends various options to CATALINA_OPTS to configure encoding, module access, XML parser implementations, and Log4j settings.
+# GLOWROOT_ENABLED: If set to "true", the Glowroot agent is added to CATALINA_OPTS.
+# GLOWROOT_CONF_DIR: Directory for Glowroot configuration files. Defaults to $CATALINA_HOME/glowroot/local-web if GLOWROOT_WEB_UI_ENABLED is "true", otherwise defaults to $GLOWROOT_SHARED_FOLDER.
+# GLOWROOT_LOG_DIR: Directory for Glowroot log files. Defaults to $GLOWROOT_CONF_DIR/logs if not set.
+# GLOWROOT_TMP_DIR: Directory for Glowroot temporary files. Defaults to $GLOWROOT_CONF_DIR/tmp if not set.
+# GLOWROOT_DATA_DIR: Directory for Glowroot data files. Defaults to $GLOWROOT_SHARED_FOLDER/data if not set.
+# GLOWROOT_AGENT_ID: If set, specifies the agent ID for Glowroot and enables multi-directory mode.
+# GLOWROOT_COLLECTOR_ADDRESS: If set, specifies the collector address for Glowroot.
+
+add_glowroot_agent() {
+    if ! echo "$CATALINA_OPTS" | grep -q '\-javaagent:.*glowroot\.jar'; then
+        echo "Adding Glowroot agent to CATALINA_OPTS"
+        if [ "$GLOWROOT_ENABLED" = "true" ]; then
+          export CATALINA_OPTS="$CATALINA_OPTS -javaagent:$CATALINA_HOME/glowroot/glowroot.jar"
+
+          export GLOWROOT_SHARED_FOLDER="/data/shared/glowroot"
+
+          # Set GLOWROOT_CONF_DIR based on GLOWROOT_WEB_UI_ENABLED
+          if [ -z "$GLOWROOT_CONF_DIR" ]; then
+              GLOWROOT_CONF_DIR="$([ "$GLOWROOT_WEB_UI_ENABLED" = "true" ] && echo "$CATALINA_HOME/glowroot/local-web" || echo "$GLOWROOT_SHARED_FOLDER")"
+          fi
+          CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.conf.dir=$GLOWROOT_CONF_DIR"
+          # We may want to modify these defaults
+          CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.log.dir=${GLOWROOT_LOG_DIR:=$GLOWROOT_CONF_DIR/logs}"
+          CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.tmp.dir=${GLOWROOT_TMP_DIR:=$GLOWROOT_CONF_DIR/tmp}"
+          CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.data.dir=${GLOWROOT_DATA_DIR:=$GLOWROOT_SHARED_FOLDER/data}"
+
+          # Set GLOWROOT_AGENT_ID and enable multi-directory mode if defined
+          [ -n "$GLOWROOT_AGENT_ID" ] && CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.agent.id=$GLOWROOT_AGENT_ID -Dglowroot.multi.dir=true"
+          [ -n "$GLOWROOT_COLLECTOR_ADDRESS" ] && CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.collector.address=$GLOWROOT_COLLECTOR_ADDRESS"
+
+        fi
+    else
+      echo "Using Legacy Glowroot agent settings from CATALINA_OPTS"
+    fi
+}
+
+# Run the function to add Glowroot agent settings to CATALINA_OPTS if enabled
+add_glowroot_agent
+export CATALINA_OPTS
+export CLASSPATH

--- a/dotCMS/src/main/resources/container/tomcat9/glowroot/local-web/admin.json
+++ b/dotCMS/src/main/resources/container/tomcat9/glowroot/local-web/admin.json
@@ -1,0 +1,9 @@
+{
+  "web": {
+    "port": 4000,
+    "bindAddress": "0.0.0.0",
+    "contextPath": "/",
+    "sessionTimeoutMinutes": 30,
+    "sessionCookieName": "GLOWROOT_SESSION_ID"
+  }
+}

--- a/dotcms-integration/pom.xml
+++ b/dotcms-integration/pom.xml
@@ -16,7 +16,6 @@
 
         <version.spotless.plugin>2.37.0</version.spotless.plugin>
         <batik.version>1.16</batik.version>
-        <glowroot.version>0.14.1</glowroot.version>
         <version.cargo.plugin>1.10.6</version.cargo.plugin>
         <assembly-directory>${basedir}/target/dist</assembly-directory>
         <clean.docker.volumes>true</clean.docker.volumes>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -196,6 +196,8 @@
         <docker.skip.clean.after>false</docker.skip.clean.after>
         <debug.suspend.flag>n</debug.suspend.flag>
         <debug.port>5005</debug.port>
+        <docker.glowroot.enabled>false</docker.glowroot.enabled>
+
         <!-- Default debug port -->
         <debug.args.default>-agentlib:jdwp=transport=dt_socket,server=y,suspend=${debug.suspend.flag},address=*:${debug.port}</debug.args.default>
         <debug.args/>
@@ -206,6 +208,7 @@
         <environment.properties.folder>${maven.multiModuleProjectDirectory}/environments</environment.properties.folder>
         <environment.properties.defaults>${environment.properties.folder}/environment.properties</environment.properties.defaults>
         <spotless.skip>true</spotless.skip>
+        <glowroot.version>0.14.2</glowroot.version>
     </properties>
 
     <build>
@@ -1569,6 +1572,40 @@
                                 <phase>process-resources</phase>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>glowroot</id>
+            <activation>
+                <property>
+                    <name>docker.glowroot.enabled</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <imagesMap>
+                                <dotcms>
+                                    <run>
+                                        <ports combine.children="append">
+                                            <port>glowroot.port:4000</port>
+                                        </ports>
+                                        <env>
+                                            <GLOWROOT_ENABLED>true</GLOWROOT_ENABLED>
+                                            <GLOWROOT_WEB_UI_ENABLED>true</GLOWROOT_WEB_UI_ENABLED>
+                                        </env>
+                                    </run>
+                                </dotcms>
+                            </imagesMap>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
### Proposed Changes
* Add latest glowroot.jar to the release and package within the docker container
* Detect existing glowroot javaagent and run as is if present for backwards compatibility
* Set glowroot version to 0.14.2 and remove duplicate declarations centralising into parent/pom.xml
* Add the following environment variables with their defaults
```

GLOWROOT_ENABLED=false  # enable/disable glowroot
GLOWROOT_SHARED_FOLDER=/data/shared/glowroot  # shared folder for glowroot for persistance
GLOWROOT_WEB_UI_ENABLED=false  # enable/disable local glowroot web ui by setting bind address to 0.0.0.0, used for local developement
GLOWROOT_CONF_DIR=/data/shared/glowroot # If GLOWROOT_WEB_UI_ENABLED=true then default to  use config from $CATALINA_HOME/glowroot/local-web within container else use $GLOWROOT_SHARED_FOLDER
GLOWROOT_LOG_DIR=$GLOWROOT_CONF_DIR/logs. # WE may want to later modify the default location of this to a common logs folder.
GLOWROOT_DATA_DIR=$GLOWROOT_SHARED_FOLDER/data
GLOWROOT_TMP_DIR=$GLOWROOT_CONF_DIR/tmp. # We may want to later modify the default location of this to with a common tmp folder
GLOWROOT_AGENT_ID=  # If set then separate folders are created for each agent GLOWROOT_AGENT_ID also sets -Dglowroot.multi.dir=true which is required for multi-agent and to replicate old behavior
GLOWROOT_COLLECTOR_ADDRESS= # If set then the remote collector at this address is used instead of the DATA_DIR

```

- To simplify the use of glowroot in maven a glowroot profile that can be triggered with -Ddocker.glowroot.enabled=true is provided that will add the port mapping to port 4000 as well as add the GLOWROOT_ENABLED=true and GLOWROOT_WEB_UI_ENABLED=true environment variables.

These params will work whether we are starting up the dev docker instance or for the instance started for postman tests.  A random port mapping is used to avoid conflicts with other instances glowroot installations unless -Dglowroot.port={port} is used also.


## Documentation
Note this change should be backwards compatible to cloud engineering existing setup but will require a change to remove the existing agentpath and instead use the environment variables defined above.    We will need to add this information to the documentation 

Note the previous default behavior is for the location of the configuration, log, data, and tmp dirs to be relative to the location of the glowroot.jar in the agentpath.   This we would usually set on instances to /data/shared/glowroot 

## Tests

Test that glowroot can be enabled in development using maven while running pustman tests and using ./mvnw -pl :dotcms-core -Pdocker-start -Ddocker.glowroot.enabled=true
Test port can be overridend with -Dglowroot.port={port}

Test that glowroot can be enabled in a local docker-compose by adding GLOWROOT_WEB_UI_ENABLED=true and GLOWROOT_ENABLED=true
Test that a GLOWROOT_COLLECTOR_ADDRESS can be configured to point to a remote collector
Test each of the environment variables can be modified.
Test that an existing -agentpath is used as is without further modification of the Command line

Check for commandline options expected in each case on server startup 

When WEB_UI_ENABLED=true than it should show UI listening on 0.0.0.0:4000  otherwise it will show UI listening on 127.0.0.1:4000

'''
2024-10-14 14:07:32 2024-10-14 13:07:32.571 INFO  org.glowroot - creating glowroot schema...
2024-10-14 14:07:32 2024-10-14 13:07:32.688 INFO  org.glowroot - glowroot schema created
2024-10-14 14:07:32 2024-10-14 13:07:32.822 INFO  org.glowroot - UI listening on 0.0.0.0:4000
'''


This PR fixes: #30024