### PR TITLE
fix: Avoid dupe params on query parameters

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityUrlRequestWrapper.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityUrlRequestWrapper.java
@@ -3,6 +3,7 @@ package com.dotcms.vanityurl.filters;
 import static com.dotmarketing.filters.Constants.CMS_FILTER_QUERY_STRING_OVERRIDE;
 import static com.dotmarketing.filters.Constants.CMS_FILTER_URI_OVERRIDE;
 
+import com.dotcms.repackage.org.nfunk.jep.function.Str;
 import com.dotcms.vanityurl.model.VanityUrlResult;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
@@ -36,12 +37,20 @@ public class VanityUrlRequestWrapper extends HttpServletRequestWrapper {
         super(request);
 
         final boolean vanityHasQueryString = UtilMethods.isSet(vanityUrlResult.getQueryString());
-        
-        this.newQueryString = vanityHasQueryString && UtilMethods.isSet(request.getQueryString())
-                        ? request.getQueryString() + "&" + vanityUrlResult.getQueryString()
-                        : vanityHasQueryString 
-                            ? vanityUrlResult.getQueryString()
-                            : request.getQueryString();
+
+        String queryParams = request.getQueryString();
+        final Map<String, String> vanityParams = convertURLParamsStringToMap(vanityUrlResult.getQueryString());
+        final Map<String, String> requestParams = convertURLParamsStringToMap(request.getQueryString());
+        if(vanityHasQueryString){
+            for(final String key : vanityParams.keySet()){
+                //add to the request.getQueryString() the vanity parameters that are not already present, the key and value must not be the same
+                if(!requestParams.containsKey(key) || !requestParams.get(key).equals(vanityParams.get(key))){
+                    queryParams += "&" + key + "=" + vanityParams.get(key);
+                }
+            }
+        }
+        this.newQueryString = queryParams;
+
 
 
         // we create a new map here because it merges the 
@@ -62,6 +71,32 @@ public class VanityUrlRequestWrapper extends HttpServletRequestWrapper {
         this.setAttribute(CMS_FILTER_URI_OVERRIDE, vanityUrlResult.getRewrite());
         this.setAttribute(CMS_FILTER_QUERY_STRING_OVERRIDE, this.newQueryString);
 
+    }
+
+    /**
+     * Converts a URL parameters string to a map of key-value pairs
+     * @param input URL parameters string
+     * @return Map of key-value pairs
+     */
+    private Map<String, String> convertURLParamsStringToMap(final String input) {
+        final Map<String, String> map = new HashMap<>();
+
+        if(UtilMethods.isSet(input)) {
+            // Split the input string by '&' to get key-value pairs
+            final String[] pairs = input.split("&");
+
+            for (final String pair : pairs) {
+                // Split each pair by '=' to get the key and value
+                final String[] keyValue = pair.split("=");
+                if (keyValue.length == 2) {
+                    map.put(keyValue[0], keyValue[1]);
+                } else if (keyValue.length == 1) {
+                    map.put(keyValue[0], ""); // Handle case where there is a key with no value
+                }
+            }
+        }
+
+        return map;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityUrlRequestWrapper.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/filters/VanityUrlRequestWrapper.java
@@ -3,9 +3,7 @@ package com.dotcms.vanityurl.filters;
 import static com.dotmarketing.filters.Constants.CMS_FILTER_QUERY_STRING_OVERRIDE;
 import static com.dotmarketing.filters.Constants.CMS_FILTER_URI_OVERRIDE;
 
-import com.dotcms.repackage.org.nfunk.jep.function.Str;
 import com.dotcms.vanityurl.model.VanityUrlResult;
-import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.collect.ImmutableMap;
 import java.nio.charset.StandardCharsets;
@@ -38,18 +36,21 @@ public class VanityUrlRequestWrapper extends HttpServletRequestWrapper {
 
         final boolean vanityHasQueryString = UtilMethods.isSet(vanityUrlResult.getQueryString());
 
-        String queryParams = request.getQueryString();
+        final StringBuilder params = new StringBuilder();
+        params.append(request.getQueryString());
         final Map<String, String> vanityParams = convertURLParamsStringToMap(vanityUrlResult.getQueryString());
         final Map<String, String> requestParams = convertURLParamsStringToMap(request.getQueryString());
         if(vanityHasQueryString){
-            for(final String key : vanityParams.keySet()){
+            for (final Map.Entry<String,String> entry : vanityParams.entrySet()) {
+                final String key = entry.getKey();
+                final String value = entry.getValue();
                 //add to the request.getQueryString() the vanity parameters that are not already present, the key and value must not be the same
-                if(!requestParams.containsKey(key) || !requestParams.get(key).equals(vanityParams.get(key))){
-                    queryParams += "&" + key + "=" + vanityParams.get(key);
+                if(!requestParams.containsKey(key) || !requestParams.get(key).equals(value)){
+                    params.append("&" + key + "=" + value);
                 }
             }
         }
-        this.newQueryString = queryParams;
+        this.newQueryString = params.toString();
 
 
 

--- a/dotCMS/src/test/java/com/dotmarketing/filters/VanityUrlRequestWrapperTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/filters/VanityUrlRequestWrapperTest.java
@@ -13,6 +13,8 @@ import com.dotcms.vanityurl.filters.VanityUrlRequestWrapper;
 import com.dotcms.vanityurl.model.VanityUrlResult;
 import com.google.common.collect.ImmutableMap;
 
+import static org.junit.Assert.assertEquals;
+
 public class VanityUrlRequestWrapperTest {
 
     final String URL = "URL";
@@ -98,4 +100,28 @@ public class VanityUrlRequestWrapperTest {
         
     }
 
+
+    @Test
+    public void test_that_vanityUrlParams_requestParams_Are_Same_Should_Not_Be_Duped() {
+
+
+        final HttpServletRequest baseRequest = new MockHttpRequestUnitTest("testing", "/test?param1=" + URL + "&param2=" + URL).request();
+
+        final VanityUrlResult vanityUrlResult = new VanityUrlResult("/newUrl", "param1=" + URL + "&param2=" + URL, false);
+
+        final HttpServletRequest request = new VanityUrlRequestWrapper(baseRequest, vanityUrlResult);
+
+        final String queryString= request.getQueryString();
+        assert(queryString!=null);
+        assert(!queryString.startsWith("&"));
+        assert(!queryString.endsWith("&"));
+        assert(queryString.contains("param1=" + URL));
+        assert(queryString.contains("param2=" + URL));
+        List<NameValuePair> queryParams = URLEncodedUtils.parse(queryString, Charset.forName("UTF-8"));
+        assertEquals("Should be only 2 params since all are the same. Params: " + queryParams,2,queryParams.size());
+
+
+
+
+    }
 }


### PR DESCRIPTION
This pull request makes several important changes to the `VanityUrlRequestWrapper` class to improve the handling of query strings and adds a corresponding test to ensure the new functionality works correctly. The key changes include adding a utility method to convert URL parameters to a map, modifying how query strings are merged, and introducing a new test case.

### Improvements to Query String Handling:

* Modified the logic for merging query strings to ensure that vanity parameters are only added if they are not already present in the request parameters.
* Added a new private method `convertURLParamsStringToMap` to convert a URL parameters string into a map of key-value pairs.

### Testing Enhancements:

* Introduced a new test case `test_that_vanityUrlParams_requestParams_Are_Same_Should_Not_Be_Duped` to verify that query string parameters are not duplicated when they are the same in both the vanity URL and the request.

This PR fixes: #25178