### PR TITLE
Fix (CLI): Adding back builder to properly handle content type base types.

### DIFF
--- a/tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/model/contenttype/AbstractSaveContentTypeRequest.java
+++ b/tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/model/contenttype/AbstractSaveContentTypeRequest.java
@@ -70,4 +70,43 @@ public abstract class AbstractSaveContentTypeRequest extends ContentType {
 
     }
 
+    /**
+     * Custom Builder to handle the typeInf attribute.
+     */
+    public static class Builder extends SaveContentTypeRequest.Builder {
+
+        private Class<? extends ContentType> typeInf = SimpleContentType.class;
+
+        /**
+         * Sets the typeInf attribute based on the provided ContentType instance.
+         *
+         * @param in the ContentType instance
+         * @return the updated SaveContentTypeRequest.Builder
+         */
+        public SaveContentTypeRequest.Builder of(ContentType in) {
+            this.typeInf = in.getClass();
+            return from(in);
+        }
+
+        /**
+         * Builds the SaveContentTypeRequest and sets the typeInf attribute.
+         *
+         * @return the built SaveContentTypeRequest
+         */
+        @Override
+        public SaveContentTypeRequest build() {
+            this.typeInf(typeInf);
+            return super.build();
+        }
+    }
+
+    /**
+     * Helper method to create the custom Builder.
+     *
+     * @return a new instance of the custom Builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
 }

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/push/contenttype/ContentTypePushHandler.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/push/contenttype/ContentTypePushHandler.java
@@ -5,6 +5,7 @@ import com.dotcms.api.client.model.RestClientFactory;
 import com.dotcms.api.client.push.PushHandler;
 import com.dotcms.api.client.util.NamingUtils;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.model.contenttype.AbstractSaveContentTypeRequest;
 import com.dotcms.model.contenttype.SaveContentTypeRequest;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.control.ActivateRequestContext;
@@ -61,8 +62,8 @@ public class ContentTypePushHandler implements PushHandler<ContentType> {
 
         final ContentTypeAPI contentTypeAPI = clientFactory.getClient(ContentTypeAPI.class);
 
-        final SaveContentTypeRequest saveRequest = SaveContentTypeRequest.builder().
-                from(localContentType).build();
+        final SaveContentTypeRequest saveRequest = AbstractSaveContentTypeRequest.builder()
+                .of(localContentType).build();
         final var response = contentTypeAPI.createContentTypes(List.of(saveRequest));
 
         return response.entity().stream()
@@ -78,8 +79,8 @@ public class ContentTypePushHandler implements PushHandler<ContentType> {
 
         final ContentTypeAPI contentTypeAPI = clientFactory.getClient(ContentTypeAPI.class);
 
-        final SaveContentTypeRequest saveRequest = SaveContentTypeRequest.builder().
-                from(localContentType).build();
+        final SaveContentTypeRequest saveRequest = AbstractSaveContentTypeRequest.builder()
+                .of(localContentType).build();
         final var response = contentTypeAPI.updateContentType(localContentType.variable(),
                 saveRequest);
 

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/common/ContentTypesTestHelperService.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/common/ContentTypesTestHelperService.java
@@ -10,10 +10,12 @@ import com.dotcms.contenttype.model.field.ImmutableBinaryField;
 import com.dotcms.contenttype.model.field.ImmutableTextField;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.model.type.ImmutablePageContentType;
 import com.dotcms.contenttype.model.type.ImmutableSimpleContentType;
 import com.dotcms.contenttype.model.workflow.ImmutableWorkflow;
 import com.dotcms.model.ResponseEntityView;
 import com.dotcms.model.config.Workspace;
+import com.dotcms.model.contenttype.AbstractSaveContentTypeRequest;
 import com.dotcms.model.contenttype.SaveContentTypeRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -67,8 +69,8 @@ public class ContentTypesTestHelperService {
                 null, null, detailPage, urlMapPattern
         );
 
-        final SaveContentTypeRequest saveRequest = SaveContentTypeRequest.builder().
-                from(contentType).build();
+        final SaveContentTypeRequest saveRequest = AbstractSaveContentTypeRequest.builder()
+                .of(contentType).build();
         contentTypeAPI.createContentTypes(List.of(saveRequest));
 
         // Make sure the content type is created, and we are giving the server some time to process
@@ -77,6 +79,18 @@ public class ContentTypesTestHelperService {
         ));
 
         return contentType.variable();
+    }
+
+    /**
+     * Creates a HTML page content type descriptor in the given workspace.
+     *
+     * @param workspace The workspace in which the content type descriptor should be created.
+     * @return The result of the content type descriptor creation.
+     * @throws IOException If an error occurs while writing the content type descriptor to disk.
+     */
+    public ContentTypeDescriptorCreationResult createPageContentTypeDescriptor(Workspace workspace)
+            throws IOException {
+        return createPageContentTypeDescriptor(workspace, null, null);
     }
 
     /**
@@ -159,6 +173,33 @@ public class ContentTypesTestHelperService {
     }
 
     /**
+     * Creates a HTML page content type descriptor in the given workspace.
+     *
+     * @param workspace  The workspace in which the content type descriptor should be created.
+     * @param identifier The identifier of the content type.
+     * @param variable   The variable of the content type.
+     * @return The result of the content type descriptor creation.
+     * @throws IOException If an error occurs while writing the content type descriptor to disk.
+     */
+    public ContentTypeDescriptorCreationResult createPageContentTypeDescriptor(
+            Workspace workspace, final String identifier, final String variable)
+            throws IOException {
+
+        final ImmutablePageContentType contentType = buildPageContentType(
+                identifier, variable
+        );
+
+        final ObjectMapper objectMapper = new ClientObjectMapper().getContext(null);
+        final String asString = objectMapper.writeValueAsString(contentType);
+
+        final Path path = Path.of(workspace.contentTypes().toString(),
+                String.format("%s.json", contentType.variable()));
+        Files.writeString(path, asString);
+
+        return new ContentTypeDescriptorCreationResult(contentType.variable(), path);
+    }
+
+    /**
      * Builds a content type object.
      *
      * @param identifier    The identifier of the content type.
@@ -186,6 +227,76 @@ public class ContentTypesTestHelperService {
                 .folder("SYSTEM_FOLDER")
                 .detailPage(detailPage)
                 .urlMapPattern(urlMapPattern)
+                .addFields(
+                        ImmutableBinaryField.builder()
+                                .name("__bin_var__" + millis)
+                                .fixed(false)
+                                .listed(true)
+                                .searchable(true)
+                                .unique(false)
+                                .indexed(true)
+                                .readOnly(false)
+                                .forceIncludeInApi(false)
+                                .modDate(new Date())
+                                .required(false)
+                                .variable("lol")
+                                .sortOrder(1)
+                                .dataType(DataTypes.SYSTEM).build(),
+                        ImmutableTextField.builder()
+                                .indexed(true)
+                                .dataType(DataTypes.TEXT)
+                                .fieldType("text")
+                                .readOnly(false)
+                                .required(true)
+                                .searchable(true)
+                                .listed(true)
+                                .sortOrder(2)
+                                .searchable(true)
+                                .name("Name")
+                                .variable("name")
+                                .fixed(false)
+                                .build()
+                )
+                .workflows(
+                        List.of(
+                                ImmutableWorkflow.builder()
+                                        .id(SYSTEM_WORKFLOW_ID)
+                                        .variableName(SYSTEM_WORKFLOW_VARIABLE_NAME)
+                                        .build()
+                        )
+                );
+
+        if (identifier != null) {
+            builder.id(identifier);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Builds a HTML page content type object.
+     *
+     * @param identifier The identifier of the content type.
+     * @param variable   The variable of the content type.
+     * @return The content type object.
+     */
+    private ImmutablePageContentType buildPageContentType(
+            final String identifier, final String variable) {
+
+        final long millis = System.currentTimeMillis();
+        final String contentTypeVariable = Objects.requireNonNullElseGet(variable,
+                () -> "var_" + millis);
+
+        var builder = ImmutablePageContentType.builder()
+                .baseType(BaseContentType.HTMLPAGE)
+                .description("ct for testing.")
+                .name("name-" + contentTypeVariable)
+                .variable(contentTypeVariable)
+                .modDate(new Date())
+                .fixed(true)
+                .iDate(new Date())
+                .host("SYSTEM_HOST")
+                .folder("SYSTEM_FOLDER")
                 .addFields(
                         ImmutableBinaryField.builder()
                                 .name("__bin_var__" + millis)


### PR DESCRIPTION
This pull request introduces a custom builder for `SaveContentTypeRequest` to handle the `typeInf` attribute and updates relevant tests and methods to use this new builder. The most important changes include adding the custom builder class, updating test cases, and modifying methods to utilize the new builder.

### Enhancements to `SaveContentTypeRequest`:

* Added a custom `Builder` class to `AbstractSaveContentTypeRequest` to handle the `typeInf` attribute. (`tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/model/contenttype/AbstractSaveContentTypeRequest.java`)

### Updates to Test Cases:

* Updated imports and added new test methods in `ContentTypeAPIIT` to test the new builder functionality. (`tools/dotcms-cli/api-data-model/src/test/java/com/dotcms/api/ContentTypeAPIIT.java`) [[1]](diffhunk://#diff-f2101fd155aefd1a94a63ecac9b5675e464720447b556c8b05c60c1d52648de6R24-R30) [[2]](diffhunk://#diff-f2101fd155aefd1a94a63ecac9b5675e464720447b556c8b05c60c1d52648de6R148-R191)
* Modified existing test methods to use the new `AbstractSaveContentTypeRequest.builder().of(contentType).build()` pattern. (`tools/dotcms-cli/api-data-model/src/test/java/com/dotcms/api/ContentTypeAPIIT.java`) [[1]](diffhunk://#diff-f2101fd155aefd1a94a63ecac9b5675e464720447b556c8b05c60c1d52648de6L237-R283) [[2]](diffhunk://#diff-f2101fd155aefd1a94a63ecac9b5675e464720447b556c8b05c60c1d52648de6L361-R407) [[3]](diffhunk://#diff-f2101fd155aefd1a94a63ecac9b5675e464720447b556c8b05c60c1d52648de6L626-R675) [[4]](diffhunk://#diff-f2101fd155aefd1a94a63ecac9b5675e464720447b556c8b05c60c1d52648de6L952-R1001)

### Codebase Simplification:

* Updated `ContentTypePushHandler` to use the new builder for creating and editing content types. (`tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/push/contenttype/ContentTypePushHandler.java`) [[1]](diffhunk://#diff-ed28cb0bb540c2c7a442107ec9cf370696bc98f1b411311b3c2817b0c78d0968R8) [[2]](diffhunk://#diff-ed28cb0bb540c2c7a442107ec9cf370696bc98f1b411311b3c2817b0c78d0968L81-R83)

This PR fixes: #30438