### PR TITLE
fix(examples): Hide edit button outside editor

### DIFF
--- a/examples/nextjs/src/components/shared/contentlets.js
+++ b/examples/nextjs/src/components/shared/contentlets.js
@@ -1,7 +1,7 @@
 'use client';
-import React from 'react';
+import { useMemo } from 'react';
 import Image from 'next/image';
-import { editContentlet } from '@dotcms/client';
+import { editContentlet, isInsideEditor } from '@dotcms/client';
 
 const dateFormatOptions = {
     year: 'numeric',
@@ -10,27 +10,31 @@ const dateFormatOptions = {
 };
 
 function Contentlets({ contentlets }) {
+    const insideEditor = useMemo(isInsideEditor, []);
+
     return (
         <ul className="flex flex-col gap-7">
             {contentlets.map((contentlet) => (
                 <li className="flex gap-7 min-h-16 relative" key={contentlet.identifier}>
-                    <button
-                        onClick={() => editContentlet(contentlet)}
-                        style={{
-                            color: 'black',
-                            border: '1px solid black',
-                            position: 'absolute',
-                            bottom: 0,
-                            right: 0,
-                            width: '40px',
-                            height: '20px',
-                            zIndex: 1000,
-                            display: 'flex',
-                            justifyContent: 'center',
-                            alignItems: 'center'
-                        }}>
-                        Edit
-                    </button>
+                    {insideEditor && (
+                        <button
+                            onClick={() => editContentlet(contentlet)}
+                            style={{
+                                color: 'black',
+                                border: '1px solid black',
+                                position: 'absolute',
+                                bottom: 0,
+                                right: 0,
+                                width: '40px',
+                                height: '20px',
+                                zIndex: 1000,
+                                display: 'flex',
+                                justifyContent: 'center',
+                                alignItems: 'center'
+                            }}>
+                            Edit
+                        </button>
+                    )}
                     <a className="relative min-w-32" href={contentlet.urlMap || contentlet.url}>
                         {contentlet.image && (
                             <Image


### PR DESCRIPTION
This pull request includes changes to the `examples/nextjs/src/components/shared/contentlets.js` file to improve the functionality and performance of the `Contentlets` component. The most important changes include replacing `React` with `useMemo`, adding a new import for `isInsideEditor`, and conditionally rendering the edit button based on whether the contentlet is inside the editor.

Improvements to functionality:

* [`examples/nextjs/src/components/shared/contentlets.js`](diffhunk://#diff-b6f3603978bcab24fcdd25b0a658c2ae69d34c68a14f6f5be88a0c1fb0e8a0edL2-R4): Replaced the `React` import with `useMemo` to memoize the `isInsideEditor` function.
* [`examples/nextjs/src/components/shared/contentlets.js`](diffhunk://#diff-b6f3603978bcab24fcdd25b0a658c2ae69d34c68a14f6f5be88a0c1fb0e8a0edL2-R4): Added a new import for `isInsideEditor` from `@dotcms/client` to check if the contentlet is inside the editor.
* [`examples/nextjs/src/components/shared/contentlets.js`](diffhunk://#diff-b6f3603978bcab24fcdd25b0a658c2ae69d34c68a14f6f5be88a0c1fb0e8a0edR13-R19): Used `useMemo` to create a memoized value `insideEditor` for determining if the contentlet is inside the editor.
* [`examples/nextjs/src/components/shared/contentlets.js`](diffhunk://#diff-b6f3603978bcab24fcdd25b0a658c2ae69d34c68a14f6f5be88a0c1fb0e8a0edR37): Conditionally rendered the edit button based on the `insideEditor` value to improve user experience.

This PR fixes: #30218