### PR TITLE
fix(Content): Title override on Assets json transformation #30127

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DotAssetViewStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DotAssetViewStrategy.java
@@ -74,7 +74,7 @@ public class DotAssetViewStrategy extends WebAssetStrategy<Contentlet> {
 
         map.put(MIMETYPE_FIELD, toolBox.fileAssetAPI.getMimeType(fileName));
         map.put("isContentlet", true);
-        map.put(TITLE_FIELD, fileName);
+        map.computeIfAbsent(TITLE_FIELD, k -> fileName);
         map.put("type", "dotasset");
         map.put("path", ResourceLink.getPath(dotAsset));
         map.put("name", fileName);

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformerTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformerTest.java
@@ -405,6 +405,40 @@ public class ContentletTransformerTest extends BaseWorkflowIntegrationTest {
     }
 
     /**
+     * Given scenario: We create a dotAsset-like contentlet, set a "title" property,
+     * and then call getContentPrintableMap, which should return a map of the contentlet's properties.
+     * Expected result: The "title" property in the resulting map should match the custom title set
+     * in the original contentlet.
+     * @throws Exception in case of errors during the mapping process
+     */
+    @Test
+    public void Test_DotAsset_With_Title_Property_Pushed_into_Transformer() throws Exception {
+        final User systemUser = APILocator.systemUser();
+        final Contentlet dotAssetLikeContentlet = TestDataUtils.getDotAssetLikeContentlet();
+        dotAssetLikeContentlet.setProperty("title", "my custom title");
+
+        final Map<String, Object> map1 = ContentletUtil.getContentPrintableMap(
+                systemUser, dotAssetLikeContentlet, true);
+        Assert.assertEquals("my custom title", map1.get("title"));
+    }
+
+    /**
+     * Given scenario: We create a dotAsset-like contentlet without setting a "title" property
+     * and call getContentPrintableMap, which should return a map of the contentlet's properties.
+     * Expected result: The "title" property in the resulting map should match the asset title.
+     * @throws Exception in case of errors during the mapping process
+     */
+    @Test
+    public void Test_DotAsset_Without_Title_Property_Pushed_into_Transformer() throws Exception {
+        final User systemUser = APILocator.systemUser();
+        final Contentlet dotAssetLikeContentlet = TestDataUtils.getDotAssetLikeContentlet();
+
+        final Map<String, Object> map1 = ContentletUtil.getContentPrintableMap(
+                systemUser, dotAssetLikeContentlet, true);
+        Assert.assertEquals("test.jpg", map1.get("title"));
+    }
+
+    /**
      * Given Scenario: We have a contentlet with a dotAsset field, and we push it into the transformer prepared with the FILEASSET_VIEW strategy.
      * Expected Result: We should get the dotAsset field with the expected properties.
      * @throws Exception


### PR DESCRIPTION
### Proposed Changes
* Updated `DotAssetViewStrategy` to avoid overwriting the `title` field in the transformation map.
* Replaced `map.put(TITLE_FIELD, fileName)` with `map.computeIfAbsent(TITLE_FIELD, k -> fileName)` to ensure the `title` is only set if it is not already present.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
This fix prevents the `title` field from being overwritten when a `DotAsset` is transformed. The issue occurred because the `title` field was being replaced with the asset’s filename, even if it already had a value.

### Video
https://github.com/user-attachments/assets/2fa860c5-e1c7-4d32-912d-eec40fe0fbc5


This PR fixes: #30127