### PR TITLE
ci(semgrep): Fix trunk workflow for semgrep step passing artifact run id (#30610)

### DIFF
--- a/.github/workflows/cicd_3-trunk.yml
+++ b/.github/workflows/cicd_3-trunk.yml
@@ -97,6 +97,8 @@ jobs:
     needs: [ initialize, test ]
     if: always() && !failure() && !cancelled() && vars.DISABLE_SEMGREP != 'true'
     uses: ./.github/workflows/cicd_comp_semgrep-phase.yml
+    with:
+      artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
     secrets:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 

--- a/.github/workflows/cicd_comp_semgrep-phase.yml
+++ b/.github/workflows/cicd_comp_semgrep-phase.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Prepare Maven environment and run SonarQube analysis
+      # Create dependency files for semgrep analysis
       - name: Build Dependency Tre
         uses: ./.github/actions/core-cicd/maven-job
         with:
@@ -41,6 +41,8 @@ jobs:
           artifacts-from: ${{ inputs.artifact-run-id }}
           require-main: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          require-graalvm: false
+          requires-node: false
           maven-args: dependency:tree -DoutputFile=maven_dep_tree.txt
       - name: Create Zip File
         run: find . -type f -name 'maven_dep_tree.txt' -exec zip -r dependency-tree.zip {} +


### PR DESCRIPTION
### Proposed Changes
* Error in trunk workflow due to artifact run id not being passed into semgrep workflow

https://github.com/dotCMS/core/actions/runs/11782551202/job/32817867816#step:3:228

This PR fixes: #30610