### PR TITLE
fix(Unable to run IT from the IDE) Refs: #30564

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -323,13 +323,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
     }
 
     private static UniqueFieldValidationStrategyResolver getUniqueFieldValidationStrategyResolver() {
-        final Optional<UniqueFieldValidationStrategyResolver> uniqueFieldValidationStrategyResolver =
-                CDIUtils.getBean(UniqueFieldValidationStrategyResolver.class);
-
-        if (!uniqueFieldValidationStrategyResolver.isPresent()) {
-            throw new DotRuntimeException("Could not instance UniqueFieldValidationStrategyResolver");
-        }
-        return uniqueFieldValidationStrategyResolver.get();
+        return CDIUtils.getBeanThrows(UniqueFieldValidationStrategyResolver.class);
     }
 
     public ESContentletAPIImpl() {

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldValidationStrategyResolver.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldValidationStrategyResolver.java
@@ -16,9 +16,11 @@ import javax.inject.Inject;
 @ApplicationScoped
 public class UniqueFieldValidationStrategyResolver {
 
-    private final ESUniqueFieldValidationStrategy esUniqueFieldValidationStrategy;
+    private ESUniqueFieldValidationStrategy esUniqueFieldValidationStrategy;
 
-    private final DBUniqueFieldValidationStrategy dbUniqueFieldValidationStrategy;
+    private DBUniqueFieldValidationStrategy dbUniqueFieldValidationStrategy;
+
+    public UniqueFieldValidationStrategyResolver(){}
 
     @Inject
     public  UniqueFieldValidationStrategyResolver(final ESUniqueFieldValidationStrategy esUniqueFieldValidationStrategy,

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldValidationStrategyResolver.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldValidationStrategyResolver.java
@@ -1,14 +1,10 @@
 package com.dotcms.contenttype.business.uniquefields;
 
-import com.dotcms.cdi.CDIUtils;
 import com.dotcms.content.elasticsearch.business.ESContentletAPIImpl;
 import com.dotcms.contenttype.business.uniquefields.extratable.DBUniqueFieldValidationStrategy;
-import com.dotmarketing.exception.DotRuntimeException;
-import com.google.common.annotations.VisibleForTesting;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.Optional;
 
 /**
  * Utility class responsible for returning the appropriate {@link UniqueFieldValidationStrategy}
@@ -20,14 +16,11 @@ import java.util.Optional;
 @ApplicationScoped
 public class UniqueFieldValidationStrategyResolver {
 
-    @Inject
-    private ESUniqueFieldValidationStrategy esUniqueFieldValidationStrategy;
-    @Inject
-    private  DBUniqueFieldValidationStrategy dbUniqueFieldValidationStrategy;
+    private final ESUniqueFieldValidationStrategy esUniqueFieldValidationStrategy;
 
-    public UniqueFieldValidationStrategyResolver(){}
+    private final DBUniqueFieldValidationStrategy dbUniqueFieldValidationStrategy;
 
-    @VisibleForTesting
+    @Inject
     public  UniqueFieldValidationStrategyResolver(final ESUniqueFieldValidationStrategy esUniqueFieldValidationStrategy,
                                                  final DBUniqueFieldValidationStrategy dbUniqueFieldValidationStrategy){
         this.esUniqueFieldValidationStrategy = esUniqueFieldValidationStrategy;

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldValidationStrategyResolver.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldValidationStrategyResolver.java
@@ -2,8 +2,6 @@ package com.dotcms.contenttype.business.uniquefields;
 
 import com.dotcms.content.elasticsearch.business.ESContentletAPIImpl;
 import com.dotcms.contenttype.business.uniquefields.extratable.DBUniqueFieldValidationStrategy;
-
-import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldValidationStrategyResolver.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldValidationStrategyResolver.java
@@ -4,6 +4,7 @@ import com.dotcms.content.elasticsearch.business.ESContentletAPIImpl;
 import com.dotcms.contenttype.business.uniquefields.extratable.DBUniqueFieldValidationStrategy;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 /**
@@ -13,14 +14,12 @@ import javax.inject.Inject;
  * an {@link ESUniqueFieldValidationStrategy} is used.
  *
  */
-@ApplicationScoped
+@Dependent
 public class UniqueFieldValidationStrategyResolver {
 
-    private ESUniqueFieldValidationStrategy esUniqueFieldValidationStrategy;
+    private final ESUniqueFieldValidationStrategy esUniqueFieldValidationStrategy;
 
-    private DBUniqueFieldValidationStrategy dbUniqueFieldValidationStrategy;
-
-    public UniqueFieldValidationStrategyResolver(){}
+    private final DBUniqueFieldValidationStrategy dbUniqueFieldValidationStrategy;
 
     @Inject
     public  UniqueFieldValidationStrategyResolver(final ESUniqueFieldValidationStrategy esUniqueFieldValidationStrategy,

--- a/dotcms-integration/src/test/java/com/dotcms/IntegrationTestBase.java
+++ b/dotcms-integration/src/test/java/com/dotcms/IntegrationTestBase.java
@@ -29,10 +29,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -51,11 +51,13 @@ import org.junit.rules.TestName;
 public abstract class IntegrationTestBase extends BaseMessageResources {
 
     private static Boolean debugMode = Boolean.FALSE;
-    private final static PrintStream stdout = System.out;
-    private final static ByteArrayOutputStream output = new ByteArrayOutputStream();
+    private static final PrintStream stdout = System.out;
+    private static final ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     @Rule
-    public TestName name = new TestName();
+    public TestName getTestName() {
+        return new TestName();
+    }
 
     @BeforeClass
     public static void beforeInit() throws Exception {
@@ -64,12 +66,12 @@ public abstract class IntegrationTestBase extends BaseMessageResources {
         Config.setProperty("SYSTEM_EXIT_ON_STARTUP_FAILURE", false);
     }
 
-    protected static void setDebugMode(final boolean mode) throws UnsupportedEncodingException {
+    protected static void setDebugMode(final boolean mode) {
 
         debugMode = mode;
         if (debugMode) {
 
-            System.setOut(new PrintStream(output, true, "UTF-8"));
+            System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
         }
     }
 
@@ -126,12 +128,12 @@ public abstract class IntegrationTestBase extends BaseMessageResources {
 
         if (DbConnectionFactory.inTransaction()) {
             Logger.error(IntegrationTestBase.class,
-                    "Test " + name.getMethodName() + " has open transaction after");
+                    "Test " + getTestName().getMethodName() + " has open transaction after");
         }
 
         if (DbConnectionFactory.connectionExists()) {
             Logger.error(IntegrationTestBase.class,
-                    "Test " + name.getMethodName() + " has open connection after");
+                    "Test " + getTestName().getMethodName() + " has open connection after");
         }
 
         //Closing the session

--- a/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/FilesCollectorTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/FilesCollectorTest.java
@@ -1,6 +1,7 @@
 package com.dotcms.analytics.track.collectors;
 
 import com.dotcms.IntegrationTestBase;
+import com.dotcms.JUnit4WeldRunner;
 import com.dotcms.LicenseTestUtil;
 import com.dotcms.analytics.track.matchers.FilesRequestMatcher;
 import com.dotcms.datagen.ContentletDataGen;
@@ -18,6 +19,7 @@ import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
+import javax.enterprise.context.ApplicationScoped;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -26,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -36,6 +39,8 @@ import static org.mockito.Mockito.mock;
  * @author Jose Castro
  * @since Oct 16th, 2024
  */
+@ApplicationScoped
+@RunWith(JUnit4WeldRunner.class)
 public class FilesCollectorTest extends IntegrationTestBase {
 
     private static final String PARENT_FOLDER_1_NAME = "parent-folder";

--- a/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/PageDetailCollectorTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/PageDetailCollectorTest.java
@@ -1,6 +1,7 @@
 package com.dotcms.analytics.track.collectors;
 
 import com.dotcms.IntegrationTestBase;
+import com.dotcms.JUnit4WeldRunner;
 import com.dotcms.LicenseTestUtil;
 import com.dotcms.analytics.track.matchers.PagesAndUrlMapsRequestMatcher;
 import com.dotcms.contenttype.model.type.ContentType;
@@ -23,6 +24,7 @@ import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
+import javax.enterprise.context.ApplicationScoped;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -31,6 +33,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -42,6 +45,9 @@ import static org.mockito.Mockito.mock;
  * @author Jose Castro
  * @since Oct 14th, 2024
  */
+
+@ApplicationScoped
+@RunWith(JUnit4WeldRunner.class)
 public class PageDetailCollectorTest extends IntegrationTestBase {
 
     private static final String PARENT_FOLDER_1_NAME = "news";

--- a/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/PagesCollectorTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/PagesCollectorTest.java
@@ -1,6 +1,7 @@
 package com.dotcms.analytics.track.collectors;
 
 import com.dotcms.IntegrationTestBase;
+import com.dotcms.JUnit4WeldRunner;
 import com.dotcms.LicenseTestUtil;
 import com.dotcms.analytics.track.matchers.PagesAndUrlMapsRequestMatcher;
 import com.dotcms.contenttype.model.type.ContentType;
@@ -23,6 +24,7 @@ import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
 import io.vavr.API;
+import javax.enterprise.context.ApplicationScoped;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -31,6 +33,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -43,6 +46,8 @@ import static org.mockito.Mockito.mock;
  * @author Jose Castro
  * @since Oct 9th, 2024
  */
+@ApplicationScoped
+@RunWith(JUnit4WeldRunner.class)
 public class PagesCollectorTest extends IntegrationTestBase {
 
     private static final String TEST_PAGE_NAME = "index";

--- a/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/SyncVanitiesCollectorTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/SyncVanitiesCollectorTest.java
@@ -1,6 +1,7 @@
 package com.dotcms.analytics.track.collectors;
 
 import com.dotcms.IntegrationTestBase;
+import com.dotcms.JUnit4WeldRunner;
 import com.dotcms.LicenseTestUtil;
 import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.datagen.FileAssetDataGen;
@@ -24,6 +25,7 @@ import com.dotmarketing.portlets.templates.model.Template;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
+import javax.enterprise.context.ApplicationScoped;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -33,6 +35,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -44,6 +47,8 @@ import static org.mockito.Mockito.mock;
  * @author Jose Castro
  * @since Oct 21st, 2024
  */
+@ApplicationScoped
+@RunWith(JUnit4WeldRunner.class)
 public class SyncVanitiesCollectorTest extends IntegrationTestBase {
 
     private static final String TEST_PAGE_NAME = "index";

--- a/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/WebEventsCollectorServiceImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/WebEventsCollectorServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.dotcms.analytics.track.collectors;
 
+import com.dotcms.DataProviderWeldRunner;
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.LicenseTestUtil;
 import com.dotcms.analytics.app.AnalyticsApp;
@@ -45,6 +46,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import javax.enterprise.context.ApplicationScoped;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -76,7 +78,8 @@ import static org.mockito.Mockito.when;
  * @author Jose Castro
  * @since Oct 3rd, 2024
  */
-@RunWith(DataProviderRunner.class)
+@ApplicationScoped
+@RunWith(DataProviderWeldRunner.class)
 public class WebEventsCollectorServiceImplTest extends IntegrationTestBase {
 
     private static final String PARENT_FOLDER_1_NAME = "parent-folder";

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/ContentTypeDestroyAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/ContentTypeDestroyAPIImplTest.java
@@ -1,6 +1,7 @@
 package com.dotcms.contenttype.business;
 
 import com.dotcms.IntegrationTestBase;
+import com.dotcms.JUnit4WeldRunner;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
 import com.dotcms.contenttype.business.ContentTypeDestroyAPIImpl.ContentletVersionInfo;
@@ -14,7 +15,6 @@ import com.dotcms.datagen.PersonaDataGen;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.datagen.TagDataGen;
 import com.dotcms.datagen.TestDataUtils;
-import com.dotcms.datagen.TestWorkflowUtils;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
@@ -37,14 +37,18 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * Here we test the {@link ContentTypeDestroyAPIImpl}
  * @author Fabrizzio
  */
+@ApplicationScoped
+@RunWith(JUnit4WeldRunner.class)
 public class ContentTypeDestroyAPIImplTest extends IntegrationTestBase {
 
     @BeforeClass
@@ -140,7 +144,7 @@ public class ContentTypeDestroyAPIImplTest extends IntegrationTestBase {
         Assert.assertNull(deletedContentType);
 
         //Test no copy structure is left hang around
-        final String likeName =  String.format("%s_disposed_*", name);
+        final String likeName =  String.format("%s_disposed_*", getTestName());
         int count = new DotConnect().setSQL("select count(*) as x from structure where velocity_var_name like ? ").addParam(likeName).getInt("x");
         Assert.assertEquals(0, count);
 

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/ContentTypeInitializerTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/ContentTypeInitializerTest.java
@@ -29,8 +29,6 @@ import org.junit.runner.RunWith;
  * Test for the {@link ContentTypeInitializer}
  * @author jsanca
  */
-@ApplicationScoped
-@RunWith(JUnit4WeldRunner.class)
 public class ContentTypeInitializerTest extends IntegrationTestBase {
 
     @BeforeClass

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/ContentTypeInitializerTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/ContentTypeInitializerTest.java
@@ -1,10 +1,12 @@
 package com.dotcms.contenttype.business;
 
 import com.dotcms.IntegrationTestBase;
+import com.dotcms.JUnit4WeldRunner;
 import com.dotcms.content.elasticsearch.constants.ESMappingConstants;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.datagen.UserDataGen;
+import com.dotcms.repackage.org.directwebremoting.guice.ApplicationScoped;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Permission;
 import com.dotmarketing.business.APILocator;
@@ -21,11 +23,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
+import org.junit.runner.RunWith;
 
 /**
  * Test for the {@link ContentTypeInitializer}
  * @author jsanca
  */
+@ApplicationScoped
+@RunWith(JUnit4WeldRunner.class)
 public class ContentTypeInitializerTest extends IntegrationTestBase {
 
     @BeforeClass

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/test/ContentResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/test/ContentResourceTest.java
@@ -1,5 +1,17 @@
 package com.dotcms.contenttype.test;
 
+import static com.dotcms.rest.api.v1.workflow.WorkflowTestUtil.DM_WORKFLOW;
+import static com.dotmarketing.business.Role.ADMINISTRATOR;
+import static com.dotmarketing.portlets.workflows.business.BaseWorkflowIntegrationTest.createContentTypeAndAssignPermissions;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.dotcms.DataProviderWeldRunner;
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.FieldAPI;
@@ -62,35 +74,8 @@ import com.liferay.portal.model.User;
 import com.liferay.portal.util.WebKeys;
 import com.liferay.util.StringPool;
 import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import io.vavr.Tuple2;
-import org.glassfish.jersey.internal.util.Base64;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-
-import javax.servlet.ReadListener;
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -107,19 +92,35 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.enterprise.context.ApplicationScoped;
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.glassfish.jersey.internal.util.Base64;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
-import static com.dotcms.rest.api.v1.workflow.WorkflowTestUtil.DM_WORKFLOW;
-import static com.dotmarketing.business.Role.ADMINISTRATOR;
-import static com.dotmarketing.portlets.workflows.business.BaseWorkflowIntegrationTest.createContentTypeAndAssignPermissions;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-@RunWith(DataProviderRunner.class)
+@ApplicationScoped
+@RunWith(DataProviderWeldRunner.class)
 public class ContentResourceTest extends IntegrationTestBase {
 
     final static String REQUIRED_NUMERIC_FIELD_NAME = "numeric";


### PR DESCRIPTION
Normally, the rule for running an integration test is to annotate it with the JUnit4WeldRunner. Additionally, annotate the test as @ApplicationScoped. However, there was an issue with a bean that was instantiated deep within the core of the CMS, causing a failure that impacted integration tests. 
Particularly on `UniqueFieldValidationStrategyResolver`which has an injection problem
I resolved the problem by moving the injection to the constructor

Injecting private fields as follows is problematic :

```
@Inject
private  DBUniqueFieldValidationStrategy dbUniqueFieldValidationStrategy;

```
This problem did not surface in other scenarios, but it became visible when running directly from the integration test. Additionally, there was a public field with an @Rule in JUnit 4 that was also causing issues, which has been corrected as well.

This PR fixes: #30564