### PR TITLE
implementation ( Edit Content): #30212 Display Toast Message on Contentlet Save

### DIFF
--- a/core-web/libs/edit-content/src/lib/edit-content.shell.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/edit-content.shell.component.spec.ts
@@ -1,22 +1,18 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+
+import { Toast } from 'primeng/toast';
 
 import { EditContentShellComponent } from './edit-content.shell.component';
 
-describe('EditContentComponent', () => {
-    let component: EditContentShellComponent;
-    let fixture: ComponentFixture<EditContentShellComponent>;
+describe('EditContentShellComponent', () => {
+    let spectator: Spectator<EditContentShellComponent>;
+    const createComponent = createComponentFactory(EditContentShellComponent);
 
-    beforeEach(async () => {
-        await TestBed.configureTestingModule({
-            imports: [EditContentShellComponent]
-        }).compileComponents();
-
-        fixture = TestBed.createComponent(EditContentShellComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
+    beforeEach(() => {
+        spectator = createComponent();
     });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
+    it('should have p-toast component', () => {
+        expect(spectator.query(Toast)).toBeTruthy();
     });
 });

--- a/core-web/libs/edit-content/src/lib/edit-content.shell.component.ts
+++ b/core-web/libs/edit-content/src/lib/edit-content.shell.component.ts
@@ -1,11 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
+import { MessageService } from 'primeng/api';
+import { ToastModule } from 'primeng/toast';
+
 @Component({
     selector: 'dot-edit-content',
     standalone: true,
-    imports: [RouterModule],
-    template: '<router-outlet />',
+    imports: [RouterModule, ToastModule],
+    providers: [MessageService],
+    template: '<p-toast /> <router-outlet />',
     styleUrls: ['./edit-content.shell.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.html
+++ b/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.html
@@ -38,5 +38,4 @@
     }
 }
 
-<p-toast />
 <p-confirmDialog />

--- a/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.spec.ts
@@ -16,7 +16,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { MessageService } from 'primeng/api';
 import { ConfirmDialog } from 'primeng/confirmdialog';
 import { MessagesModule } from 'primeng/messages';
-import { Toast, ToastModule } from 'primeng/toast';
 
 import {
     DotContentTypeService,
@@ -46,8 +45,6 @@ describe('EditContentLayoutComponent', () => {
     const createComponent = createComponentFactory({
         component: EditContentLayoutComponent,
         imports: [
-            MockModule(ToastModule),
-
             MockModule(MessagesModule),
             MockComponent(DotEditContentFormComponent),
             MockComponent(DotEditContentSidebarComponent)
@@ -100,10 +97,6 @@ describe('EditContentLayoutComponent', () => {
         jest.spyOn(utils, 'getPersistSidebarState').mockReturnValue(true);
     });
 
-    it('should have p-toast component', () => {
-        expect(spectator.query(Toast)).toBeTruthy();
-    });
-
     it('should have p-confirmDialog component', () => {
         expect(spectator.query(ConfirmDialog)).toBeTruthy();
     });
@@ -126,7 +119,6 @@ describe('EditContentLayoutComponent', () => {
             expect(spectator.query(byTestId('edit-content-layout__body'))).toBeTruthy();
             expect(spectator.query(byTestId('edit-content-layout__sidebar'))).toBeTruthy();
 
-            expect(spectator.query(Toast)).toBeTruthy();
             expect(spectator.query(ConfirmDialog)).toBeTruthy();
         }));
 

--- a/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.ts
+++ b/core-web/libs/edit-content/src/lib/feature/edit-content/edit-content.layout.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
-import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { MessagesModule } from 'primeng/messages';
@@ -37,7 +36,6 @@ import { DotEditContentService } from '../../services/dot-edit-content.service';
         DotWorkflowsActionsService,
         DotWorkflowActionsFireService,
         DotEditContentService,
-        MessageService,
         DotWorkflowService,
         DotEditContentStore
     ],


### PR DESCRIPTION
### Proposed Changes
* Move `ToastModule ` to `edit-content.shell.component.ts`, to support notifications on route change. 

This PR fixes: #30212