### PR TITLE
chore(deployment): Update glowroot default temp and logging configuration (#30024)

### DIFF
--- a/docker/docker-compose-examples/single-node/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node/docker-compose.yml
@@ -57,6 +57,9 @@ services:
       DOT_ES_ENDPOINTS: 'https://opensearch:9200'
       DOT_INITIAL_ADMIN_PASSWORD: 'admin'
       DOT_DOTCMS_CLUSTER_ID: 'dotcms-production'
+      GLOWROOT_ENABLED: 'true'
+      GLOWROOT_WEB_UI_ENABLED: 'true' # Enable glowroot web ui on localhost.  do not use in production
+
       #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
     depends_on:
       - db
@@ -70,6 +73,7 @@ services:
     ports:
       - "8082:8082"
       - "8443:8443"
+      - "4000:4000" # Glowroot web ui if enabled
 
 networks:
   db_net:

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -1993,6 +1993,10 @@
                                             <todir>glowroot/local-web</todir>
                                         </configfile>
                                         <configfile>
+                                            <file>${tomcat9-overrides}/glowroot/glowroot.logback.xml</file>
+                                            <todir>glowroot</todir>
+                                        </configfile>
+                                        <configfile>
                                             <file>${tomcat9-overrides}/bin/build.conf</file>
                                             <todir>bin</todir>
                                         </configfile>

--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -62,10 +62,14 @@ fi
 # GLOWROOT_AGENT_ID: If set, specifies the agent ID for Glowroot and enables multi-directory mode.
 # GLOWROOT_COLLECTOR_ADDRESS: If set, specifies the collector address for Glowroot.
 
+if [ -z "$CATALINA_TMPDIR" ]; then
+      CATALINA_TMPDIR="$CATALINA_HOME/temp"
+fi
+
 add_glowroot_agent() {
     if ! echo "$CATALINA_OPTS" | grep -q '\-javaagent:.*glowroot\.jar'; then
-        echo "Adding Glowroot agent to CATALINA_OPTS"
         if [ "$GLOWROOT_ENABLED" = "true" ]; then
+          echo "Adding Glowroot agent to CATALINA_OPTS"
           export CATALINA_OPTS="$CATALINA_OPTS -javaagent:$CATALINA_HOME/glowroot/glowroot.jar"
 
           export GLOWROOT_SHARED_FOLDER="/data/shared/glowroot"
@@ -76,8 +80,8 @@ add_glowroot_agent() {
           fi
           CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.conf.dir=$GLOWROOT_CONF_DIR"
           # We may want to modify these defaults
-          CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.log.dir=${GLOWROOT_LOG_DIR:=$GLOWROOT_CONF_DIR/logs}"
-          CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.tmp.dir=${GLOWROOT_TMP_DIR:=$GLOWROOT_CONF_DIR/tmp}"
+          CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.tmp.dir=${GLOWROOT_TMP_DIR:=$CATALINA_TMPDIR}"
+          # Only used if when not using a collector
           CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.data.dir=${GLOWROOT_DATA_DIR:=$GLOWROOT_SHARED_FOLDER/data}"
 
           # Set GLOWROOT_AGENT_ID and enable multi-directory mode if defined

--- a/dotCMS/src/main/resources/container/tomcat9/glowroot/glowroot.logback.xml
+++ b/dotCMS/src/main/resources/container/tomcat9/glowroot/glowroot.logback.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+
+  <!-- to edit this file, copy it to the glowroot folder (where glowroot.jar resides),
+    keeping the same file name (glowroot.logback.xml), and glowroot will find it and use it instead
+    of the glowroot.logback.xml configuration file that is inside glowroot.jar -->
+
+  <appender name="CONSOLE" class="org.glowroot.agent.shaded.ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+    <!-- to use logstash encoder, comment out the encoder above, and uncomment the encoder below -->
+    <!--
+    <encoder class="org.glowroot.agent.shaded.net.logstash.logback.encoder.LogstashEncoder" />
+    -->
+</appender>
+
+  <logger name="org.glowroot.agent.shaded" level="error" />
+  <logger name="org.glowroot.agent.embedded.shaded" level="error" />
+  <!-- this is to deal with "Sending GOAWAY failed" that occur when connection to central fails
+    (which is already logged more nicely by DownstreamServiceObserver) -->
+  <logger name="org.glowroot.agent.shaded.io.netty.handler.codec.http2.Http2ConnectionHandler"
+    level="off" />
+  <root level="error">
+    <appender-ref ref="CONSOLE" />
+    <!--<appender-ref ref="FILE" />-->
+  </root>
+
+  <!-- unfortunately, cannot use logback/janino conditional to enable auditing in agent
+    due to https://github.com/qos-ch/logback/pull/291 -->
+
+  <!-- to enable auditing (step 1 of 2): comment out the line below -->
+
+  <logger name="audit" level="off" />
+
+  <!-- to enable auditing (step 2 of 2): uncomment the lines below -->
+
+  <!--
+  <appender name="AUDIT" class="org.glowroot.agent.shaded.ch.qos.logback.core.rolling.RollingFileAppender">
+    <rollingPolicy class="org.glowroot.agent.shaded.ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${glowroot.log.dir}/glowroot-audit.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="audit" level="info" additivity="false">
+    <appender-ref ref="AUDIT" />
+  </logger>
+  -->
+
+</configuration>

--- a/justfile
+++ b/justfile
@@ -59,10 +59,12 @@ build-select-module-deps module=":dotcms-core":
     ./mvnw install -pl {{ module }} --am -DskipTests=true
 
 # Development Commands
+dev-run:
+    ./mvnw -pl :dotcms-core -Pdocker-start -Ddocker.glowroot.enabled=true
 
 # Starts the dotCMS application in a Docker container on a dynamic port, running in the foreground
-dev-run:
-    ./mvnw -pl :dotcms-core -Pdocker-start,debug-suspend
+dev-run-debug:
+    ./mvnw -pl :dotcms-core -Pdocker-start,debug
 
 # Maps paths in the docker container to local paths, useful for development
 dev-run-map-dev-paths:
@@ -71,10 +73,6 @@ dev-run-map-dev-paths:
 # Starts the dotCMS application in debug mode with suspension, useful for troubleshooting
 dev-run-debug-suspend port="8082":
     ./mvnw -pl :dotcms-core -Pdocker-start,debug-suspend -Dtomcat.port={{ port }}
-
-# Starts the dotCMS Docker container in the background, running on random port
-dev-start:
-    ./mvnw -pl :dotcms-core -Pdocker-start
 
 # Starts the dotCMS Docker container in the background
 dev-start-on-port port="8082":

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -196,7 +196,6 @@
         <docker.skip.clean.after>false</docker.skip.clean.after>
         <debug.suspend.flag>n</debug.suspend.flag>
         <debug.port>5005</debug.port>
-        <docker.glowroot.enabled>false</docker.glowroot.enabled>
 
         <!-- Default debug port -->
         <debug.args.default>-agentlib:jdwp=transport=dt_socket,server=y,suspend=${debug.suspend.flag},address=*:${debug.port}</debug.args.default>
@@ -1478,14 +1477,24 @@
                                 </goals>
                                 <phase>validate</phase>
                                 <configuration>
-                                    <target>
+                                    <target xmlns:ac="antlib:net.sf.antcontrib">
                                         <!-- Here is where you define your Ant tasks -->
                                         <!--suppress UnresolvedMavenProperty -->
-                                        <echo message="DotCMS started on     : http://localhost:${tomcat.port}/dotAdmin"/>
+                                        <echo message="DotCMS started on (use fixed with -Dtomcat.port=8080)    : http://localhost:${tomcat.port}/dotAdmin"/>
+
                                         <!--suppress UnresolvedMavenProperty -->
-                                        <echo message="Postgres started on   : jdbc:postgresql://localhost:${db.port}/dotcms user = postgres pass = postgres"/>
+                                        <echo message="Postgres started on  (use fixed with -Ddb.port=5423) : jdbc:postgresql://localhost:${db.port}/dotcms user = postgres pass = postgres"/>
                                         <!--suppress UnresolvedMavenProperty -->
-                                        <echo message="OpenSearch started on : http://localhost:${es.port}"/>
+                                        <echo message="OpenSearch started on (use fixed with -Des.port=9200) : http://localhost:${es.port}"/>
+
+
+                                        <!-- Check if the glowroot profile is enabled and output the glowroot.port -->
+                                        <ac:if>
+                                            <ac:isset property="glowroot.port"/>
+                                            <then>
+                                                <echo message="Glowroot started on (use fixed with -Dglowroot.port=4000) : http://localhost:${glowroot.port}"/>
+                                            </then>
+                                        </ac:if>
                                     </target>
                                 </configuration>
                             </execution>
@@ -1584,8 +1593,7 @@
                     <value>true</value>
                 </property>
             </activation>
-            <properties>
-            </properties>
+
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
This pull request introduces several changes to the `dotCMS` project, focusing on configuration updates, new development commands, and improvements to the build process. The most important changes include the addition of a new configuration file for Glowroot, updates to development commands in the `justfile`, and enhancements to the `parent/pom.xml` file to support dynamic port configurations.

### Configuration Updates:
* Added a new Glowroot configuration file `glowroot.logback.xml` to the `dotCMS/pom.xml` file.
* Introduced the `glowroot.logback.xml` configuration file with detailed logging settings.

### Development Commands:
* Updated `justfile` to update `dev-run` command for running the application with Glowroot enabled and renamed the existing `dev-run` that added debug without suspend to `dev-run-debug`.
* Removed the `dev-start` command from the `justfile` as was confusing between dev-start and dev-run

### Build Process Enhancements:
* Modified `parent/pom.xml` to dynamically output the Glowroot port if the profile is enabled.

### Docker Environment Updates:

* Made glowroot use the  `CATALINA_TMPDIR` environment variable by default for consistent behaviour.  We may consider later changing to use a DOTCMS_TMPDIR and set CATALINA_TMPDIR and others to this at a later time.


when using maven and the just commands specifying -Ddocker.glowroot.enabled=true will enable glowroot on a dynamic local port when starting up to prevent port conflicts.   Maven will report the full url to glowroot ui.  This has been added by default in the just file to the dev-run command but can be added to any maven command that starts up the dotcms image.   The local docker port mapping can be fixed using -Dglowroot.port=4000  if required.

Whe using a development docker-compose use the following.   GLOWROOT_WEB_UI_ENABLED is required to set the listen address to 0.0.0.0 to allow access.

      GLOWROOT_ENABLED: 'true'
      GLOWROOT_WEB_UI_ENABLED: 'true'
      

In the K8s env we need to set the remote collector address and GLOWROOT_AGENT_ID e.g. 

```
        - name: GLOWROOT_ENABLED
          value: 'true'
        - name: GLOWROOT_AGENT_ID
          value: dotcms-qa::master
        - name: GLOWROOT_COLLECTOR_ADDRESS
          value: http://glowrootcentral.dotcmscloud.com:8181
```

Related to #30024 (Need to ship with the updated glowroot.jar).


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #30024