### PR TITLE
fix(vanity-urls): fixed url parse regex to include slash character in fragments

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/URLUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/URLUtils.java
@@ -2,6 +2,7 @@ package com.dotmarketing.util;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -16,7 +17,7 @@ public class URLUtils {
 	}
 
 	public static class ParsedURL {
-		
+
 		private String protocol;
 		private String host;
 		private int port;
@@ -26,7 +27,7 @@ public class URLUtils {
 		private String queryString;
 		private Map<String, String[]> parameters;
 		private String fragment;
-		
+
 		public String getProtocol() {
 			return protocol;
 		}
@@ -83,56 +84,75 @@ public class URLUtils {
 		}
 	}
 
-	private static final Pattern regexPattern = Pattern.compile(
-    "(([^:/?#]+)://([^/\\p{Cntrl}:]+)(?::(\\d+))?)?(((?:/[^\\p{Cntrl}?#]*)*)(?:/([^/\\p{Cntrl}?#]+)?))?\\??([^#]*)?(?:#(.*))?");
-	public static ParsedURL parseURL(String url) throws IllegalArgumentException {
-		
-		Matcher matcher = regexPattern.matcher(url);
+	private static final Pattern protocolHostPortPattern = Pattern.compile(
+    "^(?<protocol>[^:/?#]+)://(?<host>[^/\\p{Cntrl}:]+)(?::(?<port>\\d+))?");
 
-		if(!matcher.find())
+    private static final Pattern pathQueryFragmentPattern = Pattern.compile(
+    "(?<uri>(?<path>/[^?#]*)?/(?<resource>[^/?#]*))?(?:\\?(?<query>[^#]*))?(?:#(?<fragment>.*))?");
+
+	public static ParsedURL parseURL(final String url) throws IllegalArgumentException {
+		final ParsedURL parsedUrl = new ParsedURL();
+
+		final int pathIndex = parseProtocolHostPort(url, parsedUrl);
+		final boolean foundMatch = parsePathQueryFragment(url, parsedUrl, pathIndex);
+		if (!foundMatch) {
 			return null;
-		
-		ParsedURL parsedUrl = new ParsedURL();
-		parsedUrl.setProtocol(matcher.group(2));
-		parsedUrl.setHost(matcher.group(3));
-		parsedUrl.setPort(matcher.group(4) != null?Integer.parseInt(matcher.group(4)):0);
-		parsedUrl.setURI(matcher.group(5));
-		parsedUrl.setPath(matcher.group(6));
-		parsedUrl.setResource(matcher.group(7));
-		parsedUrl.setQueryString(matcher.group(8));
-		parsedUrl.setFragment(matcher.group(9));
+		}
+		processQueryString(parsedUrl);
 
-		Map<String, List<String>> parameters = new HashMap<>();
-		String[] queryStringSplitted = parsedUrl.queryString.split("&");
-		
-		for (int i = 0; i < queryStringSplitted.length; i++) {
-			try {
-				String[] queryParamTuple = queryStringSplitted[i].split("=");
-				String parameterKey = URLDecoder.decode(queryParamTuple[0], "UTF8");
-				if(!UtilMethods.isSet(parameterKey))
-					continue;
-				String parameterValue = queryParamTuple.length > 1?URLDecoder.decode(queryParamTuple[1], "UTF8"):null;
-				List<String> parameterValues = parameters.get(parameterKey);
-				if(parameterValues == null) {
-					parameterValues = new ArrayList<>(1);
-					parameters.put(parameterKey, parameterValues);
-				}
-				if(parameterValue != null)
-					parameterValues.add(parameterValue);
-			} catch (UnsupportedEncodingException e) {
-				Logger.error(URLUtils.class, e.getMessage(), e);
-				throw new IllegalArgumentException(e.getMessage(), e);
-			}
-		}
-		
-		Map<String, String[]> parametersToRet = new HashMap<>();
-		for(Map.Entry<String, List<String>> parameterEntry : parameters.entrySet()) {
-			String[] values = parameterEntry.getValue().toArray(new String[0]);
-			parametersToRet.put(parameterEntry.getKey(), values);
-		}
-		
-		parsedUrl.setParameters(parametersToRet);
-		
 		return parsedUrl;
 	}
+
+	private static int parseProtocolHostPort(final String url, final ParsedURL parsedUrl) {
+		final Matcher matcher = protocolHostPortPattern.matcher(url);
+		if (matcher.find()) {
+			parsedUrl.setProtocol(matcher.group("protocol"));
+			parsedUrl.setHost(matcher.group("host"));
+			parsedUrl.setPort(matcher.group("port") != null ?
+					Integer.parseInt(matcher.group("port")) : 0);
+			return matcher.end();
+		} else {
+			return 0;
+		}
+	}
+
+	private static boolean parsePathQueryFragment(final String url,
+											   final ParsedURL parsedUrl, final int pathIndex) {
+		final Matcher matcher = pathQueryFragmentPattern.matcher(url);
+		if (matcher.find(pathIndex)) {
+			parsedUrl.setURI(matcher.group("uri"));
+			parsedUrl.setPath(matcher.group("path"));
+			parsedUrl.setResource(matcher.group("resource"));
+			parsedUrl.setQueryString(matcher.group("query"));
+			parsedUrl.setFragment(matcher.group("fragment"));
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	private static void processQueryString(final ParsedURL parsedUrl) {
+		final Map<String, List<String>> parameters = new HashMap<>();
+		if (parsedUrl.getQueryString() != null) {
+			final String[] queryStringSplitted = parsedUrl.getQueryString().split("&");
+			for (String queryParam : queryStringSplitted) {
+                final String[] queryParamTuple = queryParam.split("=");
+                final String parameterKey = URLDecoder.decode(
+                        queryParamTuple[0], StandardCharsets.UTF_8);
+                if (!UtilMethods.isSet(parameterKey)) continue;
+                final String parameterValue = queryParamTuple.length > 1 ?
+                        URLDecoder.decode(queryParamTuple[1], StandardCharsets.UTF_8) : null;
+                parameters.computeIfAbsent(parameterKey,
+                        k -> new ArrayList<>()).add(parameterValue);
+            }
+		}
+
+		final Map<String, String[]> parametersToRet = new HashMap<>();
+		for (Map.Entry<String, List<String>> parameterEntry : parameters.entrySet()) {
+			parametersToRet.put(parameterEntry.getKey(),
+					parameterEntry.getValue().toArray(new String[0]));
+		}
+		parsedUrl.setParameters(parametersToRet);
+	}
+
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/URLUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/URLUtils.java
@@ -81,11 +81,10 @@ public class URLUtils {
 		public void setFragment(String fragment) {
 			this.fragment = fragment;
 		}
-	}	
+	}
 
 	private static final Pattern regexPattern = Pattern.compile(
-			"((\\w+)://([^/\\p{Cntrl}:]+)(?::(\\d+))?)?(((?:/[^/\\p{Cntrl}]+)*)(?:/([^/\\p{Cntrl}?#]+)?))?\\??([^#]*)?(?:#(.*))?");
-	
+    "(([^:/?#]+)://([^/\\p{Cntrl}:]+)(?::(\\d+))?)?(((?:/[^\\p{Cntrl}?#]*)*)(?:/([^/\\p{Cntrl}?#]+)?))?\\??([^#]*)?(?:#(.*))?");
 	public static ParsedURL parseURL(String url) throws IllegalArgumentException {
 		
 		Matcher matcher = regexPattern.matcher(url);

--- a/dotcms-integration/src/test/java/com/dotcms/filters/VanityUrlFilterTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/filters/VanityUrlFilterTest.java
@@ -239,7 +239,7 @@ public class VanityUrlFilterTest {
         filtersUtil.publishVanityUrl(contentlet1);
 
         final String resource = "/test redirect 301".replaceAll(" ", "%20");
-        final String queryWithFragment = "?param1=value 1&param2=value 2#test-fragment"
+        final String queryWithFragment = "?param1=value 1&param2=value 2#test/fragment"
                 .replaceAll(" ", "+");
         final String testURI = baseURI + resource + queryWithFragment;
         final HttpServletRequest request = new MockHttpRequestIntegrationTest(defaultHost.getHostname(), testURI).request();


### PR DESCRIPTION
Closes #30130

### Proposed Changes
* change 1
This pull request changes the regex pattern for URL parsing for vanity URLS to handle fragments correctly when the fragment includes the slash character (/).

### Checklist
- [x] Tests

This PR fixes: #30130