### PR TITLE
feat(Locales) #30300 : Include a Feature Flag for the old Languages portlet

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/ajax/DwrUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/ajax/DwrUtil.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * Provides utility methods for DWR-related classes that allow developers to retrieve common-use
  * information such as:
  * <ul>
- *     <li>The current Session, Servlet Context, and DWR objects.</li>
+ *     <li>The current Session, Request, Servlet Context, and DWR objects.</li>
  *     <li>The currently logged-in User and their Roles.</li>
  *     <li>Portlet validation data.</li>>
  * </ul>
@@ -174,6 +174,16 @@ public class DwrUtil {
     public static ServletContext getServletContext() {
         final WebContext ctx = WebContextFactory.get();
         return ctx.getServletContext();
+    }
+
+    /**
+     * Returns the current HTTP Request object from the DWR Web Context Factory.
+     *
+     * @return The current instance of the {@link HttpServletRequest} object.
+     */
+    public static HttpServletRequest getHttpServletRequest() {
+        final WebContext ctx = WebContextFactory.get();
+        return ctx.getHttpServletRequest();
     }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/business/ajax/RoleAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/ajax/RoleAjax.java
@@ -1,8 +1,5 @@
 package com.dotmarketing.business.ajax;
 
-import static com.dotmarketing.business.ajax.DwrUtil.getLoggedInUser;
-import static com.dotmarketing.business.ajax.DwrUtil.validateRolesPortletPermissions;
-
 import com.dotcms.api.system.event.Payload;
 import com.dotcms.api.system.event.SystemEventType;
 import com.dotcms.api.system.event.SystemEventsAPI;
@@ -54,6 +51,7 @@ import com.dotmarketing.quartz.ScheduledTask;
 import com.dotmarketing.quartz.job.CascadePermissionsJob;
 import com.dotmarketing.util.ActivityLogger;
 import com.dotmarketing.util.AdminLogger;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.DateUtil;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.SecurityLogger;
@@ -66,6 +64,9 @@ import com.liferay.portal.language.LanguageException;
 import com.liferay.portal.language.LanguageUtil;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.User;
+import io.vavr.Lazy;
+
+import javax.servlet.http.HttpServletRequest;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,22 +78,40 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.servlet.http.HttpServletRequest;
 
+import static com.dotmarketing.business.ajax.DwrUtil.getLoggedInUser;
+import static com.dotmarketing.business.ajax.DwrUtil.validateRolesPortletPermissions;
+import static com.dotmarketing.util.PortletID.LANGUAGES;
+
+/**
+ * This class exposes Role and Portlet-related information to the DWR framework. This class is used
+ * by several Dojo-based portlets in the dotCMS backend, and will be progressively migrated to the
+ * respective REST Endpoint classes in the near future.
+ *
+ * @author root
+ * @since Mar 22nd, 2012
+ */
 public class RoleAjax {
 
 	private final SystemEventsAPI systemEventsAPI;
+	private final PortletAPI portletAPI;
+	private final UserWebAPI userWebAPI;
+
+	private static final Lazy<Boolean> HIDE_OLD_LANGUAGES_PORTLET =
+			Lazy.of(() -> Config.getBooleanProperty("FEATURE_FLAG_LOCALES_HIDE-OLD-LANGUAGES-PORTLET", true));
 
     private static final ObjectMapper mapper = DotObjectMapperProvider.getInstance()
             .getDefaultObjectMapper();
     	
 	public RoleAjax(){
-		this(APILocator.getSystemEventsAPI());
+		this(APILocator.getSystemEventsAPI(), APILocator.getPortletAPI(), WebAPILocator.getUserWebAPI());
 	}
-	
+
 	@VisibleForTesting
-	protected RoleAjax(SystemEventsAPI systemEventsAPI) {
+	protected RoleAjax(final SystemEventsAPI systemEventsAPI, final PortletAPI portletAPI, final UserWebAPI userWebAPI) {
 		this.systemEventsAPI = systemEventsAPI;
+		this.portletAPI = portletAPI;
+		this.userWebAPI = userWebAPI;
     }
 	
 	public List<Map<String, Object>> getRolesTreeFiltered(boolean onlyUserAssignableRoles, String excludeRoles) throws DotDataException{
@@ -592,38 +611,36 @@ public class RoleAjax {
 	}
 
 	/**
-	 * Retrieves the info { title, id } of all portlets that can be added to layouts
-	 * @return
-	 * @throws SystemException
-	 * @throws LanguageException
-	 * @throws DotRuntimeException
-	 * @throws PortalException
+	 * Retrieves the title and ID of all portlets that can be added to the main menu -- i.e.,
+	 * layouts --  in the dotCMS backend
+	 *
+	 * @return A list of maps, each containing the title and ID of a portlet that can be added to
+	 * the main menu.
+	 *
+	 * @throws SystemException   An error occurred when retrieving all Portlets from the database.
+	 * @throws LanguageException An error occurred when retrieving the localized title of a
+	 *                           Portlet.
 	 */
-	public List<Map<String, Object>> getAllAvailablePortletInfoList() throws SystemException, LanguageException, DotRuntimeException, PortalException {
-
-		PortletAPI portletAPI = APILocator.getPortletAPI();
-		UserWebAPI uWebAPI = WebAPILocator.getUserWebAPI();
-		WebContext ctx = WebContextFactory.get();
-		HttpServletRequest request = ctx.getHttpServletRequest();
-
-		List<Map<String, Object>> listOfPortletsInfo = new ArrayList<>();
-
-		final Collection<Portlet> portlets = portletAPI.findAllPortlets();
-		for(final Portlet portlet: portlets) {
-			if(portletAPI.canAddPortletToLayout(portlet)) {
-				Map<String, Object> portletMap = new HashMap<>();
-				String portletTitle = LanguageUtil.get(uWebAPI.getLoggedInUser(request),"com.dotcms.repackage.javax.portlet.title." + portlet.getPortletId());
-				portletMap.put("title", portletTitle);
-				portletMap.put("id", portlet.getPortletId());
-				listOfPortletsInfo.add(portletMap);
+	@SuppressWarnings("unused")
+	public List<Map<String, Object>> getAllAvailablePortletInfoList() throws SystemException,
+			LanguageException {
+		final HttpServletRequest request = DwrUtil.getHttpServletRequest();
+		final List<Map<String, Object>> listOfPortletsInfo = new ArrayList<>();
+		final Collection<Portlet> portlets = this.portletAPI.findAllPortlets();
+		for (final Portlet portlet : portlets) {
+			if (LANGUAGES.name().equalsIgnoreCase(portlet.getPortletId()) && HIDE_OLD_LANGUAGES_PORTLET.get()) {
+				continue;
+			}
+			if (this.portletAPI.canAddPortletToLayout(portlet)) {
+				final String portletTitle = LanguageUtil.get(this.userWebAPI.getLoggedInUser(request),
+								"com.dotcms.repackage.javax.portlet.title." + portlet.getPortletId());
+				listOfPortletsInfo.add(Map.of(
+						"title", portletTitle,
+						"id", portlet.getPortletId()
+				));
 			}
 		}
-		Collections.sort(listOfPortletsInfo, new Comparator<Map<String, Object>>() {
-			public int compare(Map<String, Object> o1, Map<String, Object> o2) {
-				return ((String)o1.get("title")).compareTo(((String)o2.get("title")));
-			}
-		});
-
+		listOfPortletsInfo.sort(Comparator.comparing(o -> (((String) o.get("title"))).toLowerCase()));
 		return listOfPortletsInfo;
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/business/ajax/RoleAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/ajax/RoleAjax.java
@@ -628,7 +628,8 @@ public class RoleAjax {
 		final List<Map<String, Object>> listOfPortletsInfo = new ArrayList<>();
 		final Collection<Portlet> portlets = this.portletAPI.findAllPortlets();
 		for (final Portlet portlet : portlets) {
-			if (LANGUAGES.name().equalsIgnoreCase(portlet.getPortletId()) && HIDE_OLD_LANGUAGES_PORTLET.get()) {
+			if (LANGUAGES.name().equalsIgnoreCase(portlet.getPortletId())
+					&& Boolean.TRUE.equals(HIDE_OLD_LANGUAGES_PORTLET.get())) {
 				continue;
 			}
 			if (this.portletAPI.canAddPortletToLayout(portlet)) {
@@ -640,7 +641,7 @@ public class RoleAjax {
 				));
 			}
 		}
-		listOfPortletsInfo.sort(Comparator.comparing(o -> (((String) o.get("title"))).toLowerCase()));
+		listOfPortletsInfo.sort(Comparator.comparing(o -> ((String) o.get("title")).toLowerCase()));
 		return listOfPortletsInfo;
 	}
 


### PR DESCRIPTION
### Proposed Changes
* Includes a new Feature Flagg called `FEATURE_FLAG_LOCALES_HIDE-OLD-LANGUAGES-PORTLET` -- enabled by default -- which hides the old `Languages` portlet from the list of available portlets in the `Settings > Roles & Tools > Tools` portlet.
* If customers still need to be able to add the old `Languages` portlet into the main menu, they can just go ahead and turn the FF on.
* These are all DWR-related classes, so we don't have any Unit Tests or Integration Tests for them.

This PR fixes: #30300