### PR TITLE
fix(ut): new list for UT that needs to be ran without a transaction. Ref: #29501

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
@@ -250,7 +250,9 @@ public class StartupTasksExecutor {
                     }
 
                     if (!firstTimeStart && task.forceRun()) {
-                        HibernateUtil.startTransaction();
+                        if(!TaskLocatorUtil.getStartupRunOnceTaskClassesNoTransaction().contains(c)){
+                            HibernateUtil.startTransaction();
+                        }
                         Logger.info(this, "Running Upgrade Tasks: " + name);
                         task.executeUpgrade();
 
@@ -262,7 +264,9 @@ public class StartupTasksExecutor {
                         .addParam(new Date())
                         .loadResult();
                     Logger.info(this, "Database upgraded to version: " + taskId);
-                    HibernateUtil.closeAndCommitTransaction();
+                    if(!TaskLocatorUtil.getStartupRunOnceTaskClassesNoTransaction().contains(c)){
+                        HibernateUtil.closeAndCommitTransaction();
+                    }
                     Config.DB_VERSION = taskId;
                 }
             } catch (Exception e) {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
@@ -189,14 +189,18 @@ public class StartupTasksExecutor {
                 if (StartupTask.class.isAssignableFrom(c)) {
                     StartupTask  task = (StartupTask) c.getDeclaredConstructor().newInstance();
                     if (task.forceRun()) {
-                        HibernateUtil.startTransaction();
+                        if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
+                            HibernateUtil.startTransaction();
+                        }
                         Logger.info(this, "Running Startup Tasks : " + name);
                         task.executeUpgrade();
                     } else {
                         Logger.info(this, "Not Running Startup Tasks: " + name);
                     }
                 }
-                HibernateUtil.closeAndCommitTransaction();
+                if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
+                    HibernateUtil.closeAndCommitTransaction();
+                }
             }
             Logger.info(this, "Finishing startup tasks.");
         } catch (Throwable e) {
@@ -250,7 +254,7 @@ public class StartupTasksExecutor {
                     }
 
                     if (!firstTimeStart && task.forceRun()) {
-                        if(!TaskLocatorUtil.getStartupRunOnceTaskClassesNoTransaction().contains(c)){
+                        if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
                             HibernateUtil.startTransaction();
                         }
                         Logger.info(this, "Running Upgrade Tasks: " + name);
@@ -264,7 +268,7 @@ public class StartupTasksExecutor {
                         .addParam(new Date())
                         .loadResult();
                     Logger.info(this, "Database upgraded to version: " + taskId);
-                    if(!TaskLocatorUtil.getStartupRunOnceTaskClassesNoTransaction().contains(c)){
+                    if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
                         HibernateUtil.closeAndCommitTransaction();
                     }
                     Config.DB_VERSION = taskId;
@@ -319,7 +323,9 @@ public class StartupTasksExecutor {
                     }
 
                     if (!firstTimeStart && task.forceRun()) {
-                        HibernateUtil.startTransaction();
+                        if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
+                            HibernateUtil.startTransaction();
+                        }
                         Logger.info(this, "Running Data Upgrade Tasks: " + name);
                         task.executeUpgrade();
                     }
@@ -330,7 +336,9 @@ public class StartupTasksExecutor {
                             .addParam(new Date())
                             .loadResult();
                     Logger.info(this, "Data upgraded to version: " + taskId);
-                    HibernateUtil.closeAndCommitTransaction();
+                    if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
+                        HibernateUtil.closeAndCommitTransaction();
+                    }
                     Config.DATA_VERSION = taskId;
                 }
             } catch (Exception e) {
@@ -367,14 +375,18 @@ public class StartupTasksExecutor {
 		if (StartupTask.class.isAssignableFrom(c) && taskId > Config.DB_VERSION) {
                     StartupTask  task = (StartupTask) c.getDeclaredConstructor().newInstance();
                     if (task.forceRun()) {
-                        HibernateUtil.startTransaction();
+                        if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
+                            HibernateUtil.startTransaction();
+                        }
                         Logger.info(this, "Running Backported Tasks : " + name);
                         task.executeUpgrade();
                     } else {
                         Logger.info(this, "Not Running Backported Tasks: " + name);
                     }
                 }
-                HibernateUtil.closeAndCommitTransaction();
+                if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
+                    HibernateUtil.closeAndCommitTransaction();
+                }
             }
             Logger.info(this, "Finishing Backported tasks.");
         } catch (Throwable e) {

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -413,4 +413,10 @@ public class TaskLocatorUtil {
 		return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
 	}
 
+	public static List<Class<?>> getStartupRunOnceTaskClassesNoTransaction() {
+		final List<Class<?>> ret = new ArrayList<>();
+		ret.add(Task241014AddTemplateValueOnContentletIndex.class);
+		return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
+	}
+
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -413,7 +413,11 @@ public class TaskLocatorUtil {
 		return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
 	}
 
-	public static List<Class<?>> getStartupRunOnceTaskClassesNoTransaction() {
+	/**
+	 * List of tasks that are need to run without transaction. It can be all kind: Run-Once, Run-Always, Data, Backported, etc
+	 * @return The list of tasks
+	 */
+	public static List<Class<?>> getTaskClassesNoTransaction() {
 		final List<Class<?>> ret = new ArrayList<>();
 		ret.add(Task241014AddTemplateValueOnContentletIndex.class);
 		return ret.stream().sorted(classNameComparator).collect(Collectors.toList());


### PR DESCRIPTION
This pull request includes changes to the `StartupTasksExecutor` and `TaskLocatorUtil` classes to ensure that certain startup tasks are executed without a transaction. 


This PR fixes: #29501