### PR TITLE
fix(deployment): Publish Starter deployment failure due to incorrect credentials (#30482)

### DIFF
--- a/.github/workflows/cicd_manual_publish-starter.yml
+++ b/.github/workflows/cicd_manual_publish-starter.yml
@@ -34,7 +34,7 @@ jobs:
   get-starter:
     runs-on: macos-13
     if: github.repository == 'dotcms/core'
-    environment: trunk
+    environment: starter
     steps:
       - name: 'Github context'
         run: |


### PR DESCRIPTION
### Proposed Changes
* The workflow is now pointing to a new environment and using repo level credentials to complete the deployment phase.

### Additional Info
This PR resolves #30482 (Publish Starter deployment failure due to incorrect credentials).

This PR fixes: #30482