### PR TITLE
chore: Automate CLI Version Update for Agile Releases (#30276)

### DIFF
--- a/tools/dotcms-cli/action/.github/workflows/main.yml
+++ b/tools/dotcms-cli/action/.github/workflows/main.yml
@@ -4,23 +4,32 @@ on: [push]
 
 jobs:
 
-  dotcms-cli:
+  dotcli-runner:
     runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.dotcli-runner.outputs.url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get dotCLI latest version
-        id: dotcli-latest-version
+      - name: Install xmllint
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils        
+
+      - name: Get dotCLI runner
+        id: dotcli-runner
         run: |
-          curl -o "https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/dotcms-cli/maven-metadata.xml"
+          echo "::group::Get dotCLI runner"
+       
+          curl -o maven-metadata.xml "https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/dotcms-cli/maven-metadata.xml"
           LATEST_VERSION=$(xmllint --xpath "string(//versioning/latest)" maven-metadata.xml)
-          echo "The dotCMS CLI latest version is $LATEST_VERSION"
-          echo URL="https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/dotcms-cli/${LATEST_VERSION}/dotcms-cli-${LATEST_VERSION}-runner.jar"
+          URL="https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/dotcms-cli/${LATEST_VERSION}/dotcms-cli-${LATEST_VERSION}-runner.jar"
+
+          echo "::notice::DOTCLI RUNNER: $URL"
           echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "::endgroup::"
 
   sync-with-dotcms:
-    needs: dotcms-cli
+    needs: dotcli-runner
     runs-on: ubuntu-latest
     env:
       # Global environment expected by dotCMS CLI
@@ -32,7 +41,7 @@ jobs:
       # This is how we instruct the cli to create the workspace if it does not exist
       DOT_CREATE_WORKSPACE: ${{ vars.DOT_CREATE_WORKSPACE || 'true' }}
       # This is the CLI version to use, but we can always override this value
-      DOT_CLI_JAR_DOWNLOAD_URL: ${{ vars.DOT_CLI_JAR_DOWNLOAD_URL || needs.dotcli-latest-version.outputs.url }}
+      DOT_CLI_JAR_DOWNLOAD_URL: ${{ vars.DOT_CLI_JAR_DOWNLOAD_URL || needs.dotcli-runner.outputs.url }}
       # In case we want to force the download of the CLI jar
       DOT_FORCE_DOWNLOAD: ${{ vars.DOT_FORCE_DOWNLOAD || 'false' }}
     steps:

--- a/tools/dotcms-cli/action/.github/workflows/main.yml
+++ b/tools/dotcms-cli/action/.github/workflows/main.yml
@@ -3,7 +3,24 @@ name: dotCMS sync
 on: [push]
 
 jobs:
+
+  dotcms-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get dotCLI latest version
+        id: dotcli-latest-version
+        run: |
+          curl -o "https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/dotcms-cli/maven-metadata.xml"
+          LATEST_VERSION=$(xmllint --xpath "string(//versioning/latest)" maven-metadata.xml)
+          echo "The dotCMS CLI latest version is $LATEST_VERSION"
+          echo URL="https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/dotcms-cli/${LATEST_VERSION}/dotcms-cli-${LATEST_VERSION}-runner.jar"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
   sync-with-dotcms:
+    needs: dotcms-cli
     runs-on: ubuntu-latest
     env:
       # Global environment expected by dotCMS CLI
@@ -15,15 +32,12 @@ jobs:
       # This is how we instruct the cli to create the workspace if it does not exist
       DOT_CREATE_WORKSPACE: ${{ vars.DOT_CREATE_WORKSPACE || 'true' }}
       # This is the CLI version to use, but we can always override this value
-      DOT_CLI_JAR_DOWNLOAD_URL: ${{ vars.DOT_CLI_JAR_DOWNLOAD_URL || 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/dotcms-cli/24.10.02/dotcms-cli-24.10.02-runner.jar' }}
+      DOT_CLI_JAR_DOWNLOAD_URL: ${{ vars.DOT_CLI_JAR_DOWNLOAD_URL || needs.dotcli-latest-version.outputs.url }}
       # In case we want to force the download of the CLI jar
       DOT_FORCE_DOWNLOAD: ${{ vars.DOT_FORCE_DOWNLOAD || 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        id: checkout
-        with:
-          fetch-depth: 0
 
       - name: Load .env file
         uses: aarcangeli/load-dotenv@v1.0.0


### PR DESCRIPTION
### Proposed Changes
* A new job is included in the dotCLI GitHub Actions workflow example that calculates the latest available version of the dotcli runner. This ensures we always point to the most recent version of the jar without hardcoding any particular version. 

### Additional Info
Related to #30276 (Automate CLI Version Update for Agile Releases).

This PR fixes: #30276