### PR TITLE
fix: use UtilMethods.isSet instead of comparing against null. ref: #30130

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
@@ -377,7 +377,7 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
           final String queryString = request.getQueryString();
           final int responseCode = request.getResponseCode();
 
-          final String newUrl = uri + (queryString != null ? StringPool.QUESTION + queryString : StringPool.BLANK);
+          final String newUrl = uri + (UtilMethods.isSet(queryString) ? StringPool.QUESTION + queryString : StringPool.BLANK);
 
           if (responseCode == 301 || responseCode == 302) {
               response.setStatus(responseCode);


### PR DESCRIPTION
This pull request includes a small but important change to the `VanityUrlAPIImpl.java` file. The change improves the way query strings are handled when constructing new URLs.

* [`dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java`](diffhunk://#diff-1b71d209a0e8438b81297d8be0bf3b1868c489d30114645b3e0974025de9d5c2L380-R380): Replaced the null check for `queryString` with a call to `UtilMethods.isSet(queryString)` to improve readability and consistency.