### PR TITLE
Issue 30023 Content added as the default fileAsset content type regardless of folder settings

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/files/action/UploadMultipleFilesAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/files/action/UploadMultipleFilesAction.java
@@ -212,7 +212,13 @@ public class UploadMultipleFilesAction extends DotPortletAction {
 		if(!UtilMethods.isSet(fileNamesStr))
 			throw new ActionException(LanguageUtil.get(user, "message.file_asset.alert.please.upload"));
 
-		String selectedStructureInode = ParamUtil.getString(req, "selectedStructure");
+		String selectedStructureInode;
+
+		if (config.getPortletName().contains("site-browser")){
+			selectedStructureInode = ParamUtil.getString(req, "selectedStructure");
+		} else {
+			selectedStructureInode = folder.getDefaultFileType();
+		}
 		if(!UtilMethods.isSet(selectedStructureInode))
 			selectedStructureInode = CacheLocator.getContentTypeCache().getStructureByVelocityVarName(FileAssetAPI.DEFAULT_FILE_ASSET_STRUCTURE_VELOCITY_VAR_NAME).getInode();
 


### PR DESCRIPTION
The main issue was happening because when uploading a File, it was setting the default type (File) despite the one specified in the folder. In other words, it was ignoring the default type that was set in the folder before and setting the one of the contentlet that was being edited.

As analyzed, the only place where the File type is specified when uploading is from the site browser, in all the other cases you can't choose what type of File you want to upload so it should take the default one. That said, a fix was added to consider those cases, so now when uploading a File, it is going to have the content type specified in the parent folder.

This PR fixes: #30023