### PR TITLE
chore(edit-ema) add remove word-break: all to Page Tools dialog content

### DIFF
--- a/core-web/apps/dotcms-ui/proxy-dev.conf.mjs
+++ b/core-web/apps/dotcms-ui/proxy-dev.conf.mjs
@@ -24,6 +24,8 @@ export default [
         pathRewrite: {
             '^/assets/manifest.json': '/dotAdmin/assets/manifest.json',
             '^/assets/monaco-editor/min': '/dotAdmin/assets/monaco-editor/min',
+            '^/assets/edit-ema': '/dotAdmin/assets/edit-ema',
+            '^/assets/seo': '/dotAdmin/assets/seo',
             '^/assets': '/dotAdmin',
             '^/tinymce': '/dotAdmin/tinymce'
         }

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.scss
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.scss
@@ -53,6 +53,7 @@
 .page-tools-list__description {
     margin: 0;
     line-height: $line-height;
+    word-break: normal;
 }
 
 .page-tools-external-link {


### PR DESCRIPTION
### Proposed Changes
This pull request includes updates to the `core-web` application, specifically adding new asset paths and modifying the styling for the SEO component. The most important changes are:

### Asset Path Updates:
* [`core-web/apps/dotcms-ui/proxy-dev.conf.mjs`](diffhunk://#diff-f162544d3441baeebb73cbea3b36673232b11068a7307feb36347b6f2c7ad842R27-R28): Added new paths for `edit-ema` and `seo` assets under the `pathRewrite` configuration.

### Styling Updates:
* [`core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.scss`](diffhunk://#diff-03d938f80f3bbd2fbaaa22b6b6996b23eca019f5e4b8139c66e34397b093df92R56): Added `word-break: normal;` to the `.page-tools-list__description` class to ensure proper text wrapping.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
![CleanShot 2024-11-15 at 13 51 38@2x](https://github.com/user-attachments/assets/4a6e7aac-8a24-4727-85c7-02315e8a3063)|![CleanShot 2024-11-15 at 13 51 01@2x](https://github.com/user-attachments/assets/b141e571-9627-48e2-9bd1-358fdd0d6d53)


This PR fixes: #28644