### PR TITLE
chore: feedback message. ref: #30156

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5808,8 +5808,8 @@ edit.content.wysiwyg.confirm.switch-editor.message=Switching to the WYSIWYG view
 edit.content.wysiwyg-field.language-variable-placeholder=Language variables
 edit.content.wysiwyg-field.language-variable-tooltip=Start typing to see matching Language Variables.
 
-lts.expired.message = This version of dotCMS already reached EOL. Please contact your CSM to schedule an upgrade.
-lts.expires.soon.message = Your dotCMS version will reach EOL in {0} days. Please contact your CSM to schedule an upgrade.
+lts.expired.message = This version of dotCMS is no longer supported. Please contact your customer success manager to schedule an upgrade.
+lts.expires.soon.message = Your dotCMS version will no longer be supported in {0} days. Please contact your customer success manager to schedule an upgrade.
 
 
 analytics.search.run.query=Run Query


### PR DESCRIPTION
This pull request includes updates to the `Language.properties` file to improve the clarity and consistency of messages related to the end-of-life (EOL) status of dotCMS versions.

Updates to EOL messages:

* [`dotCMS/src/main/webapp/WEB-INF/messages/Language.properties`](diffhunk://#diff-21db9723fa4c52389731b7575f1e19bd364aa992b7e549e22c08a33456994e94L5811-R5812): Updated the `lts.expired.message` to clarify that the version is no longer supported and to use the term "customer success manager" instead of "CSM".
* [`dotCMS/src/main/webapp/WEB-INF/messages/Language.properties`](diffhunk://#diff-21db9723fa4c52389731b7575f1e19bd364aa992b7e549e22c08a33456994e94L5811-R5812): Updated the `lts.expires.soon.message` to indicate that the version will no longer be supported and to use the term "customer success manager" instead of "CSM".

This PR fixes: #30156