### PR TITLE
fix(dotcli) allow push very large files #30206

### DIFF
--- a/tools/dotcms-cli/api-data-model/src/main/resources/application.properties
+++ b/tools/dotcms-cli/api-data-model/src/main/resources/application.properties
@@ -35,3 +35,6 @@ com.dotcms.starter.site=default
 %test.com.dotcms.starter.site=default
 # We can also start our tests using a demo profile to test against a demo site
 %demo.com.dotcms.starter.site=demo.dotcms.com
+
+# The threshold to use for the amount of data that can be stored in a file for entities. -1 means no limit is set.
+dev.resteasy.entity.file.threshold=-1

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/api/client/files/PushServiceIT.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/api/client/files/PushServiceIT.java
@@ -41,6 +41,8 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import jakarta.inject.Inject;
 import org.apache.commons.io.FileUtils;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -949,6 +951,21 @@ class PushServiceIT {
         final var remoteAssetPath = buildRemoteAssetURL(siteName, folderPath, assetName);
         Assertions.assertTrue(filesTestHelper.assetExist(remoteAssetPath),
                 String.format("Asset %s was not created", remoteAssetPath));
+    }
+
+
+    /**
+     * Verifies that the RESTEasy file upload threshold is properly configured.
+     * This test ensures that the 'quarkus.resteasy.multipart.file-size-threshold' property 
+     * is set to -1, which allows for unlimited file sizes during multipart file uploads.
+     * Setting this value to -1 is crucial for handling large file uploads
+     */
+    @Test
+    void testFileThresholdProperty() {
+        final Config config = ConfigProvider.getConfig();
+        final Long fileThreshold = config.getValue("dev.resteasy.entity.file.threshold", Long.class);
+        // Assert that the property is correctly set to -1
+        Assertions.assertEquals(-1L, fileThreshold, "The file threshold should be set to -1 for unlimited file size.");
     }
 
 }


### PR DESCRIPTION
### Proposed Changes
* Added a new property `dev.resteasy.entity.file.threshold=-1` to `application.properties` to configure the file size threshold for RESTEasy file uploads.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated

### Additional Info
This change ensures that large file uploads via RESTEasy are not limited by the file size threshold, allowing for unlimited file uploads, which is crucial in certain environments where large files need to be processed.

### Screenshots

https://github.com/user-attachments/assets/d9dba1fb-a3e4-493a-84c3-5dd22db924c4


This PR fixes: #30206