### PR TITLE
fix(relationships): Add extra logging when failure to parse jsonWithRelationships

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
@@ -28,6 +28,8 @@ import com.dotmarketing.util.PaginatedContentList;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.dotmarketing.util.json.JSONObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.liferay.portal.model.User;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -812,8 +814,7 @@ public class ContentUtils {
 						new JSONObject(), null, languageId, mode.showLive, false,
 						true);
 
-				final HashMap<String,Object> relationshipsMap = DotObjectMapperProvider.getInstance()
-						.getDefaultObjectMapper().readValue(jsonWithRelationShips.toString(), HashMap.class);
+				final HashMap<String,Object> relationshipsMap = getStringObjectHashMap(jsonWithRelationShips);
 
 				if (UtilMethods.isSet(relationshipsMap)) {
 					contentlet.getMap().putAll(relationshipsMap);
@@ -830,5 +831,19 @@ public class ContentUtils {
 		}
 
 	}
-		
+
+	private static HashMap<String, Object> getStringObjectHashMap(
+			JSONObject jsonWithRelationShips) {
+		final HashMap<String, Object> relationshipsMap;
+		try {
+			relationshipsMap = DotObjectMapperProvider.getInstance()
+			.getDefaultObjectMapper().readValue(jsonWithRelationShips.toString(), new TypeReference<HashMap<String, Object>>() {});
+		} catch (JsonProcessingException e) {
+			Logger.error(ContentUtils.class, "Failed to process jsonRelationships document:", e);
+			Logger.error(ContentUtils.class, "jsonWithRelationShips: " + jsonWithRelationShips.toString());
+			throw new DotRuntimeException(e);
+		}
+		return relationshipsMap;
+	}
+
 }


### PR DESCRIPTION
Related to #30437 (Dirty Content kills cache breaks content queries).

Add extra logging on parse failure in ContentUtils.addRelationships