### PR TITLE
Add get draft method to fetch working version pages

### DIFF
--- a/core-web/libs/sdk/client/src/lib/client/sdk-js-client.spec.ts
+++ b/core-web/libs/sdk/client/src/lib/client/sdk-js-client.spec.ts
@@ -264,6 +264,30 @@ describe('DotCmsClient', () => {
             });
         });
 
+        describe('page.getDraft', () => {
+            it('should fetch draft page data successfully', async () => {
+                const mockResponse = { content: 'Draft Page data' };
+                mockFetchResponse({ entity: mockResponse });
+
+                const data = await client.page.getDraft({ path: '/home' });
+
+                expect(fetch).toHaveBeenCalledTimes(1);
+                expect(fetch).toHaveBeenCalledWith(
+                    'http://localhost/api/v1/page/json/home?mode=EDIT_MODE&host_id=123456',
+                    {
+                        headers: { Authorization: 'Bearer ABC' }
+                    }
+                );
+                expect(data).toEqual(mockResponse);
+            });
+
+            it('should throw an error if the path is not provided', async () => {
+                await expect(client.page.getDraft({} as any)).rejects.toThrowError(
+                    `The 'path' parameter is required for the Page API`
+                );
+            });
+        });
+
         describe('editor.on', () => {
             it('should listen to FETCH_PAGE_ASSET_FROM_UVE event', () => {
                 isInsideEditorSpy.mockReturnValue(true);

--- a/core-web/libs/sdk/client/src/lib/client/sdk-js-client.ts
+++ b/core-web/libs/sdk/client/src/lib/client/sdk-js-client.ts
@@ -289,6 +289,28 @@ export class DotCmsClient {
             }
 
             return response.json().then((data) => data.entity);
+        },
+
+        /**
+         * `page.getDraft` is an asynchronous method of the `DotCmsClient` class that retrieves the draft version of any Page in your dotCMS system in JSON format.
+         * It takes a `PageApiOptions` object as a parameter and returns a Promise that resolves to the response from the DotCMS API.
+         *
+         * The Page API enables you to retrieve the draft version of any Page in your dotCMS system.
+         * The elements may be retrieved in JSON format.
+         *
+         * @link https://www.dotcms.com/docs/latest/page-rest-api-layout-as-a-service-laas
+         * @async
+         * @param {PageApiOptions} options - The options for the Page API call.
+         * @returns {Promise<unknown>} - A Promise that resolves to the response from the DotCMS API.
+         * @throws {Error} - Throws an error if the options are not valid.
+         * @example
+         * ```ts
+         * const client = new DotCmsClient({ dotcmsUrl: 'https://your.dotcms.com', authToken: 'your-auth-token', siteId: 'your-site-id' });
+         * client.page.getDraft({ path: '/about-us' }).then(response => console.log(response));
+         * ```
+         */
+        getDraft: async (options: PageApiOptions): Promise<unknown> => {
+            return this.page.get({ ...options, mode: 'EDIT_MODE' });
         }
     };
 


### PR DESCRIPTION
Fixes #28003

Update the client SDK to fetch the draft version of pages.

* Add a new `getDraft` method to the `DotCmsClient` class in `core-web/libs/sdk/client/src/lib/client/sdk-js-client.ts` to fetch the draft version of a page by setting the `mode` parameter to `EDIT_MODE`.
* Add unit tests for the new `getDraft` method in `core-web/libs/sdk/client/src/lib/client/sdk-js-client.spec.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotCMS/core/issues/28003?shareId=1a609c38-af5d-44fc-830a-df1bb63f7dc8).