### PR TITLE
feat(Locales) #30297 : Generate new Full and Empty Starters with the Locales portlet

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,7 +76,7 @@
         <docker.jacoco.skip>true</docker.jacoco.skip>
         <!-- starter -->
         <starter.download.folder>${project.build.directory}/starter</starter.download.folder>
-        <starter.deploy.version>empty_20240719</starter.deploy.version>
+        <starter.deploy.version>empty_20241105</starter.deploy.version>
         <starter.deploy.filename>starter.zip</starter.deploy.filename>
         <starter.run.version>${starter.deploy.version}</starter.run.version>
         <starter.run.filename>starter-${starter.run.version}.zip</starter.run.filename>


### PR DESCRIPTION
### Proposed Changes
* Updates the `dotcms-parent/pom.xml` file to point to the latest Empty Starter: `empty_20241105`
* A new Full Starter was generated as well.
* The main goal in both Starters is to replace the old `Languages` portlet with two new portlets: `Locales`, and `Language Variables`.

This PR fixes: #30297