### PR TITLE
feat(Locales) #30387 : Remove hyphens from Feature Flag name

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/ajax/RoleAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/ajax/RoleAjax.java
@@ -98,7 +98,7 @@ public class RoleAjax {
 	private final UserWebAPI userWebAPI;
 
 	private static final Lazy<Boolean> HIDE_OLD_LANGUAGES_PORTLET =
-			Lazy.of(() -> Config.getBooleanProperty("FEATURE_FLAG_LOCALES_HIDE-OLD-LANGUAGES-PORTLET", true));
+			Lazy.of(() -> Config.getBooleanProperty("FEATURE_FLAG_LOCALES_HIDE_OLD_LANGUAGES_PORTLET", true));
 
     private static final ObjectMapper mapper = DotObjectMapperProvider.getInstance()
             .getDefaultObjectMapper();


### PR DESCRIPTION
### Proposed Changes
* Removing hyphens from Feature Flag name as they don't play well with the env var naming convention.

This PR fixes: #30387