### PR TITLE
fix(uve): Toolbar is missing due to lack of FF on config

### DIFF
--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -856,6 +856,9 @@ CONTENT_EDITOR2_ENABLED=false
 ## Localizations Enhancements
 LOCALIZATION_ENHANCEMENTS_ENABLED=false
 
+## UVE Preview Mode
+FEATURE_FLAG_UVE_PREVIEW_MODE=false
+
 STARTER_BUILD_VERSION=${starter.deploy.version}
 
 ##LTS properties to show EOL message


### PR DESCRIPTION
This pull request includes a change to the `dotmarketing-config.properties` file to add a new feature flag for UVE Preview Mode.

Configuration updates:

* [`dotCMS/src/main/resources/dotmarketing-config.properties`](diffhunk://#diff-2811adad7784fd6904fe136b6f40ab001ef040527847c1b6664178adf9bde777R859-R861): Added a new feature flag `FEATURE_FLAG_UVE_PREVIEW_MODE` set to `false` to control the UVE Preview Mode.

This PR fixes: #30459